### PR TITLE
docs(comparison): correct the false Meep-autodiff row (W4.4 honesty slice)

### DIFF
--- a/docs/public/guide/comparison.mdx
+++ b/docs/public/guide/comparison.mdx
@@ -17,9 +17,9 @@ This page will provide a structured comparison of rfx against other open-source 
 
 | Feature | rfx | Meep | OpenEMS |
 |---|---|---|---|
-| Autodiff | Native JAX | — | — |
+| Autodiff | Native JAX — `jax.grad` composes end-to-end through the public S-parameter compute API (uniform and non-uniform mesh) | Adjoint-solver module (forward + adjoint run) with autograd/JAX wrappers; supports mode-coefficient (S-parameter), DFT-field, LDOS, and far-field objectives | — |
 | GPU acceleration | JAX JIT | — | OpenCL (limited) |
 | Non-uniform mesh | Graded z | Subpixel | Graded multi-axis |
-| Topology optimisation | Built-in | External | — |
+| Topology optimisation | Built-in | Built-in (adjoint module) | — |
 
 See [Cross-Validation](../validation/) for quantitative accuracy benchmarks and [Migration Guide](../migration/) for workflow translation.


### PR DESCRIPTION
The roadmap flagged a FALSE claim on the public comparison page: `Autodiff | Meep | —`. Verified against the Meep adjoint-solver tutorial (2026-06-11): Meep has a built-in adjoint module (forward + adjoint run) with autograd/JAX wrappers supporting **mode-coefficient (S-parameter)**, DFT-field, LDOS, and far-field objectives. The Meep topology-optimisation cell was likewise wrong (External → Built-in).

The corrected row states Meep's capability accurately and pins rfx's real differentiator in the README-#139 truth-pass wording: `jax.grad` composing end-to-end through the **public S-parameter compute API**, on uniform and non-uniform mesh — versus a bespoke two-run adjoint framework.

This is the urgent honesty slice of W4.4; the full web-sourced comparison matrix (quantitative rows) remains open on the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)