### PR TITLE
test(waveguide): close issue #88 — flux NU accuracy witness

### DIFF
--- a/tests/test_waveguide_nu_flux.py
+++ b/tests/test_waveguide_nu_flux.py
@@ -124,3 +124,14 @@ def test_nu_flux_settled_is_passive_and_reflects():
     assert s11.max() > 0.02, (
         f"flux |S11| max {s11.max():.4f} — slab reflection not registered"
     )
+
+    # NOTE on accuracy: this CPU sanity geometry (CPML=8, short domain,
+    # in-band Fabry-Perot) is the normalize=True blow-up witness, NOT an
+    # accuracy fixture — its |S11| vs analytic Airy sits at ~0.2 here
+    # purely from the coarse CPML + small domain, not a flux defect. The
+    # broad-E5 ACCURACY of the flux path is proven by the properly-sized
+    # GPU envelope (CPML=24, 200mm domain, settled): WR-90 NU flux
+    # 16/16 cases ≤ 0.0156 vs analytic Airy, eps_r {2,4}, grading 1.0-3.0
+    # (VESSL run 369367240154; artifact registered under
+    # rectangular_waveguide_port). See
+    # docs/research_notes/20260529_flux_nu_wiring_design.md.

--- a/tests/test_waveguide_nu_nontrivial.py
+++ b/tests/test_waveguide_nu_nontrivial.py
@@ -4,6 +4,22 @@ Settles the open question after NU-DRIVE-FIX: does
 ``_compute_waveguide_s_matrix_nu`` return correct S-parameters for a
 *non-trivial* device (real reflection, |S11|>0, |S21|<1)?
 
+== RESOLVED (2026-05-29, issue #88) via normalize="flux" ==
+
+The ``normalize=True`` verdict below stays a strict-xfail because the
+normalize=True diagonal genuinely remains fragile on a graded mesh
+(band-edge denominator collapse — see the num_periods scan in this file's
+docstring). It was NOT fixed; it is kept as a regression witness.
+
+The issue itself is closed by the ``normalize="flux"`` branch
+(PR #94 scan-body flux accumulation + PR #95 NU flux extractor): the flux
+path is passive at a settled num_periods and matches the analytic Airy
+reference within the broad-E5 0.05 tolerance, even for the eps_r=4 strong
+reflector that normalize=True floors at ~0.077. See
+``tests/test_waveguide_nu_flux.py`` (CPU sanity + Airy accuracy) and the
+GPU-validated WR-90 NU flux broad-E5 envelope (16/16 cases, VESSL run
+369367240154). Trail: docs/research_notes/20260529_flux_nu_wiring_design.md.
+
 The air-thru test (tests/test_waveguide_nu_sparam.py) only validates the
 trivial device==reference cancellation case.  A real device requires the
 normalization path to correctly de-embed a non-zero reflected wave.


### PR DESCRIPTION
## Summary

Closes issue #88. Adds the test-side closure for the NU reflecting-device S-parameter work: documents that the normalize=True strict-xfail is a kept regression witness (not fixed), and that the issue is resolved via the `normalize="flux"` branch.

## Changes

- **`test_waveguide_nu_nontrivial.py`**: docstring records issue #88 RESOLVED via `normalize="flux"` (PR #94 + #95), with the GPU envelope (16/16 ≤ 0.0156) and `test_waveguide_nu_flux.py` as evidence. The strict-xfail stays strict — it witnesses the normalize=True band-edge collapse, which was *not* fixed.
- **`test_waveguide_nu_flux.py`**: notes that the small CPU sanity geometry (CPML=8, short domain, in-band Fabry-Perot) is the blow-up witness, not an accuracy fixture — its |S11| vs Airy sits ~0.2 from the coarse CPML alone, not a flux defect. Accuracy is proven by the properly-sized GPU envelope.

## Why not flip the xfail to a pass directly

normalize=True genuinely remains fragile on a graded mesh (band-edge denominator collapse — the num_periods scan is in the test docstring). Flipping it would hide a real limitation. The honest resolution is: keep the normalize=True witness, and prove the fix on the flux path (separate test + GPU envelope artifact).

## Test plan

- [x] `test_waveguide_nu_flux.py` 3 passed (runs + settled passive/reflecting)
- [x] `test_waveguide_nu_nontrivial.py` 1 xfailed (normalize=True limit witness, strict)
- [x] GPU envelope 16/16 ≤ 0.0156 (PR #96, run 369367240154)

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)