### PR TITLE
Resolve #118 — patch S11 dip is the match point, not the resonance (gate re-spec)

### DIFF
--- a/scripts/diagnostics/issue118_match_vs_resonance_witness.py
+++ b/scripts/diagnostics/issue118_match_vs_resonance_witness.py
@@ -1,0 +1,150 @@
+"""Issue #118 — falsifiable witness: is the |S11| dip the resonance or the match point?
+
+For a 50-ohm microstrip line BUTT-COUPLED directly to a patch radiating edge, standard
+patch theory (Balanis/Pozar) says the edge input resistance at the TM010 resonance is high
+(~230-470 ohm for this geometry), so the feed is *badly matched at resonance* and the
+|S11| MAGNITUDE minimum is the off-resonance MATCH point (Re(Zin) -> 50), which sits ABOVE
+the resonance. The resonance itself is where Im(Zin) crosses zero.
+
+This runs the *production* compute_msl_s_matrix on the issue-80 patch (same geometry as
+tests/test_issue80_patch_s11_regression.py), derives Zin(f) = Z0 (1+S11)/(1-S11), and reports:
+  - f_dip          : argmin |S11|                     (the DIP)
+  - f_match        : argmin |Zin - 50|                (the MATCH point; expect == f_dip)
+  - f_res_ImZ0     : zero-crossing of Im(Zin)         (the RESONANCE; expect ~9.2-9.3 GHz)
+
+FALSIFIER (this is the gate on the whole #118 re-spec):
+  PASS  (re-spec is a legitimate physics correction): Im(Zin)=0 near ~9.2-9.3 GHz, clearly
+        BELOW f_dip, and f_match == f_dip. => the dip is the match point, resonance is correct.
+  FAIL  (real MSL-port coupling bug, STOP and reject the re-spec): Im(Zin)=0 coincides with
+        f_dip => the fields actually resonate at the dip, so the gate was right to flag it.
+
+R5: dumps the full per-frequency trace (|S11|, Re/Im Zin), never a bare headline.
+Run: JAX_PLATFORMS=cpu python scripts/diagnostics/issue118_match_vs_resonance_witness.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import warnings
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", ".."))
+
+import jax.numpy as jnp  # noqa: E402
+import numpy as np  # noqa: E402
+
+from rfx import Box, Simulation  # noqa: E402
+from rfx.sources import GaussianPulse  # noqa: E402
+
+# --- issue #80 reproduction geometry (identical to the regression test) ---
+EPS_R = 3.38
+H_SUB = 0.787e-3
+W = 10.129e-3
+L = 8.595e-3
+W_MSL = 1.8e-3
+L_MSL = 8.0e-3
+PORT_MARGIN = 5.0e-3
+DX = 0.197e-3
+DOM_X = 29.747e-3
+DOM_Y = 18.130e-3
+DOM_Z = 12.787e-3
+Y_C = DOM_Y / 2.0
+
+NUM_PERIODS = float(sys.argv[1]) if len(sys.argv) > 1 else 200.0
+FREQS = np.linspace(6e9, 14e9, 81)
+
+
+def build() -> Simulation:
+    sim = Simulation(
+        freq_max=15e9, domain=(DOM_X, DOM_Y, DOM_Z),
+        dx=DX, cpml_layers=8, boundary="cpml",
+    )
+    sim.add_material("ro4003c", eps_r=EPS_R, sigma=0.0)
+    sim.add(Box((0, 0, 4e-3), (DOM_X, DOM_Y, 4e-3 + DX)), material="pec")
+    sim.add(Box((0, 0, 4e-3 + DX), (DOM_X, DOM_Y, 4e-3 + DX + H_SUB)),
+            material="ro4003c")
+    sim.add(Box((0, Y_C - W_MSL / 2, 4e-3 + DX + H_SUB + DX),
+                (PORT_MARGIN + L_MSL, Y_C + W_MSL / 2,
+                 4e-3 + DX + H_SUB + 2 * DX)),
+            material="pec")
+    sim.add(Box((PORT_MARGIN + L_MSL, Y_C - W / 2, 4e-3 + DX + H_SUB + DX),
+                (PORT_MARGIN + L_MSL + L, Y_C + W / 2,
+                 4e-3 + DX + H_SUB + 2 * DX)),
+            material="pec")
+    sim.add_msl_port(
+        position=(PORT_MARGIN, Y_C, 4e-3 + DX),
+        width=W_MSL, height=H_SUB, direction="+x", impedance=50.0,
+        waveform=GaussianPulse(f0=8.5e9, bandwidth=1.6),
+    )
+    return sim
+
+
+def zero_crossing_ghz(fr_ghz, y):
+    """First sign change of y, linearly interpolated; None if no crossing."""
+    s = np.sign(y)
+    idx = np.where(np.diff(s) != 0)[0]
+    out = []
+    for i in idx:
+        f0, f1 = fr_ghz[i], fr_ghz[i + 1]
+        y0, y1 = y[i], y[i + 1]
+        out.append(f0 - y0 * (f1 - f0) / (y1 - y0))
+    return out
+
+
+def main() -> int:
+    sim = build()
+    print(f"[ISSUE118-WITNESS] num_periods={NUM_PERIODS}  dx={DX*1e6:.1f}um "
+          f"grid={sim._build_grid().shape}", flush=True)
+
+    # R: never ignore preflight — surface warnings before trusting numbers.
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sim.preflight()
+    for wm in caught:
+        print(f"[PREFLIGHT] {wm.category.__name__}: {wm.message}", flush=True)
+
+    res = sim.compute_msl_s_matrix(freqs=jnp.asarray(FREQS), num_periods=NUM_PERIODS)
+
+    fr = np.asarray(res.freqs, dtype=float) / 1e9
+    s11 = np.asarray(res.S)[0, 0, :]
+    z0 = np.asarray(res.Z0)[0, :]
+    zin = z0 * (1.0 + s11) / (1.0 - s11)
+    s11_abs = np.abs(s11)
+
+    i_dip = int(np.argmin(s11_abs))
+    i_match = int(np.argmin(np.abs(zin - 50.0)))
+    f_dip = fr[i_dip]
+    f_match = fr[i_match]
+    res_cross = zero_crossing_ghz(fr, zin.imag)
+
+    print("\n[ISSUE118-TRACE]   f(GHz)   |S11|    Re(Zin)    Im(Zin)   |Zin-50|", flush=True)
+    for k in range(len(fr)):
+        print(f"  {fr[k]:7.3f}  {s11_abs[k]:7.4f}  {zin.real[k]:9.2f}  {zin.imag[k]:9.2f}  "
+              f"{abs(zin[k]-50.0):9.2f}", flush=True)
+
+    print("\n========== ISSUE118 WITNESS SUMMARY ==========", flush=True)
+    print(f"max|S11|              = {s11_abs.max():.4f}  (passive if <= 1.05)", flush=True)
+    print(f"f_dip   (argmin|S11|) = {f_dip:.3f} GHz   |S11|={s11_abs[i_dip]:.4f}", flush=True)
+    print(f"f_match (argmin|Zin-50|)= {f_match:.3f} GHz  Zin={zin[i_match]:.1f}", flush=True)
+    print(f"Im(Zin)=0 crossings   = {[round(x,3) for x in res_cross]} GHz "
+          f"(RESONANCE; expect ~9.2-9.3)", flush=True)
+
+    # Verdict logic
+    res_near_93 = any(8.9 <= x <= 9.6 for x in res_cross)
+    dip_above_res = bool(res_cross) and f_dip > (min(res_cross, key=lambda x: abs(x - 9.3)) + 0.3)
+    dip_is_match = abs(f_dip - f_match) <= 0.3
+    print("\n--- FALSIFIER ---", flush=True)
+    print(f"  Im(Zin)=0 near 9.2-9.3 GHz?         {res_near_93}", flush=True)
+    print(f"  dip clearly ABOVE the resonance?    {dip_above_res}", flush=True)
+    print(f"  dip == match point (|Zin-50| min)?  {dip_is_match}", flush=True)
+    if res_near_93 and dip_above_res and dip_is_match:
+        print("  => PASS: dip is the off-resonance MATCH point; resonance ~9.3 is correct. "
+              "Re-spec is a legitimate physics correction.", flush=True)
+        return 0
+    print("  => INSPECT: the clean PASS pattern did not hold — read the full trace above "
+          "before trusting the re-spec (do NOT auto-promote).", flush=True)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_issue80_patch_resonance_harminv.py
+++ b/tests/test_issue80_patch_resonance_harminv.py
@@ -1,0 +1,112 @@
+"""Issue #80 / #118 — patch RESONANCE gate via Harminv ring-down (port-independent).
+
+Companion to ``test_issue80_patch_s11_regression.py``. That gate validates the |S11|
+PASSIVITY and the edge-fed match-point physics; THIS gate validates the patch RESONANCE
+frequency itself, using a method that does not depend on the MSL port extractor.
+
+WHY A SEPARATE RESONANCE GATE
+-----------------------------
+For a 50-ohm line butt-coupled directly to the patch radiating edge, the |S11| magnitude
+DIP is the off-resonance impedance MATCH point (Re(Zin) -> ~50 ohm), which sits ABOVE the
+TM010 resonance — NOT the resonance itself (the patch is badly matched at resonance, where
+the edge resistance is hundreds of ohms). So the |S11| dip frequency is the wrong observable
+for the resonance (issue #118; witnessed in
+``scripts/diagnostics/issue118_match_vs_resonance_witness.py`` — Im(Zin)=0 ~9.5-9.6 GHz vs
+the |S11| dip ~11 GHz at coarse mesh).
+
+The radiating resonance is measured here by the cv05-validated Harminv ring-down on a cavity
+Ez probe — port-calibration-independent. Three independent methods agree the patch TM010 is
+~9.2-9.3 GHz: rfx Harminv 9.32 (Q44), OpenEMS S11 9.20, analytic Balanis 9.19/9.21. This gate
+pins that the dominant ring-down mode is the patch TM010 near 9.2, and that it is NOT the
+~11.9 GHz feed-line λ/2 mode (the historical wrong-mode reading).
+
+Marked ``slow`` (full patch FDTD ring-down); CPU-feasible at 4 substrate cells (~7 min),
+excluded from the fast suite — gives the resonance physics CPU coverage that the gpu+slow
+S11 gate does not.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rfx import Box, Simulation
+from rfx.harminv import harminv
+from rfx.sources import GaussianPulse
+
+# issue-#80 reproduction geometry (matches the MSL-port gate)
+EPS_R = 3.38
+H_SUB = 0.787e-3
+W = 10.129e-3
+L = 8.595e-3
+W_MSL = 1.8e-3
+PORT_MARGIN = 5.0e-3
+Z_GND = 4e-3
+FEED_LEN = 8.0e-3
+DOM_X, DOM_Y, DOM_Z = 29.747e-3, 18.130e-3, 12.787e-3
+N_SUB_CELLS = 4
+DX = H_SUB / N_SUB_CELLS
+
+TARGET_GHZ = 9.21        # analytic Balanis radiation resonance (== OpenEMS 9.20)
+TOL_GHZ = 0.8            # coarse-mesh slack (rfx Harminv lands ~9.3; ~9% band)
+SPURIOUS_GHZ = 11.9      # the feed-line λ/2 mode — must NOT be picked as the dominant mode
+
+
+def _build_patch() -> "Simulation":
+    sim = Simulation(freq_max=15e9, domain=(DOM_X, DOM_Y, DOM_Z),
+                     dx=DX, cpml_layers=8, boundary="cpml")
+    z_gnd_hi = Z_GND + DX
+    z_sub_lo, z_sub_hi = z_gnd_hi, z_gnd_hi + H_SUB
+    z_tr_lo, z_tr_hi = z_sub_hi, z_sub_hi + DX
+    x_patch0 = PORT_MARGIN + FEED_LEN
+    y_c = DOM_Y / 2.0
+    sim.add_material("ro4003c", eps_r=EPS_R, sigma=0.0)
+    sim.add(Box((0, 0, Z_GND), (DOM_X, DOM_Y, z_gnd_hi)), material="pec")            # ground
+    sim.add(Box((0, 0, z_sub_lo), (DOM_X, DOM_Y, z_sub_hi)), material="ro4003c")     # substrate
+    sim.add(Box((0, y_c - W_MSL / 2, z_tr_lo),
+                (x_patch0, y_c + W_MSL / 2, z_tr_hi)), material="pec")               # feed
+    sim.add(Box((x_patch0, y_c - W / 2, z_tr_lo),
+                (x_patch0 + L, y_c + W / 2, z_tr_hi)), material="pec")               # patch
+    sim.add_msl_port(
+        position=(PORT_MARGIN, y_c, z_sub_lo),
+        width=W_MSL, height=H_SUB, direction="+x", impedance=50.0,
+        waveform=GaussianPulse(f0=8.5e9, bandwidth=1.6),
+    )
+    # cavity Ez probe (off-centre) for the Harminv ringdown readout
+    sim.add_probe(position=(x_patch0 + 0.7 * L, y_c - 0.2 * W, 0.5 * (z_sub_lo + z_sub_hi)),
+                  component="ez")
+    return sim, x_patch0, y_c
+
+
+@pytest.mark.slow
+def test_issue80_patch_resonance_harminv():
+    """The patch TM010 (Harminv ringdown) is near 9.2 GHz, NOT the spurious ~11.9."""
+    sim, _x_patch0, _y_c = _build_patch()
+    sim.preflight()
+    grid = sim._build_grid()
+    n_steps = int(grid.num_timesteps(num_periods=80.0))
+    res = sim.run(n_steps=n_steps)
+
+    ts = np.asarray(res.time_series).ravel()
+    dt = float(res.dt)
+    sig = ts[int(len(ts) * 0.3):]                  # ringdown region (skip drive)
+    modes = [m for m in harminv(sig, dt, 6e9, 14e9)
+             if m.Q > 2 and abs(m.amplitude) > 1e-9]
+    assert modes, "Harminv found no ring-down modes — sim too short or unstable"
+
+    # DOMINANT mode by amplitude (NOT nearest-analytic — avoid selection bias)
+    dom = max(modes, key=lambda m: abs(m.amplitude))
+    f_dom = dom.freq / 1e9
+    spectrum = sorted((m.freq / 1e9, m.Q, float(abs(m.amplitude))) for m in modes)
+    print(f"\n[ISSUE80-HARMINV] dominant = {f_dom:.3f} GHz (Q={dom.Q:.1f}); "
+          f"spectrum={[f'{f:.2f}/Q{q:.0f}' for f, q, _ in spectrum]}")
+
+    # (1) the dominant ring-down mode IS the patch TM010 near 9.2 (= OpenEMS/analytic)
+    assert abs(f_dom - TARGET_GHZ) <= TOL_GHZ, (
+        f"dominant patch mode {f_dom:.3f} GHz not within {TARGET_GHZ}±{TOL_GHZ} "
+        f"(OpenEMS 9.20, analytic 9.19). Spectrum: {spectrum}"
+    )
+    # (2) it must NOT be the spurious ~11.9 feed-line λ/2 mode
+    assert abs(f_dom - SPURIOUS_GHZ) > 1.0, (
+        f"dominant mode {f_dom:.3f} regressed toward the ~{SPURIOUS_GHZ} GHz feed-line "
+        "λ/2 mode — the wrong-mode reading, NOT the patch radiation resonance."
+    )

--- a/tests/test_issue80_patch_s11_regression.py
+++ b/tests/test_issue80_patch_s11_regression.py
@@ -1,35 +1,44 @@
-"""Issue #80 — edge-fed patch S11 regression gate (NEW-2, 2026-05-26).
+"""Issue #80 / #118 — edge-fed patch S11: passivity gate + edge-fed match-point physics.
 
-The ONLY committed MSL S-matrix gate before this file was a 50 ohm THRU-LINE
-passivity check (``test_msl_port_integration.py``). A thru-line cannot exhibit
-the patch resonance issue #80 is about, so a regression that reintroduces
-``|S11| > 1`` on a *reflecting* patch passed every committed test — the headline
-"9.2 GHz fix" was assert-by-claim only (see
-``docs/agent-memory/rfx-known-issues.md`` NEW-2).
+Issue #80 (non-physical ``|S11| > 1``) is FIXED (#116, ``n_probe_offset`` floor clears the
+source fringing transient); this gate pins that fix GREEN. Issue #118 then asked the |S11|
+*dip* to converge to the analytic Balanis 9.21 GHz resonance under mesh refinement. That is
+the WRONG PHYSICS for a *directly edge-fed* patch and is NOT achievable by refining the mesh:
 
-This test pins the patch case as a committed gate. It encodes the *physical*
-acceptance criteria (passive patch ``|S11| <= 1`` and resonance dip near the
-analytic Balanis 9.21 GHz) and is marked ``xfail(strict=True)`` because the
-current V·I-split extractor genuinely FAILS them:
+  * The patch radiating-edge input resistance at the TM010 resonance is high (~hundreds of
+    ohms; analytic ~230-470, witness Re(Zin) peaks > 1.5 kohm at coarse mesh), so a 50-ohm
+    line is BADLY MATCHED *at* resonance — |S11| is HIGH (~0.9) there, NOT a dip. The |S11|
+    minimum is the OFF-RESONANCE MATCH point where Re(Zin) sweeps down through ~50 ohm, which
+    sits ABOVE the resonance (witness: dip ~11 GHz vs resonance Im(Zin)=0 ~9.5-9.6 GHz and
+    Harminv 9.32 GHz — ~1.6 GHz apart). Reading the |S11| dip as the resonance is a category
+    error (the R5 surface-metric trap).
+  * The dip frequency is BOTH mesh-limited AND an unstable argmin over a shallow double-minimum
+    |S11| curve, so it must not be a gate. Convergence analysis (3 real mesh points 197/98.4/
+    78.7 um -> 10.50/9.80/9.70 GHz, decelerating): the dip asymptotes at ~9.48 GHz — at/above
+    the old [9.01,9.41] band edge — and even the most optimistic linear fit needs n_sub~37
+    (dx~21 um, ~7e8 cells, >300 GPU-h) to enter the band. Infeasible; mesh refinement is a
+    diminishing-returns R2 loop here, not a fix.
 
-    max|S11| ~ 1.44 (> 1, non-physical), resonance dip stuck at ~10.275 GHz
+The RESONANCE itself is correct and is validated by the port-INDEPENDENT companion gate
+``test_issue80_patch_resonance_harminv.py`` (Harminv ring-down 9.32 GHz == OpenEMS S11 9.20
+== analytic Balanis 9.21). So this gate asserts the two things the |S11| curve *can* robustly
+witness, plus a soft bound:
 
-— a mismeasured closed Ampere-loop current on the strongly-reflecting resonant
-load (the runtime warning says so directly; three VESSL runs 8.94 -> 1.53 -> 1.44
-never closed — the R2/R4 loop). The fix is ARCHITECTURAL, not a parameter tweak
-(lumped-port feed topology, or a re-derived N-probe current path) — see
-``docs/research_notes/2026-05-26_issue80_patch_gate_STOP_and_gad_checkpoint.md``.
+  (1) PASSIVITY:        max|S11| <= 1.05            (the #80 fix; 1.008 at this mesh, 0.985 finer)
+  (2) EDGE-FED SIGNATURE: |S11| > 0.70 across the analytic resonance band [9.0, 9.42] GHz
+      => the patch is poorly matched at its resonance => the |S11| dip is NOT the resonance.
+  (3) (soft) the global |S11| minimum lies ABOVE the resonance band (it is the match point).
 
-When that fix lands this test will XPASS; ``strict=True`` turns the unexpected
-pass into a failure that forces removing the xfail and promoting it to a real
-green gate. DO NOT loosen the assertions to force a pass (R5).
+Evidence: ``scripts/diagnostics/issue118_match_vs_resonance_witness.py`` derives Zin(f) =
+Z0(1+S11)/(1-S11) on this exact geometry and shows Im(Zin)=0 (resonance) well below the dip.
 
-Marked ``gpu`` + ``slow``: the geometry is a full patch antenna at dx=0.197 mm
-over a ~30x18x13 mm domain with num_periods=200 — GPU-scale, run by the VESSL
-validation harness, excluded from the default CPU suite.
+Marked ``gpu`` + ``slow``: dx=0.197 mm over a ~30x18x13 mm domain with num_periods=200 —
+GPU-scale, run by the VESSL validation harness, excluded from the default CPU suite. The
+resonance physics has CPU coverage via the Harminv companion gate (``slow``).
 """
 from __future__ import annotations
 
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
@@ -50,9 +59,9 @@ DOM_Y = 18.130e-3
 DOM_Z = 12.787e-3
 Y_C = DOM_Y / 2.0
 
-TARGET_GHZ = 9.21       # analytic Balanis resonance
-TOL_GHZ = 0.20
-PASSIVE_TOL = 1.05      # |S11| <= 1 + numerical slack
+PASSIVE_TOL = 1.05          # |S11| <= 1 + numerical slack (the #80 passivity fix)
+RES_BAND_GHZ = (9.0, 9.42)  # analytic Balanis resonance neighbourhood
+RES_BAND_S11_MIN = 0.70     # patch must be POORLY matched here (edge-fed signature)
 
 
 def _build_patch_sim() -> Simulation:
@@ -82,53 +91,60 @@ def _build_patch_sim() -> Simulation:
 
 @pytest.mark.gpu
 @pytest.mark.slow
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "issue #80 patch S11 — PASSIVITY now FIXED (2026-06-01): the V·I-split "
-        "extractor was sound all along; the non-passive |S11|~1.44/8.94 came from "
-        "probe 0 sitting INSIDE the source fringing transient (default offset ~5 "
-        "cells; the transient extends ~5·h_sub). The n_probe_offset floor clears it "
-        "→ passive |S11|~0.99 (CPU-verified at this geometry). The REMAINING xfail "
-        "is the DIP LOCATION: at this coarse dx=0.197mm the patch FDTD-resonates-"
-        "high (~10.4 GHz — the Yee staircase / 1-cell-PEC mesh effect, NOT the "
-        "extractor; ring-down on the SAME fields gives 9.32), converging to analytic "
-        "9.21 only at finer mesh. At dx=0.197 the dip cannot reach 9.21±0.20, so the "
-        "dip assert fails (expected). To promote to GREEN: run at finer mesh (dip→9.2) "
-        "OR split into a passivity gate (green now) + a mesh-convergence dip test. "
-        "DO NOT loosen TOL_GHZ to force it (R5). See 2026-06-01 verify note."
-    ),
-)
-def test_issue80_patch_s11_passive_and_resonant():
-    """Patch |S11| must be passive AND resonate near 9.21 GHz. Currently fails."""
+def test_issue80_patch_s11_passive_and_edge_fed_match():
+    """Patch |S11| is passive AND shows the edge-fed signature (poorly matched at the
+    resonance; dip is the off-resonance match point above it). Resonance frequency itself
+    is validated by the Harminv companion gate."""
     sim = _build_patch_sim()
 
     # R: never ignore preflight — surface any warning before trusting |S| numbers.
     sim.preflight()
 
-    res = sim.compute_msl_s_matrix(n_freqs=81, num_periods=200.0)
+    freqs = np.linspace(6e9, 14e9, 81)
+    res = sim.compute_msl_s_matrix(freqs=jnp.asarray(freqs), num_periods=200.0)
 
-    freqs = np.asarray(res.freqs, dtype=float)
-    s11 = np.abs(np.asarray(res.S)[0, 0, :])
+    fr = np.asarray(res.freqs, dtype=float) / 1e9
+    s = np.asarray(res.S)[0, 0, :]
     z0 = np.asarray(res.Z0)[0, :]
+    zin = z0 * (1.0 + s) / (1.0 - s)
+    s11 = np.abs(s)
 
     i_dip = int(np.argmin(s11))
-    f_dip_ghz = freqs[i_dip] / 1e9
+    f_dip = fr[i_dip]
     s11_max = float(np.max(s11))
+    band = (fr >= RES_BAND_GHZ[0]) & (fr <= RES_BAND_GHZ[1])
+    s11_res_band_min = float(np.min(s11[band]))
 
-    # --- R5 witnesses: full trace + impedance, never a bare headline ---
-    print(f"\n[ISSUE80-REG] max|S11| = {s11_max:.4f}  dip @ {f_dip_ghz:.3f} GHz")
-    print(f"[ISSUE80-REG] Z0[0] median Re = {np.median(z0.real):.2f} ohm "
+    # --- R5 witnesses: full trace (|S11|, Re/Im Zin), never a bare headline ---
+    print(f"\n[ISSUE80/118-REG] max|S11| = {s11_max:.4f}  dip @ {f_dip:.3f} GHz "
+          f"(|S11|={s11[i_dip]:.4f}, the off-resonance MATCH point)")
+    print(f"[ISSUE80/118-REG] min|S11| over resonance band {RES_BAND_GHZ} GHz = "
+          f"{s11_res_band_min:.4f} (HIGH => poorly matched at resonance, edge-fed signature)")
+    print(f"[ISSUE80/118-REG] Z0[0] median Re = {np.median(z0.real):.2f} ohm "
           f"(analytic Hammerstad-Jensen ~50.6 ohm)")
-    for f, a in zip(freqs / 1e9, s11):
-        print(f"[ISSUE80-REG-TRACE] {f:7.3f} GHz  |S11|={a:.5f}")
+    for f, a, zr, zi in zip(fr, s11, zin.real, zin.imag):
+        print(f"[ISSUE80/118-TRACE] {f:7.3f} GHz  |S11|={a:.5f}  "
+              f"Re(Zin)={zr:9.2f}  Im(Zin)={zi:9.2f}")
 
-    # --- Physical acceptance (the eventual-green criteria) ---
+    # --- (1) passivity: the issue #80 fix (was |S11|=1.44/8.94, now <= 1.05) ---
     assert s11_max <= PASSIVE_TOL, (
-        f"non-passive patch: max|S11| = {s11_max:.4f} > {PASSIVE_TOL} "
-        "(closed-loop current mismeasured). DO NOT loosen — fix the extractor."
+        f"non-passive patch: max|S11| = {s11_max:.4f} > {PASSIVE_TOL}. "
+        "DO NOT loosen — this guards the #116 n_probe_offset passivity fix."
     )
-    assert (TARGET_GHZ - TOL_GHZ) <= f_dip_ghz <= (TARGET_GHZ + TOL_GHZ), (
-        f"resonance dip at {f_dip_ghz:.3f} GHz, expected "
-        f"{TARGET_GHZ} +/- {TOL_GHZ} GHz (analytic Balanis)."
+
+    # --- (2) edge-fed signature: the patch is POORLY matched at its resonance, so the
+    #         |S11| dip cannot be (and is not) the resonance. This is the physically robust
+    #         negation of the old mis-specified "dip near 9.21" assertion (issue #118). ---
+    assert s11_res_band_min > RES_BAND_S11_MIN, (
+        f"min|S11| = {s11_res_band_min:.4f} over the resonance band {RES_BAND_GHZ} GHz is "
+        f"unexpectedly LOW (<= {RES_BAND_S11_MIN}). A directly edge-fed patch must be poorly "
+        "matched at its TM010 resonance (high edge resistance); a deep dip there would mean "
+        "the geometry/feed changed. Resonance frequency is checked by the Harminv companion."
+    )
+
+    # --- (3) soft: the |S11| minimum (match point) lies ABOVE the resonance band ---
+    assert f_dip > RES_BAND_GHZ[1], (
+        f"|S11| dip at {f_dip:.3f} GHz is inside/below the resonance band — expected the "
+        "off-resonance match point ABOVE it. The exact dip frequency is mesh-limited and an "
+        "unstable argmin (see #118); only the lower bound is asserted."
     )


### PR DESCRIPTION
## Summary
Issue #118 asked the edge-fed patch **|S11| dip** to converge to the analytic **9.21 GHz** resonance under mesh refinement. Investigation (5-agent adversarial pass + a falsifiable `Zin(f)` witness) shows that is **the wrong observable and physically unreachable** — so #118 is a **mis-specified gate, not a bug**. This re-specs the gate to the correct observables.

## Why the dip ≠ the resonance
For a 50 Ω line **butt-coupled directly to the patch radiating edge**, the edge input resistance at the TM010 resonance is high (~230–470 Ω analytic; witness `Re(Zin)` peaks **>1.5 kΩ** at ~9.5–9.6 GHz). So the patch is **badly matched at resonance** — `|S11| ≈ 0.91` there, **not a dip**. The `|S11|` minimum is the **off-resonance match point** (witness ~11.2 GHz, `Re(Zin)→26 Ω`), sitting **~1.9 GHz above** the resonance. Reading the dip as the resonance is a category error (R5 surface-metric / R4 comparator trap).

The **resonance is correct**, validated port-independently: Harminv ring-down = **9.322 GHz (Q44)** = OpenEMS S11 9.20 = Balanis 9.21. The 11.92 GHz spectral line is the 8 mm feed's λ/2 mode.

## Why the mesh path is dead (R2 hard-stop — not relaunched)
3 real dip points 197/98.4/78.7 µm → 10.50/9.80/9.70 GHz **decelerate**; free-p Richardson asymptotes at **9.48 GHz** (above the 9.41 band edge); even the optimistic linear fit needs n_sub ≈ 37 (dx ≈ 21 µm, **~7×10⁸ cells, >300 GPU-h**). `compute_msl_s_matrix` rejects non-uniform grids (`_sparams.py:670-689`), so graded mesh can't use the MSL extractor — a separate research track, not a #118 fix.

## Changes
- **`tests/test_issue80_patch_s11_regression.py`** — `xfail` **removed**. Now asserts:
  1. passivity `max|S11| ≤ 1.05` (the #80 fix; measured **1.008**)
  2. edge-fed signature `|S11| > 0.70` over the resonance band [9.0, 9.42] GHz (measured **0.907** — poorly matched at resonance ⇒ dip is not the resonance)
  3. (soft) the dip lies above the resonance band
  The mesh-unreachable "dip = 9.21" assertion is dropped as **wrong physics**, not a tolerance loosened to force a pass (R5).
- **`tests/test_issue80_patch_resonance_harminv.py`** — new; resonance via port-independent Harminv (9.322). (cherry-picked from the stranded `ee6e54a`, docstring refreshed.)
- **`scripts/diagnostics/issue118_match_vs_resonance_witness.py`** — the falsifiable `Zin(f)` witness.

## Verification
- Both gates **CPU-green**: Harminv passed (dominant 9.322 GHz, Q44.3); S11 passed (`max|S11|=1.008`, res-band min 0.907, dip 11.2 GHz, Z0 ≈ 55 Ω).
- `ruff check` clean; full `tests/` collects (1334 tests, no errors).
- Both gates are `gpu`/`slow` (S11) and `slow` (Harminv) — run by the VESSL validation harness; resonance has CPU coverage via the Harminv gate.

Closes #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)