### PR TITLE
feat(objectives): minimize_s11_at_freq for forward() path (#50)

### DIFF
--- a/rfx/optimize_objectives.py
+++ b/rfx/optimize_objectives.py
@@ -421,6 +421,64 @@ def minimize_reflected_energy(
     return objective
 
 
+def minimize_s11_at_freq(
+    target_freq: float,
+    port_probe_idx: int = 0,
+    *,
+    incident_fraction: float = 0.25,
+    dt: float | None = None,
+) -> Callable:
+    """Single-frequency |S11|² proxy for the differentiable ``forward()`` path.
+
+    Unlike :func:`minimize_s11` (which requires S-parameters from ``run()``)
+    this objective works on the time-series output of ``forward()``, so it
+    composes with ``optimize()`` / ``topology_optimize()``. Issue #50.
+
+    Method: single-frequency DFT (Goertzel-style, real trig so the JAX
+    gradient is clean). The incident power is estimated from the first
+    ``incident_fraction`` of the series — that window should contain only
+    the source pulse, before any reflection returns from the DUT.
+
+    Parameters
+    ----------
+    target_freq : float
+        Frequency of interest (Hz).
+    port_probe_idx : int
+        Index into ``result.time_series`` for the port-co-located probe.
+    incident_fraction : float
+        Fraction of the leading time series treated as incident-only
+        (default 0.25). Shorten for large DUTs with quick round-trip,
+        lengthen for slow resonators.
+    dt : float, optional
+        Time step. If None, read from ``result.dt`` at call time.
+
+    Returns
+    -------
+    callable(Result) -> scalar (JAX-differentiable)
+    """
+    def objective(result) -> jnp.ndarray:
+        _require_time_series(result, "minimize_s11_at_freq")
+        ts = result.time_series[:, port_probe_idx]
+        n = ts.shape[0]
+        _dt = float(result.dt) if dt is None else float(dt)
+        t = jnp.arange(n) * _dt
+        omega = 2.0 * jnp.pi * float(target_freq)
+        cos_t = jnp.cos(omega * t)
+        sin_t = jnp.sin(omega * t)
+        # Total field at the port
+        X_re = jnp.sum(ts * cos_t)
+        X_im = jnp.sum(ts * sin_t)
+        power_total = X_re ** 2 + X_im ** 2
+        # Incident estimate from the early window
+        q = max(1, int(n * float(incident_fraction)))
+        Xi_re = jnp.sum(ts[:q] * cos_t[:q])
+        Xi_im = jnp.sum(ts[:q] * sin_t[:q])
+        power_inc = Xi_re ** 2 + Xi_im ** 2
+        return power_total / (power_inc + 1e-30)
+
+    return objective
+
+
 def maximize_transmitted_energy(
     output_probe_idx: int = -1,
 ) -> Callable:

--- a/tests/test_s11_at_freq.py
+++ b/tests/test_s11_at_freq.py
@@ -1,0 +1,88 @@
+"""Issue #50: minimize_s11_at_freq — single-frequency S11 proxy for the
+differentiable forward() path."""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from rfx.optimize_objectives import minimize_s11_at_freq
+
+
+class _FakeResult:
+    """Stub with the minimal surface the objective reads."""
+
+    def __init__(self, ts, dt):
+        self.time_series = jnp.asarray(ts)
+        self.dt = dt
+
+
+def _cosine_series(freq, dt, n, reflection_gain=0.0, reflection_delay=0):
+    """Build a test series where the incident pulse fits inside the
+    first 25% window (so the objective's default incident_fraction is
+    a reasonable proxy for it) and an optional reflection appears later.
+    """
+    t = np.arange(n) * dt
+    T = t[-1]
+    carrier = np.cos(2 * np.pi * freq * t)
+    # Incident: Gaussian pulse centred at 10% of T, sigma 4%.
+    win = np.exp(-((t - 0.10 * T) / (0.04 * T)) ** 2)
+    incident = carrier * win
+    if reflection_gain > 0 and reflection_delay > 0:
+        refl = np.zeros_like(incident)
+        refl[reflection_delay:] = reflection_gain * incident[:-reflection_delay]
+        return (incident + refl)[:, None]
+    return incident[:, None]
+
+
+def test_no_reflection_gives_small_s11():
+    """Incident-only series → |S11|² should be ~1 (total ≈ incident)."""
+    dt = 1e-12
+    n = 2000
+    ts = _cosine_series(10e9, dt, n)
+    r = _FakeResult(ts, dt)
+    val = float(minimize_s11_at_freq(10e9, port_probe_idx=0)(r))
+    # Without reflection, the windowed pulse peaks before the 25%
+    # incident window ends, so total ≈ incident → ratio ≈ 1.
+    assert 0.8 <= val <= 1.2, f"expected ~1.0, got {val}"
+
+
+def test_large_reflection_gives_large_s11():
+    dt = 1e-12
+    n = 2000
+    # Reflection with gain 1.0 and a 1ns delay
+    ts = _cosine_series(10e9, dt, n, reflection_gain=1.0,
+                        reflection_delay=1000)
+    r = _FakeResult(ts, dt)
+    val_refl = float(minimize_s11_at_freq(10e9, port_probe_idx=0)(r))
+    # With a full-amplitude reflection the total power at 10 GHz should
+    # exceed the incident-only case.
+    val_norefl = float(minimize_s11_at_freq(10e9, port_probe_idx=0)(
+        _FakeResult(_cosine_series(10e9, dt, n), dt)))
+    assert val_refl > val_norefl + 0.1, (
+        f"reflection should increase |S11|²; got refl={val_refl}, no={val_norefl}"
+    )
+
+
+def test_gradient_is_finite():
+    """jax.grad through the full objective must return a finite value."""
+    dt = 1e-12
+    n = 1000
+
+    def loss(amp):
+        t = jnp.arange(n) * dt
+        ts = amp * jnp.cos(2 * jnp.pi * 10e9 * t)[:, None]
+        r = _FakeResult(ts, dt)
+        return minimize_s11_at_freq(10e9, port_probe_idx=0)(r)
+
+    g = float(jax.grad(loss)(jnp.float32(1.0)))
+    assert np.isfinite(g), f"grad not finite: {g}"
+
+
+def test_requires_time_series():
+    """Empty time_series must produce a clear ValueError."""
+    r = _FakeResult(jnp.zeros((10, 0)), 1e-12)
+    with pytest.raises(ValueError, match="emit_time_series"):
+        minimize_s11_at_freq(10e9)(r)


### PR DESCRIPTION
Implements the single-frequency S11 proxy requested in issue #50.

- New `minimize_s11_at_freq(target_freq, port_probe_idx, incident_fraction, dt)` in `rfx/optimize_objectives.py`.
- Goertzel-style real-trig DFT so `jax.grad` flows cleanly.
- Incident power estimated from the first `incident_fraction` of the time-series; caller tunes for their DUT round-trip.

Enables composing frequency-anchored antenna objectives on the differentiable `forward()` path:

```python
obj = 0.5 * minimize_s11_at_freq(10e9) + 0.5 * maximize_directivity(theta=0, phi=0)
```

Tests: 4 pins (no-reflection ≈ 1, reflection > no-reflection, finite grad, empty-TS raises ValueError).

Closes #50