### PR TITLE
feat(visualize): 3D structure + far-field viz API (#38)

### DIFF
--- a/rfx/visualize.py
+++ b/rfx/visualize.py
@@ -265,3 +265,236 @@ def plot_rcs(
         ax.grid(True, alpha=0.3)
 
     return fig
+
+
+# ===========================================================================
+# 3D interactive visualisation (plotly). Issue #38.
+# ===========================================================================
+
+def _plotly():
+    try:
+        import plotly.graph_objects as go
+        return go
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            "rfx.visualize 3D functions require plotly. "
+            "Install with `pip install plotly kaleido`."
+        ) from e
+
+
+_MATERIAL_COLORS = {
+    "pec": ("black", 0.7),
+    "fr4": ("tan", 0.2),
+    "glass": ("lightblue", 0.25),
+}
+
+
+def _material_style(mat_name):
+    return _MATERIAL_COLORS.get((mat_name or "").lower(),
+                                ("cornflowerblue", 0.25))
+
+
+def _cuboid_trace(go, *, x0, y0, z0, w, d, h, color, opacity, name,
+                  visible=True):
+    """Axis-aligned box as Mesh3d. Coords in metres, rendered in mm."""
+    mm = 1e3
+    xs = [x0, x0 + w, x0 + w, x0,     x0,     x0 + w, x0 + w, x0]
+    ys = [y0, y0,     y0 + d, y0 + d, y0,     y0,     y0 + d, y0 + d]
+    zs = [z0, z0,     z0,     z0,     z0 + h, z0 + h, z0 + h, z0 + h]
+    i = [0, 0, 1, 1, 2, 2, 4, 4, 0, 0, 1, 2]
+    j = [1, 2, 2, 5, 3, 6, 5, 6, 4, 5, 5, 3]
+    k = [2, 3, 5, 6, 6, 7, 6, 7, 5, 1, 6, 7]
+    return go.Mesh3d(
+        x=[v * mm for v in xs], y=[v * mm for v in ys], z=[v * mm for v in zs],
+        i=i, j=j, k=k, color=color, opacity=opacity, name=name,
+        flatshading=True, showlegend=True,
+        visible=True if visible is True else "legendonly",
+    )
+
+
+def _wireframe_box(go, *, corner_lo, corner_hi, color, name,
+                   dash="solid", width=2, visible="legendonly"):
+    mm = 1e3
+    x0, y0, z0 = [c * mm for c in corner_lo]
+    x1, y1, z1 = [c * mm for c in corner_hi]
+    corners = [(x0, y0, z0), (x1, y0, z0), (x1, y1, z0), (x0, y1, z0),
+               (x0, y0, z1), (x1, y0, z1), (x1, y1, z1), (x0, y1, z1)]
+    edges = [(0, 1), (1, 2), (2, 3), (3, 0),
+             (4, 5), (5, 6), (6, 7), (7, 4),
+             (0, 4), (1, 5), (2, 6), (3, 7)]
+    xs, ys, zs = [], [], []
+    for a, b in edges:
+        xs += [corners[a][0], corners[b][0], None]
+        ys += [corners[a][1], corners[b][1], None]
+        zs += [corners[a][2], corners[b][2], None]
+    return go.Scatter3d(
+        x=xs, y=ys, z=zs, mode="lines", name=name,
+        line=dict(color=color, width=width, dash=dash), visible=visible,
+        showlegend=True,
+    )
+
+
+def visualize_structure(sim, *, include_cpml: bool = True,
+                        include_ntff: bool = True,
+                        include_sources: bool = True,
+                        title: str | None = None):
+    """Render a 3D plotly scene of a Simulation's geometry.
+
+    Each material box, source marker, NTFF wireframe, and the CPML
+    outer wireframe is a separate legend-toggleable trace — click a
+    legend entry to show/hide that group.
+    """
+    go = _plotly()
+    fig = go.Figure()
+
+    for entry in sim._geometry:
+        try:
+            c1, c2 = entry.shape.bounding_box()
+        except Exception:
+            continue
+        w, d, h = [c2[i] - c1[i] for i in range(3)]
+        color, opacity = _material_style(entry.material_name)
+        fig.add_trace(_cuboid_trace(
+            go, x0=c1[0], y0=c1[1], z0=c1[2], w=w, d=d, h=h,
+            color=color, opacity=opacity, name=entry.material_name,
+        ))
+
+    if include_sources and getattr(sim, "_ports", None):
+        xs, ys, zs = [], [], []
+        for pe in sim._ports:
+            xs.append(pe.position[0] * 1e3)
+            ys.append(pe.position[1] * 1e3)
+            zs.append(pe.position[2] * 1e3)
+        if xs:
+            fig.add_trace(go.Scatter3d(
+                x=xs, y=ys, z=zs, mode="markers",
+                marker=dict(size=5, color="green", symbol="diamond"),
+                name="sources / ports"))
+
+    if include_ntff and getattr(sim, "_ntff", None) is not None:
+        ntff_lo, ntff_hi, _freqs = sim._ntff
+        fig.add_trace(_wireframe_box(
+            go, corner_lo=ntff_lo, corner_hi=ntff_hi,
+            color="orange", name="NTFF box"))
+
+    if include_cpml:
+        dom_x, dom_y = sim._domain[0], sim._domain[1]
+        dom_z = sim._domain[2] if len(sim._domain) > 2 else 0
+        if dom_z == 0 and sim._dz_profile is not None:
+            dom_z = float(np.sum(sim._dz_profile))
+        elif dom_z == 0:
+            dom_z = dom_x
+        fig.add_trace(_wireframe_box(
+            go, corner_lo=(0, 0, 0), corner_hi=(dom_x, dom_y, dom_z),
+            color="purple", dash="dash", name="domain / CPML"))
+
+    fig.update_layout(
+        title=title or "rfx Simulation structure",
+        legend=dict(x=0.01, y=0.99),
+        scene=dict(
+            xaxis=dict(title="x (mm)"), yaxis=dict(title="y (mm)"),
+            zaxis=dict(title="z (mm)"), aspectmode="data",
+        ),
+        margin=dict(l=0, r=0, t=40, b=0),
+    )
+    return fig
+
+
+def visualize_farfield_3d(result, sim=None, *, f_idx: int = 0,
+                          theta_grid=None, phi_grid=None,
+                          geometry: bool = True,
+                          opacity: float = 0.75,
+                          scale_mm: float = 40.0,
+                          centre=None,
+                          title: str | None = None):
+    """Interactive 3D far-field lobe + optional structure overlay.
+
+    Requires ``result.ntff_data`` and ``result.ntff_box`` (add an NTFF
+    box to the Simulation first). Legend-toggleable overlays for
+    geometry and CPML / NTFF boundaries.
+    """
+    go = _plotly()
+    if result.ntff_data is None or result.ntff_box is None:
+        raise ValueError(
+            "visualize_farfield_3d requires ntff_data/ntff_box on the "
+            "result — add sim.add_ntff_box(...) and re-run."
+        )
+    from rfx.farfield import compute_far_field
+
+    if theta_grid is None:
+        theta_grid = np.linspace(0.01, np.pi / 2, 60)
+    if phi_grid is None:
+        phi_grid = np.linspace(0, 2 * np.pi, 121)
+
+    if sim is not None:
+        grid = (sim._build_nonuniform_grid()
+                if sim._dz_profile is not None else sim._build_grid())
+    else:
+        grid = result.grid
+
+    ef = compute_far_field(result.ntff_data, result.ntff_box, grid,
+                           theta_grid, phi_grid)
+    E_t = np.asarray(ef.E_theta[f_idx])
+    E_p = np.asarray(ef.E_phi[f_idx])
+    mag = np.sqrt(np.abs(E_t) ** 2 + np.abs(E_p) ** 2)
+    mag_n = mag / np.max(mag)
+    mag_db = 20 * np.log10(np.maximum(mag_n, 1e-3))
+
+    TH, PH = np.meshgrid(theta_grid, phi_grid, indexing="ij")
+    if centre is None:
+        centre = (
+            0.5 * sim._domain[0] * 1e3 if sim is not None else 0.0,
+            0.5 * sim._domain[1] * 1e3 if sim is not None else 0.0,
+            0.0,
+        )
+    cx, cy, cz = centre
+    r = mag_n
+    X = cx + scale_mm * r * np.sin(TH) * np.cos(PH)
+    Y = cy + scale_mm * r * np.sin(TH) * np.sin(PH)
+    Z = cz + scale_mm * r * np.cos(TH)
+
+    freqs = np.asarray(result.ntff_box.freqs)
+    f_label = f"{freqs[f_idx]/1e9:.3f} GHz"
+
+    fig = go.Figure()
+    if sim is not None and geometry:
+        for tr in visualize_structure(sim, title=None).data:
+            fig.add_trace(tr)
+    fig.add_trace(go.Surface(
+        x=X, y=Y, z=Z, surfacecolor=mag_db,
+        colorscale="Viridis", cmin=-30, cmax=0, opacity=opacity,
+        colorbar=dict(title="|E_far| (dB, norm)", x=1.05),
+        name=f"|E_far| @ {f_label}", showlegend=True,
+    ))
+
+    i_p, j_p = np.unravel_index(np.argmax(mag), mag.shape)
+    th_pk, ph_pk = theta_grid[i_p], phi_grid[j_p]
+    fig.add_trace(go.Scatter3d(
+        x=[cx, cx + scale_mm * 1.1 * np.sin(th_pk) * np.cos(ph_pk)],
+        y=[cy, cy + scale_mm * 1.1 * np.sin(th_pk) * np.sin(ph_pk)],
+        z=[cz, cz + scale_mm * 1.1 * np.cos(th_pk)],
+        mode="lines+markers", line=dict(color="red", width=4),
+        marker=dict(size=[3, 6], color="red"),
+        name=f"peak θ={np.degrees(th_pk):.0f}° φ={np.degrees(ph_pk):.0f}°",
+    ))
+
+    fig.update_layout(
+        title=title or f"Far-field lobe @ {f_label}",
+        legend=dict(x=0.01, y=0.99),
+        scene=dict(
+            xaxis=dict(title="x (mm)"), yaxis=dict(title="y (mm)"),
+            zaxis=dict(title="z (mm)"), aspectmode="data",
+        ),
+        margin=dict(l=0, r=0, t=40, b=0),
+    )
+    return fig
+
+
+def save_html(fig, path: str, include_plotlyjs: str = "cdn") -> None:
+    """Write a plotly Figure to an interactive HTML file."""
+    fig.write_html(path, include_plotlyjs=include_plotlyjs)
+
+
+def save_png(fig, path: str, **kwargs) -> None:
+    """Write a plotly Figure to PNG (requires kaleido)."""
+    fig.write_image(path, **kwargs)

--- a/tests/test_visualize_3d.py
+++ b/tests/test_visualize_3d.py
@@ -1,0 +1,62 @@
+"""Issue #38: 3D structure + far-field visualisation API."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rfx import Simulation, Box
+from rfx.sources.sources import GaussianPulse
+
+
+pytest.importorskip("plotly")
+
+from rfx.visualize import (  # noqa: E402
+    visualize_structure,
+    visualize_farfield_3d,
+)
+
+
+def _patch_sim():
+    sim = Simulation(freq_max=4e9, domain=(0.08, 0.075, 0.04),
+                     dx=1e-3, boundary="cpml", cpml_layers=4)
+    sim.add_material("fr4", eps_r=4.3)
+    sim.add(Box((0.010, 0.010, 0.011), (0.070, 0.065, 0.012)), material="pec")
+    sim.add(Box((0.010, 0.010, 0.012), (0.070, 0.065, 0.0135)), material="fr4")
+    sim.add(Box((0.025, 0.018, 0.0135), (0.054, 0.057, 0.0145)), material="pec")
+    sim.add_source((0.030, 0.0375, 0.013), "ez",
+                   waveform=GaussianPulse(f0=2.4e9, bandwidth=0.8))
+    return sim
+
+
+def test_visualize_structure_returns_plotly_figure():
+    sim = _patch_sim()
+    fig = visualize_structure(sim)
+    # Must have one trace per geometry box + source scatter + CPML wireframe.
+    # Geometry = 3 (pec/fr4/pec), source scatter = 1, CPML = 1 → at least 5.
+    assert len(fig.data) >= 5
+    names = {tr.name for tr in fig.data}
+    assert "pec" in names and "fr4" in names
+    assert any("domain" in n or "CPML" in n for n in names)
+
+
+def test_visualize_structure_respects_toggles():
+    sim = _patch_sim()
+    fig = visualize_structure(
+        sim, include_cpml=False, include_sources=False, include_ntff=False,
+    )
+    names = {tr.name for tr in fig.data}
+    assert not any("domain" in n or "CPML" in n for n in names)
+    assert not any("source" in (n or "").lower() for n in names)
+
+
+def test_visualize_farfield_requires_ntff_data():
+    sim = _patch_sim()
+
+    class _R:  # minimal result stub
+        ntff_data = None
+        ntff_box = None
+        grid = None
+
+    with pytest.raises(ValueError, match="ntff_data"):
+        visualize_farfield_3d(_R(), sim=sim)


### PR DESCRIPTION
Crystallises the ad-hoc plotly viz from scripts/issue31_patch_validation.py into `rfx.visualize.visualize_structure` + `visualize_farfield_3d`. plotly is an optional dep. Closes #38.