### PR TITLE
[codex] Refresh public RFX docs and maintenance checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,12 @@ Benchmarked against Balanis "Antenna Theory" and Pozar "Microwave Engineering":
 | Microstrip Z0 | Hammerstad-Jensen | 0.47% |
 | Coupled-line filter | Pozar Ch 8 | 22.5% (formula limitation) |
 
-For practical public examples, start with `examples/crossval/05_patch_antenna.py` for the patch workflow and `examples/crossval/11_waveguide_port_wr90.py` for rectangular waveguide ports. Treat non-uniform, distributed, Floquet/Bloch, subgridding, coaxial, and advanced inverse-design workflows as experimental unless the relevant guide says otherwise.
+For practical public examples, start with `examples/crossval/05_patch_antenna.py`
+for the patch workflow and `examples/crossval/11_waveguide_port_wr90.py` for
+rectangular waveguide ports. Treat non-uniform workflows as shadow unless the
+relevant guide says otherwise; treat distributed, Floquet/Bloch, subgridding,
+coaxial, and advanced inverse-design workflows as experimental unless the
+relevant guide says otherwise.
 
 ## Key Features
 
@@ -176,6 +181,7 @@ Canonical public-doc sources in this repo:
 - `docs/public/validation/` — quantitative evidence and lane-label hubs
 - `docs/agent/` — public AI-agent pages
 - `docs/guides/public_docs_architecture.md` — ownership, sync, and deploy rules
+- `docs/guides/public_docs_maintenance.md` — release/docs-sync checklist, stale-doc policy, and support-matrix cadence
 
 ### Public docs maintenance workflow
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -18,3 +18,7 @@
 /research_notes/
 /researchnote*/
 /superpowers/
+
+# Public AI-agent docs are deployed to /rfx/agent/* and must remain trackable.
+!/agent/
+!/agent/**

--- a/docs/agent/auto-config.mdx
+++ b/docs/agent/auto-config.mdx
@@ -1,0 +1,54 @@
+---
+title: "Agent Auto-Configuration"
+description: "A conservative workflow for agents using rfx auto-configuration and preflight checks."
+sidebar:
+  order: 2
+---
+
+Agents should use auto-configuration as a starting point, not as a substitute
+for RF judgement or support-matrix checks.
+
+## Recommended sequence
+
+1. Define the geometry, material, source/port family, and target frequency band.
+2. Use `auto_configure(...)` or the high-level `Simulation(...)` builder to get
+   a first mesh and time-step proposal.
+3. Inspect preflight warnings and support-boundary status before running long
+   jobs.
+4. Run a short smoke simulation first.
+5. Promote to a longer run only after the smoke output has sane field/probe
+   amplitudes and the selected feature lane is documented.
+
+## Python sketch
+
+```python
+from rfx import Simulation, Box, GaussianPulse, auto_configure
+
+geometry = [(Box((0.0, 0.0, 0.0), (0.08, 0.06, 0.0016)), "fr4")]
+materials = {"fr4": {"eps_r": 4.4, "sigma": 0.025}}
+
+config = auto_configure(
+    geometry=geometry,
+    materials=materials,
+    freq_range=(1e9, 4e9),
+    accuracy="standard",
+)
+
+sim = Simulation(**config.to_sim_kwargs())
+sim.add_material("fr4", eps_r=4.4, sigma=0.025)
+for shape, material in geometry:
+    sim.add(shape, material=material)
+sim.add_source((0.029, 0.03, 0.0008), "ez", waveform=GaussianPulse(2.4e9, 0.8))
+sim.add_probe((0.029, 0.03, 0.0008), "ez")
+
+result = sim.run(n_steps=min(config.n_steps, 200))  # smoke first; increase only after inspection
+```
+
+## What agents must report
+
+- mesh/domain/frequency assumptions
+- selected source or port family
+- support status for each advanced feature
+- smoke command and result artifact location
+- whether any generated report, plot, or Touchstone file is derived from a
+  supported, shadow, or experimental lane

--- a/docs/agent/design-workflows.mdx
+++ b/docs/agent/design-workflows.mdx
@@ -1,0 +1,45 @@
+---
+title: "Agent Design Workflows"
+description: "How agents should approach rfx design, sweep, optimization, and reporting workflows."
+sidebar:
+  order: 4
+---
+
+Agent-driven design should move from small, inspectable RF runs to larger sweeps
+or optimization only after the selected lane is understood.
+
+## Workflow ladder
+
+1. **Smoke geometry:** build the smallest geometry that exercises the intended
+   source/port/observable.
+2. **Single-run metric:** extract one metric such as resonance frequency,
+   `|S11|`, return loss, transmitted power, or a probe amplitude.
+3. **Sweep:** vary one or two physical parameters with `ParameterSweep` or a
+   small Python loop.
+4. **Report:** export plots, tables, Touchstone files, or JSON summaries with the
+   exact support status.
+5. **Optimize:** only optimize a metric whose differentiability and physics
+   support boundaries are documented for the selected lane.
+
+## Sweep skeleton
+
+```python
+from rfx.batch import ParameterSweep, run_batch
+
+sweep = ParameterSweep(width=[0.028, 0.030, 0.032], eps_r=[3.8, 4.2])
+
+results = run_batch(make_simulation, sweep, run_kwargs={"n_steps": 500})
+for params, result in results:
+    print(params, result.time_series.shape)
+```
+
+## Reporting checklist
+
+- Which public guide or example did the agent start from?
+- Which feature lane was used: supported, shadow, experimental, blocked, or
+  unsupported?
+- What exact command ran?
+- Where are generated files stored?
+- Which metric decided pass/fail?
+- Does the result require an external solver, analytic oracle, or dump replay
+  before it becomes a claims-bearing validation result?

--- a/docs/agent/overview.mdx
+++ b/docs/agent/overview.mdx
@@ -1,0 +1,45 @@
+---
+title: "AI Agent Overview"
+description: "How to use rfx public docs and support boundaries when asking an AI agent to build or review simulations."
+sidebar:
+  order: 1
+---
+
+rfx is useful with AI coding agents, but public RF/FDTD claims still need the
+same support-boundary checks as human-authored code. Treat this page as the
+agent-facing entry point for safe, reproducible rfx work.
+
+## Agent operating rules
+
+1. **Start from the supported lane.** Prefer uniform Cartesian Yee RF workflows
+   unless the task explicitly requires a shadow or experimental feature.
+2. **Check support before claiming physics.** Use the support matrix and
+   S-parameter matrix before describing a feature as validated.
+3. **Use examples before inventing loops.** Start with the closest file in
+   `examples/` or the public guide page, then adapt it.
+4. **Keep generated artifacts separate.** Store plots, Touchstone files, HDF5
+   snapshots, and reports in an output directory rather than committing runtime
+   artifacts.
+5. **Record uncertainty.** If a workflow uses non-uniform mesh, subgridding,
+   distributed execution, Floquet/Bloch, coaxial ports, or advanced inverse
+   design, say whether it is supported, shadow, experimental, or blocked.
+
+## Core references
+
+- [Quick Start](/rfx/guide/quickstart/)
+- [Sources and Ports](/rfx/guide/sources-ports/)
+- [Probes and S-Parameters](/rfx/guide/probes-sparams/)
+- [Support Boundaries](/rfx/api/support-boundaries/)
+- [Validation](/rfx/validation/)
+- `docs/guides/support_matrix.md`
+- `docs/guides/sparameter_support_matrix.md`
+- `docs/guides/physics_validation_evidence_rule.md`
+
+## Safe prompt skeleton
+
+```text
+Use rfx for a uniform Cartesian Yee RF/FDTD workflow unless the support matrix
+says another lane is supported. Build from the closest public example, run the
+smallest smoke check, and report support status, commands, and artifacts. Do not
+claim broad validation for experimental lanes.
+```

--- a/docs/agent/prompt-templates.mdx
+++ b/docs/agent/prompt-templates.mdx
@@ -1,0 +1,44 @@
+---
+title: "Agent Prompt Templates"
+description: "Reusable prompts for safe rfx simulation, validation, documentation, and review work."
+sidebar:
+  order: 3
+---
+
+Use these templates when delegating rfx work to an AI agent.
+
+## Build a small supported-lane simulation
+
+```text
+Create a minimal rfx uniform Cartesian Yee RF/FDTD example for <device>. Use the
+closest public example first. Run a short smoke test, save generated artifacts
+outside git, and report support status, command output, and known limitations.
+```
+
+## Review a physics claim
+
+```text
+Review this rfx result as a physics claim. Check docs/guides/support_matrix.md,
+docs/guides/sparameter_support_matrix.md, and
+physics_validation_evidence_rule.md. Classify the claim as supported, shadow,
+experimental, blocked, or unsupported, and list the missing evidence if it is not
+supported.
+```
+
+## Update public docs
+
+```text
+Update the rfx public docs for <feature>. Verify every API name against current
+code, run scripts/check_public_docs_manifest.py, run the public docs sync check,
+and avoid broad production wording unless the support matrix explicitly allows
+it.
+```
+
+## Prepare artifacts for a report
+
+```text
+Generate a reproducible rfx report bundle for <workflow>. Include command lines,
+input parameters, output paths, support status, and exact metrics. Keep plots,
+Touchstone files, and HDF5 snapshots out of git unless they are intentionally
+curated docs assets.
+```

--- a/docs/guides/public_docs_architecture.md
+++ b/docs/guides/public_docs_architecture.md
@@ -16,11 +16,25 @@ public `remilab.ai/rfx/` documentation surface.
 | `docs/public/api/` | curated public API pages deployed to `/rfx/api/*` | yes |
 | `docs/agent/` | public AI-agent pages deployed to `/rfx/agent/*` | yes |
 | `docs/guide/` | legacy redirect entrypoint kept for backwards navigation | no |
-| `docs/api/` | generated API docs published as subordinate deep reference under `/rfx/api/generated/*` | generated only |
+| `docs/api/` | optional generated API assets published under `/rfx/api/generated/*` when present | generated only |
 | `docs/research_notes/` | planning, handoffs, chronology | internal only |
 
 `infra/remilab-sites-gitops/.../seed-pages/rfx` is the **deploy snapshot**.
 It should be regenerated from this repo, not used as a parallel authoring home.
+
+## First-class deploy target
+
+The public site `remilab.ai/rfx` is part of the documentation deliverable, not a
+separate afterthought. A docs change is source-complete when the repo checks pass;
+it is deployment-complete only after the gitops snapshot is exported or a concrete
+missing-checkout blocker is recorded.
+
+Expected local deploy root:
+
+```text
+/root/workspace/infra/remilab-sites-gitops/deploy/obsidian-stack/astro-starlight-presets/public/seed-pages/rfx
+```
+
 
 ## Current public hierarchy
 
@@ -57,9 +71,10 @@ inventory should originate from `docs/public/` and `docs/agent/` in this repo.
 ## Maintenance workflow
 
 1. Author or edit the public pages in `docs/public/` and `docs/agent/`.
-2. Run the source drift check:
+2. Run the manifest and source drift checks:
 
    ```bash
+   python scripts/check_public_docs_manifest.py
    python scripts/check_public_docs_sync.py --format text
    ```
 
@@ -99,5 +114,6 @@ in the deploy repo.
   sources**.
 - `docs/guide/` is intentionally reduced to a single redirect-style entrypoint
   and should not receive new content.
-- `docs/api/` remains generated-only and should be exported as a subordinate
-  deep-reference surface, not treated as the primary authored API contract.
+- `docs/api/` remains generated-only and optional; when present it should be
+  exported as a subordinate deep-reference surface, not treated as the primary
+  authored API contract.

--- a/docs/guides/public_docs_maintenance.md
+++ b/docs/guides/public_docs_maintenance.md
@@ -1,0 +1,78 @@
+# rfx Public Docs Maintenance Policy
+
+This policy keeps repository docs and the public `remilab.ai/rfx` surface in
+sync without weakening physics-claim boundaries.
+
+## Source-of-truth surfaces
+
+| Surface | Role | Required check |
+|---|---|---|
+| `docs/public/**` | public `/rfx` pages | `python scripts/check_public_docs_manifest.py` |
+| `docs/agent/**` | public `/rfx/agent/*` pages | manifest check and route smoke |
+| `docs/guides/support_matrix.md` | support-status contract | reviewed whenever public claims change |
+| `docs/guides/sparameter_support_matrix.md` | S-parameter claim contract | reviewed whenever ports/S-parameters change |
+| gitops `seed-pages/rfx` | deployed `remilab.ai/rfx` snapshot | `python scripts/check_public_docs_sync.py --format text` |
+
+## PR slicing
+
+Use small documentation PRs unless a feature PR must include docs to remain
+accurate.
+
+1. **Manifest/navigation PR:** route inventory, missing pages, site map, sidebar.
+2. **User-journey PR:** quickstart, first patch, sources/ports, probes,
+   S-parameters, sweeps, visualization, examples.
+3. **Physics-claims PR:** validation, support matrix, S-parameter evidence,
+   solver/reference-lane caveats.
+4. **Deploy-sync PR:** gitops snapshot for `remilab.ai/rfx`.
+5. **Maintenance PR:** docs tooling, CI checks, stale-doc policy.
+
+## Release checklist
+
+Before publishing a release or merging a docs-heavy feature:
+
+```bash
+python scripts/check_public_docs_manifest.py
+python scripts/check_public_docs_sync.py --format text
+python scripts/export_public_docs_to_gitops.py --check
+python -m py_compile scripts/check_public_docs_manifest.py scripts/check_public_docs_sync.py scripts/export_public_docs_to_gitops.py
+```
+
+If the gitops checkout is not available, record that as a concrete blocker with
+the expected path rather than silently treating source-only docs as deployed.
+
+## Snippet and API validation
+
+For changed public docs:
+
+- grep the current API before documenting a function signature;
+- run lightweight Python smoke snippets for pure helpers such as Touchstone I/O,
+  `ParameterSweep`, and `SimulationDataset`;
+- do not run long GPU/solver examples as docs smoke unless the PR explicitly
+  changes those examples;
+- keep generated outputs outside git unless they are curated docs assets.
+
+## Support-matrix review cadence
+
+- Review `docs/guides/support_matrix.md` for any feature-status wording change.
+- Review `docs/guides/sparameter_support_matrix.md` for any source, port,
+  S-parameter, Touchstone, or RF-network wording change.
+- Review `docs/guides/physics_validation_evidence_rule.md` before calling a
+  result validated, cross-validated, or production-ready.
+- Keep public docs phrasing aligned with the strongest documented evidence, not
+  with local intuition or a passing unit test alone.
+
+## remilab.ai/rfx maintenance
+
+`remilab.ai/rfx` is a first-class deliverable. The deploy snapshot should be
+regenerated from this repository using `scripts/export_public_docs_to_gitops.py`.
+Do not hand-edit the gitops snapshot as a parallel source of truth.
+
+Expected deploy root:
+
+```text
+/root/workspace/infra/remilab-sites-gitops/deploy/obsidian-stack/astro-starlight-presets/public/seed-pages/rfx
+```
+
+If the checkout is absent, the source repo can still merge docs fixes, but the
+PR or release note must say that live-site sync remains blocked until the gitops
+repo is present and the sync check is re-run.

--- a/docs/guides/public_docs_refresh_inventory_20260530.md
+++ b/docs/guides/public_docs_refresh_inventory_20260530.md
@@ -1,0 +1,120 @@
+# 2026-05-30 public docs refresh inventory
+
+## Scope
+
+This inventory covers the canonical public rfx documentation sources and the
+`remilab.ai/rfx` deploy/sync path:
+
+- `docs/public/index.mdx`
+- `docs/public/guide/**`
+- `docs/public/examples/**`
+- `docs/public/validation/**`
+- `docs/public/api/**`
+- `docs/agent/**`
+- `docs/guides/**` support, evidence, and maintenance contracts
+- `examples/**` where public docs reference runnable entry points
+- gitops deploy target: `/root/workspace/infra/remilab-sites-gitops/deploy/obsidian-stack/astro-starlight-presets/public/seed-pages/rfx`
+
+## Baseline command results
+
+### Public manifest
+
+Command:
+
+```bash
+python scripts/check_public_docs_manifest.py
+```
+
+Baseline result before this refresh: failed because the site map referenced four
+AI-agent routes that did not have source pages:
+
+- `rfx/agent/overview`
+- `rfx/agent/auto-config`
+- `rfx/agent/prompt-templates`
+- `rfx/agent/design-workflows`
+
+### Deploy sync
+
+Command:
+
+```bash
+python scripts/check_public_docs_sync.py --format text
+```
+
+Baseline result before this refresh: drift detected because the deploy root did
+not exist in this environment:
+
+```text
+/root/workspace/infra/remilab-sites-gitops/deploy/obsidian-stack/astro-starlight-presets/public/seed-pages/rfx
+```
+
+The source tree contained public docs under `docs/public/**`, but the deploy
+snapshot had zero files because the gitops checkout/path was absent.
+
+## Stale-risk findings
+
+### Missing route sources
+
+`docs/public/site_map.json` already reserves an "AI Agent Guide" group. The
+missing source pages are a hard manifest blocker and also make README guidance
+that references `docs/agent/` inaccurate until the pages exist.
+
+### Placeholder public pages
+
+The following public pages still contained explicit placeholder or
+under-construction text at the start of this refresh and need either real
+content or a clearer support-boundary caveat:
+
+- `docs/public/guide/parametric-sweeps.mdx`
+- `docs/public/guide/antenna-metrics.mdx`
+- `docs/public/guide/comparison.mdx`
+- `docs/public/guide/conformal-pec.mdx`
+- `docs/public/guide/material-fitting.mdx`
+- `docs/public/guide/topology-optimisation.mdx`
+- `docs/public/guide/tutorial-convergence.mdx`
+
+This refresh prioritizes `parametric-sweeps` because it is part of the requested
+core user journey and because `rfx.batch` is small enough to smoke-check.
+
+### API/snippet risks found during inventory
+
+- `docs/public/guide/probes-sparams.mdx` showed `write_touchstone` with the
+  old argument order in the Touchstone section. Current API is
+  `write_touchstone(filepath, s_params, freqs, ...)` and
+  `read_touchstone(filepath) -> (s_params, freqs, z0)`.
+- Public docs mention `docs/agent/` and gitops sync, but the repository did not
+  contain `docs/agent/**` on the clean `origin/main` baseline.
+- `scripts/export_public_docs_to_gitops.py --check` treated `docs/api` as
+  required even though generated API assets are optional in the sync checker and
+  absent from this clean checkout.
+
+### Claim-bearing pages
+
+Claim-bearing support and evidence docs that must be kept aligned with public
+copy:
+
+- `docs/guides/support_matrix.md`
+- `docs/guides/support_matrix.json`
+- `docs/guides/sparameter_support_matrix.md`
+- `docs/guides/sparameter_support_matrix.json`
+- `docs/guides/physics_validation_evidence_rule.md`
+- `docs/public/api/support-boundaries.mdx`
+- `docs/public/validation/**`
+
+Any public copy that discusses S-parameters, ports, non-uniform mesh,
+subgridding, distributed execution, Floquet/Bloch, or coaxial ports must defer
+to those documents and avoid broad production wording unless the support matrix
+says so.
+
+## Prioritized work plan
+
+1. Restore manifest integrity by adding the missing `docs/agent/**` pages.
+2. Refresh the highest-risk core user journey snippets: probes/S-parameters,
+   parametric sweeps, and visualization/export.
+3. Add a maintenance policy that gives future agents and maintainers a repeatable
+   stale-doc, support-matrix, and deploy-sync workflow.
+4. Make deploy tooling tolerant of absent optional generated API assets while
+   still failing clearly when the gitops checkout is missing.
+5. Treat `remilab.ai/rfx` as a first-class target: source docs are not done until
+   the gitops snapshot is exported or the missing checkout is recorded as a
+   concrete blocker.

--- a/docs/guides/support_matrix.md
+++ b/docs/guides/support_matrix.md
@@ -89,6 +89,17 @@ Current policy:
 | Coaxial port + nonuniform | unsupported | hard-fail |
 | Lumped RLC + nonuniform | unsupported | hard-fail |
 
+
+## Reporting and export artifact rule
+
+Export helpers such as Touchstone writers, plots, HDF5 snapshots, CSV sweep
+summaries, and JSON manifests are reproducibility aids. They preserve data and
+make reviews easier, but they do **not** change the support status of the
+underlying feature. A public report should include the originating workflow,
+source/port family, support status, command, git SHA, and pass/fail metric, and
+then cite the applicable support/evidence matrix before making a physics claim.
+
+
 ## Promotion rule
 
 A lane or feature can be promoted to **supported** only when all of the following exist:

--- a/docs/public/api/generated/index.mdx
+++ b/docs/public/api/generated/index.mdx
@@ -21,11 +21,12 @@ the route that should eventually carry it.
 ## Current status
 
 This landing page is the curated entrypoint to the generated layer.
-The subordinate generated symbol pages are published as static deep-reference
-assets under the same route family, for example:
+When generated assets are present in `docs/api/`, they are published as static
+deep-reference assets under the same route family, for example:
 
 - `/rfx/api/generated/rfx.html`
 - `/rfx/api/generated/rfx/api.html`
 
-Treat those pages as useful lookup surfaces, not as the primary public API
+Some source checkouts may only carry this curated landing page. Treat generated
+pages, when present, as useful lookup surfaces rather than the primary public API
 contract.

--- a/docs/public/api/results-observables.mdx
+++ b/docs/public/api/results-observables.mdx
@@ -27,7 +27,7 @@ sidebar:
 
 | Calculator | Result object | Public status |
 |---|---|---|
-| `run(compute_s_params=True)` with lumped/wire `add_port(...)` | `Result.s_params`, `Result.freqs` | recommended path for the matching port family |
+| `run(compute_s_params=True)` with lumped/wire `add_port(...)` | `Result.s_params`, `Result.freqs` | documented path for the matching port family; claim strength follows the support envelope |
 | `forward(port_s11_freqs=...)` with lumped/wire `add_port(...)` | `ForwardResult.s_params`, `ForwardResult.freqs` | differentiable S11 vectors, not a full multi-port matrix |
 | `compute_msl_s_matrix(...)` | `MSLSMatrixResult` | specialized microstrip-line workflow |
 | `compute_waveguide_s_matrix(...)` | `WaveguideSMatrixResult` | rectangular waveguide workflow |

--- a/docs/public/api/sources-ports.mdx
+++ b/docs/public/api/sources-ports.mdx
@@ -72,5 +72,7 @@ sim.preflight_sparameters(calculator="forward")
 
 - Use sources for clean transient or resonance extraction.
 - Use ports when you need impedance-normalized outputs.
-- Treat non-uniform, coaxial, Floquet/Bloch, subgridding, and mixed advanced-port workflows as experimental unless a guide says otherwise.
+- Treat non-uniform workflows as shadow unless the relevant guide says
+  otherwise; treat coaxial, Floquet/Bloch, subgridding, and mixed
+  advanced-port workflows as experimental unless a guide says otherwise.
 - Keep public wording scoped to the current example or workflow being used.

--- a/docs/public/api/support-boundaries.mdx
+++ b/docs/public/api/support-boundaries.mdx
@@ -12,6 +12,7 @@ This page gives the public support summary without internal validation details.
 | Status | Meaning |
 |---|---|
 | **recommended default** | best place to start for public examples and ordinary RF workflows |
+| **shadow** | retained and tested, but not claims-bearing yet |
 | **experimental / under active validation** | useful, but support boundaries are narrower |
 | **unsupported** | should fail clearly rather than degrade silently |
 
@@ -30,7 +31,7 @@ This page gives the public support summary without internal validation details.
 
 | Primitive | Calculation API | Public status |
 |---|---|---|
-| lumped/wire `add_port(...)` | `run(compute_s_params=True)` | recommended for the matching port family |
+| lumped/wire `add_port(...)` | `run(compute_s_params=True)` | documented calculator for the matching port family; claim strength follows the support envelope |
 | lumped/wire `add_port(...)` | `forward(port_s11_freqs=...)` | differentiable S11 vectors on the uniform single-device path |
 | `add_msl_port(...)` | `compute_msl_s_matrix()` | specialized microstrip-line workflow |
 | `add_waveguide_port(...)` | `compute_waveguide_s_matrix()` | rectangular waveguide workflow |
@@ -38,11 +39,11 @@ This page gives the public support summary without internal validation details.
 | `add_floquet_port(...)` | experimental | periodic / unit-cell workflow under active validation |
 | sources, TFSF, probes, flux monitors | not port calculators | field/flux/time observables |
 
-## Experimental lanes
+## Non-default lanes
 
 | Lane | Public note |
 |---|---|
-| non-uniform mesh | useful for thin-substrate experiments; not the default lane |
+| non-uniform mesh | shadow thin-substrate lane; useful, but not the claims-bearing default |
 | SBP-SAT / subgridding | experimental local mesh refinement |
 | ADI | experimental accuracy/stability lane |
 | distributed execution | scaling lane; check feature combinations |
@@ -52,8 +53,22 @@ This page gives the public support summary without internal validation details.
 
 ## Unsupported combinations
 
-Unsupported combinations should fail clearly. Common examples include mixing non-uniform mesh with Floquet, TFSF, broad DFT-plane workflows, MSL S-matrix extraction, coaxial ports, or lumped RLC unless the relevant guide explicitly says that combination is supported.
+Unsupported combinations should fail clearly. Common examples include mixing
+non-uniform mesh with Floquet, TFSF, broad DFT-plane workflows, MSL S-matrix
+extraction, coaxial ports, or lumped RLC unless the relevant guide explicitly
+says that combination is supported.
 
 ## Practical rule
 
-If the workflow is not in the recommended default lane, describe it as experimental or under active validation and link to the current example or limitation page.
+If the workflow is not in the recommended default lane, describe it as shadow,
+experimental, or under active validation as appropriate and link to the current
+example or limitation page.
+
+
+## Artifact and report exports
+
+Touchstone files, plots, HDF5 snapshots, CSV sweep tables, and JSON manifests are
+interoperability or reporting artifacts. They preserve what a run produced, but
+they do not by themselves promote a workflow to supported status. Public reports
+should carry the originating port/source family, support status, command, git
+SHA, and metric used for pass/fail.

--- a/docs/public/examples/crossval.mdx
+++ b/docs/public/examples/crossval.mdx
@@ -18,4 +18,6 @@ This page points to the current public cross-check examples without exposing int
 
 - Use these scripts when you need a current runnable reference.
 - Keep claims scoped to the workflow being exercised.
-- Treat non-uniform, distributed, Floquet/Bloch, subgridding, coaxial, and advanced inverse-design paths as experimental unless a guide says otherwise.
+- Treat non-uniform paths as shadow unless a guide says otherwise; treat
+  distributed, Floquet/Bloch, subgridding, coaxial, and advanced inverse-design
+  paths as experimental unless a guide says otherwise.

--- a/docs/public/examples/index.mdx
+++ b/docs/public/examples/index.mdx
@@ -15,11 +15,14 @@ Use these examples as starting points, not as exhaustive coverage of every featu
 | [RF Workflows](./rf-workflows/) | practical workflow framing |
 | `examples/crossval/05_patch_antenna.py` | current patch antenna cross-check |
 | `examples/crossval/11_waveguide_port_wr90.py` | rectangular waveguide-port workflow |
-| `examples/nonuniform_patch_demo.py` | non-uniform mesh demo; experimental lane |
+| `examples/nonuniform_patch_demo.py` | non-uniform mesh demo; shadow lane |
 | `examples/inverse_design/multilayer_ar_coating.py` | conservative inverse-design demo |
 
 ## How to read the example surface
 
 - Start with uniform Yee RF examples when you want the safest path.
-- Treat non-uniform, distributed, Floquet/Bloch, general subgridding, coaxial, and advanced inverse-design examples as experimental unless a guide says otherwise.  The subgridding guide documents the narrow guarded one-sided production envelope.
+- Treat non-uniform examples as shadow unless a guide says otherwise; treat
+  distributed, Floquet/Bloch, general subgridding, coaxial, and advanced
+  inverse-design examples as experimental unless a guide says otherwise. The
+  subgridding guide documents the narrow guarded one-sided production envelope.
 - Prefer current scripts in `examples/crossval/` over older narrative snippets.

--- a/docs/public/examples/rf-workflows.mdx
+++ b/docs/public/examples/rf-workflows.mdx
@@ -20,7 +20,7 @@ This page is the practical example hub for public RF workflows.
 
 - `examples/crossval/05_patch_antenna.py` — practical patch antenna cross-check
 - `examples/crossval/11_waveguide_port_wr90.py` — rectangular waveguide-port workflow
-- `examples/nonuniform_patch_demo.py` — non-uniform mesh demo; experimental lane
+- `examples/nonuniform_patch_demo.py` — non-uniform mesh demo; shadow lane
 - `examples/inverse_design/multilayer_ar_coating.py` — conservative inverse-design demo
 
 ## What not to promote

--- a/docs/public/guide/index.md
+++ b/docs/public/guide/index.md
@@ -11,7 +11,8 @@ sidebar:
 | Lane | What to expect |
 |---|---|
 | **Recommended default** | uniform Cartesian Yee RF workflows: cavity, waveguide, patch-style resonance, probes, Harminv, selected S-parameter workflows, and benchmarked far-field workflows |
-| **Experimental / under active validation** | non-uniform mesh, distributed execution, Floquet/Bloch, SBP-SAT subgridding, coaxial and advanced port workflows, and inverse-design extensions |
+| **Shadow** | non-uniform mesh thin-substrate workflows |
+| **Experimental / under active validation** | distributed execution, Floquet/Bloch, SBP-SAT subgridding, coaxial and advanced port workflows, and inverse-design extensions |
 
 Start with the recommended default lane unless you specifically need an experimental feature.
 
@@ -32,7 +33,7 @@ Start with the recommended default lane unless you specifically need an experime
 | [Sources & Ports](/rfx/guide/sources-ports/) | Soft sources, lumped/wire ports, waveguide ports, and experimental port surfaces |
 | [Probes & S-Parameters](/rfx/guide/probes-sparams/) | DFT probes, S-matrix helpers, Harminv, de-embedding, and exports |
 | [Memory Reduction](/rfx/guide/memory-reduction/) | How to reduce FDTD/AD memory without crossing validation boundaries |
-| [Non-Uniform Mesh](/rfx/guide/nonuniform-mesh/) | Experimental thin-substrate mesh workflows |
+| [Non-Uniform Mesh](/rfx/guide/nonuniform-mesh/) | Shadow thin-substrate mesh workflows |
 | [Waveguide Ports](/rfx/guide/waveguide-ports/) | Modal waveguide excitation and S-matrix extraction |
 | [Floquet Ports](/rfx/guide/floquet-ports/) | Experimental Bloch-periodic unit-cell workflows |
 
@@ -74,6 +75,7 @@ Start with the recommended default lane unless you specifically need an experime
 - [Validation](/rfx/validation/) — support and validation overview
 - [API](/rfx/api/) — curated public API contract
 - [Generated API](/rfx/api/generated/) — subordinate generated symbol reference
+- [AI Agent Guide](/rfx/agent/overview/) — safe agent prompts, auto-configuration, and review workflow
 
 ## Quick Links
 

--- a/docs/public/guide/parametric-sweeps.mdx
+++ b/docs/public/guide/parametric-sweeps.mdx
@@ -1,23 +1,160 @@
 ---
 title: "Parametric Sweeps"
-description: "Sequential sweep and jax.vmap batch evaluation for design-space exploration in rfx."
+description: "Sequential sweeps, batch result collection, and vmap-oriented design-space exploration in rfx."
 sidebar:
   order: 26
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
-<Aside type="caution" title="Under construction">
-  This page is a placeholder. Content will be added in a future update.
+Parametric sweeps are the safest way to explore a small RF design space before
+committing to a long optimization run. Start with a sequential sweep that you can
+inspect, then move to vectorized or accelerator-heavy evaluation only after the
+metric is stable.
+
+<Aside type="caution" title="Support boundary">
+  A sweep multiplies the assumptions of the underlying simulation. If a single
+  run uses a shadow or experimental lane, the sweep results stay shadow or
+  experimental until the relevant support/evidence matrix promotes that lane.
 </Aside>
 
-## Overview
+## 1. Define the parameter grid
 
-This guide will cover how to run parametric sweeps in rfx:
+`rfx.batch.ParameterSweep` stores a Cartesian product of scalar parameter
+values. It is intentionally small and explicit so every case can be inspected.
 
-- **Sequential sweep** — loop over parameter values with standard Python iteration
-- **`jax.vmap` batch evaluation** — vectorised parallel simulation for independent parameter points
-- **Result aggregation** — collecting S-parameters, resonances, and metrics across sweep dimensions
-- **Use cases** — substrate thickness sweeps, feed-point optimisation, frequency scaling studies
+```python
+from rfx.batch import ParameterSweep
 
-See [Simulation API](../api-reference/) for the `Simulation` builder interface.
+sweep = ParameterSweep(
+    patch_width=[0.028, 0.030, 0.032],
+    eps_r=[3.8, 4.2],
+)
+
+print(sweep.keys)   # ['patch_width', 'eps_r']
+print(sweep.total)  # 6
+
+for params in sweep.combinations():
+    print(params)
+```
+
+## 2. Build a simulation factory
+
+Keep the factory pure: all parameters needed to construct the case should come
+from the `params` dictionary. Store generated plots, Touchstone files, and HDF5
+snapshots outside git unless they are curated docs assets.
+
+```python
+from rfx import Simulation, Box, GaussianPulse
+
+
+def make_patch_sim(patch_width: float, eps_r: float) -> Simulation:
+    sim = Simulation(freq_max=4e9, domain=(0.08, 0.06, 0.025), boundary="cpml")
+    sim.add_material("substrate", eps_r=eps_r)
+    sim.add(Box((0.0, 0.0, 0.0), (0.08, 0.06, 0.0016)), material="substrate")
+    sim.add(Box((0.024, 0.015, 0.0016), (0.052, 0.015 + patch_width, 0.0016)), material="pec")
+    sim.add_source((0.029, 0.030, 0.0008), "ez", waveform=GaussianPulse(2.4e9, 0.8))
+    sim.add_probe((0.029, 0.030, 0.0008), "ez")
+    return sim
+```
+
+## 3. Run a sequential batch
+
+`run_batch(...)` calls `sim_factory(**params)` for each parameter combination and
+returns a list of `(params, result)` tuples.
+
+```python
+from rfx.batch import run_batch
+
+results = run_batch(
+    make_patch_sim,
+    sweep,
+    run_kwargs={"n_steps": 500},  # use a short smoke first
+)
+
+for params, result in results:
+    print(params, result.time_series.shape)
+```
+
+For long runs, include a case identifier in your output path and write a manifest
+with the input parameters, command line, git SHA, support status, and metric used
+to rank the case. That manifest is what lets reviewers reproduce a plotted sweep.
+
+## 4. Aggregate metrics into a dataset
+
+`SimulationDataset.from_results(...)` converts batch outputs into rectangular
+arrays. The `output_fn` should return a one-dimensional numeric feature vector.
+
+```python
+import numpy as np
+from rfx.batch import SimulationDataset
+
+
+def output_fn(result):
+    # Example diagnostic metric: peak absolute probe signal.
+    probe = np.asarray(result.time_series[:, 0])
+    return np.array([np.max(np.abs(probe))])
+
+
+dataset = SimulationDataset.from_results(
+    results,
+    input_keys=["patch_width", "eps_r"],
+    output_fn=output_fn,
+)
+
+X, y = dataset.to_numpy()
+dataset.to_csv("sweep_metrics.csv")
+```
+
+## 5. S-parameter and Touchstone sweeps
+
+If the sweep uses a promoted S-parameter calculator, keep the port family and
+support envelope with the output files.
+
+```python
+from pathlib import Path
+from rfx import write_touchstone
+
+out_dir = Path("outputs/sweep")
+out_dir.mkdir(parents=True, exist_ok=True)
+
+for i, (params, result) in enumerate(results):
+    if result.s_params is None:
+        continue
+    path = out_dir / f"case_{i:03d}.s2p"
+    write_touchstone(path, result.s_params, result.freqs, z0=50.0)
+```
+
+Touchstone export is an interoperability format, not validation by itself. Link
+any S-parameter claims to the current port-family evidence in
+`docs/guides/sparameter_support_matrix.md`.
+
+## 6. When to use `jax.vmap`
+
+Use `jax.vmap` when the computation is already a pure array function, such as a
+surrogate model, a closed-form RF approximation, or a differentiable objective
+that has been written without Python-side side effects. Most full `Simulation`
+object construction is easier to inspect and debug with explicit Python loops.
+
+```python
+import jax
+import jax.numpy as jnp
+
+
+def quarter_wave_freq(length_m, eps_eff):
+    c0 = 299_792_458.0
+    return c0 / (4.0 * length_m * jnp.sqrt(eps_eff))
+
+lengths = jnp.array([0.026, 0.028, 0.030])
+eps_eff = jnp.array([3.0, 3.2, 3.4])
+freqs = jax.vmap(quarter_wave_freq)(lengths, eps_eff)
+```
+
+## Checklist before scaling up
+
+- Did a single case run and produce physically plausible fields/probes?
+- Is the selected source/port family documented for the claimed metric?
+- Are generated files outside git or intentionally curated docs assets?
+- Does every case record parameters, git SHA, command, support status, and metric?
+- If results are public-facing, do they cite the support matrix rather than only
+  saying that tests passed?

--- a/docs/public/guide/probes-sparams.mdx
+++ b/docs/public/guide/probes-sparams.mdx
@@ -247,12 +247,14 @@ plot_field_slice(result, "ez", axis="z", index=30)  # 2-D Ez cross-section
 
 ## Touchstone I/O
 
+Touchstone export uses rfx's canonical S-matrix shape `(n_ports, n_ports, n_freqs)`. Reading returns `(s_params, freqs, z0)`.
+
 ```python
 from rfx import write_touchstone, read_touchstone
 
 # Write 2-port S-params to a .s2p file
-write_touchstone("patch_antenna.s2p", result.freqs, result.s_params)
+write_touchstone("patch_antenna.s2p", result.s_params, result.freqs, z0=50.0)
 
 # Read back
-freqs, s_matrix = read_touchstone("patch_antenna.s2p")
+s_matrix, freqs, z0 = read_touchstone("patch_antenna.s2p")
 ```

--- a/docs/public/guide/tutorial-patch-antenna.mdx
+++ b/docs/public/guide/tutorial-patch-antenna.mdx
@@ -37,7 +37,7 @@ Expected output is a console summary and generated local artifacts from the scri
 
 - Use Harminv resonance as the primary frequency estimate.
 - Treat lumped-port S11 dips as secondary diagnostics.
-- Treat non-uniform mesh variants as experimental unless the page you are following says otherwise.
+- Treat non-uniform mesh variants as shadow unless the page you are following says otherwise.
 - For top-level claims, keep the wording narrow: this is a recommended patch workflow, not a universal antenna guarantee.
 
 ## Where to go next

--- a/docs/public/guide/validation.mdx
+++ b/docs/public/guide/validation.mdx
@@ -38,7 +38,7 @@ These features may have examples and tests, but their support boundaries are nar
 |---|---|
 | `examples/crossval/05_patch_antenna.py` | current patch cross-check and practical antenna reference |
 | `examples/crossval/11_waveguide_port_wr90.py` | rectangular waveguide-port reference workflow |
-| `examples/nonuniform_patch_demo.py` | quick non-uniform thin-substrate demo; experimental lane |
+| `examples/nonuniform_patch_demo.py` | quick non-uniform thin-substrate demo; shadow lane |
 | `examples/inverse_design/multilayer_ar_coating.py` | inverse-design demo with a conservative public scope |
 
 ## Practical takeaway

--- a/docs/public/guide/visualization-and-analysis.md
+++ b/docs/public/guide/visualization-and-analysis.md
@@ -145,7 +145,7 @@ integrate with the actual cell-volume weights instead of `grid.dx**3`.
 ```python
 from rfx import save_state, save_snapshots, write_touchstone
 
-# Touchstone for ADS/CST/HFSS
+# Touchstone for ADS/CST/HFSS. Shape is (n_ports, n_ports, n_freqs).
 write_touchstone("device.s2p", result.s_params, result.freqs, z0=50.0)
 
 # HDF5 for the final field state
@@ -165,3 +165,8 @@ used to judge the result.
 
 When you write public notes or reports, describe the exact metric you used
 instead of saying only that a design "looks good".
+
+
+For reports, keep a small machine-readable manifest next to exported plots or
+Touchstone files. Include the command, git SHA, support status, and metric used
+to make the figure so the artifact can be reproduced.

--- a/docs/public/index.mdx
+++ b/docs/public/index.mdx
@@ -11,13 +11,14 @@ rfx is a 3-D finite-difference time-domain (FDTD) electromagnetic simulator buil
 
 ## Current public status
 
-Use rfx with two simple lanes in mind:
+Use rfx with explicit support lanes in mind:
 
 | Lane | Use it for | Status |
 |---|---|---|
 | **Recommended default: uniform Cartesian Yee RF workflows** | cavity and waveguide studies, patch-style resonance workflows, probes, Harminv, selected port/S-parameter workflows, and benchmarked far-field workflows | best place to start |
 | **Narrow guarded subgrid envelope** | one-sided PEC/no-CPML z-slab source/probe, static-material, and single-cell lumped-port S-parameter runs | supported only inside the subgridding guide boundary |
-| **Experimental / under active validation** | non-uniform meshes, distributed execution, Floquet/Bloch workflows, general SBP-SAT subgridding, coaxial and advanced port workflows, and inverse-design extensions | useful for experiments; check current limitations |
+| **Shadow** | non-uniform thin-substrate workflows | retained and tested, but not the claims-bearing default |
+| **Experimental / under active validation** | distributed execution, Floquet/Bloch workflows, general SBP-SAT subgridding, coaxial and advanced port workflows, and inverse-design extensions | useful for experiments; check current limitations |
 
 The docs keep advanced features visible, but they should not be read as blanket guarantees.
 
@@ -31,7 +32,7 @@ The docs keep advanced features visible, but they should not be read as blanket 
 | **Differentiable simulation** | `jax.grad` through time-domain workflows for inverse design |
 | **RF workflow tools** | materials, sources, probes, ports, S-parameter helpers, Harminv, far-field utilities |
 | **Recommended examples** | current runnable scripts under `examples/crossval/` and `examples/inverse_design/` |
-| **Experimental lanes** | non-uniform mesh, distributed runs, Floquet/Bloch, general SBP-SAT subgridding, coaxial/advanced ports |
+| **Shadow / experimental lanes** | non-uniform mesh is shadow; distributed runs, Floquet/Bloch, general SBP-SAT subgridding, and coaxial/advanced ports are experimental |
 
 ---
 
@@ -84,7 +85,7 @@ print(f"Resonance: {modes[0].freq/1e9:.4f} GHz")
 - [Sources & Ports](guide/sources-ports/) — point sources, lumped/wire ports, waveguide ports, experimental Floquet/coaxial surfaces
 - [Probes & S-Parameters](guide/probes-sparams/) — DFT probes, S-matrix helpers, Harminv, de-embedding, exports
 - [Memory Reduction](guide/memory-reduction/) — reduce FDTD/AD memory while preserving validation boundaries
-- [Non-Uniform Mesh](guide/nonuniform-mesh/) — experimental thin-substrate workflows
+- [Non-Uniform Mesh](guide/nonuniform-mesh/) — shadow thin-substrate workflows
 - [Waveguide Ports](guide/waveguide-ports/) — rectangular waveguide modal workflows
 - [Floquet Ports](guide/floquet-ports/) — experimental Bloch-periodic unit-cell workflows
 
@@ -120,3 +121,4 @@ print(f"Resonance: {modes[0].freq/1e9:.4f} GHz")
 - [Validation](/rfx/validation/) — public support and validation overview
 - [API](/rfx/api/) — curated public API contract
 - [Generated API](/rfx/api/generated/) — subordinate generated symbol reference
+- [AI Agent Guide](/rfx/agent/overview/) — safe agent prompts, auto-configuration, and review workflow

--- a/docs/public/validation/index.mdx
+++ b/docs/public/validation/index.mdx
@@ -12,15 +12,26 @@ Use this hub to decide how strongly to describe a feature.
 | Lane | Public wording |
 |---|---|
 | uniform Cartesian Yee RF/FDTD workflows | recommended default path |
-| non-uniform mesh, distributed execution, Floquet/Bloch, SBP-SAT subgridding, coaxial/advanced ports, inverse-design extensions | experimental or under active validation |
+| non-uniform mesh | shadow thin-substrate lane; retained but not the default claims-bearing path |
+| distributed execution, Floquet/Bloch, SBP-SAT subgridding, coaxial/advanced ports, inverse-design extensions | experimental or under active validation |
 
 ## Current practical anchors
 
 - `examples/crossval/05_patch_antenna.py` — practical patch antenna cross-check
 - `examples/crossval/11_waveguide_port_wr90.py` — rectangular waveguide-port workflow
-- `examples/nonuniform_patch_demo.py` — non-uniform mesh demo; experimental lane
+- `examples/nonuniform_patch_demo.py` — non-uniform mesh demo; shadow lane
 - `examples/inverse_design/multilayer_ar_coating.py` — conservative inverse-design demo
 
 ## Practical takeaway
 
 Lead with the recommended default lane. Mention experimental lanes only with the current limitations and examples that apply to the user’s workflow.
+
+
+## Evidence, artifacts, and reports
+
+Generated plots, Touchstone files, HDF5 snapshots, CSV tables, and report bundles
+are useful review artifacts. They become validation evidence only when they are
+paired with a documented analytic oracle, dump replay, external-solver
+comparison, convergence study, or benchmark envelope. See
+`docs/guides/physics_validation_evidence_rule.md` before using artifacts as
+claims-bearing evidence.

--- a/docs/public/validation/reference-lane.mdx
+++ b/docs/public/validation/reference-lane.mdx
@@ -17,13 +17,13 @@ Start with the **uniform Cartesian Yee RF/FDTD lane**:
 
 This is the lane to use first for ordinary RF examples and public tutorials.
 
-## Experimental / under active validation
+## Non-default lanes
 
 The following surfaces are real and useful, but should be treated as narrower than the default lane:
 
 | Surface | Public status |
 |---|---|
-| non-uniform mesh | useful for thin-substrate experiments; not the default claim lane |
+| non-uniform mesh | shadow thin-substrate lane; retained but not the default claim lane |
 | distributed execution | scaling lane; check feature combinations before use |
 | Floquet/Bloch | experimental periodic/unit-cell workflow |
 | SBP-SAT subgridding | research/experimental local mesh refinement |
@@ -39,4 +39,6 @@ The following surfaces are real and useful, but should be treated as narrower th
 
 ## Practical rule
 
-If a feature is not in the recommended default lane, call it experimental or under active validation and point users to the current example or limitation page.
+If a feature is not in the recommended default lane, call it shadow,
+experimental, or under active validation as appropriate and point users to the
+current example or limitation page.

--- a/scripts/check_public_docs_sync.py
+++ b/scripts/check_public_docs_sync.py
@@ -209,6 +209,7 @@ def make_report(repo_root: Path, deploy_root: Path) -> AuditReport:
     public_root = repo_root / "docs" / "public"
     public_subtrees = discover_public_subtrees(public_root)
     generated_api_source = repo_root / "docs" / "api"
+    generated_api_deploy = deploy_root / "api" / "generated"
 
     sections = [
         compare_section("top-level", public_root, deploy_root, recursive=False),
@@ -219,12 +220,16 @@ def make_report(repo_root: Path, deploy_root: Path) -> AuditReport:
         compare_section("agent", repo_root / "docs" / "agent", deploy_root / "agent"),
     ]
 
-    if generated_api_source.exists() or (deploy_root / "api" / "generated").exists():
+    deploy_has_generated_assets = generated_api_deploy.exists() and any(
+        iter_files(generated_api_deploy, recursive=True, include=is_generated_api_asset)
+    )
+
+    if generated_api_source.exists() or deploy_has_generated_assets:
         sections.append(
             compare_section(
                 "api-generated-assets",
                 generated_api_source,
-                deploy_root / "api" / "generated",
+                generated_api_deploy,
                 include_source=is_generated_api_asset,
                 include_deploy=is_generated_api_asset,
             )

--- a/scripts/export_public_docs_to_gitops.py
+++ b/scripts/export_public_docs_to_gitops.py
@@ -94,6 +94,7 @@ def main() -> int:
     public_subtrees = discover_public_subtrees(public_root)
     src_agent = repo_root / "docs" / "agent"
     src_generated_api = repo_root / "docs" / "api"
+    has_generated_api = src_generated_api.exists()
 
     dst_root = (
         gitops_root
@@ -109,11 +110,12 @@ def main() -> int:
     required = [
         public_root,
         src_agent,
-        src_generated_api,
         gitops_root,
         *source_root_docs,
         *public_subtrees,
     ]
+    if has_generated_api:
+        required.append(src_generated_api)
     missing = [str(path) for path in required if not path.exists()]
     if missing:
         raise SystemExit("missing required paths:\n" + "\n".join(missing))
@@ -124,7 +126,10 @@ def main() -> int:
         print(f"root_docs: {[path.name for path in source_root_docs]}")
         print(f"public_subtrees: {[path.name for path in public_subtrees]}")
         print(f"agent: {src_agent}")
-        print(f"generated_api: {src_generated_api}")
+        if has_generated_api:
+            print(f"generated_api: {src_generated_api}")
+        else:
+            print("generated_api: absent (skipped)")
         print(f"gitops: {gitops_root}")
         return 0
 
@@ -145,13 +150,17 @@ def main() -> int:
         copy_tree(subtree, dst_root / subtree.name)
 
     copy_tree(src_agent, dst_root / "agent")
-    sync_generated_api_assets(src_generated_api, dst_generated_api)
+    if has_generated_api:
+        sync_generated_api_assets(src_generated_api, dst_generated_api)
 
     print("exported public docs to gitops snapshot")
     print(f"target: {dst_root}")
     print(f"root_docs: {[path.name for path in source_root_docs]}")
     print(f"public_subtrees: {[path.name for path in public_subtrees]}")
-    print("generated_api_target: api/generated")
+    if has_generated_api:
+        print("generated_api_target: api/generated")
+    else:
+        print("generated_api_target: skipped (docs/api absent)")
     return 0
 
 


### PR DESCRIPTION
## Summary
- refresh the public RFX documentation source of truth for current APIs, support boundaries, validation pages, and agent-maintenance routes
- add docs maintenance inventory and remilab.ai/rfx export guidance
- make the public-docs sync audit tolerate the curated `docs/public/api/generated` landing page when generated API assets are absent
- tighten S-parameter wording so artifact/report docs follow the current support envelope instead of over-claiming calculator status

## Validation
- `python scripts/check_public_docs_manifest.py`
- `python -m py_compile scripts/check_public_docs_manifest.py scripts/check_public_docs_sync.py scripts/export_public_docs_to_gitops.py`
- temp gitops export via `python scripts/export_public_docs_to_gitops.py --gitops-root <tempdir>`
- temp export drift audit via `python scripts/check_public_docs_sync.py --deploy-root <temp-export>/rfx --strict`
- docs symbol smoke imports for public snippets
- `git diff --check`

## Not verified
- live remilab.ai/rfx gitops export because `/root/workspace/infra/remilab-sites-gitops` is not present in this environment.