### PR TITLE
feat(nonuniform): NU runner feature parity + inverse-design unblock

### DIFF
--- a/docs/research_notes/2026-04-15_distributed_nu_cpml_deferred.md
+++ b/docs/research_notes/2026-04-15_distributed_nu_cpml_deferred.md
@@ -1,0 +1,75 @@
+# Deferred — distributed NonUniformGrid + CPML / dispersion — 2026-04-15
+
+## Status
+
+Deferred out of the `nonuniform-completion` branch. Tracked here so the
+scope doesn't get lost.
+
+## What landed in Phase B (this branch)
+
+`rfx/runners/distributed_nu.py` (new) + edits to `rfx/runners/distributed_v2.py`
+and `rfx/api.py`. Enables multi-device `shard_map` FDTD with a
+`NonUniformGrid` for the vacuum / PEC case.
+
+Tests: `tests/test_distributed_nu_smoke.py`,
+`tests/test_distributed_nu_kernel.py` (4/4 pass under
+`XLA_FLAGS=--xla_force_host_platform_device_count=2`).
+
+## What is NOT supported on the distributed + NU path
+
+The runner-level guardrail in `rfx/runners/distributed_v2.py` and the
+API-level guard in `rfx/api.py` raise `NotImplementedError` /
+`ValueError` for:
+
+1. **CPML on NU + distributed.** Reason: existing
+   `_apply_cpml_*_distributed` kernels hard-code scalar `grid.dx` in y/z
+   face curls. Reusing them for an anisotropic NU grid would be silently
+   incorrect on y/z. A correct `_apply_cpml_*_distributed_nu` needs
+   per-axis `dx`/`dy`/`dz` plumbing and a NU-aware `CPMLAxisParams`
+   path. ~2–3 days of focused work, independently verifiable.
+
+2. **Debye / Lorentz dispersion on NU + distributed.** Reason: the
+   single-device NU runner (`rfx/nonuniform.py::_update_e_nu_dispersive`)
+   does the ADE math correctly, but porting it to the distributed path
+   means adding an `_update_e_local_nu_with_dispersion` kernel and
+   threading ADE coefficient sharding through `shard_map` in_specs.
+   ~1–2 days.
+
+## Why deferred
+
+The NonUniformGrid completion target (patch antenna / microstrip CPW /
+single-cavity workloads, 0.4–1.3 M cells after graded-mesh reduction)
+fits on a single A6000 48 GB with substantial headroom. Multi-GPU +
+NonUniformGrid + CPML only becomes load-bearing for multi-element
+arrays, dense via grids, or broadband time-stepping — all workloads
+outside the current target.
+
+Step 4 (capability coverage: DFT plane probe, lumped RLC, NTFF,
+waveguide port on the NU path) is the actual blocker for the target
+workloads and takes priority over distributed extensions.
+
+## How to pick this up later
+
+Branch off `main` (or wherever Phase B landed) as
+`distributed-nu-cpml-dispersion`. Two independent sub-branches are
+cleaner than one:
+
+- `distributed-nu-cpml`: per-axis CPML apply kernels in
+  `rfx/runners/distributed_nu.py` (mirror the existing
+  `_apply_cpml_*_distributed` but take `CPMLAxisParams` and per-axis
+  dx/dy/dz). Remove the runtime NotImplementedError in
+  `distributed_v2.py` for `use_cpml and is_nu`. Add `tests/
+  test_distributed_nu_cpml.py::test_graded_x_cpml_reflection_matches_single`.
+
+- `distributed-nu-dispersive`: port `_update_e_nu_dispersive` to
+  `_update_e_local_nu_with_dispersion`. Extend `_update_e_shmap` NU
+  branch to thread Debye/Lorentz ADE coeffs. Add
+  `tests/test_distributed_nu_dispersive.py`.
+
+Both sub-branches must keep the uniform distributed path bit-identical
+(`tests/test_distributed.py` 30/30 green).
+
+## Reference commit
+
+Phase B landing commit on `nonuniform-completion` branch: to be filled
+in after the partial-Phase-B commit lands.

--- a/docs/research_notes/2026-04-15_nonuniform_completion_handoff.md
+++ b/docs/research_notes/2026-04-15_nonuniform_completion_handoff.md
@@ -1,0 +1,83 @@
+# NonUniformGrid Completion — handoff and plan — 2026-04-15
+
+## Why this note exists
+
+The SBP-SAT modified-Yee subgrid effort (branch `subgrid-modified-yee-singlegrid`, frozen at commit `7758c9d`) validated the interior physics but was blocked by a structural PML–SBP-stencil incompatibility. See companion note `2026-04-15_sbp_sat_cpml_research_crosscheck.md` for the full negative-result record.
+
+After freezing that branch, a 5-probe parallel investigation (scientist, codex, critic, and four gap-probe agents) re-evaluated memory-efficient FDTD alternatives from scratch, with JAX-native advantage preservation as a hard constraint. Hybrid FDTD–FEM was excluded (tracked separately in `rfx-adv`).
+
+This note records the findings and the resulting work plan.
+
+## Evaluation of alternatives
+
+Candidates surveyed: Bérenger Huygens subgridding (HSG, TAP 2006), Chilton–Lee provably-stable FE-projection subgridding (TAP 2007), Okoniewski overlapping subgrid (OS-FDTD, TAP 1997), Xiao–Liu enlarged-cell interpolation at PML (AWPL 2007), high-order FDTD(2,4) multi-resolution, JAX-speculative vmap multi-resolution, and completion of the existing NonUniformGrid graded mesh.
+
+Rejected and why:
+- **OS-FDTD** — author-confirmed late-time instability; recapitulates the SBP-SAT failure mode class (boundary-interpolation coupling into PML).
+- **FDTD(2,4)** — wide-stencil + PML = same structural coupling risk; speculative for rfx JAX architecture.
+- **Xiao–Liu** — a correctness patch for nonuniform + CPML interface, not a standalone memory technique. Retained as a potential refinement of the NonUniformGrid path.
+- **vmap multi-resolution** — no CEM production track record; `jax.vmap` does not solve the coupling problem.
+- **Bérenger HSG** — the author explicitly states in TAP 2006 that the scheme is not naturally stable. The "Switched HSG" patch (Hartley et al., TAP 2022) is empirical, not a formal proof. Useful only if paired with the switching mechanism, which is non-trivial.
+
+Retained:
+- **Lead — NonUniformGrid completion.** Existing `rfx/nonuniform.py`, `rfx/runners/nonuniform.py`, `rfx/core/yee.py` nonuniform kernels, and the `_build_nonuniform_grid` path in `rfx/simulation.py` cover the graded-mesh lane on a single uniform-update architecture. CPML already duck-types per-axis cell sizes. The lane is real but partially blocked; unblocking it is a finite 2.5–3 person-week scope.
+- **Backup — Chilton–Lee TAP 2007.** Provably energy-conserving and charge-conserving FE-projection subgridding with arbitrary odd refinement ratios and material traversal. Citation: R. A. Chilton and R. Lee, "Conservative and provably stable FDTD subgridding," IEEE Trans. Antennas Propag. 55(9), 2537–2548, 2007, DOI 10.1109/TAP.2007.904092. Full dissertation openly available via OhioLINK ETD. This is distinct from the Bérenger HSG surface-injection scheme. Reserved for the case where disjoint fine regions become necessary (multi-element arrays, via grids, multi-scale PCB).
+
+Dispute resolution (critic verdict, 2026-04-15): the initial scientist claim that NonUniformGrid is "production-ready, full JAX jit/gradient/shard_map" overstated the state. Codex was right that the lane is blocked in several load-bearing ways. Specifically:
+1. `rfx/simulation.py:448-450` rejects `boundary='upml'` under nonuniform profiles.
+2. `rfx/simulation.py:501-503` rejects ADI under nonuniform profiles.
+3. `rfx/runners/distributed_v2.py` has zero nonuniform awareness — multi-GPU lane is uniform-only.
+4. `tests/test_nonuniform_api.py:113-179` hard-rejects NTFF, DFT plane probe, TFSF, waveguide ports, and lumped RLC on the nonuniform path.
+5. No gradient-through-nonuniform test exists.
+
+## Gap probes — empirical findings
+
+**Gradient.** `jax.grad` through the nonuniform lane works with respect to source amplitude (AD vs finite-difference, 0.11% error at `n_steps=80`, grid 18×18×38). It breaks with respect to `dz_profile` because `make_nonuniform_grid` calls `np.asarray` and `float(np.min(dz_full))` on the traced input before any JAX operation touches it — a Python-level host boundary. Gradient-through-geometry requires refactoring `make_nonuniform_grid` to stay inside the trace. Source/material gradients are safe today; geometry gradients are a separate future scope.
+
+**UPML unblock.** The blocker is `_sigma_profile_1d` computing `d = n_layers * dx` with a single scalar. The fix is to accept a per-cell width array and compute cumulative physical positions for grading. Estimated 3–5 hours. Landmines: `_get_axis_cell_sizes` currently returns boundary scalars, not slices; `cb_ex/dx` at line 213 conflates stencil-spacing and PML-grading `dx` and must be disentangled; uniform x/y fast-path must be preserved for existing CPML tests.
+
+**Distributed + nonuniform.** Tractable with restrictions: shard along x only, grading ratio ≤5:1 globally (shared `dt`, no cross-device sub-cycling), x-axis CPML cells uniform (already true via `make_nonuniform_grid` padding), TFSF remains single-device. This is exactly the constraint set used by Meep, Lumerical FDTD Solutions, and XFdtd. Estimated 7 days: ~3 days for per-axis `inv_dx` slab threading through `update_h_nu`/`update_e_nu` distributed kernels, ~1.5 days for CPML init fix (axis-aware cell size instead of scalar `grid.dx`), ~0.5 day for `run_distributed` duck-typing guard, ~2 days for 2-GPU wave-crossing + CPML reflection graded-mesh tests.
+
+**Cell-count reduction, measured by geometry class.** Analytic cell counting on three representative workloads, anisotropic per-axis minimum resolution with 1.3× grading ratio and 8-layer CPML:
+
+| Geometry | Uniform cells | Graded cells | Ratio |
+|---|---|---|---|
+| Patch antenna (FR4 0.5 mm substrate + 37.5 mm air, 2.4 GHz) | 8.0 M | 0.43 M | 18.5× |
+| Microstrip CPW (0.2 mm strip, 50 mm domain, 10 GHz) | 134 M | 1.26 M | 106× (memory) |
+| Cavity with 0.1 mm PEC slot (20 mm cavity, 10 GHz) | 1.6 M | 0.49 M | 3.1× |
+
+For planar thin-substrate structures, the 5–10× plan-note claim is a lower bound. For fine features that span the full domain on any axis, 2–5× is the realistic ceiling. A single-number headline of "5–10×" is defensible across the workload mix but undersells the antenna/microstrip class.
+
+**Huygens citation integrity.** Both the scientist and codex reports conflated Bérenger's Huygens subgridding (TAP 2006, author-acknowledged unstable) with Chilton–Lee's provably-stable FE-projection subgridding (TAP 2007). Neither of the IEEE TAP 56(8) 2008 citations used earlier in this repo holds. For the backup candidate, the correct reference is TAP 55(9) 2007.
+
+## Work plan — new branch
+
+Branch: `nonuniform-completion` (forked from current `main`, not from the frozen SBP-SAT branch).
+
+Ordered by cost-risk, lowest first. Each item closes with an explicit verification step. All work preserves the `subgrid-modified-yee-singlegrid` branch as a frozen negative-result artefact; it is not merged.
+
+1. **UPML + nonuniform coupling.** Remove `rfx/simulation.py:448-450` guard. Rewrite `_sigma_profile_1d` in `rfx/boundaries/upml.py` to accept per-cell width array. Thread full PML cell-width slice through `_axis_sigma_E_H`. Disentangle stencil `dx` from PML-grading `dx` in `cb_ex/dx`. Preserve uniform x/y scalar fast-path. Verify: reflection diagnostic (existing UPML plane-wave test pattern) on a graded z-profile reaches the same -20 dB+ absorption as the uniform UPML baseline. Estimated: 3–5 h work + 1 day test hardening.
+
+2. **Gradient-through-source regression test.** Add `tests/test_nonuniform_gradient.py` with two cases: (a) `jax.grad` w.r.t. source amplitude (expected: works, FD agreement <1%); (b) `jax.grad` w.r.t. `dz_profile` (expected: `TracerArrayConversionError`, marked `xfail` with pointer to the refactor scope). Purpose: lock in the source-side differentiability that was just empirically confirmed, surface the geometry-gradient gap as a known scope item instead of a silent hole. Estimated: 1 day.
+
+3. **Distributed nonuniform kernels.** Implement `_update_h_local_nu` / `_update_e_local_nu` in `rfx/runners/distributed.py` (or a new `distributed_nu.py`) accepting `inv_dx`, `inv_dy`, `inv_dz` slabs. Update `rfx/runners/distributed_v2.py` shard_map `in_specs` to shard `inv_dx` along `P("x")` alongside the field slab. Fix `_init_cpml_distributed` to call `_get_axis_cell_sizes` per face. Add duck-typing guard in `run_distributed` to accept `NonUniformGrid`. Verify: 2-GPU wave-crossing with 3:1 x-axis grading matches single-GPU nonuniform reference to eps-level agreement; 2-GPU CPML reflection stays within 1 dB of single-GPU at the same layer count. Estimated: 7 days.
+
+4. **Capability coverage scoping.** For NTFF / DFT plane probe / TFSF / waveguide ports / lumped RLC on the nonuniform lane, decide per-feature: unblock now, unblock later, or permanently scope-cut. Document the decision matrix. Do not unblock NTFF before the distributed lane is working (the two interact through the radiation-box sampling that depends on cell-size arrays). Estimated: 0.5 day decision + variable implementation.
+
+5. **Optional — differentiable geometry.** Refactor `make_nonuniform_grid` to stay inside the JAX trace (replace `np.asarray` / `float(np.min)` with `jnp` equivalents; make CPML coefficient arrays JAX-traceable). Enables `jax.grad` w.r.t. `dz_profile`. Only worth doing if a shape-optimization workload is planned; not on the critical path for memory efficiency. Estimated: +1 week.
+
+Exit criteria for the branch to be merge-ready: steps 1–3 complete and green on CI; step 4 has a written decision matrix; step 5 is either done or explicitly deferred with a tracking issue.
+
+## Do-not-repeat
+- Do not claim NonUniformGrid is "production-ready" without checking `rfx/simulation.py:440-510` guards and `tests/test_nonuniform_api.py` capability list.
+- Do not cite "Chilton & Sarris TAP 56(8) 2008" for any stability result. The subgridding stability proof is Chilton & Lee TAP 55(9) 2007. TAP 56(8) 2008 is the Lobatto p-refinement paper.
+- Do not cite Bérenger TAP 2006 as a stable Huygens subgrid — the author explicitly does not claim stability.
+- Do not put CPML or UPML on the interior interface of any two-block subgrid scheme (lesson from SBP-SAT frozen result).
+- Do not treat the existing `docs/research_notes/2026-04-03_nonuniform_mesh_plan.md` cell-reduction numbers as a ceiling — they are a reasonable single-number summary but understate the thin-substrate class.
+
+## Files of record
+- Frozen negative result: commit `7758c9d` on `subgrid-modified-yee-singlegrid`; note `docs/research_notes/2026-04-15_sbp_sat_cpml_research_crosscheck.md`.
+- This note: `docs/research_notes/2026-04-15_nonuniform_completion_handoff.md`.
+- Existing nonuniform surface: `rfx/nonuniform.py`, `rfx/runners/nonuniform.py`, `rfx/core/yee.py` (`update_h_nu`, `update_e_nu`), `rfx/boundaries/cpml.py` (`_get_axis_cell_sizes`), `rfx/simulation.py` (`_build_nonuniform_grid`, guards at 448-450 and 501-503).
+- Existing tests: `tests/test_nonuniform_api.py`, `tests/test_nonuniform_convergence.py`, `tests/test_nonuniform_xy.py`.
+- Earlier plan: `docs/research_notes/2026-04-03_nonuniform_mesh_plan.md`; integration handoff: `docs/research_notes/2026-04-03_nonuniform_integration_handoff.md`.

--- a/docs/research_notes/2026-04-15_nonuniform_completion_session_handoff.md
+++ b/docs/research_notes/2026-04-15_nonuniform_completion_session_handoff.md
@@ -1,0 +1,187 @@
+# Session handoff — nonuniform-completion — 2026-04-15
+
+## State at end of session
+
+Branch: `nonuniform-completion` (forked from `main`, not from the frozen
+SBP-SAT branch). Off-main. Five commits on top of main.
+
+```
+2679f1d feat(api): guardrail — distributed+nonuniform fails loudly (Phase A)
+af3d97f test(nonuniform): gradient-through-source regression + xfail geometry
+1269350 feat(api): unblock boundary='upml' on nonuniform dz/dx/dy profiles
+85de45f feat(upml): per-axis inverse spacing — unblock nonuniform grids
+6b1d3ec docs(subgrid): NonUniformGrid completion handoff — 5-probe investigation
+```
+
+Tests green on the non-multi-GPU subset. Specifically verified:
+- `tests/test_api.py`, `tests/test_simulation.py`, `tests/test_cpml.py`,
+  `tests/test_cfs_cpml.py`, `tests/test_nonuniform_api.py`,
+  `tests/test_nonuniform_xy.py`: 92 passed, 1 skipped, 0 regressions.
+- `tests/test_nonuniform_gradient.py` (new): 1 passed + 1 xfail(strict)
+  as designed.
+- `tests/test_nonuniform_api.py::test_nonuniform_upml_smoke` (new):
+  passes, confirms UPML+nonuniform runs stable.
+- `tests/test_nonuniform_api.py::test_nonuniform_rejects_distributed`
+  (new): passes under `XLA_FLAGS=--xla_force_host_platform_device_count=2`,
+  skipped otherwise.
+- Modified-Yee PML suite on `subgrid-modified-yee-singlegrid` stays
+  frozen with strict xfail markers — unchanged.
+
+Related frozen artefact: commit `7758c9d` on
+`subgrid-modified-yee-singlegrid` (SBP-SAT subgrid physics validated,
+PML coupling structurally blocked — see
+`docs/research_notes/2026-04-15_sbp_sat_cpml_research_crosscheck.md`).
+
+## What landed
+
+**Step 1 — UPML + nonuniform coupling.** Completed.
+- `rfx/boundaries/upml.py`: extended `UPMLCoeffs` with `inv_dx/inv_dy/inv_dz`
+  (E-position) and `inv_dx_h/inv_dy_h/inv_dz_h` (H-position). `init_upml`
+  now builds these by duck-typing the grid (reads `grid.inv_dx` etc. on
+  `NonUniformGrid`, falls back to scalar `1/grid.dx`). `apply_upml_h` /
+  `apply_upml_e` multiply each curl component by its own axis's inverse
+  before applying `db_h*` / `cb_e*`.
+- `rfx/api.py`: dropped the two `ValueError` guards at 447-450 that
+  refused `boundary='upml'` when any non-uniform profile was set.
+- `tests/test_api.py`: removed the paired rejection assertion in
+  `test_validation_errors`.
+- `tests/test_nonuniform_api.py::test_nonuniform_upml_smoke`: pins the
+  newly-unblocked combination — runs, stable, no late-time energy
+  sourcing.
+
+Uniform-grid UPML stays bit-identical because all `inv_*` fields
+collapse to a single scalar `1/grid.dx` that broadcasts the same way as
+the old pre-folded `cb/db` coefficients.
+
+**Step 2 — gradient-through-source regression.** Completed.
+- `tests/test_nonuniform_gradient.py`: `jax.grad` w.r.t. a scalar source
+  amplitude agrees with centered FD to <1% (reproduces the 0.11% the
+  2026-04-15 gap probe measured). A second test takes `jax.grad` w.r.t.
+  `dz_profile` and is `xfail(strict=True)` with a pointer to Step 5 —
+  when that refactor lands, the test flips to XPASS and fails loudly.
+
+**Step 3 — distributed + nonuniform.** Phase A only.
+- `rfx/api.py`: explicit `ValueError` when the user combines
+  `devices=[...]` (len > 1) with any non-uniform profile. Before this
+  commit the distributed lane silently called `sim._build_grid()` and
+  dropped the profile on the floor — a latent correctness bug.
+- `tests/test_nonuniform_api.py::test_nonuniform_rejects_distributed`:
+  regression that runs only when ≥2 JAX devices are visible (CI) and
+  skips otherwise.
+- Phase B / Phase C not started.
+
+## What's pending
+
+**Step 3 Phase B — distributed non-uniform kernels.** Not started.
+Estimated 5 days of focused work.
+- Add `_update_h_local_nu` / `_update_e_local_nu` in a new
+  `rfx/runners/distributed_nu.py`. Do not touch `rfx/runners/distributed.py`
+  — keep the uniform kernel frozen.
+- Edit `rfx/runners/distributed_v2.py` `shard_map` `in_specs` around
+  lines 894-910 and 918-960 to shard `inv_dx` as `P("x")` alongside the
+  field slab; keep `inv_dy`, `inv_dz` replicated (`P(None)`).
+- Fix `_init_cpml_sharded` (`rfx/runners/distributed_v2.py:406`) to call
+  `_get_axis_cell_sizes` per face instead of consuming a scalar
+  `grid.dx`.
+- Replace `run_distributed`'s `sim._build_grid()` call at
+  `distributed_v2.py:547` with a branch that builds a `NonUniformGrid`
+  when the profiles are set. This obsoletes the Phase A guardrail —
+  keep the guardrail as the fallback while Phase B is incomplete.
+- Constraints (carry over from handoff): shard x only, global grading
+  ratio ≤ 5:1, x-axis CPML cells uniform (already true via
+  `make_nonuniform_grid` padding), TFSF remains single-device.
+
+**Step 3 Phase C — graded validation.** Not started.
+- 2-GPU wave-crossing with 3:1 x-axis grading vs single-GPU non-uniform
+  reference, eps-level agreement.
+- 2-GPU CPML reflection on graded x within 1 dB of single-GPU at the
+  same layer count.
+- Tests live in `tests/test_distributed_nonuniform.py` marked
+  `@pytest.mark.gpu_multi`.
+
+**Step 4 — capability coverage.** Re-scoped.
+- Original planner claim: DFT plane probe and lumped RLC unblock is
+  "trivial, near-zero risk". Verified in this session that the
+  non-uniform runner (`rfx/nonuniform.py::run_nonuniform`) has
+  `wire_ports` but no `dft_plane` integration path — the rejection
+  guards at `rfx/api.py:2572, 2590` are not a 30-minute flip, they are
+  feature-addition in the non-uniform runner itself.
+- Defer until after Phase B lands and we have empirical memory numbers
+  — Step 4 is capability coverage, not memory-efficiency load-bearing.
+
+**Step 5 — differentiable geometry.** Not started. Optional.
+- Refactor `rfx/nonuniform.py::make_nonuniform_grid` and `_pad_profile`
+  to stay inside the JAX trace. Every `np.asarray`, `float(np.min(...))`,
+  `int(round(domain/dx))` needs to become `jnp`. Note that
+  `nx_interior = int(round(domain_xy[0]/dx))` forces grid shape to
+  depend on a traced scalar — either require a ready-made `dx_profile`
+  array in the differentiable signature, or accept `nx` as a static arg.
+- Landmines listed in handoff note step 5.
+- When complete, `test_grad_wrt_dz_profile_blocked` flips from xfail to
+  XPASS — strict xfail catches the closure.
+
+## Suggested next session structure
+
+1. **Re-read** `docs/research_notes/2026-04-15_nonuniform_completion_handoff.md`
+   (the master plan) and this session handoff.
+2. **Decide scope** — Phase B full 5 days in one session, or Phase B
+   split into its own three sub-sessions matching planner's Phase
+   A/B/C checkpoint structure.
+3. **Before editing** `rfx/runners/distributed_v2.py`: re-invoke the
+   planner with the current commit hashes so the implementation plan
+   reflects the code state, not the pre-Phase-A code state.
+4. **Run the multi-GPU smoke test early** (Phase A checkpoint of the
+   original planner note — degenerate-uniform non-uniform grid must
+   match uniform 2-GPU baseline before touching kernels).
+
+## Known risks for Phase B
+
+Ranked by planner (confirmed relevant against current code):
+
+1. **`inv_dx` replicated instead of sharded** under `shard_map` →
+   kernel uses wrong slab on each device → curl magnitude scales by the
+   grading ratio → catches in wave-crossing check.
+2. **Ghost-cell exchange drops last cell of `inv_dx`** at
+   `rfx/runners/distributed_v2.py:114-180` → one-cell boundary layer
+   with stale `inv_dx` → fixed-location energy anomaly near slab
+   boundaries.
+3. **`grid.dx` scalar still read inside a shard-local kernel** → silent
+   use of boundary cell size everywhere → wave-speed error proportional
+   to grading → catches in the Phase B checkpoint.
+4. **`inv_dx_h` off-by-one at slab boundary** → late-time instability
+   after ~10^4 steps. Does NOT catch in Phase A/B smoke. Add an
+   explicit unit test on the slab-boundary `inv_dx_h` values before
+   running Phase C.
+
+## Files that matter next session
+
+- `rfx/runners/distributed_v2.py` — 1172 lines; read
+  `run_distributed` (466), `_init_cpml_sharded` (406),
+  shard_map blocks (894-960), and the top-level helpers (114-250).
+- `rfx/runners/distributed.py` — 1563 lines; pulls in the uniform
+  `_update_h_local` / `_update_e_local` used by `distributed_v2`.
+- `rfx/runners/nonuniform.py` — reference single-device non-uniform
+  runner. Kernels already use `inv_dx_h` / `inv_dy_h` / `inv_dz_h`.
+- `rfx/core/yee.py` — `update_h_nu` / `update_e_nu` (lines 206+) are
+  the exact kernels the distributed path needs to adapt.
+- `rfx/boundaries/cpml.py` — `_get_axis_cell_sizes` (155-173) is the
+  pattern to follow in `_init_cpml_sharded`.
+- `rfx/api.py:3178-3198` — routing fork; Phase A guardrail lives here.
+
+## Do-not-repeat reminders
+
+- Do not delete the `_run_nonuniform` or the Phase A guardrail until a
+  working Phase B replaces it — the handoff explicitly wants the
+  single-device non-uniform lane to stay available.
+- Do not touch `rfx/runners/distributed.py` uniform kernels; they are
+  the reference baseline. Add new kernels in a new file.
+- Do not mark `test_grad_wrt_dz_profile_blocked` as xfail-lenient. The
+  strict flavour is load-bearing: it is how Step 5 announces itself.
+- Do not cite Bérenger TAP 2006 or Chilton TAP 56(8) 2008 as
+  provably-stable subgridding proofs. If Step 3 Phase B runs into
+  corner cases and someone proposes Huygens subgridding, the correct
+  reference is Chilton &amp; Lee TAP 55(9) 2007 (different method) or an
+  explicitly-empirical citation.
+- Do not relax the ≤5:1 grading constraint for the distributed lane
+  without revisiting CFL sub-cycling — it maps exactly to
+  Meep/Lumerical/XFdtd industry practice and breaks if relaxed.

--- a/docs/research_notes/2026-04-15_nu_feature_completion_and_crossval.md
+++ b/docs/research_notes/2026-04-15_nu_feature_completion_and_crossval.md
@@ -1,0 +1,206 @@
+# Non-uniform runner feature completion, crossval, and inverse-design unblock
+
+**Date**: 2026-04-15
+**Branch**: `nonuniform-completion`
+**Context**: continuation of the NU-completion work from the morning session;
+wired the missing features into the NU runner, validated against OpenEMS on
+GPU, and cleared four GitHub feature-request / bug issues that had been
+blocking gradient-based inverse design on NU grids.
+
+---
+
+## Scope
+
+1. Wire all remaining simulation primitives into `rfx/runners/nonuniform.py`
+   (Steps 4a–4e of the NU roadmap).
+2. Run an end-to-end antenna demo on the NU runner and confirm physical
+   accuracy against the Balanis TL analytic target and against OpenEMS.
+3. Quantify the real memory saving of NU vs uniform at matched physical
+   accuracy.
+4. Address open GitHub issues that blocked NU / inverse-design workflows:
+   #29, #30, #32, #33.
+
+---
+
+## NU runner feature parity (Step 4 series)
+
+Prior commits (already on branch at session start):
+
+| Step | Commit | Feature |
+|------|--------|---------|
+| 4a   | `65a73b8` | DFT plane probe on NU runner |
+| 4b   | `9deaa1b` | Lumped RLC element support on NU runner |
+| 4c   | `4aa5ff4` | NTFF box support on NU runner |
+| 4d   | `a475354` | Waveguide port support on NU runner |
+| 4e   | `d42b659` | TFSF +x/-x plane-wave source on NU runner |
+
+The NU runner now exposes the same primitive set as the uniform runner.
+UPML on NU is unblocked at `rfx/boundaries/upml.py` via per-axis inverse
+spacing (`inv_dx`, `inv_dy`, `inv_dz`).
+
+Still missing on NU forward: Floquet ports, `pec_occupancy_override`,
+`checkpoint=True` plumbed into the NU scan body. Tracked as known gaps
+in the commit message of the NU-forward patch.
+
+---
+
+## 2.4 GHz FR4 patch antenna demo (examples/nonuniform_patch_demo.py)
+
+Standalone 198-line demo, substrate 0.25 mm / air 1 mm NU z mesh
+(`smooth_grading`, max_ratio=1.3), x/y uniform 1 mm,
+probe-fed Gaussian source, `boundary="cpml"`, 8 CPML layers,
+finite 60×55 mm ground plane.
+
+**Local CPU result** (1.7 s wall, 324k NU cells):
+- rfx Harminv f = 2.4621 GHz
+- Balanis TL analytic f = 2.4235 GHz
+- Error: **1.59 %** (pass criterion < 8 %: PASS)
+
+Plots saved to `examples/nonuniform_patch_demo/`:
+- `probe_ez_timeseries.png`
+- `dz_mesh_profile.png`
+
+---
+
+## GPU + OpenEMS crossval (VESSL `369367233458`)
+
+VESSL job on `remilab-c0 / gpu-rtx4090` using the microwave-energy
+OpenEMS install recipe pattern ported to the `nvcr.io/nvidia/jax:24.10-py3`
+image (py3.10, Ubuntu 22.04):
+
+```yaml
+apt-get install -y --no-install-recommends \
+  openems python3-openems libopenems0 libcsxcad0 python3-matplotlib git
+/usr/bin/python3 -m pip install -e ".[dev]" "numpy<2"
+```
+
+The image's bundled JAX (0.4.33 dev) saw the GPU (`[CudaDevice(id=0)]`),
+openEMS + CSXCAD imports were verified before the runs.
+
+**Final crossval output (examples/crossval/05_patch_antenna.py on GPU):**
+
+| Measurement                         | f_res (GHz) | Δ vs Balanis TL |
+|-------------------------------------|-------------|-----------------|
+| Balanis TL analytic                 | 2.4235      | —               |
+| OpenEMS Harminv on port V(t)        | 2.4868      | +2.61 %         |
+| rfx Harminv (probe ringdown)        | 2.4621      | +1.59 %         |
+
+**Pass criteria (all PASS):**
+- rfx internal self-consistency (Harminv vs lumped-port S11): **0.08 %**
+- rfx vs analytic: **1.59 %**
+- rfx vs OpenEMS Harminv: **0.99 %**
+- S11 passivity |S11| ≤ 1: max **0.991**
+
+rfx and OpenEMS agree to within 1 % on the TM010 patch resonance on
+a 2.4 GHz FR4 patch with finite ground plane, CPML absorbers, and
+probe-fed lumped excitation.
+
+Two earlier VESSL attempts failed and are the reason this note carries
+the install recipe explicitly:
+- first attempt: `pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime` —
+  bash heredoc termination failed inside `run: |-` block scalar. Use
+  one-line `python3 -c "..."` instead.
+- second attempt: same image — `python3-openems` apt package installs
+  into Ubuntu 20.04's `/usr/bin/python3` (py3.8) which cannot run rfx
+  (requires-python ≥ 3.10). Switched to the Nvidia JAX image on
+  Ubuntu 22.04 whose `/usr/bin/python3` is py3.10 and matches the
+  `python3-openems` apt binding.
+
+---
+
+## Memory saving — NU vs uniform at matched physical accuracy
+
+Measured with `sim.estimate_ad_memory(n_steps=2000)` (added in this
+session as part of issue #30 preflight):
+
+| Configuration | cells | forward | checkpointed AD | full AD |
+|-|-:|-:|-:|-:|
+| **NU** (dx=dy=1mm, graded z 0.25→1mm) | 553,288 | 40.5 MB | 161.9 MB | 30.5 GB |
+| Uniform fine (0.25mm isotropic)       | 20,724,826 | 1324 MB | 5297 MB | 996 GB |
+| Uniform coarse (1mm isotropic — substrate under-resolved) | 553,288 | 35.4 MB | 141.4 MB | 26.6 GB |
+
+**Ratios (NU vs accuracy-matched 0.25mm uniform):**
+- **37.5× cell-count reduction**
+- **32.7× forward memory reduction**
+- **32.7× checkpointed-AD memory reduction**
+
+The earlier plan-note ceiling of 5–10× is conservative for
+thin-substrate antenna workloads. A thin substrate forces either
+(a) isotropic 0.25 mm (996 GB full-AD → OOM on any commodity GPU)
+or (b) NU grading that preserves substrate resolution only where it
+is needed.
+
+Practical consequence: on a 24 GB GPU, gradient-based inverse design
+of this patch **fits comfortably in the NU path** (162 MB with
+checkpointing) and **does not fit at all** under isotropic fine uniform
+(5.3 GB checkpointed; full-AD in the hundreds of GB). The 2.85× demo
+number reported by `nonuniform_patch_demo.py` compares z-axis cells
+only — the 3D AD comparison is an order of magnitude larger.
+
+---
+
+## GitHub issues closed
+
+| # | Commit | Impact |
+|---|-|-|
+| **#33** — forward() on NU mesh for differentiable optimization | `e1da198` | NU grids now usable in `sim.optimize()` / `sim.topology_optimize()`. JAX-grad through NU scan verified (AD vs centered FD rel err < 2 %). |
+| **#32** — `maximize_directivity` always-zero gradient | `9f25ea2` | Absolute-power objective (~1e-27, float32 noise) replaced with scale-invariant directivity ratio `U(θ,φ)/P_rad` integrated over the hemisphere, `stop_gradient` on denominator. Issue-reported fix: directivity gate regressed from flat `-4.4e-31` loss to 9400 % improvement, 7.6 dBi. |
+| **#29** — forward() waveguide port broadcast error `(8,1,1) vs (7,42,13)` | `f4f7dd1` | `_forward_from_materials` was not forwarding `grid.cpml_axes` — CPML state was allocated for axes without padding. The run() path forwards them; now forward() does too. Unblocks gradient-based waveguide optimisation. |
+| **#30** — inverse-design preflight | `598f755` | Four new preflight checks (tightened resolution thresholds, NTFF↔PEC overlap, NTFF near-field λ/4 gap, reverse-mode AD memory with VRAM comparison). Exposed as `sim.estimate_ad_memory(n_steps, ...)` for direct use. |
+
+Remaining issue #31 (checkpointed NU + mixed precision + temporal
+windowing for memory-bounded inverse design) is scoped but deferred
+to a separate session.
+
+---
+
+## Files of record
+
+- Commits on `nonuniform-completion`:
+  `e1da198`, `9f25ea2`, `f4f7dd1`, `598f755`, plus example `21f5675`.
+- Demo: `examples/nonuniform_patch_demo.py`.
+- VESSL job spec (gitignored by repo policy; keep local):
+  `examples/vessl_nu_patch_crossval.yaml`.
+- Completed VESSL run: `369367233458` (Apr 15).
+- Crossval reference: `examples/crossval/05_patch_antenna.py` (rfx +
+  OpenEMS, both on GPU).
+- Prior session handoff:
+  `docs/research_notes/2026-04-15_nonuniform_completion_handoff.md`
+  and `2026-04-15_nonuniform_completion_session_handoff.md`.
+
+---
+
+## Do not repeat
+
+- Do **not** use `pytorch/pytorch:*-runtime` as the rfx+openEMS image —
+  Ubuntu 20.04's `/usr/bin/python3` is py3.8 and rfx needs ≥ 3.10.
+  Use `nvcr.io/nvidia/jax:24.10-py3` (Ubuntu 22.04, py3.10) and
+  `apt install python3-openems`; invoke `/usr/bin/python3` so the
+  apt-installed binding is visible.
+- Do **not** embed bash heredocs (`<<'PY'`) inside VESSL `run: |-`
+  blocks — the terminator is indented by the block scalar and bash
+  never reaches it. Use `python3 -c "..."` inline instead.
+- Do **not** quote "2.85× memory saving" without saying "z-axis cells
+  only" — the realistic 3D AD comparison is ~33× for this geometry
+  class. The earlier plan-note 5–10× range is also conservative.
+- Do **not** add a second preflight entry point when the existing
+  `sim.preflight()` already collects warnings/errors into a list —
+  extend flags, don't fork the harness (pattern used by #30).
+
+---
+
+## Next steps (for the next session)
+
+1. File follow-up GitHub issues for the NU-forward gaps (`pec_occupancy`,
+   `checkpoint=`, Floquet port) noted in `e1da198` commit message.
+2. Issue #31 — memory-efficient inverse design. Scope:
+   - plumb `checkpoint=True` into `run_nonuniform_path` so the NU scan
+     body is rematerialised by `jax.checkpoint`.
+   - optional mixed-precision for the scan state (fp16 fields, fp32
+     accumulators for DFT / probes).
+   - temporal windowing for very long runs where the full time series
+     is not needed (inverse design typically wants only the S-parameter
+     frequency probe, not the full trace).
+3. Open a PR from `nonuniform-completion` → `main` once #31 scope is
+   decided; current branch has 12 commits ahead, all passing the
+   touched tests.

--- a/examples/nonuniform_patch_demo.py
+++ b/examples/nonuniform_patch_demo.py
@@ -1,0 +1,225 @@
+"""Nonuniform-mesh demo: 2.4 GHz FR4 patch antenna — NU runner validation.
+
+Exercises the NU runner (rfx/runners/nonuniform.py) end-to-end:
+  - Non-uniform z mesh (fine in substrate, coarser in air)
+  - Broadband Gaussian Ez source + Ez probe
+  - Harminv resonance extraction
+
+Geometry matches crossval/05_patch_antenna.py exactly.
+No OpenEMS code, no comparison bookkeeping — pure NU plumbing check.
+
+Run:
+  python examples/nonuniform_patch_demo.py
+"""
+
+import math
+import os
+import time
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+from rfx import Simulation, Box
+from rfx.sources.sources import GaussianPulse
+from rfx.auto_config import smooth_grading
+from rfx.harminv import harminv
+
+C0 = 2.998e8
+OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                       "nonuniform_patch_demo")
+os.makedirs(OUT_DIR, exist_ok=True)
+
+# =============================================================================
+# Geometry constants (identical to 05_patch_antenna.py)
+# =============================================================================
+f_design  = 2.4e9
+eps_r     = 4.3
+h_sub     = 1.5e-3
+W         = 38.0e-3
+L         = 29.5e-3
+gx        = 60.0e-3
+gy        = 55.0e-3
+air_above = 25.0e-3
+air_below = 12.0e-3
+probe_inset = 8.0e-3
+
+dx   = 1.0e-3
+n_cpml = 8
+n_sub  = 6
+dz_sub = h_sub / n_sub          # 0.25 mm
+
+n_below = int(math.ceil(air_below / dx))
+n_above = int(math.ceil(air_above / dx))
+
+dom_x = gx + 2 * 10e-3
+dom_y = gy + 2 * 10e-3
+dom_z = air_below + h_sub + air_above
+
+gx_lo = (dom_x - gx) / 2;  gx_hi = gx_lo + gx
+gy_lo = (dom_y - gy) / 2;  gy_hi = gy_lo + gy
+patch_x_lo = dom_x / 2 - L / 2;  patch_x_hi = dom_x / 2 + L / 2
+patch_y_lo = dom_y / 2 - W / 2;  patch_y_hi = dom_y / 2 + W / 2
+feed_x = patch_x_lo + probe_inset
+feed_y = dom_y / 2
+
+z_gnd_lo  = air_below - dz_sub
+z_gnd_hi  = air_below
+z_sub_lo  = air_below
+z_sub_hi  = air_below + h_sub
+z_patch_lo = z_sub_hi
+z_patch_hi = z_sub_hi + dz_sub
+
+# =============================================================================
+# Analytic reference (Balanis, Ch. 14)
+# =============================================================================
+eps_eff = (eps_r + 1) / 2 + (eps_r - 1) / 2 * (1 + 12 * h_sub / W) ** (-0.5)
+delta_L = 0.412 * h_sub * ((eps_eff + 0.3) * (W / h_sub + 0.264)) / \
+          ((eps_eff - 0.258) * (W / h_sub + 0.8))
+f_an = C0 / (2 * (L + 2 * delta_L) * math.sqrt(eps_eff))
+
+print("=" * 60)
+print("Nonuniform-mesh patch antenna demo — NU runner validation")
+print("=" * 60)
+print(f"  Patch: W={W*1e3:.1f} mm, L={L*1e3:.1f} mm, εr={eps_r}")
+print(f"  Analytic f_res = {f_an/1e9:.4f} GHz")
+
+# =============================================================================
+# Non-uniform z mesh
+# =============================================================================
+raw_dz = np.concatenate([
+    np.full(n_below, dx),       # air below GP
+    np.full(1, dz_sub),         # GP cell
+    np.full(n_sub, dz_sub),     # substrate
+    np.full(n_above, dx),       # air above patch
+])
+dz_profile = smooth_grading(raw_dz, max_ratio=1.3)
+
+# Uniform-equivalent cell count (if everything at dz_sub)
+nx = int(math.ceil(dom_x / dx))
+ny = int(math.ceil(dom_y / dx))
+nz_nu = len(dz_profile)
+n_cells_nu = nx * ny * nz_nu
+
+nz_uniform_equiv = int(math.ceil(dom_z / dz_sub))
+n_cells_uniform = nx * ny * nz_uniform_equiv
+ratio = n_cells_uniform / n_cells_nu
+
+print(f"\nMesh:")
+print(f"  NU:      {nx} x {ny} x {nz_nu} = {n_cells_nu:,} cells")
+print(f"  Uniform: {nx} x {ny} x {nz_uniform_equiv} = {n_cells_uniform:,} cells")
+print(f"  Memory saving ratio: {ratio:.2f}x")
+
+# =============================================================================
+# Build simulation
+# =============================================================================
+src_z   = z_sub_lo + dz_sub * 2.5
+probe_z = src_z
+
+sim = Simulation(
+    freq_max=4e9,
+    domain=(dom_x, dom_y, 0),
+    dx=dx,
+    dz_profile=dz_profile,
+    boundary="cpml",
+    cpml_layers=n_cpml,
+)
+sim.add_material("fr4", eps_r=eps_r, sigma=0.0)
+
+# Finite ground plane
+sim.add(Box((gx_lo, gy_lo, z_gnd_lo), (gx_hi, gy_hi, z_gnd_hi)), material="pec")
+# FR4 substrate
+sim.add(Box((gx_lo, gy_lo, z_sub_lo), (gx_hi, gy_hi, z_sub_hi)), material="fr4")
+# Patch
+sim.add(Box((patch_x_lo, patch_y_lo, z_patch_lo),
+            (patch_x_hi, patch_y_hi, z_patch_hi)), material="pec")
+
+# Broadband source at feed point
+sim.add_source(
+    position=(feed_x, feed_y, src_z),
+    component="ez",
+    waveform=GaussianPulse(f0=f_design, bandwidth=1.2),
+)
+# Probe at separate substrate point (avoid source overlap)
+sim.add_probe(
+    position=(dom_x / 2 + 5e-3, dom_y / 2 + 5e-3, probe_z),
+    component="ez",
+)
+
+# =============================================================================
+# Run
+# =============================================================================
+print(f"\nRunning NU simulation (num_periods=60)...")
+t0 = time.time()
+result = sim.run(num_periods=60)
+elapsed = time.time() - t0
+print(f"Done in {elapsed:.1f} s")
+
+# =============================================================================
+# Harminv resonance extraction
+# =============================================================================
+ts = np.asarray(result.time_series).ravel()
+dt_val = float(result.dt)
+
+skip = int(len(ts) * 0.3)
+signal = ts[skip:]
+print(f"\nHarminv on last {len(signal)} samples (ringdown region)...")
+
+modes = harminv(signal, dt_val, 1.5e9, 3.5e9)
+modes_good = [m for m in modes if m.Q > 2 and m.amplitude > 1e-8]
+
+if modes_good:
+    modes_good.sort(key=lambda m: abs(m.freq - f_an))
+    best = modes_good[0]
+    f_harminv = float(best.freq)
+    Q_harminv  = float(best.Q)
+    err_pct    = 100 * abs(f_harminv - f_an) / f_an
+else:
+    f_harminv = float("nan")
+    Q_harminv  = float("nan")
+    err_pct    = float("inf")
+
+print(f"\nResults:")
+print(f"  Analytic f_res   = {f_an/1e9:.4f} GHz")
+print(f"  Harminv f_res    = {f_harminv/1e9:.4f} GHz  (Q = {Q_harminv:.1f})")
+print(f"  Error vs analytic = {err_pct:.2f} %")
+pass_str = "PASS" if err_pct < 8.0 else "FAIL"
+print(f"  Pass criterion (<8%): {pass_str}")
+
+# =============================================================================
+# Plot (a): probe Ez time series
+# =============================================================================
+t_axis = np.arange(len(ts)) * dt_val * 1e9   # ns
+fig, ax = plt.subplots(figsize=(8, 3))
+ax.plot(t_axis, ts, lw=0.7)
+ax.axvline(skip * dt_val * 1e9, color="r", ls="--", lw=1.0, label="Harminv start")
+ax.set_xlabel("Time (ns)")
+ax.set_ylabel("Ez (a.u.)")
+ax.set_title("Probe Ez — patch ringdown (NU runner)")
+ax.legend()
+fig.tight_layout()
+plot_ts = os.path.join(OUT_DIR, "probe_ez_timeseries.png")
+fig.savefig(plot_ts, dpi=120)
+plt.close(fig)
+print(f"\nPlot (a): {plot_ts}")
+
+# =============================================================================
+# Plot (b): dz mesh profile (stem)
+# =============================================================================
+z_edges = np.concatenate([[0.0], np.cumsum(dz_profile)]) * 1e3   # mm
+z_centers = 0.5 * (z_edges[:-1] + z_edges[1:])
+fig2, ax2 = plt.subplots(figsize=(8, 3))
+ax2.stem(z_centers, dz_profile * 1e3, markerfmt="C0.", basefmt="k-",
+         linefmt="C0-")
+ax2.axvspan(air_below * 1e3, (air_below + h_sub) * 1e3,
+            alpha=0.15, color="orange", label="FR4 substrate")
+ax2.set_xlabel("z (mm)")
+ax2.set_ylabel("dz (mm)")
+ax2.set_title("Non-uniform z mesh profile")
+ax2.legend()
+fig2.tight_layout()
+plot_mesh = os.path.join(OUT_DIR, "dz_mesh_profile.png")
+fig2.savefig(plot_mesh, dpi=120)
+plt.close(fig2)
+print(f"Plot (b): {plot_mesh}")

--- a/rfx/api.py
+++ b/rfx/api.py
@@ -2566,13 +2566,6 @@ class Simulation:
                     "mesh. Use the uniform reference lane."
                 )
 
-            # P2.4: Waveguide ports unsupported on non-uniform path
-            if self._waveguide_ports:
-                raise ValueError(
-                    "Waveguide ports are not supported on non-uniform z mesh. "
-                    "Use the uniform reference lane for waveguide workflows."
-                )
-
             # P2.6: CPML z-thickness on non-uniform mesh
             if self._boundary == "cpml" and self._cpml_layers > 0:
                 cpml_z_thick = sum(float(d) for d in self._dz_profile[:self._cpml_layers])

--- a/rfx/api.py
+++ b/rfx/api.py
@@ -3180,6 +3180,21 @@ class Simulation:
         if self._boundary == "upml" and devices is not None and len(devices) > 1:
             raise ValueError("boundary='upml' does not support distributed execution")
 
+        # ---- Distributed + nonuniform is a known gap (Phase B, see
+        # docs/research_notes/2026-04-15_nonuniform_completion_handoff.md).
+        # Without this guard the distributed path silently builds a uniform
+        # grid via _build_grid() and drops the user's profile on the floor.
+        if (devices is not None and len(devices) > 1
+                and (self._dz_profile is not None
+                     or self._dx_profile is not None
+                     or self._dy_profile is not None)):
+            raise ValueError(
+                "Non-uniform grids (dz_profile / dx_profile / dy_profile) "
+                "are not yet supported on the distributed multi-device "
+                "path. Run without `devices=` for the single-device "
+                "non-uniform lane, or request Phase B implementation."
+            )
+
         # ---- Distributed multi-device path ----
         if devices is not None and len(devices) > 1:
             if n_steps is None:

--- a/rfx/api.py
+++ b/rfx/api.py
@@ -2971,11 +2971,23 @@ class Simulation:
 
         periodic_bool = periodic if periodic is not None else (False, False, False)
 
+        # Forward cpml_axes from the grid — when waveguide ports are
+        # present the grid restricts CPML to the non-propagation axes.
+        # The default _run cpml_axes="xyz" builds CPML state for axes
+        # that have no padding, producing shape-broadcast errors like
+        # (8,1,1) vs (nx,ny,nz) during the scan (issue #29). The run()
+        # path forwards these explicitly at api.py:2012, so does the
+        # waveguide compute path at :2077 / :2092.
+        cpml_axes_run = grid.cpml_axes
+        pec_axes_run = "".join(a for a in "xyz" if a not in cpml_axes_run)
+
         result = _run(
             grid,
             materials,
             n_steps,
             boundary=self._boundary,
+            cpml_axes=cpml_axes_run,
+            pec_axes=pec_axes_run,
             periodic=periodic_bool,
             debye=debye,
             lorentz=lorentz,

--- a/rfx/api.py
+++ b/rfx/api.py
@@ -2559,13 +2559,6 @@ class Simulation:
         # P2: Non-uniform mesh shadow-lane limitations
         # ================================================================
         if self._dz_profile is not None:
-            # P2.1: NTFF unsupported on non-uniform path
-            if self._ntff is not None:
-                raise ValueError(
-                    "NTFF far-field is not supported on non-uniform z mesh. "
-                    "Use the uniform reference lane for far-field computation."
-                )
-
             # P2.3: TFSF unsupported on non-uniform path
             if self._tfsf is not None:
                 raise ValueError(

--- a/rfx/api.py
+++ b/rfx/api.py
@@ -2566,13 +2566,6 @@ class Simulation:
                     "Use the uniform reference lane for far-field computation."
                 )
 
-            # P2.2: DFT plane probes unsupported on non-uniform path
-            if self._dft_planes:
-                raise ValueError(
-                    "DFT plane probes are not supported on non-uniform z mesh. "
-                    "Use the uniform reference lane for DFT-plane workflows."
-                )
-
             # P2.3: TFSF unsupported on non-uniform path
             if self._tfsf is not None:
                 raise ValueError(

--- a/rfx/api.py
+++ b/rfx/api.py
@@ -2559,12 +2559,23 @@ class Simulation:
         # P2: Non-uniform mesh shadow-lane limitations
         # ================================================================
         if self._dz_profile is not None:
-            # P2.3: TFSF unsupported on non-uniform path
+            # P2.3: TFSF on nonuniform mesh — narrowed scope.
+            # Axis-aligned ±x incidence with angle_deg=0 runs the 1D
+            # auxiliary along the uniform x axis and is supported. The
+            # z-directed and oblique cases would need a z-nonuniform 1D
+            # aux (resp. nonuniform 2D aux) and are deferred.
             if self._tfsf is not None:
-                raise ValueError(
-                    "TFSF plane-wave source is not supported on non-uniform z "
-                    "mesh. Use the uniform reference lane."
-                )
+                if self._tfsf.direction in ("+z", "-z"):
+                    raise ValueError(
+                        "TFSF z-directed incidence is not yet supported on "
+                        "nonuniform z mesh. Axis-aligned incidence along x "
+                        "(direction='+x' or '-x') is supported."
+                    )
+                if abs(self._tfsf.angle_deg) > 0.01:
+                    raise ValueError(
+                        "TFSF oblique incidence is not yet supported on "
+                        "nonuniform z mesh. Use angle_deg=0."
+                    )
 
             # P2.6: CPML z-thickness on non-uniform mesh
             if self._boundary == "cpml" and self._cpml_layers > 0:

--- a/rfx/api.py
+++ b/rfx/api.py
@@ -2997,6 +2997,45 @@ class Simulation:
             freqs=getattr(result, "freqs", None),
         )
 
+    def _forward_nonuniform_from_materials(
+        self,
+        *,
+        eps_override: jnp.ndarray | None = None,
+        sigma_override: jnp.ndarray | None = None,
+        pec_mask_override: jnp.ndarray | None = None,
+        n_steps: int,
+        checkpoint: bool = True,
+    ) -> ForwardResult:
+        """Differentiable forward on the non-uniform mesh path.
+
+        Routes through ``run_nonuniform_path`` with optimisation overrides
+        applied after material assembly, then repackages the returned
+        ``Result`` into the minimal ``ForwardResult`` schema.
+
+        ``checkpoint`` is accepted for API symmetry with the uniform
+        forward but is not currently plumbed into ``run_nonuniform`` —
+        the NU scan body does not yet expose a checkpoint toggle.
+        Memory cost scales with n_steps for reverse-mode AD on this path.
+        """
+        del checkpoint  # Reserved for future NU-scan checkpoint support.
+        from rfx.runners.nonuniform import run_nonuniform_path
+
+        result = run_nonuniform_path(
+            self,
+            n_steps=n_steps,
+            eps_override=eps_override,
+            sigma_override=sigma_override,
+            pec_mask_override=pec_mask_override,
+        )
+        return ForwardResult(
+            time_series=result.time_series,
+            ntff_data=result.ntff_data,
+            ntff_box=result.ntff_box,
+            grid=result.grid,
+            s_params=getattr(result, "s_params", None),
+            freqs=getattr(result, "freqs", None),
+        )
+
     # ---- forward (differentiable) ----
 
     def forward(
@@ -3039,13 +3078,30 @@ class Simulation:
         ForwardResult
             Minimal differentiable observables (time series and optional NTFF).
         """
-        if (self._dz_profile is not None
-                or self._dx_profile is not None
-                or self._dy_profile is not None):
-            raise ValueError(
-                "forward() does not support non-uniform mesh profiles "
-                "(dx_profile / dy_profile / dz_profile). Use run() instead, "
-                "or remove the profiles for a uniform-mesh differentiable sim."
+        is_nonuniform = (
+            self._dz_profile is not None
+            or self._dx_profile is not None
+            or self._dy_profile is not None
+        )
+        if is_nonuniform:
+            if pec_occupancy_override is not None:
+                raise ValueError(
+                    "pec_occupancy_override is not yet supported on the "
+                    "non-uniform forward path (run_nonuniform has no soft-PEC "
+                    "occupancy field). Use pec_mask_override for hard PEC."
+                )
+            # Let the NU runner build grid/materials so it can apply the
+            # NU-aware pec_mask and port/source setup against per-axis widths.
+            if n_steps is None:
+                grid_probe = self._build_nonuniform_grid()
+                period = 1.0 / float(self._freq_max)
+                n_steps = int(np.ceil(num_periods * period / float(grid_probe.dt)))
+            return self._forward_nonuniform_from_materials(
+                eps_override=eps_override,
+                sigma_override=sigma_override,
+                pec_mask_override=pec_mask_override,
+                n_steps=n_steps,
+                checkpoint=checkpoint,
             )
         grid = self._build_grid()
         materials, debye_spec, lorentz_spec, pec_mask, _, _ = self._assemble_materials(grid)

--- a/rfx/api.py
+++ b/rfx/api.py
@@ -78,6 +78,20 @@ MATERIAL_LIBRARY: dict[str, dict] = {
 # Result container
 # ---------------------------------------------------------------------------
 
+class AD_MemoryEstimate(NamedTuple):
+    """Reverse-mode AD memory estimate (issue #30 CHECK 4).
+
+    All sizes are in gigabytes. ``warning`` is populated when the
+    checkpointed estimate exceeds 85% of ``available_gb``.
+    """
+    forward_gb: float
+    ad_checkpointed_gb: float
+    ad_full_gb: float
+    ntff_dft_gb: float
+    available_gb: float | None
+    warning: str | None
+
+
 class Result(NamedTuple):
     """Structured simulation result.
 
@@ -2306,15 +2320,23 @@ class Simulation:
                         + hint,
                         stacklevel=3,
                     )
-                elif dim < 3 * cell:
-                    axis_name = "xyz"[axis]
-                    cells = dim / cell
-                    _w.warn(
-                        f"'{mat_name}' {axis_name}-extent {dim*1e3:.2f}mm = "
-                        f"{cells:.1f} cells — under-resolved (< 3 cells). "
-                        f"Consider finer mesh for accurate results.",
-                        stacklevel=3,
-                    )
+                else:
+                    # Tightened thresholds (issue #30 CHECK 1):
+                    # - PEC features carrying current need ≥5 cells
+                    # - Dielectric features need ≥10 cells for accurate fields
+                    mat = self._resolve_material(mat_name)
+                    is_pec = mat.sigma >= self._PEC_SIGMA_THRESHOLD
+                    thresh = 5 if is_pec else 10
+                    if dim < thresh * cell:
+                        axis_name = "xyz"[axis]
+                        cells = dim / cell
+                        kind = "PEC" if is_pec else "dielectric"
+                        _w.warn(
+                            f"'{mat_name}' {axis_name}-extent {dim*1e3:.2f}mm = "
+                            f"{cells:.1f} cells — under-resolved ({kind} needs "
+                            f"≥{thresh} cells). Consider finer mesh.",
+                            stacklevel=3,
+                        )
 
         # Check gaps between PEC structures
         pec_entries = [e for e in self._geometry if e.material_name == "pec"]
@@ -2339,7 +2361,16 @@ class Simulation:
                     except (NotImplementedError, TypeError, AttributeError):
                         continue
 
-    def preflight(self, *, strict: bool = False) -> list[str]:
+    def preflight(
+        self,
+        *,
+        strict: bool = False,
+        check_ntff: bool = True,
+        check_resolution: bool = True,
+        check_ad_memory: bool = False,
+        n_steps_for_memory: int | None = None,
+        available_memory_gb: float | None = None,
+    ) -> list[str]:
         """Run all pre-simulation checks and return warnings.
 
         Parameters
@@ -2347,6 +2378,20 @@ class Simulation:
         strict : bool
             If True, raise ValueError on the first issue instead of
             collecting warnings.
+        check_ntff : bool
+            Run inverse-design NTFF checks (PEC overlap hard-error,
+            λ/4 near-field gap warning). Default True.
+        check_resolution : bool
+            Run the tightened resolution check (existing _validate_mesh_quality
+            uses per-material thresholds already — this flag kept for
+            symmetry and future tightening). Default True.
+        check_ad_memory : bool
+            Run AD memory estimate and warn if > 85% of available VRAM.
+            Requires n_steps_for_memory. Default False (diagnostic only).
+        n_steps_for_memory : int or None
+            Step count for AD memory sizing. Required when check_ad_memory.
+        available_memory_gb : float or None
+            Override VRAM detection. If None, best-effort via JAX devices.
 
         Returns
         -------
@@ -2359,8 +2404,11 @@ class Simulation:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             try:
-                self._validate_mesh_quality()
+                if check_resolution:
+                    self._validate_mesh_quality()
                 self._validate_simulation_config()
+                if check_ntff:
+                    self._validate_ntff_inverse_design()
             except ValueError as e:
                 if strict:
                     raise
@@ -2372,6 +2420,19 @@ class Simulation:
                 raise ValueError(msg)
             issues.append(msg)
 
+        if check_ad_memory:
+            if n_steps_for_memory is None:
+                raise ValueError("check_ad_memory=True requires n_steps_for_memory")
+            est = self.estimate_ad_memory(
+                n_steps_for_memory,
+                available_memory_gb=available_memory_gb,
+            )
+            if est.warning:
+                msg = est.warning
+                if strict:
+                    raise ValueError(msg)
+                issues.append(msg)
+
         if issues:
             for iss in issues:
                 print(f"  [PREFLIGHT] {iss}")
@@ -2379,6 +2440,203 @@ class Simulation:
             print("  [PREFLIGHT] All checks passed.")
 
         return issues
+
+    # ---- Inverse-design preflight extensions (issue #30) ----
+
+    def _validate_ntff_inverse_design(self) -> None:
+        """NTFF inverse-design checks: PEC overlap (error) and λ/4 gap (warn).
+
+        CHECK 2: NTFF face plane strictly intersecting a PEC bbox.
+        CHECK 3: NTFF face closer than λ/4 to any geometry/source/probe.
+        """
+        import warnings as _w
+
+        if self._ntff is None:
+            return
+
+        corner_lo, corner_hi, freqs = self._ntff
+        # face = (axis, sign, coord, tangential bbox: [(lo_a, hi_a), (lo_b, hi_b)])
+        faces = []
+        for axis in range(3):
+            other = [a for a in range(3) if a != axis]
+            tang = ((corner_lo[other[0]], corner_hi[other[0]]),
+                    (corner_lo[other[1]], corner_hi[other[1]]))
+            faces.append(("lo", axis, corner_lo[axis], tang))
+            faces.append(("hi", axis, corner_hi[axis], tang))
+
+        # CHECK 2: strict PEC intersection
+        pec_entries = [e for e in self._geometry if e.material_name == "pec"]
+        for side, axis, coord, tang in faces:
+            for entry in pec_entries:
+                try:
+                    c1, c2 = entry.shape.bounding_box()
+                except (NotImplementedError, TypeError, AttributeError):
+                    continue
+                # Strict interior along normal axis
+                if not (c1[axis] < coord < c2[axis]):
+                    continue
+                # Tangential overlap along the other two axes
+                other = [a for a in range(3) if a != axis]
+                overlap = True
+                for idx, (tlo, thi) in zip(other, tang):
+                    if c2[idx] <= tlo or c1[idx] >= thi:
+                        overlap = False
+                        break
+                if overlap:
+                    raise ValueError(
+                        f"NTFF face {'xyz'[axis]}_{side} at {coord*1e3:.2f}mm "
+                        f"intersects PEC geometry '{entry.material_name}' "
+                        f"(bbox {c1}–{c2}). NTFF box must enclose all radiators "
+                        f"with no PEC crossing any face. Shrink or move the NTFF box."
+                    )
+
+        # CHECK 3: λ/4 near-field gap to any geometry/source/probe
+        if freqs is None:
+            return
+        try:
+            f_max = float(jnp.max(jnp.asarray(freqs)))
+        except Exception:
+            f_max = float(self._freq_max)
+        lam_min = C0 / max(f_max, 1.0)
+        gap_thresh = lam_min / 4.0
+
+        # Collect candidate bboxes and point positions
+        bboxes: list[tuple[str, tuple, tuple]] = []
+        for entry in self._geometry:
+            try:
+                c1, c2 = entry.shape.bounding_box()
+                bboxes.append((entry.material_name, c1, c2))
+            except (NotImplementedError, TypeError, AttributeError):
+                continue
+        points: list[tuple[str, tuple]] = []
+        for pe in self._ports:
+            points.append(("port/source", tuple(pe.position)))
+        for pe in self._probes:
+            points.append(("probe", tuple(pe.position)))
+
+        for side, axis, coord, tang in faces:
+            other = [a for a in range(3) if a != axis]
+            min_gap = float("inf")
+            culprit = None
+            # bbox distances
+            for name, c1, c2 in bboxes:
+                # tangential overlap check — only meaningful gap if the face
+                # is "above" the feature in the normal direction
+                overlap = True
+                for idx, (tlo, thi) in zip(other, tang):
+                    if c2[idx] <= tlo or c1[idx] >= thi:
+                        overlap = False
+                        break
+                if not overlap:
+                    continue
+                if coord <= c1[axis]:
+                    d = c1[axis] - coord
+                elif coord >= c2[axis]:
+                    d = coord - c2[axis]
+                else:
+                    d = 0.0  # already handled by CHECK 2 for PEC; skip
+                    continue
+                if d < min_gap:
+                    min_gap, culprit = d, f"geometry '{name}'"
+            # points
+            for name, pos in points:
+                # require tangential in-box for relevance
+                in_tang = all(
+                    tang[i][0] <= pos[other[i]] <= tang[i][1] for i in range(2)
+                )
+                if not in_tang:
+                    continue
+                d = abs(coord - pos[axis])
+                if d < min_gap:
+                    min_gap, culprit = d, f"{name} at {pos}"
+
+            if culprit is not None and min_gap < gap_thresh:
+                _w.warn(
+                    f"NTFF face {'xyz'[axis]}_{side} is {min_gap*1e3:.2f}mm "
+                    f"from {culprit} — below λ/4 = {gap_thresh*1e3:.2f}mm at "
+                    f"f_max={f_max/1e9:.2f}GHz. Evanescent near-field may "
+                    f"contaminate the far-field pattern. Move NTFF box further "
+                    f"from radiating/scattering structures.",
+                    stacklevel=3,
+                )
+
+    # ---- AD memory estimation (issue #30 CHECK 4) ----
+
+    def estimate_ad_memory(
+        self,
+        n_steps: int,
+        *,
+        available_memory_gb: float | None = None,
+    ) -> "AD_MemoryEstimate":
+        """Estimate reverse-mode AD memory for this simulation.
+
+        Returns an AD_MemoryEstimate with forward, checkpointed-AD, and
+        non-checkpointed-AD sizes in GB, plus a best-effort warning if
+        estimated AD memory exceeds 85% of available VRAM.
+        """
+        dx = self._dx or (C0 / self._freq_max / 20.0)
+
+        def _nx(extent: float, prof) -> int:
+            if prof is not None:
+                return len(prof) + 1 + 2 * self._cpml_layers
+            return int(math.ceil(extent / dx)) + 1 + 2 * self._cpml_layers
+
+        nx = _nx(self._domain[0], self._dx_profile)
+        ny = _nx(self._domain[1], self._dy_profile)
+        nz = _nx(self._domain[2], self._dz_profile)
+        cells = nx * ny * nz
+
+        # Forward working set: 6 field + ~6 material + ~4 CPML psi (~15%)
+        bytes_per_cell = 4  # float32
+        field_bytes = cells * 6 * bytes_per_cell
+        mat_bytes = cells * 6 * bytes_per_cell
+        cpml_bytes = int(cells * 0.15 * 24 * bytes_per_cell) if self._cpml_layers > 0 else 0
+        forward_bytes = field_bytes + mat_bytes + cpml_bytes
+
+        # NTFF DFT state: 6 faces × n_freqs × face_cells × 4 (3 E + 3 H) × complex64 (8B)
+        ntff_bytes = 0
+        if self._ntff is not None:
+            _, _, freqs = self._ntff
+            n_freqs = int(len(freqs)) if freqs is not None else 10
+            # Approx face cells from domain extents / dx
+            face_est = 2 * ((nx * ny) + (ny * nz) + (nx * nz))
+            ntff_bytes = face_est * n_freqs * 6 * 8
+
+        # Checkpointed AD: remat recomputes most of scan — ~4x forward is realistic
+        # Non-checkpointed AD: O(n_steps) tape — 6 field arrays per step
+        ad_ckpt_bytes = 4 * forward_bytes + ntff_bytes
+        ad_full_bytes = n_steps * field_bytes + ntff_bytes + forward_bytes
+
+        # VRAM detection (best effort)
+        avail_gb = available_memory_gb
+        if avail_gb is None:
+            try:
+                devs = jax.local_devices()
+                for d in devs:
+                    if d.platform == "gpu":
+                        stats = d.memory_stats() if hasattr(d, "memory_stats") else None
+                        if stats and "bytes_limit" in stats:
+                            avail_gb = stats["bytes_limit"] / 1e9
+                            break
+            except Exception:
+                avail_gb = None
+
+        to_gb = 1.0 / 1e9
+        warning = None
+        if avail_gb is not None and ad_ckpt_bytes * to_gb > avail_gb * 0.85:
+            warning = (
+                f"AD memory estimate {ad_ckpt_bytes*to_gb:.2f}GB (checkpointed) "
+                f"exceeds 85% of {avail_gb:.2f}GB available VRAM. "
+                f"Reduce grid size or n_steps, or increase domain decomposition."
+            )
+        return AD_MemoryEstimate(
+            forward_gb=forward_bytes * to_gb,
+            ad_checkpointed_gb=ad_ckpt_bytes * to_gb,
+            ad_full_gb=ad_full_bytes * to_gb,
+            ntff_dft_gb=ntff_bytes * to_gb,
+            available_gb=avail_gb,
+            warning=warning,
+        )
 
     def _validate_simulation_config(self) -> None:
         """Comprehensive pre-simulation configuration validation.

--- a/rfx/api.py
+++ b/rfx/api.py
@@ -2580,13 +2580,6 @@ class Simulation:
                     "Use the uniform reference lane for waveguide workflows."
                 )
 
-            # P2.5: Lumped RLC unsupported on non-uniform path
-            if self._lumped_rlc:
-                raise ValueError(
-                    "Lumped RLC elements are not supported on non-uniform z "
-                    "mesh. Use the uniform reference lane for RLC workflows."
-                )
-
             # P2.6: CPML z-thickness on non-uniform mesh
             if self._boundary == "cpml" and self._cpml_layers > 0:
                 cpml_z_thick = sum(float(d) for d in self._dz_profile[:self._cpml_layers])

--- a/rfx/api.py
+++ b/rfx/api.py
@@ -3180,26 +3180,70 @@ class Simulation:
         if self._boundary == "upml" and devices is not None and len(devices) > 1:
             raise ValueError("boundary='upml' does not support distributed execution")
 
-        # ---- Distributed + nonuniform is a known gap (Phase B, see
-        # docs/research_notes/2026-04-15_nonuniform_completion_handoff.md).
-        # Without this guard the distributed path silently builds a uniform
-        # grid via _build_grid() and drops the user's profile on the floor.
-        if (devices is not None and len(devices) > 1
-                and (self._dz_profile is not None
-                     or self._dx_profile is not None
-                     or self._dy_profile is not None)):
-            raise ValueError(
-                "Non-uniform grids (dz_profile / dx_profile / dy_profile) "
-                "are not yet supported on the distributed multi-device "
-                "path. Run without `devices=` for the single-device "
-                "non-uniform lane, or request Phase B implementation."
-            )
+        # ---- Distributed + nonuniform (Phase B guardrail).
+        # Phase B permits the combination for PEC boundary with grading
+        # ratio <= 5 and no TFSF. The distributed_v2 runner dispatches to
+        # the NU kernels in distributed_nu.py; dispersion and CPML on the
+        # distributed NU path are Phase C items and still raise below.
+        _nu_profile = (
+            self._dz_profile is not None
+            or self._dx_profile is not None
+            or self._dy_profile is not None
+        )
+        if (devices is not None and len(devices) > 1 and _nu_profile):
+            import warnings as _wmod
+            # Grading ratio check (shared single dt) across provided profiles.
+            _max_ratio = 1.0
+            for _prof in (
+                self._dx_profile, self._dy_profile, self._dz_profile
+            ):
+                if _prof is not None and len(_prof) > 0:
+                    _pa = np.asarray(_prof, dtype=np.float64)
+                    if float(_pa.min()) > 0.0:
+                        _max_ratio = max(
+                            _max_ratio,
+                            float(_pa.max()) / float(_pa.min()),
+                        )
+            if _max_ratio > 5.0:
+                raise ValueError(
+                    "Distributed + non-uniform requires grading ratio "
+                    "<= 5:1 for shared-dt stability; got "
+                    f"{_max_ratio:.2f}:1."
+                )
+            if self._tfsf is not None:
+                raise ValueError(
+                    "Distributed + non-uniform does not support TFSF "
+                    "plane-wave sources (Phase B scope)."
+                )
+            if self._solver == "adi":
+                raise ValueError(
+                    "Distributed + non-uniform does not support solver='adi'."
+                )
+            if _max_ratio > 3.0:
+                _wmod.warn(
+                    f"Distributed + non-uniform grading ratio {_max_ratio:.2f}"
+                    ":1 exceeds the 3:1 stability caution threshold. "
+                    "Monitor for numerical dispersion / late-time drift.",
+                    stacklevel=2,
+                )
 
         # ---- Distributed multi-device path ----
         if devices is not None and len(devices) > 1:
             if n_steps is None:
-                grid = self._build_grid()
-                n_steps = grid.num_timesteps(num_periods=num_periods)
+                if _nu_profile:
+                    # Synthesise missing dz profile so _build_nonuniform_grid
+                    # has all three axes available.
+                    if self._dz_profile is None:
+                        nz_phys = max(
+                            1, int(round(self._domain[2] / self._dx)))
+                        self._dz_profile = np.full(
+                            nz_phys, float(self._dx))
+                    _ngrid = self._build_nonuniform_grid()
+                    n_steps = int(np.ceil(
+                        num_periods / (self._freq_max * _ngrid.dt)))
+                else:
+                    grid = self._build_grid()
+                    n_steps = grid.num_timesteps(num_periods=num_periods)
             from rfx.runners.distributed_v2 import run_distributed
             return run_distributed(
                 self, n_steps=n_steps, devices=devices,

--- a/rfx/api.py
+++ b/rfx/api.py
@@ -444,11 +444,6 @@ class Simulation:
         elif any(d <= 0 for d in domain):
             raise ValueError(f"domain dimensions must be positive, got {domain}")
 
-        if boundary == "upml" and dz_profile is not None:
-            raise ValueError("boundary='upml' does not support nonuniform dz_profile")
-        if boundary == "upml" and (dx_profile is not None or dy_profile is not None):
-            raise ValueError("boundary='upml' does not support nonuniform dx/dy profile")
-
         # P2: Warn on abrupt grading in user-supplied dz_profile
         if dz_profile is not None and len(dz_profile) > 1:
             import warnings as _w

--- a/rfx/boundaries/upml.py
+++ b/rfx/boundaries/upml.py
@@ -37,7 +37,14 @@ from rfx.core.yee import EPS_0, MU_0, FDTDState, MaterialArrays, _shift_bwd, _sh
 
 
 class UPMLCoeffs(NamedTuple):
-    """Precomputed component-aware UPML update coefficients."""
+    """Precomputed component-aware UPML update coefficients.
+
+    The ``cb_*`` / ``db_*`` coefficients intentionally exclude the stencil
+    cell-size factor; per-axis inverse spacings below are applied to each
+    curl component separately so the coefficients work on both uniform
+    and non-uniform grids.  On a uniform grid the ``inv_*`` fields are
+    scalars and the computation is bit-identical to the pre-split path.
+    """
     ca_ex: jnp.ndarray
     ca_ey: jnp.ndarray
     ca_ez: jnp.ndarray
@@ -50,6 +57,12 @@ class UPMLCoeffs(NamedTuple):
     db_hx: jnp.ndarray
     db_hy: jnp.ndarray
     db_hz: jnp.ndarray
+    inv_dx: jnp.ndarray    # E-position 1/dx (scalar or (nx,1,1))
+    inv_dy: jnp.ndarray    # E-position 1/dy (scalar or (1,ny,1))
+    inv_dz: jnp.ndarray    # E-position 1/dz (scalar or (1,1,nz))
+    inv_dx_h: jnp.ndarray  # H-position 2/(dx[i]+dx[i+1])
+    inv_dy_h: jnp.ndarray  # H-position
+    inv_dz_h: jnp.ndarray  # H-position
 
 
 def _sigma_profile_1d(
@@ -160,8 +173,30 @@ def init_upml(
     mu_abs = materials.mu_r * jnp.float32(MU_0)
     sigma_mat = materials.sigma.astype(jnp.float32)
     dt = jnp.float32(grid.dt)
-    dx = jnp.float32(grid.dx)
     eps_0 = jnp.float32(EPS_0)
+
+    # Per-axis inverse cell-size broadcasts.  On NonUniformGrid these are
+    # arrays we reshape into (nx,1,1) / (1,ny,1) / (1,1,nz); on the
+    # uniform Grid they collapse to a single scalar 1/dx that broadcasts
+    # identically — the uniform path stays bit-for-bit.
+    _fallback_inv = jnp.float32(1.0) / jnp.float32(grid.dx)
+
+    def _inv_broadcast(arr_attr: str, axis: int):
+        arr = getattr(grid, arr_attr, None)
+        if arr is None:
+            return _fallback_inv
+        shape = [1, 1, 1]
+        shape[axis] = -1
+        return jnp.asarray(arr, dtype=jnp.float32).reshape(tuple(shape))
+
+    # E-position (integer-index) inverse spacings — consumed by E update.
+    inv_dx = _inv_broadcast("inv_dx", 0)
+    inv_dy = _inv_broadcast("inv_dy", 1)
+    inv_dz = _inv_broadcast("inv_dz", 2)
+    # H-position (half-integer) inverse spacings — consumed by H update.
+    inv_dx_h = _inv_broadcast("inv_dx_h", 0)
+    inv_dy_h = _inv_broadcast("inv_dy_h", 1)
+    inv_dz_h = _inv_broadcast("inv_dz_h", 2)
 
     if aniso_eps is not None:
         eps_ex, eps_ey, eps_ez = aniso_eps
@@ -210,9 +245,11 @@ def init_upml(
 
     return UPMLCoeffs(
         ca_ex=ca_ex, ca_ey=ca_ey, ca_ez=ca_ez,
-        cb_ex=cb_ex / dx, cb_ey=cb_ey / dx, cb_ez=cb_ez / dx,
+        cb_ex=cb_ex, cb_ey=cb_ey, cb_ez=cb_ez,
         da_hx=da_hx, da_hy=da_hy, da_hz=da_hz,
-        db_hx=db_hx / dx, db_hy=db_hy / dx, db_hz=db_hz / dx,
+        db_hx=db_hx, db_hy=db_hy, db_hz=db_hz,
+        inv_dx=inv_dx, inv_dy=inv_dy, inv_dz=inv_dz,
+        inv_dx_h=inv_dx_h, inv_dy_h=inv_dy_h, inv_dz_h=inv_dz_h,
     )
 
 
@@ -232,9 +269,12 @@ def apply_upml_h(
     ey = state.ey.astype(jnp.float32)
     ez = state.ez.astype(jnp.float32)
 
-    curl_x = (fwd(ez, 1) - ez) - (fwd(ey, 2) - ey)
-    curl_y = (fwd(ex, 2) - ex) - (fwd(ez, 0) - ez)
-    curl_z = (fwd(ey, 0) - ey) - (fwd(ex, 1) - ex)
+    curl_x = ((fwd(ez, 1) - ez) * coeffs.inv_dy_h
+              - (fwd(ey, 2) - ey) * coeffs.inv_dz_h)
+    curl_y = ((fwd(ex, 2) - ex) * coeffs.inv_dz_h
+              - (fwd(ez, 0) - ez) * coeffs.inv_dx_h)
+    curl_z = ((fwd(ey, 0) - ey) * coeffs.inv_dx_h
+              - (fwd(ex, 1) - ex) * coeffs.inv_dy_h)
 
     hx = (coeffs.da_hx * state.hx.astype(jnp.float32) - coeffs.db_hx * curl_x).astype(_fdtype)
     hy = (coeffs.da_hy * state.hy.astype(jnp.float32) - coeffs.db_hy * curl_y).astype(_fdtype)
@@ -259,9 +299,12 @@ def apply_upml_e(
     hy = state.hy.astype(jnp.float32)
     hz = state.hz.astype(jnp.float32)
 
-    curl_x = (hz - bwd(hz, 1)) - (hy - bwd(hy, 2))
-    curl_y = (hx - bwd(hx, 2)) - (hz - bwd(hz, 0))
-    curl_z = (hy - bwd(hy, 0)) - (hx - bwd(hx, 1))
+    curl_x = ((hz - bwd(hz, 1)) * coeffs.inv_dy
+              - (hy - bwd(hy, 2)) * coeffs.inv_dz)
+    curl_y = ((hx - bwd(hx, 2)) * coeffs.inv_dz
+              - (hz - bwd(hz, 0)) * coeffs.inv_dx)
+    curl_z = ((hy - bwd(hy, 0)) * coeffs.inv_dx
+              - (hx - bwd(hx, 1)) * coeffs.inv_dy)
 
     ex = (coeffs.ca_ex * state.ex.astype(jnp.float32) + coeffs.cb_ex * curl_x).astype(_fdtype)
     ey = (coeffs.ca_ey * state.ey.astype(jnp.float32) + coeffs.cb_ey * curl_y).astype(_fdtype)

--- a/rfx/lumped.py
+++ b/rfx/lumped.py
@@ -159,6 +159,18 @@ def _series_needs_ade(spec: LumpedRLCSpec) -> bool:
     return n_components >= 2
 
 
+def _resolve_position_to_index(grid, position):
+    """Resolve a physical (x, y, z) to grid indices.
+
+    Duck-types over uniform ``Grid`` (method) and ``NonUniformGrid``
+    (module-level helper in ``rfx.nonuniform``).
+    """
+    if hasattr(grid, "position_to_index"):
+        return grid.position_to_index(position)
+    from rfx.nonuniform import position_to_index as _nu_p2i
+    return _nu_p2i(grid, position)
+
+
 def setup_rlc_materials(grid, spec: LumpedRLCSpec, materials):
     """Fold R and C into material arrays at the element cell.
 
@@ -176,9 +188,8 @@ def setup_rlc_materials(grid, spec: LumpedRLCSpec, materials):
 
     Returns updated MaterialArrays.
     """
-    idx = grid.position_to_index(spec.position)
+    idx = _resolve_position_to_index(grid, spec.position)
     i, j, k = idx
-    dx = grid.dx
 
     sigma = materials.sigma
     eps_r = materials.eps_r
@@ -208,7 +219,7 @@ def build_rlc_meta(grid, spec: LumpedRLCSpec, materials) -> RLCCellMeta:
     sigma at the cell reflect the R and C contributions.
     """
     from rfx.sources.sources import port_d_parallel as _d_par
-    idx = grid.position_to_index(spec.position)
+    idx = _resolve_position_to_index(grid, spec.position)
     i, j, k = idx
     d_par = _d_par(grid, idx, spec.component)
     dt = grid.dt

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -489,6 +489,7 @@ def run_nonuniform(
     rlc_states: tuple = (),
     ntff_box=None,
     ntff_data=None,
+    waveguide_ports: list | None = None,
 ) -> dict:
     """Run non-uniform FDTD via jax.lax.scan.
 
@@ -510,6 +511,7 @@ def run_nonuniform(
     probes = probes or []
     wire_ports = wire_ports or []
     dft_planes = dft_planes or []
+    waveguide_ports = waveguide_ports or []
     dt = grid.dt
     use_wire_ports = len(wire_ports) > 0
     use_debye = debye is not None
@@ -517,6 +519,7 @@ def run_nonuniform(
     use_dft_planes = len(dft_planes) > 0
     use_lumped_rlc = len(rlc_metas) > 0
     use_ntff = ntff_box is not None and ntff_data is not None
+    use_waveguide_ports = len(waveguide_ports) > 0
 
     # CPML: only initialize when cpml_layers > 0 (skip for PEC boundary)
     use_cpml = grid.cpml_layers > 0
@@ -609,6 +612,22 @@ def run_nonuniform(
     if use_ntff:
         carry_init["ntff"] = ntff_data
 
+    # Waveguide-port DFT accumulators (mirrors uniform path)
+    if use_waveguide_ports:
+        carry_init["waveguide_port_accs"] = tuple(
+            (
+                cfg.v_probe_dft,
+                cfg.v_ref_dft,
+                cfg.i_probe_dft,
+                cfg.i_ref_dft,
+                cfg.v_inc_dft,
+            )
+            for cfg in waveguide_ports
+        )
+        waveguide_meta = tuple(waveguide_ports)
+    else:
+        waveguide_meta = ()
+
     def step_fn(carry, xs):
         step_idx, src_vals = xs
         st = carry["fdtd"]
@@ -656,6 +675,38 @@ def run_nonuniform(
             field = getattr(st, sc)
             field = field.at[si, sj, sk].add(src_vals[idx_s])
             st = st._replace(**{sc: field})
+
+        # Waveguide-port injection + DFT probe accumulation. The dx
+        # arg is unused by the per-cell-weighted integrals (cfg already
+        # stores u_widths/v_widths), but kept in the function signature
+        # for back-compat.
+        new_waveguide_port_accs = None
+        if use_waveguide_ports:
+            from rfx.sources.waveguide_port import (
+                inject_waveguide_port,
+                update_waveguide_port_probe,
+            )
+            t_wg = step_idx.astype(jnp.float32) * dt
+            new_waveguide_port_accs = []
+            for accs, cfg_meta in zip(
+                carry["waveguide_port_accs"], waveguide_meta
+            ):
+                cfg = cfg_meta._replace(
+                    v_probe_dft=accs[0],
+                    v_ref_dft=accs[1],
+                    i_probe_dft=accs[2],
+                    i_ref_dft=accs[3],
+                    v_inc_dft=accs[4],
+                )
+                st = inject_waveguide_port(st, cfg_meta, t_wg, dt, grid.dx)
+                cfg_updated = update_waveguide_port_probe(cfg, st, dt, grid.dx)
+                new_waveguide_port_accs.append((
+                    cfg_updated.v_probe_dft,
+                    cfg_updated.v_ref_dft,
+                    cfg_updated.i_probe_dft,
+                    cfg_updated.i_ref_dft,
+                    cfg_updated.v_inc_dft,
+                ))
 
         # Wire port V/I DFT accumulation
         t = step_idx.astype(jnp.float32) * dt
@@ -733,6 +784,8 @@ def run_nonuniform(
             new_carry["rlc_states"] = tuple(new_rlc_states)
         if use_ntff and new_ntff is not None:
             new_carry["ntff"] = new_ntff
+        if use_waveguide_ports and new_waveguide_port_accs is not None:
+            new_carry["waveguide_port_accs"] = tuple(new_waveguide_port_accs)
         return new_carry, probe_out
 
     xs = (jnp.arange(n_steps, dtype=jnp.int32), src_waveforms)
@@ -758,6 +811,21 @@ def run_nonuniform(
     # Surface final NTFF DFT accumulators
     if use_ntff:
         result["ntff_data"] = final["ntff"]
+
+    # Surface final waveguide-port configs (with accumulated DFTs)
+    if use_waveguide_ports:
+        result["waveguide_ports"] = tuple(
+            cfg_meta._replace(
+                v_probe_dft=accs[0],
+                v_ref_dft=accs[1],
+                i_probe_dft=accs[2],
+                i_ref_dft=accs[3],
+                v_inc_dft=accs[4],
+            )
+            for cfg_meta, accs in zip(
+                waveguide_meta, final["waveguide_port_accs"]
+            )
+        )
 
     # ---- Extract full S-matrix column from wire port DFTs ----
     #

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -484,6 +484,7 @@ def run_nonuniform(
     debye: tuple | None = None,
     lorentz: tuple | None = None,
     pec_faces: set[str] | None = None,
+    dft_planes: list | None = None,
 ) -> dict:
     """Run non-uniform FDTD via jax.lax.scan.
 
@@ -496,14 +497,20 @@ def run_nonuniform(
     s_param_freqs : (n_freqs,) array for S-param DFT
     debye : (DebyeCoeffs, DebyeState) or None
     lorentz : (LorentzCoeffs, LorentzState) or None
+    dft_planes : list of DFTPlaneProbe or None
+        Frequency-domain plane accumulators. The accumulation is
+        identical to the uniform path (acc += field * exp(-j2pi f t) * dt);
+        dt is scalar on both paths so no per-axis weighting is required.
     """
     sources = sources or []
     probes = probes or []
     wire_ports = wire_ports or []
+    dft_planes = dft_planes or []
     dt = grid.dt
     use_wire_ports = len(wire_ports) > 0
     use_debye = debye is not None
     use_lorentz = lorentz is not None
+    use_dft_planes = len(dft_planes) > 0
 
     # CPML: only initialize when cpml_layers > 0 (skip for PEC boundary)
     use_cpml = grid.cpml_layers > 0
@@ -577,6 +584,16 @@ def run_nonuniform(
     else:
         use_wire_ports = False
 
+    # DFT plane probe carry + static metadata
+    if use_dft_planes:
+        carry_init["dft_planes"] = tuple(probe.accumulator for probe in dft_planes)
+        dft_meta = tuple(
+            (probe.component, probe.axis, probe.index, probe.freqs)
+            for probe in dft_planes
+        )
+    else:
+        dft_meta = ()
+
     def step_fn(carry, xs):
         step_idx, src_vals = xs
         st = carry["fdtd"]
@@ -647,6 +664,26 @@ def run_nonuniform(
                     vinc_dft,
                 ))
 
+        # DFT plane probe accumulation (identical math to uniform path)
+        new_dft_planes = None
+        if use_dft_planes:
+            t_plane = step_idx.astype(jnp.float32) * dt
+            new_dft_planes = []
+            for acc, (component, axis, index, freqs) in zip(
+                carry["dft_planes"], dft_meta
+            ):
+                field = getattr(st, component)
+                if axis == 0:
+                    plane = field[index, :, :]
+                elif axis == 1:
+                    plane = field[:, index, :]
+                else:
+                    plane = field[:, :, index]
+                phase = jnp.exp(-1j * 2.0 * jnp.pi * freqs * t_plane)
+                new_dft_planes.append(
+                    acc + plane[None, :, :] * phase[:, None, None] * dt
+                )
+
         # Probes
         samples = [getattr(st, pc)[pi, pj, pk] for pi, pj, pk, pc in prb_meta]
         probe_out = jnp.stack(samples) if samples else jnp.zeros(0)
@@ -660,6 +697,8 @@ def run_nonuniform(
             new_carry["lorentz"] = lorentz_new
         if use_wire_ports and new_wire_sp is not None:
             new_carry["wire_sparams"] = tuple(new_wire_sp)
+        if use_dft_planes and new_dft_planes is not None:
+            new_carry["dft_planes"] = tuple(new_dft_planes)
         return new_carry, probe_out
 
     xs = (jnp.arange(n_steps, dtype=jnp.int32), src_waveforms)
@@ -670,6 +709,13 @@ def run_nonuniform(
         "time_series": time_series,
         "dt": dt,
     }
+
+    # Repack DFT plane probes with their final accumulators.
+    if use_dft_planes:
+        result["dft_planes"] = tuple(
+            probe._replace(accumulator=acc)
+            for probe, acc in zip(dft_planes, final["dft_planes"])
+        )
 
     # ---- Extract full S-matrix column from wire port DFTs ----
     #

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -487,6 +487,8 @@ def run_nonuniform(
     dft_planes: list | None = None,
     rlc_metas: tuple = (),
     rlc_states: tuple = (),
+    ntff_box=None,
+    ntff_data=None,
 ) -> dict:
     """Run non-uniform FDTD via jax.lax.scan.
 
@@ -514,6 +516,7 @@ def run_nonuniform(
     use_lorentz = lorentz is not None
     use_dft_planes = len(dft_planes) > 0
     use_lumped_rlc = len(rlc_metas) > 0
+    use_ntff = ntff_box is not None and ntff_data is not None
 
     # CPML: only initialize when cpml_layers > 0 (skip for PEC boundary)
     use_cpml = grid.cpml_layers > 0
@@ -600,6 +603,11 @@ def run_nonuniform(
     # Lumped RLC ADE state (one per element) — metas are Python-static
     if use_lumped_rlc:
         carry_init["rlc_states"] = tuple(rlc_states)
+
+    # NTFF accumulators — seeded from caller, updated per step via
+    # accumulate_ntff. Box indices and freqs are Python-static.
+    if use_ntff:
+        carry_init["ntff"] = ntff_data
 
     def step_fn(carry, xs):
         step_idx, src_vals = xs
@@ -700,6 +708,12 @@ def run_nonuniform(
                     acc + plane[None, :, :] * phase[:, None, None] * dt
                 )
 
+        # NTFF: accumulate tangential E/H DFT on 6 box faces
+        new_ntff = None
+        if use_ntff:
+            from rfx.farfield import accumulate_ntff
+            new_ntff = accumulate_ntff(carry["ntff"], st, ntff_box, dt, step_idx)
+
         # Probes
         samples = [getattr(st, pc)[pi, pj, pk] for pi, pj, pk, pc in prb_meta]
         probe_out = jnp.stack(samples) if samples else jnp.zeros(0)
@@ -717,6 +731,8 @@ def run_nonuniform(
             new_carry["dft_planes"] = tuple(new_dft_planes)
         if use_lumped_rlc and new_rlc_states is not None:
             new_carry["rlc_states"] = tuple(new_rlc_states)
+        if use_ntff and new_ntff is not None:
+            new_carry["ntff"] = new_ntff
         return new_carry, probe_out
 
     xs = (jnp.arange(n_steps, dtype=jnp.int32), src_waveforms)
@@ -738,6 +754,10 @@ def run_nonuniform(
             probe._replace(accumulator=acc)
             for probe, acc in zip(dft_planes, final["dft_planes"])
         )
+
+    # Surface final NTFF DFT accumulators
+    if use_ntff:
+        result["ntff_data"] = final["ntff"]
 
     # ---- Extract full S-matrix column from wire port DFTs ----
     #

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -490,6 +490,7 @@ def run_nonuniform(
     ntff_box=None,
     ntff_data=None,
     waveguide_ports: list | None = None,
+    tfsf: tuple | None = None,
 ) -> dict:
     """Run non-uniform FDTD via jax.lax.scan.
 
@@ -520,6 +521,7 @@ def run_nonuniform(
     use_lumped_rlc = len(rlc_metas) > 0
     use_ntff = ntff_box is not None and ntff_data is not None
     use_waveguide_ports = len(waveguide_ports) > 0
+    use_tfsf = tfsf is not None
 
     # CPML: only initialize when cpml_layers > 0 (skip for PEC boundary)
     use_cpml = grid.cpml_layers > 0
@@ -628,17 +630,44 @@ def run_nonuniform(
     else:
         waveguide_meta = ()
 
+    # TFSF 1D auxiliary state carry. Injection axis is x (uniform on
+    # NU paths we support — dz-only nonuniformity), so the 1D aux runs
+    # with grid.dx spacing and the E/H corrections use scalar
+    # coeff = dt / (EPS_0 * dx) etc. Oblique / +z,-z cases are
+    # rejected upstream (see rfx/runners/nonuniform.py and rfx/api.py).
+    if use_tfsf:
+        from rfx.sources.tfsf import is_tfsf_2d as _is_tfsf_2d
+        tfsf_cfg, tfsf_state = tfsf
+        if _is_tfsf_2d(tfsf_cfg):
+            raise ValueError(
+                "TFSF oblique incidence (2D auxiliary grid) is not yet "
+                "supported on nonuniform z mesh. Use angle_deg=0 along x."
+            )
+        if tfsf_cfg.direction not in ("+x", "-x"):
+            raise ValueError(
+                "TFSF on nonuniform mesh supports only direction='+x' or "
+                f"'-x' (injection along uniform x axis); got {tfsf_cfg.direction!r}."
+            )
+        carry_init["tfsf"] = tfsf_state
+
     def step_fn(carry, xs):
         step_idx, src_vals = xs
         st = carry["fdtd"]
 
         # H update (non-uniform)
         st = update_h_nu(st, materials, dt, inv_dx_h, inv_dy_h, inv_dz_h)
+        tfsf_h_state = None
+        if use_tfsf:
+            from rfx.sources.tfsf import apply_tfsf_h
+            st = apply_tfsf_h(st, tfsf_cfg, carry["tfsf"], grid.dx, dt)
         if use_cpml:
             st, cpml_new = apply_cpml_h(st, cpml_params, carry["cpml"],
                                          cpml_grid, "xyz")
         else:
             cpml_new = None
+        if use_tfsf:
+            from rfx.sources.tfsf import update_tfsf_1d_h
+            tfsf_h_state = update_tfsf_1d_h(tfsf_cfg, carry["tfsf"], grid.dx, dt)
 
         # E update: use ADE-aware path when dispersive materials are present
         debye_new = None
@@ -652,6 +681,9 @@ def run_nonuniform(
         else:
             st = update_e_nu(st, materials, dt, inv_dx, inv_dy, inv_dz)
 
+        if use_tfsf:
+            from rfx.sources.tfsf import apply_tfsf_e
+            st = apply_tfsf_e(st, tfsf_cfg, tfsf_h_state, grid.dx, dt)
         if use_cpml:
             st, cpml_new = apply_cpml_e(st, cpml_params, cpml_new,
                                          cpml_grid, "xyz")
@@ -765,6 +797,14 @@ def run_nonuniform(
             from rfx.farfield import accumulate_ntff
             new_ntff = accumulate_ntff(carry["ntff"], st, ntff_box, dt, step_idx)
 
+        # TFSF 1D auxiliary E-field update (mirrors uniform scan body:
+        # called AFTER sources, closes the leapfrog step).
+        tfsf_new = None
+        if use_tfsf:
+            from rfx.sources.tfsf import update_tfsf_1d_e
+            t_tfsf = step_idx.astype(jnp.float32) * dt
+            tfsf_new = update_tfsf_1d_e(tfsf_cfg, tfsf_h_state, grid.dx, dt, t_tfsf)
+
         # Probes
         samples = [getattr(st, pc)[pi, pj, pk] for pi, pj, pk, pc in prb_meta]
         probe_out = jnp.stack(samples) if samples else jnp.zeros(0)
@@ -786,6 +826,8 @@ def run_nonuniform(
             new_carry["ntff"] = new_ntff
         if use_waveguide_ports and new_waveguide_port_accs is not None:
             new_carry["waveguide_port_accs"] = tuple(new_waveguide_port_accs)
+        if use_tfsf and tfsf_new is not None:
+            new_carry["tfsf"] = tfsf_new
         return new_carry, probe_out
 
     xs = (jnp.arange(n_steps, dtype=jnp.int32), src_waveforms)

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -485,6 +485,8 @@ def run_nonuniform(
     lorentz: tuple | None = None,
     pec_faces: set[str] | None = None,
     dft_planes: list | None = None,
+    rlc_metas: tuple = (),
+    rlc_states: tuple = (),
 ) -> dict:
     """Run non-uniform FDTD via jax.lax.scan.
 
@@ -511,6 +513,7 @@ def run_nonuniform(
     use_debye = debye is not None
     use_lorentz = lorentz is not None
     use_dft_planes = len(dft_planes) > 0
+    use_lumped_rlc = len(rlc_metas) > 0
 
     # CPML: only initialize when cpml_layers > 0 (skip for PEC boundary)
     use_cpml = grid.cpml_layers > 0
@@ -594,6 +597,10 @@ def run_nonuniform(
     else:
         dft_meta = ()
 
+    # Lumped RLC ADE state (one per element) — metas are Python-static
+    if use_lumped_rlc:
+        carry_init["rlc_states"] = tuple(rlc_states)
+
     def step_fn(carry, xs):
         step_idx, src_vals = xs
         st = carry["fdtd"]
@@ -626,6 +633,15 @@ def run_nonuniform(
         st = apply_pec(st)
         if use_pec_mask:
             st = apply_pec_mask(st, pec_mask)
+
+        # Lumped RLC ADE update (after E update + boundaries, before sources)
+        new_rlc_states = None
+        if use_lumped_rlc:
+            from rfx.lumped import update_rlc_element
+            new_rlc_states = []
+            for rlc_st, meta in zip(carry["rlc_states"], rlc_metas):
+                st, rlc_st_new = update_rlc_element(st, rlc_st, meta)
+                new_rlc_states.append(rlc_st_new)
 
         # Sources (point sources + wire port excitation)
         for idx_s, (si, sj, sk, sc) in enumerate(src_meta):
@@ -699,6 +715,8 @@ def run_nonuniform(
             new_carry["wire_sparams"] = tuple(new_wire_sp)
         if use_dft_planes and new_dft_planes is not None:
             new_carry["dft_planes"] = tuple(new_dft_planes)
+        if use_lumped_rlc and new_rlc_states is not None:
+            new_carry["rlc_states"] = tuple(new_rlc_states)
         return new_carry, probe_out
 
     xs = (jnp.arange(n_steps, dtype=jnp.int32), src_waveforms)
@@ -709,6 +727,10 @@ def run_nonuniform(
         "time_series": time_series,
         "dt": dt,
     }
+
+    # Surface final RLC ADE states (per element).
+    if use_lumped_rlc:
+        result["rlc_states"] = tuple(final["rlc_states"])
 
     # Repack DFT plane probes with their final accumulators.
     if use_dft_planes:

--- a/rfx/optimize_objectives.py
+++ b/rfx/optimize_objectives.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 from typing import Callable
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -273,17 +274,21 @@ def maximize_bandwidth(
 def maximize_directivity(
     theta_target: float,
     phi_target: float,
+    *,
+    n_theta: int = 37,
+    n_phi: int = 73,
 ) -> Callable:
-    """Maximize far-field power in a target direction.
+    """Maximize directivity in a target direction (ratio-based, scale-invariant).
 
-    Computes the total radiated power density
-    ``|E_θ|² + |E_φ|²`` at the target (θ, φ) direction, averaged
-    over all frequencies in the far-field result, and returns
-    its negation (so minimizing drives power upward).
+    Computes the directivity ratio ``U(θ_target, φ_target) / P_rad`` where
+    ``U = |E_θ|² + |E_φ|²`` is the radiation intensity and ``P_rad`` is
+    the total radiated power integrated over the upper hemisphere. The
+    ratio is scale-invariant, so the absolute magnitude of the NTFF
+    spectral integral drops out — gradients reflect pattern shape only.
 
-    The ``result`` must carry ``ntff_data``, ``ntff_box``, and ``grid``
-    (i.e., the simulation must include an NTFF box and preserve the
-    post-processing context needed to evaluate it).
+    Prior versions used absolute ``|E|²`` at the target direction, which
+    is ~1e-27 in rfx's spectral NTFF convention and produces zero
+    gradients in ``topology_optimize`` (GitHub issue #32).
 
     Parameters
     ----------
@@ -291,6 +296,11 @@ def maximize_directivity(
         Polar angle in radians [0, π].
     phi_target : float
         Azimuthal angle in radians [0, 2π].
+    n_theta : int, optional
+        Number of polar samples in [0, π/2] for the hemisphere
+        integration (default 37 → 2.5° spacing).
+    n_phi : int, optional
+        Number of azimuthal samples in [0, 2π] (default 73 → 5° spacing).
 
     Returns
     -------
@@ -298,14 +308,16 @@ def maximize_directivity(
 
     Notes
     -----
-    This objective uses NumPy-based far-field computation internally.
-    It is differentiable through the NTFF DFT accumulation (which is
-    JAX-traced), but the angular projection itself is not
-    re-differentiated.  For gradient-based optimization, the NTFF
-    accumulation provides the necessary gradient path.
+    ``stop_gradient`` is applied to the P_rad denominator: since the
+    ratio is scale-invariant, any shape-preserving scaling leaves the
+    directivity unchanged; letting the denominator carry gradient would
+    only introduce noise and NaN risk when P_rad is near zero early in
+    optimization.
     """
     theta_arr = np.array([theta_target])
     phi_arr = np.array([phi_target])
+    theta_hemi = np.linspace(0.0, np.pi / 2.0, n_theta)
+    phi_hemi = np.linspace(0.0, 2.0 * np.pi, n_phi)
 
     def objective(result) -> jnp.ndarray:
         from rfx.farfield import compute_far_field
@@ -328,17 +340,31 @@ def maximize_directivity(
                 "can be evaluated from NTFF data."
             )
 
-        ff = compute_far_field(ntff_data, ntff_box, grid, theta_arr, phi_arr)
+        # U at target — (n_freqs, 1, 1)
+        ff_tgt = compute_far_field(ntff_data, ntff_box, grid, theta_arr, phi_arr)
+        u_target = (jnp.abs(ff_tgt.E_theta[:, 0, 0]) ** 2
+                    + jnp.abs(ff_tgt.E_phi[:, 0, 0]) ** 2)
 
-        # Power density at target direction, summed over frequencies
-        # E_theta, E_phi: (n_freqs, 1, 1)
-        power = jnp.abs(ff.E_theta[:, 0, 0]) ** 2 + jnp.abs(ff.E_phi[:, 0, 0]) ** 2
-        mean_power = jnp.mean(power)
+        # Hemisphere P_rad: ∬ U(θ,φ) sin(θ) dθ dφ — (n_freqs, n_theta, n_phi)
+        ff_hemi = compute_far_field(ntff_data, ntff_box, grid, theta_hemi, phi_hemi)
+        u_hemi = (jnp.abs(ff_hemi.E_theta) ** 2 + jnp.abs(ff_hemi.E_phi) ** 2)
+        sin_theta = jnp.asarray(np.sin(theta_hemi), dtype=u_hemi.dtype)
+        # trapz in θ then φ
+        integrand = u_hemi * sin_theta[None, :, None]
+        p_rad_phi = jnp.trapezoid(integrand, theta_hemi, axis=1)
+        p_rad = jnp.trapezoid(p_rad_phi, phi_hemi, axis=1)  # (n_freqs,)
 
-        # Negate: minimizing this = maximizing directivity
-        return -mean_power
+        directivity = u_target / (jax.lax.stop_gradient(p_rad) + 1e-30)
+        # Minimizing -D = maximizing directivity; average across freqs
+        return -jnp.mean(directivity)
 
     return objective
+
+
+# Alias for discoverability — the issue #32 fix aligned the default with
+# the ratio-based formulation, so `maximize_directivity_ratio` is simply
+# the new default under an explicit name.
+maximize_directivity_ratio = maximize_directivity
 
 
 # ---------------------------------------------------------------------------

--- a/rfx/runners/distributed_nu.py
+++ b/rfx/runners/distributed_nu.py
@@ -1,0 +1,174 @@
+"""Phase B: Non-uniform FDTD kernels for the shard_map distributed runner.
+
+This module supplies the NU analogues of the uniform kernels used by
+``rfx/runners/distributed_v2.py`` so the distributed path can accept
+``NonUniformGrid`` without silently dropping the profile. The uniform
+kernels in ``distributed.py`` remain the reference baseline and must
+not be modified from this module.
+
+Scope (Phase B minimal):
+- x-axis shard only (1D slab decomposition).
+- Global grading ratio <= 5:1 (shared single dt).
+- x-axis CPML cells are uniform (guaranteed by make_nonuniform_grid
+  boundary padding).
+- TFSF single-device only (enforced upstream).
+- Dispersive (Debye/Lorentz) E on NU distributed is NOT implemented
+  here. The public entry point in ``distributed_v2`` falls back when
+  dispersion is active.
+
+Key helper: ``_build_sharded_inv_dx_arrays`` returns per-device
+slabs of ``inv_dx`` / ``inv_dx_h`` whose slab boundary entry of
+``inv_dx_h`` is derived from the global spacing straddling the slab
+seam (NOT from the local slab alone) so H-field mean-spacing math
+remains consistent across the shard boundary.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import lax
+from jax.experimental.shard_map import shard_map
+from jax.sharding import PartitionSpec as P
+
+from rfx.core.yee import (
+    FDTDState,
+    MaterialArrays,
+    MU_0,
+    EPS_0,
+    _shift_fwd,
+    _shift_bwd,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sharded inv-spacing arrays
+# ---------------------------------------------------------------------------
+
+def _build_sharded_inv_dx_arrays(grid, n_devices, pad_x=0):
+    """Build per-device x-axis inverse-spacing slabs for the shard_map runner.
+
+    The caller has already padded the global x-extent by ``pad_x`` cells
+    (to align ``nx`` on ``n_devices``).  We replicate that padding onto
+    the cell-size profile using the boundary cell value (matching how
+    ``make_nonuniform_grid`` pads CPML cells) and rebuild the global
+    ``inv_dx`` and ``inv_dx_h`` from the padded profile, then reshape to
+    per-device slabs.
+
+    For ``inv_dx_h``, the last entry of each device's slab is the global
+    mean-spacing straddling the slab seam with the next device (or 0 at
+    the domain boundary), NOT derived from the local slab alone.
+
+    Parameters
+    ----------
+    grid : NonUniformGrid
+    n_devices : int
+    pad_x : int
+        Number of PEC-padded cells appended to the high-x end of the
+        domain so that ``(nx + pad_x) % n_devices == 0``.
+
+    Returns
+    -------
+    inv_dx_global : (nx_padded,) np.ndarray
+        Replicated — every device sees the whole thing when used with
+        ``P("x")`` (see caller packing).
+    inv_dx_h_global : (nx_padded,) np.ndarray
+    dx_padded : (nx_padded,) np.ndarray
+        The padded cell-size profile (float32) — useful for diagnostics
+        and the unit test.
+    """
+    dx_arr = np.asarray(grid.dx_arr, dtype=np.float64)
+    if pad_x > 0:
+        # pad at the high-x end with boundary-cell-size value
+        dx_arr = np.concatenate(
+            [dx_arr, np.full(pad_x, float(dx_arr[-1]))]
+        )
+    nx = dx_arr.shape[0]
+    if nx % n_devices != 0:
+        raise ValueError(
+            f"After padding nx={nx} is not divisible by n_devices={n_devices}"
+        )
+
+    inv_dx = 1.0 / dx_arr
+    # inv_dx_h[i] = 2 / (dx[i] + dx[i+1]) for i<N-1 ; 0 at end.
+    inv_dx_h_mean = 2.0 / (dx_arr[:-1] + dx_arr[1:])
+    inv_dx_h = np.concatenate([inv_dx_h_mean, np.zeros(1, dtype=np.float64)])
+
+    return (
+        inv_dx.astype(np.float32),
+        inv_dx_h.astype(np.float32),
+        dx_arr.astype(np.float32),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Local NU update kernels (operate on per-device slab including ghosts)
+# ---------------------------------------------------------------------------
+
+def _update_h_local_nu(state, materials, dt,
+                      inv_dx_slab, inv_dy_full, inv_dz_full,
+                      inv_dx_h_slab, inv_dy_h_full, inv_dz_h_full):
+    """H update on a local slab using NU inverse spacings.
+
+    Mirrors ``rfx/core/yee.py::update_h_nu`` but accepts pre-sliced
+    per-device ``inv_dx`` / ``inv_dx_h`` (length nx_local), while
+    y/z spacings are replicated (full-axis).
+    """
+    ex, ey, ez = state.ex, state.ey, state.ez
+    mu = materials.mu_r * MU_0
+
+    curl_x = (
+        (_shift_fwd(ez, 1) - ez) * inv_dy_h_full[None, :, None]
+        - (_shift_fwd(ey, 2) - ey) * inv_dz_h_full[None, None, :]
+    )
+    curl_y = (
+        (_shift_fwd(ex, 2) - ex) * inv_dz_h_full[None, None, :]
+        - (_shift_fwd(ez, 0) - ez) * inv_dx_h_slab[:, None, None]
+    )
+    curl_z = (
+        (_shift_fwd(ey, 0) - ey) * inv_dx_h_slab[:, None, None]
+        - (_shift_fwd(ex, 1) - ex) * inv_dy_h_full[None, :, None]
+    )
+
+    hx = state.hx - (dt / mu) * curl_x
+    hy = state.hy - (dt / mu) * curl_y
+    hz = state.hz - (dt / mu) * curl_z
+
+    return state._replace(hx=hx, hy=hy, hz=hz)
+
+
+def _update_e_local_nu(state, materials, dt,
+                      inv_dx_slab, inv_dy_full, inv_dz_full):
+    """E update on a local slab using NU inverse (cell-local) spacings.
+
+    Mirrors ``rfx/core/yee.py::update_e_nu``.
+    """
+    hx, hy, hz = state.hx, state.hy, state.hz
+    eps = materials.eps_r * EPS_0
+    sigma = materials.sigma
+
+    sigma_dt_2eps = sigma * dt / (2.0 * eps)
+    ca = (1.0 - sigma_dt_2eps) / (1.0 + sigma_dt_2eps)
+    cb = (dt / eps) / (1.0 + sigma_dt_2eps)
+
+    curl_x = (
+        (hz - _shift_bwd(hz, 1)) * inv_dy_full[None, :, None]
+        - (hy - _shift_bwd(hy, 2)) * inv_dz_full[None, None, :]
+    )
+    curl_y = (
+        (hx - _shift_bwd(hx, 2)) * inv_dz_full[None, None, :]
+        - (hz - _shift_bwd(hz, 0)) * inv_dx_slab[:, None, None]
+    )
+    curl_z = (
+        (hy - _shift_bwd(hy, 0)) * inv_dx_slab[:, None, None]
+        - (hx - _shift_bwd(hx, 1)) * inv_dy_full[None, :, None]
+    )
+
+    ex = ca * state.ex + cb * curl_x
+    ey = ca * state.ey + cb * curl_y
+    ez = ca * state.ez + cb * curl_z
+
+    return state._replace(ex=ex, ey=ey, ez=ez, step=state.step + 1)

--- a/rfx/runners/distributed_v2.py
+++ b/rfx/runners/distributed_v2.py
@@ -544,10 +544,30 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
     # ------------------------------------------------------------------
     # Build grid and materials (full domain)
     # ------------------------------------------------------------------
-    grid = sim._build_grid()
-    base_materials, debye_spec, lorentz_spec, pec_mask, pec_shapes, _ = (
-        sim._assemble_materials(grid)
+    # Phase B: non-uniform grid detection. When any axis profile is
+    # present on ``sim`` we build a NonUniformGrid and route updates
+    # through the NU kernels in ``distributed_nu.py``.
+    is_nu = (
+        getattr(sim, "_dz_profile", None) is not None
+        or getattr(sim, "_dx_profile", None) is not None
+        or getattr(sim, "_dy_profile", None) is not None
     )
+    if is_nu:
+        # Synthesize a uniform dz profile when only dx/dy are non-uniform
+        # (same shim the single-device NU path uses in api.py).
+        if sim._dz_profile is None:
+            nz_phys = max(1, int(round(sim._domain[2] / sim._dx)))
+            sim._dz_profile = np.full(nz_phys, float(sim._dx))
+        grid = sim._build_nonuniform_grid()
+        base_materials, debye_spec, lorentz_spec, pec_mask = (
+            sim._assemble_materials_nu(grid)
+        )
+        pec_shapes = None
+    else:
+        grid = sim._build_grid()
+        base_materials, debye_spec, lorentz_spec, pec_mask, pec_shapes, _ = (
+            sim._assemble_materials(grid)
+        )
     materials = base_materials
 
     nx, ny, nz = grid.shape
@@ -582,8 +602,50 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
     use_cpml = sim._boundary == "cpml" and grid.cpml_layers > 0
     n_cpml = grid.cpml_layers if use_cpml else 0
 
+    # Phase B: NU + CPML + distributed is not implemented yet.
+    # The api.py-level guardrail already blocks this combination; assert
+    # here as a defensive backstop in case a future caller bypasses it.
+    if is_nu and use_cpml:
+        raise NotImplementedError(
+            "Phase B supports non-uniform grids on the distributed path "
+            "with PEC boundaries only. boundary='cpml' with dx/dy/dz "
+            "profile and devices>1 is a Phase C item."
+        )
+    if is_nu and debye_spec is not None:
+        raise NotImplementedError(
+            "Phase B does not support Debye dispersion on the NU "
+            "distributed path yet."
+        )
+    if is_nu and lorentz_spec is not None:
+        raise NotImplementedError(
+            "Phase B does not support Lorentz dispersion on the NU "
+            "distributed path yet."
+        )
+
     dt = grid.dt
     dx = grid.dx
+
+    # Phase B: pre-computed per-device inv-dx arrays for NU path.
+    # Inner kernels receive the full-axis inv_dy/inv_dz replicated and
+    # the per-device slab of inv_dx / inv_dx_h (length nx_local = nx_per
+    # + 2*ghost constructed below).
+    if is_nu:
+        from rfx.runners.distributed_nu import (
+            _build_sharded_inv_dx_arrays,
+            _update_h_local_nu,
+            _update_e_local_nu,
+        )
+        inv_dx_global, inv_dx_h_global, _dx_padded = (
+            _build_sharded_inv_dx_arrays(grid, n_devices, pad_x=pad_x)
+        )
+        inv_dy_full = np.asarray(grid.inv_dy, dtype=np.float32)
+        inv_dy_h_full = np.asarray(grid.inv_dy_h, dtype=np.float32)
+        inv_dz_full = np.asarray(grid.inv_dz, dtype=np.float32)
+        inv_dz_h_full = np.asarray(grid.inv_dz_h, dtype=np.float32)
+    else:
+        inv_dx_global = inv_dx_h_global = None
+        inv_dy_full = inv_dy_h_full = None
+        inv_dz_full = inv_dz_h_full = None
 
     # ------------------------------------------------------------------
     # Create mesh
@@ -595,23 +657,54 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
     # ------------------------------------------------------------------
     sources = []
     probes = []
-    for pe in sim._ports:
-        if pe.impedance > 0.0 and pe.extent is None:
-            lp = LumpedPort(
-                position=pe.position, component=pe.component,
-                impedance=pe.impedance, excitation=pe.waveform,
-            )
-            materials = setup_lumped_port(grid, lp, materials)
-            sources.append(make_port_source(grid, lp, materials, n_steps))
-        elif pe.impedance == 0.0:
-            if sim._boundary == "cpml":
-                sources.append(make_j_source(grid, pe.position, pe.component,
-                                             pe.waveform, n_steps, materials))
-            else:
-                sources.append(make_source(grid, pe.position, pe.component,
-                                           pe.waveform, n_steps))
-    for pe in sim._probes:
-        probes.append(make_probe(grid, pe.position, pe.component))
+    if is_nu:
+        # NU source/probe build uses cumulative position lookup and the
+        # same dV-normalised current-source waveform as the single-device
+        # NU runner (rfx.nonuniform.make_current_source) so distributed
+        # and single-device results agree.
+        from rfx.nonuniform import (
+            position_to_index as _nu_pos_to_idx,
+            make_current_source as _nu_make_current_source,
+        )
+        from rfx.simulation import SourceSpec, ProbeSpec
+        for pe in sim._ports:
+            if pe.impedance > 0.0:
+                raise NotImplementedError(
+                    "Phase B distributed+NU does not support lumped / wire "
+                    "ports yet. Use single-device for ports on NU meshes."
+                )
+            if pe.impedance == 0.0:
+                idx = _nu_pos_to_idx(grid, pe.position)
+                si, sj, sk, sc, wf = _nu_make_current_source(
+                    grid, idx, pe.component, pe.waveform, n_steps, materials)
+                sources.append(SourceSpec(
+                    i=int(si), j=int(sj), k=int(sk),
+                    component=sc, waveform=jnp.asarray(wf),
+                ))
+        for pe in sim._probes:
+            idx = _nu_pos_to_idx(grid, pe.position)
+            probes.append(ProbeSpec(
+                i=int(idx[0]), j=int(idx[1]), k=int(idx[2]),
+                component=pe.component,
+            ))
+    else:
+        for pe in sim._ports:
+            if pe.impedance > 0.0 and pe.extent is None:
+                lp = LumpedPort(
+                    position=pe.position, component=pe.component,
+                    impedance=pe.impedance, excitation=pe.waveform,
+                )
+                materials = setup_lumped_port(grid, lp, materials)
+                sources.append(make_port_source(grid, lp, materials, n_steps))
+            elif pe.impedance == 0.0:
+                if sim._boundary == "cpml":
+                    sources.append(make_j_source(grid, pe.position, pe.component,
+                                                 pe.waveform, n_steps, materials))
+                else:
+                    sources.append(make_source(grid, pe.position, pe.component,
+                                               pe.waveform, n_steps))
+        for pe in sim._probes:
+            probes.append(make_probe(grid, pe.position, pe.component))
 
     # Map source/probe global indices to (device_id, local_index)
     src_device_ids = []
@@ -649,6 +742,53 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
     # each device owns nx_local rows of the sharded (n_devices*nx_local, ny, nz) array.
     shd = _x_sharding(mesh)
     rep = _rep_sharding(mesh)
+
+    # Phase B: shard per-device inv_dx / inv_dx_h slabs for NU updates.
+    if is_nu:
+        # Split the 1-D padded global arrays into per-device slabs with
+        # ghost cells, matching the field slabbing convention.
+        # inv_dx uses cell-local values (ghost cells at the domain
+        # boundary carry the neighbour-cell value to avoid divide-by-zero
+        # in update kernels); inv_dx_h uses mean-spacing values which
+        # straddle adjacent cells.
+        def _split_1d_with_ghost(arr, pad_value):
+            nx_arr = arr.shape[0]
+            assert nx_arr == nx_padded, (
+                f"NU inv-array length {nx_arr} != nx_padded={nx_padded}"
+            )
+            per = nx_per
+            slabs = np.zeros((n_devices, nx_local), dtype=arr.dtype)
+            for d in range(n_devices):
+                lo = d * per
+                hi = lo + per
+                slabs[d, ghost:ghost + per] = arr[lo:hi]
+                # left ghost
+                if d > 0:
+                    slabs[d, 0] = arr[lo - 1]
+                else:
+                    slabs[d, 0] = pad_value
+                # right ghost
+                if d < n_devices - 1:
+                    slabs[d, -1] = arr[hi]
+                else:
+                    slabs[d, -1] = pad_value
+            return slabs
+
+        _inv_dx_slabs = _split_1d_with_ghost(inv_dx_global, pad_value=1.0)
+        _inv_dx_h_slabs = _split_1d_with_ghost(inv_dx_h_global, pad_value=0.0)
+        # Shard to (n_devices * nx_local,) along P("x")
+        inv_dx_sharded = jax.device_put(
+            _inv_dx_slabs.reshape(n_devices * nx_local), shd)
+        inv_dx_h_sharded = jax.device_put(
+            _inv_dx_h_slabs.reshape(n_devices * nx_local), shd)
+        inv_dy_rep = jax.device_put(inv_dy_full, rep)
+        inv_dy_h_rep = jax.device_put(inv_dy_h_full, rep)
+        inv_dz_rep = jax.device_put(inv_dz_full, rep)
+        inv_dz_h_rep = jax.device_put(inv_dz_h_full, rep)
+    else:
+        inv_dx_sharded = inv_dx_h_sharded = None
+        inv_dy_rep = inv_dy_h_rep = None
+        inv_dz_rep = inv_dz_h_rep = None
 
     def _shard_stacked(arr):
         """Merge device axis into x, then shard."""
@@ -892,6 +1032,37 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
     # ------------------------------------------------------------------
 
     def _update_h_shmap(st, mat):
+        if is_nu:
+            @partial(
+                shard_map,
+                mesh=mesh,
+                in_specs=(
+                    P("x"), P("x"), P("x"),  # ex, ey, ez
+                    P("x"), P("x"), P("x"),  # hx, hy, hz
+                    P(),                     # step
+                    P("x"), P("x"), P("x"),  # eps_r, sigma, mu_r
+                    P("x"), P(None), P(None),  # inv_dx, inv_dy, inv_dz
+                    P("x"), P(None), P(None),  # inv_dx_h, inv_dy_h, inv_dz_h
+                ),
+                out_specs=(P("x"), P("x"), P("x"), P()),
+                check_rep=False,
+            )
+            def _h_nu(ex, ey, ez, hx, hy, hz, step, eps_r, sigma, mu_r,
+                      invdx, invdy, invdz, invdxh, invdyh, invdzh):
+                _st = FDTDState(ex=ex, ey=ey, ez=ez, hx=hx, hy=hy, hz=hz, step=step)
+                _mat = MaterialArrays(eps_r=eps_r, sigma=sigma, mu_r=mu_r)
+                new_st = _update_h_local_nu(
+                    _st, _mat, dt,
+                    invdx, invdy, invdz, invdxh, invdyh, invdzh)
+                return new_st.hx, new_st.hy, new_st.hz, new_st.step
+
+            hx, hy, hz, step = _h_nu(
+                st.ex, st.ey, st.ez, st.hx, st.hy, st.hz, st.step,
+                mat.eps_r, mat.sigma, mat.mu_r,
+                inv_dx_sharded, inv_dy_rep, inv_dz_rep,
+                inv_dx_h_sharded, inv_dy_h_rep, inv_dz_h_rep)
+            return st._replace(hx=hx, hy=hy, hz=hz, step=step)
+
         @partial(
             shard_map,
             mesh=mesh,
@@ -917,6 +1088,35 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
 
     def _update_e_shmap(st, mat, db_coeffs, db_st, lr_coeffs, lr_st):
         """E update (with optional dispersion) via shard_map."""
+        if is_nu:
+            # NU path: no dispersion (blocked upstream).
+            @partial(
+                shard_map,
+                mesh=mesh,
+                in_specs=(
+                    P("x"), P("x"), P("x"),
+                    P("x"), P("x"), P("x"),
+                    P(),
+                    P("x"), P("x"), P("x"),
+                    P("x"), P(None), P(None),
+                ),
+                out_specs=(P("x"), P("x"), P("x"), P()),
+                check_rep=False,
+            )
+            def _e_nu(ex, ey, ez, hx, hy, hz, step, eps_r, sigma, mu_r,
+                      invdx, invdy, invdz):
+                _st = FDTDState(ex=ex, ey=ey, ez=ez, hx=hx, hy=hy, hz=hz, step=step)
+                _mat = MaterialArrays(eps_r=eps_r, sigma=sigma, mu_r=mu_r)
+                new_st = _update_e_local_nu(_st, _mat, dt, invdx, invdy, invdz)
+                return new_st.ex, new_st.ey, new_st.ez, new_st.step
+
+            ex, ey, ez, step = _e_nu(
+                st.ex, st.ey, st.ez, st.hx, st.hy, st.hz, st.step,
+                mat.eps_r, mat.sigma, mat.mu_r,
+                inv_dx_sharded, inv_dy_rep, inv_dz_rep)
+            new_st = st._replace(ex=ex, ey=ey, ez=ez, step=step)
+            # db_st / lr_st are passthrough (dummies) in NU path.
+            return new_st, db_st, lr_st
 
         @partial(
             shard_map,

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -76,6 +76,115 @@ def pos_to_nu_index(grid: NonUniformGrid, pos) -> tuple[int, int, int]:
     return position_to_index(grid, pos)
 
 
+def _build_waveguide_port_config_nu(sim, entry, grid: NonUniformGrid,
+                                     freqs: jnp.ndarray, n_steps: int):
+    """NU-aware waveguide port config builder.
+
+    Mirrors the uniform-path ``Simulation._build_waveguide_port_config``
+    but resolves indices and per-axis aperture spans against the
+    NonUniformGrid (cumulative-sum cell edges).
+    """
+    from rfx.sources.waveguide_port import (
+        WaveguidePort,
+        init_waveguide_port,
+        init_multimode_waveguide_port,
+    )
+
+    normal_axis = entry.direction[1]
+    axis_idx = {"x": 0, "y": 1, "z": 2}[normal_axis]
+    pos_vec = [0.0, 0.0, 0.0]
+    pos_vec[axis_idx] = entry.x_position
+    x_index = pos_to_nu_index(grid, tuple(pos_vec))[axis_idx]
+
+    cpml = grid.cpml_layers
+    # axis-pad mirrors Grid.axis_pads convention: 0 if no CPML on that axis,
+    # else cpml. NU runner uses CPML on all axes when boundary='cpml'/'upml'.
+    axis_pads_nu = (cpml, cpml, cpml)
+
+    def _range_to_slice_nu(value_range, d_arr_jnp, n_axis, pad):
+        d_np = np.asarray(d_arr_jnp)
+        # Cell-edge positions in physical coords (interior only, edge=0 at first
+        # interior face). Length = n_interior + 1.
+        interior = d_np[pad : n_axis - pad]
+        edges = np.insert(np.cumsum(interior), 0, 0.0)
+        if value_range is None:
+            return (pad, n_axis - pad), float(edges[-1])
+        lo, hi = value_range
+        lo_local = int(np.argmin(np.abs(edges - float(lo))))
+        hi_local = int(np.argmin(np.abs(edges - float(hi))))
+        if hi_local <= lo_local:
+            raise ValueError(
+                f"range {value_range!r} does not resolve to a valid aperture on the NU grid"
+            )
+        lo_idx = lo_local + pad
+        hi_idx = hi_local + pad + 1
+        actual_span = float(edges[hi_local] - edges[lo_local])
+        if actual_span <= 0.0:
+            raise ValueError(
+                f"range {value_range!r} resolves to invalid aperture span {actual_span}"
+            )
+        return (lo_idx, hi_idx), actual_span
+
+    if normal_axis == "x":
+        u_slice, a_span = _range_to_slice_nu(entry.y_range, grid.dy_arr, grid.ny, axis_pads_nu[1])
+        v_slice, b_span = _range_to_slice_nu(entry.z_range, grid.dz, grid.nz, axis_pads_nu[2])
+    elif normal_axis == "y":
+        u_slice, a_span = _range_to_slice_nu(entry.x_range, grid.dx_arr, grid.nx, axis_pads_nu[0])
+        v_slice, b_span = _range_to_slice_nu(entry.z_range, grid.dz, grid.nz, axis_pads_nu[2])
+    else:
+        u_slice, a_span = _range_to_slice_nu(entry.x_range, grid.dx_arr, grid.nx, axis_pads_nu[0])
+        v_slice, b_span = _range_to_slice_nu(entry.y_range, grid.dy_arr, grid.ny, axis_pads_nu[1])
+
+    # Snapped source-plane physical coordinate (for waveguide_plane_positions).
+    # Use the cumulative cell-edge position corresponding to the snapped cell
+    # index along the port-normal axis.
+    if normal_axis == "x":
+        d_axis_np = np.asarray(grid.dx_arr)
+    elif normal_axis == "y":
+        d_axis_np = np.asarray(grid.dy_arr)
+    else:
+        d_axis_np = np.asarray(grid.dz)
+    _interior = d_axis_np[cpml : len(d_axis_np) - cpml]
+    _edges_axis = np.insert(np.cumsum(_interior), 0, 0.0)
+    _local_axis = max(0, min(x_index - cpml, len(_edges_axis) - 1))
+    snapped_source_plane = float(_edges_axis[_local_axis])
+
+    port = WaveguidePort(
+        x_index=x_index,
+        y_slice=None,
+        z_slice=None,
+        a=a_span,
+        b=b_span,
+        mode=entry.mode,
+        mode_type=entry.mode_type,
+        direction=entry.direction,
+        x_position=snapped_source_plane,
+        normal_axis=normal_axis,
+        u_slice=u_slice,
+        v_slice=v_slice,
+    )
+    if entry.n_modes > 1:
+        return init_multimode_waveguide_port(
+            port, grid, freqs,
+            n_modes=entry.n_modes,
+            f0=entry.f0 if entry.f0 is not None else sim._freq_max / 2,
+            bandwidth=entry.bandwidth,
+            amplitude=entry.amplitude,
+            probe_offset=entry.probe_offset,
+            ref_offset=entry.ref_offset,
+            dft_total_steps=n_steps,
+        )
+    return init_waveguide_port(
+        port, grid, freqs,
+        f0=entry.f0 if entry.f0 is not None else sim._freq_max / 2,
+        bandwidth=entry.bandwidth,
+        amplitude=entry.amplitude,
+        probe_offset=entry.probe_offset,
+        ref_offset=entry.ref_offset,
+        dft_total_steps=n_steps,
+    )
+
+
 def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=None):
     """Run simulation on non-uniform grid with graded dz.
 
@@ -297,6 +406,26 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         )
         rlc_states_init = tuple(init_rlc_state() for _ in sim._lumped_rlc)
 
+    # Waveguide ports: build per-port config via NU-aware
+    # init_waveguide_port (duck-types on grid for per-axis widths).
+    waveguide_port_cfgs = []
+    if sim._waveguide_ports:
+        wg_freqs = None
+        for pe in sim._waveguide_ports:
+            if pe.freqs is not None:
+                wg_freqs = jnp.asarray(pe.freqs, dtype=jnp.float32)
+                break
+        if wg_freqs is None:
+            wg_freqs = jnp.linspace(
+                sim._freq_max * 0.5, sim._freq_max, 20, dtype=jnp.float32
+            )
+        for pe in sim._waveguide_ports:
+            waveguide_port_cfgs.append(
+                _build_waveguide_port_config_nu(
+                    sim, pe, grid, wg_freqs, n_steps,
+                )
+            )
+
     # NTFF box: build once (indices are Python-static) + zero-init
     # DFT accumulators that will be threaded through the scan carry.
     # NonUniformGrid is a NamedTuple without ``position_to_index``, so
@@ -332,10 +461,68 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         rlc_states=rlc_states_init,
         ntff_box=ntff_box,
         ntff_data=ntff_data_init,
+        waveguide_ports=waveguide_port_cfgs if waveguide_port_cfgs else None,
     )
 
     s_params = r.get("s_params")
     freqs_out = r.get("s_param_freqs")
+
+    # Waveguide-port output: dict[name -> cfg], optional sparams dict.
+    waveguide_ports_result = None
+    waveguide_sparams_result = None
+    if sim._waveguide_ports and "waveguide_ports" in r:
+        from rfx.sources.waveguide_port import (
+            extract_waveguide_sparams,
+            waveguide_plane_positions,
+        )
+        from rfx.api import WaveguideSParamResult
+        final_cfgs = r["waveguide_ports"]
+        waveguide_ports_result = {
+            entry.name: cfg
+            for entry, cfg in zip(sim._waveguide_ports, final_cfgs)
+        }
+        waveguide_sparams_result = {}
+        for entry, cfg in zip(sim._waveguide_ports, final_cfgs):
+            plane_positions = waveguide_plane_positions(cfg)
+            source_plane = plane_positions["source"]
+            measured_reference_plane = plane_positions["reference"]
+            measured_probe_plane = plane_positions["probe"]
+            if entry.calibration_preset == "source_to_probe":
+                reference_plane = source_plane
+                probe_plane = measured_probe_plane
+                calibration_preset = "source_to_probe"
+            elif entry.reference_plane is not None or entry.probe_plane is not None:
+                reference_plane = (
+                    entry.reference_plane
+                    if entry.reference_plane is not None
+                    else measured_reference_plane
+                )
+                probe_plane = (
+                    entry.probe_plane
+                    if entry.probe_plane is not None
+                    else measured_probe_plane
+                )
+                calibration_preset = "explicit"
+            else:
+                reference_plane = measured_reference_plane
+                probe_plane = measured_probe_plane
+                calibration_preset = "measured"
+            s11, s21 = extract_waveguide_sparams(
+                cfg,
+                ref_shift=reference_plane - measured_reference_plane,
+                probe_shift=probe_plane - measured_probe_plane,
+            )
+            waveguide_sparams_result[entry.name] = WaveguideSParamResult(
+                freqs=np.array(cfg.freqs),
+                s11=np.array(s11),
+                s21=np.array(s21),
+                calibration_preset=calibration_preset,
+                source_plane=float(source_plane),
+                measured_reference_plane=measured_reference_plane,
+                measured_probe_plane=measured_probe_plane,
+                reference_plane=reference_plane,
+                probe_plane=probe_plane,
+            )
 
     # Repack DFT planes into {name: DFTPlaneProbe} dict to match
     # the uniform path's Result schema.
@@ -354,6 +541,8 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         ntff_data=r.get("ntff_data"),
         ntff_box=ntff_box,
         dft_planes=dft_planes_dict,
+        waveguide_ports=waveguide_ports_result,
+        waveguide_sparams=waveguide_sparams_result,
         grid=grid,
         dt=grid.dt,
         freq_range=(sim._freq_max / 10, sim._freq_max, sim._boundary),

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -245,6 +245,34 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         idx = pos_to_nu_index(grid, pe.position)
         probes.append((*idx, pe.component))
 
+    # DFT plane probes — mirror the uniform-path setup in
+    # runners/uniform.py, but use pos_to_nu_index so the plane
+    # coordinate resolves on a possibly-graded mesh.
+    dft_plane_probes = []
+    if sim._dft_planes:
+        from rfx.probes.probes import init_dft_plane_probe
+        axis_to_index = {"x": 0, "y": 1, "z": 2}
+        for pe in sim._dft_planes:
+            axis_idx = axis_to_index[pe.axis]
+            plane_pos = [0.0, 0.0, 0.0]
+            plane_pos[axis_idx] = pe.coordinate
+            grid_index = pos_to_nu_index(grid, tuple(plane_pos))[axis_idx]
+            freqs_arr = (
+                pe.freqs
+                if pe.freqs is not None
+                else jnp.linspace(sim._freq_max / 10, sim._freq_max, pe.n_freqs)
+            )
+            dft_plane_probes.append(
+                init_dft_plane_probe(
+                    axis=axis_idx,
+                    index=grid_index,
+                    component=pe.component,
+                    freqs=freqs_arr,
+                    grid_shape=(grid.nx, grid.ny, grid.nz),
+                    dft_total_steps=n_steps,
+                )
+            )
+
     sp_freqs = None
     if wire_port_specs and (compute_s_params is None or compute_s_params):
         sp_freqs = s_param_freqs
@@ -262,16 +290,27 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         debye=debye,
         lorentz=lorentz,
         pec_faces=getattr(sim, '_pec_faces', None),
+        dft_planes=dft_plane_probes if dft_plane_probes else None,
     )
 
     s_params = r.get("s_params")
     freqs_out = r.get("s_param_freqs")
+
+    # Repack DFT planes into {name: DFTPlaneProbe} dict to match
+    # the uniform path's Result schema.
+    dft_planes_dict = None
+    if sim._dft_planes and "dft_planes" in r:
+        dft_planes_dict = {
+            entry.name: probe
+            for entry, probe in zip(sim._dft_planes, r["dft_planes"])
+        }
 
     return Result(
         state=r["state"],
         time_series=r["time_series"],
         s_params=s_params,
         freqs=freqs_out,
+        dft_planes=dft_planes_dict,
         grid=grid,
         dt=grid.dt,
         freq_range=(sim._freq_max / 10, sim._freq_max, sim._boundary),

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -297,6 +297,26 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         )
         rlc_states_init = tuple(init_rlc_state() for _ in sim._lumped_rlc)
 
+    # NTFF box: build once (indices are Python-static) + zero-init
+    # DFT accumulators that will be threaded through the scan carry.
+    # NonUniformGrid is a NamedTuple without ``position_to_index``, so
+    # we build the box directly via ``pos_to_nu_index`` (which uses
+    # the cumulative dx_arr/dy_arr/dz lookup) and skip make_ntff_box.
+    ntff_box = None
+    ntff_data_init = None
+    if sim._ntff is not None:
+        from rfx.farfield import NTFFBox, init_ntff_data
+        corner_lo, corner_hi, ntff_freqs = sim._ntff
+        lo_idx = pos_to_nu_index(grid, corner_lo)
+        hi_idx = pos_to_nu_index(grid, corner_hi)
+        ntff_box = NTFFBox(
+            i_lo=lo_idx[0], i_hi=hi_idx[0],
+            j_lo=lo_idx[1], j_hi=hi_idx[1],
+            k_lo=lo_idx[2], k_hi=hi_idx[2],
+            freqs=jnp.asarray(ntff_freqs, dtype=jnp.float32),
+        )
+        ntff_data_init = init_ntff_data(ntff_box)
+
     r = run_nonuniform(
         grid, materials, n_steps,
         pec_mask=pec_mask,
@@ -310,6 +330,8 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         dft_planes=dft_plane_probes if dft_plane_probes else None,
         rlc_metas=rlc_metas,
         rlc_states=rlc_states_init,
+        ntff_box=ntff_box,
+        ntff_data=ntff_data_init,
     )
 
     s_params = r.get("s_params")
@@ -329,6 +351,8 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         time_series=r["time_series"],
         s_params=s_params,
         freqs=freqs_out,
+        ntff_data=r.get("ntff_data"),
+        ntff_box=ntff_box,
         dft_planes=dft_planes_dict,
         grid=grid,
         dt=grid.dt,

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -185,7 +185,9 @@ def _build_waveguide_port_config_nu(sim, entry, grid: NonUniformGrid,
     )
 
 
-def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=None):
+def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=None,
+                        eps_override=None, sigma_override=None,
+                        pec_mask_override=None):
     """Run simulation on non-uniform grid with graded dz.
 
     Parameters
@@ -196,6 +198,12 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         Number of timesteps.
     compute_s_params : bool or None
     s_param_freqs : array or None
+    eps_override, sigma_override : jnp.ndarray or None
+        When provided, replace the assembled material arrays before
+        source/port setup. Used by the differentiable ``forward()``
+        path to inject optimisation variables.
+    pec_mask_override : jnp.ndarray or None
+        Extra hard-PEC mask ORed into the geometry-derived pec_mask.
 
     Returns
     -------
@@ -204,9 +212,27 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
     from rfx.api import Result
 
     grid = build_nonuniform_grid(
-        sim._freq_max, sim._domain, sim._dx, sim._cpml_layers, sim._dz_profile
+        sim._freq_max, sim._domain, sim._dx, sim._cpml_layers, sim._dz_profile,
+        dx_profile=sim._dx_profile, dy_profile=sim._dy_profile,
     )
     materials, debye_spec, lorentz_spec, pec_mask = assemble_materials_nu(sim, grid)
+
+    # ``eps_override`` / ``sigma_override`` replace the assembled material
+    # arrays for the scan. We keep the original concrete ``materials`` for
+    # ``make_current_source`` (which calls ``float(materials.eps_r[i,j,k])``)
+    # so that source normalisation stays concrete under ``jax.grad``; the
+    # override is folded into a separate ``materials_scan`` used for
+    # port-sigma updates and the scan launch.
+    materials_concrete = materials
+    if eps_override is not None or sigma_override is not None:
+        materials = MaterialArrays(
+            eps_r=eps_override if eps_override is not None else materials.eps_r,
+            sigma=sigma_override if sigma_override is not None else materials.sigma,
+            mu_r=materials.mu_r,
+        )
+
+    if pec_mask_override is not None:
+        pec_mask = pec_mask_override if pec_mask is None else (pec_mask | pec_mask_override)
 
     # Fold RLC R/C into materials before other port/source setup
     # (mirrors the uniform path).
@@ -255,7 +281,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         if pe.impedance == 0.0:
             # Current source with dV normalization
             src = make_current_source(
-                grid, idx, pe.component, pe.waveform, n_steps, materials)
+                grid, idx, pe.component, pe.waveform, n_steps, materials_concrete)
             sources.append(src)
         elif pe.extent is not None:
             # Wire port on non-uniform grid
@@ -309,7 +335,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
                     cell[axis] = k
                     src = make_current_source(
                         grid, tuple(cell), pe.component,
-                        pe.waveform, n_steps, materials)
+                        pe.waveform, n_steps, materials_concrete)
                     # Scale by 1/n_cells for distributed excitation
                     scaled_wf = np.array(src[4]) / n_cells
                     sources.append(
@@ -354,7 +380,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
                 pec_mask = pec_mask.at[i, j, k].set(False)
             if pe.excite:
                 src = make_current_source(
-                    grid, idx, pe.component, pe.waveform, n_steps, materials)
+                    grid, idx, pe.component, pe.waveform, n_steps, materials_concrete)
                 sources.append(src)
 
     for pe in sim._probes:

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -99,6 +99,13 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
     )
     materials, debye_spec, lorentz_spec, pec_mask = assemble_materials_nu(sim, grid)
 
+    # Fold RLC R/C into materials before other port/source setup
+    # (mirrors the uniform path).
+    if sim._lumped_rlc:
+        from rfx.lumped import setup_rlc_materials
+        for spec in sim._lumped_rlc:
+            materials = setup_rlc_materials(grid, spec, materials)
+
     # Initialize Debye/Lorentz dispersion coefficients
     debye = None
     if debye_spec is not None:
@@ -280,6 +287,16 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
             sp_freqs = np.linspace(
                 sim._freq_max / 10, sim._freq_max, 50)
 
+    # Lumped RLC: build per-element metadata + zero-init ADE states
+    rlc_metas: tuple = ()
+    rlc_states_init: tuple = ()
+    if sim._lumped_rlc:
+        from rfx.lumped import build_rlc_meta, init_rlc_state
+        rlc_metas = tuple(
+            build_rlc_meta(grid, spec, materials) for spec in sim._lumped_rlc
+        )
+        rlc_states_init = tuple(init_rlc_state() for _ in sim._lumped_rlc)
+
     r = run_nonuniform(
         grid, materials, n_steps,
         pec_mask=pec_mask,
@@ -291,6 +308,8 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         lorentz=lorentz,
         pec_faces=getattr(sim, '_pec_faces', None),
         dft_planes=dft_plane_probes if dft_plane_probes else None,
+        rlc_metas=rlc_metas,
+        rlc_states=rlc_states_init,
     )
 
     s_params = r.get("s_params")

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -426,6 +426,50 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
                 )
             )
 
+    # TFSF plane-wave source. Scope: axis-aligned +x / -x incidence with
+    # angle_deg=0 so the 1D auxiliary grid runs along the uniform x axis
+    # with scalar cell size grid.dx. Oblique angles (2D auxiliary grid)
+    # and +z / -z incidence (which would require a z-nonuniform 1D aux)
+    # are rejected here with actionable messages.
+    tfsf_pair = None
+    if sim._tfsf is not None:
+        entry = sim._tfsf
+        if abs(entry.angle_deg) > 0.01:
+            raise ValueError(
+                "TFSF oblique incidence (angle_deg != 0) is not yet "
+                "supported on nonuniform z mesh — the 2D auxiliary grid "
+                "is uniform-only. Use angle_deg=0 or run on the uniform lane."
+            )
+        if entry.direction in ("+z", "-z"):
+            raise ValueError(
+                "TFSF z-directed incidence is not yet supported on "
+                "nonuniform z mesh (1D auxiliary grid would need to be "
+                "z-nonuniform). Use direction='+x' or '-x', or run on the "
+                "uniform lane."
+            )
+        if entry.direction not in ("+x", "-x"):
+            raise ValueError(
+                "TFSF on nonuniform mesh supports only direction='+x' or "
+                f"'-x'; got {entry.direction!r}."
+            )
+        from rfx.sources.tfsf import init_tfsf
+        tfsf_pair = init_tfsf(
+            grid.nx,
+            grid.dx,
+            grid.dt,
+            cpml_layers=grid.cpml_layers,
+            tfsf_margin=entry.margin,
+            f0=entry.f0 if entry.f0 is not None else sim._freq_max / 2,
+            bandwidth=entry.bandwidth,
+            amplitude=entry.amplitude,
+            polarization=entry.polarization,
+            direction=entry.direction,
+            angle_deg=entry.angle_deg,
+            ny=grid.ny,
+            nz=grid.nz,
+            waveform=getattr(entry, 'waveform', 'differentiated_gaussian'),
+        )
+
     # NTFF box: build once (indices are Python-static) + zero-init
     # DFT accumulators that will be threaded through the scan carry.
     # NonUniformGrid is a NamedTuple without ``position_to_index``, so
@@ -462,6 +506,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         ntff_box=ntff_box,
         ntff_data=ntff_data_init,
         waveguide_ports=waveguide_port_cfgs if waveguide_port_cfgs else None,
+        tfsf=tfsf_pair,
     )
 
     s_params = r.get("s_params")

--- a/rfx/sources/waveguide_port.py
+++ b/rfx/sources/waveguide_port.py
@@ -114,6 +114,12 @@ class WaveguidePortConfig(NamedTuple):
     a: float
     b: float
     dx: float
+    # Per-axis transverse cell widths covering the port aperture.
+    # Shape (nu_port,) and (nv_port,) respectively. For uniform Yee grids
+    # both arrays are constant ``dx``; on a NonUniformGrid these are the
+    # slice of ``dx_arr`` / ``dy_arr`` / ``dz`` covering the aperture.
+    u_widths: jnp.ndarray
+    v_widths: jnp.ndarray
     source_x_m: float
     reference_x_m: float
     probe_x_m: float
@@ -137,6 +143,9 @@ class WaveguidePortConfig(NamedTuple):
 
 def _te_mode_profiles(a: float, b: float, m: int, n: int,
                       y_coords: np.ndarray, z_coords: np.ndarray,
+                      *,
+                      u_widths: np.ndarray | None = None,
+                      v_widths: np.ndarray | None = None,
                       ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Compute TE_mn E and H transverse mode profiles.
 
@@ -162,9 +171,13 @@ def _te_mode_profiles(a: float, b: float, m: int, n: int,
     hz = ey.copy()
 
     # Normalize: integral(Ey² + Ez²) dA = 1
-    dy = y_coords[1] - y_coords[0] if len(y_coords) > 1 else a
-    dz = z_coords[1] - z_coords[0] if len(z_coords) > 1 else b
-    power = np.sum(ey**2 + ez**2) * dy * dz
+    if u_widths is not None and v_widths is not None:
+        dA = np.asarray(u_widths)[:, None] * np.asarray(v_widths)[None, :]
+        power = float(np.sum((ey**2 + ez**2) * dA))
+    else:
+        dy = y_coords[1] - y_coords[0] if len(y_coords) > 1 else a
+        dz = z_coords[1] - z_coords[0] if len(z_coords) > 1 else b
+        power = np.sum(ey**2 + ez**2) * dy * dz
     if power > 0:
         norm = np.sqrt(power)
         ey /= norm
@@ -177,6 +190,9 @@ def _te_mode_profiles(a: float, b: float, m: int, n: int,
 
 def _tm_mode_profiles(a: float, b: float, m: int, n: int,
                       y_coords: np.ndarray, z_coords: np.ndarray,
+                      *,
+                      u_widths: np.ndarray | None = None,
+                      v_widths: np.ndarray | None = None,
                       ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Compute TM_mn E and H transverse mode profiles.
 
@@ -197,9 +213,13 @@ def _tm_mode_profiles(a: float, b: float, m: int, n: int,
     hy = -ez.copy()
     hz = ey.copy()
 
-    dy = y_coords[1] - y_coords[0] if len(y_coords) > 1 else a
-    dz = z_coords[1] - z_coords[0] if len(z_coords) > 1 else b
-    power = np.sum(ey**2 + ez**2) * dy * dz
+    if u_widths is not None and v_widths is not None:
+        dA = np.asarray(u_widths)[:, None] * np.asarray(v_widths)[None, :]
+        power = float(np.sum((ey**2 + ez**2) * dA))
+    else:
+        dy = y_coords[1] - y_coords[0] if len(y_coords) > 1 else a
+        dz = z_coords[1] - z_coords[0] if len(z_coords) > 1 else b
+        power = np.sum(ey**2 + ez**2) * dy * dz
     if power > 0:
         norm = np.sqrt(power)
         ey /= norm
@@ -218,7 +238,7 @@ def cutoff_frequency(a: float, b: float, m: int, n: int) -> float:
 
 def init_waveguide_port(
     port: WaveguidePort,
-    dx: float,
+    dx,
     freqs: jnp.ndarray,
     f0: float = 5e9,
     bandwidth: float = 0.5,
@@ -233,11 +253,21 @@ def init_waveguide_port(
 
     Parameters
     ----------
+    dx : float or grid
+        Either a scalar Yee cell size (uniform grid path) or a Grid-like
+        object exposing per-axis cell-width arrays. NonUniformGrid is
+        supported via duck-typing on ``dx_arr``/``dy_arr``/``dz``.
     probe_offset : int
         Cells downstream from source for measurement probe.
     ref_offset : int
         Cells downstream from source for reference probe.
     """
+    # Duck-type: if `dx` looks like a grid (has dx_arr / dz arrays),
+    # use per-axis widths slicing the aperture; else assume scalar dx.
+    grid_obj = None
+    if hasattr(dx, "dx_arr") and hasattr(dx, "dz"):
+        grid_obj = dx
+        dx = float(grid_obj.dx)
     m, n = port.mode
     normal_axis = port.normal_axis
     if normal_axis not in ("x", "y", "z"):
@@ -265,13 +295,41 @@ def init_waveguide_port(
     nu_port = u_hi - u_lo
     nv_port = v_hi - v_lo
 
-    u_coords = np.linspace(0.5 * dx, port.a - 0.5 * dx, nu_port)
-    v_coords = np.linspace(0.5 * dx, port.b - 0.5 * dx, nv_port)
+    # --- Per-axis cell widths covering the transverse aperture ---
+    # The mapping (u,v) → (x,y,z) depends on normal_axis and is the same
+    # one used by `_plane_indexer`.
+    if grid_obj is not None:
+        dx_arr_np = np.asarray(grid_obj.dx_arr)
+        dy_arr_np = np.asarray(grid_obj.dy_arr)
+        dz_arr_np = np.asarray(grid_obj.dz)
+        if normal_axis == "x":
+            u_widths_np = dy_arr_np[u_lo:u_hi]
+            v_widths_np = dz_arr_np[v_lo:v_hi]
+        elif normal_axis == "y":
+            u_widths_np = dx_arr_np[u_lo:u_hi]
+            v_widths_np = dz_arr_np[v_lo:v_hi]
+        else:  # z-normal
+            u_widths_np = dx_arr_np[u_lo:u_hi]
+            v_widths_np = dy_arr_np[u_lo:u_hi] if False else dy_arr_np[v_lo:v_hi]
+    else:
+        u_widths_np = np.full(nu_port, float(dx))
+        v_widths_np = np.full(nv_port, float(dx))
+
+    # Cell-centre coordinates (cumulative-sum midpoints). For uniform
+    # widths this collapses to the original `np.linspace(0.5*dx, ...)`.
+    u_coords = np.cumsum(u_widths_np) - 0.5 * u_widths_np
+    v_coords = np.cumsum(v_widths_np) - 0.5 * v_widths_np
 
     if port.mode_type == "TE":
-        ey, ez, hy, hz = _te_mode_profiles(port.a, port.b, m, n, u_coords, v_coords)
+        ey, ez, hy, hz = _te_mode_profiles(
+            port.a, port.b, m, n, u_coords, v_coords,
+            u_widths=u_widths_np, v_widths=v_widths_np,
+        )
     else:
-        ey, ez, hy, hz = _tm_mode_profiles(port.a, port.b, m, n, u_coords, v_coords)
+        ey, ez, hy, hz = _tm_mode_profiles(
+            port.a, port.b, m, n, u_coords, v_coords,
+            u_widths=u_widths_np, v_widths=v_widths_np,
+        )
 
     f_c = cutoff_frequency(port.a, port.b, m, n)
 
@@ -282,8 +340,29 @@ def init_waveguide_port(
     ref_x = port.x_index + step_sign * ref_offset
     probe_x = port.x_index + step_sign * probe_offset
     source_x_m = float(port.x_position) if port.x_position is not None else float(port.x_index * dx)
-    reference_x_m = source_x_m + step_sign * ref_offset * dx
-    probe_x_m = source_x_m + step_sign * probe_offset * dx
+    # For NU grids, integrate the actual per-cell spacing along the port-normal
+    # axis from the source plane to the reference / probe planes. For the
+    # uniform path this reduces to offset * dx bit-identically.
+    if grid_obj is not None:
+        if normal_axis == "x":
+            d_axis = np.asarray(grid_obj.dx_arr)
+        elif normal_axis == "y":
+            d_axis = np.asarray(grid_obj.dy_arr)
+        else:
+            d_axis = np.asarray(grid_obj.dz)
+
+        def _cum_offset(from_idx: int, to_idx: int) -> float:
+            if to_idx == from_idx:
+                return 0.0
+            lo = min(from_idx, to_idx)
+            hi = max(from_idx, to_idx)
+            return float(np.sum(d_axis[lo:hi])) * (1.0 if to_idx > from_idx else -1.0)
+
+        reference_x_m = source_x_m + _cum_offset(port.x_index, ref_x)
+        probe_x_m = source_x_m + _cum_offset(port.x_index, probe_x)
+    else:
+        reference_x_m = source_x_m + step_sign * ref_offset * dx
+        probe_x_m = source_x_m + step_sign * probe_offset * dx
 
     if normal_axis == "x":
         e_u_component, e_v_component = "ey", "ez"
@@ -335,6 +414,8 @@ def init_waveguide_port(
         f_cutoff=float(f_c),
         a=port.a, b=port.b,
         dx=float(dx),
+        u_widths=jnp.asarray(u_widths_np, dtype=jnp.float32),
+        v_widths=jnp.asarray(v_widths_np, dtype=jnp.float32),
         source_x_m=float(source_x_m),
         reference_x_m=float(reference_x_m),
         probe_x_m=float(probe_x_m),
@@ -395,12 +476,18 @@ def inject_waveguide_port(state, cfg: WaveguidePortConfig,
     return state._replace(**{cfg.e_u_component: field_u, cfg.e_v_component: field_v})
 
 
+def _aperture_dA(cfg: WaveguidePortConfig) -> jnp.ndarray:
+    """Per-cell area element (nu, nv) on the port aperture."""
+    return cfg.u_widths[:, None] * cfg.v_widths[None, :]
+
+
 def modal_voltage(state, cfg: WaveguidePortConfig, x_idx: int,
                   dx: float) -> jnp.ndarray:
     """Modal voltage: V = integral E_t . e_mode dA."""
     e_u_sim = _plane_field(getattr(state, cfg.e_u_component), cfg, x_idx)
     e_v_sim = _plane_field(getattr(state, cfg.e_v_component), cfg, x_idx)
-    return jnp.sum(e_u_sim * cfg.ey_profile + e_v_sim * cfg.ez_profile) * dx * dx
+    dA = _aperture_dA(cfg)
+    return jnp.sum((e_u_sim * cfg.ey_profile + e_v_sim * cfg.ez_profile) * dA)
 
 
 def modal_current(state, cfg: WaveguidePortConfig, x_idx: int,
@@ -412,7 +499,8 @@ def modal_current(state, cfg: WaveguidePortConfig, x_idx: int,
     """
     h_u_sim = _plane_h_field(getattr(state, cfg.h_u_component), cfg, x_idx)
     h_v_sim = _plane_h_field(getattr(state, cfg.h_v_component), cfg, x_idx)
-    return jnp.sum(h_u_sim * cfg.hy_profile + h_v_sim * cfg.hz_profile) * dx * dx
+    dA = _aperture_dA(cfg)
+    return jnp.sum((h_u_sim * cfg.hy_profile + h_v_sim * cfg.hz_profile) * dA)
 
 
 def mode_self_overlap(cfg: WaveguidePortConfig, dx: float) -> float:
@@ -423,7 +511,8 @@ def mode_self_overlap(cfg: WaveguidePortConfig, dx: float) -> float:
     """
     cross = (cfg.ey_profile * cfg.hz_profile
              - cfg.ez_profile * cfg.hy_profile)
-    return float(jnp.sum(cross) * dx * dx)
+    dA = _aperture_dA(cfg)
+    return float(jnp.sum(cross * dA))
 
 
 def overlap_modal_amplitude(
@@ -448,10 +537,11 @@ def overlap_modal_amplitude(
     h_u_sim = _plane_h_field(getattr(state, cfg.h_u_component), cfg, x_idx)
     h_v_sim = _plane_h_field(getattr(state, cfg.h_v_component), cfg, x_idx)
 
+    dA = _aperture_dA(cfg)
     # P1 = ∫ (E_sim × H_mode) · n̂ dA
-    p1 = jnp.sum(e_u_sim * cfg.hz_profile - e_v_sim * cfg.hy_profile) * dx * dx
+    p1 = jnp.sum((e_u_sim * cfg.hz_profile - e_v_sim * cfg.hy_profile) * dA)
     # P2 = ∫ (E_mode × H_sim) · n̂ dA
-    p2 = jnp.sum(cfg.ey_profile * h_v_sim - cfg.ez_profile * h_u_sim) * dx * dx
+    p2 = jnp.sum((cfg.ey_profile * h_v_sim - cfg.ez_profile * h_u_sim) * dA)
 
     c_mode = mode_self_overlap(cfg, dx)
     safe_c = max(abs(c_mode), 1e-30)
@@ -1270,16 +1360,16 @@ def _overlap_cross_products(
 
     Returns (P1, P2) as scalars.
     """
-    dA = dx * dx
+    dA = _aperture_dA(cfg)
     e_u_sim = _plane_field(getattr(state, cfg.e_u_component), cfg, x_idx)
     e_v_sim = _plane_field(getattr(state, cfg.e_v_component), cfg, x_idx)
     h_u_sim = _plane_h_field(getattr(state, cfg.h_u_component), cfg, x_idx)
     h_v_sim = _plane_h_field(getattr(state, cfg.h_v_component), cfg, x_idx)
 
     # P1 = ∫(eu_sim * hv_mode - ev_sim * hu_mode) dA
-    p1 = jnp.sum(e_u_sim * cfg.hz_profile - e_v_sim * cfg.hy_profile) * dA
+    p1 = jnp.sum((e_u_sim * cfg.hz_profile - e_v_sim * cfg.hy_profile) * dA)
     # P2 = ∫(eu_mode * hv_sim - ev_mode * hu_sim) dA
-    p2 = jnp.sum(cfg.ey_profile * h_v_sim - cfg.ez_profile * h_u_sim) * dA
+    p2 = jnp.sum((cfg.ey_profile * h_v_sim - cfg.ez_profile * h_u_sim) * dA)
 
     return p1, p2
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -973,14 +973,6 @@ def test_validation_errors():
     with pytest.raises(ValueError, match="boundary='upml'"):
         Simulation(freq_max=5e9, domain=(0.03, 0.03, 0.03), boundary="upml", solver="adi")
 
-    with pytest.raises(ValueError, match="dz_profile"):
-        Simulation(
-            freq_max=5e9,
-            domain=(0.03, 0.03, 0.003),
-            boundary="upml",
-            dz_profile=np.array([1e-3, 1e-3, 1e-3]),
-        )
-
     sim = Simulation(freq_max=5e9, domain=(0.03, 0.03, 0.03))
     with pytest.raises(ValueError, match="component"):
         sim.add_port((0.01, 0.01, 0.01), "bz")

--- a/tests/test_directivity_gradient.py
+++ b/tests/test_directivity_gradient.py
@@ -1,0 +1,78 @@
+"""Regression test for issue #32: maximize_directivity gradient non-zero.
+
+Prior to the ratio-based fix, `maximize_directivity` used absolute
+|E|^2 at the target direction (~1e-27 in rfx's spectral NTFF
+convention), which produced zero gradient in `topology_optimize`.
+
+The ratio-based formulation U(target)/P_rad is scale-invariant and
+must give a non-zero gradient through the NTFF accumulation.
+"""
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from rfx.grid import Grid
+from rfx.core.yee import init_materials
+from rfx.sources.sources import GaussianPulse
+from rfx.simulation import make_source, run
+from rfx.farfield import make_ntff_box
+from rfx.optimize_objectives import (
+    maximize_directivity,
+    maximize_directivity_ratio,
+)
+
+
+def _forward(eps_scale: jnp.ndarray):
+    """Minimal NTFF-enabled forward that is jax.grad-compatible."""
+    grid = Grid(freq_max=5e9, domain=(0.02, 0.02, 0.02), cpml_layers=0)
+    materials_base = init_materials(grid.shape)
+    # Scale eps_r by a scalar — gradient target.
+    materials = materials_base._replace(eps_r=materials_base.eps_r * eps_scale)
+
+    pulse = GaussianPulse(f0=3e9, bandwidth=0.5)
+    src = make_source(grid, (0.01, 0.01, 0.01), "ez", pulse, 30)
+    ntff = make_ntff_box(
+        grid,
+        (0.003, 0.003, 0.003),
+        (0.017, 0.017, 0.017),
+        freqs=jnp.array([3e9]),
+    )
+    return run(grid, materials, 30, sources=[src], ntff=ntff)
+
+
+def test_maximize_directivity_alias():
+    assert maximize_directivity_ratio is maximize_directivity
+
+
+def test_maximize_directivity_gradient_nonzero():
+    """Gradient of the directivity objective w.r.t. a scalar eps scale
+    must be non-trivially non-zero.
+
+    This pins the fix for issue #32: the absolute-power objective
+    returned ~1e-27 values and 0.0 gradients; the ratio-based one
+    should give |dD/dα| >> 1e-12 in single precision.
+    """
+    obj = maximize_directivity(theta_target=np.pi / 2, phi_target=0.0)
+
+    def loss(alpha):
+        return obj(_forward(alpha))
+
+    value = float(loss(jnp.array(1.0)))
+    assert np.isfinite(value)
+    assert value < 0.0, "objective sign: -directivity should be < 0"
+
+    grad = float(jax.grad(loss)(jnp.array(1.0)))
+    assert np.isfinite(grad)
+    # The ratio is scale-invariant, so d/dα exactly 1.0 is a pathological
+    # case — what matters is that the path through NTFF keeps producing a
+    # meaningful, finite gradient at other probe points.
+    grad_off = float(jax.grad(loss)(jnp.array(1.2)))
+    assert np.isfinite(grad_off)
+    # Combined magnitude must exceed the float32 noise floor (~1e-7).
+    assert abs(grad) + abs(grad_off) > 1e-6, (
+        f"directivity gradient collapsed to noise: grad(1.0)={grad:.2e}, "
+        f"grad(1.2)={grad_off:.2e} (issue #32 would show ~0.0)"
+    )

--- a/tests/test_distributed_nu_kernel.py
+++ b/tests/test_distributed_nu_kernel.py
@@ -1,0 +1,206 @@
+"""Unit tests for Phase B distributed_nu kernels.
+
+These are pure-python tests that do NOT require multiple devices — they
+exercise the slab-building helper and the local H update directly.
+"""
+
+import os
+# Force 2 virtual devices for the sharded tests in sibling file; also
+# harmless here because we don't actually create a mesh in this file.
+os.environ.setdefault(
+    "XLA_FLAGS", "--xla_force_host_platform_device_count=2")
+
+import numpy as np
+import jax.numpy as jnp
+import pytest
+
+from rfx.nonuniform import make_nonuniform_grid
+from rfx.core.yee import FDTDState, MaterialArrays, MU_0, update_h_nu
+from rfx.runners.distributed_nu import (
+    _build_sharded_inv_dx_arrays,
+    _update_h_local_nu,
+)
+
+
+def _graded_profile(n_physical, dx0, ratio=1.5):
+    """Return a 1-D profile of length n_physical with geometric grading
+    of `ratio` on one side, clamping both boundary cells to dx0 so the
+    make_nonuniform_grid CPML padding is valid."""
+    # Build non-uniform interior, then force both ends back to dx0 so
+    # the CPML boundary-value invariant holds.
+    prof = dx0 * ratio ** np.linspace(0, 1, n_physical)
+    prof[0] = dx0
+    prof[-1] = dx0
+    return prof
+
+
+def test_inv_dx_h_slab_boundary_matches_global():
+    """The last entry of each device's inv_dx_h slab must equal the
+    global inv_dx_h value straddling the slab seam."""
+    nz = 8
+    ny = 8
+    n_physical = 32
+    dx0 = 1e-3
+    dx_profile = _graded_profile(n_physical, dx0, ratio=1.5)
+    dz_profile = np.full(nz, dx0)
+    grid = make_nonuniform_grid(
+        (n_physical * dx0, ny * dx0), dz_profile, dx0,
+        cpml_layers=0,
+        dx_profile=dx_profile,
+    )
+
+    n_devices = 2
+    inv_dx_g, inv_dx_h_g, dx_padded = _build_sharded_inv_dx_arrays(
+        grid, n_devices, pad_x=0
+    )
+    nx = inv_dx_g.shape[0]
+    nx_per = nx // n_devices
+
+    # Replay the slab split from distributed_v2 (ghost=1)
+    ghost = 1
+    nx_local = nx_per + 2 * ghost
+    slabs = np.zeros((n_devices, nx_local), dtype=np.float32)
+    for d in range(n_devices):
+        lo, hi = d * nx_per, (d + 1) * nx_per
+        slabs[d, ghost:ghost + nx_per] = inv_dx_h_g[lo:hi]
+        if d > 0:
+            slabs[d, 0] = inv_dx_h_g[lo - 1]
+        if d < n_devices - 1:
+            slabs[d, -1] = inv_dx_h_g[hi]
+
+    # For device 0: the rightmost real cell (index ghost+nx_per-1 in slab)
+    # must equal inv_dx_h_g[nx_per - 1] — the global mean-spacing
+    # straddling the slab seam.
+    expected = inv_dx_h_g[nx_per - 1]
+    got = slabs[0, ghost + nx_per - 1]
+    assert np.isclose(got, expected), (
+        f"Device 0 seam-cell inv_dx_h = {got}, expected global "
+        f"inv_dx_h[{nx_per - 1}] = {expected}"
+    )
+    # Verify that this value is specifically 2 / (dx[nx_per-1] + dx[nx_per])
+    expected_analytic = 2.0 / (dx_padded[nx_per - 1] + dx_padded[nx_per])
+    assert np.isclose(got, expected_analytic, atol=1e-6), (
+        f"Seam inv_dx_h = {got}, analytic 2/(dx+dx') = {expected_analytic}"
+    )
+
+
+def test_update_h_nu_local_matches_global_interior():
+    """_update_h_local_nu on device-0 slab should match the global
+    update_h_nu on the unsharded tensor at interior real cells."""
+    nz = 8
+    ny = 8
+    n_physical = 16
+    dx0 = 1e-3
+    dx_profile = _graded_profile(n_physical, dx0, ratio=1.2)
+    dz_profile = np.full(nz, dx0)
+    grid = make_nonuniform_grid(
+        (n_physical * dx0, ny * dx0), dz_profile, dx0,
+        cpml_layers=0,
+        dx_profile=dx_profile,
+    )
+    nx = grid.nx
+    n_devices = 2
+    nx_per = nx // n_devices
+    ghost = 1
+    nx_local = nx_per + 2 * ghost
+
+    # Random-ish E fields
+    rng = np.random.default_rng(42)
+    ex = jnp.asarray(rng.standard_normal((nx, ny, nz)), dtype=jnp.float32)
+    ey = jnp.asarray(rng.standard_normal((nx, ny, nz)), dtype=jnp.float32)
+    ez = jnp.asarray(rng.standard_normal((nx, ny, nz)), dtype=jnp.float32)
+    zeros_xyz = jnp.zeros((nx, ny, nz), dtype=jnp.float32)
+    state = FDTDState(
+        ex=ex, ey=ey, ez=ez,
+        hx=zeros_xyz, hy=zeros_xyz, hz=zeros_xyz,
+        step=jnp.int32(0),
+    )
+    mats = MaterialArrays(
+        eps_r=jnp.ones((nx, ny, nz), dtype=jnp.float32),
+        sigma=jnp.zeros((nx, ny, nz), dtype=jnp.float32),
+        mu_r=jnp.ones((nx, ny, nz), dtype=jnp.float32),
+    )
+
+    # Global H update
+    global_h = update_h_nu(
+        state, mats, grid.dt,
+        grid.inv_dx_h, grid.inv_dy_h, grid.inv_dz_h,
+    )
+
+    # Device-0 slab (with ghost). Pick slab build identical to runner.
+    inv_dx_g, inv_dx_h_g, _ = _build_sharded_inv_dx_arrays(
+        grid, n_devices, pad_x=0)
+
+    def _slab_1d(arr, pad_value):
+        slabs = np.zeros((n_devices, nx_local), dtype=arr.dtype)
+        for d in range(n_devices):
+            lo, hi = d * nx_per, (d + 1) * nx_per
+            slabs[d, ghost:ghost + nx_per] = arr[lo:hi]
+            if d > 0:
+                slabs[d, 0] = arr[lo - 1]
+            else:
+                slabs[d, 0] = pad_value
+            if d < n_devices - 1:
+                slabs[d, -1] = arr[hi]
+            else:
+                slabs[d, -1] = pad_value
+        return slabs
+
+    idx_slab = _slab_1d(inv_dx_g, 1.0)
+    idxh_slab = _slab_1d(inv_dx_h_g, 0.0)
+
+    def _slab_field(arr):
+        out = np.zeros((n_devices, nx_local, ny, nz), dtype=np.float32)
+        for d in range(n_devices):
+            lo, hi = d * nx_per, (d + 1) * nx_per
+            out[d, ghost:ghost + nx_per] = np.asarray(arr)[lo:hi]
+            if d > 0:
+                out[d, 0] = np.asarray(arr)[lo - 1]
+            if d < n_devices - 1:
+                out[d, -1] = np.asarray(arr)[hi]
+        return out
+
+    ex_sl = _slab_field(ex)
+    ey_sl = _slab_field(ey)
+    ez_sl = _slab_field(ez)
+    z_sl = np.zeros_like(ex_sl)
+
+    d = 0
+    slab_state = FDTDState(
+        ex=jnp.asarray(ex_sl[d]),
+        ey=jnp.asarray(ey_sl[d]),
+        ez=jnp.asarray(ez_sl[d]),
+        hx=jnp.asarray(z_sl[d]),
+        hy=jnp.asarray(z_sl[d]),
+        hz=jnp.asarray(z_sl[d]),
+        step=jnp.int32(0),
+    )
+    slab_mats = MaterialArrays(
+        eps_r=jnp.ones((nx_local, ny, nz), dtype=jnp.float32),
+        sigma=jnp.zeros((nx_local, ny, nz), dtype=jnp.float32),
+        mu_r=jnp.ones((nx_local, ny, nz), dtype=jnp.float32),
+    )
+    slab_h = _update_h_local_nu(
+        slab_state, slab_mats, grid.dt,
+        jnp.asarray(idx_slab[d]),
+        grid.inv_dy, grid.inv_dz,
+        jnp.asarray(idxh_slab[d]),
+        grid.inv_dy_h, grid.inv_dz_h,
+    )
+
+    # Compare interior real cells (exclude ghost + the seam cell, which
+    # uses the global mean-spacing; this cell's forward-diff reaches
+    # into the ghost and should match the global reference via our
+    # inv_dx_h_h pad).
+    # Interior real cells in device 0: slab indices [ghost, ghost+nx_per-1).
+    # Last real cell (ghost+nx_per-1) uses inv_dx_h straddling the seam,
+    # matching global inv_dx_h[nx_per-1], so it should match too.
+    glob_slice = np.asarray(global_h.hz)[:nx_per]
+    slab_slice = np.asarray(slab_h.hz)[ghost:ghost + nx_per]
+    # Exclude last real cell where forward-diff pulls in the ghost ex/ey
+    # which are populated from arr[nx_per] (the global interior cell),
+    # so this must still match.
+    np.testing.assert_allclose(
+        slab_slice, glob_slice, atol=1e-5,
+        err_msg="device-0 H-z slab should match global interior H-z",
+    )

--- a/tests/test_distributed_nu_smoke.py
+++ b/tests/test_distributed_nu_smoke.py
@@ -1,0 +1,95 @@
+"""Phase B smoke test: distributed runner with a degenerate-uniform
+non-uniform grid must match the uniform 2-device baseline.
+
+Forces 2 virtual CPU devices via XLA_FLAGS (set BEFORE jax import).
+"""
+
+import os
+os.environ.setdefault(
+    "XLA_FLAGS", "--xla_force_host_platform_device_count=2")
+
+import numpy as np
+import pytest
+import jax
+
+pytestmark = pytest.mark.skipif(
+    jax.device_count() < 2,
+    reason=(
+        "Phase B distributed NU smoke requires >=2 devices. "
+        "Run with XLA_FLAGS=--xla_force_host_platform_device_count=2."
+    ),
+)
+
+from rfx import Simulation  # noqa: E402
+
+
+def _make_sim_nu():
+    """Build a NU-profiled simulation with a constant profile.
+
+    Using an explicit dx_profile guarantees nx = len(profile), which is
+    what the distributed NU path assumes. The uniform-reference sim is
+    built from the same profile so the two paths agree on shape.
+    """
+    nx, ny, nz = 32, 16, 16
+    dx = 1e-3
+    sim = Simulation(
+        freq_max=3e9,
+        domain=(nx * dx, ny * dx, nz * dx),
+        dx=dx,
+        boundary="pec",
+    )
+    sim._dx_profile = np.full(nx, dx)
+    sim._dy_profile = np.full(ny, dx)
+    sim._dz_profile = np.full(nz, dx)
+    return sim
+
+
+def test_degenerate_uniform_matches_single_device_nu():
+    """The distributed NU path with a degenerate-uniform profile should
+    match the single-device NU runner to machine precision. This is the
+    cleanest equivalence check because both paths share the NU kernel.
+
+    Source is placed in the interior of device 0 (global x-index < nx_per)
+    to avoid the known Phase B seam-injection staleness: the step order
+    is H → exch H → E → exch E → PEC → source, so a source injected at
+    the first cell of device d>0 is not seen by device d-1's H update
+    until the next-next step's exchange. Interior placement sidesteps
+    this.
+    """
+    devices = jax.devices()[:2]
+    n_steps = 40
+
+    sim_multi = _make_sim_nu()
+    sim_multi.add_source(position=(4e-3, 8e-3, 8e-3), component="ez")
+    sim_multi.add_probe(position=(8e-3, 8e-3, 8e-3), component="ez")
+    res_multi = sim_multi.run(n_steps=n_steps, devices=devices)
+
+    sim_single = _make_sim_nu()
+    sim_single.add_source(position=(4e-3, 8e-3, 8e-3), component="ez")
+    sim_single.add_probe(position=(8e-3, 8e-3, 8e-3), component="ez")
+    res_single = sim_single.run(n_steps=n_steps)
+
+    ts_multi = np.asarray(res_multi.time_series)
+    ts_single = np.asarray(res_single.time_series)
+    assert ts_multi.shape == ts_single.shape, (
+        f"shape mismatch: multi {ts_multi.shape} vs single {ts_single.shape}"
+    )
+    peak = np.max(np.abs(ts_single)) + 1e-30
+    rel_err = np.max(np.abs(ts_multi - ts_single)) / peak
+    assert rel_err < 1e-3, (
+        f"Distributed-NU vs single-NU rel_err={rel_err:.2e}"
+    )
+
+
+def test_distributed_nu_produces_nonzero_signal():
+    """Minimum viability: the NU distributed path must produce a
+    non-zero probe signal through a source injection."""
+    devices = jax.devices()[:2]
+    sim = _make_sim_nu()
+    sim.add_source(position=(16e-3, 8e-3, 8e-3), component="ez")
+    sim.add_probe(position=(16e-3, 8e-3, 8e-3), component="ez")
+    res = sim.run(n_steps=30, devices=devices)
+    ts = np.asarray(res.time_series).ravel()
+    assert np.max(np.abs(ts)) > 0, (
+        "probe signal is zero — NU distributed source not injected"
+    )

--- a/tests/test_inverse_design_preflight.py
+++ b/tests/test_inverse_design_preflight.py
@@ -1,0 +1,141 @@
+"""Tests for inverse-design preflight checks (issue #30).
+
+Covers the four new checks:
+  1. Tightened minimum-resolution thresholds (5 cells PEC / 10 cells dielectric)
+  2. NTFF ↔ PEC overlap (hard error)
+  3. NTFF near-field gap < λ/4 (warning)
+  4. AD memory estimate via ``sim.estimate_ad_memory`` / ``check_ad_memory``
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from rfx.api import Simulation, AD_MemoryEstimate
+from rfx.geometry.csg import Box
+
+
+C = 2.998e8
+
+
+def _sane_sim(freq_max=5e9, domain=(0.04, 0.04, 0.04)):
+    sim = Simulation(freq_max=freq_max, domain=domain, boundary="cpml",
+                     cpml_layers=8, dx=C / freq_max / 20.0)
+    sim.add_port((domain[0] / 2, domain[1] / 2, domain[2] / 2), "ez")
+    sim.add_probe((domain[0] / 2 + 2e-3, domain[1] / 2, domain[2] / 2), "ez")
+    return sim
+
+
+def test_ntff_pec_overlap_rejects():
+    """NTFF face crossing a PEC bbox must raise an error."""
+    sim = _sane_sim()
+    # PEC waveguide-like wall spanning z = 10..40 mm, large xy extent
+    sim.add(Box((0.005, 0.005, 0.010), (0.035, 0.035, 0.040)),
+                     material="pec")
+    # NTFF z_lo=24mm sits strictly inside the PEC z-range (10..40mm)
+    sim.add_ntff_box(
+        corner_lo=(0.010, 0.010, 0.024),
+        corner_hi=(0.030, 0.030, 0.035),
+        n_freqs=4,
+    )
+    # Either raises on strict=True or shows an ERROR entry in the report
+    with pytest.raises(ValueError, match="NTFF face"):
+        sim.preflight(strict=True)
+
+    issues = sim.preflight(strict=False)
+    assert any("NTFF face" in s and "PEC" in s for s in issues), issues
+
+
+def test_ntff_near_field_gap_warns():
+    """NTFF box 2 cells above a source should warn about λ/4 gap."""
+    freq_max = 5e9
+    dx = C / freq_max / 20.0  # 3 mm
+    sim = Simulation(freq_max=freq_max, domain=(0.04, 0.04, 0.04),
+                     boundary="cpml", cpml_layers=8, dx=dx)
+    src_z = 0.020
+    sim.add_port((0.020, 0.020, src_z), "ez")
+    sim.add_probe((0.025, 0.020, src_z), "ez")
+    # NTFF z_lo only 2 cells above the source — well below λ/4
+    sim.add_ntff_box(
+        corner_lo=(0.010, 0.010, src_z + 2 * dx),
+        corner_hi=(0.030, 0.030, src_z + 3 * dx),
+        n_freqs=4,
+    )
+    issues = sim.preflight(strict=False)
+    assert any("λ/4" in s or "lambda/4" in s.lower() or "near-field" in s
+               for s in issues), (
+        "Expected a λ/4 near-field warning, got: " + "\n".join(issues)
+    )
+
+
+def test_ad_memory_estimate_reasonable():
+    """40×40×40 @ 3GHz: estimate must be > 0 and < 10GB (checkpointed).
+    At n_steps=10000 the non-checkpointed value must be much larger.
+    """
+    freq_max = 3e9
+    dx = C / freq_max / 20.0
+    # Use a small physical domain to land at ~40 cells
+    extent = 40 * dx
+    sim = Simulation(freq_max=freq_max, domain=(extent, extent, extent),
+                     boundary="cpml", cpml_layers=6, dx=dx)
+    sim.add_port((extent / 2, extent / 2, extent / 2), "ez")
+    sim.add_probe((extent / 2 + dx, extent / 2, extent / 2), "ez")
+
+    est_small = sim.estimate_ad_memory(500, available_memory_gb=40.0)
+    assert isinstance(est_small, AD_MemoryEstimate)
+    assert est_small.forward_gb > 0
+    assert 0 < est_small.ad_checkpointed_gb < 10.0
+    # checkpoint ≪ full when n_steps is large
+    est_big = sim.estimate_ad_memory(10000, available_memory_gb=40.0)
+    assert est_big.ad_full_gb > 5 * est_big.ad_checkpointed_gb
+
+
+def test_preflight_passes_on_clean_setup():
+    """A sane patch-antenna-ish sim triggers no ERROR / NTFF warnings."""
+    freq_max = 5e9
+    dx = C / freq_max / 20.0
+    extent = 0.060
+    sim = Simulation(freq_max=freq_max, domain=(extent, extent, extent),
+                     boundary="cpml", cpml_layers=8, dx=dx)
+    # Ground plane well resolved (≥5 cells PEC)
+    sim.add(Box((0.010, 0.010, 0.010), (0.050, 0.050, 0.012)),
+                     material="pec")
+    sim.add_port((0.030, 0.030, 0.020), "ez")
+    sim.add_probe((0.032, 0.030, 0.020), "ez")
+    # NTFF box with generous λ/4 margins (λ_min = 60mm at 5GHz → margin > 15mm)
+    sim.add_ntff_box(
+        corner_lo=(0.005, 0.005, 0.040),
+        corner_hi=(0.055, 0.055, 0.055),
+        n_freqs=4,
+    )
+    issues = sim.preflight(strict=False)
+    # Filter to errors/NTFF/resolution issues we just added
+    bad = [s for s in issues
+           if s.startswith("ERROR:")
+           or "NTFF face" in s
+           or "λ/4" in s]
+    assert not bad, "Clean setup should not trip new checks: " + "\n".join(bad)
+
+
+def test_waveguide_resolution_warns():
+    """WR-90 narrow wall (10.16mm) at dx=2mm → ~5 cells for dielectric
+    air inside a WR-90-shaped dielectric box should trip the ≥10-cell
+    dielectric threshold."""
+    # We emulate the "narrow wall" as a dielectric box of the narrow-wall
+    # size so the dielectric ≥10 cells rule fires.
+    freq_max = 10e9
+    dx = 2e-3
+    sim = Simulation(freq_max=freq_max, domain=(0.05, 0.05, 0.05),
+                     boundary="cpml", cpml_layers=6, dx=dx)
+    sim.add_material("diel", eps_r=2.2)
+    # 10.16mm narrow-wall × 22.86mm broad-wall × 30mm length
+    sim.add(Box((0.010, 0.010, 0.010),
+                         (0.010 + 0.01016, 0.010 + 0.02286, 0.040)),
+                     material="diel")
+    sim.add_port((0.015, 0.020, 0.025), "ez")
+    sim.add_probe((0.018, 0.020, 0.025), "ez")
+    issues = sim.preflight(strict=False)
+    assert any("under-resolved" in s and "dielectric" in s for s in issues), \
+        "Expected a dielectric under-resolution warning: " + "\n".join(issues)

--- a/tests/test_nonuniform_api.py
+++ b/tests/test_nonuniform_api.py
@@ -156,19 +156,47 @@ class TestSimulationNonUniform:
         with pytest.raises(ValueError, match="NTFF far-field is not supported"):
             sim.run(n_steps=20)
 
-    def test_nonuniform_rejects_dft_plane_probe(self):
+    def test_nonuniform_dft_plane_probe_accumulates(self):
+        """DFT plane probe runs on NU mesh and accumulates with step count.
+
+        Accumulation is monotonic for a finite-bandwidth source, so the
+        |DFT| magnitude at 200 steps must exceed the magnitude at 100
+        steps. Also asserts the plane is finite and non-zero.
+        """
         dz = np.array([0.4e-3] * 4 + [0.5e-3] * 5)
-        sim = Simulation(
-            freq_max=5e9,
-            domain=(0.02, 0.02, 0.01),
-            dx=0.5e-3,
-            dz_profile=dz,
-            boundary="cpml",
-        )
-        sim.add_source((0.01, 0.01, 0.001), "ez")
-        sim.add_dft_plane_probe(axis="x", coordinate=0.01)
-        with pytest.raises(ValueError, match="DFT plane probes are not supported"):
-            sim.run(n_steps=20)
+
+        def _run(n_steps: int):
+            sim = Simulation(
+                freq_max=5e9,
+                domain=(0.02, 0.02, 0.01),
+                dx=0.5e-3,
+                dz_profile=dz,
+                boundary="upml",
+            )
+            sim.add_source((0.01, 0.01, 0.005), "ez")
+            sim.add_dft_plane_probe(
+                axis="z", coordinate=0.005, component="ez",
+                freqs=jnp.asarray([2.4e9]),
+                name="mid_xy",
+            )
+            return sim.run(n_steps=n_steps)
+
+        r100 = _run(100)
+        r200 = _run(200)
+
+        # (a) dft_planes is present and non-empty
+        assert r200.dft_planes is not None
+        assert "mid_xy" in r200.dft_planes
+
+        acc200 = np.asarray(r200.dft_planes["mid_xy"].accumulator)
+        acc100 = np.asarray(r100.dft_planes["mid_xy"].accumulator)
+
+        # (b) finite and non-zero
+        assert np.all(np.isfinite(acc200))
+        assert np.max(np.abs(acc200)) > 0.0
+
+        # (c) longer run → larger |accumulator|
+        assert np.max(np.abs(acc200)) > np.max(np.abs(acc100))
 
     def test_nonuniform_rejects_tfsf(self):
         dz = np.array([0.4e-3] * 4 + [0.5e-3] * 5)

--- a/tests/test_nonuniform_api.py
+++ b/tests/test_nonuniform_api.py
@@ -110,6 +110,21 @@ class TestSimulationNonUniform:
         ts = np.asarray(result.time_series)
         assert ts.shape[0] == 20
 
+    def test_nonuniform_rejects_distributed(self):
+        """devices>1 + nonuniform used to drop profile silently — now raises."""
+        import jax
+        if len(jax.devices()) < 2:
+            pytest.skip("requires >=2 devices")
+        dz = np.array([0.4e-3] * 4 + [0.5e-3] * 5)
+        sim = Simulation(
+            freq_max=5e9, domain=(0.02, 0.02, 0.01),
+            dx=0.5e-3, dz_profile=dz, cpml_layers=8, boundary="cpml",
+        )
+        sim.add_source((0.01, 0.01, 0.001), "ez")
+        with pytest.raises(ValueError, match="distributed multi-device"):
+            sim.run(n_steps=10, devices=jax.devices()[:2],
+                    compute_s_params=False)
+
     def test_nonuniform_upml_smoke(self):
         """boundary='upml' accepts a nonuniform dz_profile and stays stable.
 

--- a/tests/test_nonuniform_api.py
+++ b/tests/test_nonuniform_api.py
@@ -250,19 +250,92 @@ class TestSimulationNonUniform:
         with pytest.raises(ValueError, match="TFSF plane-wave source is not supported"):
             sim.run(n_steps=20, compute_s_params=False)
 
-    def test_nonuniform_rejects_waveguide_ports(self):
-        dz = np.array([0.4e-3] * 4 + [0.5e-3] * 12)
-        sim = Simulation(
-            freq_max=10e9,
-            domain=(0.12, 0.04, 0.02),
-            boundary="cpml",
-            cpml_layers=10,
-            dx=0.002,
-            dz_profile=dz,
+    def test_nonuniform_waveguide_port_extracts_s11(self):
+        """Waveguide port runs on a NU dz mesh and produces a finite S11.
+
+        Uses a y-normal port on an x-z plane (the typical patch-antenna
+        geometry). The aperture spans x (uniform) and z (nonuniform),
+        which exercises the per-axis cell-width path.
+
+        Sanity bands:
+          (a) no exception
+          (b) |S11| finite and within [0, 1.05]
+          (c) NU result agrees with uniform reference (dz_profile = full(nz, dz_mean))
+              within 5% (degenerate NU == uniform)
+        """
+        a_wg = 0.04          # aperture along x
+        b_wg = 0.02          # aperture along z (the NU axis)
+        length = 0.06        # along y
+        dx = 0.002
+
+        # Uniform reference: dz = dx everywhere
+        nz_total = int(round(b_wg / dx))
+        dz_uniform = np.full(nz_total, float(dx))
+
+        # Degenerate-uniform NU profile (dz = dx everywhere) — used for
+        # a bit-close agreement check against the uniform reference.
+        dz_nu = np.full(nz_total, float(dx))
+
+        # f0 above TE10 cutoff (cutoff = c / (2*a))
+        from rfx.grid import C0 as _C0
+        f_c = _C0 / (2 * a_wg)
+        f0 = f_c * 1.6
+        freqs = jnp.linspace(f_c * 1.3, f_c * 2.2, 8)
+
+        def _build(dz_profile):
+            sim = Simulation(
+                freq_max=float(freqs[-1]) * 1.2,
+                domain=(a_wg, length, b_wg),
+                boundary="cpml",
+                cpml_layers=8,
+                dx=dx,
+                dz_profile=dz_profile,
+            )
+            sim.add_waveguide_port(
+                x_position=0.005,           # 5 mm into y from the -y face
+                direction="+y",
+                x_range=(0.0, a_wg),
+                z_range=(0.0, b_wg),
+                f0=f0,
+                bandwidth=0.5,
+                freqs=freqs,
+                probe_offset=10,
+                ref_offset=3,
+                name="p1",
+            )
+            return sim
+
+        sim_nu = _build(dz_nu)
+        sim_ref = _build(dz_uniform)
+
+        n_steps = 200
+        try:
+            res_nu = sim_nu.run(n_steps=n_steps, compute_s_params=False)
+            res_ref = sim_ref.run(n_steps=n_steps, compute_s_params=False)
+        except ValueError as exc:
+            # Aperture-on-NU edge cases that don't relate to the integral
+            # math should be flagged but not silently passed. Re-raise.
+            raise
+
+        assert res_nu.waveguide_sparams is not None, "NU path must surface waveguide_sparams"
+        assert "p1" in res_nu.waveguide_sparams
+        s11_nu = res_nu.waveguide_sparams["p1"].s11
+        s11_ref = res_ref.waveguide_sparams["p1"].s11
+
+        assert np.all(np.isfinite(s11_nu)), f"|S11| not finite: {s11_nu}"
+        s11_nu_mag = np.abs(s11_nu)
+        assert np.all(s11_nu_mag >= 0.0)
+        assert np.all(s11_nu_mag <= 1.05), f"|S11| exceeds 1.05: {s11_nu_mag}"
+
+        # Degenerate NU == uniform (both use dx everywhere).
+        # Compare the spectrum element-wise; allow 5% absolute tolerance
+        # on |S11|.
+        s11_ref_mag = np.abs(s11_ref)
+        diff = np.abs(s11_nu_mag - s11_ref_mag)
+        assert np.max(diff) < 0.05, (
+            f"NU |S11| disagrees with uniform reference: max|diff|={np.max(diff):.4f}, "
+            f"NU={s11_nu_mag}, REF={s11_ref_mag}"
         )
-        sim.add_waveguide_port(0.01)
-        with pytest.raises(ValueError, match="Waveguide ports are not supported"):
-            sim.run(n_steps=20, compute_s_params=False)
 
     def test_nonuniform_lumped_rlc_resistor_damps_source(self):
         """A resistor in the fine-dz region must dissipate energy.

--- a/tests/test_nonuniform_api.py
+++ b/tests/test_nonuniform_api.py
@@ -138,23 +138,61 @@ class TestSimulationNonUniform:
             f"early peak {peak:.3e} — UPML sourcing energy"
         )
 
-    def test_nonuniform_rejects_ntff(self):
+    def test_nonuniform_ntff_box_accumulates(self):
+        """NTFF box accumulates on NU mesh and yields finite far-field.
+
+        Runs an ez dipole inside the box on a graded-dz UPML domain
+        for 150 steps. Asserts: (a) result exposes ntff_data/ntff_box,
+        (b) all 6 face accumulators are finite and at least one has
+        non-zero magnitude, (c) compute_far_field returns a finite
+        far-field at a small angular sample without raising.
+        """
+        from rfx.farfield import compute_far_field
+
         dz = np.array([0.4e-3] * 4 + [0.5e-3] * 5)
         sim = Simulation(
             freq_max=5e9,
             domain=(0.02, 0.02, 0.01),
             dx=0.5e-3,
             dz_profile=dz,
-            boundary="cpml",
+            boundary="upml",
         )
-        sim.add_source((0.01, 0.01, 0.001), "ez")
+        sim.add_source((0.01, 0.01, 0.004), "ez")
         sim.add_ntff_box(
-            corner_lo=(0.002, 0.002, 0.001),
-            corner_hi=(0.018, 0.018, 0.004),
+            corner_lo=(0.004, 0.004, 0.002),
+            corner_hi=(0.016, 0.016, 0.006),
             freqs=[2.4e9],
         )
-        with pytest.raises(ValueError, match="NTFF far-field is not supported"):
-            sim.run(n_steps=20)
+        result = sim.run(n_steps=150, compute_s_params=False)
+
+        # (a) both NTFF attributes are populated on NU path
+        assert result.ntff_data is not None
+        assert result.ntff_box is not None
+
+        face_arrays = [
+            np.asarray(result.ntff_data.x_lo),
+            np.asarray(result.ntff_data.x_hi),
+            np.asarray(result.ntff_data.y_lo),
+            np.asarray(result.ntff_data.y_hi),
+            np.asarray(result.ntff_data.z_lo),
+            np.asarray(result.ntff_data.z_hi),
+        ]
+
+        # (b) every face accumulator is finite; at least one is non-zero
+        assert all(np.all(np.isfinite(f)) for f in face_arrays)
+        assert any(np.max(np.abs(f)) > 0 for f in face_arrays), (
+            "all 6 NTFF face accumulators stayed zero — scan never wrote"
+        )
+
+        # (c) far-field post-processing must run cleanly on NU grid
+        theta = np.array([np.pi / 2])
+        phi = np.array([0.0, np.pi / 2])
+        ff = compute_far_field(
+            result.ntff_data, result.ntff_box, result.grid, theta, phi,
+        )
+        assert np.all(np.isfinite(ff.E_theta))
+        assert np.all(np.isfinite(ff.E_phi))
+        assert (np.max(np.abs(ff.E_theta)) + np.max(np.abs(ff.E_phi))) > 0
 
     def test_nonuniform_dft_plane_probe_accumulates(self):
         """DFT plane probe runs on NU mesh and accumulates with step count.

--- a/tests/test_nonuniform_api.py
+++ b/tests/test_nonuniform_api.py
@@ -226,19 +226,59 @@ class TestSimulationNonUniform:
         with pytest.raises(ValueError, match="Waveguide ports are not supported"):
             sim.run(n_steps=20, compute_s_params=False)
 
-    def test_nonuniform_rejects_lumped_rlc(self):
+    def test_nonuniform_lumped_rlc_resistor_damps_source(self):
+        """A resistor in the fine-dz region must dissipate energy.
+
+        Runs the same NU configuration twice — once with a parallel
+        50 Ω resistor co-located with the source, once without — and
+        confirms the peak probe amplitude is strictly lower with the
+        resistor present.
+        """
         dz = np.array([0.4e-3] * 4 + [0.5e-3] * 5)
-        sim = Simulation(
-            freq_max=5e9,
-            domain=(0.02, 0.02, 0.01),
-            dx=0.5e-3,
-            dz_profile=dz,
-            boundary="cpml",
+        domain = (0.02, 0.02, 0.01)
+        src_pos = (0.01, 0.01, 0.001)  # inside the fine-dz region
+
+        def _build(with_r: bool):
+            sim = Simulation(
+                freq_max=5e9,
+                domain=domain,
+                dx=0.5e-3,
+                dz_profile=dz,
+                boundary="upml",
+            )
+            sim.add_source(
+                src_pos, "ez",
+                waveform=GaussianPulse(f0=2.5e9, bandwidth=0.8),
+            )
+            sim.add_probe(src_pos, "ez")
+            if with_r:
+                sim.add_lumped_rlc(
+                    position=src_pos, component="ez",
+                    R=50.0, L=0.0, C=0.0, topology="parallel",
+                )
+            return sim
+
+        sim_free = _build(with_r=False)
+        sim_rlc = _build(with_r=True)
+
+        res_free = sim_free.run(n_steps=300)
+        res_rlc = sim_rlc.run(n_steps=300)
+
+        ts_free = np.asarray(res_free.time_series).reshape(-1)
+        ts_rlc = np.asarray(res_rlc.time_series).reshape(-1)
+
+        peak_free = float(np.max(np.abs(ts_free)))
+        peak_rlc = float(np.max(np.abs(ts_rlc)))
+
+        assert np.all(np.isfinite(ts_free))
+        assert np.all(np.isfinite(ts_rlc))
+        assert peak_free > 0
+        assert peak_rlc > 0
+        # The resistor must damp the on-cell field response.
+        assert peak_rlc < peak_free, (
+            f"expected R=50Ω to damp the probe peak; "
+            f"got peak_rlc={peak_rlc:.3e} vs peak_free={peak_free:.3e}"
         )
-        sim.add_source((0.01, 0.01, 0.001), "ez")
-        sim.add_lumped_rlc(position=(0.01, 0.01, 0.001), component="ez", R=50.0)
-        with pytest.raises(ValueError, match="Lumped RLC elements are not supported"):
-            sim.run(n_steps=20)
 
 
 class TestAutoConfigNonUniform:

--- a/tests/test_nonuniform_api.py
+++ b/tests/test_nonuniform_api.py
@@ -110,21 +110,6 @@ class TestSimulationNonUniform:
         ts = np.asarray(result.time_series)
         assert ts.shape[0] == 20
 
-    def test_nonuniform_rejects_distributed(self):
-        """devices>1 + nonuniform used to drop profile silently — now raises."""
-        import jax
-        if len(jax.devices()) < 2:
-            pytest.skip("requires >=2 devices")
-        dz = np.array([0.4e-3] * 4 + [0.5e-3] * 5)
-        sim = Simulation(
-            freq_max=5e9, domain=(0.02, 0.02, 0.01),
-            dx=0.5e-3, dz_profile=dz, cpml_layers=8, boundary="cpml",
-        )
-        sim.add_source((0.01, 0.01, 0.001), "ez")
-        with pytest.raises(ValueError, match="distributed multi-device"):
-            sim.run(n_steps=10, devices=jax.devices()[:2],
-                    compute_s_params=False)
-
     def test_nonuniform_upml_smoke(self):
         """boundary='upml' accepts a nonuniform dz_profile and stays stable.
 

--- a/tests/test_nonuniform_api.py
+++ b/tests/test_nonuniform_api.py
@@ -236,7 +236,14 @@ class TestSimulationNonUniform:
         # (c) longer run → larger |accumulator|
         assert np.max(np.abs(acc200)) > np.max(np.abs(acc100))
 
-    def test_nonuniform_rejects_tfsf(self):
+    def test_nonuniform_tfsf_x_incidence_accumulates(self):
+        """TFSF +x plane-wave runs on an NU dz mesh and excites fields.
+
+        The 1D auxiliary grid runs along the uniform x axis (scalar
+        grid.dx), so no aux-grid refactor is required — the usual
+        init_tfsf / apply_tfsf_e / apply_tfsf_h / update_tfsf_1d_*
+        machinery works unchanged on NU.
+        """
         dz = np.array([0.4e-3] * 4 + [0.5e-3] * 5)
         sim = Simulation(
             freq_max=8e9,
@@ -246,8 +253,34 @@ class TestSimulationNonUniform:
             dx=0.001,
             dz_profile=dz,
         )
-        sim.add_tfsf_source(f0=4e9, bandwidth=0.5, amplitude=1.0, margin=3)
-        with pytest.raises(ValueError, match="TFSF plane-wave source is not supported"):
+        sim.add_tfsf_source(
+            f0=4e9, bandwidth=0.5, amplitude=1.0, margin=3,
+            polarization="ez", direction="+x",
+        )
+        # Probe inside the total-field region, in vacuum (no scatterer).
+        sim.add_probe((0.04, 0.003, 0.0025), "ez")
+        r = sim.run(n_steps=200, compute_s_params=False)
+        ts = np.asarray(r.time_series[:, 0])
+        assert np.all(np.isfinite(ts))
+        assert np.max(np.abs(ts)) > 0.0
+        # No late-time exponential blow-up.
+        assert np.max(np.abs(ts[-20:])) < 2.0 * np.max(np.abs(ts))
+
+    def test_nonuniform_tfsf_oblique_rejected(self):
+        """Oblique TFSF (angle_deg != 0) is rejected on NU with a clear message."""
+        dz = np.array([0.4e-3] * 4 + [0.5e-3] * 5)
+        sim = Simulation(
+            freq_max=8e9,
+            domain=(0.08, 0.006, 0.006),
+            boundary="cpml",
+            cpml_layers=8,
+            dx=0.001,
+            dz_profile=dz,
+        )
+        sim.add_tfsf_source(
+            f0=4e9, bandwidth=0.5, amplitude=1.0, margin=3, angle_deg=30.0,
+        )
+        with pytest.raises(ValueError, match="oblique"):
             sim.run(n_steps=20, compute_s_params=False)
 
     def test_nonuniform_waveguide_port_extracts_s11(self):

--- a/tests/test_nonuniform_api.py
+++ b/tests/test_nonuniform_api.py
@@ -110,6 +110,34 @@ class TestSimulationNonUniform:
         ts = np.asarray(result.time_series)
         assert ts.shape[0] == 20
 
+    def test_nonuniform_upml_smoke(self):
+        """boundary='upml' accepts a nonuniform dz_profile and stays stable.
+
+        Commit 85de45f disentangled the scalar-dx curl scaling in UPML.
+        This regression pins that nonuniform + UPML (a) constructs,
+        (b) runs, (c) produces a non-trivial signal, (d) does not blow up.
+        """
+        dz = np.array([0.4e-3] * 4 + [0.6e-3] * 6)
+        sim = Simulation(
+            freq_max=5e9, domain=(0.02, 0.02, 0.01),
+            dx=0.5e-3, dz_profile=dz, cpml_layers=8,
+            boundary="upml",
+        )
+        sim.add_source((0.01, 0.01, 0.0025), "ez")
+        sim.add_probe((0.01, 0.01, 0.0025), "ez")
+        result = sim.run(n_steps=100, compute_s_params=False)
+        ts = np.asarray(result.time_series)
+        assert ts.shape[0] == 100
+        assert np.all(np.isfinite(ts)), "UPML+nonuniform produced NaN/Inf"
+        peak = float(np.max(np.abs(ts)))
+        assert peak > 0.0, "signal stayed zero — source / probe mismatch"
+        # Late-time amplitude must not exceed the initial pulse — absorbing
+        # boundary should damp energy, never source it.
+        assert float(np.max(np.abs(ts[-20:]))) <= 1.05 * peak, (
+            f"late-time peak {np.max(np.abs(ts[-20:])):.3e} > 1.05x "
+            f"early peak {peak:.3e} — UPML sourcing energy"
+        )
+
     def test_nonuniform_rejects_ntff(self):
         dz = np.array([0.4e-3] * 4 + [0.5e-3] * 5)
         sim = Simulation(

--- a/tests/test_nonuniform_forward_grad.py
+++ b/tests/test_nonuniform_forward_grad.py
@@ -1,0 +1,108 @@
+"""Regression tests for differentiable ``Simulation.forward()`` on the
+non-uniform mesh path (GitHub issue #33).
+
+Before this change, ``forward()`` raised ``ValueError`` whenever any of
+``dx_profile`` / ``dy_profile`` / ``dz_profile`` was set, making NU
+grids unusable for gradient-based optimisation. The forward path now
+routes NU profiles through ``_forward_nonuniform_from_materials``,
+which wraps ``run_nonuniform_path`` with ``eps_override`` /
+``sigma_override`` / ``pec_mask_override`` support.
+
+Tests:
+
+1. **Smoke**: ``sim.forward(n_steps=100)`` with ``dz_profile`` set must
+   return a finite ``ForwardResult`` (no ValueError).
+2. **AD vs FD**: ``jax.grad(loss)(eps_override)`` on a single eps cell
+   matches a centred finite-difference estimate to <2% relative error.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from rfx import Simulation
+
+
+def _build_sim():
+    """Small graded-z cavity (20×20×9 interior, CPML=4)."""
+    dz = np.array([0.5e-3] * 5 + [0.4e-3] * 4, dtype=np.float64)
+    sim = Simulation(
+        freq_max=10e9,
+        domain=(0.01, 0.01, float(np.sum(dz))),
+        dx=0.5e-3,
+        dz_profile=dz,
+        cpml_layers=4,
+    )
+    sim.add_source((0.005, 0.005, 0.001), "ez")
+    sim.add_probe((0.005, 0.005, 0.003), "ez")
+    return sim
+
+
+def test_forward_nonuniform_smoke():
+    """``forward(n_steps=...)`` on a NU-z sim must return finite data."""
+    sim = _build_sim()
+    fr = sim.forward(n_steps=100)
+    ts = np.asarray(fr.time_series)
+    assert ts.shape[0] == 100
+    assert np.all(np.isfinite(ts)), "NU forward produced NaN/Inf"
+    # Sanity: source excites something within 100 steps.
+    assert float(np.max(np.abs(ts))) > 0.0
+
+
+def test_forward_nonuniform_grad_eps_matches_fd():
+    """AD grad w.r.t. a single eps cell agrees with centred FD (<2% rel err).
+
+    We scale ``eps_override`` by a scalar ``alpha`` and differentiate a
+    squared-L2 probe loss w.r.t. ``alpha``. This reduces the grad check
+    to a 1-D comparison that's robust to step-size / noise.
+    """
+    sim = _build_sim()
+    g = sim._build_nonuniform_grid()
+    eps_base = jnp.ones(g.shape, dtype=jnp.float32)
+
+    # Target cell for the eps perturbation — well away from CPML and
+    # source/probe cells.
+    ti, tj, tk = g.nx // 2 + 2, g.ny // 2 + 2, g.nz // 2
+    n_steps = 60
+
+    def loss(alpha):
+        eps = eps_base.at[ti, tj, tk].set(alpha)
+        fr = sim.forward(eps_override=eps, n_steps=n_steps)
+        return jnp.sum(fr.time_series ** 2)
+
+    alpha0 = jnp.float32(2.0)
+    grad_ad = float(jax.grad(loss)(alpha0))
+
+    h = 1e-2
+    lp = float(loss(alpha0 + h))
+    lm = float(loss(alpha0 - h))
+    grad_fd = (lp - lm) / (2.0 * h)
+
+    rel_err = abs(grad_ad - grad_fd) / max(abs(grad_fd), 1e-12)
+    assert rel_err < 0.02, (
+        f"AD grad {grad_ad:.4e} vs FD grad {grad_fd:.4e} — "
+        f"rel_err {rel_err:.4%} above 2% threshold"
+    )
+
+
+# --- Known gaps (not yet plumbed into the NU forward path) ---------------
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "pec_occupancy_override (soft-PEC continuous occupancy) is not "
+        "yet supported on the NU forward path; run_nonuniform has no "
+        "occupancy field plumbed through its scan body. Hard PEC via "
+        "pec_mask_override works. Flipping this to XPASS means someone "
+        "wired occupancy through the NU scan — update the API to accept."
+    ),
+)
+def test_forward_nonuniform_pec_occupancy_unsupported():
+    sim = _build_sim()
+    g = sim._build_nonuniform_grid()
+    occ = jnp.zeros(g.shape, dtype=jnp.float32)
+    # Expected to raise ValueError in api.forward().
+    sim.forward(pec_occupancy_override=occ, n_steps=20)

--- a/tests/test_nonuniform_gradient.py
+++ b/tests/test_nonuniform_gradient.py
@@ -1,0 +1,127 @@
+"""Gradient regression for the NonUniformGrid run lane.
+
+Case (a) pins what already works empirically (gap-probe 2026-04-15):
+``jax.grad`` through ``run_nonuniform`` w.r.t. a scalar source amplitude
+agrees with a finite-difference estimate.
+
+Case (b) pins the known gap: differentiating w.r.t. ``dz_profile`` hits
+a host boundary inside ``make_nonuniform_grid`` (``np.asarray`` /
+``float(np.min)``) and raises ``TracerArrayConversionError``.  Marked
+``xfail(strict=True)`` so that a future grid-construction refactor that
+stays in trace flips this test to XPASS and fails loudly — the hole
+self-announces when it closes.
+
+See docs/research_notes/2026-04-15_nonuniform_completion_handoff.md
+(Step 2 + Step 5) for the scope behind this test.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from rfx.core.yee import EPS_0, MaterialArrays
+from rfx.nonuniform import make_nonuniform_grid, run_nonuniform
+
+
+def _base_waveform(n_steps: int, dt: float) -> jnp.ndarray:
+    t = jnp.arange(n_steps, dtype=jnp.float32) * jnp.float32(dt)
+    t0 = 15.0 * jnp.float32(dt)
+    width = 5.0 * jnp.float32(dt)
+    return jnp.exp(-((t - t0) / width) ** 2).astype(jnp.float32)
+
+
+def _build():
+    """Small but non-trivial graded-z sim with CPML on all sides."""
+    dz = np.array([0.5e-3] * 5 + [0.3e-3] * 4, dtype=np.float64)
+    grid = make_nonuniform_grid(
+        domain_xy=(0.005, 0.005),
+        dz_profile=dz,
+        dx=0.5e-3,
+        cpml_layers=4,
+    )
+    nx, ny, nz = grid.shape
+    shape = (nx, ny, nz)
+    materials = MaterialArrays(
+        eps_r=jnp.ones(shape, dtype=jnp.float32),
+        mu_r=jnp.ones(shape, dtype=jnp.float32),
+        sigma=jnp.zeros(shape, dtype=jnp.float32),
+    )
+    return grid, materials
+
+
+def _loss_from_amplitude(amplitude, grid, materials, n_steps):
+    """Run nonuniform sim with a single Ez source scaled by `amplitude`
+    and return the L2 energy of the probe trace (a scalar loss)."""
+    nx, ny, nz = grid.shape
+    base = _base_waveform(n_steps, grid.dt)
+    src_i, src_j, src_k = nx // 2, ny // 2, nz // 2 + 1
+    prb_i, prb_j, prb_k = nx // 2, ny // 2, nz // 2 - 1
+    sources = [(src_i, src_j, src_k, "ez", amplitude * base)]
+    probes = [(prb_i, prb_j, prb_k, "ez")]
+    out = run_nonuniform(grid, materials, n_steps,
+                         sources=sources, probes=probes)
+    ts = out["time_series"][:, 0]
+    return jnp.sum(ts * ts)
+
+
+def test_grad_wrt_source_amplitude_matches_fd():
+    """AD through the nonuniform scan agrees with centered FD to <1%."""
+    grid, materials = _build()
+    n_steps = 60
+    amp0 = jnp.float32(1.0)
+
+    grad_ad = float(jax.grad(
+        _loss_from_amplitude)(amp0, grid, materials, n_steps))
+
+    h = 1e-2
+    loss_plus  = float(_loss_from_amplitude(amp0 + h, grid, materials, n_steps))
+    loss_minus = float(_loss_from_amplitude(amp0 - h, grid, materials, n_steps))
+    grad_fd = (loss_plus - loss_minus) / (2.0 * h)
+
+    rel_err = abs(grad_ad - grad_fd) / max(abs(grad_fd), 1e-12)
+    assert rel_err < 0.01, (
+        f"AD grad {grad_ad:.4e} vs FD grad {grad_fd:.4e} — "
+        f"rel_err {rel_err:.4%} above 1% threshold"
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Geometry gradient blocked: make_nonuniform_grid calls np.asarray "
+        "and float(np.min) on the dz_profile input before any JAX op "
+        "touches it — a host boundary that breaks AD. Requires refactoring "
+        "grid construction to stay in trace (see Step 5 of "
+        "docs/research_notes/2026-04-15_nonuniform_completion_handoff.md). "
+        "When this flips to XPASS the hole has closed."
+    ),
+)
+def test_grad_wrt_dz_profile_blocked():
+    """Differentiating w.r.t. dz_profile must fail loudly until Step 5."""
+    def loss_fn(dz):
+        grid = make_nonuniform_grid(
+            domain_xy=(0.005, 0.005), dz_profile=dz,
+            dx=0.5e-3, cpml_layers=4,
+        )
+        nx, ny, nz = grid.shape
+        shape = (nx, ny, nz)
+        materials = MaterialArrays(
+            eps_r=jnp.ones(shape, dtype=jnp.float32),
+            mu_r=jnp.ones(shape, dtype=jnp.float32),
+            sigma=jnp.zeros(shape, dtype=jnp.float32),
+        )
+        base = _base_waveform(40, grid.dt)
+        sources = [(nx // 2, ny // 2, nz // 2, "ez", base)]
+        probes = [(nx // 2, ny // 2, nz // 2 - 1, "ez")]
+        out = run_nonuniform(grid, materials, 40,
+                             sources=sources, probes=probes)
+        return jnp.sum(out["time_series"] ** 2)
+
+    dz0 = jnp.asarray([0.5e-3] * 5 + [0.3e-3] * 4, dtype=jnp.float32)
+    # Expected to raise TracerArrayConversionError / TypeError —
+    # xfail(strict=True) captures both positive-grad and raised outcomes
+    # as a failure.  We call jax.grad so any raise counts as xfail.
+    _ = jax.grad(loss_fn)(dz0)

--- a/tests/test_waveguide_forward.py
+++ b/tests/test_waveguide_forward.py
@@ -1,0 +1,62 @@
+"""Regression test for issue #29: waveguide port + forward() broadcast error.
+
+`_forward_from_materials` previously called the low-level ``run`` without
+forwarding ``grid.cpml_axes``, so CPML state was built for all three
+axes even when the grid had no CPML padding on the waveguide's
+propagation axis. That produced ``(n_cpml, 1, 1) vs (nx, ny, nz)``
+broadcast errors during the scan whenever a waveguide port was present.
+"""
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from rfx import Simulation
+
+
+def _wr90_sim() -> Simulation:
+    sim = Simulation(
+        freq_max=12e9,
+        domain=(0.05, 0.02286, 0.01016),
+        dx=2e-3,
+        boundary="cpml",
+        cpml_layers=8,
+    )
+    sim.add_waveguide_port(
+        direction="+x",
+        x_position=0.01,
+        y_range=(0.0, 0.02286),
+        z_range=(0.0, 0.01016),
+        n_modes=1,
+    )
+    sim.add_probe(position=(0.03, 0.01143, 0.00508), component="ey")
+    return sim
+
+
+def test_forward_with_waveguide_port_no_broadcast_error():
+    """forward() must complete without TypeError on CPML multiplication."""
+    sim = _wr90_sim()
+    result = sim.forward(n_steps=40)
+    assert result.time_series.shape == (40, 1)
+    assert bool(jnp.all(jnp.isfinite(result.time_series)))
+
+
+def test_forward_with_waveguide_port_is_differentiable():
+    """jax.grad through a waveguide-port forward must return a finite
+    (possibly non-zero) value — the fix for #29 restores the gradient
+    path that was masked by the broadcast failure.
+    """
+    sim = _wr90_sim()
+    grid = sim._build_grid()
+    eps0 = jnp.ones(grid.shape, dtype=jnp.float32)
+
+    def loss(alpha):
+        r = sim.forward(eps_override=eps0 * alpha, n_steps=40)
+        return jnp.sum(jnp.abs(r.time_series) ** 2)
+
+    value = float(loss(jnp.float32(1.0)))
+    assert np.isfinite(value)
+    grad = float(jax.grad(loss)(jnp.float32(1.0)))
+    assert np.isfinite(grad)


### PR DESCRIPTION
## Summary

- **NU runner feature parity** (Step 4a–4e + UPML per-axis inverse spacing): DFT plane probe, lumped RLC, NTFF box, waveguide port, TFSF ±x plane-wave source all wired into `rfx/runners/nonuniform.py`.
- **Inverse-design unblock**: `forward()` now supports NU grids (#33), directivity objective now gradient-producing (#32), waveguide-port CPML broadcast fixed (#29), new preflight checks for NTFF/PEC overlap, λ/4 gap, and AD memory (#30).
- **Validated** against OpenEMS on GPU: rfx vs OpenEMS Harminv agreement **0.99 %** on 2.4 GHz FR4 patch (VESSL run `369367233458`).
- **Memory** at matched accuracy: NU **37.5× cell reduction** and **32.7× AD-memory reduction** vs isotropic 0.25 mm uniform (162 MB ckpt-AD vs 5.3 GB, or 996 GB full-AD → OOM on any commodity GPU).

## GitHub issues closed

| # | Commit | What it fixes |
|---|--------|---------------|
| #33 | `e1da198` | `forward()` now supports `dx_profile`/`dy_profile`/`dz_profile`. `sim.optimize()` / `sim.topology_optimize()` work on NU. AD-vs-FD pin test < 2 %. |
| #32 | `9f25ea2` | `maximize_directivity` replaced with scale-invariant `U(θ,φ)/P_rad` ratio; gradient no longer collapses to float32 noise floor. Reported 9400% loss improvement, 7.6 dBi. |
| #29 | `f4f7dd1` | `_forward_from_materials` forwards `grid.cpml_axes` so CPML state matches the waveguide-normal-axis-free grid. Unblocks gradient-based waveguide opt. |
| #30 | `598f755` | `sim.preflight()` gains `check_ntff` / `check_resolution` / `check_ad_memory`; new `sim.estimate_ad_memory(n_steps)` returns `AD_MemoryEstimate` with checkpointed vs full AD memory and VRAM comparison. |

## Non-uniform runner feature parity (earlier in branch)

- `65a73b8` Step 4a — DFT plane probe
- `9deaa1b` Step 4b — lumped RLC elements
- `4aa5ff4` Step 4c — NTFF box
- `a475354` Step 4d — waveguide port
- `d42b659` Step 4e — TFSF ±x plane-wave source
- `85de45f` UPML per-axis inverse spacing (NU unblock)
- `1269350` remove UPML+NU guards in api.py
- `2679f1d` guardrail — distributed+NU fails loudly (Phase A)
- `af3d97f` regression: jax.grad through NU scan w.r.t. source amplitude
- `72d25b0` Phase B partial: NU+distributed vacuum/PEC path

## Examples + docs

- `examples/nonuniform_patch_demo.py` — 198-line standalone 2.4 GHz FR4 patch; local CPU Harminv **1.59 %** vs Balanis TL, 1.7 s, 2.85× cells vs z-only uniform baseline.
- `docs/research_notes/2026-04-15_nu_feature_completion_and_crossval.md` — full session capture (VESSL install recipe, memory numbers, do-not-repeat).

## GPU + OpenEMS crossval — VESSL `369367233458`

Image `nvcr.io/nvidia/jax:24.10-py3` (Ubuntu 22.04, py3.10) + `apt install openems python3-openems`. On `remilab-c0 / gpu-rtx4090`:

| Measurement                   | f_res (GHz) | Δ vs Balanis TL |
|-------------------------------|-------------|-----------------|
| Balanis TL analytic           | 2.4235      | —               |
| OpenEMS Harminv on port V(t)  | 2.4868      | +2.61 %         |
| rfx Harminv (probe ringdown)  | 2.4621      | +1.59 %         |

All pass gates PASS: rfx internal 0.08 %, rfx vs analytic 1.59 %, rfx vs OpenEMS 0.99 %, S11 passivity max 0.991.

## Deferred

- **#31** memory-efficient inverse design (checkpointed NU + mixed precision + temporal windowing). Scoped in the research note.
- NU-forward gaps noted in commit messages: `pec_occupancy_override`, `checkpoint=True` plumbing, Floquet port.

## Test plan

- [x] `tests/test_nonuniform_forward_grad.py` — NU forward smoke + AD-vs-FD (eps) pin
- [x] `tests/test_directivity_gradient.py` — #32 non-zero gradient pin
- [x] `tests/test_waveguide_forward.py` — #29 broadcast regression + AD
- [x] `tests/test_inverse_design_preflight.py` — 5 new #30 checks
- [x] `tests/test_nonuniform_gradient.py` — pre-existing pin still green
- [x] No regressions on `tests/test_api.py`, `tests/test_nonuniform_api.py`, `tests/test_simulation.py`, `tests/test_farfield.py`, `tests/test_waveguide_port.py`, `tests/test_multimode_waveguide.py`, `tests/test_optimize.py`, `tests/test_topology.py` (78+ passed on the final combined run, 1 skipped, 0 failed)
- [x] GPU end-to-end via VESSL crossval (`369367233458`) PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)