### PR TITLE
feat: agent-automation guards + precedent-aligned preflight redesign

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: lint
+
+# Re-enables the ruff lint gate that previously sat dormant in
+# .github/workflows/disabled/test.yml. The full CPU/GPU test suite runs on the
+# sharded `scientific-validation` workflow (and on VESSL); this workflow is the
+# cheap, fast gate that catches undefined names, unused variables, and other
+# pyflakes/pycodestyle issues on every push and pull request, so regressions
+# don't reach main unreviewed. Selector + ignore list are carried over verbatim
+# from the disabled job; production rfx/ and tests/ are clean under it today.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Lint rfx/ and tests/
+        run: ruff check rfx/ tests/ --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,50 @@
+name: pr-tests
+
+# Fast, BOUNDED pytest gate so the agent-automation guards, the preflight
+# redesign, the regression locks, and the conformal stale-check tripwire
+# actually run on every PR and push-to-main. The full "not gpu" suite remains
+# on validation.yml (weekly, sharded) — that run OOM'd unsharded on the 7 GB
+# runner, so this job is deliberately scoped to the affected surface to stay
+# fast and memory-safe. Mark this job a REQUIRED check in branch protection so
+# the tripwire/regression-locks gate merges.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  guards-and-preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install package with dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Guard + preflight suite (incl. upml/Floquet regression locks)
+        run: |
+          python -m pytest -q -p no:cacheprovider \
+            tests/test_sparam_passivity_guard.py \
+            tests/test_result_finite_guard.py \
+            tests/test_run_preflight_parity.py \
+            tests/test_preflight_structured_and_guards.py \
+            tests/test_auto_preflight.py \
+            tests/test_preflight_false_positives.py \
+            tests/test_preflight_physics_thresholds.py \
+            tests/test_port_preflight.py \
+            tests/test_msl_port_preflight.py \
+            tests/test_inverse_design_preflight.py \
+            tests/test_api.py
+
+      - name: Conformal stale-check tripwire (slow-marked; xfails today, HARD-FAILS when the NaN is fixed)
+        run: |
+          python -m pytest -q -p no:cacheprovider -o addopts="" \
+            "tests/test_subpixel_pec.py::test_mesh_convergence_s21_with_conformal_pec"

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -231,7 +231,10 @@ class _ExecuteMixin:
         for w in config.warnings:
             _w.warn(w, stacklevel=3)
 
-    def _auto_preflight(self, *, skip: bool = False, context: str = "forward") -> None:
+    def _auto_preflight(
+        self, *, skip: bool = False, context: str = "forward",
+        check_ntff: bool = True,
+    ) -> None:
         """Emit a UserWarning if preflight finds issues (issue #66).
 
         Called automatically at the start of ``forward()``, ``optimize()``,
@@ -239,6 +242,12 @@ class _ExecuteMixin:
         (under-resolved mesh, geometry in CPML, probe in PEC, ...) before
         spending minutes of GPU compute. Pass ``skip_preflight=True`` at
         the call site to opt out (tests, already-validated configs).
+
+        ``check_ntff`` gates the inverse-design NTFF checks (PEC-overlap hard
+        error + λ/4 near-field gap warning). ``run()`` passes ``check_ntff=
+        False`` because those are inverse-design concerns that ``run()``
+        historically never ran — only ``forward(port_s11_freqs=...)`` /
+        ``optimize`` (the inverse-design entry points) should hard-fail on them.
         """
         if skip:
             return
@@ -246,7 +255,7 @@ class _ExecuteMixin:
         # a validator itself crashes (a bug, e.g. a non-ValueError). Let that
         # propagate loudly (Phase D) — do NOT degrade a validator bug to a soft
         # warning that hides it and lets a broken run proceed.
-        issues = self.preflight(strict=False)
+        issues = self.preflight(strict=False, check_ntff=check_ntff)
         if not issues:
             return
         import warnings
@@ -1691,7 +1700,11 @@ class _ExecuteMixin:
         # so the documented lumped/wire S-parameter path via
         # run(compute_s_params=True) silently missed part of the best
         # proactive error surface in the codebase.
-        self._auto_preflight(skip=skip_preflight, context="run")
+        # check_ntff=False: run() historically never ran the inverse-design
+        # NTFF PEC-overlap check; keep that surface (it belongs to
+        # forward(port_s11_freqs=...)/optimize). Avoids hard-failing run() on
+        # an NTFF-box-crosses-PEC config that completed before this change.
+        self._auto_preflight(skip=skip_preflight, context="run", check_ntff=False)
 
         if self._solver == "adi" and devices is not None and len(devices) > 1:
             raise ValueError("solver='adi' does not support distributed execution")

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -242,16 +242,11 @@ class _ExecuteMixin:
         """
         if skip:
             return
-        try:
-            issues = self.preflight(strict=False)
-        except Exception as exc:
-            import warnings
-            warnings.warn(
-                f"[{context}] auto-preflight raised {type(exc).__name__}: "
-                f"{exc}. Call sim.preflight() manually to investigate.",
-                UserWarning, stacklevel=3,
-            )
-            return
+        # preflight(strict=False) COLLECTS findings as issues; it only raises if
+        # a validator itself crashes (a bug, e.g. a non-ValueError). Let that
+        # propagate loudly (Phase D) — do NOT degrade a validator bug to a soft
+        # warning that hides it and lets a broken run proceed.
+        issues = self.preflight(strict=False)
         if not issues:
             return
         import warnings

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -255,12 +255,28 @@ class _ExecuteMixin:
         if not issues:
             return
         import warnings
-        body = "\n  - ".join(issues)
-        warnings.warn(
-            f"[{context}] preflight found {len(issues)} issue(s) - "
-            f"pass skip_preflight=True to suppress:\n  - {body}",
-            UserWarning, stacklevel=3,
-        )
+        errors = [i for i in issues if getattr(i, "severity", "warning") == "error"]
+        warns = [i for i in issues if getattr(i, "severity", "warning") != "error"]
+        if warns:
+            body = "\n  - ".join(warns)
+            warnings.warn(
+                f"[{context}] preflight found {len(warns)} advisory issue(s) - "
+                f"pass skip_preflight=True to suppress:\n  - {body}",
+                UserWarning, stacklevel=3,
+            )
+        if errors:
+            # Error-severity findings are structurally-impossible configs
+            # (e.g. upml+refinement, Floquet+non-uniform-z) whose validators
+            # raise ValueError. run()/forward() used to call those validators
+            # directly so the error PROPAGATED; routing through preflight must
+            # preserve that hard-fail, else a known-invalid run silently
+            # proceeds. Re-raise (aligns with Tidy3D/Meep raise-on-setup-error).
+            # skip_preflight=True remains the explicit escape hatch.
+            detail = "\n  - ".join(errors)
+            raise ValueError(
+                f"[{context}] preflight found {len(errors)} blocking error(s) "
+                f"(pass skip_preflight=True to bypass):\n  - {detail}"
+            )
 
     def _run_adi_from_materials(
         self,

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -29,7 +29,12 @@ from rfx.materials.lorentz import init_lorentz  # noqa: F401  (local import in m
 from rfx.adi import ADIState2D, run_adi_2d
 from rfx.boundaries.spec import BoundarySpec  # noqa: F401  (referenced by moved comments)
 from rfx.simulation import SnapshotSpec  # noqa: F401  (run() signature type-hint)
-from rfx.api._spec import ForwardResult, Result, MATERIAL_LIBRARY
+from rfx.api._spec import (
+    ForwardResult,
+    Result,
+    MATERIAL_LIBRARY,
+    _warn_if_nonfinite_result,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -1543,7 +1548,7 @@ class _ExecuteMixin:
         if n_steps is None:
             n_steps = grid.num_timesteps(num_periods=num_periods)
 
-        return self._forward_from_materials(
+        _res = self._forward_from_materials(
             grid,
             materials,
             debye_spec,
@@ -1555,6 +1560,8 @@ class _ExecuteMixin:
             pec_occupancy=pec_occupancy_override,
             port_s11_freqs=port_s11_freqs,
         )
+        _warn_if_nonfinite_result(_res, context="forward")
+        return _res
 
     # ---- run ----
 
@@ -1579,6 +1586,7 @@ class _ExecuteMixin:
         conformal_min_weight: float = 0.1,
         devices: list | None = None,
         exchange_interval: int = 1,
+        skip_preflight: bool = False,
     ) -> Result:
         """Run the simulation.
 
@@ -1663,8 +1671,16 @@ class _ExecuteMixin:
         )
 
         # ---- P0: Pre-simulation validation ----
-        self._validate_mesh_quality()
-        self._validate_simulation_config()
+        # Run the SAME consolidated, skippable preflight that forward() gets
+        # (issue #66 parity): _auto_preflight wraps preflight() — mesh quality,
+        # simulation config AND the NTFF/inverse-design check — into one
+        # UserWarning, and is robust under tracing (it try/except-wraps
+        # preflight). Previously run() called only the mesh + config validators
+        # directly, as scattered raw warnings with no skip_preflight control,
+        # so the documented lumped/wire S-parameter path via
+        # run(compute_s_params=True) silently missed part of the best
+        # proactive error surface in the codebase.
+        self._auto_preflight(skip=skip_preflight, context="run")
 
         if self._solver == "adi" and devices is not None and len(devices) > 1:
             raise ValueError("solver='adi' does not support distributed execution")
@@ -1746,10 +1762,12 @@ class _ExecuteMixin:
                     grid = self._build_grid()
                     n_steps = grid.num_timesteps(num_periods=num_periods)
             from rfx.runners.distributed_v2 import run_distributed
-            return run_distributed(
+            _res = run_distributed(
                 self, n_steps=n_steps, devices=devices,
                 exchange_interval=exchange_interval,
             )
+            _warn_if_nonfinite_result(_res, context="run")
+            return _res
 
         # ---- Non-uniform mesh path ----
         if (self._dz_profile is not None
@@ -1770,13 +1788,15 @@ class _ExecuteMixin:
             if n_steps is None:
                 n_steps = int(np.ceil(
                     num_periods / (self._freq_max * nu_grid.dt)))
-            return self._run_nonuniform(
+            _res = self._run_nonuniform(
                 n_steps=n_steps,
                 compute_s_params=compute_s_params,
                 s_param_freqs=s_param_freqs,
                 subpixel_smoothing=subpixel_smoothing,
                 checkpoint=checkpoint,
             )
+            _warn_if_nonfinite_result(_res, context="run")
+            return _res
 
         grid = self._build_grid()
         base_materials, debye_spec, lorentz_spec, pec_mask, pec_shapes, _, kerr_chi3 = self._assemble_materials(grid)
@@ -1788,7 +1808,7 @@ class _ExecuteMixin:
                 raise ValueError("solver='adi' does not support snapshots yet")
             if n_steps is None:
                 n_steps = grid.num_timesteps(num_periods=num_periods)
-            return self._run_adi_from_materials(
+            _res = self._run_adi_from_materials(
                 grid,
                 base_materials,
                 debye_spec,
@@ -1797,6 +1817,8 @@ class _ExecuteMixin:
                 pec_mask=pec_mask,
                 return_state=True,
             )
+            _warn_if_nonfinite_result(_res, context="run")
+            return _res
 
         # ---- Subgridded path ----
         if self._refinement is not None:
@@ -1819,13 +1841,15 @@ class _ExecuteMixin:
                 subgrid_n_steps = grid.num_timesteps(num_periods=num_periods) * int(
                     self._refinement["ratio"]
                 )
-            return self._run_subgridded(
+            _res = self._run_subgridded(
                 grid, base_materials, pec_mask,
                 n_steps=subgrid_n_steps,
                 compute_s_params=compute_s_params,
                 s_param_freqs=s_param_freqs,
                 s_param_n_steps=s_param_n_steps,
             )
+            _warn_if_nonfinite_result(_res, context="run")
+            return _res
 
         # ---- Uniform path ----
         if n_steps is None:
@@ -1833,7 +1857,7 @@ class _ExecuteMixin:
 
         from rfx.runners.uniform import run_uniform
         _field_dtype = jnp.float16 if self._precision == "mixed" else None
-        return run_uniform(
+        _res = run_uniform(
             self,
             n_steps=n_steps,
             until_decay=until_decay,
@@ -1859,3 +1883,5 @@ class _ExecuteMixin:
             kerr_chi3=kerr_chi3,
             field_dtype=_field_dtype,
         )
+        _warn_if_nonfinite_result(_res, context="run")
+        return _res

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -15,6 +15,7 @@ indentation, decorators, signatures, and logic. ``Simulation`` inherits
 
 from __future__ import annotations
 
+import json
 import math
 
 import jax.numpy as jnp
@@ -25,15 +26,91 @@ from rfx.core.yee import MaterialArrays
 from rfx.core.jax_utils import is_tracer
 
 
-class PreflightErrorWarning(UserWarning):
-    """A preflight finding that is error-severity but emitted as a warning.
+class PreflightWarning(UserWarning):
+    """Base for structured preflight findings carried on the warning instance.
 
-    Emitting (rather than raising) keeps the rest of the preflight suite
-    running so the user sees ALL issues at once, while ``preflight()`` still
-    tags the resulting :class:`PreflightIssue` with ``severity="error"`` so an
-    automation agent can gate on it. Use for known-bad configurations (e.g.
-    the conformal-PEC fine-mesh NaN) that should stop a claims-bearing run.
+    Mirrors the in-repo report idioms (:class:`SubgridValidationIssue`,
+    :class:`PortValidationIssue`): the check site sets a stable lowercase-slug
+    ``code`` and a ``severity`` on the warning instance, plus optional ``loc``
+    (where in the setup the finding applies) and ``source`` (the check method
+    name). ``preflight()`` reads these fields off ``w.message`` so the issue
+    record is coded at the check site rather than inferred from text.
+
+    Emit with ``warnings.warn(PreflightWarning(msg, code="...", source="..."))``.
     """
+
+    def __init__(
+        self,
+        message,
+        *,
+        code: str = "uncoded",
+        severity: str = "warning",
+        loc: str | None = None,
+        source: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = str(message)
+        self.code = code
+        self.severity = severity
+        self.loc = loc
+        self.source = source
+
+    def __str__(self) -> str:  # back-compat: warning prints as its message
+        return self.message
+
+
+class PreflightErrorWarning(PreflightWarning):
+    """An error-severity preflight finding emitted as a warning.
+
+    Re-parented under :class:`PreflightWarning` (Phase A). Emitting (rather than
+    raising) keeps the rest of the preflight suite running so the user sees ALL
+    issues at once, while ``preflight()`` still tags the resulting
+    :class:`PreflightIssue` with ``severity="error"`` so an automation agent can
+    gate on it. Use for known-bad configurations that should stop a run.
+
+    ``severity`` defaults to ``"error"``; the legacy
+    ``warnings.warn("msg", PreflightErrorWarning)`` form (category, no instance
+    attrs) still surfaces as error-severity via ``preflight()``'s
+    ``issubclass(w.category, PreflightErrorWarning)`` derivation.
+    """
+
+    def __init__(
+        self,
+        message,
+        *,
+        code: str = "uncoded",
+        severity: str = "error",
+        loc: str | None = None,
+        source: str | None = None,
+    ) -> None:
+        super().__init__(
+            message, code=code, severity=severity, loc=loc, source=source
+        )
+
+
+class PreflightConfigError(ValueError):
+    """A structurally-impossible-config raise carrying a check-site ``code``.
+
+    The structurally-impossible config validators (``upml``+refinement,
+    Floquet+non-uniform-z, ...) raise this so ``preflight()`` can record the
+    error-severity :class:`PreflightIssue` with the slug set at the check site
+    instead of inferring it from the message. It subclasses ``ValueError`` so
+    every existing ``except ValueError`` / ``pytest.raises(ValueError)`` site
+    (including the run() regression locks) is unaffected.
+    """
+
+    def __init__(
+        self,
+        message,
+        *,
+        code: str = "uncoded",
+        loc: str | None = None,
+        source: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.loc = loc
+        self.source = source
 
 
 class PreflightIssue(str):
@@ -50,48 +127,136 @@ class PreflightIssue(str):
             ...  # stop before spending GPU minutes on a doomed run
 
     ``severity`` is ``"error"`` for hard contradictions / known-bad configs and
-    ``"warning"`` for advisories. ``code`` is a coarse best-effort category slug
-    (e.g. ``"conformal_nan"``, ``"resolution"``, ``"absorber"``) for filtering.
+    ``"warning"`` for advisories. ``code`` is the lowercase-slug category set at
+    the check site (e.g. ``"conformal_nan"``, ``"mesh_resolution"``,
+    ``"absorber_overlap"``). ``loc`` and ``source`` are optional provenance.
+
+    The str subclass silently drops these attrs under ``json.dumps`` — never
+    serialize a :class:`PreflightIssue` directly; use :meth:`to_dict` or the
+    owning :class:`PreflightReport`'s :meth:`PreflightReport.to_dict` /
+    :meth:`PreflightReport.to_json`.
     """
 
     severity: str
     code: str
+    loc: str | None
+    source: str | None
 
-    def __new__(cls, message, *, severity: str = "warning", code: str = "general"):
+    def __new__(
+        cls,
+        message,
+        *,
+        severity: str = "warning",
+        code: str = "uncoded",
+        loc: str | None = None,
+        source: str | None = None,
+    ):
         obj = super().__new__(cls, str(message))
         obj.severity = severity
         obj.code = code
+        obj.loc = loc
+        obj.source = source
         return obj
 
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable, JSON-serializable record of this finding."""
+        return {
+            "message": str(self),
+            "code": self.code,
+            "severity": self.severity,
+            "loc": self.loc,
+            "source": self.source,
+        }
 
-def _preflight_code_for(message: str) -> str:
-    """Best-effort coarse category slug for a preflight message (for agent
-    filtering; not load-bearing). Kept deliberately simple."""
-    m = message.lower()
-    table = (
-        ("conformal", "conformal_nan"),
-        ("artificial q", "lossless_q"),
-        ("lossless", "lossless_q"),
-        ("cells per", "resolution"),
-        ("cells/λ", "resolution"),
-        ("resolution", "resolution"),
-        ("ntff", "ntff"),
-        ("far-field", "ntff"),
-        ("cpml", "absorber"),
-        ("upml", "absorber"),
-        ("absorber", "absorber"),
-        ("pmc", "symmetry"),
-        ("waveguide", "port"),
-        ("msl", "port"),
-        ("port", "port"),
-        ("pec", "pec"),
-        ("memory", "ad_memory"),
-        ("vram", "ad_memory"),
-    )
-    for key, code in table:
-        if key in m:
-            return code
-    return "general"
+
+class PreflightReport(list):
+    """Structured result of :meth:`Simulation.preflight`.
+
+    A ``list`` subclass holding :class:`PreflightIssue` items, so it IS a list
+    and every legacy ``list[str]`` call site (iterate / ``"\\n".join`` / ``len``
+    / truthiness) keeps working unchanged. It also exposes the canonical report
+    API shared with :class:`rfx.validation.PortValidationReport` and
+    :class:`rfx.subgridding.validation.SubgridValidationReport`.
+    """
+
+    @property
+    def issues(self) -> list:
+        """All findings as a plain list (mirrors the other report classes)."""
+        return list(self)
+
+    @property
+    def errors(self) -> list:
+        """Error-severity findings only."""
+        return [i for i in self if getattr(i, "severity", "warning") == "error"]
+
+    @property
+    def warnings(self) -> list:
+        """Non-error (advisory) findings only."""
+        return [i for i in self if getattr(i, "severity", "warning") != "error"]
+
+    @property
+    def ok(self) -> bool:
+        """Whether the report contains no error-severity finding."""
+        return not self.errors
+
+    def by_code(self, code: str) -> list:
+        """Return all findings with diagnostic ``code``."""
+        return [i for i in self if getattr(i, "code", None) == code]
+
+    def format(self) -> str:
+        """Return a compact human-readable multiline summary."""
+        status = "PASS" if self.ok else "FAIL"
+        if not self:
+            return f"preflight: {status} (no issues)"
+        lines = [f"preflight: {status} ({len(self)} issue(s))"]
+        for issue in self:
+            sev = getattr(issue, "severity", "warning")
+            code = getattr(issue, "code", "uncoded")
+            lines.append(f"- {sev.upper()} [{code}] {issue}")
+        return "\n".join(lines)
+
+    def raise_for_failure(self) -> "PreflightReport":
+        """Raise ``ValueError`` listing every error-severity finding.
+
+        Returns ``self`` on success so callers can use it as both a fail-fast
+        gate and an artifact (the R3 pre-VESSL gate). No-op when :attr:`ok`.
+        """
+        errors = self.errors
+        if errors:
+            detail = "\n  - ".join(str(e) for e in errors)
+            raise ValueError(
+                f"preflight found {len(errors)} blocking error(s):\n  - {detail}"
+            )
+        return self
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable, JSON-serializable validation artifact.
+
+        Real serialization (unlike ``json.dumps`` of a bare
+        :class:`PreflightIssue`, which drops the code/severity attrs).
+        """
+        return {
+            "ok": self.ok,
+            "n_issues": len(self),
+            "n_errors": len(self.errors),
+            "issues": [
+                i.to_dict() if isinstance(i, PreflightIssue)
+                else {
+                    "message": str(i),
+                    "code": getattr(i, "code", "uncoded"),
+                    "severity": getattr(i, "severity", "warning"),
+                    "loc": getattr(i, "loc", None),
+                    "source": getattr(i, "source", None),
+                }
+                for i in self
+            ],
+        }
+
+    def to_json(self, **kwargs: object) -> str:
+        """Serialize the report for research-note artifacts."""
+        options = {"indent": 2, "sort_keys": True}
+        options.update(kwargs)
+        return json.dumps(self.to_dict(), **options)
 
 
 class _PreflightMixin:
@@ -365,10 +530,14 @@ class _PreflightMixin:
                     # Zero-thickness geometry
                     axis_name = "xyz"[axis]
                     _w.warn(
-                        f"Zero-thickness geometry '{mat_name}' along "
-                        f"{axis_name}-axis. On non-uniform mesh this may "
-                        f"produce empty rasterization. Consider giving it "
-                        f"at least one cell of thickness ({cell*1e3:.2f}mm).",
+                        PreflightWarning(
+                            f"Zero-thickness geometry '{mat_name}' along "
+                            f"{axis_name}-axis. On non-uniform mesh this may "
+                            f"produce empty rasterization. Consider giving it "
+                            f"at least one cell of thickness ({cell*1e3:.2f}mm).",
+                            code="mesh_resolution",
+                            source="_validate_mesh_quality",
+                        ),
                         stacklevel=3,
                     )
                 elif dim < cell:
@@ -383,9 +552,13 @@ class _PreflightMixin:
                         " Use non-uniform mesh or reduce dx."
                     )
                     _w.warn(
-                        f"'{mat_name}' {axis_name}-extent {dim*1e3:.2f}mm = "
-                        f"{cells_count:.1f} cells — below 1 cell resolution."
-                        + hint,
+                        PreflightWarning(
+                            f"'{mat_name}' {axis_name}-extent {dim*1e3:.2f}mm = "
+                            f"{cells_count:.1f} cells — below 1 cell resolution."
+                            + hint,
+                            code="mesh_resolution",
+                            source="_validate_mesh_quality",
+                        ),
                         stacklevel=3,
                     )
                 else:
@@ -403,10 +576,14 @@ class _PreflightMixin:
                         if (3.0 <= cells < 5.0
                                 and not is_thin_along_some_axis):
                             _w.warn(
-                                f"PEC '{mat_name}' {axis_name}-extent "
-                                f"{dim*1e3:.2f}mm = {cells:.1f} cells — "
-                                "volume under-resolved (PEC volume needs "
-                                "≥5 cells; thin sheets <3 cells are fine).",
+                                PreflightWarning(
+                                    f"PEC '{mat_name}' {axis_name}-extent "
+                                    f"{dim*1e3:.2f}mm = {cells:.1f} cells — "
+                                    "volume under-resolved (PEC volume needs "
+                                    "≥5 cells; thin sheets <3 cells are fine).",
+                                    code="mesh_resolution",
+                                    source="_validate_mesh_quality",
+                                ),
                                 stacklevel=3,
                             )
                     else:
@@ -447,14 +624,18 @@ class _PreflightMixin:
                                 "1st-order convergence at ε interfaces."
                             )
                             _w.warn(
-                                f"dielectric '{mat_name}' on {axis_name}: "
-                                f"{cells_per_lam:.1f} cells per λ_eff "
-                                f"(eps_r={eps_r:.2f}, freq_max="
-                                f"{self._freq_max/1e9:.2f}GHz, "
-                                f"dx={cell*1e3:.3f}mm). Need ≥"
-                                f"{threshold:.0f} cells/λ_eff for "
-                                f"phase-accurate propagation."
-                                f"{suffix}",
+                                PreflightWarning(
+                                    f"dielectric '{mat_name}' on {axis_name}: "
+                                    f"{cells_per_lam:.1f} cells per λ_eff "
+                                    f"(eps_r={eps_r:.2f}, freq_max="
+                                    f"{self._freq_max/1e9:.2f}GHz, "
+                                    f"dx={cell*1e3:.3f}mm). Need ≥"
+                                    f"{threshold:.0f} cells/λ_eff for "
+                                    f"phase-accurate propagation."
+                                    f"{suffix}",
+                                    code="mesh_resolution",
+                                    source="_validate_mesh_quality",
+                                ),
                                 stacklevel=3,
                             )
 
@@ -472,10 +653,14 @@ class _PreflightMixin:
                             cell = [dx, dx, min_dz][ax]
                             if 0 < gap < 3 * cell:
                                 _w.warn(
-                                    f"Gap between PEC structures: "
-                                    f"{gap*1e3:.2f}mm = {gap/cell:.1f} cells "
-                                    f"along {'xyz'[ax]} — coupling may be "
-                                    f"under-resolved.",
+                                    PreflightWarning(
+                                        f"Gap between PEC structures: "
+                                        f"{gap*1e3:.2f}mm = {gap/cell:.1f} cells "
+                                        f"along {'xyz'[ax]} — coupling may be "
+                                        f"under-resolved.",
+                                        code="mesh_resolution",
+                                        source="_validate_mesh_quality",
+                                    ),
                                     stacklevel=3,
                                 )
                     except (NotImplementedError, TypeError, AttributeError):
@@ -544,12 +729,16 @@ class _PreflightMixin:
             )
             worst = max(errors, key=errors.get)
             _w.warn(
-                f"FDTD numerical dispersion at freq_max="
-                f"{self._freq_max/1e9:.2f}GHz exceeds 2%: {parts}. "
-                f"Worst axis: {worst} (cell {d['xyz'.index(worst)]*1e3:.3f}mm). "
-                f"Phase velocity error causes resonance frequency bias. "
-                f"Refine the coarse axis or co-refine all axes together "
-                f"(Taflove Ch. 4).",
+                PreflightWarning(
+                    f"FDTD numerical dispersion at freq_max="
+                    f"{self._freq_max/1e9:.2f}GHz exceeds 2%: {parts}. "
+                    f"Worst axis: {worst} (cell {d['xyz'.index(worst)]*1e3:.3f}mm). "
+                    f"Phase velocity error causes resonance frequency bias. "
+                    f"Refine the coarse axis or co-refine all axes together "
+                    f"(Taflove Ch. 4).",
+                    code="numerical_dispersion",
+                    source="_check_numerical_dispersion",
+                ),
                 stacklevel=4,
             )
 
@@ -609,15 +798,19 @@ class _PreflightMixin:
                 ratio_below = _ratio(dz_below, dz_here)
                 if max(ratio_above, ratio_below) > 1.5:
                     _w.warn(
-                        f"Thin PEC '{entry.material_name}' on axis "
-                        f"{axis_name} sits in a cell of dz={dz_here*1e3:.3f}"
-                        f"mm with asymmetric neighbours "
-                        f"(below {dz_below*1e3:.3f}, above "
-                        f"{dz_above*1e3:.3f} mm). Meep/OpenEMS require "
-                        f"equal cell sizes across a metal plane; "
-                        f"radiation pattern may be corrupted (issue #48). "
-                        f"Put the metal on a preserved-region boundary "
-                        f"or refine the neighbouring cell.",
+                        PreflightWarning(
+                            f"Thin PEC '{entry.material_name}' on axis "
+                            f"{axis_name} sits in a cell of dz={dz_here*1e3:.3f}"
+                            f"mm with asymmetric neighbours "
+                            f"(below {dz_below*1e3:.3f}, above "
+                            f"{dz_above*1e3:.3f} mm). Meep/OpenEMS require "
+                            f"equal cell sizes across a metal plane; "
+                            f"radiation pattern may be corrupted (issue #48). "
+                            f"Put the metal on a preserved-region boundary "
+                            f"or refine the neighbouring cell.",
+                            code="thin_metal_nu_mesh",
+                            source="_validate_thin_metal_on_nu_mesh",
+                        ),
                         stacklevel=4,
                     )
 
@@ -692,15 +885,19 @@ class _PreflightMixin:
                 next_label = (f"TE{mn_next[0]}{mn_next[1]}"
                               if mn_next[0] is not None else "next")
                 _w.warn(
-                    f"Waveguide port '{entry.name}': max measurement frequency "
-                    f"{f_check / 1e9:.3f} GHz exceeds 0.90 × fc_next="
-                    f"{threshold / 1e9:.3f} GHz "
-                    f"(fc_{entry.mode_type}{m0}{n0}={fc_excited / 1e9:.3f} GHz, "
-                    f"fc_{next_label}={fc_next / 1e9:.3f} GHz). "
-                    f"Evanescent {next_label} contamination may exceed 1 % and "
-                    f"registers as |S11| < 1 in a lossless structure. "
-                    f"Restrict measurement freqs below {threshold / 1e9:.3f} GHz "
-                    f"or increase port-to-obstacle distance.",
+                    PreflightWarning(
+                        f"Waveguide port '{entry.name}': max measurement frequency "
+                        f"{f_check / 1e9:.3f} GHz exceeds 0.90 × fc_next="
+                        f"{threshold / 1e9:.3f} GHz "
+                        f"(fc_{entry.mode_type}{m0}{n0}={fc_excited / 1e9:.3f} GHz, "
+                        f"fc_{next_label}={fc_next / 1e9:.3f} GHz). "
+                        f"Evanescent {next_label} contamination may exceed 1 % and "
+                        f"registers as |S11| < 1 in a lossless structure. "
+                        f"Restrict measurement freqs below {threshold / 1e9:.3f} GHz "
+                        f"or increase port-to-obstacle distance.",
+                        code="port_evanescent",
+                        source="_check_waveguide_port_evanescent",
+                    ),
                     stacklevel=4,
                 )
 
@@ -713,7 +910,7 @@ class _PreflightMixin:
         check_ad_memory: bool = False,
         n_steps_for_memory: int | None = None,
         available_memory_gb: float | None = None,
-    ) -> list[str]:
+    ) -> "PreflightReport":
         """Run all pre-simulation checks and return warnings.
 
         Parameters
@@ -738,11 +935,13 @@ class _PreflightMixin:
 
         Returns
         -------
-        list of str
-            Warning messages. Empty if no issues found.
+        PreflightReport
+            A ``list`` subclass of :class:`PreflightIssue` (each a ``str``
+            subclass), back-compatible with the legacy ``list[str]`` return.
+            Empty if no issues found.
         """
         import warnings
-        issues = []
+        issues = PreflightReport()
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
@@ -755,22 +954,41 @@ class _PreflightMixin:
             except ValueError as e:
                 if strict:
                     raise
+                # Structurally-impossible configs raise PreflightConfigError
+                # with the slug set at the check site; any other ValueError is
+                # error-severity but uncoded.
                 issues.append(PreflightIssue(
                     f"ERROR: {e}",
                     severity="error",
-                    code=_preflight_code_for(str(e)),
+                    code=getattr(e, "code", "uncoded"),
+                    loc=getattr(e, "loc", None),
+                    source=getattr(e, "source", None),
                 ))
 
         for w in caught:
             msg = str(w.message)
             if strict:
                 raise ValueError(msg)
-            severity = (
-                "error" if issubclass(w.category, PreflightErrorWarning)
-                else "warning"
-            )
+            # Prefer the structured fields carried on the warning INSTANCE
+            # (PreflightWarning); fall back to the category-derived severity for
+            # the legacy ``warnings.warn(msg, PreflightErrorWarning)`` form, and
+            # to severity="warning"/code="uncoded" for any plain UserWarning.
+            inst = w.message
+            if isinstance(inst, PreflightWarning):
+                severity = inst.severity
+                code = inst.code
+                loc = inst.loc
+                source = inst.source
+            else:
+                severity = (
+                    "error" if issubclass(w.category, PreflightErrorWarning)
+                    else "warning"
+                )
+                code = "uncoded"
+                loc = None
+                source = None
             issues.append(PreflightIssue(
-                msg, severity=severity, code=_preflight_code_for(msg)
+                msg, severity=severity, code=code, loc=loc, source=source
             ))
 
         if check_ad_memory:
@@ -1086,11 +1304,13 @@ class _PreflightMixin:
                         overlap = False
                         break
                 if overlap:
-                    raise ValueError(
+                    raise PreflightConfigError(
                         f"NTFF face {'xyz'[axis]}_{side} at {coord*1e3:.2f}mm "
                         f"intersects PEC geometry '{entry.material_name}' "
                         f"(bbox {c1}–{c2}). NTFF box must enclose all radiators "
-                        f"with no PEC crossing any face. Shrink or move the NTFF box."
+                        f"with no PEC crossing any face. Shrink or move the NTFF box.",
+                        code="ntff_pec_overlap",
+                        source="_validate_ntff_inverse_design",
                     )
 
         # CHECK 3: λ/2 (Huygens) and λ/4 (reactive-near-field) gaps to any
@@ -1162,21 +1382,29 @@ class _PreflightMixin:
 
             if culprit is not None and min_gap < gap_thresh:
                 _w.warn(
-                    f"NTFF face {'xyz'[axis]}_{side} is {min_gap*1e3:.2f}mm "
-                    f"from {culprit} — below λ/4 = {gap_thresh*1e3:.2f}mm at "
-                    f"f_max={f_max/1e9:.2f}GHz. NTFF will integrate reactive "
-                    f"near-field; directivity / pattern likely corrupted. "
-                    f"Move NTFF box ≥ λ/2 from any radiating/scattering "
-                    f"structure (Huygens-equivalence rule).",
+                    PreflightWarning(
+                        f"NTFF face {'xyz'[axis]}_{side} is {min_gap*1e3:.2f}mm "
+                        f"from {culprit} — below λ/4 = {gap_thresh*1e3:.2f}mm at "
+                        f"f_max={f_max/1e9:.2f}GHz. NTFF will integrate reactive "
+                        f"near-field; directivity / pattern likely corrupted. "
+                        f"Move NTFF box ≥ λ/2 from any radiating/scattering "
+                        f"structure (Huygens-equivalence rule).",
+                        code="ntff_near_field",
+                        source="_validate_ntff_inverse_design",
+                    ),
                     stacklevel=3,
                 )
             elif culprit is not None and min_gap < huygens_thresh:
                 _w.warn(
-                    f"NTFF face {'xyz'[axis]}_{side} is {min_gap*1e3:.2f}mm "
-                    f"from {culprit} — below λ/2 = {huygens_thresh*1e3:.2f}mm "
-                    f"at f_max={f_max/1e9:.2f}GHz. Close to reactive near-"
-                    f"field; far-field pattern accuracy may degrade. Move "
-                    f"NTFF box ≥ λ/2 from radiating/scattering structures.",
+                    PreflightWarning(
+                        f"NTFF face {'xyz'[axis]}_{side} is {min_gap*1e3:.2f}mm "
+                        f"from {culprit} — below λ/2 = {huygens_thresh*1e3:.2f}mm "
+                        f"at f_max={f_max/1e9:.2f}GHz. Close to reactive near-"
+                        f"field; far-field pattern accuracy may degrade. Move "
+                        f"NTFF box ≥ λ/2 from radiating/scattering structures.",
+                        code="ntff_near_field",
+                        source="_validate_ntff_inverse_design",
+                    ),
                     stacklevel=3,
                 )
 
@@ -1281,13 +1509,18 @@ class _PreflightMixin:
             # will hard-fail (XPASS) to force this removal. See
             # docs/agent-memory/rfx-known-issues.md (conformal-PEC item).
             _w.warn(
-                f"conformal PEC is enabled on faces {sorted(cf)} with a min "
-                f"cell size {min_cell * 1e3:.3f} mm <= 2 mm — this is a KNOWN "
-                f"NaN (discrete-adjointness break, not CFL; 4 fix methods "
-                f"falsified — see docs/agent-memory/rfx-known-issues.md). "
-                f"normalize=False is NOT a safe workaround at fine dx. Use "
-                f"conformal=False (staircase PEC) or a coarser mesh "
-                f"(dx > 2 mm) until the contour-FIT redesign lands.",
+                PreflightWarning(
+                    f"conformal PEC is enabled on faces {sorted(cf)} with a min "
+                    f"cell size {min_cell * 1e3:.3f} mm <= 2 mm — this is a KNOWN "
+                    f"NaN (discrete-adjointness break, not CFL; 4 fix methods "
+                    f"falsified — see docs/agent-memory/rfx-known-issues.md). "
+                    f"normalize=False is NOT a safe workaround at fine dx. Use "
+                    f"conformal=False (staircase PEC) or a coarser mesh "
+                    f"(dx > 2 mm) until the contour-FIT redesign lands.",
+                    code="conformal_nan",
+                    severity="warning",
+                    source="_validate_cfg_conformal_fine_dx",
+                ),
                 stacklevel=2,
             )
 
@@ -1343,12 +1576,16 @@ class _PreflightMixin:
         if lossless_names and not any_lossy_dielectric:
             uniq = sorted(set(lossless_names))
             _w.warn(
-                f"all dielectric(s) {uniq} are perfectly lossless in an open "
-                f"({self._boundary.upper()}) domain. If you are measuring "
-                f"Q / resonance, this gives an ARTIFICIALLY infinite Q "
-                f"(design-guide Anti-Pattern #1, an R5 surface-metric trap) — "
-                f"add loss, e.g. sigma = 2*pi*f*eps0*eps_r*tan_delta. "
-                f"(Harmless if you are not measuring Q.)",
+                PreflightWarning(
+                    f"all dielectric(s) {uniq} are perfectly lossless in an open "
+                    f"({self._boundary.upper()}) domain. If you are measuring "
+                    f"Q / resonance, this gives an ARTIFICIALLY infinite Q "
+                    f"(design-guide Anti-Pattern #1, an R5 surface-metric trap) — "
+                    f"add loss, e.g. sigma = 2*pi*f*eps0*eps_r*tan_delta. "
+                    f"(Harmless if you are not measuring Q.)",
+                    code="lossless_q",
+                    source="_validate_cfg_lossless_resonator_in_absorber",
+                ),
                 stacklevel=2,
             )
 
@@ -1406,27 +1643,37 @@ class _PreflightMixin:
             if has_finite_pec:
                 pec_face_list = ", ".join(sorted(self._pec_faces))
                 _w.warn(
-                    f"pec_faces={{{pec_face_list}}} creates an INFINITE PEC "
-                    f"boundary AND the geometry contains finite PEC objects. "
-                    f"For antennas or finite-GP structures, the pec_faces "
-                    f"boundary makes the ground plane cover the entire domain "
-                    f"face, which changes the physics (cavity vs radiating "
-                    f"antenna). If you need a finite ground plane, remove "
-                    f"pec_faces and use an explicit PEC Box instead.",
+                    PreflightWarning(
+                        f"pec_faces={{{pec_face_list}}} creates an INFINITE PEC "
+                        f"boundary AND the geometry contains finite PEC objects. "
+                        f"For antennas or finite-GP structures, the pec_faces "
+                        f"boundary makes the ground plane cover the entire domain "
+                        f"face, which changes the physics (cavity vs radiating "
+                        f"antenna). If you need a finite ground plane, remove "
+                        f"pec_faces and use an explicit PEC Box instead.",
+                        code="pec_faces_finite_pec",
+                        source="_validate_cfg_pec_faces_with_finite_pec",
+                    ),
                     stacklevel=3,
                 )
 
     def _validate_cfg_upml_refinement(self) -> None:
         """UPML boundary does not support subgridding/refinement."""
         if self._boundary == "upml" and self._refinement is not None:
-            raise ValueError("boundary='upml' does not support subgridding/refinement")
+            raise PreflightConfigError(
+                "boundary='upml' does not support subgridding/refinement",
+                code="upml_refinement",
+                source="_validate_cfg_upml_refinement",
+            )
 
     def _validate_cfg_floquet_nonuniform(self) -> None:
         """P1.1: Floquet + non-uniform mesh — no silent fallback allowed."""
         if self._floquet_ports and self._dz_profile is not None:
-            raise ValueError(
+            raise PreflightConfigError(
                 "Floquet ports do not support non-uniform z mesh (dz_profile). "
-                "Use the uniform reference lane and set dx explicitly."
+                "Use the uniform reference lane and set dx explicitly.",
+                code="floquet_nonuniform",
+                source="_validate_cfg_floquet_nonuniform",
             )
 
     def _validate_cfg_absorber_placement(
@@ -1448,10 +1695,14 @@ class _PreflightMixin:
                     ct_hi = cpml_thick_hi[ax_i]
                     if coord < ct_lo * 0.5 or coord > domain_extent - ct_hi * 0.5:
                         _w.warn(
-                            f"Probe at {pos} is near/inside {absorber_label} region "
-                            f"({absorber_label} {'xyz'[ax]}-thickness: "
-                            f"lo={ct_lo*1e3:.1f}mm, hi={ct_hi*1e3:.1f}mm). "
-                            f"Signal will be attenuated. Move probe to interior.",
+                            PreflightWarning(
+                                f"Probe at {pos} is near/inside {absorber_label} region "
+                                f"({absorber_label} {'xyz'[ax]}-thickness: "
+                                f"lo={ct_lo*1e3:.1f}mm, hi={ct_hi*1e3:.1f}mm). "
+                                f"Signal will be attenuated. Move probe to interior.",
+                                code="absorber_overlap",
+                                source="_validate_cfg_absorber_placement",
+                            ),
                             stacklevel=3,
                         )
                         break
@@ -1465,10 +1716,14 @@ class _PreflightMixin:
                     ct_hi = cpml_thick_hi[ax_i]
                     if coord < ct_lo * 0.5 or coord > domain_extent - ct_hi * 0.5:
                         _w.warn(
-                            f"Source/port at {pos} is near/inside {absorber_label} region "
-                            f"({absorber_label} {'xyz'[ax]}-thickness: "
-                            f"lo={ct_lo*1e3:.1f}mm, hi={ct_hi*1e3:.1f}mm). "
-                            f"Energy will be absorbed. Move source to interior.",
+                            PreflightWarning(
+                                f"Source/port at {pos} is near/inside {absorber_label} region "
+                                f"({absorber_label} {'xyz'[ax]}-thickness: "
+                                f"lo={ct_lo*1e3:.1f}mm, hi={ct_hi*1e3:.1f}mm). "
+                                f"Energy will be absorbed. Move source to interior.",
+                                code="absorber_overlap",
+                                source="_validate_cfg_absorber_placement",
+                            ),
                             stacklevel=3,
                         )
                         break
@@ -1578,7 +1833,14 @@ class _PreflightMixin:
                         else:
                             msg = None      # tangential H or normal E on PEC is legit
                     if msg is not None:
-                        _w.warn(msg, stacklevel=3)
+                        _w.warn(
+                            PreflightWarning(
+                                msg,
+                                code="source_decoupled",
+                                source="_validate_cfg_source_on_reflector_plane",
+                            ),
+                            stacklevel=3,
+                        )
 
     def _validate_cfg_ntff_absorber_overlap(
         self,
@@ -1598,9 +1860,13 @@ class _PreflightMixin:
                 ct_hi = cpml_thick_hi[ax_i]
                 if corner_lo[ax] < ct_lo or corner_hi[ax] > domain_ext - ct_hi:
                     _w.warn(
-                        f"NTFF box extends into {absorber_label} region along "
-                        f"{'xyz'[ax]}-axis. Far-field results will be "
-                        f"corrupted. Shrink NTFF box to interior.",
+                        PreflightWarning(
+                            f"NTFF box extends into {absorber_label} region along "
+                            f"{'xyz'[ax]}-axis. Far-field results will be "
+                            f"corrupted. Shrink NTFF box to interior.",
+                            code="absorber_overlap",
+                            source="_validate_cfg_ntff_absorber_overlap",
+                        ),
                         stacklevel=3,
                     )
                     break
@@ -1687,11 +1953,15 @@ class _PreflightMixin:
                                       and not intentional_hi)
                             if lo_hit or hi_hit:
                                 _w.warn(
-                                    f"Material '{entry.material_name}' extends "
-                                    f"into CPML region along {'xyz'[ax]}-axis. "
-                                    f"{absorber_label} modifies field updates — "
-                                    f"geometry inside the absorber is physically "
-                                    f"meaningless (issue #61).",
+                                    PreflightWarning(
+                                        f"Material '{entry.material_name}' extends "
+                                        f"into CPML region along {'xyz'[ax]}-axis. "
+                                        f"{absorber_label} modifies field updates — "
+                                        f"geometry inside the absorber is physically "
+                                        f"meaningless (issue #61).",
+                                        code="geometry_in_absorber",
+                                        source="_validate_cfg_geometry_in_cpml",
+                                    ),
                                     stacklevel=3,
                                 )
                                 break
@@ -1728,9 +1998,13 @@ class _PreflightMixin:
                             if is_h_component and is_thin_pec:
                                 continue
                             _w.warn(
-                                f"Port/source at {pos} is inside PEC geometry "
-                                f"'{entry.material_name}'. Field will be zero. "
-                                f"Move source outside PEC.",
+                                PreflightWarning(
+                                    f"Port/source at {pos} is inside PEC geometry "
+                                    f"'{entry.material_name}'. Field will be zero. "
+                                    f"Move source outside PEC.",
+                                    code="port_in_pec",
+                                    source="_validate_cfg_port_inside_pec",
+                                ),
                                 stacklevel=3,
                             )
                     except (NotImplementedError, TypeError):
@@ -1810,13 +2084,17 @@ class _PreflightMixin:
             if has_adjacent_pec:
                 continue
             _w.warn(
-                f"Single-cell port at {pos} ({pe.component}) sits inside "
-                f"dielectric '{enclosing_name}' (eps_r={enclosing_eps_r:.2f}) "
-                f"with no adjacent PEC along the {pe.component[1]}-axis. A "
-                f"floating single-cell port inside substrate does not "
-                f"couple to patch-antenna TM modes. Pass "
-                f"extent=<substrate_height> to create a WirePort spanning "
-                f"ground → patch plane (issue #71).",
+                PreflightWarning(
+                    f"Single-cell port at {pos} ({pe.component}) sits inside "
+                    f"dielectric '{enclosing_name}' (eps_r={enclosing_eps_r:.2f}) "
+                    f"with no adjacent PEC along the {pe.component[1]}-axis. A "
+                    f"floating single-cell port inside substrate does not "
+                    f"couple to patch-antenna TM modes. Pass "
+                    f"extent=<substrate_height> to create a WirePort spanning "
+                    f"ground → patch plane (issue #71).",
+                    code="floating_port",
+                    source="_validate_cfg_floating_single_cell_port",
+                ),
                 stacklevel=3,
             )
 
@@ -1824,9 +2102,13 @@ class _PreflightMixin:
         """P0.4: PEC boundary on likely open structure."""
         if self._boundary == "pec" and self._ntff is not None:
             _w.warn(
-                "PEC boundary with NTFF far-field: PEC reflects all energy "
-                "back into domain. Use boundary='cpml' or boundary='upml' for open structures "
-                "(antennas, scatterers).",
+                PreflightWarning(
+                    "PEC boundary with NTFF far-field: PEC reflects all energy "
+                    "back into domain. Use boundary='cpml' or boundary='upml' for open structures "
+                    "(antennas, scatterers).",
+                    code="pec_boundary_open",
+                    source="_validate_cfg_pec_boundary_open_structure",
+                ),
                 stacklevel=3,
             )
 
@@ -1840,8 +2122,12 @@ class _PreflightMixin:
             and not self._msl_ports
         ):
             _w.warn(
-                "No sources, ports, TFSF, or waveguide/Floquet/MSL ports configured. "
-                "Simulation will produce zero fields.",
+                PreflightWarning(
+                    "No sources, ports, TFSF, or waveguide/Floquet/MSL ports configured. "
+                    "Simulation will produce zero fields.",
+                    code="no_sources",
+                    source="_validate_cfg_no_sources",
+                ),
                 stacklevel=3,
             )
 
@@ -1857,15 +2143,19 @@ class _PreflightMixin:
             # aux (resp. nonuniform 2D aux) and are deferred.
             if self._tfsf is not None:
                 if self._tfsf.direction in ("+z", "-z"):
-                    raise ValueError(
+                    raise PreflightConfigError(
                         "TFSF z-directed incidence is not yet supported on "
                         "nonuniform z mesh. Axis-aligned incidence along x "
-                        "(direction='+x' or '-x') is supported."
+                        "(direction='+x' or '-x') is supported.",
+                        code="nonuniform_tfsf",
+                        source="_validate_cfg_nonuniform_limitations",
                     )
                 if abs(self._tfsf.angle_deg) > 0.01:
-                    raise ValueError(
+                    raise PreflightConfigError(
                         "TFSF oblique incidence is not yet supported on "
-                        "nonuniform z mesh. Use angle_deg=0."
+                        "nonuniform z mesh. Use angle_deg=0.",
+                        code="nonuniform_tfsf",
+                        source="_validate_cfg_nonuniform_limitations",
                     )
 
             # P2.6: CPML z-thickness on non-uniform mesh.
@@ -1876,11 +2166,15 @@ class _PreflightMixin:
                 cpml_z_thick = sum(float(d) for d in self._dz_profile[:self._cpml_layers])
                 if cpml_z_thick < cpml_thickness * 0.3:
                     _w.warn(
-                        f"CPML z-thickness is {cpml_z_thick*1e3:.1f}mm "
-                        f"({self._cpml_layers} cells), much thinner than "
-                        f"xy-thickness {cpml_thickness*1e3:.1f}mm. "
-                        f"Absorbing performance may be asymmetric. "
-                        f"Consider more z cells or fewer CPML layers.",
+                        PreflightWarning(
+                            f"CPML z-thickness is {cpml_z_thick*1e3:.1f}mm "
+                            f"({self._cpml_layers} cells), much thinner than "
+                            f"xy-thickness {cpml_thickness*1e3:.1f}mm. "
+                            f"Absorbing performance may be asymmetric. "
+                            f"Consider more z cells or fewer CPML layers.",
+                            code="nonuniform_cpml_thin",
+                            source="_validate_cfg_nonuniform_limitations",
+                        ),
                         stacklevel=3,
                     )
 
@@ -1894,30 +2188,50 @@ class _PreflightMixin:
         if self._refinement is not None:
             if self._dft_planes:
                 _w.warn(
-                    "DFT plane probes are not supported with SBP-SAT "
-                    "subgridding.",
+                    PreflightWarning(
+                        "DFT plane probes are not supported with SBP-SAT "
+                        "subgridding.",
+                        code="subgrid_unsupported_feature",
+                        source="_validate_cfg_subgrid_limitations",
+                    ),
                     stacklevel=3,
                 )
             if self._waveguide_ports:
                 _w.warn(
-                    "Waveguide ports are not supported with SBP-SAT "
-                    "subgridding.",
+                    PreflightWarning(
+                        "Waveguide ports are not supported with SBP-SAT "
+                        "subgridding.",
+                        code="subgrid_unsupported_feature",
+                        source="_validate_cfg_subgrid_limitations",
+                    ),
                     stacklevel=3,
                 )
             if self._floquet_ports:
                 _w.warn(
-                    "Floquet ports are not supported with SBP-SAT subgridding.",
+                    PreflightWarning(
+                        "Floquet ports are not supported with SBP-SAT subgridding.",
+                        code="subgrid_unsupported_feature",
+                        source="_validate_cfg_subgrid_limitations",
+                    ),
                     stacklevel=3,
                 )
             if self._tfsf is not None:
                 _w.warn(
-                    "TFSF source is not supported with SBP-SAT subgridding.",
+                    PreflightWarning(
+                        "TFSF source is not supported with SBP-SAT subgridding.",
+                        code="subgrid_unsupported_feature",
+                        source="_validate_cfg_subgrid_limitations",
+                    ),
                     stacklevel=3,
                 )
             if self._lumped_rlc:
                 _w.warn(
-                    "Lumped RLC elements are not supported with SBP-SAT "
-                    "subgridding.",
+                    PreflightWarning(
+                        "Lumped RLC elements are not supported with SBP-SAT "
+                        "subgridding.",
+                        code="subgrid_unsupported_feature",
+                        source="_validate_cfg_subgrid_limitations",
+                    ),
                     stacklevel=3,
                 )
 
@@ -1959,21 +2273,27 @@ class _PreflightMixin:
                 effective = (entry.reference_plane if entry.reference_plane is not None
                              else entry.x_position)
                 if effective < 0 or effective > domain_ext:
-                    raise ValueError(
+                    raise PreflightConfigError(
                         f"waveguide_port reference plane = {effective:.4g} m is "
                         f"outside the {direction[-1]}-domain [0, {domain_ext:.4g}] m. "
-                        f"Check x_position / reference_plane."
+                        f"Check x_position / reference_plane.",
+                        code="waveguide_reference_plane",
+                        source="_validate_cfg_waveguide_reference_plane",
                     )
                 if effective < ct_lo or effective > domain_ext - ct_hi:
                     _w.warn(
-                        f"waveguide_port reference plane = {effective*1e3:.3g} mm is "
-                        f"inside the CPML absorbing region along the "
-                        f"{direction[-1]}-axis (CPML extent: "
-                        f"[0, {ct_lo*1e3:.3g}] and "
-                        f"[{(domain_ext - ct_hi)*1e3:.3g}, {domain_ext*1e3:.3g}] mm). "
-                        f"S-matrix phase will be distorted by CPML stretching. "
-                        f"Move x_position / reference_plane to the interior or "
-                        f"reduce cpml_layers.",
+                        PreflightWarning(
+                            f"waveguide_port reference plane = {effective*1e3:.3g} mm is "
+                            f"inside the CPML absorbing region along the "
+                            f"{direction[-1]}-axis (CPML extent: "
+                            f"[0, {ct_lo*1e3:.3g}] and "
+                            f"[{(domain_ext - ct_hi)*1e3:.3g}, {domain_ext*1e3:.3g}] mm). "
+                            f"S-matrix phase will be distorted by CPML stretching. "
+                            f"Move x_position / reference_plane to the interior or "
+                            f"reduce cpml_layers.",
+                            code="waveguide_reference_plane",
+                            source="_validate_cfg_waveguide_reference_plane",
+                        ),
                         stacklevel=3,
                     )
                 # Device overlap warning: check if any geometry box spans
@@ -1986,14 +2306,18 @@ class _PreflightMixin:
                             continue
                         if lo[ax_i] <= effective <= hi[ax_i]:
                             _w.warn(
-                                f"waveguide_port reference plane at "
-                                f"{effective*1e3:.3g} mm intersects geometry "
-                                f"'{getattr(g, 'material', '?')}' "
-                                f"(bounds {lo[ax_i]*1e3:.3g}–{hi[ax_i]*1e3:.3g} mm "
-                                f"on {direction[-1]}). Modal decomposition "
-                                f"assumes a uniform cross-section at the port "
-                                f"plane; reported S-params will mix modes. Move "
-                                f"the reference plane into the empty-guide region.",
+                                PreflightWarning(
+                                    f"waveguide_port reference plane at "
+                                    f"{effective*1e3:.3g} mm intersects geometry "
+                                    f"'{getattr(g, 'material', '?')}' "
+                                    f"(bounds {lo[ax_i]*1e3:.3g}–{hi[ax_i]*1e3:.3g} mm "
+                                    f"on {direction[-1]}). Modal decomposition "
+                                    f"assumes a uniform cross-section at the port "
+                                    f"plane; reported S-params will mix modes. Move "
+                                    f"the reference plane into the empty-guide region.",
+                                    code="waveguide_reference_plane",
+                                    source="_validate_cfg_waveguide_reference_plane",
+                                ),
                                 stacklevel=3,
                             )
                             break
@@ -2053,14 +2377,18 @@ class _PreflightMixin:
                 if c < recommended:
                     pct = max(0.0, (1.0 - c / recommended)) * 15.0
                     _w.warn(
-                        f"MSL port '{pe.name}' (trace W={w_trace*1e6:.0f}µm, "
-                        f"h_sub={h_sub*1e6:.0f}µm): lateral clearance to "
-                        f"{side} absorbing boundary = {c*1e6:.0f}µm < "
-                        f"recommended {recommended*1e6:.0f}µm (= 2·h_sub). "
-                        f"Fringing field will be clipped → Z0 may be biased "
-                        f"HIGH by ~{pct:.0f}%, mesh-conv may diverge. "
-                        f"Increase domain y-extent OR move port further from "
-                        f"sidewall.",
+                        PreflightWarning(
+                            f"MSL port '{pe.name}' (trace W={w_trace*1e6:.0f}µm, "
+                            f"h_sub={h_sub*1e6:.0f}µm): lateral clearance to "
+                            f"{side} absorbing boundary = {c*1e6:.0f}µm < "
+                            f"recommended {recommended*1e6:.0f}µm (= 2·h_sub). "
+                            f"Fringing field will be clipped → Z0 may be biased "
+                            f"HIGH by ~{pct:.0f}%, mesh-conv may diverge. "
+                            f"Increase domain y-extent OR move port further from "
+                            f"sidewall.",
+                            code="msl_port_geometry",
+                            source="_check_msl_port_geometry",
+                        ),
                         stacklevel=3,
                     )
 
@@ -2068,12 +2396,16 @@ class _PreflightMixin:
             n_z_sub = max(1, int(round(h_sub / dx)))
             if n_z_sub < 4:
                 _w.warn(
-                    f"MSL port '{pe.name}': only {n_z_sub} substrate cell(s) "
-                    f"in z (h_sub={h_sub*1e6:.0f}µm, dx={dx*1e6:.0f}µm). "
-                    f"Yee staircase at dielectric interface is O(dx) — "
-                    f"Z0 staircase error >5% expected. Refine to dx ≤ "
-                    f"{h_sub*1e6/4:.0f}µm (4+ substrate cells) for "
-                    f"<5% Z0 bias.",
+                    PreflightWarning(
+                        f"MSL port '{pe.name}': only {n_z_sub} substrate cell(s) "
+                        f"in z (h_sub={h_sub*1e6:.0f}µm, dx={dx*1e6:.0f}µm). "
+                        f"Yee staircase at dielectric interface is O(dx) — "
+                        f"Z0 staircase error >5% expected. Refine to dx ≤ "
+                        f"{h_sub*1e6/4:.0f}µm (4+ substrate cells) for "
+                        f"<5% Z0 bias.",
+                        code="msl_port_geometry",
+                        source="_check_msl_port_geometry",
+                    ),
                     stacklevel=3,
                 )
 
@@ -2098,17 +2430,21 @@ class _PreflightMixin:
                 dx_low = h_sub / n_above   # frac=0
                 dx_high = h_sub / n_below  # frac=0
                 _w.warn(
-                    f"MSL port '{pe.name}': h_sub/dx = "
-                    f"{h_sub/dx:.3f} (fractional part {frac:.3f}) lands "
-                    f"in the [0.10, 0.40] mixed-cell danger zone. The "
-                    f"substrate-air interface bisects the same Yee cell "
-                    f"that holds the trace; AD-traceable "
-                    f"``pec_occupancy_override`` zeros the whole cell "
-                    f"and produces unphysical |S21|² > 1 in this regime. "
-                    f"Hard ``Box(material='pec')`` is unaffected. To "
-                    f"snap onto a safe alignment, set dx = "
-                    f"{dx_low*1e6:.1f}µm (= h_sub/{n_above}) or "
-                    f"{dx_high*1e6:.1f}µm (= h_sub/{n_below}).",
+                    PreflightWarning(
+                        f"MSL port '{pe.name}': h_sub/dx = "
+                        f"{h_sub/dx:.3f} (fractional part {frac:.3f}) lands "
+                        f"in the [0.10, 0.40] mixed-cell danger zone. The "
+                        f"substrate-air interface bisects the same Yee cell "
+                        f"that holds the trace; AD-traceable "
+                        f"``pec_occupancy_override`` zeros the whole cell "
+                        f"and produces unphysical |S21|² > 1 in this regime. "
+                        f"Hard ``Box(material='pec')`` is unaffected. To "
+                        f"snap onto a safe alignment, set dx = "
+                        f"{dx_low*1e6:.1f}µm (= h_sub/{n_above}) or "
+                        f"{dx_high*1e6:.1f}µm (= h_sub/{n_below}).",
+                        code="msl_port_geometry",
+                        source="_check_msl_port_geometry",
+                    ),
                     stacklevel=3,
                 )
 
@@ -2121,12 +2457,16 @@ class _PreflightMixin:
             )
             if x_clearance < recommended:
                 _w.warn(
-                    f"MSL port '{pe.name}' at x={x_feed*1e3:.2f}mm, "
-                    f"direction={pe.direction!r}: distance to nearest "
-                    f"x-CPML = {x_clearance*1e6:.0f}µm < recommended "
-                    f"{recommended*1e6:.0f}µm (= 2·h_sub). Source-side "
-                    f"CPML reflection may inflate |S11|. Move port further "
-                    f"from boundary OR increase domain x-extent.",
+                    PreflightWarning(
+                        f"MSL port '{pe.name}' at x={x_feed*1e3:.2f}mm, "
+                        f"direction={pe.direction!r}: distance to nearest "
+                        f"x-CPML = {x_clearance*1e6:.0f}µm < recommended "
+                        f"{recommended*1e6:.0f}µm (= 2·h_sub). Source-side "
+                        f"CPML reflection may inflate |S11|. Move port further "
+                        f"from boundary OR increase domain x-extent.",
+                        code="msl_port_geometry",
+                        source="_check_msl_port_geometry",
+                    ),
                     stacklevel=3,
                 )
 
@@ -2216,18 +2556,22 @@ class _PreflightMixin:
 
             if nearest_d < min_probe_clear and nearest_label is not None:
                 _w.warn(
-                    f"MSL port '{pe.name}' (direction={pe.direction!r}): "
-                    f"3-probe V₃ at x={x_v3*1e3:.2f}mm sits {nearest_d*1e6:.0f}µm "
-                    f"from a strong reflector ({nearest_label}); recommended "
-                    f"≥ {min_probe_clear*1e6:.0f}µm "
-                    f"(= λ_g/4 at f_max with ε_eff_proxy={EPS_EFF_PROXY:.1f}). "
-                    f"Standing-wave content at the probes will bias "
-                    f"`compute_msl_s_matrix`'s Z₀ extraction and |S11|@notch — "
-                    f"physical |S11|→1 at a quarter-wave open stub may read "
-                    f"as -5 to -10 dB instead of 0 dB.  Mitigation: "
-                    f"extend L_LINE so the line between port and reflector "
-                    f"is ≥ λ_g/2, OR bump n_probe_offset on add_msl_port to "
-                    f"push V₃ further into a clean travelling-wave region.",
+                    PreflightWarning(
+                        f"MSL port '{pe.name}' (direction={pe.direction!r}): "
+                        f"3-probe V₃ at x={x_v3*1e3:.2f}mm sits {nearest_d*1e6:.0f}µm "
+                        f"from a strong reflector ({nearest_label}); recommended "
+                        f"≥ {min_probe_clear*1e6:.0f}µm "
+                        f"(= λ_g/4 at f_max with ε_eff_proxy={EPS_EFF_PROXY:.1f}). "
+                        f"Standing-wave content at the probes will bias "
+                        f"`compute_msl_s_matrix`'s Z₀ extraction and |S11|@notch — "
+                        f"physical |S11|→1 at a quarter-wave open stub may read "
+                        f"as -5 to -10 dB instead of 0 dB.  Mitigation: "
+                        f"extend L_LINE so the line between port and reflector "
+                        f"is ≥ λ_g/2, OR bump n_probe_offset on add_msl_port to "
+                        f"push V₃ further into a clean travelling-wave region.",
+                        code="msl_port_geometry",
+                        source="_check_msl_port_geometry",
+                    ),
                     stacklevel=3,
                 )
 

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -25,6 +25,75 @@ from rfx.core.yee import MaterialArrays
 from rfx.core.jax_utils import is_tracer
 
 
+class PreflightErrorWarning(UserWarning):
+    """A preflight finding that is error-severity but emitted as a warning.
+
+    Emitting (rather than raising) keeps the rest of the preflight suite
+    running so the user sees ALL issues at once, while ``preflight()`` still
+    tags the resulting :class:`PreflightIssue` with ``severity="error"`` so an
+    automation agent can gate on it. Use for known-bad configurations (e.g.
+    the conformal-PEC fine-mesh NaN) that should stop a claims-bearing run.
+    """
+
+
+class PreflightIssue(str):
+    """One preflight finding.
+
+    Subclasses ``str`` so it is 100% back-compatible with the plain
+    ``list[str]`` that ``preflight()`` has always returned — it prints, joins,
+    compares, and regex-matches exactly like its message — while also carrying
+    machine-readable fields so an automation agent can gate deterministically::
+
+        report = sim.preflight()
+        errors = [i for i in report if i.severity == "error"]
+        if errors:
+            ...  # stop before spending GPU minutes on a doomed run
+
+    ``severity`` is ``"error"`` for hard contradictions / known-bad configs and
+    ``"warning"`` for advisories. ``code`` is a coarse best-effort category slug
+    (e.g. ``"conformal_nan"``, ``"resolution"``, ``"absorber"``) for filtering.
+    """
+
+    severity: str
+    code: str
+
+    def __new__(cls, message, *, severity: str = "warning", code: str = "general"):
+        obj = super().__new__(cls, str(message))
+        obj.severity = severity
+        obj.code = code
+        return obj
+
+
+def _preflight_code_for(message: str) -> str:
+    """Best-effort coarse category slug for a preflight message (for agent
+    filtering; not load-bearing). Kept deliberately simple."""
+    m = message.lower()
+    table = (
+        ("conformal", "conformal_nan"),
+        ("artificial q", "lossless_q"),
+        ("lossless", "lossless_q"),
+        ("cells per", "resolution"),
+        ("cells/λ", "resolution"),
+        ("resolution", "resolution"),
+        ("ntff", "ntff"),
+        ("far-field", "ntff"),
+        ("cpml", "absorber"),
+        ("upml", "absorber"),
+        ("absorber", "absorber"),
+        ("pmc", "symmetry"),
+        ("waveguide", "port"),
+        ("msl", "port"),
+        ("port", "port"),
+        ("pec", "pec"),
+        ("memory", "ad_memory"),
+        ("vram", "ad_memory"),
+    )
+    for key, code in table:
+        if key in m:
+            return code
+    return "general"
+
+
 class _PreflightMixin:
     """Preflight / validation methods mixed into :class:`Simulation`."""
 
@@ -686,13 +755,23 @@ class _PreflightMixin:
             except ValueError as e:
                 if strict:
                     raise
-                issues.append(f"ERROR: {e}")
+                issues.append(PreflightIssue(
+                    f"ERROR: {e}",
+                    severity="error",
+                    code=_preflight_code_for(str(e)),
+                ))
 
         for w in caught:
             msg = str(w.message)
             if strict:
                 raise ValueError(msg)
-            issues.append(msg)
+            severity = (
+                "error" if issubclass(w.category, PreflightErrorWarning)
+                else "warning"
+            )
+            issues.append(PreflightIssue(
+                msg, severity=severity, code=_preflight_code_for(msg)
+            ))
 
         if check_ad_memory:
             if n_steps_for_memory is None:
@@ -705,7 +784,9 @@ class _PreflightMixin:
                 msg = est.warning
                 if strict:
                     raise ValueError(msg)
-                issues.append(msg)
+                issues.append(PreflightIssue(
+                    msg, severity="warning", code="ad_memory"
+                ))
 
         if issues:
             for iss in issues:
@@ -1147,12 +1228,119 @@ class _PreflightMixin:
         self._validate_cfg_no_sources(_w)
         self._validate_cfg_nonuniform_limitations(_w, cpml_thickness)
         self._validate_cfg_subgrid_limitations(_w)
+        self._validate_cfg_conformal_fine_dx(dx)
+        self._validate_cfg_lossless_resonator_in_absorber(_w)
         self._validate_cfg_waveguide_reference_plane(
             _w, cpml_thick_lo, cpml_thick_hi
         )
 
         self._check_waveguide_port_evanescent()
         self._check_msl_port_geometry(dx, cpml_thick_lo, cpml_thick_hi)
+
+    def _validate_cfg_conformal_fine_dx(self, dx: float) -> None:
+        """Flag the KNOWN conformal-PEC fine-mesh NaN before it wastes a run.
+
+        ``Boundary(conformal=True)`` / conformal faces at a min cell size
+        <= ~2 mm drives the field to NaN. Root cause is a discrete-adjointness
+        break (the E-update-only ``eps_eff=eps/w`` makes the update operator
+        non-SPSD), NOT a CFL issue — reducing dt does not cure it, and four fix
+        methods are falsified (see docs/agent-memory/rfx-known-issues.md, the
+        conformal-PEC item). ``normalize=False`` is NOT a safe workaround.
+        Surfacing this at preflight converts a silent-NaN GPU run into an
+        instant redirect. Emitted as :class:`PreflightErrorWarning` (error
+        severity) so an agent can gate on it without it masking other checks.
+        """
+        spec = getattr(self, "_boundary_spec", None)
+        if spec is None or not hasattr(spec, "conformal_faces"):
+            return
+        try:
+            cf = spec.conformal_faces()
+        except Exception:
+            return
+        if not cf:
+            return
+        cells = [
+            c for c in (
+                self._dx,
+                getattr(self, "_dy", None),
+                getattr(self, "_dz", None),
+            )
+            if c
+        ]
+        min_cell = min(cells) if cells else dx
+        if min_cell <= 2.0e-3:
+            import warnings as _w
+            _w.warn(
+                f"conformal PEC is enabled on faces {sorted(cf)} with a min "
+                f"cell size {min_cell * 1e3:.3f} mm <= 2 mm — this is a KNOWN "
+                f"NaN (discrete-adjointness break, not CFL; 4 fix methods "
+                f"falsified — see docs/agent-memory/rfx-known-issues.md). "
+                f"normalize=False is NOT a safe workaround at fine dx. Use "
+                f"conformal=False (staircase PEC) or a coarser mesh "
+                f"(dx > 2 mm) until the contour-FIT redesign lands.",
+                PreflightErrorWarning, stacklevel=2,
+            )
+
+    def _validate_cfg_lossless_resonator_in_absorber(self, _w) -> None:
+        """Warn when EVERY dielectric is perfectly lossless in an open (CPML/
+        UPML) domain — design-guide Anti-Pattern #1: a lossless substrate in an
+        open boundary yields an artificially infinite Q that reads as a
+        plausible-but-wrong resonance (an R5 surface-metric trap detectable
+        purely from setup). Deliberately narrow + single-shot to avoid noise:
+        it fires only when no dielectric carries any loss, and is hedged
+        because it is harmless if you are not measuring Q.
+        """
+        if self._boundary not in ("cpml", "upml"):
+            return
+        try:
+            from rfx.api._spec import MATERIAL_LIBRARY
+        except Exception:
+            MATERIAL_LIBRARY = {}
+
+        def _resolve(name):
+            mspec = self._materials.get(name) if self._materials else None
+            if mspec is not None:
+                return (
+                    float(getattr(mspec, "eps_r", 1.0)),
+                    float(getattr(mspec, "sigma", 0.0)),
+                    bool(getattr(mspec, "debye_poles", None)
+                         or getattr(mspec, "lorentz_poles", None)),
+                )
+            lib = MATERIAL_LIBRARY.get(name)
+            if isinstance(lib, dict):
+                return (
+                    float(lib.get("eps_r", 1.0)),
+                    float(lib.get("sigma", 0.0)),
+                    bool(lib.get("debye_poles") or lib.get("lorentz_poles")),
+                )
+            return None
+
+        lossless_names: list[str] = []
+        any_lossy_dielectric = False
+        for entry in self._geometry:
+            resolved = _resolve(entry.material_name)
+            if resolved is None:
+                continue
+            eps_r, sigma, has_poles = resolved
+            # Dielectric (not vacuum/air, not a conductor/PEC).
+            if not (eps_r > 1.05 and sigma < 1.0):
+                continue
+            if sigma <= 0.0 and not has_poles:
+                lossless_names.append(entry.material_name)
+            else:
+                any_lossy_dielectric = True
+
+        if lossless_names and not any_lossy_dielectric:
+            uniq = sorted(set(lossless_names))
+            _w.warn(
+                f"all dielectric(s) {uniq} are perfectly lossless in an open "
+                f"({self._boundary.upper()}) domain. If you are measuring "
+                f"Q / resonance, this gives an ARTIFICIALLY infinite Q "
+                f"(design-guide Anti-Pattern #1, an R5 surface-metric trap) — "
+                f"add loss, e.g. sigma = 2*pi*f*eps0*eps_r*tan_delta. "
+                f"(Harmless if you are not measuring Q.)",
+                stacklevel=2,
+            )
 
     def _validate_cfg_compute_cpml_thickness(
         self, cpml_thickness: float

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1270,6 +1270,16 @@ class _PreflightMixin:
         min_cell = min(cells) if cells else dx
         if min_cell <= 2.0e-3:
             import warnings as _w
+            # WARNING severity (NOT error/forbid): the conformal-fine-dx NaN is
+            # a KNOWN, actively-worked bug, and convergence/development tests
+            # must still be able to RUN this config — a hard-fail would block
+            # the very work fixing it. Agents gate on the code (conformal_nan),
+            # not on a hard-stop.
+            # MAINTENANCE: delete this guard when the BCK/USC contour-FIT
+            # redesign lands. The strict-xfail tracker
+            # tests/test_subpixel_pec.py::test_mesh_convergence_s21_with_conformal_pec
+            # will hard-fail (XPASS) to force this removal. See
+            # docs/agent-memory/rfx-known-issues.md (conformal-PEC item).
             _w.warn(
                 f"conformal PEC is enabled on faces {sorted(cf)} with a min "
                 f"cell size {min_cell * 1e3:.3f} mm <= 2 mm — this is a KNOWN "
@@ -1278,7 +1288,7 @@ class _PreflightMixin:
                 f"normalize=False is NOT a safe workaround at fine dx. Use "
                 f"conformal=False (staircase PEC) or a coarser mesh "
                 f"(dx > 2 mm) until the contour-FIT redesign lands.",
-                PreflightErrorWarning, stacklevel=2,
+                stacklevel=2,
             )
 
     def _validate_cfg_lossless_resonator_in_absorber(self, _w) -> None:

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1049,8 +1049,12 @@ class _PreflightMixin:
             One of ``"run"``, ``"forward"``, ``"msl"``, or ``"waveguide"``
             (the corresponding method names are accepted as aliases).
         strict:
-            If True, raise the underlying ``ValueError`` /
-            ``NotImplementedError`` instead of returning it as an issue string.
+            If True, escalate findings to a raise: collect every issue, then
+            raise a single ``ValueError`` listing them all (aggregate-then-raise,
+            matching ``preflight(strict=True)``). The underlying
+            ``NotImplementedError`` is recorded as an error-severity issue and
+            re-surfaced as part of that aggregated ``ValueError`` (its exact type
+            is not preserved).
         normalize:
             Waveguide non-uniform preflight uses this to mirror
             ``compute_waveguide_s_matrix(normalize=...)``.  ``None`` means the
@@ -1061,9 +1065,11 @@ class _PreflightMixin:
 
         Returns
         -------
-        list of str
-            Empty when the selected calculator is valid for the registered
-            port families.  Otherwise contains actionable issue messages.
+        PreflightReport
+            A ``list`` subclass of :class:`PreflightIssue` (back-compatible with
+            the historical ``list[str]``). Empty when the selected calculator is
+            valid for the registered port families.  Otherwise contains
+            actionable, coded issues.
         """
 
         aliases = {
@@ -1497,8 +1503,10 @@ class _PreflightMixin:
         methods are falsified (see docs/agent-memory/rfx-known-issues.md, the
         conformal-PEC item). ``normalize=False`` is NOT a safe workaround.
         Surfacing this at preflight converts a silent-NaN GPU run into an
-        instant redirect. Emitted as :class:`PreflightErrorWarning` (error
-        severity) so an agent can gate on it without it masking other checks.
+        instant redirect. Emitted as a WARNING-severity ``PreflightWarning``
+        (code ``conformal_nan``), NOT error — conformal is actively-worked and
+        convergence/development tests must still RUN this config, so it must not
+        hard-fail; agents gate on the code, not a hard-stop.
         """
         spec = getattr(self, "_boundary_spec", None)
         if spec is None or not hasattr(spec, "conformal_faces"):

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1029,7 +1029,7 @@ class _PreflightMixin:
         strict: bool = False,
         normalize: bool | str | None = None,
         include_general: bool = False,
-    ) -> list[str]:
+    ) -> "PreflightReport":
         """Preflight the selected S-parameter calculator without running FDTD.
 
         This is a routing/contract check for the port-family-specific
@@ -1088,7 +1088,7 @@ class _PreflightMixin:
                 f"Choose one of: {allowed}."
             )
 
-        issues: list[str] = []
+        issues = PreflightReport()
 
         try:
             if key == "run":
@@ -1121,12 +1121,26 @@ class _PreflightMixin:
             elif key == "coaxial":
                 self._validate_coaxial_sparameter_request_for_preflight()
         except (ValueError, NotImplementedError) as exc:
-            if strict:
-                raise
-            issues.append(f"{type(exc).__name__}: {exc}")
+            # Collect as a coded error-severity issue (aggregated raise below
+            # under strict) — consistent with preflight()'s PreflightIssue
+            # contract instead of the old bare f-string.
+            issues.append(PreflightIssue(
+                f"{type(exc).__name__}: {exc}",
+                severity="error",
+                code=getattr(exc, "code", f"sparam_routing_{key}"),
+                source="preflight_sparameters",
+            ))
 
         if include_general:
-            issues.extend(self.preflight(strict=strict))
+            # strict=False here: collect the general findings, then aggregate
+            # everything in one raise below (don't fail-on-first).
+            issues.extend(self.preflight(strict=False))
+
+        if strict and issues:
+            raise ValueError(
+                f"preflight_sparameters (strict) found {len(issues)} issue(s):"
+                "\n  - " + "\n  - ".join(issues)
+            )
 
         if issues:
             for issue in issues:

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -952,8 +952,8 @@ class _PreflightMixin:
                 if check_ntff:
                     self._validate_ntff_inverse_design()
             except ValueError as e:
-                if strict:
-                    raise
+                # Collect (do NOT fail-on-first): the aggregated raise at the
+                # end escalates every finding at once under strict.
                 # Structurally-impossible configs raise PreflightConfigError
                 # with the slug set at the check site; any other ValueError is
                 # error-severity but uncoded.
@@ -967,8 +967,7 @@ class _PreflightMixin:
 
         for w in caught:
             msg = str(w.message)
-            if strict:
-                raise ValueError(msg)
+            # Collect (do NOT fail-on-first): aggregated raise at the end.
             # Prefer the structured fields carried on the warning INSTANCE
             # (PreflightWarning); fall back to the category-derived severity for
             # the legacy ``warnings.warn(msg, PreflightErrorWarning)`` form, and
@@ -999,12 +998,21 @@ class _PreflightMixin:
                 available_memory_gb=available_memory_gb,
             )
             if est.warning:
-                msg = est.warning
-                if strict:
-                    raise ValueError(msg)
                 issues.append(PreflightIssue(
-                    msg, severity="warning", code="ad_memory"
+                    est.warning, severity="warning", code="ad_memory"
                 ))
+
+        if strict and issues:
+            # Aggregate-then-raise: escalate ALL findings at once. Preserves the
+            # historical "strict escalates any issue to ValueError" contract,
+            # but reports every problem in one pass instead of fail-on-first
+            # (pydantic / Tidy3D pattern). For an errors-only gate that lets
+            # advisories through, call ``report.raise_for_failure()`` on a
+            # ``strict=False`` report instead.
+            raise ValueError(
+                f"preflight (strict) found {len(issues)} issue(s):\n  - "
+                + "\n  - ".join(issues)
+            )
 
         if issues:
             for iss in issues:

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -258,6 +258,11 @@ class _SparamMixin:
                 _res_nu,
                 extractor="compute_waveguide_s_matrix",
                 strict=strict_passivity,
+                # normalize=False carries documented Yee-dispersion + band-edge
+                # |S11| overshoot (validated paths reach ~1.4-1.7), so use a
+                # loose bound there that still catches gross extractor bugs
+                # (|S11|>>1); normalize=True/"flux" correct dispersion -> tight.
+                passivity_tol=2.0 if normalize is False else 0.10,
             )
             return _res_nu
 
@@ -546,6 +551,7 @@ class _SparamMixin:
                 _res_mm,
                 extractor="compute_waveguide_s_matrix",
                 strict=strict_passivity,
+                passivity_tol=2.0 if normalize is False else 0.10,
             )
             return _res_mm
 
@@ -699,6 +705,7 @@ class _SparamMixin:
             _res_sm,
             extractor="compute_waveguide_s_matrix",
             strict=strict_passivity,
+            passivity_tol=2.0 if normalize is False else 0.10,
         )
         return _res_sm
 

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -40,6 +40,83 @@ from rfx.api._spec import (
 )
 
 
+def _warn_if_nonpassive_smatrix(
+    result,
+    *,
+    extractor: str,
+    strict: bool = False,
+    passivity_tol: float = 0.10,
+) -> None:
+    """Auto-run the passivity/finiteness self-check on a freshly-extracted
+    S-matrix and surface a non-physical result as a warning (or raise when
+    ``strict``).
+
+    This operationalizes the R5 "no surface-metric verdict" discipline
+    (CLAUDE.md): a passive structure cannot scatter more power than it
+    receives, so a per-column power > 1 (e.g. ``|S11| > 1`` on a one-port)
+    means the *extractor* is wrong — mismeasured current sign/scale or a
+    bad reference plane — and the S-parameters are untrustworthy, NOT that
+    the device is exotic. Waveguide and coaxial extractors previously had
+    no such self-check; only ``compute_msl_s_matrix`` did. Wiring the
+    existing :func:`rfx.validation.validate_port_smatrix` in here is the
+    guard that would have short-circuited the multi-session WR-90 ``|S11|``
+    chase recorded in durable memory.
+
+    Tracer-safe: under ``jax.grad`` / ``jax.jit`` tracing ``result.s_params``
+    is an abstract tracer with no concrete value, so the numpy-based check is
+    skipped entirely. The diagnostic is for the eager forward call (the
+    common research-tool usage); it deliberately does not fire per optimizer
+    iteration.
+    """
+    s = getattr(result, "s_params", None)
+    if s is None:
+        return
+    try:
+        if isinstance(s, jax.core.Tracer):
+            return
+    except Exception:
+        pass
+    try:
+        s_np = np.asarray(s)
+        f_np = np.asarray(result.freqs)
+    except Exception:
+        # Traced / non-materializable — never let a diagnostic break the
+        # numeric return path.
+        return
+
+    from rfx.validation import validate_port_smatrix
+
+    report = validate_port_smatrix(
+        s_params=s_np,
+        freqs=f_np,
+        port_names=tuple(result.port_names),
+        source=extractor,
+        check_passivity=True,
+        passivity_limit=1.0,
+        passivity_tol=float(passivity_tol),
+    )
+    bad = [
+        i for i in report.issues
+        if i.code in ("passivity_violation", "nonfinite_sparams")
+    ]
+    if not bad:
+        return
+    detail = "; ".join(f"{i.code}: {i.message}" for i in bad)
+    msg = (
+        f"{extractor}: extracted S-matrix failed a passivity/finiteness "
+        f"self-check — {detail}. A passive structure cannot have column "
+        f"power > 1; this almost always means the extractor (current "
+        f"sign/scale or reference plane) is wrong and the S-parameters are "
+        f"UNRELIABLE. Inspect the V/I dump via "
+        f"rfx.validation.validate_port_smatrix / replay_smatrix_from_vi_dump "
+        f"before trusting or optimizing against these numbers."
+    )
+    if strict:
+        raise ValueError(msg)
+    import warnings as _w
+    _w.warn(msg, stacklevel=3)
+
+
 class _SparamMixin:
     """S-parameter extraction methods mixed into :class:`Simulation`."""
 
@@ -53,6 +130,7 @@ class _SparamMixin:
         eps_override: "jnp.ndarray | None" = None,
         sigma_override: "jnp.ndarray | None" = None,
         checkpoint_segments: int | None = None,
+        strict_passivity: bool = False,
     ) -> WaveguideSMatrixResult:
         """Compute a theoretically clean axis-normal boundary-aperture waveguide S-matrix.
 
@@ -171,11 +249,17 @@ class _SparamMixin:
                     + "; ".join(unsupported)
                     + ". Drop the dx/dy profile to use the uniform lane."
                 )
-            return self._compute_waveguide_s_matrix_nu(
+            _res_nu = self._compute_waveguide_s_matrix_nu(
                 n_steps=n_steps,
                 num_periods=num_periods,
                 normalize=normalize,
             )
+            _warn_if_nonpassive_smatrix(
+                _res_nu,
+                extractor="compute_waveguide_s_matrix",
+                strict=strict_passivity,
+            )
+            return _res_nu
 
         grid = self._build_grid()
         base_materials, debye_spec, lorentz_spec, pec_mask_wg, pec_shapes, boundary_pec_shapes, _ = self._assemble_materials(grid)
@@ -451,13 +535,19 @@ class _SparamMixin:
                 entry = entries[port_idx]
                 port_names_mm.append(f"{entry.name}_mode{mode_idx}_{mtype}{m_n[0]}{m_n[1]}")
                 port_directions_mm.append(entry.direction)
-            return WaveguideSMatrixResult(
+            _res_mm = WaveguideSMatrixResult(
                 s_params=s_params,
                 freqs=jnp.asarray(freqs),
                 port_names=tuple(port_names_mm),
                 port_directions=tuple(port_directions_mm),
                 reference_planes=reference_planes,
             )
+            _warn_if_nonpassive_smatrix(
+                _res_mm,
+                extractor="compute_waveguide_s_matrix",
+                strict=strict_passivity,
+            )
+            return _res_mm
 
         # Single-mode path (original behavior)
         cfgs = raw_cfgs
@@ -598,13 +688,19 @@ class _SparamMixin:
             ],
             dtype=float,
         )
-        return WaveguideSMatrixResult(
+        _res_sm = WaveguideSMatrixResult(
             s_params=s_params,
             freqs=jnp.asarray(freqs),
             port_names=tuple(entry.name for entry in entries),
             port_directions=tuple(entry.direction for entry in entries),
             reference_planes=reference_planes,
         )
+        _warn_if_nonpassive_smatrix(
+            _res_sm,
+            extractor="compute_waveguide_s_matrix",
+            strict=strict_passivity,
+        )
+        return _res_sm
 
     def compute_msl_s_matrix(
         self,
@@ -1209,6 +1305,7 @@ class _SparamMixin:
         magnetic_ratio: float = 1.0,
         signal_floor: float = 1.0e-12,
         reference_plane_axial_index_offset: int = 0,
+        strict_passivity: bool = False,
     ) -> "CoaxialSMatrixResult":
         """Experimental coaxial S-matrix via distributed TEM plane sources.
 
@@ -1491,7 +1588,7 @@ class _SparamMixin:
             dtype=float,
         )
 
-        return CoaxialSMatrixResult(
+        _res_coax = CoaxialSMatrixResult(
             s_params=s,
             freqs=np.asarray(freqs, dtype=float),
             port_names=tuple(f"coax_{i}" for i in range(n_ports)),
@@ -1502,6 +1599,12 @@ class _SparamMixin:
             currents=i_dump,
             status=status,
         )
+        _warn_if_nonpassive_smatrix(
+            _res_coax,
+            extractor="compute_coaxial_s_matrix",
+            strict=strict_passivity,
+        )
+        return _res_coax
 
     def compute_coaxial_line_reflection(
         self,

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -188,6 +188,60 @@ class MeshIntelligenceReport(NamedTuple):
         return json.dumps(self.to_dict(), **options)
 
 
+def _nonfinite_fields(result) -> list[tuple[str, int]]:
+    """Return ``[(field_name, nonfinite_count), ...]`` for the numeric array
+    observables on a ``Result`` / ``ForwardResult``.
+
+    Tracer-safe: a value under ``jax.grad`` / ``jax.jit`` tracing is an
+    abstract tracer with no concrete data, so it is skipped (returns ``[]``
+    rather than raising). Never raises — a divergence diagnostic must not
+    itself break the return path.
+    """
+    import jax
+
+    bad: list[tuple[str, int]] = []
+    for name in ("time_series", "s_params"):
+        arr = getattr(result, name, None)
+        if arr is None:
+            continue
+        try:
+            if isinstance(arr, jax.core.Tracer):
+                continue
+            a = np.asarray(arr)
+        except Exception:
+            continue
+        if a.size == 0 or not np.issubdtype(a.dtype, np.number):
+            continue
+        n_bad = int(a.size - np.count_nonzero(np.isfinite(a)))
+        if n_bad:
+            bad.append((name, n_bad))
+    return bad
+
+
+_NONFINITE_CAUSE_HINT = (
+    "the FDTD likely diverged. Common causes: dt above CFL, conformal=True "
+    "at fine dx (a known NaN — see docs/agent-memory/rfx-known-issues.md), "
+    "PEC inside the CPML region, or a sub-cell PEC feature."
+)
+
+
+def _warn_if_nonfinite_result(result, *, context: str) -> None:
+    """Emit a UserWarning (tracer-safe, never raising) when a freshly-computed
+    result carries NaN/Inf observables, so an eager forward/run surfaces a
+    divergence with a cause hint instead of returning silent garbage."""
+    bad = _nonfinite_fields(result)
+    if not bad:
+        return
+    detail = ", ".join(f"{n} ({c} value(s))" for n, c in bad)
+    import warnings as _w
+
+    _w.warn(
+        f"[{context}] result contains non-finite values in {detail} — "
+        f"{_NONFINITE_CAUSE_HINT}",
+        stacklevel=3,
+    )
+
+
 class Result(NamedTuple):
     """Structured simulation result.
 
@@ -302,6 +356,36 @@ class Result(NamedTuple):
                                         source_decay_time=source_decay_time)
 
         return modes
+
+    def assert_finite(self, *, raise_on_nonfinite: bool = False) -> bool:
+        """Check that the result's observables contain no NaN/Inf.
+
+        A non-finite ``time_series`` or ``s_params`` almost always means the
+        FDTD diverged rather than that the device is exotic. Returns ``True``
+        when finite. With ``raise_on_nonfinite=True`` raises ``ValueError``
+        instead of warning, so an automation loop can fail fast with a cause
+        hint right after ``run()`` instead of propagating silent garbage into
+        a downstream metric. Tracer-safe — a no-op under jax.grad/jit.
+
+        Returns
+        -------
+        bool
+            ``True`` if all inspected observables are finite (or unavailable
+            for inspection, e.g. under tracing), ``False`` otherwise.
+        """
+        bad = _nonfinite_fields(self)
+        if not bad:
+            return True
+        detail = ", ".join(f"{n} ({c} value(s))" for n, c in bad)
+        msg = (
+            f"Result contains non-finite values in {detail} — "
+            f"{_NONFINITE_CAUSE_HINT}"
+        )
+        if raise_on_nonfinite:
+            raise ValueError(msg)
+        import warnings as _w
+        _w.warn(msg, stacklevel=2)
+        return False
 
 
 class ForwardResult(NamedTuple):

--- a/rfx/artifacts.py
+++ b/rfx/artifacts.py
@@ -149,7 +149,6 @@ def _jsonable(value: Any, *, array_values: bool = False, max_array_values: int =
     if isinstance(value, (list, tuple, set, frozenset)):
         return [_jsonable(v, array_values=array_values, max_array_values=max_array_values) for v in value]
     if _is_array_like(value):
-        shape = tuple(int(x) for x in getattr(value, "shape", ()))
         size = int(getattr(value, "size", 0) or 0)
         if array_values and size <= max_array_values:
             try:

--- a/rfx/ntff_sweep.py
+++ b/rfx/ntff_sweep.py
@@ -84,11 +84,16 @@ def ntff_sweep(sim, freqs, *, batch_size: int | None = None,
     batches: list[np.ndarray] = [
         freqs[i:i + batch_size] for i in range(0, len(freqs), batch_size)
     ]
+    # Same sim across all frequency batches → preflight once (first batch),
+    # skip thereafter to avoid flooding the loop with repeated preflight
+    # warnings/prints. Honor a user-supplied skip_preflight as-is.
+    _sp_explicit = "skip_preflight" in run_kwargs
     per_batch_data: list[NTFFData] = []
     try:
-        for batch in batches:
+        for _i, batch in enumerate(batches):
             sim._ntff = (corner_lo, corner_hi, batch)
-            result = sim.run(**run_kwargs)
+            _rk = run_kwargs if _sp_explicit else {**run_kwargs, "skip_preflight": _i > 0}
+            result = sim.run(**_rk)
             if result.ntff_data is None:
                 raise RuntimeError(
                     "ntff_sweep: sim.run returned no ntff_data — "

--- a/rfx/optimize.py
+++ b/rfx/optimize.py
@@ -235,14 +235,17 @@ def optimize(
 
     grad_fn = jax.value_and_grad(forward)
 
+    last_good = latent  # last design with a confirmed-finite forward+gradient
     for it in range(n_iters):
         loss, grad = grad_fn(latent)
 
         # NaN/Inf gradient guard. A non-finite gradient does not crash an
         # inverse-design loop — the Adam update below would silently poison
         # ``latent`` (and every later iteration), so the optimizer "succeeds"
-        # while wandering on garbage. Stop fast with a cause hint and preserve
-        # the last finite design instead of returning a NaN one.
+        # while wandering on garbage. Stop fast with a cause hint and RESTORE
+        # the last design whose forward was finite (the CURRENT ``latent`` is
+        # the one that just diverged, so returning it would hand back a
+        # divergence-causing design).
         if not (bool(jnp.isfinite(loss)) and bool(jnp.all(jnp.isfinite(grad)))):
             import warnings as _w
             _w.warn(
@@ -250,13 +253,15 @@ def optimize(
                 f"{it} — the FDTD forward almost certainly diverged. Common "
                 f"causes: dt above CFL, conformal=True at fine dx (a known NaN, "
                 f"see docs/agent-memory/rfx-known-issues.md), PEC inside the "
-                f"CPML region, or a sub-cell PEC feature. Stopping early; the "
-                f"returned design is the last finite one (before iteration "
+                f"CPML region, or a sub-cell PEC feature. Stopping early and "
+                f"returning the last finite design (from before iteration "
                 f"{it}).",
                 stacklevel=2,
             )
+            latent = last_good
             break
 
+        last_good = latent  # this design produced a finite forward+gradient
         it_count[0] = it + 1
         loss_val = float(loss)
         loss_history.append(loss_val)

--- a/rfx/optimize.py
+++ b/rfx/optimize.py
@@ -237,6 +237,26 @@ def optimize(
 
     for it in range(n_iters):
         loss, grad = grad_fn(latent)
+
+        # NaN/Inf gradient guard. A non-finite gradient does not crash an
+        # inverse-design loop — the Adam update below would silently poison
+        # ``latent`` (and every later iteration), so the optimizer "succeeds"
+        # while wandering on garbage. Stop fast with a cause hint and preserve
+        # the last finite design instead of returning a NaN one.
+        if not (bool(jnp.isfinite(loss)) and bool(jnp.all(jnp.isfinite(grad)))):
+            import warnings as _w
+            _w.warn(
+                f"optimize: non-finite loss/gradient (NaN or Inf) at iteration "
+                f"{it} — the FDTD forward almost certainly diverged. Common "
+                f"causes: dt above CFL, conformal=True at fine dx (a known NaN, "
+                f"see docs/agent-memory/rfx-known-issues.md), PEC inside the "
+                f"CPML region, or a sub-cell PEC feature. Stopping early; the "
+                f"returned design is the last finite one (before iteration "
+                f"{it}).",
+                stacklevel=2,
+            )
+            break
+
         it_count[0] = it + 1
         loss_val = float(loss)
         loss_history.append(loss_val)

--- a/rfx/sources/waveguide_port.py
+++ b/rfx/sources/waveguide_port.py
@@ -415,7 +415,6 @@ def _galerkin_eigh_separable_laplacian_2d(
     strong-form operator). Returns ``(evals, evecs)`` with evecs as columns
     in the ORIGINAL φ basis (unit-mass-normalized), ascending eigenvalue.
     """
-    nu = len(mu); nv = len(mv)
     Mv = np.diag(mv); Mu = np.diag(mu)
     big = np.kron(Ku, Mv) + np.kron(Mu, Kv)        # (nu*nv, nu*nv) symmetric
     m_diag = np.kron(mu, mv)                         # diagonal of (Mu⊗Mv)

--- a/rfx/sweep.py
+++ b/rfx/sweep.py
@@ -132,10 +132,16 @@ def parametric_sweep(
     if until_decay is not None:
         kw["until_decay"] = until_decay
 
+    # Preflight only the FIRST sim (sweeps re-run a structurally-identical
+    # setup, so per-iteration preflight just floods the loop with repeated
+    # warnings + [PREFLIGHT] prints). A user-supplied skip_preflight in
+    # run_kwargs is honored as-is.
+    _sp_explicit = "skip_preflight" in kw
     results = []
-    for val in param_values:
+    for _i, val in enumerate(param_values):
         sim = sim_factory(float(val))
-        result = sim.run(**kw)
+        _kw = kw if _sp_explicit else {**kw, "skip_preflight": _i > 0}
+        result = sim.run(**_kw)
         results.append(result)
 
     return SweepResult(

--- a/rfx/topology.py
+++ b/rfx/topology.py
@@ -523,6 +523,24 @@ def topology_optimize(
         beta_history.append(beta)
 
         loss, grad = jax.value_and_grad(lambda logit_: forward(logit_, beta))(logit)
+
+        # NaN/Inf gradient guard (see optimize() for rationale): a non-finite
+        # gradient would silently poison ``logit`` via the optax update and
+        # every later iteration. Stop fast with a cause hint, preserving the
+        # last finite design.
+        if not (bool(jnp.isfinite(loss)) and bool(jnp.all(jnp.isfinite(grad)))):
+            import warnings as _w
+            _w.warn(
+                f"topology_optimize: non-finite loss/gradient (NaN or Inf) at "
+                f"iteration {it} — the FDTD forward almost certainly diverged "
+                f"(dt above CFL, conformal=True at fine dx, PEC inside CPML, or "
+                f"a sub-cell PEC feature; see docs/agent-memory/"
+                f"rfx-known-issues.md). Stopping early; the returned design is "
+                f"the last finite one (before iteration {it}).",
+                stacklevel=2,
+            )
+            break
+
         loss_val = float(loss)
         history.append(loss_val)
 

--- a/rfx/topology.py
+++ b/rfx/topology.py
@@ -518,6 +518,7 @@ def topology_optimize(
             return objective(result, ntff_box=result.ntff_box)
         return objective(result)
 
+    last_good = logit  # last design with a confirmed-finite forward+gradient
     for it in range(n_iterations):
         beta = _get_beta(it, beta_schedule)
         beta_history.append(beta)
@@ -526,8 +527,9 @@ def topology_optimize(
 
         # NaN/Inf gradient guard (see optimize() for rationale): a non-finite
         # gradient would silently poison ``logit`` via the optax update and
-        # every later iteration. Stop fast with a cause hint, preserving the
-        # last finite design.
+        # every later iteration. Stop fast with a cause hint and RESTORE the
+        # last design whose forward was finite (the current ``logit`` is the
+        # one that just diverged).
         if not (bool(jnp.isfinite(loss)) and bool(jnp.all(jnp.isfinite(grad)))):
             import warnings as _w
             _w.warn(
@@ -535,12 +537,14 @@ def topology_optimize(
                 f"iteration {it} — the FDTD forward almost certainly diverged "
                 f"(dt above CFL, conformal=True at fine dx, PEC inside CPML, or "
                 f"a sub-cell PEC feature; see docs/agent-memory/"
-                f"rfx-known-issues.md). Stopping early; the returned design is "
-                f"the last finite one (before iteration {it}).",
+                f"rfx-known-issues.md). Stopping early and returning the last "
+                f"finite design (from before iteration {it}).",
                 stacklevel=2,
             )
+            logit = last_good
             break
 
+        last_good = logit  # this design produced a finite forward+gradient
         loss_val = float(loss)
         history.append(loss_val)
 

--- a/rfx/vmap_sweep.py
+++ b/rfx/vmap_sweep.py
@@ -615,7 +615,7 @@ def _sequential_fallback(
     mat_name, field = _parse_param_name(param_name)
 
     all_ts = []
-    for val in param_values:
+    for _i, val in enumerate(param_values):
         # Clone the simulation and modify the material
         import copy
         sim_copy = copy.deepcopy(sim)
@@ -635,7 +635,10 @@ def _sequential_fallback(
                 sim_copy._materials[name] = replace(
                     mat, **{field: float(val)})
 
-        result = sim_copy.run(n_steps=n_steps)
+        # Preflight only the first sim (this sequential fallback re-runs a
+        # structurally-identical setup); skip thereafter to avoid per-iteration
+        # preflight noise.
+        result = sim_copy.run(n_steps=n_steps, skip_preflight=_i > 0)
         all_ts.append(np.asarray(result.time_series))
 
     # Stack into (n_batch, n_steps, n_probes)

--- a/tests/test_distributed_nu_kernel.py
+++ b/tests/test_distributed_nu_kernel.py
@@ -479,7 +479,6 @@ def _phase2b_gauss_waveform(t, t0=8e-12, tau=2.5e-12):
 def _phase2b_shard_mat(materials, sharded_grid):
     """Shard a full-domain MaterialArrays for Phase 2B's runner."""
     n_devices = sharded_grid.n_devices
-    nx_local = sharded_grid.nx_local
     ghost = sharded_grid.ghost_width
     pad_x = sharded_grid.pad_x
 
@@ -734,7 +733,6 @@ def test_distributed_h_ghost_exchange_recovers_global_field():
     """
     devices = jax.devices()[:2]
     n_devices = 2
-    n_steps = 20
 
     grid = _phase2b_build_test_grid(nx_physical=16, ny=8, nz=8, ratio=1.0)
     materials = _phase2b_make_materials(grid)
@@ -1380,7 +1378,6 @@ def test_distributed_mixed_dispersion_grad_no_corner_nan():
     from rfx import Simulation, Box
 
     devices = jax.devices()[:2]
-    n_devices = 2
     n_steps = 30
 
     # Minimum-scale repro that keeps CI cost low but still exercises the
@@ -2175,7 +2172,7 @@ def test_distributed_emit_time_series_false_skips_probe():
     n_steps = 16
 
     grid = _phase2b_build_test_grid(nx_physical=16, ny=8, nz=8, ratio=1.2)
-    nx, ny, nz = grid.nx, grid.ny, grid.nz
+    _nx, _ny, _nz = grid.nx, grid.ny, grid.nz
     sharded_grid = build_sharded_nu_grid(grid, n_devices=n_devices,
                                          exchange_interval=1)
 
@@ -2243,7 +2240,6 @@ def test_distributed_emit_time_series_false_skips_probe():
     # The objective is the rank-0 slab's |E|^2 sum on the SHARDED final
     # state (rank-0 slab is sliced by axis-0 indexing, which composes
     # well with the sharded backward).
-    nx_local = sharded_grid.nx_local
     base_wf = jnp.asarray(src_wf)
 
     def loss(amp):

--- a/tests/test_extract_s_matrix_pec_mask.py
+++ b/tests/test_extract_s_matrix_pec_mask.py
@@ -32,7 +32,6 @@ def _build_pec_cavity_with_dielectric():
     # Closed PEC cavity walls via geometry (not just simulation boundary).
     # The interior shell rasterises into pec_mask — exactly the path
     # that would silently get dropped without the fix.
-    wall = 0.0  # shell at corner_lo and corner_hi inferred from boundary="pec"
     # 1-cell PEC wall on z=0 face (a "ground plane")
     sim.add(Box((0.0, 0.0, 0.0), (a, a, 2e-3)), material="pec")
     # ε=4 filler everywhere above

--- a/tests/test_msl_broad_e5_envelope_gates.py
+++ b/tests/test_msl_broad_e5_envelope_gates.py
@@ -105,7 +105,6 @@ def _make_stub_case_npz(
     n = 41
     f = np.linspace(f_lo, f_hi, n)
     # Background ~ 1, dip = 10**(-25/20) at f_dip with Gaussian width.
-    bg_db = 0.0
     dip_amp = 10 ** (dip_db / 20.0)
     s21 = 1.0 + (dip_amp - 1.0) * np.exp(-((f - f_dip) / bandwidth) ** 2)
     s = np.zeros((2, 2, n), dtype=complex)

--- a/tests/test_nonuniform_api.py
+++ b/tests/test_nonuniform_api.py
@@ -345,7 +345,7 @@ class TestSimulationNonUniform:
         try:
             res_nu = sim_nu.run(n_steps=n_steps, compute_s_params=False)
             res_ref = sim_ref.run(n_steps=n_steps, compute_s_params=False)
-        except ValueError as exc:
+        except ValueError:
             # Aperture-on-NU edge cases that don't relate to the integral
             # math should be flagged but not silently passed. Re-raise.
             raise

--- a/tests/test_preflight_structured_and_guards.py
+++ b/tests/test_preflight_structured_and_guards.py
@@ -1,0 +1,115 @@
+"""Tier-2: structured preflight records + two new setup guards.
+
+(a) preflight() returns PreflightIssue (a str subclass — fully back-compatible
+    with the old list[str]) carrying .severity / .code so an agent can gate:
+    errors = [i for i in sim.preflight() if i.severity == "error"].
+(b) conformal-PEC + fine dx (<=2mm) is a KNOWN NaN; surface it at setup as an
+    error-severity PreflightErrorWarning instead of wasting a run.
+(c) all-lossless dielectric in an open domain => artificial-Q trap warning
+    (design-guide Anti-Pattern #1), narrow + single-shot to avoid noise.
+"""
+import warnings
+from types import SimpleNamespace
+
+import pytest
+
+from rfx.api import Simulation
+from rfx.api._preflight import (
+    _PreflightMixin,
+    PreflightErrorWarning,
+    PreflightIssue,
+    _preflight_code_for,
+)
+from rfx.geometry.csg import Box
+
+
+# ---------------------------------------------------------------- (a) records
+def test_preflight_returns_back_compatible_structured_issues():
+    sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
+    sim.add_source((0.01, 0.01, 0.018), component="ez")   # near CPML => issue
+    sim.add_probe((0.01, 0.01, 0.019), component="ez")
+    report = sim.preflight()
+    assert report, "expected a preflight finding for a source/probe in CPML"
+    for issue in report:
+        assert isinstance(issue, PreflightIssue)
+        assert isinstance(issue, str)          # back-compat: still a string
+        assert issue.severity in ("warning", "error")
+        assert isinstance(issue.code, str) and issue.code
+    # Back-compat operations the old list[str] supported still work.
+    assert isinstance("\n".join(report), str)
+
+
+def test_preflight_issue_is_a_real_string():
+    pi = PreflightIssue("ERROR: x", severity="error", code="conformal_nan")
+    assert pi == "ERROR: x" and pi.startswith("ERROR") and pi.severity == "error"
+
+
+def test_code_inference():
+    assert _preflight_code_for("probe near CPML region") == "absorber"
+    assert _preflight_code_for("conformal PEC NaN") == "conformal_nan"
+    assert _preflight_code_for("4.1 cells per lambda") == "resolution"
+
+
+def test_error_severity_mapping_end_to_end():
+    """A PreflightErrorWarning emitted by any validator must surface as a
+    severity='error' PreflightIssue (not masking other checks)."""
+    sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
+    sim.add_source((0.01, 0.01, 0.01), component="ez")
+    sim._validate_ntff_inverse_design = lambda: warnings.warn(
+        "forced known-bad config", PreflightErrorWarning
+    )
+    report = sim.preflight()
+    errs = [i for i in report if i.severity == "error"]
+    assert any("forced known-bad" in i for i in errs)
+
+
+# --------------------------------------------------------- (b) conformal guard
+def _fake_conformal(dx, dy=None, dz=None, faces=("z_lo", "z_hi")):
+    spec = SimpleNamespace(conformal_faces=lambda: set(faces))
+    return SimpleNamespace(_boundary_spec=spec, _dx=dx, _dy=dy, _dz=dz)
+
+
+def test_conformal_fine_dx_warns_error_severity():
+    fake = _fake_conformal(1e-3)
+    with pytest.warns(PreflightErrorWarning, match="KNOWN"):
+        _PreflightMixin._validate_cfg_conformal_fine_dx(fake, 1e-3)
+
+
+def test_conformal_coarse_dx_silent():
+    fake = _fake_conformal(3e-3)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _PreflightMixin._validate_cfg_conformal_fine_dx(fake, 3e-3)
+
+
+def test_no_conformal_silent():
+    fake = _fake_conformal(1e-3, faces=())
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _PreflightMixin._validate_cfg_conformal_fine_dx(fake, 1e-3)
+
+
+# --------------------------------------------------- (c) lossless-resonator
+def _box_sim(material):
+    sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
+    sim.add(Box((0.005,) * 3, (0.015,) * 3), material=material)
+    sim.add_source((0.01, 0.01, 0.01), component="ez")
+    sim.add_probe((0.01, 0.01, 0.012), component="ez")
+    return sim
+
+
+def _lossless_warnings(sim):
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        _PreflightMixin._validate_cfg_lossless_resonator_in_absorber(sim, warnings)
+    return [w for w in rec if "artificially" in str(w.message).lower()]
+
+
+def test_lossless_dielectric_in_cpml_warns():
+    # alumina: eps_r 9.8, sigma 0 (built-in, resolved via MATERIAL_LIBRARY).
+    assert len(_lossless_warnings(_box_sim("alumina"))) == 1
+
+
+def test_lossy_dielectric_silent():
+    # fr4: sigma 0.025 => not the artificial-Q trap, no false positive.
+    assert len(_lossless_warnings(_box_sim("fr4"))) == 0

--- a/tests/test_preflight_structured_and_guards.py
+++ b/tests/test_preflight_structured_and_guards.py
@@ -251,3 +251,46 @@ def test_to_dict_and_to_json_roundtrip_carry_code_and_severity():
     back = json.loads(report.to_json())
     assert back["issues"][0]["code"] == report[0].code
     assert back["issues"][0]["severity"] == report[0].severity
+
+
+# ------------------------------------------------ Phase C-full: aggregate strict
+def test_strict_aggregates_all_issues_in_one_raise():
+    """strict=True escalates EVERY finding in ONE ValueError (aggregate-then-
+    raise), not fail-on-first — preserving the historical 'strict escalates any
+    issue' contract while reporting all problems at once."""
+    sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
+    sim.add_source((0.01, 0.01, 0.018), component="ez")   # near CPML
+    sim.add_probe((0.01, 0.01, 0.019), component="ez")     # near CPML
+    # strict=False shows >= 2 findings...
+    report = sim.preflight()
+    assert len(report) >= 2, f"need a multi-issue config; got {list(report)}"
+    # ...and strict raises ONCE listing all of them.
+    with pytest.raises(ValueError) as exc:
+        sim.preflight(strict=True)
+    text = str(exc.value)
+    assert text.count("\n  - ") >= 2, f"expected aggregated list, got: {text}"
+
+
+def test_raise_for_failure_is_errors_only_gate():
+    """report.raise_for_failure() is the SOFTER pre-launch gate: it raises only
+    on error-severity, letting advisory warnings through (unlike strict=True)."""
+    report = _bad_sim_probe_in_cpml().preflight()   # warnings only, no errors
+    assert report and report.ok          # ok == no error-severity issues
+    report.raise_for_failure()           # must NOT raise on warning-only report
+
+
+# ------------------------------------------------ Phase D: validator crash is loud
+def test_validator_crash_propagates_not_swallowed():
+    """A validator raising a NON-ValueError is a bug, not a finding — it must
+    propagate (loud), not degrade to a soft advisory that hides it."""
+    sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
+    sim.add_source((0.01, 0.01, 0.01), component="ez")
+    sim.add_probe((0.01, 0.01, 0.012), component="ez")
+
+    def _boom():
+        raise RuntimeError("validator bug")
+    sim._validate_ntff_inverse_design = _boom
+
+    # Via the auto-preflight path (run) the bug must surface, not be swallowed.
+    with pytest.raises(RuntimeError, match="validator bug"):
+        sim.run(n_steps=5)

--- a/tests/test_preflight_structured_and_guards.py
+++ b/tests/test_preflight_structured_and_guards.py
@@ -69,9 +69,12 @@ def _fake_conformal(dx, dy=None, dz=None, faces=("z_lo", "z_hi")):
     return SimpleNamespace(_boundary_spec=spec, _dx=dx, _dy=dy, _dz=dz)
 
 
-def test_conformal_fine_dx_warns_error_severity():
+def test_conformal_fine_dx_warns():
+    # WARNING severity (not error/forbid): conformal-fine-dx is a known,
+    # development-coupled bug; convergence tests must still RUN it, so it must
+    # not hard-fail. Agents gate on the code, not a hard-stop.
     fake = _fake_conformal(1e-3)
-    with pytest.warns(PreflightErrorWarning, match="KNOWN"):
+    with pytest.warns(UserWarning, match="KNOWN"):
         _PreflightMixin._validate_cfg_conformal_fine_dx(fake, 1e-3)
 
 

--- a/tests/test_preflight_structured_and_guards.py
+++ b/tests/test_preflight_structured_and_guards.py
@@ -289,8 +289,51 @@ def test_validator_crash_propagates_not_swallowed():
 
     def _boom():
         raise RuntimeError("validator bug")
-    sim._validate_ntff_inverse_design = _boom
+    # Target a validator run() actually invokes (run() uses check_ntff=False, so
+    # the NTFF inverse-design check is NOT on its path).
+    sim._validate_simulation_config = _boom
 
     # Via the auto-preflight path (run) the bug must surface, not be swallowed.
     with pytest.raises(RuntimeError, match="validator bug"):
         sim.run(n_steps=5)
+
+
+# ----------------------------------------- run() error-severity + NTFF surface
+def test_run_skips_ntff_inverse_design_check_but_forward_runs_it():
+    """run() must NOT hard-fail on the inverse-design NTFF check (it historically
+    never ran it — run() uses check_ntff=False), while forward()/optimize (the
+    inverse-design entry points) still do. Regression lock for the NTFF/PEC
+    behavior change flagged in cold review."""
+    def _sim():
+        s = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
+        s.add_source((0.01, 0.01, 0.01), component="ez")
+        s.add_probe((0.01, 0.01, 0.012), component="ez")
+        # Stand in for an NTFF-box-crosses-PEC error-severity finding.
+        s._validate_ntff_inverse_design = lambda: (_ for _ in ()).throw(
+            ValueError("NTFF box face crosses PEC")
+        )
+        return s
+
+    # run(): check_ntff=False -> the NTFF validator is not invoked -> no hard-fail
+    _sim().run(n_steps=5)
+    # forward(): check_ntff=True -> invoked -> error-severity -> re-raised
+    with pytest.raises(ValueError, match="NTFF box face crosses PEC"):
+        _sim().forward(n_steps=5)
+
+
+def test_run_hard_fails_on_error_severity_and_skip_bypasses():
+    """run() re-raises on a structurally-impossible (error-severity) config, and
+    skip_preflight=True is the documented escape hatch."""
+    sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
+    sim.add_source((0.01, 0.01, 0.01), component="ez")
+    sim.add_probe((0.01, 0.01, 0.012), component="ez")
+    sim._validate_simulation_config = lambda: (_ for _ in ()).throw(
+        ValueError("structurally impossible config")
+    )
+    with pytest.raises(ValueError, match="structurally impossible config"):
+        sim.run(n_steps=5)
+    # escape hatch: skip_preflight bypasses the preflight (and its re-raise)
+    import warnings as _w
+    with _w.catch_warnings():
+        _w.simplefilter("error")  # no preflight warning/raise should fire
+        sim.run(n_steps=5, skip_preflight=True)

--- a/tests/test_preflight_structured_and_guards.py
+++ b/tests/test_preflight_structured_and_guards.py
@@ -18,7 +18,8 @@ from rfx.api._preflight import (
     _PreflightMixin,
     PreflightErrorWarning,
     PreflightIssue,
-    _preflight_code_for,
+    PreflightReport,
+    PreflightWarning,
 )
 from rfx.geometry.csg import Box
 
@@ -44,10 +45,42 @@ def test_preflight_issue_is_a_real_string():
     assert pi == "ERROR: x" and pi.startswith("ERROR") and pi.severity == "error"
 
 
-def test_code_inference():
-    assert _preflight_code_for("probe near CPML region") == "absorber"
-    assert _preflight_code_for("conformal PEC NaN") == "conformal_nan"
-    assert _preflight_code_for("4.1 cells per lambda") == "resolution"
+def test_preflight_report_is_a_list_with_canonical_api():
+    """PreflightReport IS a list (back-compat) AND mirrors the in-repo report
+    idiom (.issues/.errors/.warnings/.ok/.format()/.to_dict()/.to_json())."""
+    sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
+    sim.add_source((0.01, 0.01, 0.018), component="ez")   # near CPML => issue
+    sim.add_probe((0.01, 0.01, 0.019), component="ez")
+    report = sim.preflight()
+    assert isinstance(report, PreflightReport) and isinstance(report, list)
+    # list[str] ops the 65 legacy call sites rely on
+    assert isinstance("\n".join(report), str)
+    assert len(report) == len(list(report)) and bool(report)
+    # canonical report API
+    assert report.issues == list(report)
+    assert report.ok == (not report.errors)
+    assert set(report.warnings) | set(report.errors) == set(report)
+    assert "preflight:" in report.format()
+
+
+def test_codes_set_at_check_site():
+    """Codes come from the checks themselves (PreflightWarning instance /
+    PreflightConfigError), NOT from text inference of the message.
+
+    Confirms the deleted ``_preflight_code_for`` is not relied on: a probe in
+    CPML carries the absorber_overlap slug set in
+    ``_validate_cfg_absorber_placement`` and the source object identifies the
+    emitting check.
+    """
+    sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
+    sim.add_source((0.01, 0.01, 0.018), component="ez")
+    sim.add_probe((0.01, 0.01, 0.019), component="ez")
+    report = sim.preflight()
+    absorber = report.by_code("absorber_overlap")
+    assert absorber, f"expected absorber_overlap code, got {[i.code for i in report]}"
+    for issue in absorber:
+        assert issue.code == "absorber_overlap"
+        assert issue.source == "_validate_cfg_absorber_placement"
 
 
 def test_error_severity_mapping_end_to_end():
@@ -116,3 +149,105 @@ def test_lossless_dielectric_in_cpml_warns():
 def test_lossy_dielectric_silent():
     # fr4: sigma 0.025 => not the artificial-Q trap, no false positive.
     assert len(_lossless_warnings(_box_sim("fr4"))) == 0
+
+
+# ------------------------------------------------ (d) Phase A meta-coverage
+def _bad_sim_probe_in_cpml():
+    sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
+    sim.add_source((0.01, 0.01, 0.018), component="ez")   # absorber_overlap
+    sim.add_probe((0.01, 0.01, 0.019), component="ez")
+    return sim
+
+
+def _bad_sim_no_sources():
+    # no_sources advisory
+    return Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="pec")
+
+
+def _bad_sim_lossless_q():
+    sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
+    sim.add(Box((0.005,) * 3, (0.015,) * 3), material="alumina")  # lossless_q
+    sim.add_source((0.01, 0.01, 0.01), component="ez")
+    sim.add_probe((0.01, 0.01, 0.012), component="ez")
+    return sim
+
+
+def _bad_sim_under_resolved_dielectric():
+    # mesh_resolution: a fat high-eps slab under-resolved at coarse dx.
+    sim = Simulation(domain=(0.04, 0.04, 0.04), freq_max=20e9, dx=2e-3,
+                     boundary="pec")
+    sim.add_material("hi", eps_r=12.0)
+    sim.add(Box((0.005, 0.005, 0.005), (0.035, 0.035, 0.035)), material="hi")
+    sim.add_source((0.02, 0.02, 0.02), component="ez")
+    sim.add_probe((0.025, 0.025, 0.025), component="ez")
+    return sim
+
+
+def _bad_sim_upml_refinement():
+    # upml_refinement: structurally-impossible config (error severity).
+    from rfx import GaussianPulse
+    sim = Simulation(freq_max=6e9, domain=(0.04, 0.04, 0.02),
+                     boundary="upml", cpml_layers=6, dx=0.002)
+    sim.add_refinement((0.004, 0.008), ratio=2)
+    sim.add_source((0.01, 0.02, 0.01), "ez",
+                   waveform=GaussianPulse(f0=3e9, bandwidth=0.5))
+    sim.add_probe((0.026, 0.02, 0.01), "ez")
+    return sim
+
+
+def _all_emitted_issues(report):
+    return list(report)
+
+
+def test_every_emitted_issue_carries_a_check_site_code():
+    """Phase A meta-test: across a battery of deliberately-bad sims, EVERY
+    emitted preflight issue must carry a non-empty code != 'uncoded' (codes are
+    set at the check site, not inferred)."""
+    builders = (
+        _bad_sim_probe_in_cpml,
+        _bad_sim_no_sources,
+        _bad_sim_lossless_q,
+        _bad_sim_under_resolved_dielectric,
+        _bad_sim_upml_refinement,
+    )
+    total = 0
+    for build in builders:
+        report = build().preflight()
+        for issue in _all_emitted_issues(report):
+            total += 1
+            assert isinstance(issue, PreflightIssue)
+            assert issue.code and issue.code != "uncoded", (
+                f"{build.__name__}: uncoded issue {str(issue)!r}"
+            )
+            assert issue.severity in ("warning", "error")
+    assert total > 0, "battery emitted no issues — meta-test is vacuous"
+
+
+def test_error_severity_config_issue_is_coded():
+    """The structurally-impossible upml+refinement raise surfaces as an
+    error-severity issue with its check-site slug (not 'uncoded')."""
+    report = _bad_sim_upml_refinement().preflight()
+    errs = report.errors
+    assert errs, "expected an error-severity issue for upml+refinement"
+    assert any(i.code == "upml_refinement" for i in errs), (
+        f"codes: {[i.code for i in errs]}"
+    )
+    assert not report.ok
+
+
+def test_to_dict_and_to_json_roundtrip_carry_code_and_severity():
+    """Real serialization: to_dict()/to_json() carry code + severity per issue
+    (the str subclass alone is NOT json-dumpable with its attrs)."""
+    import json
+
+    report = _bad_sim_probe_in_cpml().preflight()
+    assert report, "expected at least one issue to serialize"
+    d = report.to_dict()
+    assert d["n_issues"] == len(report)
+    for src, rec in zip(report, d["issues"]):
+        assert rec["code"] == src.code
+        assert rec["severity"] == src.severity
+        assert rec["message"] == str(src)
+    back = json.loads(report.to_json())
+    assert back["issues"][0]["code"] == report[0].code
+    assert back["issues"][0]["severity"] == report[0].severity

--- a/tests/test_result_finite_guard.py
+++ b/tests/test_result_finite_guard.py
@@ -1,0 +1,84 @@
+"""Tier-1 correctness guard: NaN/Inf must never propagate silently.
+
+Covers ``Result.assert_finite`` + the shared ``_warn_if_nonfinite_result``
+helper (rfx/api/_spec.py). A non-finite ``time_series`` / ``s_params`` almost
+always means the FDTD diverged; surfacing it (warn, or raise on demand) lets
+an automation loop fail fast instead of feeding garbage into a metric.
+
+The optimizer-side ``jnp.isfinite(grad)`` guard (rfx/optimize.py,
+rfx/topology.py) is the partner fix; it is exercised indirectly here via the
+helper contract and directly by the gradient-coverage suites.
+"""
+import warnings
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from rfx.api._spec import (
+    Result,
+    _nonfinite_fields,
+    _warn_if_nonfinite_result,
+)
+
+
+def _result(time_series, s_params=None):
+    return Result(
+        state=None,
+        time_series=np.asarray(time_series),
+        s_params=None if s_params is None else np.asarray(s_params),
+        freqs=None,
+    )
+
+
+def test_finite_result_assert_finite_true_and_silent():
+    r = _result(np.zeros((10, 2)), s_params=np.full((1, 1, 3), 0.4 + 0j))
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert r.assert_finite() is True
+
+
+def test_nan_time_series_warns_and_returns_false():
+    ts = np.zeros((10, 2))
+    ts[3, 1] = np.nan
+    r = _result(ts)
+    with pytest.warns(UserWarning, match="non-finite"):
+        assert r.assert_finite() is False
+
+
+def test_inf_sparams_raise_on_demand():
+    s = np.full((1, 1, 3), 0.5 + 0j)
+    s[0, 0, 1] = np.inf
+    r = _result(np.zeros((4, 1)), s_params=s)
+    with pytest.raises(ValueError, match="non-finite"):
+        r.assert_finite(raise_on_nonfinite=True)
+
+
+def test_nonfinite_fields_reports_counts():
+    ts = np.zeros((5, 2))
+    ts[0, 0] = np.nan
+    ts[1, 1] = np.inf
+    bad = _nonfinite_fields(_result(ts))
+    assert dict(bad)["time_series"] == 2
+
+
+def test_warn_helper_silent_when_finite():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_if_nonfinite_result(_result(np.ones((3, 1))), context="run")
+
+
+def test_assert_finite_is_tracer_safe_under_jax_grad():
+    """Under jax.grad the observables are tracers; assert_finite must be a
+    no-op (never convert/raise), so it is safe to call inside forward()/run()
+    on the AD path."""
+
+    def f(x):
+        r = Result(state=None, time_series=x, s_params=None, freqs=None)
+        # Even though x carries non-finite-looking magnitude, tracing must skip.
+        r.assert_finite()
+        return jnp.sum(x)
+
+    g = jax.grad(f)(jnp.full((4,), 3.0))
+    assert bool(jnp.all(jnp.isfinite(g)))

--- a/tests/test_result_finite_guard.py
+++ b/tests/test_result_finite_guard.py
@@ -82,3 +82,30 @@ def test_assert_finite_is_tracer_safe_under_jax_grad():
 
     g = jax.grad(f)(jnp.full((4,), 3.0))
     assert bool(jnp.all(jnp.isfinite(g)))
+
+
+def test_optimize_nan_gradient_warns_and_returns_last_good():
+    """The optimizer NaN/Inf-gradient guard must (1) warn, (2) stop early, and
+    (3) return the last FINITE design — not the divergence-causing one. Here a
+    NaN objective makes the gradient NaN at iteration 0, so the loop breaks
+    before any update and the returned design is the (finite) initial latent."""
+    from rfx.api import Simulation
+    from rfx.optimize import optimize, DesignRegion, OptimizeResult
+
+    sim = Simulation(freq_max=5e9, domain=(0.015, 0.015, 0.015), boundary="pec")
+    sim.add_port((0.005, 0.0075, 0.0075), "ez")
+    sim.add_probe((0.01, 0.0075, 0.0075), "ez")
+    region = DesignRegion(
+        corner_lo=(0.006, 0.006, 0.006),
+        corner_hi=(0.009, 0.009, 0.009),
+        eps_range=(1.0, 4.4),
+    )
+    with pytest.warns(UserWarning, match="non-finite"):
+        result = optimize(
+            sim, region,
+            lambda r: jnp.nan * jnp.sum(r.time_series),  # NaN loss => NaN grad
+            n_iters=3, lr=0.01, verbose=False,
+        )
+    assert isinstance(result, OptimizeResult)
+    assert len(result.loss_history) == 0          # broke at iteration 0
+    assert np.all(np.isfinite(np.asarray(result.eps_design)))  # last-good is finite

--- a/tests/test_run_preflight_parity.py
+++ b/tests/test_run_preflight_parity.py
@@ -1,0 +1,53 @@
+"""Tier-1: run() must get the same consolidated, skippable preflight that
+forward() already gets (issue #66 parity).
+
+Previously run() emitted only scattered raw mesh/config warnings with no
+skip_preflight control, so the documented lumped/wire S-parameter path via
+run(compute_s_params=True) silently missed part of the proactive error
+surface. This locks: (1) run() surfaces a setup footgun, (2) skip_preflight
+suppresses it, (3) the consolidated warning routes through _auto_preflight.
+"""
+import warnings
+
+import pytest
+
+from rfx.api import Simulation
+
+
+def _sim_with_probe_in_cpml():
+    # Probe + source pushed to the very edge => preflight flags CPML overlap.
+    sim = Simulation(domain=(0.02, 0.02, 0.02), freq_max=10e9, boundary="cpml")
+    sim.add_source((0.01, 0.01, 0.01), component="ez")
+    sim.add_probe((0.01, 0.01, 0.018), component="ez")
+    return sim
+
+
+def test_run_emits_preflight_warning_by_default():
+    sim = _sim_with_probe_in_cpml()
+    with pytest.warns(UserWarning, match="(?i)preflight|CPML"):
+        sim.run(n_steps=10)
+
+
+def test_run_skip_preflight_suppresses_it():
+    sim = _sim_with_probe_in_cpml()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any preflight UserWarning => failure
+        # A genuine numerical warning unrelated to preflight could still fire;
+        # this config only trips the preflight surface, so silence == success.
+        sim.run(n_steps=10, skip_preflight=True)
+
+
+def test_run_preflight_warning_is_consolidated_single_warning():
+    """_auto_preflight folds all issues into ONE UserWarning (vs the old
+    scattered raw warnings)."""
+    sim = _sim_with_probe_in_cpml()
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        sim.run(n_steps=10)
+    preflight_warnings = [
+        w for w in rec
+        if issubclass(w.category, UserWarning) and "preflight" in str(w.message).lower()
+    ]
+    assert len(preflight_warnings) == 1, (
+        f"expected one consolidated preflight warning, got {len(preflight_warnings)}"
+    )

--- a/tests/test_sparam_passivity_guard.py
+++ b/tests/test_sparam_passivity_guard.py
@@ -105,3 +105,30 @@ def test_guard_is_tracer_safe_under_jax_grad():
 
     g = jax.grad(f)(jnp.full((4,), 5.0))  # 5.0 => |S11|=5 > 1, but traced
     assert bool(jnp.all(jnp.isfinite(g)))
+
+
+def test_normalize_aware_tol_tolerates_documented_overshoot():
+    """compute_waveguide_s_matrix(normalize=False) has documented Yee-dispersion
+    + band-edge |S11| overshoot (validated paths reach ~1.4); the loose tol used
+    on that path must stay SILENT on a column-power ~2.0 (|S11|~1.41) result,
+    while the tight tol used on normalize=True/"flux" still flags it. Gross
+    extractor bugs (|S11|>>1) are caught under either tol."""
+    s = np.zeros((1, 1, 3), dtype=complex)
+    s[0, 0, :] = np.sqrt(2.0)  # column power 2.0  (|S11| = 1.414)
+    # loose tol (the normalize=False path) -> silent
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_if_nonpassive_smatrix(
+            _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=2.0
+        )
+    # tight tol (the normalize=True/"flux" path) -> warns
+    with pytest.warns(UserWarning, match="passivity"):
+        _warn_if_nonpassive_smatrix(
+            _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=0.10
+        )
+    # a gross bug is caught even under the loose tol
+    s[0, 0, :] = 8.94
+    with pytest.warns(UserWarning, match="passivity"):
+        _warn_if_nonpassive_smatrix(
+            _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=2.0
+        )

--- a/tests/test_sparam_passivity_guard.py
+++ b/tests/test_sparam_passivity_guard.py
@@ -1,0 +1,107 @@
+"""Tier-1 correctness guard: waveguide/coax S-matrix extractors must
+self-flag a non-physical (non-passive / non-finite) result.
+
+This locks the wiring of ``rfx.validation.validate_port_smatrix`` into the
+NON-MSL extractors via ``_warn_if_nonpassive_smatrix`` (rfx/api/_sparams.py).
+Operationalizes the R5 "no surface-metric verdict" discipline: a passive
+structure cannot have column power > 1, so |S11| > 1 means the extractor is
+wrong — exactly the failure mode behind the multi-session WR-90 |S11| chase.
+
+The guard is exercised at the helper level (cheap, no FDTD) for the warn /
+raise / pass / NaN / tracer-safety contract.
+"""
+from types import SimpleNamespace
+
+import warnings
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from rfx.api._sparams import _warn_if_nonpassive_smatrix
+
+
+def _result(s_params, freqs=None, names=("port0",)):
+    s = np.asarray(s_params)
+    n_f = s.shape[-1]
+    if freqs is None:
+        freqs = np.linspace(1e9, 2e9, n_f)
+    return SimpleNamespace(
+        s_params=s,
+        freqs=np.asarray(freqs, dtype=float),
+        port_names=names,
+    )
+
+
+def test_passive_smatrix_is_silent():
+    """A physical |S11| <= 1 must NOT warn."""
+    s = np.full((1, 1, 4), 0.5 + 0.0j)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning => test failure
+        _warn_if_nonpassive_smatrix(
+            _result(s), extractor="compute_waveguide_s_matrix"
+        )
+
+
+def test_nonpassive_smatrix_warns():
+    """|S11| = 8.94 (the canonical WR-90 detour value) must warn."""
+    s = np.zeros((1, 1, 4), dtype=complex)
+    s[0, 0, :] = 8.94
+    with pytest.warns(UserWarning, match="passivity"):
+        _warn_if_nonpassive_smatrix(
+            _result(s), extractor="compute_waveguide_s_matrix"
+        )
+
+
+def test_nonpassive_smatrix_raises_under_strict():
+    """strict=True turns the non-physical result into a hard error so an
+    automation loop fails fast instead of optimizing against garbage."""
+    s = np.zeros((1, 1, 4), dtype=complex)
+    s[0, 0, :] = 1.5
+    with pytest.raises(ValueError, match="UNRELIABLE"):
+        _warn_if_nonpassive_smatrix(
+            _result(s), extractor="compute_coaxial_s_matrix", strict=True
+        )
+
+
+def test_nonfinite_smatrix_warns():
+    """NaN/Inf in the S-matrix must surface, not pass silently."""
+    s = np.full((1, 1, 4), 0.3 + 0.0j)
+    s[0, 0, 2] = np.nan
+    with pytest.warns(UserWarning):
+        _warn_if_nonpassive_smatrix(
+            _result(s), extractor="compute_waveguide_s_matrix"
+        )
+
+
+def test_small_passivity_overage_within_tol_is_silent():
+    """Numerical Yee impedance mismatch (~3%, documented for the
+    normalize=False strong-reflector path) must not false-positive: the
+    default tol matches the MSL honesty guard (|S11| <= ~1.05, i.e. column
+    power <= 1.10), so a |S11| ~ 1.04 stays silent."""
+    s = np.full((1, 1, 3), 1.04 + 0.0j)  # column power 1.0816 < 1.10
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_if_nonpassive_smatrix(
+            _result(s), extractor="compute_waveguide_s_matrix"
+        )
+
+
+def test_guard_is_tracer_safe_under_jax_grad():
+    """Under jax.grad the S-matrix is an abstract tracer; the numpy-based
+    guard MUST be skipped (never raise / convert), so AD through an extractor
+    that calls it stays intact."""
+
+    def f(x):
+        # x stands in for a traced s_params produced inside an extractor.
+        res = SimpleNamespace(
+            s_params=x.reshape(1, 1, -1),
+            freqs=np.linspace(1e9, 2e9, x.shape[0]),
+            port_names=("port0",),
+        )
+        _warn_if_nonpassive_smatrix(res, extractor="compute_waveguide_s_matrix")
+        return jnp.real(jnp.sum(x))
+
+    g = jax.grad(f)(jnp.full((4,), 5.0))  # 5.0 => |S11|=5 > 1, but traced
+    assert bool(jnp.all(jnp.isfinite(g)))

--- a/tests/test_stage2_dual_path.py
+++ b/tests/test_stage2_dual_path.py
@@ -42,7 +42,6 @@ def test_simulation_run_with_aniso_inv_eps_runs_finite():
         dx=0.001,
         cpml_layers=4,
     )
-    state0 = init_state(grid.shape)
     materials = init_materials(grid.shape)
 
     inv_xx = jnp.ones(grid.shape, dtype=jnp.float32)

--- a/tests/test_subpixel_pec.py
+++ b/tests/test_subpixel_pec.py
@@ -620,9 +620,14 @@ def test_mesh_convergence_s21_with_conformal_pec_baseline():
         "Diagnosed 2026-05-02 — root cause not yet identified; conformal "
         "path is verified functional on the PEC-short single-run "
         "normalize=False gate (test_pec_short_s11_with_conformal_face_pec). "
-        "Tracks the Stage 1 follow-up listed in rfx-known-issues.md."
+        "Tracks the Stage 1 follow-up listed in rfx-known-issues.md. "
+        "STRICT TRIPWIRE: when the BCK/USC contour-FIT redesign lands and the "
+        "NaN is gone, this XPASSes and strict=True HARD-FAILS the suite — which "
+        "is the signal to DELETE the _validate_cfg_conformal_fine_dx preflight "
+        "guard (it would then be a false positive). Self-detecting stale-check "
+        "(mypy --warn-unused-ignores / rustc expect pattern)."
     ),
-    strict=False,
+    strict=True,
 )
 def test_mesh_convergence_s21_with_conformal_pec():
     """``Boundary(conformal=True)`` must keep mesh refinement on the S21
@@ -642,6 +647,14 @@ def test_mesh_convergence_s21_with_conformal_pec():
         s21 = float(np.abs(s[port_idx["right"], port_idx["left"], 0]))
         s21_values.append(s21)
         print(f"[meshconv-conformal] dx={dx*1e3:.1f}mm cpml={layers} |S21|={s21:.4f}")
+
+    # PRIMARY signal (hardened): the actual failure mode is NaN |S21| at fine
+    # dx, not a tolerance miss. Assert finiteness explicitly so XPASS means
+    # "the NaN is gone" (clean tripwire), not "the tolerance happened to pass".
+    assert np.all(np.isfinite(s21_values)), (
+        f"conformal=True produced non-finite |S21| at fine dx: {s21_values} — "
+        "the known conformal-fine-dx NaN (see rfx-known-issues.md)."
+    )
 
     coarse_delta = abs(s21_values[0] - s21_values[1])
     fine_delta = abs(s21_values[1] - s21_values[2])


### PR DESCRIPTION
Makes rfx more agent-drivable by wiring its own R2/R4/R5 discipline ("don't trust a surface metric") into runtime guards, then redesigning the preflight system to match how mature tools (Tidy3D, Meep, openEMS, HFSS/Lumerical/COMSOL, and LSP/ruff/rustc/mypy/pydantic) do pre-run validation. All additive, tracer-safe (no-op under `jax.grad`/`jit`), and **non-MSL** (the MSL extractor in `_sparams.py` is owned by a separate track and is untouched here).

## Part 1 — correctness guards (`5a74656`, `faed457`)
- **Auto-passivity self-check** on `compute_waveguide_s_matrix` + `compute_coaxial_s_matrix` (runs `validate_port_smatrix`; `|S11|>1` / NaN → warn, or raise under `strict_passivity`). The guard that would have short-circuited the multi-session WR-90 `|S11|` chase.
- **NaN guards**: `Result.assert_finite()`, forward/run NaN-result warnings (all 5 `run()` return paths), and an `isfinite(grad)` guard in `optimize()`/`topology_optimize()` — stops a silent NaN gradient from poisoning inverse design.
- **`run()` preflight parity** with `forward()` (`skip_preflight=` added). This initially regressed structurally-impossible configs to warnings; **fixed** so error-severity findings hard-fail (re-raise) again.
- **Ruff lint gate** (`.github/workflows/lint.yml`) on push/PR + cleanup of 14 pre-existing `F841`s so it's green tree-wide.

## Part 2 — preflight redesign, A–E (`b37e912`, `a1cf936`, `e0230e6`)
Plan reviewed to consensus (critic: REVISE → ACCEPT-WITH-CHANGES). Grounded in source-verified precedent.
- **Structured `PreflightReport`** — a `list` subclass (full back-compat with the legacy `list[str]`) that mirrors the repo's existing `SubgridValidationReport`/`PortValidationReport` idiom: `.errors`/`.warnings`/`.ok`/`.by_code()`/`.format()`/`.raise_for_failure()`/`.to_dict()`/`.to_json()`. So an agent can gate: `errors = [i for i in sim.preflight() if i.severity == "error"]`.
- **Stable codes at the check site** (lowercase slugs like `conformal_nan`, `mesh_resolution`, `absorber_overlap`) — replaces the backwards "infer code from the message" scheme; `_preflight_code_for` deleted. `PreflightWarning`/`PreflightConfigError` carry `code`/`severity`/`loc`/`source`.
- **`strict=True` = aggregate-then-raise** (every issue in one error, not fail-on-first), preserving the "strict escalates any issue" contract.
- **Validator bugs are loud** — `_auto_preflight` no longer swallows a crashing validator into a soft warning.
- **Self-detecting conformal stale-check** — the conformal-fine-dx NaN guard is tied to `test_mesh_convergence_s21_with_conformal_pec`, now `xfail(strict=True)` with an explicit `isfinite` assert: when the contour-FIT redesign fixes the NaN, the test XPASSes and **hard-fails CI**, forcing deletion of the now-false-positive guard (the mypy `--warn-unused-ignores` / rustc `expect` pattern).

## Tests
4 new test files (passivity, finite-result, run-preflight parity, structured-preflight + guards) plus the conformal tripwire. Verified locally: 117 preflight/guard/api tests pass, full ruff gate green, AD end-to-end intact (`jax.grad` flows through the guarded extractors), and the `upml`/Floquet hard-fail regression lock is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)