### PR TITLE
Add preflight warnings for PEC probes and soft-source reflected-energy use

### DIFF
--- a/rfx/api.py
+++ b/rfx/api.py
@@ -144,6 +144,8 @@ class Result(NamedTuple):
     grid: object = None
     dt: float | None = None
     freq_range: tuple | None = None
+    matched_port_count: int | None = None
+    soft_source_count: int | None = None
 
     def find_resonances(self, freq_range=None, probe_idx=0,
                          source_decay_time=None, bandpass=None):
@@ -228,6 +230,8 @@ class ForwardResult(NamedTuple):
     grid: object = None
     s_params: object = None
     freqs: object = None
+    matched_port_count: int | None = None
+    soft_source_count: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -2211,6 +2215,31 @@ class Simulation:
             s_param_freqs=s_param_freqs,
         )
 
+    def _measurement_context_counts(self) -> tuple[int, int]:
+        """Return counts of matched ports and soft sources.
+
+        `add_source()` is represented internally as a port entry with
+        `impedance=0.0`, while `add_port()` carries a positive impedance.
+        """
+        matched_ports = 0
+        soft_sources = 0
+        for pe in self._ports:
+            if getattr(pe, "impedance", 0.0) and pe.impedance > 0.0:
+                matched_ports += 1
+            else:
+                soft_sources += 1
+        return matched_ports, soft_sources
+
+    def _attach_result_context(self, result):
+        """Attach source/port context metadata to a Result-like object."""
+        if result is None or not hasattr(result, "_replace"):
+            return result
+        matched_ports, soft_sources = self._measurement_context_counts()
+        return result._replace(
+            matched_port_count=matched_ports,
+            soft_source_count=soft_sources,
+        )
+
     def _auto_configure_mesh(self) -> None:
         """P1: Auto-detect features and set dx/dz_profile when dx=None.
 
@@ -2954,6 +2983,26 @@ class Simulation:
                     except (NotImplementedError, TypeError):
                         pass
 
+        # P1.8b: Probe inside PEC geometry
+        for pe in self._probes:
+            pos = pe.position
+            for entry in self._geometry:
+                if entry.material_name != "pec":
+                    continue
+                if hasattr(entry.shape, "bounding_box"):
+                    try:
+                        c1, c2 = entry.shape.bounding_box()
+                        inside = all(c1[ax] <= pos[ax] <= c2[ax] for ax in range(3))
+                        if inside:
+                            _w.warn(
+                                f"Probe at {pos} is inside PEC geometry "
+                                f"'{entry.material_name}'. E-field is zero inside PEC — "
+                                f"probe will record no signal.",
+                                stacklevel=3,
+                            )
+                    except (NotImplementedError, TypeError):
+                        pass
+
         # P0.4: PEC boundary on likely open structure
         if self._boundary == "pec" and self._ntff is not None:
             _w.warn(
@@ -3157,18 +3206,18 @@ class Simulation:
                     hx=hx_f, hy=hy_f, hz=hz_f,
                     step=jnp.asarray(n_steps, dtype=jnp.int32),
                 )
-                return Result(
+                return self._attach_result_context(Result(
                     state=state,
                     time_series=probe_data,
                     s_params=None, freqs=None,
                     grid=grid_out, dt=dt,
                     freq_range=(self._freq_max / 10, self._freq_max, self._boundary),
-                )
-            return ForwardResult(
+                ))
+            return self._attach_result_context(ForwardResult(
                 time_series=probe_data,
                 ntff_data=None, ntff_box=None,
                 grid=grid_out,
-            )
+            ))
 
         # ---- 2D TMz path ----
         sources = []
@@ -3223,7 +3272,7 @@ class Simulation:
                 hy=hy_f,
                 step=jnp.asarray(n_steps, dtype=jnp.int32),
             )
-            return Result(
+            return self._attach_result_context(Result(
                 state=state,
                 time_series=probe_data,
                 s_params=None,
@@ -3231,14 +3280,14 @@ class Simulation:
                 grid=grid_out,
                 dt=dt,
                 freq_range=(self._freq_max / 10, self._freq_max, self._boundary),
-            )
+            ))
 
-        return ForwardResult(
+        return self._attach_result_context(ForwardResult(
             time_series=probe_data,
             ntff_data=None,
             ntff_box=None,
             grid=grid_out,
-        )
+        ))
 
     def _forward_from_materials(
         self,
@@ -3416,14 +3465,14 @@ class Simulation:
             pec_occupancy=pec_occupancy_local,
             return_state=False,
         )
-        return ForwardResult(
+        return self._attach_result_context(ForwardResult(
             time_series=result.time_series,
             ntff_data=result.ntff_data,
             ntff_box=result.ntff_box,
             grid=result.grid,
             s_params=getattr(result, "s_params", None),
             freqs=getattr(result, "freqs", None),
-        )
+        ))
 
     def _forward_nonuniform_from_materials(
         self,
@@ -3460,14 +3509,14 @@ class Simulation:
             checkpoint_every=checkpoint_every,
             n_warmup=n_warmup,
         )
-        return ForwardResult(
+        return self._attach_result_context(ForwardResult(
             time_series=result.time_series,
             ntff_data=result.ntff_data,
             ntff_box=result.ntff_box,
             grid=result.grid,
             s_params=getattr(result, "s_params", None),
             freqs=getattr(result, "freqs", None),
-        )
+        ))
 
     # ---- forward (differentiable) ----
 
@@ -3734,10 +3783,10 @@ class Simulation:
                     grid = self._build_grid()
                     n_steps = grid.num_timesteps(num_periods=num_periods)
             from rfx.runners.distributed_v2 import run_distributed
-            return run_distributed(
+            return self._attach_result_context(run_distributed(
                 self, n_steps=n_steps, devices=devices,
                 exchange_interval=exchange_interval,
-            )
+            ))
 
         # ---- Non-uniform mesh path ----
         if (self._dz_profile is not None
@@ -3753,11 +3802,11 @@ class Simulation:
             if n_steps is None:
                 n_steps = int(np.ceil(
                     num_periods / (self._freq_max * nu_grid.dt)))
-            return self._run_nonuniform(
+            return self._attach_result_context(self._run_nonuniform(
                 n_steps=n_steps,
                 compute_s_params=compute_s_params,
                 s_param_freqs=s_param_freqs,
-            )
+            ))
 
         grid = self._build_grid()
         base_materials, debye_spec, lorentz_spec, pec_mask, pec_shapes, kerr_chi3 = self._assemble_materials(grid)
@@ -3769,7 +3818,7 @@ class Simulation:
                 raise ValueError("solver='adi' does not support snapshots yet")
             if n_steps is None:
                 n_steps = grid.num_timesteps(num_periods=num_periods)
-            return self._run_adi_from_materials(
+            return self._attach_result_context(self._run_adi_from_materials(
                 grid,
                 base_materials,
                 debye_spec,
@@ -3777,14 +3826,14 @@ class Simulation:
                 n_steps=n_steps,
                 pec_mask=pec_mask,
                 return_state=True,
-            )
+            ))
 
         # ---- Subgridded path ----
         if self._refinement is not None:
-            return self._run_subgridded(
+            return self._attach_result_context(self._run_subgridded(
                 grid, base_materials, pec_mask,
                 n_steps=n_steps or grid.num_timesteps(num_periods=num_periods),
-            )
+            ))
 
         # ---- Uniform path ----
         if n_steps is None:
@@ -3792,7 +3841,7 @@ class Simulation:
 
         from rfx.runners.uniform import run_uniform
         _field_dtype = jnp.float16 if self._precision == "mixed" else None
-        return run_uniform(
+        return self._attach_result_context(run_uniform(
             self,
             n_steps=n_steps,
             until_decay=until_decay,
@@ -3817,7 +3866,7 @@ class Simulation:
             pec_mask=pec_mask,
             kerr_chi3=kerr_chi3,
             field_dtype=_field_dtype,
-        )
+        ))
 
     def __repr__(self) -> str:
         grid = self._build_grid()

--- a/rfx/optimize.py
+++ b/rfx/optimize.py
@@ -110,6 +110,9 @@ def optimize(
     -------
     OptimizeResult
     """
+    sim._validate_mesh_quality()
+    sim._validate_simulation_config()
+
     grid = sim._build_grid()
 
     # Compute design-region grid indices, clamped to interior (exclude CPML).

--- a/rfx/optimize_objectives.py
+++ b/rfx/optimize_objectives.py
@@ -409,8 +409,30 @@ def minimize_reflected_energy(
     -------
     callable(Result) -> scalar (JAX-differentiable)
     """
+    warned_soft_source_only = False
+
     def objective(result) -> jnp.ndarray:
+        nonlocal warned_soft_source_only
         _require_time_series(result, "minimize_reflected_energy")
+        matched_ports = getattr(result, "matched_port_count", None)
+        soft_sources = getattr(result, "soft_source_count", None)
+        if (
+            not warned_soft_source_only
+            and soft_sources is not None
+            and soft_sources > 0
+            and matched_ports == 0
+        ):
+            import warnings as _w
+
+            _w.warn(
+                "minimize_reflected_energy() is most accurate with an "
+                "impedance-matched port (add_port). Using it with a soft "
+                "source (add_source) may give incorrect S11 estimates "
+                "because reflected waves are not absorbed.",
+                UserWarning,
+                stacklevel=2,
+            )
+            warned_soft_source_only = True
         ts = result.time_series[:, port_probe_idx]
         n = ts.shape[0]
         split = int(n * (1.0 - late_fraction))

--- a/rfx/topology.py
+++ b/rfx/topology.py
@@ -384,6 +384,9 @@ def topology_optimize(
     TopologyResult
         Contains final density, permittivity, loss history, and beta history.
     """
+    sim._validate_mesh_quality()
+    sim._validate_simulation_config()
+
     try:
         import optax
     except ImportError:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,6 +44,17 @@ def test_basic_simulation():
     assert peak > 0, "Probe should detect non-zero field"
 
 
+def test_warns_when_probe_inside_pec_geometry():
+    """Probe inside PEC should warn before run() proceeds."""
+    sim = Simulation(freq_max=5e9, domain=(0.03, 0.03, 0.03), boundary="pec")
+    sim.add(Box((0.01, 0.01, 0.01), (0.02, 0.02, 0.02)), material="pec")
+    sim.add_source((0.005, 0.005, 0.005), "ez")
+    sim.add_probe((0.015, 0.015, 0.015), "ez")
+
+    with pytest.warns(UserWarning, match="Probe at .* inside PEC geometry"):
+        sim.run(n_steps=20, compute_s_params=False)
+
+
 def test_upml_boundary_runs_through_api():
     """UPML boundary should be accepted for the uniform-grid Yee path."""
     sim = Simulation(

--- a/tests/test_optimize_proxy_objectives.py
+++ b/tests/test_optimize_proxy_objectives.py
@@ -15,6 +15,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+import warnings
 
 from rfx.optimize_objectives import (
     minimize_s11,
@@ -40,6 +41,8 @@ class _MockResult(NamedTuple):
     freqs: object
     ntff_data: object = None
     ntff_box: object = None
+    matched_port_count: int | None = None
+    soft_source_count: int | None = None
 
 
 def _make_mock_result_no_sparams(n_steps: int = 200, n_probes: int = 2):
@@ -208,6 +211,70 @@ class TestMinimizeReflectedEnergy:
         # Different split points should generally give different losses
         # (not strictly guaranteed but highly likely with our mock data)
         assert loss_50 != loss_30 or True  # Just check it doesn't crash
+
+    def test_warns_when_only_soft_source_context_is_present(self):
+        """Soft-source-only measurement contexts should warn once."""
+        result = _MockResult(
+            state=None,
+            time_series=_make_mock_result_no_sparams().time_series,
+            s_params=None,
+            freqs=None,
+            matched_port_count=0,
+            soft_source_count=1,
+        )
+        obj = minimize_reflected_energy(port_probe_idx=0)
+        with pytest.warns(UserWarning, match="impedance-matched port"):
+            loss = obj(result)
+        assert jnp.isfinite(loss)
+
+    def test_no_warning_when_matched_port_context_is_present(self):
+        """Matched-port contexts should not emit the soft-source warning."""
+        result = _MockResult(
+            state=None,
+            time_series=_make_mock_result_no_sparams().time_series,
+            s_params=None,
+            freqs=None,
+            matched_port_count=1,
+            soft_source_count=0,
+        )
+        obj = minimize_reflected_energy(port_probe_idx=0)
+        with warnings.catch_warnings(record=True) as record:
+            warnings.simplefilter("always")
+            loss = obj(result)
+        assert jnp.isfinite(loss)
+        assert not record
+
+    def test_forward_attaches_measurement_context_counts(self):
+        """Simulation.forward should tag results with source/port context."""
+        from rfx import Simulation
+
+        sim_src = Simulation(freq_max=5e9, domain=(0.03, 0.03, 0.03), boundary="pec")
+        sim_src.add_source((0.015, 0.015, 0.015), "ez")
+        sim_src.add_probe((0.018, 0.018, 0.018), "ez")
+        result_src = sim_src.forward(n_steps=20)
+        assert result_src.soft_source_count == 1
+        assert result_src.matched_port_count == 0
+
+        sim_port = Simulation(freq_max=5e9, domain=(0.03, 0.03, 0.03), boundary="pec")
+        sim_port.add_port((0.015, 0.015, 0.015), "ez", impedance=50.0)
+        sim_port.add_probe((0.018, 0.018, 0.018), "ez")
+        result_port = sim_port.forward(n_steps=20)
+        assert result_port.soft_source_count == 0
+        assert result_port.matched_port_count == 1
+
+    def test_warns_for_actual_soft_source_forward_result(self):
+        """Actual ForwardResult from add_source() should trigger the warning."""
+        from rfx import Simulation
+
+        sim = Simulation(freq_max=5e9, domain=(0.03, 0.03, 0.03), boundary="pec")
+        sim.add_source((0.015, 0.015, 0.015), "ez")
+        sim.add_probe((0.018, 0.018, 0.018), "ez")
+        result = sim.forward(n_steps=20)
+
+        obj = minimize_reflected_energy(port_probe_idx=0)
+        with pytest.warns(UserWarning, match="impedance-matched port"):
+            loss = obj(result)
+        assert jnp.isfinite(loss)
 
 
 class TestMaximizeTransmittedEnergy:
@@ -387,3 +454,29 @@ class TestOptimizeWithProxy:
         assert all(np.isfinite(l) for l in result.loss_history)
         print(f"\n  [Proxy S21] initial={result.loss_history[0]:.6e}, "
               f"final={result.loss_history[-1]:.6e}")
+
+    def test_optimize_warns_when_probe_is_inside_pec(self):
+        """Optimization preflight should warn about probes inside PEC."""
+        from rfx.api import Simulation
+        from rfx.geometry.csg import Box
+        from rfx.optimize import DesignRegion, optimize
+
+        sim = Simulation(
+            freq_max=5e9,
+            domain=(0.03, 0.03, 0.03),
+            boundary="pec",
+        )
+        sim.add(Box((0.012, 0.012, 0.012), (0.020, 0.020, 0.020)), material="pec")
+        sim.add_source((0.006, 0.006, 0.006), "ez")
+        sim.add_probe((0.015, 0.015, 0.015), "ez")
+
+        region = DesignRegion(
+            corner_lo=(0.022, 0.0, 0.0),
+            corner_hi=(0.026, 0.01, 0.01),
+            eps_range=(1.0, 2.0),
+        )
+        obj = minimize_reflected_energy(port_probe_idx=0)
+
+        with pytest.warns(UserWarning, match="Probe at .* inside PEC geometry"):
+            result = optimize(sim, region, obj, n_iters=1, lr=0.01, verbose=False)
+        assert len(result.loss_history) == 1


### PR DESCRIPTION
## Summary

This PR fixes two small but high-signal diagnostics issues:

- #62: warn when a probe is placed inside a PEC volume
- #63: warn when `minimize_reflected_energy()` is used in a soft-source-only measurement context

## What changed

### #62 probe-inside-PEC detection
- Added a preflight warning in `Simulation._validate_simulation_config()` for probes inside PEC geometry
- Added focused regression coverage in `tests/test_api.py`
- Added the same validation hook to `optimize()` and `topology_optimize()` so the warning also appears on optimization paths that currently bypass `forward()`

### #63 reflected-energy proxy warning
- Added source/port context metadata to `Result` and `ForwardResult`
- `minimize_reflected_energy()` now warns once per objective instance when the result came from a soft-source-only setup with no matched port
- Added focused regression coverage in `tests/test_optimize_proxy_objectives.py`

## Why

Both issues are easy to miss and can waste a lot of debugging time:
- a probe inside PEC records zero field and can produce NaN optimization behavior
- reflected-energy proxy loss can look reasonable while the physical S11 interpretation is wrong if there is no matched port

## Verification

```bash
python -m compileall rfx/api.py rfx/optimize_objectives.py rfx/optimize.py rfx/topology.py tests/test_api.py tests/test_optimize_proxy_objectives.py
pytest -q tests/test_api.py -k 'probe_inside_pec or upml_rejects_subgridding_refinement'
pytest -q tests/test_optimize_proxy_objectives.py -k 'warns_when_only_soft_source_context_is_present or no_warning_when_matched_port_context_is_present or forward_attaches_measurement_context_counts or actual_soft_source_forward_result or optimize_warns_when_probe_is_inside_pec'
pytest -q tests/test_optimize_proxy_objectives.py tests/test_optimize.py tests/test_topology.py -k 'not distributed and (optimize or reflected_energy or transmitted_energy or topology_optimize)'
```

## Notes for review

This PR is intentionally narrow:
- warning-only behavior, not semantic changes to simulation math
- preserves differentiable paths
- does not attempt the larger `optimize()/topology_optimize() -> forward()` reroute from #64
