### PR TITLE
docs(api): complete forward() kwarg docs + curated rfx.__all__ + docstring contract test (W5.5)

### DIFF
--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -174,3 +174,114 @@ from rfx.convergence import (
     convergence_study, ConvergenceResult, richardson_extrapolation,
     quick_convergence,
 )
+
+# ---------------------------------------------------------------------------
+# Curated public surface (W5.5).
+#
+# ``__all__`` is the *front door*: ``from rfx import *`` and rendered API
+# references use it. It is intentionally a strict subset of the ~245 flat
+# symbols imported above — every back-compat import is KEPT (so existing
+# ``import rfx; rfx.<name>`` keeps working), but per-step kernel internals,
+# low-level bookkeeping/state classes, and dump/replay round-trip helpers are
+# omitted from the star-import surface.
+#
+# Excluded categories (still importable by explicit attribute access):
+#   - per-step Yee/port kernels: init_*/update_*/inject_*/apply_waveguide_port_*,
+#     adi_step_2d/3d, thomas_solve
+#   - low-level state/bookkeeping classes: ADIState2D/3D, RLCState, RLCCellMeta,
+#     Coaxial*PlaneVI, CoaxialPlaneSourceSpec, FloquetDFTAccumulator,
+#     PortVIDump/PortDumpMetadata/PortSMatrixObservable/PortReplayComparison,
+#     SubgridValidationIssue/Report, BATCH_MANIFEST_SCHEMA
+#   - low-level coaxial/floquet/waveguide plane helpers and modal builders
+#     (coaxial_tem_*, *_plane_vi*, extract_floquet_modes, extract_multimode_*,
+#     init_multimode_waveguide_port, solve_rectangular_modes,
+#     waveguide_plane_positions, floquet_phase_shift/wave_vector)
+#   - dump/replay round-trip + secondary IO: save_*/load_*_npz,
+#     save_snapshots/load_snapshots, save_materials/load_materials,
+#     replay_smatrix_from_port_vi_dump, save_optimization_trajectory,
+#     render_artifact_markdown, validate_artifact_report, build_*_report/artifact
+__all__ = [
+    # grid / core simulation entry points
+    "Grid", "NonUniformGrid", "make_nonuniform_grid",
+    "Simulation", "run", "run_until_decay", "run_nonuniform",
+    "make_source", "make_probe", "make_port_source", "make_current_source",
+    "SimResult", "SnapshotSpec",
+    # result + S-matrix types
+    "Result", "WaveguideSParamResult", "WaveguideSMatrixResult",
+    "MSLSMatrixResult", "CoaxialSMatrixResult",
+    "AD_MemoryEstimate", "ADMemoryPlan", "MeshIntelligenceReport",
+    # geometry
+    "Box", "Sphere", "Cylinder", "PolylineWire", "CurvedPatch", "Via",
+    "PCBLayer", "Stackup",
+    # sources / waveforms / ports (builder classes; not per-step kernels)
+    "GaussianPulse", "ModulatedGaussian", "CWSource", "CustomWaveform",
+    "WaveguidePort", "WaveguidePortConfig", "CoaxialPort",
+    "FloquetPort", "RISUnitCell", "RISSweepResult",
+    # high-level S-parameter / port extractors (AD-contract-classified surface)
+    "extract_waveguide_s_matrix", "extract_waveguide_sparams",
+    "extract_waveguide_s11", "extract_waveguide_s21",
+    "extract_s_matrix_wire", "compute_floquet_s_params",
+    "compute_rcs", "RCSResult",
+    # materials / dispersion / fitting
+    "DebyePole", "LorentzPole", "drude_pole", "lorentz_pole",
+    "ThinConductor", "MATERIAL_LIBRARY",
+    "load_material_csv", "fit_debye", "fit_lorentz", "eval_debye", "eval_lorentz",
+    "plot_material_fit", "DebyeFitResult", "LorentzFitResult",
+    "differentiable_material_fit", "MaterialFitResult", "sparam_loss",
+    # far-field / antenna
+    "NTFFBox", "NTFFData", "FarFieldResult", "make_ntff_box",
+    "compute_far_field", "compute_far_field_jax", "radiation_pattern", "directivity",
+    "axial_ratio", "axial_ratio_dB", "polarization_tilt", "polarization_sense",
+    "antenna_gain", "antenna_gain_dB", "antenna_efficiency",
+    "half_power_beamwidth", "front_to_back_ratio",
+    "antenna_bandwidth", "BandwidthResult", "plot_antenna_summary",
+    # optimization / inverse design + objectives
+    "DesignRegion", "OptimizeResult", "optimize",
+    "GradientCheckResult", "gradient_check",
+    "ProgressiveStage", "ProgressiveOptimizeResult", "progressive_optimize",
+    "TopologyDesignRegion", "TopologyResult", "topology_optimize", "density_to_eps",
+    "minimize_s11", "maximize_s21", "target_impedance", "maximize_bandwidth",
+    "maximize_directivity", "minimize_reflected_energy",
+    "maximize_transmitted_energy", "steer_probe_array",
+    # sweeps / batch
+    "parametric_sweep", "SweepResult", "plot_sweep",
+    "vmap_material_sweep", "VmapSweepResult",
+    "ParameterSweep", "BatchCaseResult", "run_batch", "run_batch_with_manifest",
+    "summarize_batch_manifest",
+    # probes / measurements / spectral
+    "wire_port_voltage", "wire_port_current",
+    "FluxMonitor", "flux_spectrum",
+    "harminv", "harminv_from_probe", "HarminvMode",
+    # eigenmode (optional scipy)
+    "WaveguideMode", "solve_waveguide_modes",
+    # lumped
+    "LumpedRLCSpec",
+    # auto config / mesh planning / convergence / amr
+    "auto_configure", "SimConfig", "analyze_features",
+    "MeshPlan", "plan_mesh", "plan_simulation_mesh",
+    "convergence_study", "ConvergenceResult", "richardson_extrapolation",
+    "quick_convergence",
+    "compute_error_indicator", "suggest_refinement_regions", "auto_refine",
+    # de-embedding
+    "deembed_port_extension", "deembed_thru",
+    # validation entry points
+    "PortValidationIssue", "PortValidationReport",
+    "validate_port_smatrix", "assert_port_smatrix_valid",
+    "normalize_port_smatrix", "compare_replayed_smatrix",
+    "replay_smatrix_from_vi_dump",
+    # io / touchstone / artifacts / checkpoint
+    "TouchstoneData", "read_touchstone", "read_touchstone_full", "write_touchstone",
+    "network_quality_metrics",
+    "save_optimization_result", "load_optimization_result",
+    "save_far_field", "export_radiation_pattern", "export_geometry_json",
+    "save_experiment_report", "save_simulation_dataset",
+    "ArtifactBundle", "export_artifact_bundle",
+    "save_state", "load_state",
+    # visualization
+    "plot_field_slice", "plot_s_params", "plot_radiation_pattern",
+    "plot_time_series", "plot_rcs", "plot_smith",
+    "plot_geometry_3d", "plot_field_3d", "save_field_vtk", "save_field_animation",
+    # gpu / surrogate
+    "device_info", "benchmark",
+    "export_training_data", "export_geometry_sdf",
+]

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -1617,6 +1617,52 @@ class _ExecuteMixin:
             Number of periods at freq_max for auto step count.
         checkpoint : bool
             Enable gradient checkpointing (default True).
+        checkpoint_segments : int or None
+            If set, route the uniform single-device forward through the
+            segmented-checkpoint path (issue #73), which trades ≈2x compute
+            for ≈sqrt(n_steps) reverse-mode memory.  Must divide *n_steps*
+            exactly (padding is rejected so DFT accumulator windows do not
+            shift).  ``None`` (default) keeps the legacy per-step
+            ``jax.checkpoint`` behaviour.  Currently wired only on the
+            uniform single-device path; non-uniform meshes and
+            ``distributed=True`` raise ``NotImplementedError`` (use
+            *checkpoint_every* on the non-uniform path instead).
+        emit_time_series : bool
+            Emit the probe time series in the returned ``ForwardResult``
+            (default True).  ``emit_time_series=False`` skips the time-series
+            buffers and is currently only supported on the non-uniform
+            forward path; on the uniform path it raises
+            ``NotImplementedError`` (frequency-domain objectives such as NTFF
+            and S-params still emit the series there).
+        checkpoint_every : int or None
+            Non-uniform-mesh counterpart of *checkpoint_segments* (a chunk
+            size, not a segment count; issue #73).  When set to a positive
+            integer ``K``, the non-uniform scan is run as a scan-of-scan that
+            remats every ``K`` steps for ≈sqrt(n_steps) memory.  Currently
+            only supported on the non-uniform forward path; on the uniform
+            path it raises ``NotImplementedError`` (use *checkpoint_segments*
+            there).  ``None`` (default) leaves forward-only runs unchanged.
+        n_warmup : int
+            Number of leading timesteps to run with the carry
+            ``stop_gradient``'d so reverse-mode AD builds no tape for the
+            initial transient (issue #40).  Only the trailing
+            ``n_steps - n_warmup`` steps participate in autodiff.  Must
+            satisfy ``n_warmup < n_steps``.  Default ``0`` (all steps
+            differentiated).
+        skip_preflight : bool
+            Skip the consolidated :meth:`preflight` validation suite that
+            normally runs before the forward simulation (default False).
+            Use only when preflight has already been run by the caller
+            (e.g. :func:`rfx.optimize` runs it once at entry) or to bypass a
+            known-spurious warning on a deliberate configuration.
+        design_mask : jnp.ndarray or None
+            Boolean array with shape ``grid.shape`` selecting the
+            differentiable design region (issue #41).  Cells where the mask
+            is ``True`` keep their gradient; cells where it is ``False`` have
+            ``stop_gradient`` applied each step, so AD memory tracks only the
+            design subvolume while forward physics is bit-identical.
+            Currently only supported on the non-uniform forward path; on the
+            uniform path it raises ``NotImplementedError``.
         distributed : bool, optional
             **Opt-in, unstable, pending GPU evidence (issue #44).**  When
             ``True`` and a non-uniform mesh is configured, route the
@@ -1642,6 +1688,15 @@ class _ExecuteMixin:
             ``run_nonuniform_distributed_pec``; other values are
             forward-compatible reservations and will raise inside the
             runner.
+        port_s11_freqs : array-like or None
+            Frequencies (Hz) at which to accumulate per-port V/I DFTs inside
+            the JIT scan body so that ``ForwardResult.s_params`` is populated
+            with wave-decomposition |S11| values for lumped/wire ports
+            (issue #72) — the AD-traceable counterpart of
+            ``run(compute_s_params=True)``.  Required by the
+            :func:`minimize_s11_at_freq_wave_decomp` objective.  Currently
+            wired only on the uniform single-device path; non-uniform meshes
+            and ``distributed=True`` raise ``NotImplementedError``.
 
         Returns
         -------
@@ -1657,9 +1712,10 @@ class _ExecuteMixin:
             import warnings as _w
             _w.warn(
                 "Simulation.forward(distributed=True) is opt-in and pending "
-                "GPU evidence (see issue #44). Set distributed=True only "
-                "after reading "
-                "docs/research_notes/2026-04-16_issue44_v3_plan.md.",
+                "GPU evidence (see issue #44). The distributed lane is "
+                "'experimental / scaling' and not part of the "
+                "correctness-bearing baseline; see the Distributed row of "
+                "docs/guides/support_matrix.md before relying on it.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/tests/test_forward_docstring_contract.py
+++ b/tests/test_forward_docstring_contract.py
@@ -1,0 +1,108 @@
+"""W5.5 contract tests: forward() docstring completeness + curated __all__.
+
+Fast, dependency-free introspection guards so the public surface cannot drift
+silently:
+
+1. Every keyword argument of ``Simulation.forward`` is documented in its
+   docstring ``Parameters`` section.
+2. ``rfx.__all__`` is a curated subset (materially smaller than the full flat
+   export surface) and every listed name resolves on the package.
+3. ``from rfx import *`` binds exactly ``__all__`` and every name is importable.
+"""
+
+import inspect
+import re
+
+import rfx
+from rfx import Simulation
+
+
+def _parameters_section(docstring: str) -> str:
+    """Return the text of the NumPy-style ``Parameters`` section only.
+
+    Slices from the ``Parameters`` header to the next section header
+    (``Returns``/``Raises``/``Examples``/...) so a kwarg name that only
+    appears in ``Returns`` prose does not count as documented.
+    """
+    assert docstring, "Simulation.forward has no docstring"
+    lines = docstring.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if line.strip() == "Parameters" and i + 1 < len(lines) and set(
+            lines[i + 1].strip()
+        ) == {"-"}:
+            start = i + 2
+            break
+    assert start is not None, "forward() docstring has no 'Parameters' section"
+
+    end = len(lines)
+    for j in range(start, len(lines) - 1):
+        underline = lines[j + 1].strip()
+        if lines[j].strip() and underline and set(underline) == {"-"} and len(
+            underline
+        ) >= 3:
+            end = j
+            break
+    return "\n".join(lines[start:end])
+
+
+def test_forward_every_kwarg_documented():
+    sig = inspect.signature(Simulation.forward)
+    kwargs = [
+        name
+        for name, p in sig.parameters.items()
+        if name != "self"
+        and p.kind
+        in (inspect.Parameter.KEYWORD_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+    ]
+    assert kwargs, "forward() exposes no keyword arguments — introspection broke"
+
+    params_text = _parameters_section(inspect.getdoc(Simulation.forward))
+
+    missing = []
+    for name in kwargs:
+        # Match a NumPy-style parameter entry: name at start of a line,
+        # followed by ' :' or end-of-line (type annotation optional).
+        pattern = rf"(?m)^\s*{re.escape(name)}\s*(:|$)"
+        if not re.search(pattern, params_text):
+            missing.append(name)
+
+    assert not missing, (
+        "forward() kwargs missing from the docstring Parameters section: "
+        f"{missing}"
+    )
+
+
+def test_all_is_curated_subset():
+    assert hasattr(rfx, "__all__"), "rfx defines no __all__"
+    names = rfx.__all__
+    assert isinstance(names, list)
+    assert len(names) == len(set(names)), "rfx.__all__ contains duplicates"
+    # Curated: materially smaller than the full ~245-symbol flat surface.
+    assert len(names) < 200, f"rfx.__all__ too large to be curated: {len(names)}"
+    missing = [n for n in names if not hasattr(rfx, n)]
+    assert not missing, f"rfx.__all__ lists names not on the package: {missing}"
+
+
+def test_all_excludes_per_step_internals():
+    # The curated surface must not re-export per-step kernel internals.
+    forbidden_prefixes = ("init_", "update_", "inject_", "apply_waveguide_port_")
+    leaked = [
+        n
+        for n in rfx.__all__
+        if n.startswith(forbidden_prefixes)
+        or n in {"thomas_solve", "adi_step_2d", "adi_step_3d"}
+    ]
+    assert not leaked, f"per-step internals leaked into rfx.__all__: {leaked}"
+
+
+def test_star_import_binds_all_and_is_importable():
+    ns: dict = {}
+    exec("from rfx import *", ns)
+    star_names = {n for n in ns if not n.startswith("__")}
+    assert star_names == set(rfx.__all__), (
+        "from rfx import * did not bind exactly __all__; "
+        f"symmetric_difference={star_names ^ set(rfx.__all__)}"
+    )
+    for name in rfx.__all__:
+        assert ns[name] is getattr(rfx, name)


### PR DESCRIPTION
## Summary

Roadmap W5.5:

- **forward() docstring completed** — the 7 undocumented kwargs (`checkpoint_segments`, `emit_time_series`, `checkpoint_every`, `n_warmup`, `skip_preflight`, `design_mask`, `port_s11_freqs`) are documented with semantics read from the implementation and their issues (#40/#41/#72/#73), not guessed.
- **UserWarning pointer fixed** — the `distributed=True` warning pointed at a gitignored research note a public user cannot read; now points at the tracked Distributed row of `docs/guides/support_matrix.md`.
- **Curated `rfx.__all__`** — 176 of 245 flat exports (star-import surface). Excluded: per-step Yee/port kernels, low-level state/bookkeeping classes, plane/modal helpers, dump-replay IO. **No imports removed or renamed** — every old name stays importable via attribute access, so `dir(rfx)` and the W4.7 symbol inventory are unchanged (verified: no drift).
- **New contract test** `tests/test_forward_docstring_contract.py` — introspects forward()'s signature and fails if any kwarg is missing from the docstring Parameters section; also pins `__all__` sanity (size < 200, every name resolvable, star-import works).

## Verification (executor + independent re-run by reviewing session)

- contract test 4 passed (re-verified); `check_api_reference.py` OK — no inventory drift (re-verified)
- star-import OK, `__all__` = 176 (re-verified)
- fast slice (import/api/contract/forward/namespace): 194 passed, 2 skipped, 1 xfailed
- ruff clean; full fast suite gates this PR in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)