### PR TITLE
fix(directivity): sign-correct gradient via log-ratio objective (closes #129)

### DIFF
--- a/rfx/optimize_objectives.py
+++ b/rfx/optimize_objectives.py
@@ -287,6 +287,8 @@ def maximize_directivity(
     *,
     n_theta: int = 37,
     n_phi: int = 73,
+    log_ratio: bool = False,
+    eps: float = 1e-37,
 ) -> Callable:
     """Maximize directivity in a target direction (ratio-based, scale-invariant).
 
@@ -316,13 +318,41 @@ def maximize_directivity(
     -------
     callable(Result) -> scalar (JAX-differentiable)
 
+    Parameters (continued)
+    ----------------------
+    log_ratio : bool, optional
+        If True, optimize ``-(log U - log P)`` (full, sign-correct quotient
+        gradient ``U'/U - P'/P``) instead of the legacy ``-U/stop_gradient(P)``.
+        Default False (legacy, back-compat). USE ``log_ratio=True`` (or the
+        ``maximize_directivity_logratio`` factory) for any DoF that changes
+        total radiated power — see the warning below.
+    eps : float, optional
+        Floor for the ``log_ratio`` log arguments (default 1e-37). It only
+        guards ``log(0)``; the log-ratio gradient ``U'/U`` is scale-invariant, so
+        eps must be BELOW the working U/P magnitude (rfx spectral NTFF U,P are
+        ~1e-27 in full antenna runs, ~1e-32 in small/early sims). A floor at or
+        above U/P (e.g. the old 1e-30 on a 1e-32 sim) clamps the log argument and
+        zeros the gradient — keep eps well below min(U, P). (The legacy path's
+        denominator floor is hardcoded 1e-30 and is unaffected by this.)
+
     Notes
     -----
-    ``stop_gradient`` is applied to the P_rad denominator: since the
-    ratio is scale-invariant, any shape-preserving scaling leaves the
-    directivity unchanged; letting the denominator carry gradient would
-    only introduce noise and NaN risk when P_rad is near zero early in
-    optimization.
+    In the default (``log_ratio=False``) mode, ``stop_gradient`` is applied to
+    the P_rad denominator: the ratio is scale-invariant, so a shape-preserving
+    scaling leaves the directivity unchanged, and letting the denominator carry
+    gradient would add noise + NaN risk when P_rad is near zero.
+
+    WARNING (GitHub #129): that legacy mode drops the ``-U*P'/P^2`` quotient-rule
+    term, so it yields WRONG-SIGN gradients for any DoF that changes total
+    radiated power — conductors / PEC topology (``topology_optimize(material_fg=
+    "pec")``, Yagi director/reflector offsets+lengths, parasitics), lossy/sigma
+    DoFs, and (magnitude-only) dielectric reshaping. It is correct ONLY for pure
+    shape-preserving DoFs (the original #32 target, ``P_rad ~ const``). For
+    power-changing DoFs pass ``log_ratio=True``: the full quotient
+    ``grad = U'/U - P'/P`` is sign-correct, still scale-invariant (preserving the
+    #32 property), monotone in the directivity (same optimum), and NaN-safe via
+    independent ``eps`` floors (each log argument is O(1), avoiding the
+    1e-27/1e-30 backward blow-up of a naive full quotient).
     """
     theta_arr = np.array([theta_target])
     phi_arr = np.array([phi_target])
@@ -364,6 +394,20 @@ def maximize_directivity(
         p_rad_phi = jnp.trapezoid(integrand, theta_hemi, axis=1)
         p_rad = jnp.trapezoid(p_rad_phi, phi_hemi, axis=1)  # (n_freqs,)
 
+        if log_ratio:
+            # Full, NaN-safe quotient: grad = U'/U - P'/P (== true dD/dθ up to
+            # the positive factor 1/D, so sign-correct + monotone). Floors are
+            # applied INDEPENDENTLY so each log argument is O(1) — a single
+            # shared 1e-30 floor on U/P (the ~1e-27 spectral NTFF scale) makes
+            # the backward pass NaN. No stop_gradient -> correct sign for
+            # power-changing DoFs (GitHub #129).
+            log_dir = (jnp.log(jnp.maximum(u_target, eps))
+                       - jnp.log(jnp.maximum(p_rad, eps)))
+            return -jnp.mean(log_dir)
+        # Legacy scale-invariant ratio. CORRECT ONLY for shape-preserving DoFs;
+        # WRONG-SIGN for power-changing DoFs (see #129 warning above). The 1e-30
+        # denominator floor is hardcoded here for exact back-compat (the `eps`
+        # param tunes the log_ratio floor only).
         directivity = u_target / (jax.lax.stop_gradient(p_rad) + 1e-30)
         # Minimizing -D = maximizing directivity; average across freqs
         return -jnp.mean(directivity)
@@ -375,6 +419,29 @@ def maximize_directivity(
 # the ratio-based formulation, so `maximize_directivity_ratio` is simply
 # the new default under an explicit name.
 maximize_directivity_ratio = maximize_directivity
+
+
+def maximize_directivity_logratio(
+    theta_target: float,
+    phi_target: float,
+    *,
+    n_theta: int = 37,
+    n_phi: int = 73,
+    eps: float = 1e-37,
+) -> Callable:
+    """Directivity objective with the full, sign-correct quotient gradient.
+
+    Equivalent to ``maximize_directivity(..., log_ratio=True)``: optimizes
+    ``-(log U - log P)`` so the gradient ``U'/U - P'/P`` carries the
+    ``-U*P'/P^2`` term the legacy ``stop_gradient`` mode drops. PREFER this for
+    any power-changing DoF (PEC / topology / lossy / dielectric reshaping); the
+    legacy default gives wrong-sign gradients for those (GitHub #129). See
+    :func:`maximize_directivity` for the full warning and parameters.
+    """
+    return maximize_directivity(
+        theta_target, phi_target,
+        n_theta=n_theta, n_phi=n_phi, log_ratio=True, eps=eps,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_directivity_gradient.py
+++ b/tests/test_directivity_gradient.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 import numpy as np
-import pytest
 
 from rfx.grid import Grid
 from rfx.core.yee import init_materials
@@ -22,6 +21,7 @@ from rfx.farfield import make_ntff_box
 from rfx.optimize_objectives import (
     maximize_directivity,
     maximize_directivity_ratio,
+    maximize_directivity_logratio,
 )
 
 
@@ -76,3 +76,95 @@ def test_maximize_directivity_gradient_nonzero():
         f"directivity gradient collapsed to noise: grad(1.0)={grad:.2e}, "
         f"grad(1.2)={grad_off:.2e} (issue #32 would show ~0.0)"
     )
+
+
+# ---------------------------------------------------------------------------
+# GitHub #129 — maximize_directivity wrong-sign gradient for power-changing DoFs.
+# The legacy `-U/stop_gradient(P)` drops the -U*P'/P^2 quotient term, so for any
+# DoF that changes total radiated power (here: a lossy `sigma` block) the gradient
+# can come out WRONG-SIGNED vs finite difference. `log_ratio=True` optimizes
+# `-(log U - log P)` (full quotient `U'/U - P'/P`) which is sign-correct, scale-
+# invariant, and NaN-safe.
+# ---------------------------------------------------------------------------
+_S0, _H = 50.0, 5.0  # base lossy-block scale + central-FD half-step
+
+
+def _forward_lossy(sigma_scale):
+    """NTFF forward with a POWER-CHANGING DoF: a lossy sigma block near the source.
+
+    Adding conductivity dissipates power, so P_rad moves with the DoF — the regime
+    where the legacy stop_gradient objective is wrong (#129).
+    """
+    grid = Grid(freq_max=5e9, domain=(0.02, 0.02, 0.02), cpml_layers=0)
+    mb = init_materials(grid.shape)
+    sx, sy, sz = grid.shape
+    mask = np.zeros(grid.shape, dtype=np.float32)
+    mask[sx // 2:sx // 2 + 4, sy // 2 - 2:sy // 2 + 2, sz // 2 - 2:sz // 2 + 2] = 1.0
+    materials = mb._replace(sigma=mb.sigma + sigma_scale * jnp.asarray(mask))
+    pulse = GaussianPulse(f0=3e9, bandwidth=0.5)
+    src = make_source(grid, (0.01, 0.01, 0.01), "ez", pulse, 40)
+    ntff = make_ntff_box(grid, (0.003, 0.003, 0.003), (0.017, 0.017, 0.017),
+                         freqs=jnp.array([3e9]))
+    return run(grid, materials, 40, sources=[src], ntff=ntff)
+
+
+def _u_target_and_p_rad(result):
+    """Value-only (no AD) U(target) and hemisphere P_rad — for the ground-truth FD."""
+    from rfx.farfield import compute_far_field
+    th = np.array([np.pi / 2])
+    ph = np.array([0.0])
+    th_h = np.linspace(0.0, np.pi / 2, 37)
+    ph_h = np.linspace(0.0, 2 * np.pi, 73)
+    ff = compute_far_field(result.ntff_data, result.ntff_box, result.grid, th, ph)
+    u = float(jnp.abs(ff.E_theta[0, 0, 0]) ** 2 + jnp.abs(ff.E_phi[0, 0, 0]) ** 2)
+    ffh = compute_far_field(result.ntff_data, result.ntff_box, result.grid, th_h, ph_h)
+    uh = jnp.abs(ffh.E_theta) ** 2 + jnp.abs(ffh.E_phi) ** 2
+    st = jnp.asarray(np.sin(th_h))
+    p = float(jnp.trapezoid(jnp.trapezoid(uh * st[None, :, None], th_h, axis=1),
+                            ph_h, axis=1)[0])
+    return u, p
+
+
+def test_directivity_logratio_sign_correct_vs_fd_power_changing_dof():
+    """#129: log_ratio is sign-correct + matches FD where legacy flips sign."""
+    rm, rp = _forward_lossy(_S0 - _H), _forward_lossy(_S0 + _H)
+    um, pm = _u_target_and_p_rad(rm)
+    up, pp = _u_target_and_p_rad(rp)
+    d_dir = ((up / pp) - (um / pm)) / (2 * _H)          # true directivity slope
+    assert abs(d_dir) > 1e-9, "setup: directivity must vary with the DoF"
+    true_loss_grad = -d_dir                              # loss = -D
+
+    # central FD of the log-ratio loss = -(log U - log P), same 1e-37 floor.
+    e = 1e-37
+    def _log_loss(u, p):
+        return -(np.log(max(u, e)) - np.log(max(p, e)))
+    g_log_fd = (_log_loss(up, pp) - _log_loss(um, pm)) / (2 * _H)
+
+    g_leg = float(jax.grad(
+        lambda s: maximize_directivity(np.pi / 2, 0.0)(_forward_lossy(s))
+    )(jnp.asarray(_S0)))
+    g_log = float(jax.grad(
+        lambda s: maximize_directivity(np.pi / 2, 0.0, log_ratio=True)(_forward_lossy(s))
+    )(jnp.asarray(_S0)))
+
+    assert np.isfinite(g_leg) and np.isfinite(g_log)
+    assert abs(g_log) > 1e-7, "log_ratio gradient collapsed to noise"
+    # (1) FIX is sign-correct vs the true directivity ascent direction.
+    assert np.sign(g_log) == np.sign(true_loss_grad), (
+        f"log_ratio sign {g_log:+.3e} != true loss grad {true_loss_grad:+.3e}")
+    # (2) FIX AD matches central-FD of its own objective (self-consistent).
+    rel = abs(g_log - g_log_fd) / (abs(g_log_fd) + 1e-30)
+    assert rel < 0.05, f"log_ratio AD {g_log:+.3e} vs FD {g_log_fd:+.3e} rel_err {rel:.3f}"
+    # (3) BUG repro: legacy stop_gradient opposes the correct direction here.
+    assert np.sign(g_leg) != np.sign(g_log), (
+        f"#129 not reproduced: legacy {g_leg:+.3e} should oppose log_ratio {g_log:+.3e}")
+
+
+def test_maximize_directivity_logratio_factory_matches_flag():
+    """The factory == maximize_directivity(log_ratio=True) (value + finite grad)."""
+    r = _forward_lossy(_S0)
+    fac = maximize_directivity_logratio(np.pi / 2, 0.0)
+    flag = maximize_directivity(np.pi / 2, 0.0, log_ratio=True)
+    assert float(fac(r)) == float(flag(r))
+    g = float(jax.grad(lambda s: maximize_directivity_logratio(np.pi / 2, 0.0)(_forward_lossy(s)))(jnp.asarray(_S0)))
+    assert np.isfinite(g) and abs(g) > 1e-7


### PR DESCRIPTION
Closes #129.

## Problem
`maximize_directivity`'s legacy objective `−U/stop_gradient(P)` drops the `−U·P'/P²` quotient-rule term. For any DoF that **changes total radiated power** (PEC/topology, lossy/σ, dielectric reshaping — i.e. the antenna inverse-design knobs), the AD gradient can come out **wrong-signed** vs finite difference and silently steer directivity optimization the wrong way.

## Fix (opt-in, back-compat)
Add a log-ratio objective `−(log U − log P)` → full quotient `U'/U − P'/P`: sign-correct, scale-invariant (keeps the #32 property), monotone (same optimum), NaN-safe (no `P²` float32 underflow). Exposed as:
- `maximize_directivity(..., log_ratio=True)`
- `maximize_directivity_logratio(...)` factory

**Legacy default unchanged** (loud docstring warning added).

## eps floor: 1e-37, not 1e-30
The log-ratio gradient `U'/U` is scale-invariant, and rfx spectral-NTFF `U,P` are ~1e-32 in small/early sims — a 1e-30 floor clamps the log argument there and **zeros the gradient** (verified empirically). 1e-37 only guards `log(0)` and stays float32-safe. The legacy path keeps its hardcoded 1e-30 denominator (exact back-compat).

## Validation (R5) — `tests/test_directivity_gradient.py`
On a power-changing lossy-σ DoF:
| objective | AD loss-grad | true loss-grad (central FD) | sign |
|---|---|---|---|
| legacy `−U/stop_grad(P)` | **+9.5e-6** | −4.4e-5 | **WRONG** |
| `log_ratio=True` | **−2.12e-4** | (−(1/D)dD/dθ = −2.13e-4) | correct |

log_ratio AD matches central-FD of its own objective to **rel_err 0.005**. 4/4 directivity tests pass; the #32 back-compat tests are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
