### PR TITLE
docs(agent): three public task recipes

### DIFF
--- a/docs/agent/recipe-resonance-extraction.mdx
+++ b/docs/agent/recipe-resonance-extraction.mdx
@@ -1,0 +1,131 @@
+---
+title: "Resonance Extraction"
+description: "Extract resonant frequencies, decay rates, and Q factors from free-ringdown probe signals using Harminv."
+sidebar:
+  order: 9
+---
+
+Use this recipe when the target quantity is a resonant mode of a cavity, ring resonator, resonant defect, photonic crystal, or similar structure. The usual outputs are modal frequency, decay rate, complex amplitude, and quality factor (Q).
+
+This is not the right primitive for source-driven steady-state amplitude or transmission. Use `add_flux_monitor` for R(f)/T(f) measurements instead — see the [R/T measurement recipe](./recipe-rt-measurement).
+
+## The primitive
+
+```python
+from rfx.harminv import harminv
+```
+
+`harminv` implements the Matrix Pencil Method to extract resonant modes from a scalar time trace. It requires the trace to contain free ringing — the source must be off before the analysis window starts.
+
+**Signature:**
+
+```python
+modes = harminv(signal, dt, f_min, f_max)
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `signal` | 1D array | Time-domain field trace (real or complex) |
+| `dt` | float | Timestep in seconds |
+| `f_min` | float | Lower bound of frequency search range (Hz) |
+| `f_max` | float | Upper bound of frequency search range (Hz) |
+
+Each returned `HarminvMode` has:
+
+| Attribute | Description |
+|-----------|-------------|
+| `.freq` | Mode frequency (Hz) |
+| `.decay` | Decay rate (1/s), positive = decaying |
+| `.Q` | Quality factor |
+| `.amplitude` | Amplitude magnitude |
+| `.phase` | Phase in radians |
+| `.error` | Relative error estimate |
+
+## Canonical pattern
+
+```python
+import math
+import numpy as np
+
+from rfx import Simulation
+from rfx.boundaries.spec import BoundarySpec
+from rfx.harminv import harminv
+from rfx.sources.sources import ModulatedGaussian
+
+# --- Parameters ---
+C0 = 3e8
+fcen_hz = 200e9           # target resonance (Hz)
+bandwidth = 0.5           # fractional bandwidth of excitation
+expected_q = 500          # rough estimate for sizing the run length
+domain_m = 20e-3          # domain size (m)
+dx = 0.5e-3               # cell size (m)
+
+# --- Build simulation ---
+sim = Simulation(
+    freq_max=fcen_hz * 2,
+    domain=(domain_m, domain_m, dx),
+    dx=dx,
+    boundary=BoundarySpec.uniform("upml"),
+    mode="2d_tmz",
+)
+
+waveform = ModulatedGaussian(f0=fcen_hz, bandwidth=bandwidth, cutoff=5.0)
+sim.add_source(position=(0.0, 0.0, 0.0), component="ez", waveform=waveform)
+sim.add_probe(position=(0.0, 0.0, 0.0), component="ez")
+
+# --- Run long enough for source to decay + sufficient ringdown ---
+# Ringdown time ~ Q / (pi * f); aim for ~10 Q-cycles
+ringdown_s = 10.0 * expected_q / (math.pi * fcen_hz)
+source_off_s = waveform.t0 + 3.0 * waveform.tau   # source effectively off after ~3 tau past peak
+total_s = source_off_s + ringdown_s
+dt_est = dx / (C0 * math.sqrt(2)) * 0.99
+n_steps = int(total_s / dt_est)
+
+result = sim.run(n_steps=n_steps)
+
+# --- Extract harminv from the ringdown portion only ---
+ts = np.asarray(result.time_series).ravel()
+dt = float(result.dt)
+
+# Skip the source-active prefix; use only free-ringing tail
+source_off_index = int(math.ceil(source_off_s / dt))
+ringdown = ts[source_off_index:]
+
+fmin_hz = fcen_hz * 0.7
+fmax_hz = fcen_hz * 1.3
+
+modes = harminv(ringdown, dt, fmin_hz, fmax_hz)
+
+for m in modes:
+    print(f"f={m.freq:.4e} Hz  Q={m.Q:.0f}  amp={m.amplitude:.3e}")
+```
+
+### Convenience method
+
+`Result` also exposes a `find_resonances` helper that handles the ringdown slice automatically:
+
+```python
+modes = result.find_resonances(
+    freq_range=(fmin_hz, fmax_hz),
+    probe_idx=0,
+    source_decay_time=source_off_s,
+)
+```
+
+## Pitfalls
+
+**Skip the source-active prefix.** Harminv assumes pure free ringing. Including the source-on portion adds driven content that is not exponentially decaying and will corrupt the mode fit. Always slice to start after the source has turned off.
+
+**Size the ringdown for the expected Q.** A practical minimum is 5 Q-cycles; 10 Q-cycles gives reliable fits. The ringdown time in seconds is approximately `Q / (pi * f)`. Under-running produces broad, unreliable modes.
+
+**`ModulatedGaussian` cutoff default is 5.0.** This controls how many `tau` before the envelope peak the source starts. The default (`cutoff=5.0`) matches Meep convention: source peaks at `t = cutoff * tau`. Reducing `cutoff` gives a faster onset but a non-zero amplitude at `t=0`. The bandwidth of the excitation is set by `bandwidth`; changing `cutoff` shifts the source-on duration without changing which frequencies are excited.
+
+**`result.dt` must be available.** Call `sim.run(n_steps=...)` normally; `result.dt` is populated automatically. If you see a `ValueError` about `dt not available`, you are using a non-standard run path.
+
+## Canonical example
+
+`examples/crossval/02_ring_resonator.py` is the project-level ring resonator validation that uses `harminv` directly against Meep. It shows the full pattern: broadband `ModulatedGaussian` excitation, time-series extraction from `result.time_series` and `result.dt`, and the skip-fraction used to isolate the ringdown.
+
+## Background
+
+The underlying algorithm is filter diagonalization / Matrix Pencil. See Sarkar and Pereira, "Using the Matrix Pencil Method to Estimate the Parameters of a Sum of Complex Exponentials", IEEE AP Magazine, February 1995. The method is substantially more accurate than FFT for short time series and extracting high-Q modes.

--- a/docs/agent/recipe-rt-measurement.mdx
+++ b/docs/agent/recipe-rt-measurement.mdx
@@ -1,0 +1,194 @@
+---
+title: "Recipe: Broadband R(f)/T(f) of a Slab or Scatterer"
+description: "How to measure broadband reflection and transmission spectra of a dielectric slab, multilayer stack, or dispersive scatterer using rfx flux monitors and two-run reference subtraction."
+sidebar:
+  order: 8
+---
+
+Use this recipe when you need broadband complex R(f) / T(f) spectra of a slab,
+thin-film stack, periodic surface, or other scatterer. For guided-mode
+S-parameters in a bounded waveguide, see [recipe-waveguide-sparams](./recipe-waveguide-sparams)
+instead.
+
+## When to use
+
+- Broadband reflectance and transmittance vs frequency for free-space or
+  periodic-boundary geometries.
+- Dispersive materials (Lorentz resonances, Drude metals) where frequency
+  dependence is essential.
+- Any case where the analytic transfer-matrix or Fresnel stack result is
+  the benchmark.
+
+**Not for**: guided modes, coaxial lines, microstrip — those have dedicated port
+primitives and compute paths.
+
+## Right primitives
+
+### `add_flux_monitor`
+
+On-the-fly DFT accumulation of the Poynting flux on a plane. Each frequency
+component is integrated continuously throughout the run, so no time-series
+storage is needed and no post-run FFT is required.
+
+```python
+sim.add_flux_monitor(axis="x", coordinate=refl_x, freqs=freqs_rt, name="refl")
+sim.add_flux_monitor(axis="x", coordinate=trans_x, freqs=freqs_rt, name="trans")
+```
+
+### `run(until_decay=...)`
+
+Decay-adaptive termination (`rfx/api/_execute.py`, line 1593). Runs until the
+field at a chosen monitor position decays to `until_decay * peak`. This kwarg
+is load-bearing for accuracy: a fixed `n_steps` truncates the signal and aliases
+residual energy into the spectrum. `decay_monitor_component` and
+`decay_monitor_position` control which field and where to sample the decay.
+
+### Two-run reference subtraction
+
+Run once without the scatterer (reference run) and once with it (sample run).
+Subtract the DFT accumulators at the field level before computing the power flux.
+
+## Canonical two-run pattern
+
+```python
+import numpy as np
+from rfx import Simulation, Box
+from rfx.probes.probes import flux_spectrum
+
+def build_sim(with_slab: bool) -> Simulation:
+    sim = Simulation(
+        freq_max=freq_max, domain=(dom_x, dom_y, dx), dx=dx,
+        boundary="cpml", cpml_layers=20, mode="2d_tmz",
+    )
+    if with_slab:
+        sim.add_material("slab", eps_r=eps_inf, lorentz_poles=[pole])
+        # Box must span full y/z extent including CPML padding —
+        # with TFSF, transverse axes are periodic, and any cell
+        # outside the material mask breaks the plane-wave assumption.
+        sim.add(Box((slab_x_lo, -1, -1), (slab_x_hi, 1, 1)), material="slab")
+    sim.add_tfsf_source(f0=f0, bandwidth=bw, polarization="ez", direction="+x")
+    sim.add_flux_monitor(axis="x", coordinate=refl_x, freqs=freqs_rt, name="refl")
+    sim.add_flux_monitor(axis="x", coordinate=trans_x, freqs=freqs_rt, name="trans")
+    return sim
+
+# Run 1 — reference (no scatterer)
+sim_ref = build_sim(with_slab=False)
+res_ref = sim_ref.run(
+    n_steps=12000,
+    until_decay=1e-5,
+    decay_monitor_component="ez",
+    decay_monitor_position=(trans_x, y_center, 0),
+)
+ref_refl_fm = res_ref.flux_monitors["refl"]
+ref_trans_flux = np.asarray(flux_spectrum(res_ref.flux_monitors["trans"]))
+
+# Run 2 — sample (with scatterer)
+sim_slab = build_sim(with_slab=True)
+res_slab = sim_slab.run(
+    n_steps=12000,
+    until_decay=1e-5,
+    decay_monitor_component="ez",
+    decay_monitor_position=(trans_x, y_center, 0),
+)
+slab_refl_fm = res_slab.flux_monitors["refl"]
+slab_trans_flux = np.asarray(flux_spectrum(res_slab.flux_monitors["trans"]))
+
+# Field-level subtraction for reflection
+# (FluxMonitor is a NamedTuple; field names: e1_dft, e2_dft, h1_dft, h2_dft)
+scat_refl_fm = slab_refl_fm._replace(
+    e1_dft=slab_refl_fm.e1_dft - ref_refl_fm.e1_dft,
+    e2_dft=slab_refl_fm.e2_dft - ref_refl_fm.e2_dft,
+    h1_dft=slab_refl_fm.h1_dft - ref_refl_fm.h1_dft,
+    h2_dft=slab_refl_fm.h2_dft - ref_refl_fm.h2_dft,
+)
+scat_refl_flux = np.asarray(flux_spectrum(scat_refl_fm))
+
+# Reflection and transmission coefficients
+T = slab_trans_flux / ref_trans_flux      # transmittance
+R = -scat_refl_flux / ref_trans_flux      # reflectance (sign: reflection is −x)
+```
+
+## Critical details
+
+### (a) Field-level subtraction is required
+
+Poynting flux is bilinear in E and H. If you subtract the pre-computed flux
+values (`F_slab - F_ref`), the cross terms do not cancel, and the result is
+wrong for all scatterers. Subtracting the E and H DFT accumulators first, then
+calling `flux_spectrum`, is exact because Maxwell's equations are linear.
+
+### (b) `until_decay` is load-bearing
+
+A fixed `n_steps` makes the DFT aliasing depend on where the signal happens to
+be truncated. For dispersive or high-Q scatterers, use `until_decay=1e-5` or
+tighter. For simple lossless slabs `1e-3` is often sufficient.
+
+`until_decay` is not supported with `solver='adi'`; a `ValueError` is raised if
+you try.
+
+### (c) TFSF transverse-periodicity gotcha
+
+`add_tfsf_source` forces the transverse axes (y, z) to be periodic. The
+material `Box` must span the full y/z extent including the CPML padding. Any
+cell outside the material mask breaks the plane-wave assumption. Use oversized
+corners: `Box((x_lo, -1, -1), (x_hi, 1, 1))`.
+
+### (d) Cell-alignment nudge for slab thickness
+
+`Box` uses inclusive bounds (`coords >= lo and coords <= hi`), so a physically
+`d`-thick slab can map to `d + dx` cells. Nudge the upper x-corner down by
+`dx/2` to hit the last interior cell: `slab_x_hi = center + d/2 - dx/2`.
+
+## Do NOT use
+
+**`add_probe` (time-series) + `np.fft.rfft`** for dispersive media.
+
+A chirped pulse transmitted through a dispersive slab has frequencies arriving
+at different times. Any time-gate window (Hann, Tukey, rectangular) introduces
+a frequency-dependent bias because the chirped transmitted pulse and the
+incident reference pulse have different effective envelopes under the same
+window. This bias is independent of grid resolution — halving `dx` does not
+reduce it.
+
+`add_flux_monitor` sidesteps this entirely: each frequency is integrated
+continuously, and `until_decay` ensures the signal has truly ended before the
+DFT is read.
+
+For dispersionless media there is no group-velocity chirp, so the raw
+time-series approach does not produce this artifact — but `add_flux_monitor`
+is still preferred for its cleaner interface and decay-adaptive stopping.
+
+## Known accuracy
+
+`examples/crossval/04_multilayer_fresnel.py` gates rfx against the analytic
+Fresnel / transfer-matrix result with a mean-error threshold of 0.05 (5%) for
+both T(f) and R(f), as well as energy conservation R+T within 5%. In practice
+rfx passes this gate with substantially lower error for well-resolved, lossless
+slabs.
+
+For dispersive media there is currently **no tracked R(f)/T(f) accuracy oracle**
+in this repository — treat dispersive R/T results as unvalidated against
+analytic references until such a gate exists. Two source-verifiable facts to
+keep in mind when comparing against other solvers: rfx discretizes
+Lorentz/Debye poles with a second-order central-difference ADE
+(`rfx/materials/lorentz.py`), while some other FDTD solvers use
+recursive-convolution D-field updates; both are O(Δt²) but produce slightly
+different effective ε(f) near stiff resonances, so a small residual between
+solvers at a sharp Lorentz peak is a discretization-level difference, not
+necessarily a usage error in either tool.
+
+## Canonical examples
+
+- `examples/crossval/04_multilayer_fresnel.py` — dispersionless Fresnel slab,
+  analytic comparison. Note: this script uses a raw Yee loop (`update_e` /
+  `update_h`) rather than the `Simulation` API. The raw-loop approach works for
+  dispersionless media because there is no group-velocity chirp; for dispersive
+  media use `add_flux_monitor` via the `Simulation` API.
+
+## Companion primitives
+
+- `add_dft_plane_probe` — full complex E/H snapshot on a 2D plane; useful for
+  mode patterns and near-field maps.
+- `add_ntff_box` — near-to-far-field transform for 3D scatterers.
+- `compute_waveguide_s_matrix` — S-parameters in bounded waveguides (not
+  plane-wave); see [recipe-waveguide-sparams](./recipe-waveguide-sparams).

--- a/docs/agent/recipe-waveguide-sparams.mdx
+++ b/docs/agent/recipe-waveguide-sparams.mdx
@@ -1,0 +1,185 @@
+---
+title: "Recipe: Waveguide S-Parameters"
+description: "How to measure bounded rectangular waveguide multi-port S-parameters in rfx using waveguide ports."
+sidebar:
+  order: 7
+---
+
+Use this recipe for bounded rectangular waveguide problems where the quantity
+of interest is a multi-port scattering matrix between guided modes. Typical
+targets include straight waveguide transmission, bends, discontinuities,
+tapers, dielectric-loaded sections, and iris filters.
+
+For plane-wave slab reflection/transmission in open space, use
+[R/T Measurement](./recipe-rt-measurement) instead.
+
+## Primitives
+
+The canonical workflow uses two waveguide ports and then computes the
+scattering matrix:
+
+- **`Simulation.add_waveguide_port(x_position, direction, mode, ...)`** — each
+  port acts as both source and receiver. rfx launches the selected mode,
+  records reflected and transmitted modal coefficients, and uses PEC walls on
+  the transverse axes.
+- **`Simulation.compute_waveguide_s_matrix(normalize=True, num_periods=...)`**
+  — runs the simulation once per driven port plus a vacuum reference run and
+  returns an N×N×n_freqs complex S-matrix.
+
+Implementation lives in `rfx/api/_sparams.py`.
+
+## Canonical code block
+
+```python
+import numpy as np
+import jax.numpy as jnp
+from rfx import Simulation, Box
+
+C0 = 299_792_458.0
+
+a_wg = 0.02286   # WR-90 broad face (m)
+b_wg = 0.01016   # WR-90 narrow face (m)
+length = 0.10    # total guide length (m)
+dx = 0.5e-3      # cell size (m)
+
+f_c = C0 / (2 * a_wg)          # TE10 cutoff
+fcen = 1.5 * f_c               # band centre
+bw = 0.4                       # fractional bandwidth
+freqs = jnp.linspace(f_c * 1.3, f_c * 1.9, 50)
+
+sim = Simulation(
+    domain=(length, a_wg, b_wg),
+    dx=dx,
+    boundary="cpml",
+    cpml_layers=10,
+)
+
+# Optional: add a dielectric plug
+# plug_lo, plug_hi = 0.04, 0.06
+# sim.add_material("plug", eps_r=2.0)
+# sim.add(Box((plug_lo, 0, 0), (plug_hi, a_wg, b_wg)), material="plug")
+
+sim.add_waveguide_port(
+    x_position=0.003,
+    direction="+x",
+    mode=(1, 0),
+    mode_type="TE",
+    freqs=freqs,
+    f0=fcen,
+    bandwidth=bw,
+    probe_offset=10,
+    ref_offset=3,
+    name="port1",
+)
+sim.add_waveguide_port(
+    x_position=length - 0.003,
+    direction="-x",
+    mode=(1, 0),
+    mode_type="TE",
+    freqs=freqs,
+    f0=fcen,
+    bandwidth=bw,
+    probe_offset=10,
+    ref_offset=3,
+    name="port2",
+)
+
+result = sim.compute_waveguide_s_matrix(num_periods=30.0, normalize=True)
+S = np.asarray(result.s_params)   # shape: (n_ports, n_ports, n_freqs)
+S11 = S[0, 0, :]
+S21 = S[1, 0, :]
+```
+
+## Critical parameters
+
+| Parameter | Guidance |
+|-----------|----------|
+| `normalize` | Use `normalize=True` for transmission measurements — cancels one-way Yee numerical-dispersion bias in |S21|. Use `normalize=False` for |S11| of strong reflectors (PEC short, high-Q resonators) where the round-trip dispersion error in the two-run path exceeds the impedance-mismatch error of the single-run path. Use `normalize="flux"` for simultaneous accuracy in both reflection and transmission. |
+| `num_periods` | Must be long enough for the source pulse and port monitor response to settle. A range of 20–40 periods covers most practical cases. |
+| `f0`, `bandwidth` | Set explicitly to match your target band: `f0 = (f_min + f_max) / 2` and `bandwidth = (f_max - f_min) / f0`. The defaults (`freq_max/2`, `bw=0.5`) may not cover your measurement band. |
+| `probe_offset` | Distance in Yee cells from the port plane to the probe plane. Must be far enough from any obstacle to avoid source-plane artifacts. Typical value: 10 cells. |
+| `ref_offset` | Distance in cells from the port plane to the reference plane. Must be consistent across compared ports. Typical value: 3 cells. |
+| Band edges | Keep `f_min > 1.3 · f_cutoff` (TE10 cutoff is `c / (2a)`) to stay away from evanescent-mode contamination. Keep `f_max` below the TE20 cutoff (`c / a`) for single-mode operation. |
+
+## Baseline accuracy
+
+The `normalize=True` extraction is tracked by
+`tests/test_normalization.py::test_normalized_s21_straight_waveguide`, which
+asserts `mean |S21| > 0.95` for an empty straight waveguide (25 frequency
+points from 1.3·f_c to 9 GHz, `num_periods=25.0`). This corresponds to a
+worst-case mean deviation from unity of up to 5 %. For individual S-parameter
+comparisons against analytic or external references, use a 15 % pass limit
+rather than 5 %.
+
+For |S11| of strong reflectors, use `normalize=False`. For simultaneous
+reflection and transmission accuracy, use `normalize="flux"`.
+
+Current evidence status for `add_waveguide_port` / `compute_waveguide_s_matrix`
+is **E5-narrow** (single-mode rectangular waveguide, validated against analytic
+Airy, Meep, OpenEMS, and Palace references). See
+[docs/guides/sparameter_support_matrix.md](../guides/sparameter_support_matrix.md)
+for the full artifact and envelope table.
+
+## Analytic reference
+
+For a dielectric slab in a rectangular waveguide, compare against the
+guided-wave Airy formula using the guided propagation constants and TE
+impedances:
+
+```python
+import numpy as np
+
+C0 = 299_792_458.0
+
+
+def guided_beta(f: float, eps_r: complex, a: float) -> complex:
+    k0 = 2 * np.pi * f / C0
+    kc = np.pi / a
+    return np.sqrt(eps_r * k0**2 - kc**2 + 0j)
+
+
+def guided_Z_TE(f: float, eps_r: complex, a: float) -> complex:
+    fc = C0 / (2 * a * np.sqrt(np.real(eps_r)))
+    eta = 377.0 / np.sqrt(eps_r)
+    return eta / np.sqrt(1 - (fc / f) ** 2 + 0j)
+
+
+def waveguide_slab_rt(
+    freqs: np.ndarray,
+    eps_r_slab: complex,
+    d_plug: float,
+    a_wg: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Airy multi-reflection S11, S21 for a dielectric plug in a rectangular waveguide."""
+    S11 = np.zeros(len(freqs), dtype=complex)
+    S21 = np.zeros(len(freqs), dtype=complex)
+    for i, f in enumerate(freqs):
+        Z_vac = guided_Z_TE(f, 1.0, a_wg)
+        Z_d = guided_Z_TE(f, eps_r_slab, a_wg)
+        beta_d = guided_beta(f, eps_r_slab, a_wg)
+        r12 = (Z_d - Z_vac) / (Z_d + Z_vac)
+        delta = beta_d * d_plug
+        e_2id = np.exp(2j * delta)
+        denom = 1.0 - r12**2 * e_2id
+        S11[i] = r12 * (1 - e_2id) / denom
+        S21[i] = (1 - r12**2) * np.exp(1j * delta) / denom
+    return S11, S21
+```
+
+## Canonical example
+
+`examples/crossval/11_waveguide_port_wr90.py` — WR-90 waveguide with three
+canonical geometries (empty guide, PEC short, dielectric slab), compared
+against analytic Airy and Meep references. The script documents band-edge
+artifacts and analytic phase-convention caveats. Authoritative regression
+gates live in `tests/test_waveguide_port_validation_battery.py` and
+`tests/test_waveguide_twoport_contract_v1.py`.
+
+## References
+
+- Pozar, *Microwave Engineering* Ch. 4 — transmission-line S-parameters
+- rfx source: `rfx/api/_sparams.py::compute_waveguide_s_matrix`,
+  `rfx/sources/` waveguide port implementations
+- rfx tests: `tests/test_normalization.py` (baseline accuracy),
+  `tests/test_conservation_laws.py` (reciprocity, unitarity)
+- Evidence and envelope: `docs/guides/sparameter_support_matrix.md`


### PR DESCRIPTION
Third batch of the public agent-knowledge stack (follows #136).

## What
Three sanitized recipe pages under `docs/agent/`:
- **recipe-waveguide-sparams.mdx** — bounded-waveguide multi-port S-params: canonical two-port code, normalize mode guidance (True / False / "flux" per the live docstring), band-selection rules, guided-wave Airy analytic reference, baseline accuracy quoted from the actual `test_normalization.py` gate.
- **recipe-rt-measurement.mdx** — broadband slab R(f)/T(f): flux-monitor two-run field-level reference subtraction, `until_decay` semantics (incl. the ADI ValueError), TFSF periodicity and cell-alignment gotchas, the do-not-FFT-probe rule, dispersive accuracy honestly labeled (no tracked oracle yet).
- **recipe-resonance-extraction.mdx** — Harminv (Matrix Pencil) resonance/Q extraction: verified signature and mode attributes, ringdown sizing, `find_resonances` convenience path, corrected literature citation (Sarkar & Pereira, matching the source).

## Verification
- Every import path, kwarg, and result attribute grep-verified against current source (transcripts in the authoring run).
- Stale master pointers caught and corrected during export: cv09/cv08 example references don't exist in the repo; unverifiable accuracy numbers and a num_periods instability claim dropped; one wrong citation fixed.
- `agent-docs-hygiene` guard green locally (zero internal-path references).
- Drafted via Codex, claim-checked + revised in a separate review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)