### PR TITLE
fix(scan): sample S-param V/I before source injection in JIT path

### DIFF
--- a/rfx/simulation.py
+++ b/rfx/simulation.py
@@ -1502,44 +1502,20 @@ def run_until_decay(
                 st, rlc_st_new = update_rlc_element(st, rlc_st, meta)
                 new_rlc_states.append(rlc_st_new)
 
-        # Soft sources — cast source value to field dtype to avoid
-        # mixed-precision scatter warnings (float32 -> float16).
-        for idx_s, (si, sj, sk, sc) in enumerate(src_meta):
-            field = getattr(st, sc)
-            field = field.at[si, sj, sk].add(src_vals[idx_s].astype(field.dtype))
-            st = st._replace(**{sc: field})
-
+        # Compute step time first; wire/lumped S-param DFT blocks below
+        # need `t` and must accumulate BEFORE source injection per the
+        # rfx/probes/probes.py update_sparam_probe docstring contract
+        # ("sample after E-update/apply_pec but before apply_lumped_port
+        # so V reflects only the cavity/load response, not the driving
+        # waveform"). The Python-loop scan path (this file, around the
+        # forward() Python-loop body) already enforces this. The JIT
+        # scan path violated it via PR #72 ordering, producing 5–10 dB
+        # train/eval |S11| disagreement on near-matched antennas where
+        # source-injection contamination is large relative to V.
         t = step_idx.astype(jnp.float32) * dt
 
-        if use_tfsf:
-            if _tfsf_is_2d:
-                tfsf_new = update_tfsf_2d_e(tfsf_cfg, tfsf_h_state, dx, dt, t)
-            else:
-                tfsf_new = update_tfsf_1d_e(tfsf_cfg, tfsf_h_state, dx, dt, t)
-
-        if use_waveguide_ports:
-            from rfx.sources.waveguide_port import (
-                update_waveguide_port_probe,
-            )
-            new_waveguide_port_accs = []
-            for accs, cfg_meta in zip(carry_in["waveguide_port_accs"], waveguide_meta):
-                cfg = cfg_meta._replace(
-                    v_probe_t=accs[0], v_ref_t=accs[1],
-                    i_probe_t=accs[2], i_ref_t=accs[3],
-                    v_inc_t=accs[4],
-                    n_steps_recorded=accs[5],
-                )
-                # TFSF-style H/E corrections applied earlier in canonical
-                # Yee sub-steps (see L1247-L1288 region).
-                cfg_updated = update_waveguide_port_probe(cfg, st, dt, dx)
-                new_waveguide_port_accs.append((
-                    cfg_updated.v_probe_t, cfg_updated.v_ref_t,
-                    cfg_updated.i_probe_t, cfg_updated.i_ref_t,
-                    cfg_updated.v_inc_t,
-                    cfg_updated.n_steps_recorded,
-                ))
-
-        # Wire port S-param DFT accumulation (JIT-integrated)
+        # Wire port S-param DFT accumulation BEFORE source injection so
+        # that sampled V/I reflects only the load/cavity response.
         if use_wire_sparams:
             new_wire_accs = []
             for accs, wp_meta in zip(carry_in["wire_sparam_accs"], wire_sparam_meta):
@@ -1563,7 +1539,9 @@ def run_until_decay(
                     vinc_dft,
                 ))
 
-        # Lumped port S-param DFT accumulation (issue #72).
+        # Lumped port S-param DFT accumulation BEFORE source injection
+        # (issue #72). Same wave-decomposition pattern as the wire-port
+        # path; mirrors the Python-loop scan body ordering.
         if use_lumped_sparams:
             new_lumped_accs = []
             for accs, lp_meta in zip(carry_in["lumped_sparam_accs"], lumped_sparam_meta):
@@ -1584,6 +1562,45 @@ def run_until_decay(
                 new_lumped_accs.append((
                     v_dft_l + v_l * phase_l,
                     i_dft_l + i_val_l * phase_l,
+                ))
+
+        # Soft sources — cast source value to field dtype to avoid
+        # mixed-precision scatter warnings (float32 -> float16).
+        for idx_s, (si, sj, sk, sc) in enumerate(src_meta):
+            field = getattr(st, sc)
+            field = field.at[si, sj, sk].add(src_vals[idx_s].astype(field.dtype))
+            st = st._replace(**{sc: field})
+
+        if use_tfsf:
+            if _tfsf_is_2d:
+                tfsf_new = update_tfsf_2d_e(tfsf_cfg, tfsf_h_state, dx, dt, t)
+            else:
+                tfsf_new = update_tfsf_1d_e(tfsf_cfg, tfsf_h_state, dx, dt, t)
+
+        if use_waveguide_ports:
+            from rfx.sources.waveguide_port import (
+                update_waveguide_port_probe,
+            )
+            new_waveguide_port_accs = []
+            for accs, cfg_meta in zip(carry_in["waveguide_port_accs"], waveguide_meta):
+                cfg = cfg_meta._replace(
+                    v_probe_t=accs[0], v_ref_t=accs[1],
+                    i_probe_t=accs[2], i_ref_t=accs[3],
+                    v_inc_t=accs[4],
+                    n_steps_recorded=accs[5],
+                )
+                # TFSF-style H/E corrections applied earlier in canonical
+                # Yee sub-steps (see L1247-L1288 region).
+                # NOTE: this samples `st` AFTER source injection above.
+                # The same docstring-contract concern as wire/lumped
+                # applies here, but waveguide-port is out of scope for
+                # this fix (issue #29 OPEN tracks waveguide-port issues).
+                cfg_updated = update_waveguide_port_probe(cfg, st, dt, dx)
+                new_waveguide_port_accs.append((
+                    cfg_updated.v_probe_t, cfg_updated.v_ref_t,
+                    cfg_updated.i_probe_t, cfg_updated.i_ref_t,
+                    cfg_updated.v_inc_t,
+                    cfg_updated.n_steps_recorded,
                 ))
 
         # Probe samples


### PR DESCRIPTION
## Summary

The JIT segmented-scan body in `rfx/simulation.py` accumulated wire-port and lumped-port S-param DFTs **after** soft-source injection, violating the docstring contract on `rfx/probes/probes.py:update_sparam_probe`. The Python-loop scan body in the same file already accumulates DFTs **before** source injection. Two paths in the same file, divergent ordering. This PR makes the JIT scan path mirror the Python-loop ordering.

## Contract being honored (`rfx/probes/probes.py:248-291`)

> Call this every timestep *after* `update_e()` / `apply_pec()` but **before** `apply_lumped_port()` so that the sampled port voltage reflects only the cavity/load response, not the source injection. Sampling after source injection contaminates V with the driving waveform, making the wave-decomposition S11 meaningless.

## Symptom

5–10 dB train/eval |S11| disagreement on near-matched antennas (e.g. ex1 DRA, ex3 patch arrays in the rfx-tap downstream paper) where source-injection contamination is large relative to V_total. The existing PEC-cavity test (`test_jit_path_matches_python_loop_extractor`) passed at the 0.05 tolerance despite the bug because |S11|≈1 makes the contamination a small fraction of V_total. Sensitive geometries reveal it.

## Fix

Move `t = step_idx * dt`, the wire_sparam DFT accumulation block, and the lumped_sparam DFT accumulation block to **before** the soft-source injection block in the JIT scan body. Mirrors the Python-loop ordering exactly. 1 file changed, 54 insertions, 37 deletions (block move + comments).

## Out of scope

`update_waveguide_port_probe` is also called after source injection and exhibits the same contract concern. Waveguide-port has its own open issues (#29) and is not exercised by the same downstream optimisation paths, so it is left unchanged in this PR. Inline `NOTE` added at the call site to flag the related concern.

## Test evidence

**Existing suite** — 38/38 pass on the local fix branch:
- `tests/test_lumped_port_sparams_jit.py` — 3/3 (incl. `test_jit_path_matches_python_loop_extractor`)
- `tests/test_sparam.py`, `tests/test_wire_sparam.py`, `tests/test_optimize_s11_wave_decomp.py`
- `tests/test_minimize_s11_at_freq_physical.py`, `tests/test_s11_at_freq.py`
- `tests/test_lumped_rlc.py`, `tests/test_twoport_wire_port.py`

**New empirical calibration** — Yi 24 GHz single-patch (RO4350B, εr=3.66, h=0.508 mm, 24.125 GHz) on NVIDIA RTX A6000 (VESSL run `369367235851`, completed 1m19s). Single Simulation, two `forward()` calls comparing the two paths on identical geometry:

| | Path A (`checkpoint_segments=None`) | Path B (`checkpoint_segments=10`) |
|---|---|---|
| scan body | Python-loop (already correct) | JIT segmented (this PR's fix) |
| n_steps | 3424 | 3430 |

Result across 13 frequencies in [22.5, 25.5] GHz: **max \|S11_A_dB − S11_B_dB\| = 1.48 × 10⁻⁵ dB** (i.e., float32 rounding floor; 5 decimal places of agreement in dB). All 13 \|diff\| values < 1.5 × 10⁻⁵ dB. Calib script + plot live in the rfx-tap paper repo (`papers/rfx-tap/experiments/ex3_yi_singlepatch_calib.py`, `papers/rfx-tap/results/ex3_yi_singlepatch_calib/`).

The same calibration pre-fix would have shown the 5–10 dB disconnect that motivated this work — the geometry is sensitive enough (|S11| ≈ −2 dB across the band, far from the PEC-cavity insensitive regime).

🤖 Generated with [Claude Code](https://claude.com/claude-code)