### PR TITLE
fix(guards)+ci+docs: Wave-1 silent-wrong fixes, fast-suite PR gate, honesty/packaging batch

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -30,21 +30,67 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Guard + preflight suite (incl. upml/Floquet regression locks)
+        # -o addopts="" overrides the pyproject default marker filter so a
+        # future slow/gpu mark inside these files cannot silently deselect
+        # tests from the required gate; the explicit -m "not gpu" keeps the
+        # job CPU-safe. --strict-markers turns marker typos into errors.
+        # The collect-count floor makes silent deselection detectable.
         run: |
-          python -m pytest -q -p no:cacheprovider \
-            tests/test_sparam_passivity_guard.py \
-            tests/test_result_finite_guard.py \
-            tests/test_run_preflight_parity.py \
-            tests/test_preflight_structured_and_guards.py \
-            tests/test_auto_preflight.py \
-            tests/test_preflight_false_positives.py \
-            tests/test_preflight_physics_thresholds.py \
-            tests/test_port_preflight.py \
-            tests/test_msl_port_preflight.py \
-            tests/test_inverse_design_preflight.py \
-            tests/test_api.py
+          set -e
+          FILES="tests/test_sparam_passivity_guard.py
+            tests/test_result_finite_guard.py
+            tests/test_run_preflight_parity.py
+            tests/test_preflight_structured_and_guards.py
+            tests/test_auto_preflight.py
+            tests/test_preflight_false_positives.py
+            tests/test_preflight_physics_thresholds.py
+            tests/test_port_preflight.py
+            tests/test_msl_port_preflight.py
+            tests/test_inverse_design_preflight.py
+            tests/test_api.py"
+          collected=$(python -m pytest --collect-only -q -o addopts="" -m "not gpu" $FILES | grep -c "::" || true)
+          echo "collected $collected guard tests"
+          if [ "$collected" -lt 100 ]; then
+            echo "FAIL: guard suite collected only $collected tests (<100) — silent deselection?"
+            exit 1
+          fi
+          python -m pytest -q -ra -p no:cacheprovider -o addopts="" \
+            -m "not gpu" --strict-markers $FILES
 
       - name: Conformal stale-check tripwire (slow-marked; xfails today, HARD-FAILS when the NaN is fixed)
         run: |
           python -m pytest -q -p no:cacheprovider -o addopts="" \
             "tests/test_subpixel_pec.py::test_mesh_convergence_s21_with_conformal_pec"
+
+  # The default fast suite ("not gpu and not slow and not slow_physics" — the
+  # suite developers run as plain `pytest`) previously ran as a whole in NO
+  # workflow: a change to rfx/core/yee.py could merge green and only surface
+  # on the weekly validation run, up to 7 days later. Sharded fresh processes
+  # avoid the XLA-cache OOM that killed the unsharded full run (roadmap W2.1).
+  fast-suite:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [1, 2, 3, 4]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install package with dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Fast suite — shard ${{ matrix.group }} of 4
+        run: >
+          pytest -q -ra -p no:cacheprovider
+          --splits 4 --group ${{ matrix.group }}
+          --ignore=tests/test_meep_crossval.py
+          --ignore=tests/test_meep_crossval_patch.py
+          --ignore=tests/test_openems_crossval.py
+          --ignore=tests/test_crossval_comprehensive.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,3 +214,138 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   reflection and has led multiple sessions in a circle.  Use an
   early-time-windowed envelope; the regression-locked version lives
   in `test_source_directionality_early_time`.
+
+---
+
+## [1.6.3] - 2026-04-17
+
+(reconstructed from commit log)
+
+### Fixed
+
+- **Periodic boundary + CPML allocation** (`#68`): `set_periodic_axes` was
+  not honoured during CPML layer allocation, causing CPML to be placed on
+  periodic faces.  Preflight now detects and rejects this configuration.
+  (`fix(boundary): #68 honor set_periodic_axes in CPML allocation + preflight`)
+
+### Added
+
+- **`distributed=True` threaded through `optimize()` and
+  `progressive_optimize()`** (`#69`): the `distributed` keyword introduced
+  in v1.6.2 for `forward()` is now propagated to the higher-level
+  optimisation entry points.
+  (`feat(optimize): #69 thread distributed=True through optimize + progressive_optimize`)
+
+---
+
+## [1.6.2] - 2026-04-17
+
+(reconstructed from commit log)
+
+### Added
+
+- **`Simulation.forward(distributed=True)` public API** (`#44`, Phase 3):
+  opt-in multi-device execution via `distributed=True`.  Covers the full
+  non-uniform runner: sharded grid metadata, ghost exchange, CPML on
+  x-slabs, Debye/Lorentz ADE ordering contract, soft-PEC occupancy
+  sharding, segmented remat + warmup + `design_mask` + `emit_ts`.
+- **`progressive_optimize` multi-resolution orchestrator** (`#42`):
+  `Simulation.progressive_optimize(...)` chains resolution levels with
+  geometry transfer.  API demo added as crossval 08.
+- **`design_mask` stop-gradient on non-design cells** (`#41`): cells
+  outside the design region are hard-stopped so gradients cannot escape
+  the design volume.
+- **Non-uniform sentinel hardening** (`#45`): tracer-safe `dz_profile`,
+  soft-PEC occupancy, and bit-identical CPML path verified against the
+  uniform runner.
+
+### Fixed
+
+- **Multi-device grad NaN at rank-0 corners** (`#44` Phase 4): corner
+  cells at rank-0 were not receiving a ghost exchange contribution,
+  producing NaN gradients in distributed training runs.
+- **`Simulation.__init__` host-coercion** (`#44`): closes NU sentinel #2 —
+  non-uniform grid parameters are coerced to host arrays at construction
+  time, preventing JIT-time shape errors.
+
+---
+
+## [1.6.1] - 2026-04-16
+
+(reconstructed from commit log)
+
+### Added
+
+- **Preflight auto-run before `forward()` / `optimize()` /
+  `topology_optimize()`** (`#66`): preflight is now invoked automatically
+  by all three execution entry points; pass `skip_preflight=True` to
+  suppress for benchmarking.
+- **`optimize()` routed through `sim.forward()`** (`#64`): optimizer now
+  uses the single differentiable forward path, removing a separate
+  code branch and unifying the differentiable-path surface.
+- **Simulation-time breakdown utility** (`#58`): `Simulation.profile()`
+  returns a per-phase timing breakdown (CPML init, Yee loop, probe
+  accumulation, post-processing).
+- **Patch antenna ground-plane size sweep** (`#59`): parametric test
+  verifying that ground-plane size does not affect resonance frequency
+  within the validated range.
+
+### Fixed
+
+- **Preflight: PEC inside CPML region** (`#61`): raises `ValueError` when
+  any PEC geometry box overlaps the CPML absorbing region.
+- **Preflight: Taflove dispersion check** replaces the earlier ratio
+  heuristic with the exact Yee dispersion criterion from Taflove &
+  Hagness Ch. 4.
+- **Preflight: probe-in-PEC check**; aspect-ratio threshold tightened to
+  2.0:1.
+- **Preflight: Courant asymmetry warning** for non-uniform grids with
+  per-axis `ν` values.
+- **Preflight: NU cell aspect-ratio warning** at > 2.5:1.
+- **Decimated Harminv** fixes F3 post-processing OOM on fine-mesh
+  convergence runs.
+
+---
+
+## [1.6.0] - 2026-04-16
+
+(reconstructed from commit log)
+
+### Added
+
+- **Memory-efficient inverse design on non-uniform mesh** (`#35`, `#36`):
+  segmented scan + remat path; `estimate_ad_memory()` gains
+  `ad_segmented_gb` field (`#39`).
+- **Non-uniform runner feature parity + inverse-design unblock** (`#34`):
+  NU runner now supports all source/boundary types available in the
+  uniform runner relevant to inverse design.
+- **Per-cell `dx`/`dy` profile support** for non-uniform grids.
+- **`n_warmup` stop-gradient split** (`#40`, `#56`): warmup steps are
+  detached from the AD tape, preventing spurious gradients from the
+  initial transient.
+- **Streaming multi-frequency NTFF sweep** (`#43`, `#55`): a single
+  forward pass accumulates DFT data at multiple frequencies without
+  storing full time-series.
+- **3D structure + far-field visualisation API** (`#38`, `#54`):
+  `Simulation.visualize_structure()` and `visualize_far_field()`.
+- **`minimize_s11_at_freq` objective** (`#50`, `#52`): single-frequency
+  S11 proxy usable directly inside `forward()`.
+- **2-port wire-port S-matrix with passive loads and direction** (`#34`
+  area): `add_wire_port` supports two-port extraction with explicit
+  termination impedance and `+`/`-` direction.
+
+### Fixed
+
+- **Physics-based resolution thresholds in preflight** (`#37`, `#53`):
+  replaces heuristic cell-count thresholds with wavelength/skin-depth
+  criteria.
+- **Thin-PEC on non-uniform mesh** (`#48`, `#51`): rasterisation fix +
+  preflight warning + mesh-aligned patch visualisation.
+- **`excite=False` guards + `forward()` profile check + preflight**:
+  sources with `excite=False` no longer contribute to the excitation
+  sum used by normalisation.
+- **`NameError` `base_materials` in differentiable forward path**.
+
+---
+
+Earlier releases (v1.0.0–v1.3.0) predate this changelog's version sections; see git tags.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+message: "If you use rfx in your research, please cite it as below."
+title: "rfx: JAX-based differentiable 3D FDTD simulator for RF engineering"
+type: software
+authors:
+  - family-names: "Kim"
+    given-names: "Byungkwan"
+    email: "byungkwan.kim@cnu.ac.kr"
+    affiliation: "REMI Lab, Chungnam National University"
+version: "1.6.3"
+date-released: "2026-04-17"
+license: MIT
+repository-code: "https://github.com/bk-squared/rfx"
+url: "https://remilab.ai/rfx/"
+keywords:
+  - FDTD
+  - electromagnetics
+  - JAX
+  - differentiable simulation
+  - RF engineering
+  - microwave

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 > **Project status (June 2026):** `rfx` remains an actively validated research/product simulator. Use the uniform Cartesian Yee RF lane first; advanced lanes are promoted only inside explicitly documented evidence envelopes rather than as blanket simulator guarantees.
 
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
-[![Tests](https://github.com/bk-squared/rfx/actions/workflows/test.yml/badge.svg)](https://github.com/bk-squared/rfx/actions)
+[![Tests](https://github.com/bk-squared/rfx/actions/workflows/pr-tests.yml/badge.svg)](https://github.com/bk-squared/rfx/actions)
 [![PyPI](https://img.shields.io/pypi/v/rfx-fdtd)](https://pypi.org/project/rfx-fdtd/)
 [![Docs](https://img.shields.io/badge/docs-remilab.ai%2Frfx-blue)](https://remilab.ai/rfx/)
 
@@ -29,7 +29,7 @@ The recommended starting point is the **uniform Cartesian Yee RF/FDTD lane**. No
 | **GPU-accelerated** | 7,309 Mcells/s on RTX 4090, 5,249 on A6000 via `jax.lax.scan` JIT |
 | **Differentiable** | `jax.grad` through full time-stepping for inverse design |
 | **Topology optimization** | Density-based with filtering, projection, and beta continuation |
-| **Conformal PEC** | Dey-Mittra method for 2nd-order accuracy on curved conductors |
+| **Conformal PEC** | Dey-Mittra weights — experimental; known NaN at fine mesh (dx <= 2 mm); 2nd-order convergence on curved conductors not validated (staircase is the supported PEC floor) |
 | **Multi-GPU** | Single-host multi-GPU distributed FDTD with 1D slab decomposition (experimental lane) |
 | **Waveguide modal ports** | Analytical TE/TM eigenmodes for documented rectangular-guide S-matrix envelopes |
 | **Coaxial line reflection** | One-port coaxial transmission-line reflection envelope via `compute_coaxial_line_reflection(...)` |
@@ -125,8 +125,8 @@ method only inside its documented coax transmission-line envelope.
 ## Key Features
 
 ### Core Simulator
-- 3D/2D Yee FDTD with CFS-CPML (kappa=5.0, < -40 dB reflectivity)
-- Conformal PEC via Dey-Mittra (2nd-order on curved surfaces)
+- 3D/2D Yee FDTD with CFS-CPML (kappa_max=1.0 default — measured sweep showed kappa_max>1 degrades guided-mode absorption)
+- Conformal PEC via Dey-Mittra (experimental — known NaN at fine mesh; staircased PEC is the supported floor)
 - Non-uniform z-mesh for thin substrates (shadow qualification lane)
 - Multi-GPU via jax.pmap (experimental distributed lane)
 - Mixed precision (float16 fields, 2x memory reduction)

--- a/docs/public/guide/conformal-pec.mdx
+++ b/docs/public/guide/conformal-pec.mdx
@@ -1,14 +1,17 @@
 ---
 title: "Conformal PEC"
-description: "Dey-Mittra method for second-order accuracy on curved PEC conductors in rfx."
+description: "Experimental Dey-Mittra conformal PEC: known NaN at fine mesh; second-order convergence on curved conductors is not validated."
 sidebar:
   order: 22
 ---
 
 import { Aside } from '@astrojs/starlight/components';
 
-<Aside type="caution" title="Under construction">
-  This page is a placeholder. Content will be added in a future update.
+<Aside type="caution" title="Experimental — not validated">
+  Conformal PEC (`conformal=True`) is experimental. Known limitation: it can
+  produce NaN at fine mesh resolution (dx &le; 2 mm). A validated accuracy
+  improvement over staircased PEC has not been demonstrated; staircased PEC
+  is the supported floor for curved conductors. This page is a placeholder.
 </Aside>
 
 ## Overview

--- a/docs/public/guide/geometry-and-limitations.md
+++ b/docs/public/guide/geometry-and-limitations.md
@@ -275,14 +275,16 @@ sim.add(Box((0, 0, -0.0001), (0.04, 0.02, 0.0)), material="pec")   # ground
 ### 3.1 Curved Surfaces and Conformal Accuracy
 
 rfx still uses a Cartesian Yee grid, so it is **not** a body-fitted CAD or
-curvilinear-mesh solver. However, it now includes **conformal PEC** support
-(Dey-Mittra) for curved conductors, which significantly reduces the classic
-staircase error on PEC structures.
+curvilinear-mesh solver. An experimental **conformal PEC** option
+(Dey-Mittra) exists for curved conductors, but it can produce NaN at fine
+mesh resolution (dx <= 2 mm) and a validated accuracy improvement over
+staircased PEC has not been demonstrated — staircased PEC is the supported
+floor.
 
 Important nuance:
 
 - **dielectric interfaces** benefit from subpixel smoothing,
-- **curved PEC** benefits from conformal PEC,
+- **curved PEC** currently relies on staircasing (conformal PEC is experimental and unvalidated),
 - but very fine curvature, imported CAD geometry, or manufacturing-grade
   meshing workflows still favor solvers with full conformal / body-fitted mesh
   support.

--- a/examples/inverse_design/differentiable_s11_design.py
+++ b/examples/inverse_design/differentiable_s11_design.py
@@ -1,0 +1,163 @@
+"""Differentiable S11 design via end-to-end AD through the rfx S-parameter API.
+
+This example demonstrates rfx's unique capability: ``jax.grad`` flows
+end-to-end through the *public* ``sim.compute_waveguide_s_matrix`` API.
+A scalar dielectric design variable (permittivity of a small plug region
+inside the waveguide) is differentiated against the |S11|^2 objective in
+one ``jax.grad`` call — no finite differences are needed to obtain the
+gradient.  A central finite-difference cross-check is then computed and
+compared, confirming the AD gradient is accurate to within 5%.
+
+Run:  python examples/inverse_design/differentiable_s11_design.py
+"""
+
+from __future__ import annotations
+
+import time
+import warnings
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from rfx import Simulation
+
+# ---------------------------------------------------------------------------
+# WR-90 geometry — identical to test_waveguide_s_matrix_ad_end_to_end
+# (tests/test_sparam_ad_end_to_end.py) so that CPU feasibility is proven.
+# ---------------------------------------------------------------------------
+
+_WR90_A = 22.86e-3    # broad wall (m)
+_WR90_B = 10.16e-3    # narrow wall (m)
+_WR90_DX = 2e-3       # cell size (m)
+_WR90_LX = 0.05       # domain length (m)
+
+# TE10 cutoff for WR-90: c/(2a) ≈ 6.56 GHz; all freqs here are above cutoff.
+_WR90_FREQS = jnp.linspace(8e9, 12e9, 8)
+
+
+def _build_sim() -> Simulation:
+    """Two-port WR-90 rectangular waveguide sim (CPU-fast, above-cutoff)."""
+    sim = Simulation(
+        freq_max=12e9,
+        domain=(_WR90_LX, _WR90_A, _WR90_B),
+        dx=_WR90_DX,
+        boundary="cpml",
+        cpml_layers=8,
+    )
+    sim.add_waveguide_port(
+        direction="+x",
+        x_position=0.01,
+        y_range=(0.0, _WR90_A),
+        z_range=(0.0, _WR90_B),
+        n_modes=1,
+        freqs=_WR90_FREQS,
+    )
+    sim.add_waveguide_port(
+        direction="-x",
+        x_position=_WR90_LX - 0.01,
+        y_range=(0.0, _WR90_A),
+        z_range=(0.0, _WR90_B),
+        n_modes=1,
+        freqs=_WR90_FREQS,
+    )
+    return sim
+
+
+# ---------------------------------------------------------------------------
+# Objective: |S11|^2 summed over all frequencies, w.r.t. a scalar design eps
+# ---------------------------------------------------------------------------
+
+def _make_objective(sim: Simulation, eps_base: jnp.ndarray):
+    """Return a scalar objective(alpha) = sum_f |S11(f)|^2.
+
+    ``alpha`` scales the background permittivity array via eps_override,
+    acting as a single differentiable design degree of freedom.  The target
+    frequency index is the midpoint of the frequency array.
+    """
+    def objective(alpha: jnp.ndarray) -> jnp.ndarray:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = sim.compute_waveguide_s_matrix(
+                n_steps=200,
+                normalize=False,
+                eps_override=eps_base * alpha,
+            )
+        S = result.s_params
+        k0 = S.shape[-1] // 2
+        return jnp.real(jnp.sum(jnp.abs(S[:, :, k0]) ** 2))
+
+    return objective
+
+
+if __name__ == "__main__":
+    print("=" * 70)
+    print("Differentiable S11 Design — end-to-end AD through rfx S-param API")
+    print("=" * 70)
+
+    sim = _build_sim()
+    grid = sim._build_grid()
+    eps_base = jnp.ones(grid.shape, dtype=jnp.float32)
+    alpha0 = jnp.float32(1.0)
+
+    objective = _make_objective(sim, eps_base)
+
+    # --- Forward pass (sanity check) ----------------------------------------
+    print("\n[1/3] Forward pass …")
+    t0 = time.time()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        fwd_result = sim.compute_waveguide_s_matrix(
+            n_steps=200,
+            normalize=False,
+            eps_override=eps_base * alpha0,
+        )
+    S_fwd = np.asarray(fwd_result.s_params)
+    s_max = float(np.max(np.abs(S_fwd)))
+    obj_val = float(objective(alpha0))
+    print(f"  Objective |S11|^2 sum = {obj_val:.6e}")
+    print(f"  |S|_max = {s_max:.4f}  (must be in [0, 1.2])")
+    assert s_max <= 1.2, f"|S| = {s_max:.4f} physically implausible"
+    assert s_max > 0.0, "|S| = 0 everywhere — broken forward pass"
+
+    # --- AD gradient ----------------------------------------------------------
+    print("\n[2/3] AD gradient via jax.grad …")
+    loss_val, g = jax.value_and_grad(objective)(alpha0)
+    g_ad = float(g)
+    print(f"  objective = {float(loss_val):.6e}")
+    print(f"  AD gradient = {g_ad:.6e}")
+    assert jnp.isfinite(g), f"AD gradient is not finite: {g}"
+    assert abs(g_ad) > 1e-10, f"AD gradient is effectively zero: {g_ad:.3e}"
+
+    # --- FD cross-check -------------------------------------------------------
+    print("\n[3/3] Central finite-difference cross-check …")
+    h = 1e-3
+    f_plus = float(objective(jnp.float32(alpha0 + h)))
+    f_minus = float(objective(jnp.float32(alpha0 - h)))
+    g_fd = (f_plus - f_minus) / (2.0 * h)
+    rel_err = abs(g_ad - g_fd) / (abs(g_fd) + 1e-12)
+    print(f"  FD gradient = {g_fd:.6e}  (h={h})")
+    print(f"  Relative error (AD vs FD) = {rel_err:.3e}")
+
+    wall = time.time() - t0
+    print(f"\n  Wall time: {wall:.1f} s")
+
+    # --- Assertions -----------------------------------------------------------
+    assert rel_err < 0.05, (
+        f"AD vs FD mismatch: AD={g_ad:.4e} FD={g_fd:.4e} "
+        f"rel_err={rel_err:.3e} (threshold 5%)"
+    )
+    assert g_ad * g_fd > 0, (
+        f"Sign disagreement: AD={g_ad:.4e} FD={g_fd:.4e}"
+    )
+
+    print("\n" + "=" * 70)
+    print("RESULT")
+    print("=" * 70)
+    print(f"  Objective value : {obj_val:.6e}")
+    print(f"  AD gradient     : {g_ad:.6e}")
+    print(f"  FD gradient     : {g_fd:.6e}")
+    print(f"  Relative error  : {rel_err:.3e}  (< 0.05 required)")
+    print(f"  Sign agreement  : {'YES' if g_ad * g_fd > 0 else 'NO'}")
+    print(f"  Wall time       : {wall:.1f} s")
+    print("\n  PASS — jax.grad flows end-to-end through compute_waveguide_s_matrix")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,10 @@ requires-python = ">=3.10"
 authors = [{name = "REMI Lab", email = "byungkwan.kim@cnu.ac.kr"}]
 keywords = ["fdtd", "electromagnetics", "jax", "rf", "simulation"]
 classifiers = [
-    "Development Status :: 5 - Production/Stable",
+    # Beta matches the README status language: reference (uniform Yee RF)
+    # lane validated; advanced lanes promoted only inside documented
+    # evidence envelopes.
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -38,8 +41,17 @@ dashboard = ["streamlit>=1.30"]
 dev = ["pytest>=7.0", "pytest-xdist", "pytest-split", "ruff"]
 all = ["rfx[optimization,visualization,dashboard,dev]"]
 
+[project.urls]
+Homepage = "https://remilab.ai/rfx/"
+Repository = "https://github.com/bk-squared/rfx"
+Documentation = "https://remilab.ai/rfx/"
+Changelog = "https://github.com/bk-squared/rfx/blob/main/CHANGELOG.md"
+
 [tool.setuptools.packages.find]
 include = ["rfx*"]
+
+[tool.setuptools.package-data]
+rfx = ["py.typed"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -1562,7 +1562,7 @@ class Simulation(
     def set_periodic_axes(self, axes: str = "xyz") -> "Simulation":
         """Set periodic boundary axes for high-level runs.
 
-        .. deprecated:: 1.7.0
+        .. deprecated:: 1.6.3
             Encode periodic axes directly in :class:`BoundarySpec`:
             ``boundary=BoundarySpec(x='periodic', y='cpml', z='cpml')``.
             This method will be removed in v2.0.

--- a/rfx/api/_compile.py
+++ b/rfx/api/_compile.py
@@ -174,7 +174,7 @@ class _CompileMixin:
         # (equivalent to UPML).  Each CPML face copies the interior-edge
         # slice outward, as if the geometry continued beyond the domain.
         if self._boundary in ("cpml", "upml") and self._cpml_layers > 0:
-            # v1.7.5: per-face allocation (pad_{axis}_lo / _hi). Reflector /
+            # Per-face allocation (2026-04): (pad_{axis}_lo / _hi). Reflector /
             # periodic faces have pad=0 on that side and the corresponding
             # replicate step is skipped so the interior cells are not
             # overwritten. The replicate depth matches the actual
@@ -448,6 +448,8 @@ class _CompileMixin:
         synthesised from the scalar ``dx`` when the profile is not set.
         """
         from rfx.runners.nonuniform import build_nonuniform_grid
+        # dz=None is synthesised locally inside build_nonuniform_grid()
+        # (pure — sim state is never mutated by a grid build).
         return build_nonuniform_grid(
             self._freq_max, self._domain, self._dx, self._cpml_layers,
             self._dz_profile,

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -114,8 +114,8 @@ class _ExecuteMixin:
         """Emit ``UserWarning`` for any Simulation.run kwarg that a given
         dispatch path drops. Only non-default values are surfaced.
 
-        Pre-v1.7.5 the distributed / non-uniform / subgridded paths
-        silently dropped most of the ``run`` kwargs; this helper makes
+        Previously the distributed / non-uniform / subgridded paths
+        silently dropped most of the ``run`` kwargs (fixed 2026-04); this helper makes
         the drop explicit at the API boundary so users can tell their
         request was not honoured. See GitHub tracking issue for the
         feature-request backlog to actually propagate these kwargs.
@@ -1476,18 +1476,14 @@ class _ExecuteMixin:
                     "forward path; remove waveguide ports or omit "
                     "distributed=True."
                 )
-            # v1.7.4 T8: PMC is now wired across all three sharded
+            # T8 (2026-04): PMC is now wired across all three sharded
             # runners (distributed_nu, distributed_v2, distributed).
             # The reject guard that used to live here (introduced in
             # f3cab7c) has been removed. The single-device PMC runtime
             # hook lives in rfx/simulation.py:703-705 and the sharded
             # PMC helpers live in each runner next to their PEC analog.
-            # Synthesise missing dz profile so the NU grid build always
-            # sees all three axes (mirrors Simulation.run() and the
-            # single-device NU forward path).
-            if self._dz_profile is None:
-                nz_phys = max(1, int(round(self._domain[2] / self._dx)))
-                self._dz_profile = np.full(nz_phys, float(self._dx))
+            # dz-profile synthesis happens locally inside
+            # _build_nonuniform_grid() — no sim-state mutation here.
             if n_steps is None:
                 grid_probe = self._build_nonuniform_grid()
                 period = 1.0 / float(self._freq_max)
@@ -1509,13 +1505,8 @@ class _ExecuteMixin:
             )
 
         if is_nonuniform:
-            # Synthesise missing dz profile so the NU grid build always
-            # sees all three axes (mirrors Simulation.run()'s pre-build
-            # synthesis in Simulation.run(), see _execute.py).  Required for sims that set
-            # only dx/dy_profile and leave dz uniform.
-            if self._dz_profile is None:
-                nz_phys = max(1, int(round(self._domain[2] / self._dx)))
-                self._dz_profile = np.full(nz_phys, float(self._dx))
+            # dz-profile synthesis happens locally inside
+            # _build_nonuniform_grid() — no sim-state mutation here.
             # Let the NU runner build grid/materials so it can apply the
             # NU-aware pec_mask and port/source setup against per-axis widths.
             if n_steps is None:
@@ -1772,13 +1763,8 @@ class _ExecuteMixin:
             })
             if n_steps is None:
                 if _nu_profile:
-                    # Synthesise missing dz profile so _build_nonuniform_grid
-                    # has all three axes available.
-                    if self._dz_profile is None:
-                        nz_phys = max(
-                            1, int(round(self._domain[2] / self._dx)))
-                        self._dz_profile = np.full(
-                            nz_phys, float(self._dx))
+                    # dz-profile synthesis happens locally inside
+                    # _build_nonuniform_grid() — no sim-state mutation here.
                     _ngrid = self._build_nonuniform_grid()
                     n_steps = int(np.ceil(
                         num_periods / (self._freq_max * _ngrid.dt)))
@@ -1802,12 +1788,8 @@ class _ExecuteMixin:
                 "until_decay": until_decay,
                 "conformal_pec": conformal_pec,
             })
-            # Synthesize a uniform dz profile from the scalar domain_z
-            # when only dx/dy are non-uniform, so the shared non-uniform
-            # runner has all three axes available.
-            if self._dz_profile is None:
-                nz_phys = max(1, int(round(self._domain[2] / self._dx)))
-                self._dz_profile = np.full(nz_phys, float(self._dx))
+            # dz-profile synthesis happens locally inside
+            # _build_nonuniform_grid() — no sim-state mutation here.
             nu_grid = self._build_nonuniform_grid()
             if n_steps is None:
                 n_steps = int(np.ceil(

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1622,7 +1622,7 @@ class _PreflightMixin:
     def _validate_cfg_compute_cpml_thickness(
         self, cpml_thickness: float
     ) -> tuple[list[float], list[float], set]:
-        """Per-face CPML thickness (v1.7.5). Mirrors Grid._face_pad:
+        """Per-face CPML thickness (2026-04). Mirrors Grid._face_pad:
         pec_faces / pmc_faces / periodic-axis faces consume 0 cells;
         remaining faces get the axis CPML thickness (non-uniform z
         aggregates the leading dz_profile entries). Under asymmetric
@@ -2284,7 +2284,7 @@ class _PreflightMixin:
 
         P2.7 (obsolete): PMC / PEC + CPML on the same axis used to emit
         a warning for the architectural offset between the reflector
-        plane and the user domain edge. v1.7.5 closed that gap on both
+        plane and the user domain edge. The per-face allocation (2026-04) closed that gap on both
         the uniform (rfx/grid.py) and non-uniform (rfx/nonuniform.py)
         paths via per-face ``pad_{axis}_{lo,hi}`` allocation. The
         warning is retained as a no-op anchor so external references

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -241,6 +241,19 @@ class _SparamMixin:
                 unsupported.append("normalize=True or normalize='flux' is required")
             if any(entry.n_modes > 1 for entry in entries):
                 unsupported.append("multi-mode ports (n_modes>1) are not supported")
+            # The NU extractor has no eps/sigma/subpixel inputs; accepting
+            # these kwargs and forwarding nothing would silently break the
+            # documented differentiable channel (G-AD-WIRE-WG2).
+            if eps_override is not None:
+                unsupported.append(
+                    "eps_override (differentiable AD channel) is not wired on the NU path"
+                )
+            if sigma_override is not None:
+                unsupported.append(
+                    "sigma_override (differentiable AD channel) is not wired on the NU path"
+                )
+            if subpixel_smoothing:
+                unsupported.append("subpixel_smoothing is not supported")
             if unsupported:
                 raise NotImplementedError(
                     "compute_waveguide_s_matrix() on a non-uniform mesh "

--- a/rfx/boundaries/cpml.py
+++ b/rfx/boundaries/cpml.py
@@ -38,7 +38,7 @@ class CPMLParams(NamedTuple):
 class CPMLAxisParams(NamedTuple):
     """Per-face CPML profiles (6 faces) for anisotropic grids.
 
-    T7 Phase 2 PR1 refactor (v1.7.1): promoted the ``x`` / ``y`` axis-level
+    T7 Phase 2 PR1 refactor (2026-04): promoted the ``x`` / ``y`` axis-level
     profiles to explicit ``x_lo`` / ``x_hi`` / ``y_lo`` / ``y_hi`` fields.
     The hi-face profile arrays are pre-flipped so the scan body no longer
     calls ``jnp.flip`` at every step.
@@ -289,7 +289,7 @@ def init_cpml(grid, *, kappa_max: float | None = None,
         ``"x_lo"``, ``"x_hi"``, ``"y_lo"``, ``"y_hi"``,
         ``"z_lo"``, ``"z_hi"``.  Default: None (CPML on all faces).
     pmc_faces : set of str or None
-        Faces carrying a PMC reflector (v1.7.5 per-face padding puts
+        Faces carrying a PMC reflector (per-face padding, 2026-04 — puts
         ``pad=0`` cells on that side of the axis). Like ``pec_faces``
         these faces receive a no-op CPML profile — otherwise the
         ``apply_cpml_e/h`` slices ``[:, :n, :]`` etc. would apply

--- a/rfx/boundaries/pmc.py
+++ b/rfx/boundaries/pmc.py
@@ -37,7 +37,7 @@ def apply_pmc_faces(state, faces: set[str]) -> object:
     side is the ghost half-cell 0.5·dx OUTSIDE the wall, which does
     not participate in the interior E-curl stencil and was previously
     zeroed with no effect — causing ``_hi`` PMC to be a silent no-op
-    that let the wall behave as PEC. Fixed in v1.7.5 (see
+    that let the wall behave as PEC. Fixed 2026-04 (see
     tests/test_boundary_pmc_hi_faces.py for the regression lock).
     """
     if not faces:

--- a/rfx/boundaries/spec.py
+++ b/rfx/boundaries/spec.py
@@ -1,4 +1,4 @@
-"""Per-axis, per-face boundary specification (T7, v1.7.0).
+"""Per-axis, per-face boundary specification (T7, 2026-04).
 
 The ``BoundarySpec`` / ``Boundary`` types replace the asymmetric
 ``boundary=<scalar> + pec_faces + set_periodic_axes()`` triad with a

--- a/rfx/farfield.py
+++ b/rfx/farfield.py
@@ -44,7 +44,7 @@ class NTFFBox(NamedTuple):
     freqs: jnp.ndarray  # (n_freqs,) Hz
     # Per-face CPML thickness (T7 Phase 2 — asymmetric-friendly NTFF offsets).
     # Default to 0 so legacy callers constructing NTFFBox without from_grid()
-    # still get the pre-v1.7.4 scalar-cpml behaviour via the fallbacks below.
+    # still get the pre-per-face-CPML scalar behaviour via the fallbacks below.
     cpml_lo_x: int = 0
     cpml_hi_x: int = 0
     cpml_lo_y: int = 0
@@ -310,7 +310,7 @@ def _face_positions(axis, idx, other_ranges, dx, cpml_lo_x, cpml_lo_y, cpml_lo_z
         Per-axis low-face CPML thicknesses; used as the physical-origin
         offset on each axis so that physical coord 0 sits at the inner
         edge of the lo-face CPML. Under symmetric face_layers these all
-        equal ``grid.cpml_layers`` (the pre-v1.7.4 scalar behavior).
+        equal ``grid.cpml_layers`` (the legacy scalar behavior).
     dy : float or None
         Y cell size. If None, uses dx (cubic cells).
     z_edges : (nz+1,) array or None

--- a/rfx/grid.py
+++ b/rfx/grid.py
@@ -98,7 +98,7 @@ class Grid:
         if self.is_2d:
             self.cpml_axes = self.cpml_axes.replace("z", "")
 
-        # Per-face CPML allocation (v1.7.5). A face whose BoundarySpec
+        # Per-face CPML allocation (2026-04). A face whose BoundarySpec
         # token is ``pec``/``pmc``/``periodic`` gets ``pad=0`` on that
         # side even when the axis as a whole participates in CPML —
         # this is the Meep / OpenEMS / Tidy3D convention and the
@@ -134,7 +134,7 @@ class Grid:
         # ``axis_pads`` carries the LEADING (``lo``) pad per axis, i.e.
         # the same number that callers subtract from array indices to
         # recover user-domain coordinates (``(idx - axis_pads[ax]) * dx``).
-        # In the pre-v1.7.5 symmetric layout this happened to equal
+        # In the legacy symmetric layout this happened to equal
         # ``pad_{axis}``; under per-face allocation the two are different
         # whenever one face is PMC/PEC/periodic. Existing callers that
         # treated ``axis_pads`` as a coordinate offset continue to work

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -46,7 +46,7 @@ class NonUniformGrid(NamedTuple):
     a face whose token is ``pmc``/``pec``/``periodic`` gets 0 cells on
     that side even when the axis as a whole uses CPML. For back-compat
     the six fields default to ``cpml_layers`` on every face (the
-    pre-v1.7.5 symmetric layout).
+    pre-per-face-allocation symmetric layout).
     """
     nx: int
     ny: int
@@ -70,7 +70,7 @@ class NonUniformGrid(NamedTuple):
     inv_dx_h: jnp.ndarray  # (nx,) — H update: 1/dx[i]; [nx-1]=0
     inv_dy_h: jnp.ndarray  # (ny,) — H update: 1/dy[j]; [ny-1]=0
     inv_dz_h: jnp.ndarray  # (nz,) — H update: 1/dz[k]; [nz-1]=0
-    # Per-face CPML padding (v1.7.5 PMC+CPML composition fix)
+    # Per-face CPML padding (PMC+CPML composition fix, 2026-04)
     pad_x_lo: int = 0
     pad_x_hi: int = 0
     pad_y_lo: int = 0
@@ -95,10 +95,10 @@ class NonUniformGrid(NamedTuple):
 def _pad_profile(profile, pad_lo: int, pad_hi: int | None = None):
     """Pad a 1-D cell-size profile with CPML cells on each end.
 
-    ``pad_lo`` and ``pad_hi`` may differ (v1.7.5 per-face allocation —
+    ``pad_lo`` and ``pad_hi`` may differ (per-face allocation, 2026-04 —
     a PMC/PEC face gets 0 cells on that side while the opposing CPML
     face keeps its allocation). If ``pad_hi`` is omitted the symmetric
-    ``pad_lo`` count is used on both ends (pre-v1.7.5 behaviour).
+    ``pad_lo`` count is used on both ends (pre-per-face-allocation behaviour).
 
     CPML uses constant spacing matching the boundary cell size, so the
     ``pad_lo`` cells on the leading side carry ``profile[0]`` and the
@@ -195,7 +195,7 @@ def make_nonuniform_grid(
         Face labels (``x_lo``, ``x_hi``, ``y_lo``, ``y_hi``, ``z_lo``,
         ``z_hi``) where the boundary is PEC / PMC. Per-face pad count
         is forced to 0 on these faces so the reflector plane aligns
-        with the user domain edge. Added in v1.7.5 to close the
+        with the user domain edge. Added 2026-04 to close the
         PMC+CPML composition gap on the non-uniform mesh path.
     cpml_axes : str
         Axes that participate in CPML allocation (default ``"xyz"``).
@@ -318,7 +318,7 @@ def _interior_line_positions(
     """Return cell-edge positions (0 at first interior face) for a padded
     cell-size array. Length = n_interior + 1.
 
-    ``pad_lo`` and ``pad_hi`` may differ (v1.7.5 per-face allocation).
+    ``pad_lo`` and ``pad_hi`` may differ (per-face allocation, 2026-04).
     Back-compat: a single-argument call treats the value as symmetric.
     """
     if pad_hi is None:
@@ -337,7 +337,7 @@ def _nominal_edges_or_actual(
 
     ``total_pad`` is ``pad_lo + pad_hi`` — the cells removed when
     slicing to the interior. ``pad_lo`` (defaulting to ``total_pad/2``
-    for the symmetric pre-v1.7.5 case) is needed by the tracer path
+    for the legacy symmetric case) is needed by the tracer path
     to reconstruct ``n_interior`` and by the concrete path to pick
     the right interior slice.
 
@@ -799,7 +799,7 @@ def run_nonuniform(
             if (lo + hi) > 0
         )
 
-    # PMC enforcement (v1.7.5). The NU scan body previously never
+    # PMC enforcement (2026-04). The NU scan body previously never
     # zeroed H_tan on PMC faces, so a half-symmetric configuration
     # that relied on the mirror plane was running with an effectively
     # free boundary. Frozen set gives JIT cache a stable hash; empty

--- a/rfx/optimize.py
+++ b/rfx/optimize.py
@@ -163,7 +163,7 @@ def optimize(
         base_materials, _, _, base_pec_mask, _, _, _ = sim._assemble_materials(grid)
         _n_steps_auto = grid.num_timesteps(num_periods=num_periods)
 
-    # Per-face clamp (v1.7.5): using the symmetric ``pad_{axis}`` would
+    # Per-face clamp (2026-04): using the symmetric ``pad_{axis}`` would
     # over-clamp a design region against a PMC/PEC reflector face whose
     # ``pad_lo`` or ``pad_hi`` is 0. Clamp each side to its own pad.
     pads_lo = (grid.pad_x_lo, grid.pad_y_lo, grid.pad_z_lo)

--- a/rfx/optimize_objectives.py
+++ b/rfx/optimize_objectives.py
@@ -520,7 +520,8 @@ def minimize_s11_at_freq(
     bandwidth to compress the pulse, or prefer a wave-decomposition
     (V/I) probe which is exact.
 
-    Prior to v1.7.6 this objective returned ``|X_tot/X_inc|² = |1+S11|²``
+    Previously this objective returned ``|X_tot/X_inc|² = |1+S11|²``
+    (fixed 2026-04, commit 1923db2)
     (see regression test ``tests/test_minimize_s11_at_freq_physical.py``),
     which minimises toward ``S11 = −1`` (perfect short) rather than
     ``S11 = 0`` (matched load). Fixed on branch

--- a/rfx/runners/distributed.py
+++ b/rfx/runners/distributed.py
@@ -1262,7 +1262,7 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
         devices = jax.devices()
     n_devices = len(devices)
 
-    # Resolve PMC faces (v1.7.4 T8). ``BoundarySpec.pmc_faces()`` returns
+    # Resolve PMC faces (T8, 2026-04). ``BoundarySpec.pmc_faces()`` returns
     # a set; freeze it so it is safely closed-over by the pmap scan
     # bodies defined below. Empty frozenset == no-op inside the helper.
     _pmc_faces_frozen = frozenset(
@@ -1450,7 +1450,7 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
                     st,
                 )
 
-                # 3b. PMC face (H-tangential = 0) — v1.7.4 T8. H-half
+                # 3b. PMC face (H-tangential = 0) — T8, 2026-04. H-half
                 #     hook per OQ9: after H ghost exchange, before E
                 #     update. PMC must fire before the next E-update
                 #     reads H via curl.
@@ -1538,7 +1538,7 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
                     st,
                 )
 
-                # 2b. PMC face (H-tangential = 0) — v1.7.4 T8. H-half
+                # 2b. PMC face (H-tangential = 0) — T8, 2026-04. H-half
                 #     hook per OQ9: after H ghost exchange, before E
                 #     update.
                 st = _apply_pmc_local(

--- a/rfx/runners/distributed_v2.py
+++ b/rfx/runners/distributed_v2.py
@@ -570,7 +570,7 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
         devices = jax.devices()
     n_devices = len(devices)
 
-    # Resolve PMC faces (v1.7.4 T8). ``BoundarySpec.pmc_faces()`` returns
+    # Resolve PMC faces (T8, 2026-04). ``BoundarySpec.pmc_faces()`` returns
     # a set; freeze it so it is safely closed-over by the traced scan
     # bodies below.
     _pmc_faces_frozen = frozenset(
@@ -599,11 +599,8 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
         or getattr(sim, "_dy_profile", None) is not None
     )
     if is_nu:
-        # Synthesize a uniform dz profile when only dx/dy are non-uniform
-        # (same shim the single-device NU path uses in api.py).
-        if sim._dz_profile is None:
-            nz_phys = max(1, int(round(sim._domain[2] / sim._dx)))
-            sim._dz_profile = np.full(nz_phys, float(sim._dx))
+        # dz-profile synthesis happens locally inside
+        # _build_nonuniform_grid() — no sim-state mutation here.
         grid = sim._build_nonuniform_grid()
         base_materials, debye_spec, lorentz_spec, pec_mask = (
             sim._assemble_materials_nu(grid)
@@ -1249,7 +1246,7 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
             st,
         )
 
-        # 3b. PMC face (H-tangential = 0) — v1.7.4 T8. H-half hook per
+        # 3b. PMC face (H-tangential = 0) — T8, 2026-04. H-half hook per
         #     OQ9: after H ghost exchange, before E update. PMC must
         #     fire before the next E-update reads H via curl.
         st = _apply_pmc_shmap(
@@ -1302,7 +1299,7 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
             st,
         )
 
-        # 2b. PMC face (H-tangential = 0) — v1.7.4 T8. H-half hook per
+        # 2b. PMC face (H-tangential = 0) — T8, 2026-04. H-half hook per
         #     OQ9: after H ghost exchange, before E update.
         st = _apply_pmc_shmap(
             st, mesh, n_devices, nx_local, _pmc_faces_frozen)

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -30,10 +30,18 @@ def build_nonuniform_grid(
     ``dx_profile`` / ``dy_profile`` are optional; when omitted the
     corresponding axis is uniform with spacing ``dx`` across
     ``domain``. ``pec_faces`` / ``pmc_faces`` force per-face pad=0 on
-    the listed faces (v1.7.5 PMC+CPML composition fix on the NU path).
+    the listed faces (PMC+CPML composition fix on the NU path, 2026-04).
     """
     if dx is None:
         dx = C0 / freq_max / 20.0
+    if dz_profile is None:
+        # Synthesise the uniform dz profile LOCALLY (pure) when only
+        # dx/dy are non-uniform. This used to be done at every
+        # forward()/run()/runner call site via
+        # ``sim._dz_profile = np.full(...)``, permanently mutating sim
+        # state as a side effect of execution (roadmap W1.3).
+        nz_phys = max(1, int(round(domain[2] / dx)))
+        dz_profile = np.full(nz_phys, float(dx))
     domain_xy = (domain[0], domain[1])
     return make_nonuniform_grid(
         domain_xy, dz_profile, dx, cpml_layers,
@@ -101,7 +109,7 @@ def _build_waveguide_port_config_nu(sim, entry, grid: NonUniformGrid,
     pos_vec[axis_idx] = entry.x_position
     x_index = pos_to_nu_index(grid, tuple(pos_vec))[axis_idx]
 
-    # v1.7.5 per-face NU allocation: pass (pad_lo, pad_hi) for each axis.
+    # Per-face NU allocation (2026-04): pass (pad_lo, pad_hi) for each axis.
     pads_lo_hi = {
         "x": (grid.pad_x_lo, grid.pad_x_hi),
         "y": (grid.pad_y_lo, grid.pad_y_hi),

--- a/rfx/topology.py
+++ b/rfx/topology.py
@@ -425,7 +425,7 @@ def topology_optimize(
     # Clamp indices to the interior region (exclude CPML padding).
     # Without this, a design region at the domain edge can overlap
     # with CPML cells, causing shape mismatches and incorrect gradients.
-    # Per-face pads (v1.7.5): a PMC/PEC/periodic face has pad=0 on its
+    # Per-face pads (2026-04): a PMC/PEC/periodic face has pad=0 on its
     # side, so the design can touch that reflector.
     pads_lo = (grid.pad_x_lo, grid.pad_y_lo, grid.pad_z_lo)
     pads_hi = (grid.pad_x_hi, grid.pad_y_hi, grid.pad_z_hi)

--- a/rfx/vmap_sweep.py
+++ b/rfx/vmap_sweep.py
@@ -297,6 +297,30 @@ def _build_full_scan_fn(
     has_waveguide = len(sim._waveguide_ports) > 0
     has_dispersion = debye_spec is not None or lorentz_spec is not None
 
+    # Allowlist guard: the vmap scan bodies implement ONLY pec/periodic
+    # walls and CPML. Anything below must take the sequential fallback
+    # (return None) or it would be SILENTLY DROPPED from the swept runs:
+    #   - boundary='upml': neither scan body applies a UPML step, so the
+    #     fast path would run with no absorber at all;
+    #   - lumped RLC elements: not wired into either scan body;
+    #   - flux monitors / DFT planes / NTFF: frequency-domain accumulators
+    #     exist only in the canonical Simulation.run() loop;
+    #   - non-uniform mesh profiles: scan bodies assume a uniform grid.
+    if boundary == "upml":
+        return None
+    if getattr(sim, "_lumped_rlc", None):
+        return None
+    if getattr(sim, "_flux_monitors", None) or getattr(sim, "_dft_planes", None):
+        return None
+    if getattr(sim, "_ntff", None) is not None:
+        return None
+    if (
+        getattr(sim, "_dx_profile", None) is not None
+        or getattr(sim, "_dy_profile", None) is not None
+        or getattr(sim, "_dz_profile", None) is not None
+    ):
+        return None
+
     # Build sources and probes from the simulation.
     # For CPML J-sources the Cb coefficient depends on material properties
     # at the source cell, so we store *raw* (un-normalized) waveforms and

--- a/tests/test_boundary_cpml_oracle.py
+++ b/tests/test_boundary_cpml_oracle.py
@@ -1,4 +1,4 @@
-"""T7 Phase 2 — asymmetric CPML analytic oracle (v1.7.2).
+"""T7 Phase 2 — asymmetric CPML analytic oracle (2026-04).
 
 Closes critic blocker #2: the asymmetric-CPML claim must be backed by
 a QUANTITATIVE σ_max oracle that catches the "computed with wrong n"

--- a/tests/test_boundary_pmc_composition.py
+++ b/tests/test_boundary_pmc_composition.py
@@ -5,7 +5,7 @@ mixed-boundary setups rather than asserting a "correct" answer. When a
 setup turns out to be ambiguous or dangerous, the test fails loudly so
 future sessions pick up the tracking item.
 
-Per the v1.7.4 open-questions log (.omc/plans/open-questions.md §OQ7/8),
+Per the T8/2026-04 open-questions log (.omc/plans/open-questions.md §OQ7/8),
 these are T10 candidates tracked for visibility, not blockers.
 
 OQ7 — TFSF + PMC scan-body ordering:

--- a/tests/test_boundary_pmc_distributed.py
+++ b/tests/test_boundary_pmc_distributed.py
@@ -1,4 +1,4 @@
-"""v1.7.4 T8 — sharded PMC runtime smoke tests.
+"""T8 (2026-04) — sharded PMC runtime smoke tests.
 
 Covers the three sharded runners:
   - ``rfx/runners/distributed_nu.py``   — NU path, reached via direct
@@ -15,7 +15,7 @@ Covers the three sharded runners:
                                           reached via a direct call to
                                           ``run_distributed`` — this is
                                           the only code path that exercises
-                                          the v1.7.4 T8 ``_apply_pmc_local``
+                                          the T8 (2026-04) ``_apply_pmc_local``
                                           hook inside its pmap scan body.
 
 Case 2 includes a NEGATIVE assertion that non-owning ranks' x-face

--- a/tests/test_boundary_pmc_guard.py
+++ b/tests/test_boundary_pmc_guard.py
@@ -1,7 +1,7 @@
-"""T7-E runtime tests (v1.7.1-alpha).
+"""T7-E runtime tests (T7 Phase 2, 2026-04).
 
-Phase 1 (v1.7.0) rejected ``'pmc'`` tokens at Simulation construction
-via ``_check_pmc_phase1``. Phase 2 PR3 (v1.7.1) ships
+Phase 1 (T7-C/D/E) rejected ``'pmc'`` tokens at Simulation construction
+via ``_check_pmc_phase1``. Phase 2 PR3 ships
 ``rfx/boundaries/pmc.py::apply_pmc_faces`` wired into the uniform scan
 body; the guard is removed. These tests now assert the runtime
 accepts PMC faces and produces finite output (the module-level

--- a/tests/test_boundary_pmc_hi_faces.py
+++ b/tests/test_boundary_pmc_hi_faces.py
@@ -1,4 +1,4 @@
-"""Regression lock: PMC enforcement on every ``_hi`` face (v1.7.5 fix).
+"""Regression lock: PMC enforcement on every ``_hi`` face (fix 2026-04).
 
 Background — discovered 2026-04-19 while building
 ``examples/crossval/09_half_symmetric_waveguide.py``:
@@ -108,7 +108,7 @@ def _dominant_mode_freq(axis: str, side: str) -> float:
 def test_pmc_quarter_wave_on_every_face(axis: str, side: str):
     """PMC-PEC cavity mirrored onto each of the six faces must land
     within 10 % of the quarter-wave analytic ``c/(4L)``. Before the
-    v1.7.5 fix, ``_hi`` faces landed at ``c/(2L)`` (twice f_0,
+    Before the 2026-04 fix, ``_hi`` faces landed at ``c/(2L)`` (twice f_0,
     PEC-PEC behaviour) because PMC was a silent no-op on hi-side
     faces.
     """
@@ -120,5 +120,5 @@ def test_pmc_quarter_wave_on_every_face(axis: str, side: str):
         f"analytic quarter-wave {_F0_QW/1e9:.3f} GHz "
         f"(rel err {rel_err_qw:.3%}). rel err to PEC-PEC half-wave "
         f"{2.0*_F0_QW/1e9:.3f} GHz: {rel_err_hw:.3%}. The hi-face "
-        f"silent-drop bug (pre-v1.7.5) gives PEC-PEC behaviour here."
+        f"silent-drop bug (pre-2026-04 fix) gives PEC-PEC behaviour here."
     )

--- a/tests/test_boundary_pmc_oracle.py
+++ b/tests/test_boundary_pmc_oracle.py
@@ -1,4 +1,4 @@
-"""T7-E Phase 2 — PMC λ/4 cavity mode-ladder oracle (v1.7.2).
+"""T7-E Phase 2 — PMC λ/4 cavity mode-ladder oracle (T7 Phase 2, 2026-04).
 
 Closes critic blocker #5: the shipped PMC tests (tangential-H=0,
 dual-boundary Hx sample) prove the PMC hook fires and is a distinct

--- a/tests/test_boundary_pmc_runtime.py
+++ b/tests/test_boundary_pmc_runtime.py
@@ -18,7 +18,7 @@ Mechanism pins:
    CPML share an axis.
 4. **Dual-boundary Hx sample** — PMC zeros Hx at the face cell while
    PEC leaves it free, confirming the two code paths are engaged.
-5. **Distributed-PMC acceptance** (v1.7.4 T8) — the sharded NU forward
+5. **Distributed-PMC acceptance** (T8, 2026-04) — the sharded NU forward
    path now wires ``apply_pmc_faces`` via ``_apply_pmc_face_nu_shmap``
    (and dually in ``distributed_v2.py`` / ``distributed.py``).
    ``forward(distributed=True)`` with any PMC face must NOT raise
@@ -27,7 +27,7 @@ Mechanism pins:
 
 Additional quantitative oracles beyond the λ/4 ladder (closed-box
 energy conservation, analytic impedance matching) are tracked as a
-v1.7.3 follow-up harness — they need a source-calibrated long run.
+follow-up harness — they need a source-calibrated long run.
 """
 
 from __future__ import annotations
@@ -101,7 +101,7 @@ def test_mixed_pmc_cpml_seam_is_finite():
 
 
 def test_pmc_plus_distributed_forward_accepts():
-    """v1.7.4 T8: PMC is now wired into the sharded NU forward path.
+    """T8 (2026-04): PMC is now wired into the sharded NU forward path.
 
     The reject guard that used to live at ``rfx/api.py:4264-4274`` was
     removed in T8 once ``_apply_pmc_face_nu_shmap`` landed in the

--- a/tests/test_boundary_spec.py
+++ b/tests/test_boundary_spec.py
@@ -2,7 +2,7 @@
 
 Covers the type surface, construction-time validation, and
 serialisation round-trips for the per-axis, per-face boundary
-specification introduced in v1.7.0.
+specification introduced in T7-A (2026-04).
 """
 
 from __future__ import annotations

--- a/tests/test_boundary_spec_thickness.py
+++ b/tests/test_boundary_spec_thickness.py
@@ -1,8 +1,8 @@
 """T7-C spec + runtime tests.
 
-Phase 1 (v1.7.0) introduced ``Boundary.lo_thickness`` /
+Phase 1 (2026-04) introduced ``Boundary.lo_thickness`` /
 ``hi_thickness`` as spec-level fields with a runtime guard that
-rejected asymmetric thickness. Phase 2 PR2 (v1.7.1) replaced the
+rejected asymmetric thickness. Phase 2 PR2 (2026-04) replaced the
 guard with the padded-profile runtime, so these tests now assert
 that asymmetric thickness builds and runs end-to-end.
 """

--- a/tests/test_crossval_migration_smoke.py
+++ b/tests/test_crossval_migration_smoke.py
@@ -1,4 +1,4 @@
-"""v1.7.4 T9 — crossval BoundarySpec migration smoke tests.
+"""T9 (2026-04) — crossval BoundarySpec migration smoke tests.
 
 Per-script rfx-only smoke for the 6 migrated crossval scripts. Pins
 that the BoundarySpec-migrated scripts still build a valid Simulation

--- a/tests/test_device_count_sentinel.py
+++ b/tests/test_device_count_sentinel.py
@@ -1,0 +1,29 @@
+"""Device-count sentinel (roadmap W1.6).
+
+conftest.py injects ``XLA_FLAGS=--xla_force_host_platform_device_count=2``
+via ``os.environ.setdefault`` and only ``warnings.warn``s when fewer than
+two devices are visible. Every 2-device test then ``pytest.skip``s
+individually, so a late/lost flag silently degrades the whole
+distributed/2-device lane to green skips.
+
+This test FAILS (not skips) when the 2-device environment is missing,
+unless a lane explicitly opts out by exporting ``RFX_ALLOW_SINGLE_DEVICE=1``.
+"""
+
+import os
+
+import jax
+
+
+def test_two_devices_visible_unless_opted_out():
+    if os.environ.get("RFX_ALLOW_SINGLE_DEVICE") == "1":
+        return
+    n = len(jax.devices())
+    assert n >= 2, (
+        f"Only {n} JAX device(s) visible — the XLA_FLAGS 2-device injection "
+        "from conftest.py did not take effect, so every 2-device/distributed "
+        "test in this session is silently skipping. Either fix the flag "
+        "injection (it must be set before jax initializes) or export "
+        "RFX_ALLOW_SINGLE_DEVICE=1 for lanes that legitimately run "
+        "single-device."
+    )

--- a/tests/test_distributed_nu_composition.py
+++ b/tests/test_distributed_nu_composition.py
@@ -135,7 +135,7 @@ def _make_nu_sim_small(
 # jax 0.6.x, but Phase 2F shipped a `custom_vjp` workaround that is the
 # production segmented-remat path; the minimal-reproducer xfail sentinel
 # is no longer needed.  If JAX upstream fixes the composition, the
-# custom_vjp path can be removed in a v1.7.0 simplification pass, but
+# custom_vjp path can be removed in a future simplification pass, but
 # that is a refactor opportunity, not a correctness gate.)
 #
 # ---------------------------------------------------------------------------
@@ -931,7 +931,7 @@ def test_forward_distributed_nan_propagates_via_ghost_exchange():
 
 
 # ---------------------------------------------------------------------------
-# v1.7.4 Bundle C.1 — distributed-CPML preflight error text names per-face
+# Bundle C.1 (2026-04) — distributed-CPML preflight error text names per-face
 # thickness alternative. Users hitting `cpml_layers*2 >= nx_local` may now
 # mitigate via `Boundary(lo_thickness=..., hi_thickness=...)` on the axis,
 # not only by reducing the global `cpml_layers` scalar or growing nx.

--- a/tests/test_farfield_asymmetric_cpml.py
+++ b/tests/test_farfield_asymmetric_cpml.py
@@ -1,6 +1,6 @@
 """Bundle C.2 — NTFFBox.from_grid and per-face CPML origin asymmetry.
 
-These tests pin the v1.7.4 refactor: per-face CPML thickness now threads
+These tests pin the 2026-04 per-face refactor: per-face CPML thickness now threads
 through NTFF box construction so NTFF integration surfaces sit outside the
 CPML-active region on each face independently, not behind a scalar
 cpml_layers origin.

--- a/tests/test_silent_drop_warnings.py
+++ b/tests/test_silent_drop_warnings.py
@@ -1,6 +1,6 @@
-"""Regression locks for the silent-drop class bug (v1.7.5).
+"""Regression locks for the silent-drop class bug (fixed 2026-04).
 
-Pre-v1.7.5 the distributed, non-uniform, and subgridded dispatch paths
+Previously the distributed, non-uniform, and subgridded dispatch paths
 in ``Simulation.run`` silently dropped most of the run-time kwargs
 (``checkpoint``, ``snapshot``, ``until_decay``, ``decay_*``,
 ``conformal_pec``, ``conformal_min_weight``). ``subpixel_smoothing`` on
@@ -77,7 +77,7 @@ def test_warn_helper_fires_on_non_defaults():
 
 
 # --------------------------------------------------------------------
-# NU-path dispatch: warn for the kwargs that stay dropped after 1.7.5.
+# NU-path dispatch: warn for the kwargs that stay dropped after the 2026-04 fix.
 # --------------------------------------------------------------------
 
 def _make_nu_sim():
@@ -134,7 +134,7 @@ def test_nu_path_warns_on_dropped_kwargs(kw, val):
 
 
 def test_nu_path_checkpoint_does_not_warn():
-    """checkpoint is propagated through _run_nonuniform as of v1.7.5."""
+    """checkpoint is propagated through _run_nonuniform (wired 2026-04)."""
     sim = _make_nu_sim()
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
@@ -166,8 +166,8 @@ def test_nu_path_subpixel_does_not_warn():
 # --------------------------------------------------------------------
 
 def test_preflight_silent_on_pmc_plus_cpml_uniform_path():
-    """Uniform mesh with PMC+CPML composition: after v1.7.5 per-face
-    grid allocation the reflector wall aligns with the user domain
+    """Uniform mesh with PMC+CPML composition: after the per-face
+    grid allocation (2026-04) the reflector wall aligns with the user domain
     edge (pad=0 on the PMC side), so P2.7 does NOT fire."""
     spec = BoundarySpec(
         x="periodic",
@@ -185,13 +185,13 @@ def test_preflight_silent_on_pmc_plus_cpml_uniform_path():
     sim.add_probe((2e-3, 6e-3, 2e-3), "ex")
     issues = sim.preflight()
     assert not any("P2.7" in s for s in issues), (
-        f"P2.7 must not fire on uniform path (v1.7.5 per-face padding "
+        f"P2.7 must not fire on uniform path (per-face padding 2026-04 "
         f"closes the gap). Got: {issues}"
     )
 
 
 def test_preflight_silent_on_pmc_plus_cpml_nu_path():
-    """NU path: v1.7.5 extended per-face allocation to NonUniformGrid,
+    """NU path: per-face allocation (2026-04) extended to NonUniformGrid,
     so P2.7 is silent on NU too (gap closed on both paths)."""
     spec = BoundarySpec(
         x="periodic",
@@ -210,7 +210,7 @@ def test_preflight_silent_on_pmc_plus_cpml_nu_path():
     sim.add_probe((2e-3, 6e-3, 2e-3), "ex")
     issues = sim.preflight()
     assert not any("P2.7" in s for s in issues), (
-        f"P2.7 must not fire on NU path after v1.7.5. Got: {issues}"
+        f"P2.7 must not fire on NU path after per-face fix. Got: {issues}"
     )
 
 

--- a/tests/test_state_purity_dz_profile.py
+++ b/tests/test_state_purity_dz_profile.py
@@ -1,0 +1,49 @@
+"""Regression locks for dz-profile state purity (roadmap W1.3).
+
+forward()/run()/the distributed runner used to PERSIST a synthesized dz
+profile onto ``sim._dz_profile`` as a side effect of execution, while the
+NU S-matrix extractor save/restored the same attribute — hidden state
+divergence depending on which entry point ran first. The synthesis now
+happens locally inside ``_build_nonuniform_grid()`` and sim state must
+stay untouched.
+"""
+
+import numpy as np
+
+from rfx import Simulation, GaussianPulse
+
+
+def _dx_only_nu_sim() -> Simulation:
+    """Minimal runnable sim with ONLY dx_profile set (dz left None)."""
+    sim = Simulation(
+        freq_max=5e9,
+        domain=(0.02, 0.01, 0.004),
+        dx=1e-3,
+        boundary="cpml",
+        cpml_layers=4,
+        dx_profile=np.full(20, 1e-3),
+    )
+    sim.add_source((0.01, 0.005, 0.002), "ez", waveform=GaussianPulse(f0=3e9))
+    sim.add_probe((0.012, 0.005, 0.002), "ez")
+    return sim
+
+
+def test_build_nonuniform_grid_does_not_persist_dz():
+    sim = _dx_only_nu_sim()
+    assert sim._dz_profile is None
+    grid = sim._build_nonuniform_grid()
+    assert grid is not None
+    assert sim._dz_profile is None, (
+        "_build_nonuniform_grid() persisted the synthesized dz profile "
+        "onto sim state — synthesis must stay local to the grid build"
+    )
+
+
+def test_run_does_not_persist_synthesized_dz():
+    sim = _dx_only_nu_sim()
+    res = sim.run(n_steps=5)
+    assert res is not None
+    assert sim._dz_profile is None, (
+        "run() persisted a synthesized dz profile onto sim state — the "
+        "NU dispatch must not mutate the simulation as a side effect"
+    )

--- a/tests/test_vmap_sweep_eligibility.py
+++ b/tests/test_vmap_sweep_eligibility.py
@@ -1,0 +1,121 @@
+"""Eligibility guards for the vmap_material_sweep fast path (roadmap W1.2).
+
+The vmap scan bodies implement only pec/periodic walls and CPML. Before
+this guard, a sim with ``boundary='upml'`` was routed to a scan body that
+applies NO absorber at all, and lumped RLC elements / flux monitors /
+DFT planes / NTFF / non-uniform profiles were silently dropped from the
+swept runs. These tests pin the sequential fallback for every such case
+and pin that the supported fast path still does NOT fall back.
+
+CPU-runnable on tiny grids (intentionally not gpu-marked so the PR gate
+exercises this file).
+"""
+
+import warnings
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from rfx import Simulation, GaussianPulse, Box
+from rfx.vmap_sweep import vmap_material_sweep, VmapSweepResult
+
+_FALLBACK_MATCH = "Falling back to sequential"
+
+
+def _base_sim(boundary: str = "cpml", eps_r: float = 4.0) -> Simulation:
+    kwargs = {"cpml_layers": 6} if boundary == "cpml" else {}
+    sim = Simulation(
+        freq_max=5e9,
+        domain=(0.02, 0.02, 0.02),
+        boundary=boundary,
+        dx=0.002,
+        **kwargs,
+    )
+    sim.add_material("substrate", eps_r=eps_r)
+    sim.add(Box((0.005, 0, 0), (0.015, 0.02, 0.02)), material="substrate")
+    sim.add_source((0.01, 0.01, 0.01), "ez", waveform=GaussianPulse(f0=3e9))
+    sim.add_probe((0.005, 0.01, 0.01), "ez")
+    return sim
+
+
+def test_upml_takes_sequential_fallback_and_matches_run():
+    """UPML must NOT take the vmap fast path (scan bodies apply no UPML)."""
+    sim = _base_sim(boundary="upml")
+    eps_values = np.array([2.0, 6.0])
+    n_steps = 40
+
+    with pytest.warns(UserWarning, match=_FALLBACK_MATCH):
+        result = vmap_material_sweep(
+            sim, "substrate.eps_r", eps_values, n_steps=n_steps,
+        )
+
+    assert isinstance(result, VmapSweepResult)
+    assert result.time_series.shape[0] == len(eps_values)
+
+    # The sequential fallback runs the canonical loop, so each swept entry
+    # must match a direct sim.run() with that eps_r value.
+    for idx, eps_val in enumerate(eps_values):
+        sim_single = _base_sim(boundary="upml", eps_r=float(eps_val))
+        single_ts = np.asarray(sim_single.run(n_steps=n_steps).time_series)
+        npt.assert_allclose(
+            np.asarray(result.time_series[idx]), single_ts,
+            rtol=1e-5, atol=1e-12,
+            err_msg=f"UPML fallback diverges from direct run at eps_r={eps_val}",
+        )
+
+
+def test_lumped_rlc_takes_sequential_fallback():
+    """Lumped RLC elements are not wired into the vmap scan bodies."""
+    sim = _base_sim(boundary="cpml")
+    sim.add_lumped_rlc((0.015, 0.01, 0.01), "ez", R=50.0)
+
+    with pytest.warns(UserWarning, match=_FALLBACK_MATCH):
+        vmap_material_sweep(
+            sim, "substrate.eps_r", np.array([2.0, 4.0]), n_steps=20,
+        )
+
+
+def test_flux_monitor_takes_sequential_fallback():
+    """Flux monitors only accumulate in the canonical run() loop."""
+    sim = _base_sim(boundary="cpml")
+    sim.add_flux_monitor(
+        axis="x", coordinate=0.016, freqs=np.array([3e9]), name="t",
+    )
+
+    with pytest.warns(UserWarning, match=_FALLBACK_MATCH):
+        vmap_material_sweep(
+            sim, "substrate.eps_r", np.array([2.0, 4.0]), n_steps=20,
+        )
+
+
+def test_nonuniform_profile_takes_sequential_fallback():
+    """NU mesh profiles are incompatible with the uniform-grid scan bodies."""
+    sim = Simulation(
+        freq_max=5e9,
+        domain=(0.02, 0.02, 0.02),
+        boundary="cpml",
+        cpml_layers=6,
+        dx=0.002,
+        dx_profile=np.full(10, 0.002),
+    )
+    sim.add_material("substrate", eps_r=4.0)
+    sim.add(Box((0.005, 0, 0), (0.015, 0.02, 0.02)), material="substrate")
+    sim.add_source((0.01, 0.01, 0.01), "ez", waveform=GaussianPulse(f0=3e9))
+    sim.add_probe((0.005, 0.01, 0.01), "ez")
+
+    with pytest.warns(UserWarning, match=_FALLBACK_MATCH):
+        vmap_material_sweep(
+            sim, "substrate.eps_r", np.array([2.0, 4.0]), n_steps=20,
+        )
+
+
+def test_supported_cpml_sim_still_uses_fast_path():
+    """Control: the plain CPML dielectric sim must NOT fall back."""
+    sim = _base_sim(boundary="cpml")
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", message=f".*{_FALLBACK_MATCH}.*")
+        result = vmap_material_sweep(
+            sim, "substrate.eps_r", np.array([2.0, 4.0]), n_steps=20,
+        )
+    assert result.time_series.shape[0] == 2

--- a/tests/test_waveguide_nu_nontrivial.py
+++ b/tests/test_waveguide_nu_nontrivial.py
@@ -386,49 +386,52 @@ def test_nu_nontrivial_slab_verdict():
     print(f"\n[NU-VALIDATE] NU passivity (|S11|²+|S21|²): "
           f"{np.array2string(passivity_nu, precision=4)}  max={passivity_nu.max():.4f}")
 
-    # --- Verdict logic ---
-    injection_is_real = a_inc_mag.mean() > 1e-25
-    reflection_is_real = s11_nu.max() > 0.02
-    s21_agrees = np.abs(s21_nu - s21_uni).max() < 0.15
-    passivity_ok = passivity_nu.max() <= 1.10
+    # --- Verdict logic (roadmap W1.5 split) ---
+    # These two gates HOLD on main today and must HARD-FAIL on regression.
+    # The previous runtime ``pytest.xfail(...)`` here was always non-strict,
+    # so ANY regression (including in these passing gates) reported as
+    # green-"xfailed" forever.
+    assert a_inc_mag.mean() > 1e-25, (
+        f"NU injection at noise floor: mean|a_inc|={a_inc_mag.mean():.3e} "
+        "<= 1e-25. NU-DRIVE-FIX has REGRESSED for non-trivial devices."
+    )
+    assert passivity_nu.max() <= 1.10, (
+        f"Passivity violation: max(|S11|²+|S21|²)={passivity_nu.max():.4f} > 1.10."
+    )
 
-    verdict_pass = injection_is_real and reflection_is_real and s21_agrees and passivity_ok
+    # The genuinely-unvalidated claims (NU reflection magnitude and
+    # NU-vs-uniform S21 agreement) live in
+    # test_nu_nontrivial_matches_uniform below under a decorator-level
+    # STRICT xfail, so the day the NU lane is fixed they XPASS-fail and
+    # force promotion to hard gates.
 
-    if not verdict_pass:
-        fail_parts = []
-        if not injection_is_real:
-            fail_parts.append(
-                f"NU injection at noise floor: mean|a_inc|={a_inc_mag.mean():.3e} <= 1e-25. "
-                "NU-DRIVE-FIX is NOT complete for non-trivial devices."
-            )
-        if not reflection_is_real:
-            fail_parts.append(
-                f"|S11_nu| max={s11_nu.max():.4f} <= 0.02 — no reflection registered; "
-                "NU S11 is at noise, not physical slab reflection."
-            )
-        if not s21_agrees:
-            fail_parts.append(
-                f"|S21_nu - S21_uni| max={np.abs(s21_nu - s21_uni).max():.4f} >= 0.15 — "
-                "NU disagrees with uniform path by more than tolerance."
-            )
-        if not passivity_ok:
-            fail_parts.append(
-                f"Passivity violation: max(|S11|²+|S21|²)={passivity_nu.max():.4f} > 1.10."
-            )
-        pytest.xfail(
-            "NU-VALIDATE: NU NOT validated for non-trivial devices — "
-            "NU-DRIVE-FIX REOPENED. Evidence: " + "; ".join(fail_parts)
-        )
 
-    # Asserts only reached when verdict_pass=True
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "NU S-matrix is at noise level for non-trivial devices "
+        "(|S11_nu|~1e-4, ~50x below uniform; device-run b cancels against "
+        "reference-run b; root cause OPEN — see rfx-known-issues item 'NU "
+        "non-trivial device'). XPASS = the NU lane was fixed: promote these "
+        "asserts into test_nu_nontrivial_slab_verdict and update the "
+        "known-issues entry."
+    ),
+)
+def test_nu_nontrivial_matches_uniform():
+    """Strict-xfail tripwire for the unvalidated NU claims (W1.5)."""
+    res_nu = _get_nu_result()
+    res_uni = _get_uni_result()
+    s_nu = np.array(res_nu.s_params)
+    s_uni = np.array(res_uni.s_params)
+    s11_nu = np.abs(s_nu[0, 0, :])
+    s21_nu = np.abs(s_nu[1, 0, :])
+    s21_uni = np.abs(s_uni[1, 0, :])
+
     assert s11_nu.max() > 0.02, (
         f"|S11_nu| max={s11_nu.max():.4f} — slab should produce measurable reflection"
     )
     assert np.abs(s21_nu - s21_uni).max() < 0.15, (
         f"|S21_nu - S21_uni| max={np.abs(s21_nu - s21_uni).max():.4f} >= 0.15"
-    )
-    assert passivity_nu.max() <= 1.10, (
-        f"Passivity violation: max(|S11|²+|S21|²)={passivity_nu.max():.4f}"
     )
 
 

--- a/tests/test_waveguide_nu_sparam.py
+++ b/tests/test_waveguide_nu_sparam.py
@@ -32,6 +32,8 @@ from __future__ import annotations
 
 import warnings
 
+import pytest
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -343,3 +345,32 @@ def test_nu_assembly_ad_traceable():
     assert float(grad) >= 0.0, (
         f"AD grad = {float(grad):.6e} < 0; |sum(|S|^2)| gradient must be non-negative."
     )
+
+
+# ---------------------------------------------------------------------------
+# W1.1 (roadmap 2026-06-10): the NU dispatch must REJECT kwargs it cannot
+# forward. eps_override/sigma_override are the documented differentiable
+# channels (G-AD-WIRE-WG2); silently dropping them produced silently-wrong
+# gradients on graded meshes.
+# ---------------------------------------------------------------------------
+
+def test_nu_dispatch_rejects_eps_override():
+    sim = _make_wr90_nu_sim()
+    with pytest.raises(NotImplementedError, match="eps_override"):
+        sim.compute_waveguide_s_matrix(
+            normalize=True, eps_override=jnp.ones((2, 2, 2)),
+        )
+
+
+def test_nu_dispatch_rejects_sigma_override():
+    sim = _make_wr90_nu_sim()
+    with pytest.raises(NotImplementedError, match="sigma_override"):
+        sim.compute_waveguide_s_matrix(
+            normalize=True, sigma_override=jnp.zeros((2, 2, 2)),
+        )
+
+
+def test_nu_dispatch_rejects_subpixel_smoothing():
+    sim = _make_wr90_nu_sim()
+    with pytest.raises(NotImplementedError, match="subpixel_smoothing"):
+        sim.compute_waveguide_s_matrix(normalize=True, subpixel_smoothing=True)


### PR DESCRIPTION
Executes roadmap Waves 1 + 2.1/2.2 + the CPU-feasible Wave-4 items (three-lens review roadmap, 2026-06-10).

## Wave 1 — silent-wrong correctness fixes
- **W1.1** NU dispatch of `compute_waveguide_s_matrix` now raises on `eps_override`/`sigma_override`/`subpixel_smoothing` instead of silently dropping the documented differentiable channels (3 new tests).
- **W1.2** `vmap_material_sweep` falls back to sequential for UPML (fast path applied **no absorber**), lumped RLC, flux monitors/DFT/NTFF, NU profiles (5 new tests incl. UPML-equivalence + fast-path control).
- **W1.3** dz-profile synthesis is now pure (inside `build_nonuniform_grid`); 5 sim-state mutation sites deleted (2 purity regression tests).
- **W1.4** 32 phantom v1.7.x references → PR/date-anchored phrasing; `grep v1.7` over rfx/+tests/ = 0.
- **W1.5** NU non-trivial verdict: passing gates → hard asserts; unvalidated claims → decorator-level strict xfail (runtime xfail could never turn CI red).
- **W1.6** device-count sentinel FAILS (not skips) when 2-device XLA_FLAGS injection is lost.

## CI (W2.1/W2.2)
- New `fast-suite` job: the default ~1400-test suite, 4 sharded fresh processes — previously NO workflow ran it as a whole.
- Guard step hardened: addopts override, `--strict-markers`, collected-count floor.

## Docs + packaging (W4.1/W4.3/W4.5)
- Conformal-PEC overclaims removed; CPML claim fixed to measured default; CHANGELOG `[1.6.0]`–`[1.6.3]` sections reconstructed; CITATION.cff + project.urls + py.typed + Beta classifier + badge fix.
- **Flagship example** `differentiable_s11_design.py`: jax.grad through the public S-matrix API, FD cross-check asserted (measured rel err 4.5e-4, 14.7 s CPU).

## Verification
- Full fast suite green locally in 4 sharded fresh processes (1378 passed). One known dirty-tree-only sensitivity (`test_port_external_reference_audit_*` counts local artifacts) passes on clean checkout — verified against a clean main worktree.
- ruff green tree-wide; wheel build verified to contain py.typed; cffconvert validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)