### PR TITLE
feat(nonuniform): Poynting flux-monitor accumulation in the NU scan body (issue #88 Step A)

### DIFF
--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -723,6 +723,7 @@ def run_nonuniform(
     ntff_data=None,
     waveguide_ports: list | None = None,
     tfsf: tuple | None = None,
+    flux_monitors: list | None = None,
     checkpoint: bool = False,
     emit_time_series: bool = True,
     checkpoint_every: int | None = None,
@@ -751,11 +752,13 @@ def run_nonuniform(
     wire_ports = wire_ports or []
     dft_planes = dft_planes or []
     waveguide_ports = waveguide_ports or []
+    flux_monitors = flux_monitors or []
     dt = grid.dt
     use_wire_ports = len(wire_ports) > 0
     use_debye = debye is not None
     use_lorentz = lorentz is not None
     use_dft_planes = len(dft_planes) > 0
+    use_flux_monitors = len(flux_monitors) > 0
     use_lumped_rlc = len(rlc_metas) > 0
     use_ntff = ntff_box is not None and ntff_data is not None
     use_waveguide_ports = len(waveguide_ports) > 0
@@ -872,6 +875,25 @@ def run_nonuniform(
         )
     else:
         dft_meta = ()
+
+    # Flux monitor carry + static metadata (mirrors the uniform scan body
+    # in rfx/simulation.py). The NU dt is scalar, so the DFT kernels need
+    # no per-axis time weighting; the axis-aware area element dA already
+    # lives on each FluxMonitor (handles graded tangential cells).
+    if use_flux_monitors:
+        from rfx.probes.probes import _FLUX_COMPONENTS as _FC
+        flux_meta = tuple(
+            (fm.axis, fm.index, fm.freqs, _FC[fm.axis],
+             fm.lo1, fm.hi1, fm.lo2, fm.hi2,
+             fm.total_steps, fm.window, fm.window_alpha)
+            for fm in flux_monitors
+        )
+        carry_init["flux_monitors"] = tuple(
+            (fm.e1_dft, fm.e2_dft, fm.h1_dft, fm.h2_dft)
+            for fm in flux_monitors
+        )
+    else:
+        flux_meta = ()
 
     # Lumped RLC ADE state (one per element) — metas are Python-static
     if use_lumped_rlc:
@@ -1083,6 +1105,51 @@ def run_nonuniform(
                     acc + plane[None, :, :] * phase[:, None, None] * dt
                 )
 
+        # Flux monitor accumulation (mirrors uniform scan body in
+        # rfx/simulation.py). H is offset +dx/2 along the normal axis on
+        # the Yee grid; average H at idx-1 and idx to co-locate with E at
+        # idx for a correct Poynting cross-product. E is sampled at
+        # t=step*dt, H at t-dt/2.
+        new_flux_monitors = None
+        if use_flux_monitors:
+            from rfx.core.dft_utils import dft_window_weight as _dft_w
+            t_flux = step_idx.astype(jnp.float32) * dt
+            new_flux_monitors = []
+            for (e1_acc, e2_acc, h1_acc, h2_acc), (
+                ax, idx, fqs, comp_names, _lo1, _hi1, _lo2, _hi2,
+                _tot_steps, _win_name, _win_alpha,
+            ) in zip(carry["flux_monitors"], flux_meta):
+                e1n, e2n, h1n, h2n = comp_names
+                idx_m1 = max(idx - 1, 0)
+                if ax == 0:
+                    e1 = getattr(st, e1n)[idx, _lo1:_hi1, _lo2:_hi2]
+                    e2 = getattr(st, e2n)[idx, _lo1:_hi1, _lo2:_hi2]
+                    h1 = (getattr(st, h1n)[idx_m1, _lo1:_hi1, _lo2:_hi2] + getattr(st, h1n)[idx, _lo1:_hi1, _lo2:_hi2]) * 0.5
+                    h2 = (getattr(st, h2n)[idx_m1, _lo1:_hi1, _lo2:_hi2] + getattr(st, h2n)[idx, _lo1:_hi1, _lo2:_hi2]) * 0.5
+                elif ax == 1:
+                    e1 = getattr(st, e1n)[_lo1:_hi1, idx, _lo2:_hi2]
+                    e2 = getattr(st, e2n)[_lo1:_hi1, idx, _lo2:_hi2]
+                    h1 = (getattr(st, h1n)[_lo1:_hi1, idx_m1, _lo2:_hi2] + getattr(st, h1n)[_lo1:_hi1, idx, _lo2:_hi2]) * 0.5
+                    h2 = (getattr(st, h2n)[_lo1:_hi1, idx_m1, _lo2:_hi2] + getattr(st, h2n)[_lo1:_hi1, idx, _lo2:_hi2]) * 0.5
+                else:
+                    e1 = getattr(st, e1n)[_lo1:_hi1, _lo2:_hi2, idx]
+                    e2 = getattr(st, e2n)[_lo1:_hi1, _lo2:_hi2, idx]
+                    h1 = (getattr(st, h1n)[_lo1:_hi1, _lo2:_hi2, idx_m1] + getattr(st, h1n)[_lo1:_hi1, _lo2:_hi2, idx]) * 0.5
+                    h2 = (getattr(st, h2n)[_lo1:_hi1, _lo2:_hi2, idx_m1] + getattr(st, h2n)[_lo1:_hi1, _lo2:_hi2, idx]) * 0.5
+                t_f64 = t_flux.astype(jnp.float64)
+                fqs64 = fqs.astype(jnp.float64)
+                _w = _dft_w(step_idx, _tot_steps, _win_name, _win_alpha).astype(jnp.float64)
+                phase_e = jnp.exp(-1j * 2.0 * jnp.pi * fqs64 * t_f64)
+                phase_h = jnp.exp(-1j * 2.0 * jnp.pi * fqs64 * (t_f64 - jnp.float64(dt * 0.5)))
+                kernel_e = (phase_e[:, None, None] * dt * _w).astype(jnp.complex128)
+                kernel_h = (phase_h[:, None, None] * dt * _w).astype(jnp.complex128)
+                new_flux_monitors.append((
+                    e1_acc + e1.astype(jnp.float64)[None, :, :] * kernel_e,
+                    e2_acc + e2.astype(jnp.float64)[None, :, :] * kernel_e,
+                    h1_acc + h1.astype(jnp.float64)[None, :, :] * kernel_h,
+                    h2_acc + h2.astype(jnp.float64)[None, :, :] * kernel_h,
+                ))
+
         # NTFF: accumulate tangential E/H DFT on 6 box faces
         new_ntff = None
         if use_ntff:
@@ -1131,6 +1198,8 @@ def run_nonuniform(
             new_carry["wire_sparams"] = tuple(new_wire_sp)
         if use_dft_planes and new_dft_planes is not None:
             new_carry["dft_planes"] = tuple(new_dft_planes)
+        if use_flux_monitors and new_flux_monitors is not None:
+            new_carry["flux_monitors"] = tuple(new_flux_monitors)
         if use_lumped_rlc and new_rlc_states is not None:
             new_carry["rlc_states"] = tuple(new_rlc_states)
         if use_ntff and new_ntff is not None:
@@ -1233,6 +1302,16 @@ def run_nonuniform(
         result["dft_planes"] = tuple(
             probe._replace(accumulator=acc)
             for probe, acc in zip(dft_planes, final["dft_planes"])
+        )
+
+    # Repack flux monitors with their final E/H DFT accumulators so the
+    # caller can call flux_spectrum() on them (same schema as uniform).
+    if use_flux_monitors:
+        result["flux_monitors"] = tuple(
+            mon._replace(e1_dft=e1, e2_dft=e2, h1_dft=h1, h2_dft=h2)
+            for mon, (e1, e2, h1, h2) in zip(
+                flux_monitors, final["flux_monitors"]
+            )
         )
 
     # Surface final NTFF DFT accumulators

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -225,19 +225,19 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
     """
     from rfx.api import Result
 
-    # Flux monitors are accumulated in the uniform scan body only (see
-    # rfx/simulation.py::_run_sim and rfx/runners/uniform.py). The NU scan
-    # body does not plumb them, so silently dropping them would lose the
-    # user's observable without warning. Fail fast — direct the caller to
-    # the uniform lane or NTFF-box alternative.
-    if getattr(sim, "_flux_monitors", None):
-        raise NotImplementedError(
-            "add_flux_monitor() is not supported on the non-uniform mesh "
-            "path; the NU scan body does not accumulate flux DFTs. Drop "
-            "the dx/dy/dz profile to use the uniform lane for R/T "
-            "measurements, or use add_ntff_box() for far-field observables "
-            "on NU meshes."
-        )
+    # Flux monitors: the NU scan body now accumulates Poynting-flux DFTs
+    # (parity with the uniform path). Full-plane monitors are supported;
+    # finite-region (``size=``) monitors still need NU cumulative-edge
+    # index conversion and are rejected below until that lands.
+    for _fm in getattr(sim, "_flux_monitors", None) or []:
+        if getattr(_fm, "size", None) is not None:
+            raise NotImplementedError(
+                "add_flux_monitor(size=...) finite-region monitors are not "
+                "yet supported on the non-uniform mesh path; the tangential "
+                "sub-region index conversion against the graded cumulative "
+                "edges is not implemented. Use a full-plane flux monitor "
+                "(omit size=) or the uniform lane."
+            )
 
     grid = build_nonuniform_grid(
         sim._freq_max, sim._domain, sim._dx, sim._cpml_layers, sim._dz_profile,
@@ -477,6 +477,44 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
                 )
             )
 
+    # Flux monitors — full-plane only (finite-region rejected above).
+    # Tangential cell sizes are passed as per-cell arrays so a graded
+    # tangential axis is integrated correctly by FluxMonitor.dA.
+    flux_monitor_objs = []
+    if getattr(sim, "_flux_monitors", None):
+        from rfx.probes.probes import init_flux_monitor
+        axis_to_index = {"x": 0, "y": 1, "z": 2}
+        # Per-axis tangential cell-size arrays for dA.
+        _d_arr = {
+            0: (np.asarray(grid.dy_arr), np.asarray(grid.dz)),
+            1: (np.asarray(grid.dx_arr), np.asarray(grid.dz)),
+            2: (np.asarray(grid.dx_arr), np.asarray(grid.dy_arr)),
+        }
+        for pe in sim._flux_monitors:
+            axis_idx = axis_to_index[pe.axis]
+            plane_pos = [0.0, 0.0, 0.0]
+            plane_pos[axis_idx] = pe.coordinate
+            grid_index = pos_to_nu_index(grid, tuple(plane_pos))[axis_idx]
+            freqs_arr = (
+                pe.freqs
+                if pe.freqs is not None
+                else jnp.linspace(sim._freq_max / 10, sim._freq_max, pe.n_freqs)
+            )
+            d1_arr, d2_arr = _d_arr[axis_idx]
+            flux_monitor_objs.append(
+                init_flux_monitor(
+                    axis=axis_idx,
+                    index=grid_index,
+                    freqs=freqs_arr,
+                    grid_shape=(grid.nx, grid.ny, grid.nz),
+                    d1=d1_arr,
+                    d2=d2_arr,
+                    dft_total_steps=n_steps,
+                    dft_window=getattr(pe, "dft_window", "rect"),
+                    dft_window_alpha=getattr(pe, "dft_window_alpha", 0.25),
+                )
+            )
+
     sp_freqs = None
     if wire_port_specs and (compute_s_params is None or compute_s_params):
         sp_freqs = s_param_freqs
@@ -592,6 +630,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         pec_faces=getattr(sim, '_pec_faces', None),
         pmc_faces=sim._boundary_spec.pmc_faces() if getattr(sim, '_boundary_spec', None) is not None else None,
         dft_planes=dft_plane_probes if dft_plane_probes else None,
+        flux_monitors=flux_monitor_objs if flux_monitor_objs else None,
         rlc_metas=rlc_metas,
         rlc_states=rlc_states_init,
         ntff_box=ntff_box,
@@ -674,6 +713,14 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
             for entry, probe in zip(sim._dft_planes, r["dft_planes"])
         }
 
+    # Repack flux monitors into {name: FluxMonitor} dict (uniform schema).
+    flux_monitors_dict = None
+    if getattr(sim, "_flux_monitors", None) and "flux_monitors" in r:
+        flux_monitors_dict = {
+            entry.name: mon
+            for entry, mon in zip(sim._flux_monitors, r["flux_monitors"])
+        }
+
     return Result(
         state=r["state"],
         time_series=r["time_series"],
@@ -682,6 +729,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         ntff_data=r.get("ntff_data"),
         ntff_box=ntff_box,
         dft_planes=dft_planes_dict,
+        flux_monitors=flux_monitors_dict,
         waveguide_ports=waveguide_ports_result,
         waveguide_sparams=waveguide_sparams_result,
         grid=grid,

--- a/tests/test_nonuniform_api.py
+++ b/tests/test_nonuniform_api.py
@@ -583,8 +583,10 @@ class TestNonUniformDispersive:
 
 
 class TestFluxMonitorOnNonUniform:
-    """``add_flux_monitor`` is uniform-path-only; the NU runner must fail
-    fast rather than silently drop the observable (T5 polish)."""
+    """``add_flux_monitor`` is now supported on the NU path for full-plane
+    monitors (issue #88 flux-extractor prerequisite). Finite-region
+    (``size=``) monitors still raise until the cumulative-edge index
+    conversion lands."""
 
     def _make_nu_sim(self):
         dz = np.array([0.4e-3] * 4 + [0.5e-3] * 8, dtype=np.float64)
@@ -599,17 +601,24 @@ class TestFluxMonitorOnNonUniform:
         sim.add_probe((0.005, 0.005, 0.003), "ez")
         return sim
 
-    def test_flux_monitor_on_nu_run_raises(self):
+    def test_full_plane_flux_monitor_on_nu_run_works(self):
+        """Full-plane NU flux monitor accumulates and surfaces finite,
+        physical flux (no NotImplementedError)."""
+        from rfx.probes.probes import flux_spectrum
         sim = self._make_nu_sim()
         sim.add_flux_monitor(axis="z", coordinate=0.002)
-        with pytest.raises(NotImplementedError, match="flux_monitor"):
-            sim.run(n_steps=20)
+        result = sim.run(n_steps=60)
+        assert result.flux_monitors is not None
+        mon = next(iter(result.flux_monitors.values()))
+        flux = np.asarray(flux_spectrum(mon))
+        assert np.all(np.isfinite(flux))
 
-    def test_flux_monitor_on_nu_forward_raises(self):
+    def test_finite_region_flux_monitor_on_nu_run_raises(self):
+        """Finite-region (size=) monitors are still rejected on NU."""
         sim = self._make_nu_sim()
-        sim.add_flux_monitor(axis="z", coordinate=0.002)
-        with pytest.raises(NotImplementedError, match="flux_monitor"):
-            sim.forward(n_steps=20, skip_preflight=True)
+        sim.add_flux_monitor(axis="z", coordinate=0.002, size=(0.004, 0.004))
+        with pytest.raises(NotImplementedError, match="finite-region"):
+            sim.run(n_steps=20)
 
     def test_no_flux_monitor_nu_runs_fine(self):
         """Sanity: without a flux monitor the NU path stays green."""


### PR DESCRIPTION
## Summary

Step A of the issue #88 real fix. Gives the non-uniform FDTD path the ability to accumulate Poynting-flux DFTs, which is the prerequisite for wiring the `extract_waveguide_s_matrix_flux` extractor (the uniform broad-E5 silver bullet) into `_compute_waveguide_s_matrix_nu`.

Before this PR `add_flux_monitor` on a non-uniform mesh raised `NotImplementedError` — the NU scan body simply had no flux accumulation.

## Changes

- **`run_nonuniform`**: new `flux_monitors` param; carry-init + scan-body accumulation (a byte-for-byte port of the uniform block at `simulation.py:1082-1126`, including H Yee co-location — average idx-1/idx to align H with E at idx, E at t=step·dt, H at t−dt/2, per-freq DFT kernel with window weight) + final `FluxMonitor` repack. Gated by `use_flux_monitors` so existing NU runs are bit-identical.
- **`run_nonuniform_path`**: convert `sim._flux_monitors` → `init_flux_monitor` objects with per-cell tangential `dy`/`dz` arrays (so `FluxMonitor.dA` integrates a graded tangential axis correctly), thread into `run_nonuniform`, surface in `Result.flux_monitors`. Full-plane only; finite-region (`size=`) still raises pending cumulative-edge index conversion.

## Validation (CPU)

Free-space dipole, full-plane flux monitor, run through the uniform path vs the NU path on an **identical** mesh. The normalized flux spectrum shapes agree to **1.48%**:

```
uniform shape: [1, 0.569, 0.263, 0.079, 0.016]
NU shape     : [1, 0.554, 0.257, 0.077, 0.016]
```

Regression tests updated — `TestFluxMonitorOnNonUniform` now asserts full-plane works + finite-region raises (3 passed).

## Note: pre-existing source-convention gap (not introduced here)

Absolute NU flux is ~1.57e16× the uniform value because `make_current_source` on the NU path normalizes a ~1.25e8× stronger field than the uniform soft source. This is **not** a flux-accumulation bug — the normalized shapes match — it is an independent NU/uniform source-amplitude convention difference. It is **harmless for the flux extractor**, which uses P_inc/P_dev *ratios* that cancel any common amplitude factor. Flagged for a separate issue if absolute NU source calibration ever matters.

## What remains (Step B, separate PR + GPU validation)

- Inject the run function into `extract_waveguide_s_matrix_flux` (currently hardcodes the uniform `run`).
- Add a `normalize="flux"` branch to `_compute_waveguide_s_matrix_nu`.
- GPU: flip the `test_waveguide_nu_nontrivial` strict-xfail to a real pass and extend the WR-90 NU broad-E5 envelope to eps_r=4.

Design doc on the branch: `docs/research_notes/20260529_flux_nu_wiring_design.md`. Full issue #88 diagnosis in the issue thread.

## Test plan

- [x] `TestFluxMonitorOnNonUniform` (3 passed — full-plane works, finite-region raises, no-monitor sanity)
- [x] CPU uniform-vs-NU normalized flux shape match (1.48%)
- [x] `test_nonuniform_api.py` + `test_waveguide_nu_sparam.py` (flux-off NU path unchanged: 29 passed pre-existing)
- [ ] CI full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)