### PR TITLE
feat(ntff): streaming multi-frequency NTFF sweep (#43)

### DIFF
--- a/rfx/ntff_sweep.py
+++ b/rfx/ntff_sweep.py
@@ -1,0 +1,103 @@
+"""Streaming NTFF multi-frequency accumulation (issue #43).
+
+NTFF DFT arrays scale as ``n_freqs × face_cells × 4`` complex64. For
+broadband antenna sweeps (100+ frequency points) this dominates the
+working set. ``ntff_sweep`` splits the frequency list into small
+batches, reruns the simulation once per batch, and concatenates the
+per-batch NTFFData along the frequency axis — trading wall-time for
+memory.
+
+Not JAX-differentiable; this is an orchestrator for post-processing
+runs where the Simulation object is reused. For gradient-based
+inverse design at a single frequency, keep using ``sim.forward`` with
+a 1-frequency NTFF box.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+import numpy as np
+
+from rfx.farfield import NTFFData
+
+
+def _concat_faces(per_batch: list[NTFFData]) -> NTFFData:
+    """Stack per-batch NTFFData along the frequency axis (axis 0)."""
+    def _cat(field):
+        arrs = [getattr(b, field) for b in per_batch]
+        arrs = [np.asarray(a) for a in arrs]
+        return np.concatenate(arrs, axis=0)
+    return NTFFData(
+        x_lo=_cat("x_lo"), x_hi=_cat("x_hi"),
+        y_lo=_cat("y_lo"), y_hi=_cat("y_hi"),
+        z_lo=_cat("z_lo"), z_hi=_cat("z_hi"),
+        c_x_lo=_cat("c_x_lo"), c_x_hi=_cat("c_x_hi"),
+        c_y_lo=_cat("c_y_lo"), c_y_hi=_cat("c_y_hi"),
+        c_z_lo=_cat("c_z_lo"), c_z_hi=_cat("c_z_hi"),
+    )
+
+
+def ntff_sweep(sim, freqs, *, batch_size: int | None = None,
+               run_kwargs: dict | None = None) -> tuple[NTFFData, np.ndarray]:
+    """Accumulate NTFF data over ``freqs`` in memory-bounded batches.
+
+    Parameters
+    ----------
+    sim : Simulation
+        Must already have ``add_ntff_box(...)`` called so the Huygens
+        box corners are known. The frequency list is overridden per
+        batch; the original list is restored before return.
+    freqs : array-like of Hz
+        Full sweep frequency list.
+    batch_size : int, optional
+        Per-batch frequency count. Default: full list (single run).
+        Pick smaller values when the NTFF accumulator dominates memory.
+    run_kwargs : dict, optional
+        Forwarded to ``sim.run``. Example: ``{"num_periods": 60,
+        "compute_s_params": False}``.
+
+    Returns
+    -------
+    (NTFFData, np.ndarray)
+        Concatenated NTFFData plus the original freqs array.
+
+    Notes
+    -----
+    - Each sub-run is fully independent; the per-batch cost is one
+      full forward simulation.
+    - Side effect: the sim's NTFF box's freqs field is restored on
+      success or exception (try/finally).
+    """
+    if getattr(sim, "_ntff", None) is None:
+        raise ValueError(
+            "ntff_sweep requires sim.add_ntff_box(...) first — it "
+            "inherits the box corners but overrides the freq list."
+        )
+    freqs = np.asarray(freqs, dtype=np.float64)
+    if freqs.ndim != 1 or freqs.size == 0:
+        raise ValueError("freqs must be a non-empty 1-D array of Hz")
+    if batch_size is None or batch_size <= 0 or batch_size > len(freqs):
+        batch_size = len(freqs)
+
+    corner_lo, corner_hi, orig_freqs = sim._ntff
+    run_kwargs = run_kwargs or {}
+
+    batches: list[np.ndarray] = [
+        freqs[i:i + batch_size] for i in range(0, len(freqs), batch_size)
+    ]
+    per_batch_data: list[NTFFData] = []
+    try:
+        for batch in batches:
+            sim._ntff = (corner_lo, corner_hi, batch)
+            result = sim.run(**run_kwargs)
+            if result.ntff_data is None:
+                raise RuntimeError(
+                    "ntff_sweep: sim.run returned no ntff_data — "
+                    "check that the NTFF box is valid."
+                )
+            per_batch_data.append(result.ntff_data)
+    finally:
+        sim._ntff = (corner_lo, corner_hi, orig_freqs)
+
+    combined = _concat_faces(per_batch_data)
+    return combined, freqs

--- a/tests/test_ntff_sweep.py
+++ b/tests/test_ntff_sweep.py
@@ -1,0 +1,82 @@
+"""Issue #43: streaming NTFF multi-frequency sweep.
+
+Batched sweep must produce identical NTFFData to the single-run
+sweep (same frequencies accumulated from the same source). Side
+effect: sim._ntff.freqs restored on return.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rfx import Simulation, Box
+from rfx.ntff_sweep import ntff_sweep
+
+
+def _small_sim(freqs):
+    dz = np.array([0.4e-3] * 4 + [0.5e-3] * 5, dtype=np.float64)
+    sim = Simulation(
+        freq_max=5e9, domain=(0.02, 0.02, 0.01),
+        dx=0.5e-3, dz_profile=dz, boundary="upml",
+    )
+    sim.add_source((0.01, 0.01, 0.004), "ez")
+    sim.add_ntff_box(
+        corner_lo=(0.004, 0.004, 0.002),
+        corner_hi=(0.016, 0.016, 0.006),
+        freqs=freqs,
+    )
+    return sim
+
+
+def _close(a, b, atol=1e-6):
+    return np.allclose(np.asarray(a), np.asarray(b), atol=atol, rtol=1e-5)
+
+
+def test_batched_equals_full():
+    full_freqs = np.array([2.0e9, 2.4e9, 2.8e9, 3.2e9], dtype=np.float64)
+    sim_ref = _small_sim(full_freqs)
+    ref_res = sim_ref.run(n_steps=120, compute_s_params=False)
+    ref_data = ref_res.ntff_data
+
+    sim_batch = _small_sim(np.array([full_freqs[0]]))  # seed with one
+    batched, freqs_out = ntff_sweep(
+        sim_batch, full_freqs, batch_size=2,
+        run_kwargs=dict(n_steps=120, compute_s_params=False),
+    )
+    np.testing.assert_array_equal(freqs_out, full_freqs)
+    for face in ("x_lo", "x_hi", "y_lo", "y_hi", "z_lo", "z_hi"):
+        ref_face = np.asarray(getattr(ref_data, face))
+        batch_face = np.asarray(getattr(batched, face))
+        assert ref_face.shape == batch_face.shape, (
+            f"{face}: shape {ref_face.shape} != {batch_face.shape}")
+        assert _close(ref_face, batch_face), (
+            f"{face}: batched differs from full-run "
+            f"max abs diff {np.max(np.abs(ref_face-batch_face))}")
+
+
+def test_requires_ntff_box():
+    sim = Simulation(freq_max=5e9, domain=(0.01, 0.01, 0.005), dx=0.5e-3,
+                     cpml_layers=4)
+    with pytest.raises(ValueError, match="add_ntff_box"):
+        ntff_sweep(sim, [2.4e9])
+
+
+def test_restores_freqs_on_success():
+    original = np.array([2.4e9, 3.0e9])
+    sim = _small_sim(original)
+    ntff_sweep(sim, [2.0e9, 2.4e9], batch_size=1,
+               run_kwargs=dict(n_steps=40, compute_s_params=False))
+    restored = sim._ntff[2]
+    np.testing.assert_array_equal(restored, original)
+
+
+def test_restores_freqs_on_exception():
+    original = np.array([2.4e9, 3.0e9])
+    sim = _small_sim(original)
+    # Force failure by passing an invalid run kwarg.
+    with pytest.raises(TypeError):
+        ntff_sweep(sim, [2.0e9], batch_size=1,
+                   run_kwargs=dict(not_a_real_kwarg=True))
+    restored = sim._ntff[2]
+    np.testing.assert_array_equal(restored, original)


### PR DESCRIPTION
`rfx.ntff_sweep.ntff_sweep` runs the sim once per frequency batch and concatenates NTFFData along the freq axis. Memory ∝ 1/N_batches at wall-time cost N_batches × single-run. Closes #43.