### PR TITLE
feat(batch): summarize batch manifests for audit reports (#104 reopened)

### DIFF
--- a/docs/guides/network_interop_batch_provenance.md
+++ b/docs/guides/network_interop_batch_provenance.md
@@ -82,6 +82,8 @@ physics paths.
   directories do not silently return stale cases.
 - Support `continue_on_error=True` when a sweep should record failed cases and
   continue through later parameter points instead of failing fast.
+- Record manifest summary and lightweight host environment metadata for quick
+  auditability, and expose `summarize_batch_manifest()` for report generation.
 - Add a tiny physical sweep gate that proves resume does not corrupt metrics or
   silently rerun completed cases.
 

--- a/docs/public/guide/parametric-sweeps.mdx
+++ b/docs/public/guide/parametric-sweeps.mdx
@@ -160,6 +160,7 @@ It writes `manifest.json` under the output directory with:
 - stable case IDs derived from parameter values
 - per-case status, timing, metrics, parameter digest, and artifact paths
 - artifact file size/hash metadata for resume integrity
+- summary counts, last-run status, and lightweight Python/platform metadata
 - resume-safe completed-case records
 
 ```python
@@ -167,7 +168,11 @@ import json
 from pathlib import Path
 import numpy as np
 
-from rfx.batch import ParameterSweep, run_batch_with_manifest
+from rfx.batch import (
+    ParameterSweep,
+    run_batch_with_manifest,
+    summarize_batch_manifest,
+)
 
 sweep = ParameterSweep(amplitude=[0.5, 1.0, 2.0])
 
@@ -193,6 +198,9 @@ records = run_batch_with_manifest(
     artifact_fn=artifact_fn,
     resume=True,
 )
+
+summary = summarize_batch_manifest("runs/amplitude-sweep/manifest.json")
+print(summary["status_counts"])
 ```
 
 `resume=True` skips only records that are marked `completed`, match the current

--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -77,6 +77,11 @@ from rfx.io import (
     export_geometry_json, save_experiment_report,
     save_simulation_dataset, save_optimization_trajectory,
 )
+from rfx.batch import (
+    BATCH_MANIFEST_SCHEMA, BatchCaseResult, ParameterSweep,
+    case_id_from_params, run_batch, run_batch_with_manifest,
+    summarize_batch_manifest,
+)
 from rfx.deembed import deembed_port_extension, deembed_thru
 from rfx.validation import (
     PortDumpMetadata, PortReplayComparison, PortSMatrixObservable,

--- a/rfx/batch.py
+++ b/rfx/batch.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import hashlib
+from importlib import metadata as importlib_metadata
 import itertools
 import json
+import platform
 from pathlib import Path
+import sys
 import time
 from typing import Callable, Any
 
@@ -109,6 +112,85 @@ def _utc_now() -> str:
     return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
 
 
+def _environment_metadata() -> dict[str, Any]:
+    """Return lightweight host metadata for manifest provenance."""
+    try:
+        rfx_version = importlib_metadata.version("rfx-fdtd")
+    except importlib_metadata.PackageNotFoundError:
+        rfx_version = None
+    return {
+        "python_version": sys.version.split()[0],
+        "platform": platform.platform(),
+        "numpy_version": np.__version__,
+        "rfx_version": rfx_version,
+    }
+
+
+def _status_counts_from_records(cases: dict[str, Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for record in cases.values():
+        if not isinstance(record, dict):
+            status = "unknown"
+        else:
+            status = str(record.get("status", "unknown"))
+        counts[status] = counts.get(status, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _status_counts_from_results(results: list[BatchCaseResult]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for result in results:
+        counts[result.status] = counts.get(result.status, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _refresh_manifest_summary(manifest: dict[str, Any]) -> None:
+    """Update top-level manifest summary counts in-place."""
+    cases = manifest.setdefault("cases", {})
+    status_counts = _status_counts_from_records(cases)
+    expected_total = manifest.get("sweep", {}).get("total")
+    completed = status_counts.get("completed", 0)
+    failed = status_counts.get("failed", 0)
+    running = status_counts.get("running", 0)
+    manifest["summary"] = {
+        "case_count": len(cases),
+        "expected_total": expected_total,
+        "status_counts": status_counts,
+        "completed_case_count": completed,
+        "failed_case_count": failed,
+        "running_case_count": running,
+        "failed_case_ids": sorted(
+            case_id
+            for case_id, record in cases.items()
+            if isinstance(record, dict) and record.get("status") == "failed"
+        ),
+        "all_cases_completed": (
+            expected_total is not None
+            and len(cases) == expected_total
+            and completed == expected_total
+        ),
+    }
+
+
+def summarize_batch_manifest(
+    manifest_or_path: dict[str, Any] | str | Path,
+) -> dict[str, Any]:
+    """Return an inspectable status summary for a batch manifest.
+
+    ``manifest_or_path`` may be a manifest dictionary or a path to a manifest
+    JSON file.  The returned summary is detached from the input so callers can
+    use it for reports without mutating the manifest.
+    """
+    if isinstance(manifest_or_path, (str, Path)):
+        with open(manifest_or_path) as f:
+            manifest = json.load(f)
+    else:
+        manifest = dict(manifest_or_path)
+        manifest["cases"] = dict(manifest_or_path.get("cases", {}))
+    _refresh_manifest_summary(manifest)
+    return dict(manifest["summary"])
+
+
 def _read_manifest(path: Path) -> dict[str, Any]:
     if not path.exists():
         return {
@@ -117,6 +199,7 @@ def _read_manifest(path: Path) -> dict[str, Any]:
             "updated_at": None,
             "sweep": {},
             "cases": {},
+            "summary": {},
         }
     with open(path) as f:
         manifest = json.load(f)
@@ -130,6 +213,7 @@ def _read_manifest(path: Path) -> dict[str, Any]:
 
 def _write_manifest_atomic(path: Path, manifest: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    _refresh_manifest_summary(manifest)
     manifest["updated_at"] = _utc_now()
     tmp = path.with_suffix(path.suffix + ".tmp")
     with open(tmp, "w") as f:
@@ -282,6 +366,7 @@ def run_batch_with_manifest(
     continue_on_error: bool = False,
     manifest_name: str = "manifest.json",
     run_fingerprint: str | None = None,
+    include_environment: bool = True,
 ) -> list[BatchCaseResult]:
     """Run a sequential sweep with durable per-case provenance.
 
@@ -311,6 +396,16 @@ def run_batch_with_manifest(
         "run_kwargs": run_kwargs_json,
         "user_fingerprint": run_fingerprint,
         "run_fingerprint": expected_run_fingerprint,
+    }
+    if include_environment:
+        manifest["environment"] = _environment_metadata()
+    manifest["last_run"] = {
+        "started_at": _utc_now(),
+        "completed_at": None,
+        "status": "running",
+        "resume": bool(resume),
+        "run_fingerprint": expected_run_fingerprint,
+        "result_status_counts": {},
     }
 
     returned: list[BatchCaseResult] = []
@@ -414,9 +509,21 @@ def run_batch_with_manifest(
                 result=None,
                 error=record["error"],
             ))
+            manifest["last_run"].update({
+                "completed_at": _utc_now(),
+                "status": "failed",
+                "result_status_counts": _status_counts_from_results(returned),
+            })
+            _write_manifest_atomic(manifest_path, manifest)
             if not continue_on_error:
                 raise
 
+    manifest["last_run"].update({
+        "completed_at": _utc_now(),
+        "status": "completed",
+        "result_status_counts": _status_counts_from_results(returned),
+    })
+    _write_manifest_atomic(manifest_path, manifest)
     return returned
 
 

--- a/tests/test_batch_provenance.py
+++ b/tests/test_batch_provenance.py
@@ -12,6 +12,7 @@ from rfx.batch import (
     ParameterSweep,
     case_id_from_params,
     run_batch_with_manifest,
+    summarize_batch_manifest,
 )
 
 
@@ -74,6 +75,12 @@ def test_run_batch_with_manifest_records_and_resumes_completed_cases(tmp_path: P
     manifest = json.loads((tmp_path / "manifest.json").read_text())
     assert manifest["schema_version"] == BATCH_MANIFEST_SCHEMA
     assert manifest["sweep"] == {"keys": ["width"], "total": 2}
+    assert manifest["summary"]["all_cases_completed"] is True
+    assert manifest["summary"]["status_counts"] == {"completed": 2}
+    assert "environment" in manifest
+    assert manifest["environment"]["python_version"]
+    assert manifest["last_run"]["status"] == "completed"
+    assert manifest["last_run"]["result_status_counts"] == {"completed": 2}
     assert len(manifest["cases"]) == 2
     assert all(record["status"] == "completed" for record in manifest["cases"].values())
 
@@ -97,6 +104,10 @@ def test_run_batch_with_manifest_records_and_resumes_completed_cases(tmp_path: P
         "sha256" in record["artifact_metadata"]["metrics"]
         for record in manifest["cases"].values()
     )
+    manifest_after_resume = json.loads((tmp_path / "manifest.json").read_text())
+    assert manifest_after_resume["last_run"]["status"] == "completed"
+    assert manifest_after_resume["last_run"]["result_status_counts"] == {"skipped": 2}
+    assert summarize_batch_manifest(tmp_path / "manifest.json")["all_cases_completed"] is True
 
 
 def test_resume_does_not_skip_completed_record_with_missing_artifact(tmp_path: Path):
@@ -428,6 +439,27 @@ def test_continue_on_error_records_failure_and_runs_remaining_cases(tmp_path: Pa
         1 for record in manifest["cases"].values()
         if record["status"] == "failed"
     ) == 1
+
+
+def test_summarize_batch_manifest_accepts_dict_or_path(tmp_path: Path):
+    calls: list[float] = []
+    sweep = ParameterSweep(width=[1.0])
+
+    def factory(width):
+        return _FakeSimulation(width, calls)
+
+    run_batch_with_manifest(
+        factory,
+        sweep,
+        tmp_path,
+        metric_fn=lambda r: {"value": float(r.value)},
+        artifact_fn=_write_metric_artifact,
+    )
+
+    manifest_path = tmp_path / "manifest.json"
+    manifest = json.loads(manifest_path.read_text())
+    assert summarize_batch_manifest(manifest_path) == summarize_batch_manifest(manifest)
+    assert summarize_batch_manifest(manifest)["status_counts"] == {"completed": 1}
 
 
 def test_manifest_without_metric_fn_still_records_resume_metric(tmp_path: Path):


### PR DESCRIPTION
Adds `summarize_batch_manifest()` (status counts + lightweight host/env metadata) for report generation. Re-targeted to main after #100 squash auto-closed original #104; batch.py handler + test conflicts with #103 resolved (failure provenance written, then conditional raise — both behaviours preserved).