### PR TITLE
[codex] P0 host-side Touchstone interop and batch provenance

### DIFF
--- a/docs/guides/network_interop_batch_provenance.md
+++ b/docs/guides/network_interop_batch_provenance.md
@@ -1,0 +1,89 @@
+# Network Interop and Batch Provenance Roadmap
+
+This note records the next two bounded contribution topics after runtime artifact
+bundles. It is intentionally scoped to host-side interoperability and repeatable
+workflow infrastructure; it does not change FDTD update equations or solver
+physics paths.
+
+## 1. Touchstone / RF network interop hardening
+
+### Current rfx surface
+
+- `rfx.io.write_touchstone()` / `read_touchstone()` provide Touchstone-style
+  S-parameter I/O for RI, MA, DB formats and Hz/kHz/MHz/GHz frequency units.
+- The legacy API returns `(s_params, freqs, z0)` and writes scalar reference
+  impedance in the option line.
+- Existing tests cover round-trips and basic ordering, but the contract does not
+  yet expose structured metadata or Touchstone 2.0 keywords.
+
+### Gap vs RF ecosystem
+
+- Touchstone 2.0 formalizes metadata such as `[Number of Ports]`,
+  `[Number of Frequencies]`, `[Reference]`, `[Matrix Format]`, and explicit
+  two-port data ordering.
+- For three or more ports, the standard arranges each frequency block in
+  matrix row-wise order. rfx must preserve any existing legacy behavior while
+  adding an explicit standard path.
+- RF network tooling such as scikit-rf exposes richer impedance/write controls;
+  rfx should at least preserve impedance metadata and fail clearly on unsupported
+  mixed-mode or non-S-parameter variants.
+
+### Proposed bounded contribution
+
+- Add a metadata-aware Touchstone reader/writer path while preserving the legacy
+  tuple API.
+- Keep existing v1 calls on the legacy rfx multi-port layout unless callers opt
+  into `layout="standard"` or `version="2.0"`.
+- Support standard 3+ port row-wise layout and retain a named legacy layout for
+  backwards compatibility.
+- Parse/write useful Touchstone 2.0 metadata: version, number of ports,
+  frequency count, matrix format, two-port order, and per-port `[Reference]` for
+  S-parameters. Legacy tuple reads must raise on nonuniform references instead
+  of silently collapsing them.
+- Validate writer inputs against the file suffix and finite numeric data so rfx
+  does not emit self-inconsistent `.sNp` files.
+- Add physical/interop gates based on passive/reciprocal known networks, not only
+  random numeric round-trips.
+
+## 2. Sweep/result dataset provenance + resumable batch
+
+### Current rfx surface
+
+- `rfx.batch.ParameterSweep` defines Cartesian sweeps while preserving
+  JSON-compatible scalar types such as strings, booleans, ints, and floats.
+- `run_batch()` executes cases sequentially and returns in-memory tuples.
+- `SimulationDataset` can export compact arrays to HDF5 or CSV.
+
+### Gap vs repeatable simulation workflows
+
+- There is no stable case ID, case manifest, completed-case resume/skip behavior,
+  or per-case status summary.
+- There is no standard place to record physical metrics for each case, such as
+  return loss, passivity margin, reciprocity error, resonance frequency, or a
+  user-supplied metric.
+- FDTD workflow tools commonly persist structured output metadata and geometry or
+  field views so that external tools and later audits can inspect the run.
+
+### Proposed bounded contribution
+
+- Add a manifest-backed batch runner that records parameters, status, timing,
+  metric summaries, and artifact paths for each case.
+- Add deterministic case IDs derived from parameter values.
+- Add resume behavior that skips completed cases only when status, parameters,
+  non-empty metrics, and declared artifact file hashes are intact;
+  missing/corrupt artifacts must invalidate skip.
+- Record a run fingerprint derived from run settings, with a user-supplied
+  override for factory/metric/external-input changes, so reused output
+  directories do not silently return stale cases.
+- Add a tiny physical sweep gate that proves resume does not corrupt metrics or
+  silently rerun completed cases.
+
+## Final validation rule
+
+Both topics require unit tests plus a physical/interop performance gate:
+
+1. Touchstone gate: a known passive reciprocal network must survive export/read
+   with bounded passivity and reciprocity error.
+2. Batch gate: a tiny physical sweep must produce a manifest with stable case
+   IDs and metrics, then a second run must resume/skip completed cases while
+   preserving the manifest integrity.

--- a/docs/public/guide/parametric-sweeps.mdx
+++ b/docs/public/guide/parametric-sweeps.mdx
@@ -150,6 +150,63 @@ eps_eff = jnp.array([3.0, 3.2, 3.4])
 freqs = jax.vmap(quarter_wave_freq)(lengths, eps_eff)
 ```
 
+## Manifest-backed sweeps
+
+For claim-bearing or long-running sweeps, prefer `run_batch_with_manifest()`.
+It writes `manifest.json` under the output directory with:
+
+- schema version
+- sweep keys and total case count
+- stable case IDs derived from parameter values
+- per-case status, timing, metrics, parameter digest, and artifact paths
+- artifact file size/hash metadata for resume integrity
+- resume-safe completed-case records
+
+```python
+import json
+from pathlib import Path
+import numpy as np
+
+from rfx.batch import ParameterSweep, run_batch_with_manifest
+
+sweep = ParameterSweep(amplitude=[0.5, 1.0, 2.0])
+
+
+def metric_fn(result):
+    state = result.state
+    peak_ez = float(np.max(np.abs(np.asarray(state.ez))))
+    return {"peak_ez": peak_ez}
+
+
+def artifact_fn(case_dir: Path, params, result):
+    path = case_dir / "metric.json"
+    path.write_text(json.dumps(metric_fn(result), sort_keys=True))
+    # Case-local paths are normalized into output-root-relative manifest paths.
+    return {"metric": "metric.json"}
+
+records = run_batch_with_manifest(
+    make_simulation,
+    sweep,
+    "runs/amplitude-sweep",
+    run_kwargs={"n_steps": 200},
+    metric_fn=metric_fn,
+    artifact_fn=artifact_fn,
+    resume=True,
+)
+```
+
+`resume=True` skips only records that are marked `completed`, match the current
+case parameters, include at least one metric, and still have all declared
+artifact files on disk with matching size/hash metadata. Missing or modified
+artifacts, empty metrics, interrupted `running` cases, and previous failures are
+not silently treated as valid completed runs.
+
+`run_kwargs` are fingerprinted into each case record. Reusing the same output
+directory with a different run budget, such as a changed `n_steps`, forces a
+rerun instead of returning stale cases. If the simulation factory, metric
+definition, mesh source, or any external input changes while `run_kwargs` stay
+the same, pass a new `run_fingerprint="..."` value to invalidate old cases.
+
 ## Checklist before scaling up
 
 - Did a single case run and produce physically plausible fields/probes?

--- a/docs/public/guide/probes-sparams.mdx
+++ b/docs/public/guide/probes-sparams.mdx
@@ -250,11 +250,15 @@ plot_field_slice(result, "ez", axis="z", index=30)  # 2-D Ez cross-section
 Touchstone export uses rfx's canonical S-matrix shape `(n_ports, n_ports, n_freqs)`. Reading returns `(s_params, freqs, z0)`.
 
 ```python
-from rfx import write_touchstone, read_touchstone
+from rfx import write_touchstone, read_touchstone, read_touchstone_full
 
 # Write 2-port S-params to a .s2p file
 write_touchstone("patch_antenna.s2p", result.s_params, result.freqs, z0=50.0)
 
-# Read back
+# Read back (legacy tuple API)
 s_matrix, freqs, z0 = read_touchstone("patch_antenna.s2p")
+
+# Metadata-aware Touchstone 2.0 read path preserves per-port references
+network = read_touchstone_full("device_v2.s4p")
+print(network.reference)
 ```

--- a/docs/public/guide/visualization-and-analysis.md
+++ b/docs/public/guide/visualization-and-analysis.md
@@ -143,10 +143,21 @@ integrate with the actual cell-volume weights instead of `grid.dx**3`.
 ### Export for External Tools
 
 ```python
-from rfx import save_state, save_snapshots, write_touchstone
+from rfx import save_state, save_snapshots, write_touchstone, read_touchstone_full
 
-# Touchstone for ADS/CST/HFSS. Shape is (n_ports, n_ports, n_freqs).
+# Legacy-compatible Touchstone for ADS/CST/HFSS. Shape is (n_ports, n_ports, n_freqs).
 write_touchstone("device.s2p", result.s_params, result.freqs, z0=50.0)
+
+# Metadata-rich Touchstone 2.0 export for a standard row-wise 4-port result
+write_touchstone(
+    "device_v2.s4p",
+    four_port_result.s_params,
+    four_port_result.freqs,
+    version="2.0",
+    layout="standard",
+    port_z0=[50.0, 50.0, 50.0, 50.0],
+)
+network = read_touchstone_full("device_v2.s4p")
 
 # HDF5 for the final field state
 save_state("fields.h5", result.state, grid=result.grid)

--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -70,7 +70,7 @@ from rfx.topology import (
     topology_optimize, apply_density_filter, apply_projection, density_to_eps,
 )
 from rfx.io import (
-    read_touchstone, write_touchstone,
+    TouchstoneData, read_touchstone, read_touchstone_full, write_touchstone,
     save_optimization_result, load_optimization_result,
     save_far_field, export_radiation_pattern,
     export_geometry_json, save_experiment_report,

--- a/rfx/batch.py
+++ b/rfx/batch.py
@@ -2,10 +2,35 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+import hashlib
 import itertools
+import json
+from pathlib import Path
+import time
 from typing import Callable, Any
 
 import numpy as np
+
+
+BATCH_MANIFEST_SCHEMA = "rfx-batch-manifest-v1"
+
+
+@dataclass(frozen=True)
+class BatchCaseResult:
+    """Result record returned by :func:`run_batch_with_manifest`.
+
+    ``result`` is ``None`` for cases skipped through resume.
+    """
+
+    case_id: str
+    params: dict[str, Any]
+    status: str
+    metrics: dict[str, Any]
+    artifacts: dict[str, str]
+    result: Any = None
+    error: str | None = None
+    skipped: bool = False
 
 
 class ParameterSweep:
@@ -41,7 +66,355 @@ class ParameterSweep:
     def combinations(self):
         """Iterate over all parameter combinations as dicts."""
         for combo in itertools.product(*self._values):
-            yield dict(zip(self._keys, [float(c) for c in combo]))
+            yield dict(zip(self._keys, [_jsonable(c) for c in combo]))
+
+
+def _jsonable(value: Any) -> Any:
+    """Convert common NumPy/JAX-ish values into deterministic JSON values."""
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, dict):
+        return {str(k): _jsonable(value[k]) for k in sorted(value)}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    return str(value)
+
+
+def case_id_from_params(params: dict[str, Any], *, prefix: str = "case") -> str:
+    """Return a stable, compact case id for a parameter dictionary."""
+    canonical = json.dumps(_jsonable(params), sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:12]
+    return f"{prefix}-{digest}"
+
+
+def _json_digest(value: Any, *, length: int = 16) -> str:
+    canonical = json.dumps(_jsonable(value), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:length]
+
+
+def _run_fingerprint(run_kwargs: dict[str, Any], user_fingerprint: str | None) -> str:
+    """Return a stable cache-validity token for run settings."""
+    payload = {
+        "run_kwargs": _jsonable(run_kwargs),
+        "user_fingerprint": user_fingerprint,
+    }
+    return _json_digest(payload)
+
+
+def _utc_now() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _read_manifest(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {
+            "schema_version": BATCH_MANIFEST_SCHEMA,
+            "created_at": _utc_now(),
+            "updated_at": None,
+            "sweep": {},
+            "cases": {},
+        }
+    with open(path) as f:
+        manifest = json.load(f)
+    if manifest.get("schema_version") != BATCH_MANIFEST_SCHEMA:
+        raise ValueError(
+            f"Unsupported batch manifest schema: {manifest.get('schema_version')!r}"
+        )
+    manifest.setdefault("cases", {})
+    return manifest
+
+
+def _write_manifest_atomic(path: Path, manifest: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    manifest["updated_at"] = _utc_now()
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with open(tmp, "w") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True, default=_jsonable)
+        f.write("\n")
+    tmp.replace(path)
+
+
+def _artifact_path(root: Path, artifact_path: str) -> Path | None:
+    if not isinstance(artifact_path, str) or not artifact_path:
+        return None
+    path = Path(artifact_path)
+    if str(path) == ".":
+        return None
+    candidate = path if path.is_absolute() else root / path
+    if _path_relative_to(candidate, root) is None:
+        return None
+    return candidate
+
+
+def _hash_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _artifact_metadata(root: Path, artifacts: dict[str, str]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    for name, artifact_path in artifacts.items():
+        candidate = _artifact_path(root, artifact_path)
+        if candidate is None or not candidate.is_file():
+            raise ValueError(
+                "artifact paths must point to files inside the output directory"
+            )
+        stat = candidate.stat()
+        metadata[str(name)] = {
+            "path": artifact_path,
+            "size": stat.st_size,
+            "sha256": _hash_file(candidate),
+        }
+    return metadata
+
+
+def _artifact_metadata_valid(
+    root: Path,
+    artifacts: dict[str, str],
+    artifact_metadata: Any,
+) -> bool:
+    if not isinstance(artifact_metadata, dict):
+        return False
+    try:
+        current = _artifact_metadata(root, artifacts)
+    except (OSError, ValueError):
+        return False
+    return current == artifact_metadata
+
+
+def _completed_record_valid(
+    root: Path,
+    record: dict[str, Any],
+    expected_run_fingerprint: str,
+    expected_params: dict[str, Any],
+    expected_params_digest: str,
+) -> bool:
+    metrics = record.get("metrics")
+    artifacts = record.get("artifacts")
+    return (
+        record.get("status") == "completed"
+        and record.get("run_fingerprint") == expected_run_fingerprint
+        and record.get("params") == expected_params
+        and record.get("params_digest") == expected_params_digest
+        and isinstance(metrics, dict)
+        and len(metrics) > 0
+        and isinstance(artifacts, dict)
+        and _artifact_metadata_valid(root, artifacts, record.get("artifact_metadata"))
+    )
+
+
+def _path_relative_to(path: Path, root: Path) -> str | None:
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return None
+
+
+def _normalize_artifacts(
+    output_root: Path,
+    case_dir: Path,
+    artifacts: dict[str, Any],
+) -> dict[str, str]:
+    """Normalize artifact paths to manifest-stable strings.
+
+    ``artifact_fn`` is usually called with ``case_dir`` and naturally returns
+    case-local paths such as ``"metrics.json"``.  The manifest, however, needs
+    paths that can be validated from the output root during a later resume.
+    Paths already relative to ``output_root`` are preserved; absolute paths
+    inside ``output_root`` are stored relatively.  Absolute paths outside the
+    output root and ``..`` escapes are rejected so manifests remain portable.
+    """
+    normalized: dict[str, str] = {}
+    for name, value in artifacts.items():
+        if isinstance(value, Path):
+            artifact_path = value
+        elif isinstance(value, str):
+            artifact_path = Path(value)
+        else:
+            raise ValueError("artifact_fn must return path strings or Path values")
+
+        if str(artifact_path) in ("", "."):
+            raise ValueError("artifact paths must not be empty or '.'")
+
+        if artifact_path.is_absolute():
+            rel = _path_relative_to(artifact_path, output_root)
+            if rel is None:
+                raise ValueError("artifact paths must stay inside output_dir")
+            normalized[str(name)] = rel
+            continue
+
+        root_candidate = output_root / artifact_path
+        case_candidate = case_dir / artifact_path
+        if (
+            _path_relative_to(root_candidate, output_root) is None
+            and _path_relative_to(case_candidate, output_root) is None
+        ):
+            raise ValueError("artifact paths must stay inside output_dir")
+        if root_candidate.exists():
+            normalized[str(name)] = artifact_path.as_posix()
+        elif case_candidate.exists():
+            normalized[str(name)] = case_candidate.relative_to(output_root).as_posix()
+        else:
+            # Preserve the caller-provided path so resume validation will fail
+            # rather than silently blessing a missing artifact.
+            normalized[str(name)] = artifact_path.as_posix()
+    return normalized
+
+
+def run_batch_with_manifest(
+    sim_factory: Callable[..., Any],
+    sweep: ParameterSweep,
+    output_dir: str | Path,
+    *,
+    run_kwargs: dict | None = None,
+    metric_fn: Callable[[Any], dict[str, Any]] | None = None,
+    artifact_fn: Callable[
+        [Path, dict[str, Any], Any], dict[str, str | Path] | None
+    ] | None = None,
+    resume: bool = True,
+    manifest_name: str = "manifest.json",
+    run_fingerprint: str | None = None,
+) -> list[BatchCaseResult]:
+    """Run a sequential sweep with durable per-case provenance.
+
+    The runner records stable case ids, parameters, status, timings, metrics,
+    and optional artifact paths.  ``artifact_fn`` may return paths relative to
+    the case directory, paths relative to the output root, or absolute paths
+    inside the output root.
+    The runner automatically fingerprints ``run_kwargs`` so changing run
+    settings (for example ``n_steps``) invalidates resume.  Pass
+    ``run_fingerprint`` when simulation factory, metric semantics, or external
+    inputs changed but ``run_kwargs`` did not.  When ``resume=True``, a case is
+    skipped only if the manifest record is completed, has the expected run
+    fingerprint, contains at least one metric, and all declared artifact paths
+    still exist.
+    """
+    if run_kwargs is None:
+        run_kwargs = {}
+    output_root = Path(output_dir)
+    output_root.mkdir(parents=True, exist_ok=True)
+    manifest_path = output_root / manifest_name
+    manifest = _read_manifest(manifest_path)
+    manifest["sweep"] = {"keys": sweep.keys, "total": sweep.total}
+    run_kwargs_json = _jsonable(run_kwargs)
+    expected_run_fingerprint = _run_fingerprint(run_kwargs_json, run_fingerprint)
+    manifest["run_config"] = {
+        "run_kwargs": run_kwargs_json,
+        "user_fingerprint": run_fingerprint,
+        "run_fingerprint": expected_run_fingerprint,
+    }
+
+    returned: list[BatchCaseResult] = []
+    for params in sweep.combinations():
+        params_json = _jsonable(params)
+        case_id = case_id_from_params(params_json)
+        params_digest = _json_digest(params_json)
+        case_dir = output_root / case_id
+        case_dir.mkdir(parents=True, exist_ok=True)
+
+        existing = manifest["cases"].get(case_id)
+        if (
+            resume
+            and isinstance(existing, dict)
+            and _completed_record_valid(
+                output_root,
+                existing,
+                expected_run_fingerprint,
+                params_json,
+                params_digest,
+            )
+        ):
+            returned.append(BatchCaseResult(
+                case_id=case_id,
+                params=existing.get("params", params_json),
+                status="skipped",
+                metrics=existing.get("metrics", {}),
+                artifacts=existing.get("artifacts", {}),
+                result=None,
+                skipped=True,
+            ))
+            continue
+
+        start = time.time()
+        record = {
+            "case_id": case_id,
+            "params": params_json,
+            "params_digest": params_digest,
+            "run_fingerprint": expected_run_fingerprint,
+            "run_config": manifest["run_config"],
+            "status": "running",
+            "started_at": _utc_now(),
+            "completed_at": None,
+            "duration_s": None,
+            "metrics": {},
+            "artifacts": {},
+            "error": None,
+        }
+        manifest["cases"][case_id] = record
+        _write_manifest_atomic(manifest_path, manifest)
+
+        try:
+            sim = sim_factory(**params)
+            result = sim.run(**run_kwargs)
+            metrics = _jsonable(
+                metric_fn(result) if metric_fn else {"completed": True}
+            )
+            if not isinstance(metrics, dict):
+                raise ValueError("metric_fn must return a dict")
+            artifacts = (
+                artifact_fn(case_dir, params_json, result) if artifact_fn else {}
+            )
+            artifacts = _jsonable(artifacts or {})
+            if not isinstance(artifacts, dict):
+                raise ValueError("artifact_fn must return a dict of artifact paths")
+            artifacts = _normalize_artifacts(output_root, case_dir, artifacts)
+            artifact_metadata = _artifact_metadata(output_root, artifacts)
+
+            record.update({
+                "status": "completed",
+                "completed_at": _utc_now(),
+                "duration_s": time.time() - start,
+                "metrics": metrics,
+                "artifacts": artifacts,
+                "artifact_metadata": artifact_metadata,
+                "error": None,
+            })
+            _write_manifest_atomic(manifest_path, manifest)
+            returned.append(BatchCaseResult(
+                case_id=case_id,
+                params=params_json,
+                status="completed",
+                metrics=metrics,
+                artifacts=artifacts,
+                result=result,
+            ))
+        except Exception as exc:
+            record.update({
+                "status": "failed",
+                "completed_at": _utc_now(),
+                "duration_s": time.time() - start,
+                "error": f"{type(exc).__name__}: {exc}",
+            })
+            _write_manifest_atomic(manifest_path, manifest)
+            returned.append(BatchCaseResult(
+                case_id=case_id,
+                params=params_json,
+                status="failed",
+                metrics={},
+                artifacts={},
+                result=None,
+                error=record["error"],
+            ))
+            raise
+
+    return returned
 
 
 def run_batch(

--- a/rfx/io.py
+++ b/rfx/io.py
@@ -1,27 +1,60 @@
 """Touchstone (.sNp) S-parameter file I/O.
 
-Reads and writes industry-standard Touchstone v1 format for interoperability
-with ADS, CST, HFSS, and other RF tools.
+Reads and writes the legacy rfx Touchstone v1-compatible format plus a bounded
+metadata-aware Touchstone 2.0 S-parameter subset for interoperability with ADS,
+CST, HFSS, scikit-rf-style workflows, and other RF tools.
 
 Supports:
-- .s1p (1-port), .s2p (2-port), .s4p (4-port), .snp (N-port)
+- .s1p (1-port), .s2p (2-port), .s4p (4-port), .sNp (N-port by extension)
 - Data formats: RI (real/imaginary), MA (magnitude/angle), DB (dB/angle)
 - Frequency units: Hz, kHz, MHz, GHz
+- Touchstone 2.0 metadata subset: [Version], [Number of Ports],
+  [Number of Frequencies], [Reference], [Matrix Format] Full,
+  [Two-Port Data Order], [Network Data], [End]
 
-Multi-port layout (Touchstone v1):
+Legacy rfx multi-port layout:
 - 1-port and 2-port: all S-parameter data on one line per frequency
 - 3+ ports: max 4 S-parameter pairs per line; first line starts with
   frequency, continuation lines are indented without a frequency column.
   Column-major order: S11, S21, ..., SN1, S12, ..., SNN.
+
+Standard Touchstone layout is available with ``layout="standard"`` or
+``version="2.0"`` and uses row-wise 3+ port full matrices.
 """
 
 from __future__ import annotations
 
-import numpy as np
+from dataclasses import dataclass
 from pathlib import Path
+
+import numpy as np
 
 # Maximum number of S-parameter pairs per line for N>=3 ports (Touchstone v1).
 _MAX_PAIRS_PER_LINE = 4
+
+
+@dataclass(frozen=True)
+class TouchstoneData:
+    """Metadata-aware Touchstone read result.
+
+    The legacy :func:`read_touchstone` API intentionally returns only
+    ``(s_params, freqs, z0)``.  Use this dataclass through
+    :func:`read_touchstone_full` when Touchstone 2.0 metadata such as per-port
+    reference impedances or explicit matrix layout matters.
+    """
+
+    s_params: np.ndarray
+    freqs: np.ndarray
+    z0: float | np.ndarray
+    reference: np.ndarray
+    version: str
+    parameter: str
+    fmt: str
+    freq_unit: str
+    layout: str
+    matrix_format: str
+    two_port_order: str
+    comments: tuple[str, ...] = ()
 
 
 def _format_pair(s: complex, fmt: str) -> tuple[str, str]:
@@ -50,6 +83,87 @@ def _parse_pair(v1: float, v2: float, fmt: str) -> complex:
         raise ValueError(f"Unknown format: {fmt!r}")
 
 
+def _reference_vector(z0: float | np.ndarray, port_z0: np.ndarray | None,
+                      n_ports: int) -> np.ndarray:
+    """Return one reference impedance per port."""
+    if port_z0 is None:
+        refs = np.full(n_ports, float(z0), dtype=float)
+    else:
+        refs = np.asarray(port_z0, dtype=float).reshape(-1)
+        if refs.shape != (n_ports,):
+            raise ValueError(
+                f"port_z0 must contain one value per port "
+                f"(expected {n_ports}, got {refs.size})"
+            )
+    if not np.all(np.isfinite(refs)):
+        raise ValueError("reference impedances must be finite")
+    return refs
+
+
+def _uniform_reference_or_none(reference: np.ndarray) -> float | None:
+    """Return scalar reference if all ports share one value."""
+    refs = np.asarray(reference, dtype=float).reshape(-1)
+    if refs.size == 0:
+        return None
+    if np.allclose(refs, refs[0], rtol=0.0, atol=0.0):
+        return float(refs[0])
+    return None
+
+
+def _pair_indices(n_ports: int, *, layout: str,
+                  two_port_order: str) -> list[tuple[int, int]]:
+    """Return ``(receiver, driven)`` order for one frequency block."""
+    layout = layout.lower()
+    order = two_port_order.upper()
+
+    if n_ports == 1:
+        return [(0, 0)]
+
+    if n_ports == 2:
+        if order in ("21_12", "S21_S12"):
+            return [(0, 0), (1, 0), (0, 1), (1, 1)]
+        if order in ("12_21", "S12_S21"):
+            return [(0, 0), (0, 1), (1, 0), (1, 1)]
+        raise ValueError(
+            "two_port_order must be '21_12' or '12_21' for 2-port data"
+        )
+
+    if layout in ("legacy-rfx", "legacy", "column-major"):
+        # Historical rfx layout: S11, S21, ..., SN1, S12, ...
+        return [(i, j) for j in range(n_ports) for i in range(n_ports)]
+    if layout in ("standard", "touchstone", "row-major"):
+        # Touchstone 2.0 full matrix layout for 3+ ports: rows of S.
+        return [(i, j) for i in range(n_ports) for j in range(n_ports)]
+    raise ValueError("layout must be 'legacy-rfx' or 'standard'")
+
+
+def _format_frequency_block(
+    s_params: np.ndarray,
+    fi: int,
+    fmt: str,
+    *,
+    layout: str,
+    two_port_order: str,
+) -> list[tuple[str, str]]:
+    n_ports = s_params.shape[0]
+    return [
+        _format_pair(s_params[i, j, fi], fmt)
+        for i, j in _pair_indices(
+            n_ports, layout=layout, two_port_order=two_port_order
+        )
+    ]
+
+
+def _infer_touchstone_port_count(filepath: str | Path) -> int | None:
+    """Infer numeric port count from a Touchstone suffix."""
+    ext = Path(filepath).suffix.lower()
+    if not (ext.startswith(".s") and ext.endswith("p")):
+        raise ValueError(f"Cannot determine port count from extension: {ext}")
+    token = ext[2:-1]
+    return int(token) if token.isdigit() else None
+
+
+
 def write_touchstone(
     filepath: str | Path,
     s_params: np.ndarray,
@@ -58,8 +172,14 @@ def write_touchstone(
     freq_unit: str = "GHz",
     fmt: str = "RI",
     comments: list[str] | None = None,
+    *,
+    version: str = "1.0",
+    layout: str | None = None,
+    port_z0: np.ndarray | None = None,
+    matrix_format: str = "Full",
+    two_port_order: str = "21_12",
 ) -> None:
-    """Write S-parameters to a Touchstone v1 file.
+    """Write S-parameters to a Touchstone file.
 
     Parameters
     ----------
@@ -71,13 +191,70 @@ def write_touchstone(
     freq_unit : "Hz", "kHz", "MHz", or "GHz"
     fmt : "RI" (real/imag), "MA" (mag/angle), or "DB" (dB/angle)
     comments : optional comment lines
+    version : "1.0" or "2.0"
+        ``"1.0"`` preserves the historical rfx writer shape.  ``"2.0"``
+        writes Touchstone 2.0 metadata keywords for the supported S-parameter
+        subset.
+    layout : "legacy-rfx", "standard", or None
+        Multi-port order.  ``None`` means historical legacy layout for
+        Touchstone 1.0 output and standard layout for Touchstone 2.0 output.
+        The legacy rfx layout is column-major for all port counts.  The
+        standard layout is row-major for 3+ ports.  Two-port standard order is
+        controlled by ``two_port_order``.
+    port_z0 : array-like or None
+        Optional per-port reference impedances.  Requires ``version="2.0"``
+        when non-uniform.
+    matrix_format : str
+        Touchstone 2.0 matrix format.  Only ``"Full"`` is supported.
+    two_port_order : "21_12" or "12_21"
+        Explicit 2-port data order for standard Touchstone 2.0 files.
     """
     s_params = np.asarray(s_params)
     freqs = np.asarray(freqs)
+    if s_params.ndim != 3 or s_params.shape[0] != s_params.shape[1]:
+        raise ValueError("s_params must have shape (n_ports, n_ports, n_freqs)")
     n_ports = s_params.shape[0]
     n_freqs = s_params.shape[2]
+    if freqs.shape != (n_freqs,):
+        raise ValueError("freqs must have shape (n_freqs,)")
+    if not np.all(np.isfinite(s_params)):
+        raise ValueError("s_params must contain only finite values")
+    if not np.all(np.isfinite(freqs)):
+        raise ValueError("freqs must contain only finite values")
 
-    scale = {"Hz": 1.0, "kHz": 1e3, "MHz": 1e6, "GHz": 1e9}[freq_unit]
+    version = str(version)
+    if version not in ("1.0", "2.0"):
+        raise ValueError("version must be '1.0' or '2.0'")
+    ext_n_ports = _infer_touchstone_port_count(filepath)
+    if ext_n_ports is not None and ext_n_ports != n_ports:
+        raise ValueError(
+            f"file extension declares {ext_n_ports} ports, "
+            f"but s_params has {n_ports}"
+        )
+    if ext_n_ports is None and version != "2.0":
+        raise ValueError(
+            "non-numeric .sNp extensions require version='2.0' "
+            "with [Number of Ports] metadata"
+        )
+    if layout is None:
+        layout = "standard" if version == "2.0" else "legacy-rfx"
+    layout = layout.lower()
+    fmt = fmt.upper()
+    matrix_format = matrix_format.capitalize()
+    two_port_order = two_port_order.upper()
+    if matrix_format != "Full":
+        raise ValueError("Only Touchstone matrix_format='Full' is supported")
+
+    refs = _reference_vector(z0, port_z0, n_ports)
+    uniform_z0 = _uniform_reference_or_none(refs)
+    if version != "2.0" and uniform_z0 is None:
+        raise ValueError("non-uniform port_z0 requires version='2.0'")
+
+    try:
+        scale = {"Hz": 1.0, "kHz": 1e3, "MHz": 1e6, "GHz": 1e9}[freq_unit]
+    except KeyError as exc:
+        raise ValueError("freq_unit must be 'Hz', 'kHz', 'MHz', or 'GHz'") from exc
+    option_z0 = uniform_z0 if uniform_z0 is not None else float(refs[0])
 
     with open(filepath, "w") as f:
         # Comments
@@ -87,19 +264,32 @@ def write_touchstone(
             for c in comments:
                 f.write(f"! {c}\n")
 
+        if version == "2.0":
+            f.write("[Version] 2.0\n")
+
         # Option line
-        f.write(f"# {freq_unit} S {fmt} R {z0:.1f}\n")
+        f.write(f"# {freq_unit} S {fmt} R {option_z0:.12g}\n")
+
+        if version == "2.0":
+            f.write(f"[Number of Ports] {n_ports}\n")
+            f.write(f"[Number of Frequencies] {n_freqs}\n")
+            f.write("[Reference] " + " ".join(f"{v:.12g}" for v in refs) + "\n")
+            f.write(f"[Matrix Format] {matrix_format}\n")
+            if n_ports == 2:
+                f.write(f"[Two-Port Data Order] {two_port_order}\n")
+            f.write("[Network Data]\n")
 
         # Data — layout depends on port count
         for fi in range(n_freqs):
             freq_scaled = freqs[fi] / scale
 
-            # Collect all S-parameter pairs in column-major order:
-            # S11, S21, ..., SN1, S12, S22, ..., SN2, ...
-            pairs: list[tuple[str, str]] = []
-            for j in range(n_ports):
-                for i in range(n_ports):
-                    pairs.append(_format_pair(s_params[i, j, fi], fmt))
+            pairs = _format_frequency_block(
+                s_params,
+                fi,
+                fmt,
+                layout=layout,
+                two_port_order=two_port_order,
+            )
 
             if n_ports <= 2:
                 # 1-port and 2-port: everything on one line
@@ -129,12 +319,16 @@ def write_touchstone(
                     # Indent continuation lines to distinguish from freq lines
                     f.write("  " + " ".join(cont_tokens) + "\n")
 
+        if version == "2.0":
+            f.write("[End]\n")
+
 
 def read_touchstone(filepath: str | Path) -> tuple[np.ndarray, np.ndarray, float]:
-    """Read S-parameters from a Touchstone v1 file.
+    """Read S-parameters from a Touchstone file.
 
-    Handles both single-line (1- and 2-port) and multi-line (3+ port) data
-    blocks.  Inline comments (``! ...``) after data values are stripped.
+    This legacy compatibility API returns a scalar reference impedance.  If a
+    Touchstone 2.0 file carries non-uniform per-port references, use
+    :func:`read_touchstone_full` instead.
 
     Parameters
     ----------
@@ -146,34 +340,164 @@ def read_touchstone(filepath: str | Path) -> tuple[np.ndarray, np.ndarray, float
     freqs : (n_freqs,) float in Hz
     z0 : float reference impedance
     """
+    data = read_touchstone_full(filepath)
+    scalar_z0 = _uniform_reference_or_none(data.reference)
+    if scalar_z0 is None:
+        raise ValueError(
+            "Touchstone file has non-uniform per-port [Reference] values; "
+            "use read_touchstone_full() to preserve reference metadata"
+        )
+    return data.s_params, data.freqs, scalar_z0
+
+
+def read_touchstone_full(filepath: str | Path, *,
+                         layout: str = "auto") -> TouchstoneData:
+    """Read S-parameters and Touchstone metadata.
+
+    Supported subset:
+    - S-parameters only
+    - RI, MA, and DB numeric formats
+    - Touchstone 1-style data blocks
+    - Touchstone 2.0 metadata keywords used by rfx interop
+    - Full matrix data only
+
+    For backwards compatibility, Touchstone 1-style files default to the
+    historical rfx multi-port layout.  Touchstone 2.0 files default to the
+    standard full-matrix row-wise layout for 3+ ports.
+    """
     filepath = Path(filepath)
 
     # Infer port count from extension
-    ext = filepath.suffix.lower()
-    if ext.startswith(".s") and ext.endswith("p"):
-        n_ports = int(ext[2:-1])
-    else:
-        raise ValueError(f"Cannot determine port count from extension: {ext}")
+    ext_n_ports = _infer_touchstone_port_count(filepath)
+    n_ports = ext_n_ports
 
+    freq_unit = "GHz"
     freq_scale = 1e9  # default GHz
+    # Preserve old no-option-line rfx behavior as RI, but Touchstone option
+    # lines default to MA when the format token is omitted.
     fmt = "RI"
     z0 = 50.0
+    version = "1.0"
+    parameter = "S"
+    matrix_format = "Full"
+    two_port_order = "21_12"
+    reference_values: list[float] | None = None
+    declared_n_freqs: int | None = None
+    comments: list[str] = []
+    has_v2_keywords = False
 
     raw_data_lines: list[str] = []
+    in_network_data = False
+    in_reference = False
 
     with open(filepath) as f:
         for line in f:
-            line = line.strip()
-            if not line or line.startswith("!"):
+            stripped = line.strip()
+            if not stripped:
                 continue
+            if stripped.startswith("!"):
+                comments.append(stripped[1:].strip())
+                continue
+            if stripped.startswith("["):
+                has_v2_keywords = True
+                end = stripped.find("]")
+                if end < 0:
+                    raise ValueError(f"Malformed Touchstone keyword: {stripped}")
+                key = stripped[1:end].strip().lower()
+                rest = stripped[end + 1:].strip()
+                if "!" in rest:
+                    rest = rest[:rest.index("!")].strip()
+
+                in_network_data = False
+                in_reference = False
+
+                if key == "version":
+                    version = (rest.split()[0] if rest else version)
+                    if version not in ("1.0", "2.0"):
+                        raise ValueError(
+                            f"Unsupported Touchstone [Version] {version!r}; "
+                            "only 1.0/2.0 S-parameter files are supported"
+                        )
+                elif key == "number of ports":
+                    if rest:
+                        declared_n_ports = int(rest.split()[0])
+                        if ext_n_ports is not None and declared_n_ports != ext_n_ports:
+                            raise ValueError(
+                                "[Number of Ports] does not match file extension "
+                                f"({declared_n_ports} != {ext_n_ports})"
+                            )
+                        n_ports = declared_n_ports
+                elif key == "number of frequencies":
+                    if rest:
+                        declared_n_freqs = int(rest.split()[0])
+                elif key == "reference":
+                    if n_ports is None:
+                        raise ValueError(
+                            "[Number of Ports] is required before [Reference] "
+                            "when the extension does not encode the port count"
+                        )
+                    vals = [float(x) for x in rest.split()] if rest else []
+                    reference_values = vals
+                    in_reference = rest == ""
+                elif key == "matrix format":
+                    matrix_format = (rest.split()[0] if rest else "Full").capitalize()
+                    if matrix_format != "Full":
+                        raise ValueError("Only Touchstone [Matrix Format] Full is supported")
+                elif key == "two-port data order":
+                    two_port_order = rest.upper() if rest else two_port_order
+                elif key == "network data":
+                    if n_ports is None:
+                        raise ValueError(
+                            "Cannot determine port count; use an .sNp extension "
+                            "with N digits or provide [Number of Ports] before "
+                            "[Network Data]"
+                        )
+                    in_network_data = True
+                elif key == "end":
+                    break
+                else:
+                    raise ValueError(f"Unsupported Touchstone keyword [{key}]")
+                continue
+
+            # Strip inline comments: "1.0 0.5 0.3 ! my comment"
+            line = stripped
+            if "!" in line:
+                line = line[:line.index("!")]
+            line = line.strip()
+            if not line:
+                continue
+
+            if in_reference:
+                vals = [float(x) for x in line.split()]
+                reference_values = (reference_values or []) + vals
+                if n_ports is None:
+                    raise ValueError(
+                        "[Number of Ports] is required before multi-line [Reference]"
+                    )
+                if len(reference_values) >= n_ports:
+                    in_reference = False
+                continue
+
             if line.startswith("#"):
-                # Parse option line
+                # Parse option line.  Touchstone option-line defaults are:
+                # GHz, S, MA, R 50.  Existing no-option-line files keep the
+                # historical RI fallback initialized above.
+                freq_unit = "GHz"
+                freq_scale = 1e9
+                parameter = "S"
+                fmt = "MA"
+                z0 = 50.0
                 tokens = line[1:].split()
                 i = 0
                 while i < len(tokens):
                     t = tokens[i].upper()
                     if t in ("HZ", "KHZ", "MHZ", "GHZ"):
+                        freq_unit = {"HZ": "Hz", "KHZ": "kHz", "MHZ": "MHz", "GHZ": "GHz"}[t]
                         freq_scale = {"HZ": 1.0, "KHZ": 1e3, "MHZ": 1e6, "GHZ": 1e9}[t]
+                    elif t in ("S", "Y", "Z", "G", "H"):
+                        parameter = t
+                        if parameter != "S":
+                            raise ValueError("Only Touchstone S-parameter files are supported")
                     elif t in ("RI", "MA", "DB"):
                         fmt = t
                     elif t == "R" and i + 1 < len(tokens):
@@ -182,12 +506,14 @@ def read_touchstone(filepath: str | Path) -> tuple[np.ndarray, np.ndarray, float
                     i += 1
                 continue
 
-            # Strip inline comments: "1.0 0.5 0.3 ! my comment"
-            if "!" in line:
-                line = line[:line.index("!")]
-            line = line.strip()
-            if line:
+            if in_network_data or not has_v2_keywords:
                 raw_data_lines.append(line)
+
+    if n_ports is None:
+        raise ValueError(
+            "Cannot determine port count; use an .sNp extension with N digits "
+            "or provide [Number of Ports] metadata"
+        )
 
     # Number of value pairs expected per frequency point
     n_pairs = n_ports * n_ports  # one complex pair per S-parameter
@@ -211,6 +537,11 @@ def read_touchstone(filepath: str | Path) -> tuple[np.ndarray, np.ndarray, float
         )
 
     n_freqs = len(all_values) // n_values_expected
+    if declared_n_freqs is not None and n_freqs != declared_n_freqs:
+        raise ValueError(
+            "[Number of Frequencies] declares "
+            f"{declared_n_freqs} points, but parsed {n_freqs}"
+        )
 
     # Parse into structured arrays
     freqs_list: list[float] = []
@@ -232,17 +563,48 @@ def read_touchstone(filepath: str | Path) -> tuple[np.ndarray, np.ndarray, float
 
     freqs = np.array(freqs_list)
 
-    # Touchstone stores network data column-major:
-    # S11, S21, ..., SN1, S12, S22, ..., SN2, ...
-    s_params = np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex128)
-    for fi in range(n_freqs):
-        idx = 0
-        for j in range(n_ports):
-            for i in range(n_ports):
-                s_params[i, j, fi] = s_data[fi][idx]
-                idx += 1
+    if layout == "auto":
+        resolved_layout = "standard" if has_v2_keywords else "legacy-rfx"
+    else:
+        resolved_layout = layout.lower()
 
-    return s_params, freqs, z0
+    if reference_values is None:
+        reference = np.full(n_ports, z0, dtype=float)
+    else:
+        reference = np.asarray(reference_values, dtype=float).reshape(-1)
+        if reference.shape != (n_ports,):
+            raise ValueError(
+                f"[Reference] must contain {n_ports} values, got {reference.size}"
+            )
+
+    scalar_z0 = _uniform_reference_or_none(reference)
+    z0_out: float | np.ndarray = scalar_z0 if scalar_z0 is not None else reference.copy()
+
+    s_params = np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex128)
+    indices = _pair_indices(
+        n_ports,
+        layout=resolved_layout,
+        two_port_order=two_port_order,
+    )
+    for fi in range(n_freqs):
+        for idx, (i, j) in enumerate(indices):
+            s_params[i, j, fi] = s_data[fi][idx]
+
+    return TouchstoneData(
+        s_params=s_params,
+        freqs=freqs,
+        z0=z0_out,
+        reference=reference,
+        version=version,
+        parameter=parameter,
+        fmt=fmt,
+        freq_unit=freq_unit,
+        layout=resolved_layout,
+        matrix_format=matrix_format,
+        two_port_order=two_port_order,
+        comments=tuple(comments),
+    )
+
 
 
 # =========================================================================

--- a/tests/test_batch_provenance.py
+++ b/tests/test_batch_provenance.py
@@ -1,0 +1,481 @@
+"""Manifest-backed batch provenance and resume tests."""
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rfx import GaussianPulse, Simulation
+from rfx.batch import (
+    BATCH_MANIFEST_SCHEMA,
+    ParameterSweep,
+    case_id_from_params,
+    run_batch_with_manifest,
+)
+
+
+class _FakeSimulation:
+    def __init__(self, value: float, calls: list[float]):
+        self.value = value
+        self.calls = calls
+
+    def run(self, **kwargs):
+        self.calls.append(self.value)
+        return type("R", (), {"value": self.value, "kwargs": kwargs})()
+
+
+def _write_metric_artifact(case_dir: Path, params, result):
+    path = case_dir / "metrics.json"
+    path.write_text(json.dumps({"value": float(result.value)}))
+    # Return a case-local path.  The manifest runner should normalize this to
+    # an output-root-relative path so resume validation works across processes.
+    return {"metrics": "metrics.json"}
+
+
+def test_case_id_from_params_is_stable_across_dict_order():
+    assert case_id_from_params({"b": 2.0, "a": 1.0}) == case_id_from_params({"a": 1.0, "b": 2.0})
+
+
+def test_parameter_sweep_preserves_typed_values():
+    sweep = ParameterSweep(material=["air", "pec"], enabled=[True, False], n=[3])
+
+    combos = list(sweep.combinations())
+
+    assert combos == [
+        {"material": "air", "enabled": True, "n": 3},
+        {"material": "air", "enabled": False, "n": 3},
+        {"material": "pec", "enabled": True, "n": 3},
+        {"material": "pec", "enabled": False, "n": 3},
+    ]
+    assert all(isinstance(c["material"], str) for c in combos)
+    assert all(isinstance(c["enabled"], bool) for c in combos)
+    assert all(isinstance(c["n"], int) for c in combos)
+
+
+def test_run_batch_with_manifest_records_and_resumes_completed_cases(tmp_path: Path):
+    calls: list[float] = []
+    sweep = ParameterSweep(width=[1.0, 2.0])
+
+    def factory(width):
+        return _FakeSimulation(width, calls)
+
+    first = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        run_kwargs={"n_steps": 3},
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+    )
+    assert [r.status for r in first] == ["completed", "completed"]
+    assert calls == [1.0, 2.0]
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert manifest["schema_version"] == BATCH_MANIFEST_SCHEMA
+    assert manifest["sweep"] == {"keys": ["width"], "total": 2}
+    assert len(manifest["cases"]) == 2
+    assert all(record["status"] == "completed" for record in manifest["cases"].values())
+
+    def forbidden_factory(width):  # pragma: no cover - only runs on regression
+        raise AssertionError("resume should skip completed cases")
+
+    second = run_batch_with_manifest(
+        forbidden_factory,
+        sweep,
+        tmp_path,
+        run_kwargs={"n_steps": 3},
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+        resume=True,
+    )
+    assert [r.status for r in second] == ["skipped", "skipped"]
+    assert all(r.skipped for r in second)
+    assert [r.metrics["value"] for r in second] == [1.0, 2.0]
+    assert all(r.artifacts["metrics"].startswith(r.case_id + "/") for r in first)
+    assert all(
+        "sha256" in record["artifact_metadata"]["metrics"]
+        for record in manifest["cases"].values()
+    )
+
+
+def test_resume_does_not_skip_completed_record_with_missing_artifact(tmp_path: Path):
+    calls: list[float] = []
+    sweep = ParameterSweep(width=[1.0])
+
+    def factory(width):
+        return _FakeSimulation(width, calls)
+
+    first = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+    )
+    assert first[0].status == "completed"
+    artifact = tmp_path / first[0].artifacts["metrics"]
+    artifact.unlink()
+
+    second = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+        resume=True,
+    )
+    assert second[0].status == "completed"
+    assert calls == [1.0, 1.0]
+    assert artifact.exists()
+
+
+def test_resume_does_not_skip_when_manifest_params_are_corrupt(tmp_path: Path):
+    calls: list[float] = []
+    sweep = ParameterSweep(width=[1.0])
+
+    def factory(width):
+        return _FakeSimulation(width, calls)
+
+    first = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+    )
+    manifest_path = tmp_path / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["cases"][first[0].case_id]["params"] = {"width": 999.0}
+    manifest_path.write_text(json.dumps(manifest))
+
+    second = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+        resume=True,
+    )
+
+    assert second[0].status == "completed"
+    assert calls == [1.0, 1.0]
+
+
+def test_resume_does_not_skip_when_artifact_content_changes(tmp_path: Path):
+    calls: list[float] = []
+    sweep = ParameterSweep(width=[1.0])
+
+    def factory(width):
+        return _FakeSimulation(width, calls)
+
+    first = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+    )
+    artifact = tmp_path / first[0].artifacts["metrics"]
+    artifact.write_text(json.dumps({"value": 999.0}))
+
+    second = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+        resume=True,
+    )
+
+    assert second[0].status == "completed"
+    assert calls == [1.0, 1.0]
+
+
+def test_resume_does_not_skip_completed_record_with_empty_artifact_path(tmp_path: Path):
+    calls: list[float] = []
+    sweep = ParameterSweep(width=[1.0])
+
+    def factory(width):
+        return _FakeSimulation(width, calls)
+
+    first = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+    )
+    assert first[0].status == "completed"
+
+    manifest_path = tmp_path / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["cases"][first[0].case_id]["artifacts"] = {"bad": ""}
+    manifest_path.write_text(json.dumps(manifest))
+
+    second = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+        resume=True,
+    )
+    assert second[0].status == "completed"
+    assert calls == [1.0, 1.0]
+
+
+def test_resume_does_not_skip_completed_record_with_empty_metrics(tmp_path: Path):
+    calls: list[float] = []
+    sweep = ParameterSweep(width=[1.0])
+
+    def factory(width):
+        return _FakeSimulation(width, calls)
+
+    first = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+    )
+    assert first[0].status == "completed"
+
+    manifest_path = tmp_path / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["cases"][first[0].case_id]["metrics"] = {}
+    manifest_path.write_text(json.dumps(manifest))
+
+    second = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+        resume=True,
+    )
+    assert second[0].status == "completed"
+    assert calls == [1.0, 1.0]
+
+
+def test_artifact_fn_empty_path_marks_case_failed(tmp_path: Path):
+    sweep = ParameterSweep(width=[1.0])
+
+    def factory(width):
+        return _FakeSimulation(width, [])
+
+    def bad_artifact(case_dir: Path, params, result):
+        return {"bad": ""}
+
+    with pytest.raises(ValueError, match="artifact paths"):
+        run_batch_with_manifest(
+            factory,
+            sweep,
+            tmp_path,
+            metric_fn=lambda r: {"value": float(r.value)},
+            artifact_fn=bad_artifact,
+        )
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    record = next(iter(manifest["cases"].values()))
+    assert record["status"] == "failed"
+    assert "ValueError" in record["error"]
+
+
+def test_run_kwargs_change_invalidates_resume(tmp_path: Path):
+    calls: list[float] = []
+    sweep = ParameterSweep(width=[1.0])
+
+    def factory(width):
+        return _FakeSimulation(width, calls)
+
+    first = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        run_kwargs={"n_steps": 3},
+        metric_fn=lambda r: {"value": float(r.value), "n_steps": r.kwargs["n_steps"]},
+        artifact_fn=_write_metric_artifact,
+    )
+    assert first[0].status == "completed"
+
+    second = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        run_kwargs={"n_steps": 4},
+        metric_fn=lambda r: {"value": float(r.value), "n_steps": r.kwargs["n_steps"]},
+        artifact_fn=_write_metric_artifact,
+        resume=True,
+    )
+    assert second[0].status == "completed"
+    assert second[0].metrics["n_steps"] == 4
+    assert calls == [1.0, 1.0]
+
+
+def test_user_run_fingerprint_change_invalidates_resume(tmp_path: Path):
+    calls: list[float] = []
+    sweep = ParameterSweep(width=[1.0])
+
+    def factory(width):
+        return _FakeSimulation(width, calls)
+
+    first = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        run_kwargs={"n_steps": 3},
+        run_fingerprint="mesh-a",
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+    )
+    first_manifest = json.loads((tmp_path / "manifest.json").read_text())
+    first_fp = first_manifest["cases"][first[0].case_id]["run_fingerprint"]
+
+    second = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        run_kwargs={"n_steps": 3},
+        run_fingerprint="mesh-b",
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+        resume=True,
+    )
+    second_manifest = json.loads((tmp_path / "manifest.json").read_text())
+    record = second_manifest["cases"][second[0].case_id]
+
+    assert second[0].status == "completed"
+    assert calls == [1.0, 1.0]
+    assert record["run_config"]["user_fingerprint"] == "mesh-b"
+    assert record["run_fingerprint"] != first_fp
+
+
+def test_failed_manifest_record_is_not_resumed_as_completed(tmp_path: Path):
+    calls: list[str] = []
+    sweep = ParameterSweep(width=[1.0])
+
+    class _FailingSimulation:
+        def run(self, **kwargs):
+            calls.append("failed")
+            raise RuntimeError("intentional boom")
+
+    def failing_factory(width):
+        return _FailingSimulation()
+
+    with pytest.raises(RuntimeError, match="intentional boom"):
+        run_batch_with_manifest(
+            failing_factory,
+            sweep,
+            tmp_path,
+            run_kwargs={"n_steps": 3},
+            run_fingerprint="failure-case",
+        )
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    record = next(iter(manifest["cases"].values()))
+    assert record["status"] == "failed"
+    assert "RuntimeError" in record["error"]
+    assert record["params"] == {"width": 1.0}
+    assert record["params_digest"]
+    assert record["run_fingerprint"]
+    assert record["run_config"]["run_kwargs"] == {"n_steps": 3}
+    assert record["run_config"]["user_fingerprint"] == "failure-case"
+    assert record["started_at"]
+    assert record["completed_at"]
+    assert record["duration_s"] >= 0.0
+
+    def factory(width):
+        return _FakeSimulation(width, [])
+
+    second = run_batch_with_manifest(factory, sweep, tmp_path, resume=True)
+    assert second[0].status == "completed"
+    assert calls == ["failed"]
+
+
+def test_manifest_without_metric_fn_still_records_resume_metric(tmp_path: Path):
+    calls: list[float] = []
+    sweep = ParameterSweep(width=[1.0])
+
+    def factory(width):
+        return _FakeSimulation(width, calls)
+
+    first = run_batch_with_manifest(factory, sweep, tmp_path)
+    assert first[0].metrics == {"completed": True}
+
+    def forbidden_factory(width):  # pragma: no cover - only runs on regression
+        raise AssertionError("default completion metric should permit resume")
+
+    second = run_batch_with_manifest(forbidden_factory, sweep, tmp_path, resume=True)
+    assert second[0].status == "skipped"
+    assert second[0].metrics == {"completed": True}
+    assert calls == [1.0]
+
+
+def _physical_factory(amplitude: float):
+    sim = Simulation(freq_max=5e9, domain=(0.02, 0.02, 0.02), boundary="pec", dx=0.002)
+    sim.add_port(
+        (0.005, 0.01, 0.01),
+        "ez",
+        waveform=GaussianPulse(f0=3e9, amplitude=amplitude),
+    )
+    return sim
+
+
+def _physical_metric(result):
+    ts = np.asarray(result.time_series)
+    samples = int(ts.shape[0]) if ts.ndim >= 1 else 0
+    ts_peak = float(np.max(np.abs(ts))) if ts.size else 0.0
+    state = result.state
+    field_peak = max(
+        float(np.max(np.abs(np.asarray(getattr(state, comp)))))
+        for comp in ("ex", "ey", "ez", "hx", "hy", "hz")
+    )
+    return {
+        "peak_time_series": ts_peak,
+        "peak_field": field_peak,
+        "samples": samples,
+    }
+
+
+def _physical_artifact(case_dir: Path, params, result):
+    path = case_dir / "physical_metric.json"
+    path.write_text(json.dumps(_physical_metric(result), sort_keys=True))
+    return {"physical_metric": "physical_metric.json"}
+
+
+def test_tiny_physical_sweep_records_metrics_and_resumes(tmp_path: Path):
+    """Physical gate: tiny FDTD sweep metrics persist and resume skips cases."""
+    sweep = ParameterSweep(amplitude=[1.0, 2.0])
+    first = run_batch_with_manifest(
+        _physical_factory,
+        sweep,
+        tmp_path,
+        run_kwargs={"n_steps": 20},
+        metric_fn=_physical_metric,
+        artifact_fn=_physical_artifact,
+    )
+
+    assert [r.status for r in first] == ["completed", "completed"]
+    assert all(r.metrics["samples"] == 20 for r in first)
+    assert all(r.metrics["peak_field"] >= 0.0 for r in first)
+    assert first[1].metrics["peak_field"] > first[0].metrics["peak_field"]
+    assert first[1].metrics["peak_time_series"] >= first[0].metrics["peak_time_series"]
+    manifest_before = json.loads((tmp_path / "manifest.json").read_text())
+
+    def forbidden_factory(amplitude):  # pragma: no cover - only runs on regression
+        raise AssertionError("resume should skip completed physical cases")
+
+    second = run_batch_with_manifest(
+        forbidden_factory,
+        sweep,
+        tmp_path,
+        run_kwargs={"n_steps": 20},
+        metric_fn=_physical_metric,
+        artifact_fn=_physical_artifact,
+        resume=True,
+    )
+    assert [r.status for r in second] == ["skipped", "skipped"]
+    assert [r.metrics for r in second] == [r.metrics for r in first]
+    manifest_after = json.loads((tmp_path / "manifest.json").read_text())
+    assert manifest_after["cases"] == manifest_before["cases"]

--- a/tests/test_touchstone_interop.py
+++ b/tests/test_touchstone_interop.py
@@ -1,0 +1,280 @@
+"""Touchstone metadata and physical interop gates."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rfx import TouchstoneData, read_touchstone, read_touchstone_full, write_touchstone
+
+
+def test_read_touchstone_full_parses_v2_s4p_standard_row_wise(tmp_path: Path):
+    text = "\n".join([
+        "[Version] 2.0",
+        "# GHz S RI R 50",
+        "[Number of Ports] 4",
+        "[Number of Frequencies] 1",
+        "[Reference] 50 55 60 65",
+        "[Matrix Format] Full",
+        "[Network Data]",
+        # Standard full matrix order for 3+ ports: row-wise S11,S12,...S44.
+        "1.0  1 0 2 0 3 0 4 0",
+        "  5 0 6 0 7 0 8 0",
+        "  9 0 10 0 11 0 12 0",
+        "  13 0 14 0 15 0 16 0",
+        "[End]",
+    ])
+    path = tmp_path / "standard.s4p"
+    path.write_text(text)
+
+    data = read_touchstone_full(path)
+
+    assert isinstance(data, TouchstoneData)
+    assert data.version == "2.0"
+    assert data.layout == "standard"
+    np.testing.assert_allclose(data.reference, [50, 55, 60, 65])
+    np.testing.assert_allclose(data.freqs, [1e9])
+    expected = np.arange(1, 17, dtype=float).reshape(4, 4)
+    np.testing.assert_allclose(data.s_params[:, :, 0].real, expected)
+
+
+def test_legacy_read_touchstone_rejects_nonuniform_references(tmp_path: Path):
+    path = tmp_path / "nonuniform.s2p"
+    path.write_text("\n".join([
+        "[Version] 2.0",
+        "# GHz S RI R 50",
+        "[Number of Ports] 2",
+        "[Number of Frequencies] 1",
+        "[Reference] 50 75",
+        "[Two-Port Data Order] 12_21",
+        "[Network Data]",
+        "1.0  11 0 12 0 21 0 22 0",
+        "[End]",
+    ]))
+
+    data = read_touchstone_full(path)
+    np.testing.assert_allclose(data.reference, [50, 75])
+    assert data.s_params[0, 1, 0] == 12 + 0j
+    assert data.s_params[1, 0, 0] == 21 + 0j
+
+    with pytest.raises(ValueError, match="read_touchstone_full"):
+        read_touchstone(path)
+
+
+def test_v2_uniform_reference_still_supports_legacy_tuple_api(tmp_path: Path):
+    s_params = np.zeros((2, 2, 1), dtype=np.complex128)
+    s_params[0, 0, 0] = 11
+    s_params[0, 1, 0] = 12
+    s_params[1, 0, 0] = 21
+    s_params[1, 1, 0] = 22
+    freqs = np.array([1e9])
+    path = tmp_path / "uniform.s2p"
+
+    write_touchstone(
+        path,
+        s_params,
+        freqs,
+        version="2.0",
+        port_z0=np.array([50.0, 50.0]),
+        two_port_order="12_21",
+    )
+
+    data = read_touchstone_full(path)
+    assert data.two_port_order == "12_21"
+    np.testing.assert_allclose(data.s_params, s_params)
+
+    s_read, f_read, z0 = read_touchstone(path)
+    np.testing.assert_allclose(s_read, s_params)
+    np.testing.assert_allclose(f_read, freqs)
+    assert z0 == 50.0
+
+
+def test_v2_writer_preserves_nonuniform_reference_and_legacy_api_rejects(
+    tmp_path: Path,
+):
+    s_params = np.eye(3, dtype=np.complex128)[:, :, None] * 0.1
+    freqs = np.array([1.5e9])
+    path = tmp_path / "nonuniform_writer.s3p"
+
+    write_touchstone(
+        path,
+        s_params,
+        freqs,
+        version="2.0",
+        port_z0=np.array([50.0, 55.0, 60.0]),
+    )
+
+    data = read_touchstone_full(path)
+    np.testing.assert_allclose(data.s_params, s_params)
+    np.testing.assert_allclose(data.reference, [50.0, 55.0, 60.0])
+    np.testing.assert_allclose(np.asarray(data.z0), [50.0, 55.0, 60.0])
+
+    with pytest.raises(ValueError, match="read_touchstone_full"):
+        read_touchstone(path)
+
+
+def test_v1_writer_rejects_nonuniform_reference(tmp_path: Path):
+    s_params = np.zeros((2, 2, 1), dtype=np.complex128)
+    freqs = np.array([1e9])
+
+    with pytest.raises(ValueError, match="non-uniform port_z0"):
+        write_touchstone(
+            tmp_path / "bad_reference.s2p",
+            s_params,
+            freqs,
+            version="1.0",
+            port_z0=np.array([50.0, 75.0]),
+        )
+
+
+def test_option_line_omitted_format_defaults_to_touchstone_ma(tmp_path: Path):
+    path = tmp_path / "default_ma.s2p"
+    path.write_text("\n".join([
+        "# GHz S R 50",
+        "1.0  0.5 90  0.1 0  0.1 0  0.5 -90",
+    ]))
+
+    data = read_touchstone_full(path)
+
+    assert data.fmt == "MA"
+    np.testing.assert_allclose(data.s_params[0, 0, 0], 0.5j, atol=1e-15)
+    np.testing.assert_allclose(data.s_params[1, 1, 0], -0.5j, atol=1e-15)
+    np.testing.assert_allclose(data.s_params[1, 0, 0], 0.1 + 0j, atol=1e-15)
+
+
+def test_writer_rejects_extension_port_mismatch_and_nonfinite_data(
+    tmp_path: Path,
+):
+    freqs = np.array([1e9])
+    three_port = np.zeros((3, 3, 1), dtype=np.complex128)
+
+    with pytest.raises(ValueError, match="extension declares 2 ports"):
+        write_touchstone(tmp_path / "bad.s2p", three_port, freqs, version="2.0")
+
+    bad_s = np.zeros((2, 2, 1), dtype=np.complex128)
+    bad_s[0, 0, 0] = np.nan
+    with pytest.raises(ValueError, match="finite"):
+        write_touchstone(tmp_path / "bad_nan.s2p", bad_s, freqs)
+
+    with pytest.raises(ValueError, match="finite"):
+        write_touchstone(
+            tmp_path / "bad_freq.s2p",
+            np.zeros((2, 2, 1), dtype=np.complex128),
+            np.array([np.inf]),
+        )
+
+
+def test_v2_writer_defaults_to_standard_row_wise_multiport_layout(tmp_path: Path):
+    s_params = np.zeros((3, 3, 1), dtype=np.complex128)
+    # Non-symmetric values expose row-major vs column-major ordering bugs.
+    for i in range(3):
+        for j in range(3):
+            s_params[i, j, 0] = 10 * (i + 1) + (j + 1)
+    freqs = np.array([2.5e9])
+    path = tmp_path / "standard-default.s3p"
+
+    write_touchstone(path, s_params, freqs, version="2.0")
+    data = read_touchstone_full(path)
+
+    assert data.version == "2.0"
+    assert data.layout == "standard"
+    np.testing.assert_allclose(data.s_params, s_params)
+
+
+def test_legacy_layout_remains_default_for_existing_v1_multiport(tmp_path: Path):
+    s_params = np.zeros((3, 3, 1), dtype=np.complex128)
+    # Values chosen so row-wise and column-major layouts would differ.
+    for i in range(3):
+        for j in range(3):
+            s_params[i, j, 0] = 10 * (i + 1) + (j + 1)
+    freqs = np.array([2e9])
+    path = tmp_path / "legacy.s3p"
+
+    write_touchstone(path, s_params, freqs)
+    s_read, f_read, z0 = read_touchstone(path)
+
+    np.testing.assert_allclose(s_read, s_params)
+    np.testing.assert_allclose(f_read, freqs)
+    assert z0 == 50.0
+
+
+def test_v2_reader_rejects_declared_frequency_count_mismatch(tmp_path: Path):
+    path = tmp_path / "bad_count.s2p"
+    path.write_text("\n".join([
+        "[Version] 2.0",
+        "# GHz S RI R 50",
+        "[Number of Ports] 2",
+        "[Number of Frequencies] 2",
+        "[Network Data]",
+        "1.0  11 0 21 0 12 0 22 0",
+        "[End]",
+    ]))
+
+    with pytest.raises(ValueError, match="Number of Frequencies"):
+        read_touchstone_full(path)
+
+
+def test_v2_reader_rejects_port_count_extension_mismatch(tmp_path: Path):
+    path = tmp_path / "bad_ports.s2p"
+    path.write_text("\n".join([
+        "[Version] 2.0",
+        "# GHz S RI R 50",
+        "[Number of Ports] 3",
+        "[Number of Frequencies] 1",
+        "[Network Data]",
+        "1.0  11 0 21 0 12 0 22 0",
+        "[End]",
+    ]))
+
+    with pytest.raises(ValueError, match="file extension"):
+        read_touchstone_full(path)
+
+
+def _passivity_excess(s_matrix: np.ndarray) -> float:
+    excess = 0.0
+    for fi in range(s_matrix.shape[2]):
+        mat = s_matrix[:, :, fi]
+        max_eval = float(np.linalg.eigvalsh(mat.conj().T @ mat).max())
+        excess = max(excess, max_eval - 1.0)
+    return max(0.0, excess)
+
+
+def _reciprocity_error(s_matrix: np.ndarray) -> float:
+    return float(np.max(np.abs(s_matrix - np.swapaxes(s_matrix, 0, 1))))
+
+
+def test_passive_reciprocal_fixture_survives_standard_v2_roundtrip(tmp_path: Path):
+    """Physical/interop gate: passive reciprocal network survives Touchstone I/O."""
+    n_ports = 4
+    freqs = np.array([1e9, 2e9, 3e9])
+    s_params = np.zeros((n_ports, n_ports, freqs.size), dtype=np.complex128)
+    for fi in range(freqs.size):
+        diag = 0.10 + 0.01 * fi
+        coupling = 0.025 + 0.005 * fi
+        mat = np.full((n_ports, n_ports), coupling, dtype=np.complex128)
+        np.fill_diagonal(mat, diag)
+        s_params[:, :, fi] = mat
+
+    assert _passivity_excess(s_params) <= 0.0
+    assert _reciprocity_error(s_params) == 0.0
+
+    path = tmp_path / "passive_reciprocal.s4p"
+    write_touchstone(
+        path,
+        s_params,
+        freqs,
+        version="2.0",
+        layout="standard",
+        port_z0=np.array([50.0, 50.0, 50.0, 50.0]),
+        fmt="RI",
+    )
+    text = path.read_text()
+    assert "[Version] 2.0" in text
+    assert "[Matrix Format] Full" in text
+    assert "[Reference]" in text
+
+    data = read_touchstone_full(path)
+    np.testing.assert_allclose(data.s_params, s_params, atol=1e-12)
+    np.testing.assert_allclose(data.reference, np.full(n_ports, 50.0))
+    assert _passivity_excess(data.s_params) <= 1e-12
+    assert _reciprocity_error(data.s_params) <= 1e-12


### PR DESCRIPTION
## Summary

P0 foundation for host-side RF interop and repeatable sweep provenance.

- Adds `TouchstoneData`, `read_touchstone_full()`, and a bounded Touchstone 2.0 S-parameter metadata subset while preserving legacy tuple APIs.
- Supports explicit standard-vs-legacy multiport layouts, per-port `[Reference]`, suffix/finite-data validation, and nonuniform-reference rejection in the legacy API.
- Adds manifest-backed sequential batch execution with stable case IDs, parameter digests, run fingerprints, artifact size/SHA validation, and resume-safe completed-case checks.
- Adds docs and tests, including passive/reciprocal network roundtrip and tiny physical FDTD sweep resume gates.

## Stack

Base: `main`.
Follow-up PRs P1-P4 are independent branches based on this P0 branch.

## Validation

- `python -m py_compile rfx/io.py rfx/batch.py rfx/__init__.py`
- `python -m pytest -q tests/test_io.py tests/test_touchstone_interop.py tests/test_batch.py tests/test_batch_provenance.py` → 48 passed
- `git diff --check`

## Notes

No FDTD solver/update-kernel paths are modified.
