### PR TITLE
fix(msl): issue #80 — floor n_probe_offset to clear the source fringing transient

### DIFF
--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -997,12 +997,18 @@ class Simulation(
             → passive matched termination only.
         n_probe_offset : int, optional
             Distance (cells) from the feed plane to the first probe plane.
-            When ``None``, bound to the wavelength (issue #80 Fix B):
+            When ``None``, bound to the LARGER of two near-field clearances:
+            (a) the wavelength reactive far-field (issue #80 Fix B),
             ``round(0.5 * lam_min_eff / (2*pi) / dx)`` with
-            ``lam_min_eff = c / freq_max / sqrt(eps_r_sub_estimate)``. This
-            places probe 1 at ~λ/(4π) at the highest design frequency, well
-            into the source far-field, and keeps the 3-probe extractor away
-            from its q→1 numerical singularity under mesh refinement.
+            ``lam_min_eff = c / freq_max / sqrt(eps_r_sub_estimate)``; and
+            (b) the source FRINGING transient ``round(5 * h_sub / dx)``,
+            which decays over a few substrate thicknesses (``h_sub`` = the
+            port ``height``), NOT over λ. For a thin high-εr substrate (b)
+            dominates: clearing only (a) leaves probe 0 inside the fringing
+            transient and corrupts the V·I-split S11 of a high-Q resonant
+            load (issue #80 patch: |S11|=8.94/1.11 → passive ~0.99 once
+            cleared). Pass an explicit value to override; ``< 5*h_sub/dx``
+            triggers a preflight near-field warning.
         n_probe_spacing : int, optional
             Distance (cells) between consecutive probe planes. When ``None``,
             bound so the total N-probe array span stays ~``lam_min_eff/8``
@@ -1076,10 +1082,20 @@ class Simulation(
                 if mat_eps > 1.0:
                     eps_r_sub_estimate = max(eps_r_sub_estimate, mat_eps)
         lam_min_eff = C0 / self._freq_max / math.sqrt(eps_r_sub_estimate)
+        # Probe 0 must clear BOTH near-field scales of the MSL launch:
+        #  (a) λ/(2π) reactive far-field of the quasi-TEM mode, and
+        #  (b) the SOURCE FRINGING transient, which decays over a few
+        #      substrate thicknesses (~5·h_sub), NOT over λ.  For a thin
+        #      high-εr substrate (b) dominates; clearing only (a) leaves
+        #      probe 0 inside the fringing transient and corrupts the
+        #      V·I-split S11 of a high-Q resonant load — the issue #80
+        #      edge-fed patch read |S11|=8.94/1.11 at the (a)-only offset
+        #      (~5 cells) and a passive ~0.99 once cleared to ~5·h_sub.
+        #      ``height`` is the port cross-section height = substrate h_sub.
+        _lam_cells = int(round(0.5 * lam_min_eff / (2.0 * math.pi) / _dx))
+        _hsub_cells = int(round(5.0 * height / _dx))
         if n_probe_offset is None:
-            n_probe_offset = max(
-                3, int(round(0.5 * lam_min_eff / (2.0 * math.pi) / _dx))
-            )
+            n_probe_offset = max(3, _lam_cells, _hsub_cells)
         if n_probe_spacing is None:
             # Bind the default so the TOTAL N-probe array span stays
             # ~lam/8 (the original Fix B 3-probe span of 2*lam/16),

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -179,6 +179,23 @@ class _PreflightMixin:
         messages: list[str] = []
         if self._msl_ports:
             messages.append("MSL ports use compute_msl_s_matrix()")
+            # Near-field guard (issue #80): probe 0 must clear the source
+            # FRINGING transient (~5·h_sub), which decays over a few substrate
+            # thicknesses, not over λ. Inside it the V·I-split S11 of a high-Q
+            # resonant load is corrupted (the issue-#80 edge-fed patch read
+            # |S11|=8.94/1.11 at offset~5; passive ~0.99 once cleared). The
+            # default n_probe_offset already floors to max(λ-clearance,
+            # 5·h_sub/dx); this warns when an EXPLICIT value under-provisions it.
+            for pe in self._msl_ports:
+                if self._dx and pe.n_probe_offset < 5.0 * pe.height / self._dx:
+                    messages.append(
+                        f"MSL port {pe.name!r}: n_probe_offset="
+                        f"{pe.n_probe_offset} sits within the source fringing "
+                        f"transient (~{5.0 * pe.height / self._dx:.0f} cells = "
+                        f"5·h_sub/dx); probe 0 may corrupt the V·I-split S11 of "
+                        f"a high-Q resonant load (issue #80) — increase "
+                        f"n_probe_offset or leave it None for the safe default."
+                    )
         if self._waveguide_ports:
             messages.append("waveguide ports use compute_waveguide_s_matrix()")
         if self._floquet_ports:

--- a/scripts/diagnostics/issue80_production_verify.py
+++ b/scripts/diagnostics/issue80_production_verify.py
@@ -1,0 +1,64 @@
+# ruff: noqa: E402, E702, E401
+"""Issue #80 — verify the PRODUCTION compute_msl_s_matrix V·I split gives a PASSIVE patch S11 once
+probe 0 clears the source near-field. The production diagonal S11 is already the local V·I split
+(_sparams.py:1015-1019, a=(V+Z0·I)/2, b=(V-Z0·I)/2, closed Ampère-loop I, HJ Z0) — the same thing
+validated offline. The historical |S11|=8.94 came from the default n_probe_offset (~5 cells ≈ 1mm)
+placing probe 0 INSIDE the ~13-cell source transient. Sweep n_probe_offset and confirm:
+  small offset → non-passive (reproduce 8.94 family);  cleared offset → PASSIVE, dip toward 9.2.
+Run: python issue80_production_verify.py <n_probe_offset>   (cells; e.g. 5 vs 18)."""
+from __future__ import annotations
+
+import os, sys, warnings
+import numpy as np
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import jax.numpy as jnp  # noqa: E402
+from rfx import Box, Simulation  # noqa: E402
+from rfx.sources import GaussianPulse  # noqa: E402
+
+EPS_R = 3.38; H_SUB = 0.787e-3; W = 10.129e-3; L = 8.595e-3; W_MSL = 1.8e-3
+Z_GND = 4e-3; PORT_MARGIN = 5e-3; FEED_LEN = 8.0e-3
+DOM = (29.747e-3, 18.130e-3, 12.787e-3)
+FREQS = np.linspace(6e9, 14e9, 41)
+NUM_PERIODS = 120.0
+
+
+def build(dx, n_probe_offset):
+    sim = Simulation(freq_max=15e9, domain=DOM, dx=dx, cpml_layers=8, boundary="cpml")
+    sim.add_material("ro4003c", eps_r=EPS_R, sigma=0.0)
+    z_gnd_hi = Z_GND + dx; z_sub_lo, z_sub_hi = z_gnd_hi, z_gnd_hi + H_SUB
+    z_tr_lo, z_tr_hi = z_sub_hi, z_sub_hi + dx
+    x_patch0 = PORT_MARGIN + FEED_LEN; y_c = DOM[1] / 2.0
+    sim.add(Box((0, 0, Z_GND), (DOM[0], DOM[1], z_gnd_hi)), material="pec")
+    sim.add(Box((0, 0, z_sub_lo), (DOM[0], DOM[1], z_sub_hi)), material="ro4003c")
+    sim.add(Box((0, y_c - W_MSL / 2, z_tr_lo), (x_patch0, y_c + W_MSL / 2, z_tr_hi)), material="pec")
+    sim.add(Box((x_patch0, y_c - W / 2, z_tr_lo), (x_patch0 + L, y_c + W / 2, z_tr_hi)), material="pec")
+    sim.add_msl_port(position=(PORT_MARGIN, y_c, z_sub_lo), width=W_MSL, height=H_SUB,
+                     direction="+x", impedance=50.0,
+                     waveform=GaussianPulse(f0=8.5e9, bandwidth=1.6), eps_r_sub=EPS_R, mode="laplace",
+                     n_probes=4, n_probe_offset=n_probe_offset)
+    return sim
+
+
+def main():
+    arg = sys.argv[1] if len(sys.argv) > 1 else "d"
+    offs = None if arg in ("d", "default") else int(arg)   # None -> floored default
+    dx = H_SUB / 4.0
+    sim = build(dx, offs)
+    resolved = sim._msl_ports[0].n_probe_offset
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        msgs = sim.preflight()
+        res = sim.compute_msl_s_matrix(freqs=jnp.asarray(FREQS), num_periods=NUM_PERIODS)
+    nf_warn = [m for m in (msgs or []) if "fringing transient" in m]
+    S11 = np.asarray(res.S)[0, 0, :]
+    mag = np.abs(S11); db = 20 * np.log10(mag + 1e-30); fr = FREQS / 1e9; i = int(np.argmin(mag))
+    print(f"n_probe_offset arg={arg} -> RESOLVED={resolved} cells (~{resolved*dx*1e3:.1f}mm)  dx={dx*1e6:.0f}µm")
+    print(f"  preflight near-field warning fired: {bool(nf_warn)}")
+    print(f"  max|S11|={mag.max():.3f}  PASSIVE={mag.max()<=1.05}  dip @ {fr[i]:.2f} GHz ({db[i]:+.2f} dB)")
+    print("  |S11| curve: " + " ".join(f"{fr[k]:.0f}:{mag[k]:.2f}" for k in range(0, 41, 3)))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_issue80_patch_s11_regression.py
+++ b/tests/test_issue80_patch_s11_regression.py
@@ -85,11 +85,18 @@ def _build_patch_sim() -> Simulation:
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "issue #80 patch S11: V·I-split extractor gives non-passive |S11|~1.44 "
-        "(>1) with resonance dip ~10.275 GHz vs analytic 9.21 GHz — mismeasured "
-        "closed Ampere-loop current on the reflecting resonant load. Architectural "
-        "fix needed (lumped-port feed / re-derived current path). XPASS => fixed; "
-        "remove this xfail and promote to a green gate. See 2026-05-26 STOP note."
+        "issue #80 patch S11 — PASSIVITY now FIXED (2026-06-01): the V·I-split "
+        "extractor was sound all along; the non-passive |S11|~1.44/8.94 came from "
+        "probe 0 sitting INSIDE the source fringing transient (default offset ~5 "
+        "cells; the transient extends ~5·h_sub). The n_probe_offset floor clears it "
+        "→ passive |S11|~0.99 (CPU-verified at this geometry). The REMAINING xfail "
+        "is the DIP LOCATION: at this coarse dx=0.197mm the patch FDTD-resonates-"
+        "high (~10.4 GHz — the Yee staircase / 1-cell-PEC mesh effect, NOT the "
+        "extractor; ring-down on the SAME fields gives 9.32), converging to analytic "
+        "9.21 only at finer mesh. At dx=0.197 the dip cannot reach 9.21±0.20, so the "
+        "dip assert fails (expected). To promote to GREEN: run at finer mesh (dip→9.2) "
+        "OR split into a passivity gate (green now) + a mesh-convergence dip test. "
+        "DO NOT loosen TOL_GHZ to force it (R5). See 2026-06-01 verify note."
     ),
 )
 def test_issue80_patch_s11_passive_and_resonant():


### PR DESCRIPTION
## Summary

The production `compute_msl_s_matrix` diagonal S11 is already the OpenEMS-style **local V·I split** (`a=(V+Z0·I)/2`, `b=(V−Z0·I)/2`, closed Ampère-loop current, HJ Z0) and is **correct**. Its historical non-passivity on the issue-#80 edge-fed patch (`|S11|=8.94/1.44`) was **not** the extractor and **not** the current — it was **probe placement**.

The default `n_probe_offset = round(0.5·λ/(2π)/dx) ≈ 5 cells` put probe 0 **inside the source fringing transient**, which decays over a few substrate thicknesses (`~5·h_sub`), **not** over λ. For a thin high-εr substrate that transient dominates and corrupts the V·I split of a high-Q resonant load.

## Fix (3 parts)
- **Floor** the default to `max(λ-clearance, 5·h_sub/dx)`. The patch now reads **passive |S11|=0.994 by default** (offset auto-resolves 5→20 cells), vs non-passive 1.108 at the old default — issue #80's headline symptom is fixed with **no manual config**.
- **Preflight warning** when an explicit `n_probe_offset < 5·h_sub/dx`.
- **Docstring**: document both near-field scales.

## Verification (CPU, dx=0.197mm)
| check | result |
|---|---|
| patch, default offset | RESOLVED=20 cells, **max\|S11\|=0.994 PASSIVE** (was 1.108 @ offset 5) |
| cv06b notch crossval | **UNCHANGED**: 1.63% error, −34.6 dB, Z0 57.7Ω (notch is plane-invariant → no golden re-baseline) |
| MSL golden suite | green (`test_msl_port_integration` + AD smoke + replay-f64) |

## Scope / honest limits
The |S11| **dip location** (≈10.4 GHz @ dx=0.197) is the **separate Yee-staircase / 1-cell-PEC mesh effect** (ring-down on the same fields gives 9.32; converges to analytic 9.21 only at finer mesh), **not** the extractor. `test_issue80_patch_s11_regression` (`gpu`+`slow`, not CI-blocking) still xfails on the **dip** (not passivity); its reason string is updated honestly. Fully greening it needs a finer-mesh GPU run OR splitting into a passivity gate + a mesh-convergence dip test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)