### PR TITLE
test(sparam-ad): checkpoint the MSL AD M1 tape so it runs on GPU (#123)

### DIFF
--- a/tests/test_sparam_ad_end_to_end.py
+++ b/tests/test_sparam_ad_end_to_end.py
@@ -148,7 +148,7 @@ def _build_wg_sim() -> Simulation:
 # Tests
 # ---------------------------------------------------------------------------
 
-@pytest.mark.gpu  # reverse-mode AD tape = ~3934 steps x 145k cells x 6 x 4B ~ 14 GB; OOMs the 7 GB CPU-CI runner. Runs on the GPU/VESSL harness.
+@pytest.mark.gpu  # MSL AD over ~3934 steps: the un-checkpointed reverse tape OOMs even a 48 GB A6000 (VESSL run 369367241162). checkpoint_segments=64 (~sqrt of the step count) caps the peak to a few GB; kept gpu so it runs on the VESSL harness (CPU restoration tracked in #123).
 def test_msl_s_matrix_ad_end_to_end():
     """G-AD-WIRE M1: jax.grad flows end-to-end through compute_msl_s_matrix.
 
@@ -171,6 +171,7 @@ def test_msl_s_matrix_ad_end_to_end():
                 n_freqs=8,
                 num_periods=3,
                 eps_override=eps_base * alpha,
+                checkpoint_segments=14,  # cap the reverse-AD tape peak (else OOM, even on 48 GB); 14 | n_steps=3934 (= 2·7·281), ≈ √n_steps memory
             )
         S = result.S
         k0 = S.shape[-1] // 2


### PR DESCRIPTION
Closes the GPU half of #123.

`test_msl_s_matrix_ad_end_to_end` was marked `gpu` in #119 (its reverse-mode AD tape OOMs the 7 GB CPU runner). **VESSL run `369367241162` showed it OOMs even a 48 GB A6000** (`RESOURCE_EXHAUSTED`): the un-checkpointed tape over 3934 steps exceeds the 14 GB estimate at peak (CPML ψ-state + backward cotangents), so it had only ever passed on a 503 GB-host CPU box.

**Fix:** `checkpoint_segments=14` on the value_and_grad'd `compute_msl_s_matrix` call (14 | 3934 = 2·7·281, the divisor nearest √n_steps; padding is rejected as it would shift the DFT windows). The gradient is unchanged (checkpointing only recomputes the forward in the backward pass).

**Verified:**
- Local CPU: `1 passed in 238 s` (vs 214 s un-checkpointed — ~10% recompute overhead; grad finite + non-zero preserved).
- **GPU (VESSL run `369367241164`, A6000): `2 passed in 81 s`, backend `gpu [CudaDevice(id=0)]`** — both MSL AD tests pass.

Kept `@pytest.mark.gpu`. The peak is now a few GB, so **un-gpu-marking to restore CPU-CI coverage is feasible** — left as a follow-up since it needs a sharded-CI timing check (~238 s on a fast box → longer on the 2-core runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)