### PR TITLE
test(sparam-ad): restore MSL AD tests on CPU CI — un-gpu-mark (closes #123)

### DIFF
--- a/.test_durations
+++ b/.test_durations
@@ -1006,5 +1006,7 @@
   "tests/test_simulation.py::test_extract_waveguide_s_matrix_two_port_reciprocity": 1.898948575835675,
   "tests/test_simulation.py::test_init_tfsf_rejects_impossible_geometry": 0.0006363547872751951,
   "tests/test_simulation.py::test_low_level_run_supports_upml_boundary": 0.5568517807405442,
-  "tests/test_simulation.py::test_run_until_decay_supports_upml_boundary": 0.3713054219260812
+  "tests/test_simulation.py::test_run_until_decay_supports_upml_boundary": 0.3713054219260812,
+  "tests/test_sparam_ad_end_to_end.py::test_msl_s_matrix_ad_end_to_end": 225.0,
+  "tests/test_sparam_ad_end_to_end.py::test_forward_eps_override_is_differentiable_msl": 5.0
 }

--- a/tests/test_sparam_ad_end_to_end.py
+++ b/tests/test_sparam_ad_end_to_end.py
@@ -148,7 +148,10 @@ def _build_wg_sim() -> Simulation:
 # Tests
 # ---------------------------------------------------------------------------
 
-@pytest.mark.gpu  # MSL AD over ~3934 steps: the un-checkpointed reverse tape OOMs even a 48 GB A6000 (VESSL run 369367241162). checkpoint_segments=64 (~sqrt of the step count) caps the peak to a few GB; kept gpu so it runs on the VESSL harness (CPU restoration tracked in #123).
+# MSL AD over ~3934 steps: the un-checkpointed reverse tape OOMs even a 48 GB A6000
+# (VESSL run 369367241162). checkpoint_segments=14 (below) caps the peak to a few GB,
+# so this runs on the CPU CI again (was @pytest.mark.gpu in #119 before checkpointing;
+# #123). ~4 min on the shard.
 def test_msl_s_matrix_ad_end_to_end():
     """G-AD-WIRE M1: jax.grad flows end-to-end through compute_msl_s_matrix.
 
@@ -307,7 +310,6 @@ def test_waveguide_s_matrix_ad_end_to_end():
 # (mirrors tests/test_waveguide_forward.py — here for completeness)
 # ---------------------------------------------------------------------------
 
-@pytest.mark.gpu  # same ~14 GB MSL reverse-mode AD tape as the M1 test; OOMs the 7 GB CPU-CI runner.
 def test_forward_eps_override_is_differentiable_msl():
     """Positive control: jax.grad through forward(eps_override=) + probe loss.
 


### PR DESCRIPTION
Closes #123. The two MSL AD tests no longer need the GPU/VESSL harness, so the CPU CI exercises the AD-traceability path again:

- `test_msl_s_matrix_ad_end_to_end`: checkpoint_segments=14 (#125) caps the reverse-AD peak to a few GB. **CI shard 4 ran it green in 14 min — confirms it fits the 7 GB runner.**
- `test_forward_eps_override_is_differentiable_msl`: was over-marked gpu in #119 — it's a tiny 20-step `forward()` (~34 MB, 4.4 s), never a 14 GB tape. The mark + its "~14 GB" comment were wrong.

Both `@pytest.mark.gpu` dropped; their durations added to `.test_durations` so pytest-split balances M1 (225 s) onto the lightest shard. **All 4 CI shards green (14–31 min, well under 60).** Whole file: 4 passed in 240 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)