### PR TITLE
diag(msl): broad-E5 blocked on V·I-split extractor (issue #80) — VESSL not submitted

### DIFF
--- a/scripts/diagnostics/port_external_reference_requirements.json
+++ b/scripts/diagnostics/port_external_reference_requirements.json
@@ -83,7 +83,7 @@
         "nonuniform MSL S-parameter validation",
         "broader substrate/mesh/frequency envelope"
       ],
-      "notes": "Existing openEMS evidence supports the narrow laplace/quasi-TEM lane only.",
+      "notes": "Existing openEMS evidence supports the narrow laplace/quasi-TEM lane only. 2026-05-29 broad-E5 envelope attempt BLOCKED on the extractor (not mesh): a CPU sanity gate on a uniform 50-ohm thru-line shows compute_msl_s_matrix returns non-physical S (passivity |S11|^2+|S21|^2 = 1.30 at h_sub/4, 1.45 at h_sub/6 with |S21|>1, and a spurious |S11|=0.57 on a matched line). The N-probe Z0 IS mesh-convergent (58%->27%->4% as cells/h_sub rises 4->6), but the passivity violation is NOT mesh-convergent and the error is trace-length-dependent (passivity 1.30 at 8mm vs 4.74 at 37mm, same mesh) - a thru-line must be length-invariant, so this is a structural V/I single-plane wave-split bug (rfx/api/_sparams.py:1006-1038), the same extraction family as issue #80. The 16-case VESSL envelope was deliberately NOT submitted; it would overclaim around a known-broken extractor. Fix issue #80 (assemble S from the multi-plane extract_msl_nprobe a/b fit, gate on thru-line length-invariance) before building the envelope. Trail: docs/research_notes/20260529_msl_broad_e5_extractor_blocker.md.",
       "external_comparison_artifacts": [
         ".omx/physics-gate/2026-05-09-m29-msl-openems-generic-comparison/msl_openems_generic_sparameter_comparison.json"
       ],


### PR DESCRIPTION
## Summary

Records why the MSL broad-E5 envelope was **not** submitted to VESSL: a CPU sanity gate shows `compute_msl_s_matrix` returns non-physical S on a uniform 50 Ω thru-line, and the failure is structural (issue #80), not mesh.

## Evidence (RO4003C thru-line, num_periods=15 settled)

| trace | cells/h_sub | Z0 | \|S11\|max | \|S21\|max | passivity |
|---|---|---|---|---|---|
| 37 mm | 4 | 79 Ω (58%) | 1.89 | 1.08 | 4.74 |
| 8 mm | 4 | 63.7 Ω (27%) | 0.724 | 0.881 | 1.302 |
| 8 mm | 6 | **52.0 Ω (4%)** | 0.573 | **1.058** | **1.449** |

Two failure modes, cleanly separated:
1. **Z0 is mesh-convergent** (Yee-staircase): 58% → 27% → 4% as cells rise. Mesh fixes it.
2. **Passivity is NOT mesh-convergent** (structural): 1.30 → 1.45, |S21|>1, and a spurious |S11|=0.57 on a *matched uniform line* even after Z0 → 50 Ω.
3. **Trace-length dependence is the clincher**: a thru-line must be length-invariant, yet passivity is 1.30 (8 mm) vs 4.74 (37 mm) at the same mesh — the extractor injects a length-accumulating error.

## Root cause

`rfx/api/_sparams.py:1006-1038` — the V·I single-plane wave split (`a=(V+Z0·I)/2`, `b=(V−Z0·I)/2`, `S11=b/a`) does not correctly separate forward/backward waves on a line with standing-wave content, and the error neither vanishes with mesh nor with a converged Z0. Same extraction family as issue #80.

## Why not submit anyway

At the best measured point (8 mm, N=6) passivity is still 1.45. Even if a finer mesh + shorter trace squeaked under 1.1, that validates only a cherry-picked regime around a length-dependent extractor — the manifest `broad_e5` contract forbids narrow/partial framing. Submitting would overclaim and burn GPU.

## Changes

- `port_external_reference_requirements.json` — concise blocker note on `microstrip_line_port` (no status change; still `narrow_e5_passed_broad_blocked`).
- (local, gitignored) `docs/research_notes/20260529_msl_broad_e5_extractor_blocker.md` — full diagnosis.

## Recommendation

(a) Fix issue #80 first: assemble S from the multi-plane `extract_msl_nprobe` a/b fit (not the single-plane V·I split), gate on thru-line length-invariance (|S11|→0, |S21|→1 at any length), then build the envelope. Or (b) pivot to coaxial matched/open/load gates (no blocked extractor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)