### PR TITLE
test(ad): AD-surface contract test + ad_traceable support-matrix column (W4.6)

### DIFF
--- a/docs/guides/sparameter_support_matrix.json
+++ b/docs/guides/sparameter_support_matrix.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "updated": "2026-06-10",
+  "updated": "2026-06-11",
   "result_convention": {
     "full_s_matrix_shape": "(n_ports, n_ports, n_freqs)",
     "frequency_shape": "(n_freqs,)",
@@ -79,7 +79,9 @@
         "broad E5 still needs external references plus a larger mesh/frequency/geometry envelope",
         "M47 sweep is still a narrow PEC-box external comparison and does not replace matched/open/short/load broad lumped-port E5 evidence",
         "M50 adds a VESSL parallelization plan and per-case aggregation path for the M47 lumped/openEMS slow sweep; it is orchestration-only and not additional E4/E5 physics evidence until jobs run and aggregate artifacts pass"
-      ]
+      ],
+      "ad_traceable": "yes",
+      "ad_evidence": "jax.grad through forward(port_s11_freqs=...): tests/test_s11_at_freq.py, tests/test_minimize_s11_at_freq_physical.py"
     },
     {
       "primitive": "add_port(extent=...)",
@@ -141,7 +143,9 @@
         "M15 sweep is an internal uniform-Yee sweep and does not replace external solver evidence",
         "wire off-diagonal replay mirrors the current per-cell impedance convention; do not cite it as a generalized modal port calibration",
         "nonuniform finite/AD coverage is not physics validation"
-      ]
+      ],
+      "ad_traceable": "yes",
+      "ad_evidence": "jax.grad through forward(port_s11_freqs=...): tests/test_wire_port_sparams_forward.py"
     },
     {
       "primitive": "add_msl_port(...)",
@@ -191,7 +195,9 @@
         "mode=\"eigenmode\" is strict-xfailed / unsupported until Path-B/FDFD eigenmode validation lands",
         "nonuniform MSL S-parameters remain unsupported",
         "current |S11| floor around 0.10 is acceptable only for narrow/demo wording"
-      ]
+      ],
+      "ad_traceable": "yes",
+      "ad_evidence": "tests/test_msl_sparam_ad.py::test_compute_msl_s_matrix_ad_smoke_has_finite_gradient, tests/test_sparam_ad_end_to_end.py::test_msl_s_matrix_ad_end_to_end"
     },
     {
       "primitive": "add_waveguide_port(...)",
@@ -241,7 +247,9 @@
         "branch/T-junction S-parameters deferred until per-port reference geometry exists",
         "multi-mode normalize=True unsupported",
         "broad nonuniform waveguide S-parameters remain shadow/blocked"
-      ]
+      ],
+      "ad_traceable": "yes",
+      "ad_evidence": "tests/test_sparam_ad_end_to_end.py::test_waveguide_s_matrix_ad_end_to_end, tests/test_waveguide_sparam_ad.py::test_wg_smatrix_assembly_ad_traceable"
     },
     {
       "primitive": "add_coaxial_port(...)",
@@ -294,7 +302,9 @@
         "Do not cite compute_coaxial_s_matrix(...) as the promoted coaxial evidence path; it is deprecated / experimental",
         "Do not generalize the one-port line-reflection envelope to arbitrary coax launches, multi-port networks, nonuniform meshes, or mixed port families",
         "The openEMS coax-line path is superseded because the available openEMS v0.0.35 lacks AddCoaxialPort; MEEP is the retained broad-E4 external comparison"
-      ]
+      ],
+      "ad_traceable": "no",
+      "ad_evidence": "empirically verified TracerArrayConversionError through coaxial_line_reflection_from_plane_voltages (numpy matrix-pencil): tests/test_ad_surface_contract.py::test_coaxial_reflection_extraction_breaks_tape"
     },
     {
       "primitive": "add_floquet_port(...)",
@@ -355,7 +365,9 @@
         "Simulation.run() and Simulation.forward() still reject high-level Floquet S-parameter requests",
         "requires RCWA/external periodic-cell references before promotion",
         "requires mesh/frequency/scan-angle/polarization envelope before E5 promotion"
-      ]
+      ],
+      "ad_traceable": "untested",
+      "ad_evidence": "no pytest caller of compute_floquet_s_params; jnp-pure by static inspection, AD unverified either way — https://github.com/bk-squared/rfx/issues/141"
     },
     {
       "primitive": "add_source(...) / add_polarized_source(...)",
@@ -384,7 +396,8 @@
       "claim_envelope": "field excitation, not impedance-defined port calibration",
       "caveats": [
         "do not document as a substitute for ports"
-      ]
+      ],
+      "ad_traceable": "not_applicable"
     },
     {
       "primitive": "add_tfsf_source(...)",
@@ -415,7 +428,8 @@
       "claim_envelope": "plane-wave field/flux workflow",
       "caveats": [
         "does not define a port impedance/reference plane"
-      ]
+      ],
+      "ad_traceable": "not_applicable"
     },
     {
       "primitive": "add_probe(...) / add_dft_plane_probe(...) / add_flux_monitor(...)",
@@ -444,7 +458,8 @@
       "claim_envelope": "field/flux/time observable only",
       "caveats": [
         "does not define a port impedance or S-matrix reference"
-      ]
+      ],
+      "ad_traceable": "not_applicable"
     }
   ],
   "physics_evidence_rule": "docs/guides/physics_validation_evidence_rule.md",

--- a/rfx/floquet.py
+++ b/rfx/floquet.py
@@ -524,6 +524,11 @@ def compute_floquet_s_params(
 ) -> dict:
     """Compute Floquet S-parameters from DFT accumulators.
 
+    .. warning:: **Experimental / untested.** This pipeline has no pytest
+        caller and no end-to-end S-parameter or autodiff validation; its only
+        caller is a diagnostics script. Do not build accuracy claims on it.
+        Tracking: https://github.com/bk-squared/rfx/issues/141
+
     Uses incident, reflected, and (optionally) transmitted plane
     DFT data to compute S11 (reflection) and S21 (transmission).
 

--- a/tests/test_ad_surface_contract.py
+++ b/tests/test_ad_surface_contract.py
@@ -1,0 +1,219 @@
+"""AD-surface contract (roadmap W4.6).
+
+Every public S-parameter-shaped entry point — top-level ``rfx`` exports
+matching ``compute_*``/``extract_*`` plus ``Simulation.compute_*`` methods —
+must carry an explicit autodiff classification:
+
+- ``grad-safe``     : a named grad smoke/end-to-end test exists (pointer kept
+                      honest by ``test_grad_safe_evidence_pointers_exist``).
+- ``not-traceable`` : numpy / concretizing by design (diagnostic post-
+                      processors); the load-bearing coaxial case is verified
+                      EMPIRICALLY below, not by prose.
+- ``untested``      : no grad evidence either way; must cite a tracking
+                      pointer so it cannot silently rot.
+
+The point of the contract: exporting a new ``compute_*``/``extract_*`` without
+deciding its AD story fails ``test_every_sparam_entry_point_is_ad_classified``.
+The per-port-family view of the same information lives in
+``docs/guides/sparameter_support_matrix.json`` (``ad_traceable`` column),
+locked by ``test_support_matrix_has_ad_traceable_column``.
+
+These tests do not run FDTD.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import re
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import rfx
+from rfx import Simulation
+
+MATRIX_PATH = Path("docs/guides/sparameter_support_matrix.json")
+
+GRAD_SAFE = "grad-safe"
+NOT_TRACEABLE = "not-traceable"
+UNTESTED = "untested"
+
+# name -> (classification, evidence)
+# GRAD_SAFE evidence is "path::test[, path::test...]" and is existence-checked.
+AD_CLASSIFICATION = {
+    # --- Simulation methods -------------------------------------------------
+    "Simulation.compute_waveguide_s_matrix": (
+        GRAD_SAFE,
+        "tests/test_sparam_ad_end_to_end.py::test_waveguide_s_matrix_ad_end_to_end, "
+        "tests/test_waveguide_sparam_ad.py::test_wg_smatrix_assembly_ad_traceable",
+    ),
+    "Simulation.compute_msl_s_matrix": (
+        GRAD_SAFE,
+        "tests/test_msl_sparam_ad.py::test_compute_msl_s_matrix_ad_smoke_has_finite_gradient, "
+        "tests/test_sparam_ad_end_to_end.py::test_msl_s_matrix_ad_end_to_end",
+    ),
+    "Simulation.compute_coaxial_s_matrix": (
+        NOT_TRACEABLE,
+        "deprecated single-plane V/I path; numpy extraction, no differentiable input",
+    ),
+    "Simulation.compute_coaxial_line_reflection": (
+        NOT_TRACEABLE,
+        "numpy matrix-pencil extraction; verified empirically by "
+        "test_coaxial_reflection_extraction_breaks_tape in this file",
+    ),
+    # --- top-level exports --------------------------------------------------
+    "compute_error_indicator": (
+        NOT_TRACEABLE,
+        "numpy AMR diagnostic (rfx/amr.py)",
+    ),
+    "compute_far_field": (
+        NOT_TRACEABLE,
+        "numpy NTFF post-processor; the AD path is compute_far_field_jax",
+    ),
+    "compute_far_field_jax": (
+        GRAD_SAFE,
+        "tests/test_directivity_gradient.py::test_maximize_directivity_gradient_nonzero",
+    ),
+    "compute_rcs": (
+        NOT_TRACEABLE,
+        "numpy RCS post-processor on top of compute_far_field",
+    ),
+    "compute_floquet_s_params": (
+        UNTESTED,
+        "no pytest caller; jnp-pure by static inspection, AD unverified — "
+        "https://github.com/bk-squared/rfx/issues/141",
+    ),
+    "extract_floquet_modes": (
+        UNTESTED,
+        "structure tests only (tests/test_floquet.py), no grad evidence — "
+        "https://github.com/bk-squared/rfx/issues/141",
+    ),
+    "extract_coaxial_plane_vi_from_dft": (
+        NOT_TRACEABLE,
+        "numpy V/I diagnostic extractor (rfx/sources/coaxial_port.py)",
+    ),
+    "extract_multimode_s_matrix": (
+        NOT_TRACEABLE,
+        "concretizing casts in the multimode assembly (rfx/sources/waveguide_port.py)",
+    ),
+    "extract_s_matrix_wire": (
+        NOT_TRACEABLE,
+        "numpy run()-path post-processor; the wire-port AD path is "
+        "forward(port_s11_freqs=...) — tests/test_wire_port_sparams_forward.py",
+    ),
+    "extract_waveguide_s_matrix": (
+        GRAD_SAFE,
+        "exercised inside Simulation.compute_waveguide_s_matrix: "
+        "tests/test_sparam_ad_end_to_end.py::test_waveguide_s_matrix_ad_end_to_end",
+    ),
+    "extract_waveguide_port_waves": (
+        UNTESTED,
+        "jnp-pure helper, no direct grad smoke test",
+    ),
+    "extract_waveguide_sparams": (
+        UNTESTED,
+        "jnp-pure legacy helper, no direct grad smoke test",
+    ),
+    "extract_waveguide_s11": (
+        UNTESTED,
+        "jnp-pure legacy helper, no direct grad smoke test",
+    ),
+    "extract_waveguide_s21": (
+        UNTESTED,
+        "jnp-pure legacy helper, no direct grad smoke test",
+    ),
+}
+
+
+def _exported_surface() -> set[str]:
+    names = {
+        n
+        for n in dir(rfx)
+        if n.startswith(("compute_", "extract_")) and callable(getattr(rfx, n))
+    }
+    for n, _ in inspect.getmembers(Simulation, predicate=inspect.isfunction):
+        if n.startswith("compute_"):
+            names.add(f"Simulation.{n}")
+    return names
+
+
+def test_every_sparam_entry_point_is_ad_classified():
+    surface = _exported_surface()
+    missing = sorted(surface - AD_CLASSIFICATION.keys())
+    stale = sorted(AD_CLASSIFICATION.keys() - surface)
+    assert not missing, (
+        "New compute_*/extract_* entry points exported without an AD "
+        f"classification: {missing}. Add each to AD_CLASSIFICATION in this "
+        "file (grad-safe with a named grad test, not-traceable with the "
+        "reason, or untested with a tracking pointer) and mirror the port-"
+        "family view in docs/guides/sparameter_support_matrix.json."
+    )
+    assert not stale, (
+        f"AD_CLASSIFICATION entries no longer exported: {stale}. Remove them."
+    )
+
+
+def test_grad_safe_evidence_pointers_exist():
+    for name, (status, evidence) in AD_CLASSIFICATION.items():
+        if status != GRAD_SAFE:
+            continue
+        refs = re.findall(r"(tests/[\w/]+\.py)::(\w+)", evidence)
+        assert refs, f"{name}: grad-safe entry must cite at least one path::test"
+        for path, testname in refs:
+            p = Path(path)
+            assert p.exists(), f"{name}: evidence file {path} is gone"
+            assert f"def {testname}" in p.read_text(), (
+                f"{name}: evidence test {path}::{testname} no longer exists"
+            )
+
+
+def test_coaxial_reflection_extraction_breaks_tape():
+    """Empirical basis for the coaxial ``not-traceable`` classification.
+
+    The roadmap critic flagged the earlier "coax breaks the tape" claim as
+    digest prose; this test IS the evidence. A synthetic two-wave voltage
+    profile with planted A=theta, B=0.3 must (a) give the planted |B/A| on the
+    concrete path (witness that we exercise the real extractor) and (b) raise
+    TracerArrayConversionError under jax.grad, because
+    ``coaxial_line_reflection_from_plane_voltages`` is numpy (np.asarray /
+    np.linalg.lstsq / complex()). If (b) starts succeeding, the extraction
+    became traceable — upgrade the classification instead of deleting this.
+    """
+    from rfx.sources.coaxial_port import coaxial_line_reflection_from_plane_voltages
+
+    z = np.linspace(0.002, 0.013, 12)
+
+    def objective(theta):
+        V = theta * jnp.exp(1j * 300.0 * jnp.asarray(z)) + 0.3 * jnp.exp(
+            -1j * 300.0 * jnp.asarray(z)
+        )
+        res = coaxial_line_reflection_from_plane_voltages(
+            z, V, reference_plane_m=0.0
+        )
+        return jnp.abs(jnp.asarray(res.reflection))
+
+    concrete = float(objective(jnp.asarray(0.7)))
+    assert abs(concrete - 0.3 / 0.7) < 1e-3, (
+        f"concrete witness drifted: |Gamma|={concrete:.6f}, expected ~{0.3/0.7:.6f}"
+    )
+    with pytest.raises(jax.errors.TracerArrayConversionError):
+        jax.grad(objective)(jnp.asarray(0.7))
+
+
+def test_support_matrix_has_ad_traceable_column():
+    data = json.loads(MATRIX_PATH.read_text())
+    allowed = {"yes", "no", "untested", "not_applicable"}
+    for fam in data["port_families"]:
+        name = fam["family"]
+        assert "ad_traceable" in fam, f"{name}: missing ad_traceable"
+        assert fam["ad_traceable"] in allowed, (
+            f"{name}: ad_traceable={fam['ad_traceable']!r} not in {sorted(allowed)}"
+        )
+        if fam["ad_traceable"] in {"yes", "no", "untested"}:
+            assert fam.get("ad_evidence"), (
+                f"{name}: ad_traceable={fam['ad_traceable']} requires ad_evidence"
+            )


### PR DESCRIPTION
## Summary

Roadmap W4.6 (`20260610_rfx_roadmap_three_lens_review.md`): the AD coverage of the public S-parameter surface was asymmetric and unmapped. This PR makes the map executable.

- **`tests/test_ad_surface_contract.py`** — enumerates every top-level `compute_*`/`extract_*` export plus every `Simulation.compute_*` method (18 entry points today) against an explicit classification: `grad-safe` (named grad test, pointer existence-checked), `not-traceable` (numpy/concretizing by design), or `untested` (tracking pointer required). **Exporting a new entry point without an AD classification fails the suite** — the W4.6 gate.
- **Coax classification is empirical, not prose** (critic requirement): a synthetic two-wave probe through `coaxial_line_reflection_from_plane_voltages` returns the planted |B/A|=0.4286 concretely (witness) and raises `TracerArrayConversionError` under `jax.grad` (numpy matrix-pencil). If it ever becomes traceable the test fails, forcing a classification upgrade.
- **`docs/guides/sparameter_support_matrix.json`** — `ad_traceable` + `ad_evidence` on all 9 port families (locked by a contract test).
- **Floquet** (roadmap option B): `compute_floquet_s_params` has zero pytest callers — docstring now carries an experimental/untested warning pointing at #141.

## Validation

- `tests/test_ad_surface_contract.py` — 4/4 pass
- `tests/test_sparameter_support_contract.py` + `tests/test_floquet.py` — 38 pass (JSON consumers + docstring neighbor)
- ruff clean; JSON valid, formatting preserved (25-line diff)

No physics or numerics changes — tests, docs metadata, and one docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)