### PR TITLE
feat(api): expose raw lumped_port_sparams on ForwardResult for 2-port AD

### DIFF
--- a/rfx/api.py
+++ b/rfx/api.py
@@ -222,6 +222,14 @@ class ForwardResult(NamedTuple):
 
     Carries only the observables needed by gradient-based objectives,
     avoiding the broader stateful surface of :class:`Result`.
+
+    ``lumped_port_sparams`` exposes the raw per-port (V_dft, I_dft) tuples
+    accumulated inside the JIT scan body when ``forward(port_s11_freqs=...)``
+    is used.  Single-port objectives can keep using ``s_params`` (which is
+    populated with per-port |S11| via :func:`extract_lumped_s11`).  Multi-
+    port AD objectives (e.g. 2-port |S21| topology optimisation) read raw
+    V/I from this field and compose their own wave decomposition, since
+    ``extract_lumped_s11`` collapses each port to its self-reflection only.
     """
     time_series: jnp.ndarray
     ntff_data: object = None
@@ -229,6 +237,7 @@ class ForwardResult(NamedTuple):
     grid: object = None
     s_params: object = None
     freqs: object = None
+    lumped_port_sparams: object = None
 
 
 # ---------------------------------------------------------------------------
@@ -4555,6 +4564,7 @@ class Simulation:
             grid=result.grid,
             s_params=s_params_out,
             freqs=freqs_out,
+            lumped_port_sparams=result.lumped_port_sparams,
         )
 
     def _forward_nonuniform_from_materials(


### PR DESCRIPTION
## Summary

Adds a single optional field on `ForwardResult` (`lumped_port_sparams: object = None`) that propagates the underlying `SimResult.lumped_port_sparams` tuple unchanged. Enables differentiable multi-port objectives (e.g. 2-port |S21| topology optimisation) without bypassing the public forward path.

## Motivation

PR #72 added per-port `(V_dft, I_dft)` DFT accumulation inside the JIT scan body when `forward(port_s11_freqs=...)` is used. The raw V/I tuples are then collapsed to per-port |S11| via `extract_lumped_s11` and stored in `ForwardResult.s_params`:

```python
# rfx/api.py (current main)
for spec, accs in result.lumped_port_sparams:
    v_dft, i_dft = accs
    s_list.append(extract_lumped_s11(v_dft, i_dft, z0=spec.impedance))
s_params_out = ... # stacked per-port |S11|
return ForwardResult(s_params=s_params_out, ...)  # raw V/I dropped
```

This is correct and convenient for single-port impedance-match optimisation. It does not, however, expose the cross-port wave information that any multi-port AD objective needs.

Concretely: a 2-port topology optimisation that wants |S21| in the loss needs raw V₁/I₁ at the driven port AND V₂/I₂ at the passive matched port, so it can compute

```
a₁ = (−V₁ + Z₀·I₁) / (2·√Z₀)         (incident at active port)
b₂ = (−V₂ − Z₀·I₂) / (2·√Z₀)         (outgoing at passive matched port, a₂ = 0)
S₂₁ = b₂ / a₁ = (V₂ + Z₀·I₂) / (V₁ − Z₀·I₁)
```

`extract_lumped_s11(V_i, I_i, Z0)` collapses each port to its own `b_i/a_i = (V_i+Z₀·I_i)/(V_i−Z₀·I_i)`. On the passive matched port `a_i ≈ 0`, making that ratio singular. So `s_params[passive_port_idx]` is not usable for S21; the raw V/I pair is what we need.

Bypassing the public `Simulation.forward()` and accessing `_forward_from_materials`'s underlying `SimResult` is private-API surface and brittle. Exposing the raw tuple as one extra field on `ForwardResult` is the smallest correct change.

## Change

```python
class ForwardResult(NamedTuple):
    time_series: jnp.ndarray
    ntff_data: object = None
    ntff_box: object = None
    grid: object = None
    s_params: object = None
    freqs: object = None
    lumped_port_sparams: object = None  # NEW
```

And in `_forward_from_materials`:

```python
return ForwardResult(
    ...,
    s_params=s_params_out,
    freqs=freqs_out,
    lumped_port_sparams=result.lumped_port_sparams,  # NEW
)
```

The field is `None` when `port_s11_freqs=None` — default callers see no change. The existing `s_params` (per-port |S11| stack) is preserved verbatim.

## Verification

- 2-port smoke test (1 active + 1 passive matched lumped port at distinct positions, `freqs=jnp.linspace(3e9, 7e9, 7)` on a small CPU PEC cavity):
  - `result.s_params.shape == (2, 7)` (existing behaviour preserved)
  - `result.lumped_port_sparams` is a `tuple` of length 2
  - Each element is `(LumpedPortSParamSpec, (V_dft, I_dft))` with V/I shape `(7,)` complex
  - V[0] at the active port: `-1.83e-12 + 4.78e-12j` (driven, finite)
  - V[0] at the passive port: `-1.12e-15 + 8.10e-16j` (orders of magnitude smaller, as expected for a matched probe at a distance from the active source)
- All previously merged tests pass on the smoke setup; no test code modified by this PR.

## Downstream consumer

`papers/rfx-tap/experiments/ex2_bpf_topology.py` (forthcoming) — 5 GHz hairpin-class bandpass filter via density topology optimisation. Uses the new field to compute differentiable |S11| AND |S21| from raw V/I DFTs and avoid the bake/voxel-rasterizer path entirely (decouples ex2 from rfx issue #75).

## Test plan

- [x] Existing single-port `s_params` shape preserved (verified by smoke test)
- [x] Two-port `result.lumped_port_sparams` returns the raw V/I per port
- [x] No regression on `forward(port_s11_freqs=None)` (field defaults to None)
- [ ] (Follow-up) Same field on the NU forward path (`_forward_nonuniform_from_materials`) — out of scope for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)