### PR TITLE
fix(runners): land 6-vs-7-tuple _assemble_materials unpack fix on main

### DIFF
--- a/rfx/differentiable_material_fit.py
+++ b/rfx/differentiable_material_fit.py
@@ -391,7 +391,7 @@ def differentiable_material_fit(
         sim = sim_factory(eps_inf, debye_poles, lorentz_poles)
 
         # Assemble materials (geometry masks are static, but eps_inf flows through)
-        materials, debye_spec, lorentz_spec, pec_mask, _, _ = sim._assemble_materials(grid)
+        materials, debye_spec, lorentz_spec, pec_mask, *_ = sim._assemble_materials(grid)
 
         # Setup ports (fold port impedance into materials)
         for pe in sim._ports:

--- a/rfx/runners/distributed.py
+++ b/rfx/runners/distributed.py
@@ -1273,7 +1273,7 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
 
     # Build grid and materials (full domain)
     grid = sim._build_grid()
-    base_materials, debye_spec, lorentz_spec, pec_mask, pec_shapes, _ = (
+    base_materials, debye_spec, lorentz_spec, pec_mask, pec_shapes, *_ = (
         sim._assemble_materials(grid)
     )
     materials = base_materials

--- a/rfx/runners/distributed_v2.py
+++ b/rfx/runners/distributed_v2.py
@@ -611,7 +611,7 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
         pec_shapes = None
     else:
         grid = sim._build_grid()
-        base_materials, debye_spec, lorentz_spec, pec_mask, pec_shapes, _ = (
+        base_materials, debye_spec, lorentz_spec, pec_mask, pec_shapes, *_ = (
             sim._assemble_materials(grid)
         )
     materials = base_materials

--- a/rfx/sources/coaxial_port.py
+++ b/rfx/sources/coaxial_port.py
@@ -271,7 +271,7 @@ def coaxial_tem_reference_plane_vi(
     if h_phi.shape[-1] < 1:
         raise ValueError("h_phi_samples must have at least one azimuthal sample")
 
-    trapezoid = getattr(np, "trapezoid", np.trapz)
+    trapezoid = np.trapezoid if hasattr(np, "trapezoid") else np.trapz
     voltage = float(voltage_sign) * trapezoid(
         e_radial,
         radial_positions,

--- a/rfx/topology.py
+++ b/rfx/topology.py
@@ -450,7 +450,7 @@ def topology_optimize(
     if filt_r is not None:
         filter_radius_cells = filt_r / grid.dx
 
-    base_materials, debye_spec, lorentz_spec, base_pec_mask, _, _ = sim._assemble_materials(grid)
+    base_materials, debye_spec, lorentz_spec, base_pec_mask, *_ = sim._assemble_materials(grid)
     base_eps_r = base_materials.eps_r
     base_sigma = base_materials.sigma
     base_mu_r = base_materials.mu_r

--- a/rfx/vmap_sweep.py
+++ b/rfx/vmap_sweep.py
@@ -550,7 +550,7 @@ def vmap_material_sweep(
 
     # Build grid and base materials once
     grid = sim._build_grid()
-    base_materials, debye_spec, lorentz_spec, pec_mask, _, _ = sim._assemble_materials(grid)
+    base_materials, debye_spec, lorentz_spec, pec_mask, *_ = sim._assemble_materials(grid)
 
     if n_steps is None:
         n_steps = grid.num_timesteps(num_periods=num_periods)

--- a/tests/test_thin_conductor.py
+++ b/tests/test_thin_conductor.py
@@ -112,7 +112,7 @@ def test_thin_conductor_api_integration():
 
     # Should build without error
     grid = sim._build_grid()
-    materials, debye, lorentz, pec_mask, pec_shapes, kerr = sim._assemble_materials(grid)
+    materials, debye, lorentz, pec_mask, pec_shapes, *_ = sim._assemble_materials(grid)
 
     # Copper thin conductor is PEC-level → check pec_mask, not sigma
     tc_box = Box((0.005, 0.005, 0.001), (0.015, 0.015, 0.001))

--- a/tests/test_topology.py
+++ b/tests/test_topology.py
@@ -458,7 +458,7 @@ def test_pec_foreground_gradient_is_finite_and_nonzero():
     hi_idx = grid.position_to_index(region.corner_hi)
     design_shape = tuple(hi_idx[d] - lo_idx[d] + 1 for d in range(3))
 
-    base_materials, debye_spec, lorentz_spec, base_pec_mask, _, _ = sim._assemble_materials(grid)
+    base_materials, debye_spec, lorentz_spec, base_pec_mask, *_ = sim._assemble_materials(grid)
 
     def loss_fn(logit):
         rho = jax.nn.sigmoid(logit)


### PR DESCRIPTION
## Why

The scheduled `scientific-validation` workflow on `main` has failed on every run (2026-05-11, -18, -25):

```
FAILED tests/test_boundary_pmc_composition.py::test_oq9_distributed_v2_cpml_path_enforces_pec_face_via_cpml_init
  ValueError: too many values to unpack (expected 6)
  rfx/runners/distributed_v2.py:615
```

`Simulation._assemble_materials()` has returned a **7-tuple** (`…, pec_shapes, boundary_pec_shapes, kerr_chi3`) since `b7683f2` (2026-05-17), but several runner / sweep call sites still unpacked **6** targets and raise on any distributed / vmap-sweep path. These paths are latent under the default CPU gate, so the break only surfaced in the full scheduled suite.

The cluster was already repaired in commit **`73c3f3b`** ("fix(runners): repair 6-vs-7-tuple _assemble_materials unpack cluster + numpy-2 trapz"), but that commit only ever lived on the issue-#80 branches and was **never merged to main**. This PR lands it on main, decoupled from issue #80.

## What

- **`2efc83b`** — cherry-pick of `73c3f3b`: fixes `distributed.py`, `distributed_v2.py`, `topology.py`, `differentiable_material_fit.py`, `tests/test_topology.py`, `tests/test_thin_conductor.py` (trailing `*_`), plus the numpy-2 `np.trapezoid` guard in `coaxial_port.py`. The `_compile.py` docstring conflict was resolved in favour of main (no diff there).
- **`7638c4a`** — completes the cluster: `73c3f3b` itself **missed** `rfx/vmap_sweep.py:553` (also 6 targets, same latent crash). Fixed with the same trailing `*_`.

## Verification

- **Exhaustive audit**: every `_assemble_materials()` unpack site in `rfx/` and `tests/` now uses 7 targets or `*_`. No 6-target sites remain in the package/test surface.
- `python -m py_compile` passes on all 7 changed files.
- JAX is not installable in the authoring env, so the distributed test itself runs in CI/VESSL — the fix is a pure unpack-arity correction matching the exact CI error.

## Out of scope

Seven one-off diagnostic scripts under `scripts/` still carry the latent 6-target unpack (`scripts/_wr90_port_oracle_matrix.py`, `scripts/isolate_extractor_vs_engine.py`, etc.). They are not part of the package or CI and were left untouched.

## Falsifier

The named test `test_oq9_distributed_v2_cpml_path_enforces_pec_face_via_cpml_init` going green on a main that includes this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)