### PR TITLE
fix(api): refactor cleanup + Kottke port dilation guard (#82, #83)

### DIFF
--- a/rfx/api/_compile.py
+++ b/rfx/api/_compile.py
@@ -113,14 +113,15 @@ class _CompileMixin:
     def _assemble_materials(
         self,
         grid: Grid,
-    ) -> tuple[MaterialArrays, _DebyeSpec | None, _LorentzSpec | None, jnp.ndarray | None, list, jnp.ndarray | None]:
+    ) -> tuple[MaterialArrays, _DebyeSpec | None, _LorentzSpec | None, jnp.ndarray | None, list, list, jnp.ndarray | None]:
         """Build material arrays plus per-pole dispersion masks.
 
         Returns
         -------
-        materials, debye_spec, lorentz_spec, pec_mask, pec_shapes, kerr_chi3
+        materials, debye_spec, lorentz_spec, pec_mask, pec_shapes, boundary_pec_shapes, kerr_chi3
             pec_mask is a boolean array (True at PEC cells) or None.
             pec_shapes is a list of Shape objects that are PEC.
+            boundary_pec_shapes is a list of PEC shapes from boundary conditions.
             kerr_chi3 is a float32 array of chi3 values or None.
         """
         # Start with vacuum

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -700,8 +700,8 @@ class _ExecuteMixin:
         # The default _run cpml_axes="xyz" builds CPML state for axes
         # that have no padding, producing shape-broadcast errors like
         # (8,1,1) vs (nx,ny,nz) during the scan (issue #29). The run()
-        # path forwards these explicitly at api.py:2012, so does the
-        # waveguide compute path at :2077 / :2092.
+        # path forwards these explicitly (see Simulation.run in _execute.py),
+        # so does the waveguide compute path (see _sparams.py).
         cpml_axes_run = grid.cpml_axes
         pec_axes_run = "".join(a for a in "xyz" if a not in cpml_axes_run)
 
@@ -1456,7 +1456,7 @@ class _ExecuteMixin:
         if is_nonuniform:
             # Synthesise missing dz profile so the NU grid build always
             # sees all three axes (mirrors Simulation.run()'s pre-build
-            # synthesis at api.py ~4268).  Required for sims that set
+            # synthesis in Simulation.run(), see _execute.py).  Required for sims that set
             # only dx/dy_profile and leave dz uniform.
             if self._dz_profile is None:
                 nz_phys = max(1, int(round(self._domain[2] / self._dx)))

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -460,6 +460,9 @@ class _ExecuteMixin:
         else:
             _s11_freqs_arr = None
 
+        # Collect all port cell indices for Kottke dilation guard (issue #82).
+        _port_cleared_cells: list[tuple[int, int, int]] = []
+
         for pe in self._ports:
             if pe.impedance == 0.0:
                 from rfx.simulation import make_j_source
@@ -490,6 +493,7 @@ class _ExecuteMixin:
                         pec_mask_local = pec_mask_local.at[cell[0], cell[1], cell[2]].set(False)
                     if pec_occupancy_local is not None:
                         pec_occupancy_local = pec_occupancy_local.at[cell[0], cell[1], cell[2]].set(0.0)
+                    _port_cleared_cells.append((int(cell[0]), int(cell[1]), int(cell[2])))
                 # Register a JIT-integrated S-param accumulator for this
                 # WirePort when forward(port_s11_freqs=...) was requested
                 # (issue #79 follow-up to PR #72). Mirrors the lumped
@@ -522,6 +526,7 @@ class _ExecuteMixin:
                 pec_mask_local = pec_mask_local.at[idx[0], idx[1], idx[2]].set(False)
             if pec_occupancy_local is not None:
                 pec_occupancy_local = pec_occupancy_local.at[idx[0], idx[1], idx[2]].set(0.0)
+            _port_cleared_cells.append((int(idx[0]), int(idx[1]), int(idx[2])))
             # Register a JIT-integrated S-param accumulator for this
             # lumped port when the user requested forward(port_s11_freqs=...)
             # (issue #72). Skipping passive ports keeps S11 indexing
@@ -607,6 +612,7 @@ class _ExecuteMixin:
                         pec_mask_local = pec_mask_local.at[cell[0], cell[1], cell[2]].set(False)
                     if pec_occupancy_local is not None:
                         pec_occupancy_local = pec_occupancy_local.at[cell[0], cell[1], cell[2]].set(0.0)
+                    _port_cleared_cells.append((int(cell[0]), int(cell[1]), int(cell[2])))
 
         for pe in self._probes:
             probes.append(make_probe(grid, pe.position, pe.component))
@@ -707,6 +713,21 @@ class _ExecuteMixin:
 
         # Stage 2 Kottke for AD-traceable PEC density (opt-in via env
         # ``RFX_PEC_OCC_KOTTKE=1``).  When enabled and
+        # ── Port-aware Kottke dilation guard (issue #82) ──────────
+        # Kottke's ``occ_dilated = max(f, roll(f,±1,...))`` picks up
+        # non-zero occupancy from cells adjacent to each port cell.
+        # For a probe-fed patch (port 1 cell below the PEC sheet),
+        # the z+1 neighbor carries the patch occupancy into the port's
+        # inv_eps, causing 60x–223% AD gradient mismatch.  Fix: also
+        # zero the 6 face-neighbors of every port cell before Kottke.
+        if pec_occupancy_local is not None and _port_cleared_cells:
+            for ci, cj, ck in _port_cleared_cells:
+                for di, dj, dk in ((1,0,0),(-1,0,0),(0,1,0),(0,-1,0),(0,0,1),(0,0,-1)):
+                    ni = min(max(ci + di, 0), grid.nx - 1)
+                    nj = min(max(cj + dj, 0), grid.ny - 1)
+                    nk = min(max(ck + dk, 0), grid.nz - 1)
+                    pec_occupancy_local = pec_occupancy_local.at[ni, nj, nk].set(0.0)
+
         # ``pec_occupancy_local`` is supplied, build an ``aniso_inv_eps``
         # tensor via Kottke's PEC limit ((1−f)/ε perpendicular, 0
         # parallel) using the gradient of the occupancy as the


### PR DESCRIPTION
## Summary
- Fix _assemble_materials type hint/docstring (7-tuple, not 6) — #83
- Update stale line-number references from pre-refactor api.py — #83
- Clear Kottke dilation neighbors around port cells — #82

## Kottke port dilation guard

Kottke occ_dilated = max(f, roll(f,+/-1,...)) picks up non-zero occupancy from cells adjacent to each port. For probe-fed patches (port 1 cell below PEC sheet), this leaks the patch occupancy gradient into the port inv_eps tensor.

Before fix: 60x-223% AD-vs-FD gradient mismatch on |S11|^2 objectives
After fix: Port cell + 6 face-neighbors zeroed in pec_occupancy_local before kottke_inv_eps_from_occupancy call

Closes #82, closes #83