### PR TITLE
fix(waveguide): stamp grid.dt onto compiled-run port cfgs (S-matrix returned 0)

### DIFF
--- a/rfx/simulation.py
+++ b/rfx/simulation.py
@@ -1242,6 +1242,15 @@ def run(
     if use_waveguide_ports:
         final_waveguide_ports = tuple(
             cfg_meta._replace(
+                # Stamp the scan's authoritative dt so the post-scan rect-DFT
+                # extractor uses the right Δt. The jit-safe in-scan probe
+                # accumulator cannot run update_waveguide_port_probe's
+                # ``float(dt)`` stamp, so a cfg built via init_waveguide_port
+                # without dt= would otherwise keep dt=0 and silently zero every
+                # extracted spectrum (S→0). The manual Python-loop path already
+                # stamps dt via update_waveguide_port_probe; this makes the
+                # compiled run() symmetric with it.
+                dt=float(grid.dt),
                 v_probe_t=accs[0],
                 v_ref_t=accs[1],
                 i_probe_t=accs[2],
@@ -1912,6 +1921,11 @@ def run_until_decay(
     if use_waveguide_ports:
         final_waveguide_ports = tuple(
             cfg_meta._replace(
+                # Stamp the scan dt (see run() above): the jit-safe in-scan
+                # probe accumulator can't run update_waveguide_port_probe's
+                # float(dt) stamp, so without this a cfg built without dt= keeps
+                # dt=0 and the post-scan rect-DFT zeroes every spectrum.
+                dt=float(grid.dt),
                 v_probe_t=accs[0], v_ref_t=accs[1],
                 i_probe_t=accs[2], i_ref_t=accs[3],
                 v_inc_t=accs[4],

--- a/rfx/sources/waveguide_port.py
+++ b/rfx/sources/waveguide_port.py
@@ -2095,6 +2095,9 @@ def extract_waveguide_s_matrix(
         final_cfgs = result.waveguide_ports or ()
         if len(final_cfgs) != n_ports:
             raise RuntimeError("waveguide S-matrix extraction expected one final config per port")
+        # NB: run() stamps grid.dt onto every returned waveguide cfg, so the
+        # post-scan rect-DFT extractor below uses the correct Δt even when the
+        # cfgs were built via init_waveguide_port without dt=.
 
         a_drive, b_drive = extract_waveguide_port_waves(
             final_cfgs[drive_idx],

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -603,7 +603,13 @@ def test_extract_waveguide_s_matrix_two_port_reciprocity():
 
     grid = _CompiledWgGrid(length, a_wg, b_wg, dx, nc)
     materials = init_materials(grid.shape)
-    freqs = jnp.linspace(4.5e9, 8e9, 12)
+    # Single-mode band only: for a=40mm, TE10 cutoff = c/(2a) = 3.75 GHz and
+    # TE20 cutoff = c/a = 7.5 GHz. The non-flux V·I extractor is valid only for a
+    # single propagating mode away from cutoff — near 3.75 GHz (small beta) and
+    # at/above 7.5 GHz (TE20 onset) the single-mode |S11| is non-physical. This
+    # test validates the S-matrix ASSEMBLY/reciprocity, so it runs in the clean
+    # single-mode band; broad-band/multimode is the normalize='flux' path (#88).
+    freqs = jnp.linspace(5.0e9, 7.0e9, 12)
     n_steps = grid.num_timesteps(num_periods=30)
 
     port0 = WaveguidePort(
@@ -674,7 +680,10 @@ def test_extract_waveguide_s_matrix_mixed_normal_branch_reciprocity():
             sigma=jnp.where(mask, 1e10, materials.sigma),
         )
 
-    freqs = jnp.linspace(4.5e9, 8.0e9, 10)
+    # Single-mode band (a=40mm: TE10 cutoff 3.75 GHz, TE20 cutoff 7.5 GHz). The
+    # non-flux V·I extractor is single-mode-only; this reciprocity check runs
+    # away from both cutoffs (broad-band/multimode is the flux path — #88).
+    freqs = jnp.linspace(5.0e9, 7.0e9, 10)
     n_steps = grid.num_timesteps(num_periods=30)
     padx, pady, padz = grid.axis_pads
     xslice = (padx + int(round(0.04 / dx)), padx + int(round(0.08 / dx)) + 1)


### PR DESCRIPTION
Fixes 3 long-standing RED-on-main tests in `test_simulation.py` (waveguide S21=0 / compiled-vs-manual 1.11 divergence).

**Root cause (verified numerically):** the post-scan rect-DFT scales by `2·dt`, and `cfg.dt` was **0**. `init_waveguide_port` defaults `dt=0.0`; the manual loop stamps the real dt via `update_waveguide_port_probe`, but the jit-safe in-scan accumulator can't run that `float(dt)` stamp, so `run()`'s returned cfgs kept dt=0 → **every** extracted spectrum was identically zero (all S→0). That asymmetry is the 1.11 compiled-vs-manual divergence (compiled=0 vs manual≈1.15).

**Fix:** `run()` and `run_until_decay()` stamp `dt=float(grid.dt)` onto returned waveguide cfgs. Also fixes production `compute_waveguide_s_matrix(normalize=False)`.

A numerical probe **disproved** an earlier debugger hypothesis (`b_recv→a_recv`): all waves incl. the driven port's own incident `a` were 0, so the convention was never the issue.

The 2 reciprocity tests were additionally restricted to the single-mode band (5–7 GHz; TE10 cutoff 3.75 / TE20 onset 7.5 GHz) — the non-flux V·I extractor is single-mode/away-from-cutoff only; broad-band/multimode is the `normalize='flux'` path (#88). **Assertions unchanged.**

**Regression:** test_simulation + waveguide_sparam_ad + normalize_flux + multimode + nu_flux green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)