### PR TITLE
[codex] P3 continue manifest batches after failed cases

### DIFF
--- a/docs/guides/network_interop_batch_provenance.md
+++ b/docs/guides/network_interop_batch_provenance.md
@@ -75,6 +75,8 @@ physics paths.
 - Record a run fingerprint derived from run settings, with a user-supplied
   override for factory/metric/external-input changes, so reused output
   directories do not silently return stale cases.
+- Support `continue_on_error=True` when a sweep should record failed cases and
+  continue through later parameter points instead of failing fast.
 - Add a tiny physical sweep gate that proves resume does not corrupt metrics or
   silently rerun completed cases.
 

--- a/docs/public/guide/parametric-sweeps.mdx
+++ b/docs/public/guide/parametric-sweeps.mdx
@@ -207,6 +207,10 @@ rerun instead of returning stale cases. If the simulation factory, metric
 definition, mesh source, or any external input changes while `run_kwargs` stay
 the same, pass a new `run_fingerprint="..."` value to invalidate old cases.
 
+By default the manifest-backed runner is fail-fast. For exploratory grids where
+later cases are still useful after one case fails, pass
+`continue_on_error=True`; failed cases are recorded with `status="failed"`.
+
 ## Checklist before scaling up
 
 - Did a single case run and produce physically plausible fields/probes?

--- a/rfx/batch.py
+++ b/rfx/batch.py
@@ -279,6 +279,7 @@ def run_batch_with_manifest(
         [Path, dict[str, Any], Any], dict[str, str | Path] | None
     ] | None = None,
     resume: bool = True,
+    continue_on_error: bool = False,
     manifest_name: str = "manifest.json",
     run_fingerprint: str | None = None,
 ) -> list[BatchCaseResult]:
@@ -294,7 +295,8 @@ def run_batch_with_manifest(
     inputs changed but ``run_kwargs`` did not.  When ``resume=True``, a case is
     skipped only if the manifest record is completed, has the expected run
     fingerprint, contains at least one metric, and all declared artifact paths
-    still exist.
+    still exist.  With ``continue_on_error=True``, failed cases are recorded and
+    later cases continue; the default preserves the fail-fast behavior.
     """
     if run_kwargs is None:
         run_kwargs = {}
@@ -412,7 +414,8 @@ def run_batch_with_manifest(
                 result=None,
                 error=record["error"],
             ))
-            raise
+            if not continue_on_error:
+                raise
 
     return returned
 

--- a/tests/test_batch_provenance.py
+++ b/tests/test_batch_provenance.py
@@ -393,6 +393,43 @@ def test_failed_manifest_record_is_not_resumed_as_completed(tmp_path: Path):
     assert calls == ["failed"]
 
 
+def test_continue_on_error_records_failure_and_runs_remaining_cases(tmp_path: Path):
+    calls: list[float] = []
+    sweep = ParameterSweep(width=[1.0, 2.0, 3.0])
+
+    class _MaybeFailingSimulation:
+        def __init__(self, width: float):
+            self.width = width
+
+        def run(self, **kwargs):
+            calls.append(self.width)
+            if self.width == 2.0:
+                raise RuntimeError("boom")
+            return type("R", (), {"value": self.width})()
+
+    def factory(width):
+        return _MaybeFailingSimulation(width)
+
+    results = run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+        continue_on_error=True,
+    )
+
+    assert calls == [1.0, 2.0, 3.0]
+    assert [r.status for r in results] == ["completed", "failed", "completed"]
+    assert "RuntimeError" in results[1].error
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text())
+    assert sum(
+        1 for record in manifest["cases"].values()
+        if record["status"] == "failed"
+    ) == 1
+
+
 def test_manifest_without_metric_fn_still_records_resume_metric(tmp_path: Path):
     calls: list[float] = []
     sweep = ParameterSweep(width=[1.0])


### PR DESCRIPTION
## Summary

P3 adds opt-in partial-failure execution for manifest-backed sweeps.

- Adds `continue_on_error=True` to `run_batch_with_manifest()`.
- Keeps default behavior fail-fast for compatibility.
- Records failed cases with explicit status/error/duration while continuing later cases when opted in.
- Adds tests for `completed`, `failed`, `completed` sweep behavior.

## Stack

Base: `codex/p0-network-interop-batch-provenance`.
Independent of P1/P2/P4.

## Validation

- `python -m py_compile rfx/batch.py`
- `python -m pytest -q tests/test_batch.py tests/test_batch_provenance.py` → 19 passed
- `git diff --check`
