### PR TITLE
feat(io): expose S-matrix quality metrics for reports (#102 reopened)

### DIFF
--- a/docs/guides/network_interop_batch_provenance.md
+++ b/docs/guides/network_interop_batch_provenance.md
@@ -45,6 +45,8 @@ physics paths.
 - Accept Fortran-style `D` exponent numeric tokens emitted by some RF tools.
 - Validate writer inputs against the file suffix and finite numeric data so rfx
   does not emit self-inconsistent `.sNp` files.
+- Provide `network_quality_metrics()` for host-side passivity, reciprocity,
+  finite-data, and magnitude diagnostics that can be recorded in reports.
 - Add physical/interop gates based on passive/reciprocal known networks, not only
   random numeric round-trips.
 

--- a/docs/public/guide/probes-sparams.mdx
+++ b/docs/public/guide/probes-sparams.mdx
@@ -92,6 +92,20 @@ observables. They do not define a port impedance or S-matrix reference.
 See `docs/guides/sparameter_support_matrix.md` for the artifact, metric, and
 envelope attached to each claim.
 
+For host-side report checks on any S-matrix cube, use
+`network_quality_metrics()`:
+
+```python
+from rfx import network_quality_metrics
+
+quality = network_quality_metrics(s_matrix)
+print(quality["passivity_excess"], quality["reciprocity_error"])
+```
+
+This helper reports finite-data, passivity, reciprocity, max magnitude, and
+column-power diagnostics. It is an interop/reporting gate, not a substitute for
+the port-family physics evidence listed in the support matrix.
+
 ### Lumped port S-matrix
 
 When one or more lumped ports are added with `add_port()`, pass `compute_s_params=True`:

--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -71,6 +71,7 @@ from rfx.topology import (
 )
 from rfx.io import (
     TouchstoneData, read_touchstone, read_touchstone_full, write_touchstone,
+    network_quality_metrics,
     save_optimization_result, load_optimization_result,
     save_far_field, export_radiation_pattern,
     export_geometry_json, save_experiment_report,

--- a/rfx/io.py
+++ b/rfx/io.py
@@ -666,6 +666,62 @@ def read_touchstone_full(filepath: str | Path, *,
     )
 
 
+def network_quality_metrics(
+    s_params: np.ndarray,
+    *,
+    reciprocity_tol: float = 1e-12,
+    passivity_tol: float = 1e-12,
+) -> dict[str, object]:
+    """Return common RF network quality metrics for an S-matrix cube.
+
+    The input must have shape ``(n_ports, n_ports, n_freqs)``.  Metrics are
+    host-side diagnostics for reports and interop gates; they do not alter any
+    solver path.
+    """
+    s = np.asarray(s_params)
+    if s.ndim != 3 or s.shape[0] != s.shape[1]:
+        raise ValueError("s_params must have shape (n_ports, n_ports, n_freqs)")
+
+    n_ports, _, n_freqs = s.shape
+    finite = bool(np.all(np.isfinite(s)))
+    if not finite:
+        return {
+            "n_ports": int(n_ports),
+            "n_freqs": int(n_freqs),
+            "finite": False,
+            "max_abs_s": float("nan"),
+            "max_column_power": float("nan"),
+            "max_singular_value": float("nan"),
+            "passivity_excess": float("nan"),
+            "reciprocity_error": float("nan"),
+            "is_passive": False,
+            "is_reciprocal": False,
+        }
+
+    max_column_power = 0.0
+    max_singular_value = 0.0
+    for fi in range(n_freqs):
+        mat = s[:, :, fi]
+        column_power = float(np.max(np.sum(np.abs(mat) ** 2, axis=0)))
+        max_column_power = max(max_column_power, column_power)
+        eig_max = float(np.linalg.eigvalsh(mat.conj().T @ mat).max())
+        max_singular_value = max(max_singular_value, float(np.sqrt(max(eig_max, 0.0))))
+
+    passivity_excess = max(0.0, max_singular_value**2 - 1.0)
+    reciprocity_error = float(np.max(np.abs(s - np.swapaxes(s, 0, 1))))
+    return {
+        "n_ports": int(n_ports),
+        "n_freqs": int(n_freqs),
+        "finite": True,
+        "max_abs_s": float(np.max(np.abs(s))) if s.size else 0.0,
+        "max_column_power": float(max_column_power),
+        "max_singular_value": float(max_singular_value),
+        "passivity_excess": float(passivity_excess),
+        "reciprocity_error": reciprocity_error,
+        "is_passive": bool(passivity_excess <= passivity_tol),
+        "is_reciprocal": bool(reciprocity_error <= reciprocity_tol),
+    }
+
 
 # =========================================================================
 # Result export (HDF5)

--- a/tests/test_touchstone_interop.py
+++ b/tests/test_touchstone_interop.py
@@ -7,6 +7,7 @@ import pytest
 
 from rfx import (
     TouchstoneData,
+    network_quality_metrics,
     read_touchstone,
     read_touchstone_full,
     write_touchstone,
@@ -348,3 +349,25 @@ def test_passive_reciprocal_fixture_survives_standard_v2_roundtrip(tmp_path: Pat
     np.testing.assert_allclose(data.reference, np.full(n_ports, 50.0))
     assert _passivity_excess(data.s_params) <= 1e-12
     assert _reciprocity_error(data.s_params) <= 1e-12
+
+    quality = network_quality_metrics(data.s_params)
+    assert quality["finite"] is True
+    assert quality["is_passive"] is True
+    assert quality["is_reciprocal"] is True
+    assert quality["passivity_excess"] <= 1e-12
+    assert quality["reciprocity_error"] <= 1e-12
+
+
+def test_network_quality_metrics_detects_nonreciprocal_or_active_network():
+    passive_nonreciprocal = np.zeros((2, 2, 1), dtype=np.complex128)
+    passive_nonreciprocal[1, 0, 0] = 0.2
+    active = np.eye(2, dtype=np.complex128)[:, :, None] * 1.1
+
+    passive_quality = network_quality_metrics(passive_nonreciprocal)
+    assert passive_quality["is_passive"] is True
+    assert passive_quality["is_reciprocal"] is False
+    assert passive_quality["reciprocity_error"] == pytest.approx(0.2)
+
+    active_quality = network_quality_metrics(active)
+    assert active_quality["is_passive"] is False
+    assert active_quality["passivity_excess"] == pytest.approx(0.21)


### PR DESCRIPTION
Adds `network_quality_metrics()` (passivity/reciprocity/finite-data/max-mag/column-power diagnostics) for host-side report checks. Re-targeted to main after #100 squash auto-closed original #102; test import-union conflict with #101 resolved.