### PR TITLE
ci: W2.4 maintained GPU suite harness + W2.5 exit-2 retrofit, scheduled crossval lane, monthly openEMS lane

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -41,3 +41,109 @@ jobs:
           --ignore=tests/test_meep_crossval_patch.py
           --ignore=tests/test_openems_crossval.py
           --ignore=tests/test_crossval_comprehensive.py
+
+  # ---------------------------------------------------------------------------
+  # Scheduled / manual external-reference crossval lane (roadmap W2.5b).
+  #
+  # Runs the Meep/analytic crossval scripts against a REAL conda-forge Meep so
+  # the rfx-vs-Meep cross-checks are actually exercised (the slow-tests job
+  # above deliberately --ignores every Meep crossval test because the CI image
+  # has no Meep). This is a SCHEDULED + MANUAL lane only — never a PR gate.
+  #
+  # NOTE / correction to the roadmap text: the roadmap said "pip-installed
+  # Meep", but Meep ships only via conda-forge (pymeep); there is no working
+  # pip wheel. This job uses the conda-forge path (setup-miniconda + mamba
+  # install -c conda-forge pymeep) instead.
+  #
+  # Exit-code convention (per script, see examples/crossval/*.py docstrings):
+  #   0 -> full PASS incl. external reference        => table row PASS
+  #   1 -> rfx self-check failed (real physics/infra) => table row FAIL, job RED
+  #   2 -> self-check OK but reference missing        => table row SKIP, job green
+  # The job fails (red) iff any script exits 1. exit 2 is surfaced as a visible
+  # SKIP in the step summary but never silently turns the lane green.
+  crossval-external:
+    # Existing slow-tests stays on the workflow's Monday cron untouched; this
+    # lane shares the same schedule + manual dispatch and is gated so adding it
+    # does not change any other job's behaviour.
+    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '0 6 * * 1'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120  # cv02 ring resonator with real Meep can be slow
+    defaults:
+      run:
+        shell: bash -el {0}  # login shell so the conda env is active per step
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up conda (miniforge + mamba)
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          python-version: "3.11"
+          miniforge-version: latest
+          use-mamba: true
+          activate-environment: rfx-crossval
+
+      - name: Install Meep from conda-forge
+        run: mamba install -y -c conda-forge pymeep "numpy>=1.26,<2"
+
+      - name: Install rfx package
+        run: pip install -e ".[dev]"
+
+      - name: Run external-reference crossval scripts (per-script exit codes)
+        run: |
+          set -uo pipefail
+          mkdir -p crossval_logs
+          export PYTHONPATH="$PWD"
+          export MPLBACKEND=Agg
+          export JAX_ENABLE_X64=1
+
+          # Six scripts under the W2.5 retrofit. cv09/cv10 are pure analytic /
+          # internal references (no external dep) — included so the lane also
+          # exercises them end to end.
+          scripts=(
+            01_waveguide_bend
+            02_ring_resonator
+            03_straight_waveguide_flux
+            04_multilayer_fresnel
+            09_half_symmetric_waveguide
+            10_pmc_cpml_half_symmetric
+          )
+
+          echo "## rfx external-reference crossval lane" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| script | exit | verdict |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|--------|------|---------|" >> "$GITHUB_STEP_SUMMARY"
+
+          fail=0
+          for s in "${scripts[@]}"; do
+            log="crossval_logs/${s}.log"
+            echo ">>> running ${s} ..."
+            # Per-script generous timeout (cv02 with real Meep is the slowest).
+            timeout 5400 python "examples/crossval/${s}.py" > "$log" 2>&1
+            code=$?
+            case $code in
+              0) verdict="PASS (full crossval incl. reference)";;
+              2) verdict="SKIP (reference missing — inconclusive)";;
+              124) verdict="TIMEOUT"; fail=1;;
+              *) verdict="FAIL (rfx self-check / numeric gate)"; fail=1;;
+            esac
+            echo "    -> exit=${code}  ${verdict}"
+            echo "| ${s} | ${code} | ${verdict} |" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$fail" -ne 0 ]; then
+            echo "**Lane result: FAIL** — at least one script exited 1 (or timed out)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "**Lane result: green** (any SKIP rows are inconclusive, not pass)." >> "$GITHUB_STEP_SUMMARY"
+          fi
+          exit "$fail"
+
+      - name: Upload per-script crossval logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crossval-external-logs
+          path: crossval_logs/
+          retention-days: 30

--- a/examples/crossval/01_waveguide_bend.py
+++ b/examples/crossval/01_waveguide_bend.py
@@ -35,10 +35,17 @@ PASS criteria:
 
 Reference: https://meep.readthedocs.io/en/latest/Python_Tutorials/Basics/
 
+Exit codes (rfx crossval convention):
+  0 = all PASS including the Meep cross-check
+  1 = rfx self-check failed (broken physics / infra)
+  2 = rfx self-check OK but Meep reference is unavailable — inconclusive
+      crossval, NOT a pass. CI must not treat this as green.
+
 Save: examples/crossval/01_waveguide_bend.png
 """
 
 import os
+import sys
 import time
 
 os.environ.setdefault("JAX_ENABLE_X64", "1")
@@ -207,8 +214,14 @@ try:
     above_r = (f_ref > f_cutoff + 0.005) & (f_ref < 0.20)
     meep_mean = float(np.mean(uniform_filter1d(T_meep, size=20)[above_r]))
     print(f"  Meep T = {meep_mean:.4f}")
-except ImportError:
-    print("\nMeep not available — skipping reference comparison")
+except Exception as _e:
+    # Catch ImportError AND any exception raised while importing/running Meep
+    # (e.g. a Meep wheel compiled against NumPy 1.x crashing under NumPy 2.x
+    # raises ImportError "numpy.core.multiarray failed to import"). The rfx
+    # self-checks above have already run; this only disables the reference.
+    print(f"\n[SKIP] external reference unavailable (Meep: {type(_e).__name__}: "
+          f"{_e}) — exit 2")
+    print("       rfx self-checks still run; this is NOT a crossval PASS.")
 
 # =============================================================================
 # Validation
@@ -301,7 +314,22 @@ plt.savefig(out_path, dpi=150)
 plt.close()
 print(f"\nPlot saved: {out_path}")
 
+# =============================================================================
+# Exit code (rfx crossval convention)
+# =============================================================================
+# `PASS` tracks the rfx self-checks AND, when Meep ran, the |rfx − Meep| gate.
+# Separate the two so a missing reference exits 2 (inconclusive) rather than 0.
+if meep_mean is None:
+    # rfx self-check ran but the Meep reference was unavailable.
+    if PASS:
+        print("\nrfx SELF-CHECKS PASSED")
+        print("[SKIP] Meep reference unavailable — crossval inconclusive (exit 2)")
+        sys.exit(2)
+    print("\nSOME CHECKS FAILED")
+    sys.exit(1)
+
 if PASS:
     print("\nALL CHECKS PASSED")
-else:
-    print("\nSOME CHECKS FAILED")
+    sys.exit(0)
+print("\nSOME CHECKS FAILED")
+sys.exit(1)

--- a/examples/crossval/02_ring_resonator.py
+++ b/examples/crossval/02_ring_resonator.py
@@ -14,11 +14,20 @@ Meep tutorial parameters:
   fcen = 0.15, df = 0.1
   Source: GaussianSource at (r+0.1, 0)
 
+Exit codes (rfx crossval convention):
+  0 = all PASS including the Meep cross-check (≥2 matched modes, mean err < 5%)
+  1 = rfx self-check failed (rfx Harminv found no ring modes — broken physics)
+  2 = rfx self-check OK but Meep reference is unavailable — inconclusive
+      crossval, NOT a pass. CI must not treat this as green.
+
 Run:
   JAX_ENABLE_X64=1 python examples/crossval/02_ring_resonator.py
 """
 
-import os, sys, math, time
+import os
+import sys
+import math
+import time
 os.environ.setdefault("JAX_ENABLE_X64", "1")
 
 import matplotlib; matplotlib.use("Agg")
@@ -76,38 +85,53 @@ print("=" * 70)
 print("PART 1: Meep — Harminv resonance extraction")
 print("=" * 70)
 
-import meep as mp
+try:
+    import meep as mp
+except Exception as _e:
+    # Catch ImportError AND any exception during import (a Meep wheel built
+    # against NumPy 1.x crashes under NumPy 2.x with "numpy.core.multiarray
+    # failed to import"). Treat as reference-missing — the rfx Harminv
+    # self-check (PART 2) still runs below and the script exits 2, not 0.
+    HAVE_MEEP = False
+    print(f"[SKIP] external reference unavailable (Meep: {type(_e).__name__}: "
+          f"{_e}) — exit 2")
+    print("       rfx Harminv self-check still runs; NOT a crossval PASS.")
+    meep_modes = []
+    meep_freqs = []
+    meep_Qs = []
+else:
+    HAVE_MEEP = True
 
-cell_meep = mp.Vector3(sxy, sxy)
-pml_meep = [mp.PML(dpml)]
-geo_meep = [
-    mp.Cylinder(radius=r + w, material=mp.Medium(index=n_wg)),
-    mp.Cylinder(radius=r),
-]
-src_meep_list = [mp.Source(mp.GaussianSource(fcen, fwidth=df),
-                           component=mp.Ez,
-                           center=mp.Vector3(r + 0.1, 0))]
+if HAVE_MEEP:
+    cell_meep = mp.Vector3(sxy, sxy)
+    pml_meep = [mp.PML(dpml)]
+    geo_meep = [
+        mp.Cylinder(radius=r + w, material=mp.Medium(index=n_wg)),
+        mp.Cylinder(radius=r),
+    ]
+    src_meep_list = [mp.Source(mp.GaussianSource(fcen, fwidth=df),
+                               component=mp.Ez,
+                               center=mp.Vector3(r + 0.1, 0))]
 
-sim_meep = mp.Simulation(cell_size=cell_meep, boundary_layers=pml_meep,
-                         geometry=geo_meep, sources=src_meep_list,
-                         resolution=resolution)
+    sim_meep = mp.Simulation(cell_size=cell_meep, boundary_layers=pml_meep,
+                             geometry=geo_meep, sources=src_meep_list,
+                             resolution=resolution)
 
-# Harminv monitor at source location
-h = mp.Harminv(mp.Ez, mp.Vector3(r + 0.1, 0), fcen, df)
+    # Harminv monitor at source location
+    h = mp.Harminv(mp.Ez, mp.Vector3(r + 0.1, 0), fcen, df)
 
-# Run: source active, then after_sources with harminv for 300 time units
-sim_meep.run(until_after_sources=300, *[h])
+    # Run: source active, then after_sources with harminv for 300 time units
+    sim_meep.run(until_after_sources=300, *[h])
 
-meep_modes = []
-print(f"\n  Meep Harminv results:")
-print(f"  {'freq':>10} {'Q':>10} {'amp':>12}")
-for m in h.modes:
-    meep_modes.append(m)
-    print(f"  {m.freq:>10.6f} {m.Q:>10.1f} {abs(m.amp):>12.6f}")
+    print("\n  Meep Harminv results:")
+    print(f"  {'freq':>10} {'Q':>10} {'amp':>12}")
+    for m in h.modes:
+        meep_modes.append(m)
+        print(f"  {m.freq:>10.6f} {m.Q:>10.1f} {abs(m.amp):>12.6f}")
 
-print(f"\n  Found {len(meep_modes)} modes")
-meep_freqs = [m.freq for m in meep_modes]
-meep_Qs = [m.Q for m in meep_modes]
+    print(f"\n  Found {len(meep_modes)} modes")
+    meep_freqs = [m.freq for m in meep_modes]
+    meep_Qs = [m.Q for m in meep_modes]
 
 # =============================================================================
 # PART 2: rfx — find resonances with Harminv
@@ -141,7 +165,13 @@ sim_rfx.add_probe(position=(src_rfx_x, src_rfx_y, 0), component="ez")
 
 # Run long enough for source to decay + ringdown
 # Meep ran ~200 time units after source; convert to rfx steps
-meep_total_t = sim_meep.meep_time()  # in Meep units (c=1)
+if HAVE_MEEP:
+    meep_total_t = sim_meep.meep_time()  # in Meep units (c=1)
+else:
+    # Meep absent: use the tutorial's nominal source + 300 after-source time
+    # units so the rfx ringdown is long enough for Harminv (matches the run
+    # length Meep would have produced).
+    meep_total_t = 450.0
 rfx_total_t = meep_total_t * a / C0  # physical seconds
 dt_rfx = dx / (C0 * math.sqrt(2)) * 0.99
 n_steps_rfx = int(rfx_total_t / dt_rfx) + 500
@@ -166,7 +196,7 @@ rfx_modes_raw = harminv(signal, dt, fmin_hz, fmax_hz)
 rfx_modes = [(m.freq, m.Q, m.amplitude)
              for m in rfx_modes_raw if m.Q > 1 and m.amplitude > 1e-10]
 
-print(f"\n  rfx Harminv results:")
+print("\n  rfx Harminv results:")
 print(f"  {'freq (Hz)':>16} {'freq (Meep)':>12} {'Q':>10} {'amp':>12}")
 for freq, Q, amp in rfx_modes:
     f_meep = freq * a / C0
@@ -321,81 +351,85 @@ else:
     print(f"\n  Saved: {out}")
 
 # =============================================================================
-# PART 5: Broadband field envelope comparison
+# PART 5: Broadband field envelope comparison (Meep cross-check only)
 # =============================================================================
 print(f"\n{'=' * 70}")
 print("PART 5: Broadband field snapshot comparison")
 print("=" * 70)
 
-ez_rfx_broad = np.asarray(res_rfx.snapshots["ez"])
-grid_broad = sim_rfx._build_grid()
-pad_b = grid_broad.pad_x
-n_dom_b = int(np.ceil(domain / dx)) + 1
+if not HAVE_MEEP:
+    print("  [SKIP] Meep reference unavailable — no rfx-vs-Meep field "
+          "comparison to render.")
+else:
+    ez_rfx_broad = np.asarray(res_rfx.snapshots["ez"])
+    grid_broad = sim_rfx._build_grid()
+    pad_b = grid_broad.pad_x
+    n_dom_b = int(np.ceil(domain / dx)) + 1
 
-capture_ps = [0.10, 0.30, 0.60, 1.00, 1.50, 2.50]
-rfx_steps = [min(ez_rfx_broad.shape[0]-1, int(t*1e-12/dt))
-             for t in capture_ps]
-rfx_frames = [ez_rfx_broad[s, pad_b:pad_b+n_dom_b, pad_b:pad_b+n_dom_b]
-              for s in rfx_steps]
+    capture_ps = [0.10, 0.30, 0.60, 1.00, 1.50, 2.50]
+    rfx_steps = [min(ez_rfx_broad.shape[0]-1, int(t*1e-12/dt))
+                 for t in capture_ps]
+    rfx_frames = [ez_rfx_broad[s, pad_b:pad_b+n_dom_b, pad_b:pad_b+n_dom_b]
+                  for s in rfx_steps]
 
-# Meep broadband snapshots
-sim_meep_b = mp.Simulation(cell_size=cell_meep, boundary_layers=pml_meep,
-                           geometry=geo_meep, sources=src_meep_list,
-                           resolution=resolution)
-sim_meep_b.init_sim()
-meep_times = [t * 1e-12 * C0 / a for t in capture_ps]
-meep_frames = []
-for target_t in meep_times:
-    remaining = target_t - sim_meep_b.meep_time()
-    if remaining > 0:
-        sim_meep_b.run(until=remaining)
-    ez = sim_meep_b.get_array(center=mp.Vector3(), size=cell_meep,
-                               component=mp.Ez)
-    pml_cells = int(dpml * resolution)
-    meep_frames.append(ez[pml_cells:-pml_cells, pml_cells:-pml_cells].copy())
+    # Meep broadband snapshots
+    sim_meep_b = mp.Simulation(cell_size=cell_meep, boundary_layers=pml_meep,
+                               geometry=geo_meep, sources=src_meep_list,
+                               resolution=resolution)
+    sim_meep_b.init_sim()
+    meep_times = [t * 1e-12 * C0 / a for t in capture_ps]
+    meep_frames = []
+    for target_t in meep_times:
+        remaining = target_t - sim_meep_b.meep_time()
+        if remaining > 0:
+            sim_meep_b.run(until=remaining)
+        ez = sim_meep_b.get_array(center=mp.Vector3(), size=cell_meep,
+                                   component=mp.Ez)
+        pml_cells = int(dpml * resolution)
+        meep_frames.append(ez[pml_cells:-pml_cells, pml_cells:-pml_cells].copy())
 
-fig2, axes2 = plt.subplots(len(capture_ps), 3,
-                            figsize=(18, 4 * len(capture_ps)))
-for i, t_ps in enumerate(capture_ps):
-    n_c = min(rfx_frames[i].shape[0], meep_frames[i].shape[0])
-    rf = rfx_frames[i][:n_c, :n_c]
-    mf = meep_frames[i][:n_c, :n_c]
+    fig2, axes2 = plt.subplots(len(capture_ps), 3,
+                                figsize=(18, 4 * len(capture_ps)))
+    for i, t_ps in enumerate(capture_ps):
+        n_c = min(rfx_frames[i].shape[0], meep_frames[i].shape[0])
+        rf = rfx_frames[i][:n_c, :n_c]
+        mf = meep_frames[i][:n_c, :n_c]
 
-    vm_r = max(np.max(np.abs(rf)), 1e-30) * 0.9
-    vm_m = max(np.max(np.abs(mf)), 1e-30) * 0.9
+        vm_r = max(np.max(np.abs(rf)), 1e-30) * 0.9
+        vm_m = max(np.max(np.abs(mf)), 1e-30) * 0.9
 
-    axes2[i, 0].imshow(rf.T, origin="lower", cmap="RdBu_r",
-                        vmin=-vm_r, vmax=vm_r)
-    axes2[i, 0].set_title(f"rfx Ez (t={t_ps:.2f}ps)", fontsize=10)
-    axes2[i, 0].set_ylabel("y")
+        axes2[i, 0].imshow(rf.T, origin="lower", cmap="RdBu_r",
+                            vmin=-vm_r, vmax=vm_r)
+        axes2[i, 0].set_title(f"rfx Ez (t={t_ps:.2f}ps)", fontsize=10)
+        axes2[i, 0].set_ylabel("y")
 
-    axes2[i, 1].imshow(mf.T, origin="lower", cmap="RdBu_r",
-                        vmin=-vm_m, vmax=vm_m)
-    axes2[i, 1].set_title(f"Meep Ez (t={t_ps:.2f}ps)", fontsize=10)
+        axes2[i, 1].imshow(mf.T, origin="lower", cmap="RdBu_r",
+                            vmin=-vm_m, vmax=vm_m)
+        axes2[i, 1].set_title(f"Meep Ez (t={t_ps:.2f}ps)", fontsize=10)
 
-    # Envelope diff
-    from scipy.signal import hilbert
-    def env2d(f):
-        e = np.zeros_like(f)
-        for j in range(f.shape[1]):
-            e[:, j] = np.abs(hilbert(f[:, j]))
-        return e
-    re = env2d(rf); me = env2d(mf)
-    re /= max(re.max(), 1e-30); me /= max(me.max(), 1e-30)
-    diff = re - me
-    axes2[i, 2].imshow(diff.T, origin="lower", cmap="bwr",
-                        vmin=-1, vmax=1)
-    axes2[i, 2].set_title("Envelope diff", fontsize=10)
+        # Envelope diff
+        from scipy.signal import hilbert
+        def env2d(f):
+            e = np.zeros_like(f)
+            for j in range(f.shape[1]):
+                e[:, j] = np.abs(hilbert(f[:, j]))
+            return e
+        re = env2d(rf); me = env2d(mf)
+        re /= max(re.max(), 1e-30); me /= max(me.max(), 1e-30)
+        diff = re - me
+        axes2[i, 2].imshow(diff.T, origin="lower", cmap="bwr",
+                            vmin=-1, vmax=1)
+        axes2[i, 2].set_title("Envelope diff", fontsize=10)
 
-axes2[-1, 0].set_xlabel("x"); axes2[-1, 1].set_xlabel("x")
-axes2[-1, 2].set_xlabel("x")
-fig2.suptitle("Ring Resonator: Broadband Field Snapshots — rfx vs Meep",
-              fontsize=13, fontweight="bold")
-plt.tight_layout()
-out2 = os.path.join(SCRIPT_DIR, "02_broadband_fields.png")
-plt.savefig(out2, dpi=150)
-plt.close()
-print(f"  Saved: {out2}")
+    axes2[-1, 0].set_xlabel("x"); axes2[-1, 1].set_xlabel("x")
+    axes2[-1, 2].set_xlabel("x")
+    fig2.suptitle("Ring Resonator: Broadband Field Snapshots — rfx vs Meep",
+                  fontsize=13, fontweight="bold")
+    plt.tight_layout()
+    out2 = os.path.join(SCRIPT_DIR, "02_broadband_fields.png")
+    plt.savefig(out2, dpi=150)
+    plt.close()
+    print(f"  Saved: {out2}")
 
 # =============================================================================
 # SUMMARY
@@ -406,7 +440,25 @@ print("=" * 70)
 print(f"  Meep modes found: {len(meep_modes)}")
 print(f"  rfx  modes found: {len(rfx_modes)}")
 print(f"  Matched modes:    {len(matched)}")
-PASS = True
+
+# rfx self-check (does NOT depend on Meep): rfx Harminv must find at least one
+# physical ring mode in the source band. If rfx finds nothing, the rfx physics
+# is broken (exit 1) regardless of the reference.
+rfx_self_ok = len(rfx_modes) >= 1
+print(f"  rfx self-check (>=1 ring mode found): "
+      f"{'PASS' if rfx_self_ok else 'FAIL'}")
+
+if not HAVE_MEEP:
+    # No Meep reference → the rfx-vs-Meep matched-mode gate cannot be evaluated.
+    if rfx_self_ok:
+        print("\nrfx SELF-CHECK PASSED")
+        print("[SKIP] Meep reference unavailable — crossval inconclusive (exit 2)")
+        sys.exit(2)
+    print("\nSOME CHECKS FAILED — rfx Harminv found no ring modes (exit 1)")
+    sys.exit(1)
+
+# Meep present → evaluate the full cross-check.
+PASS = rfx_self_ok
 if matched:
     errs = [abs(rf - mf) / mf * 100 for mf, _, rf, _ in matched]
     max_err = max(errs)
@@ -432,5 +484,4 @@ if PASS:
 else:
     print("\nSOME CHECKS FAILED")
 
-import sys
 sys.exit(0 if PASS else 1)

--- a/examples/crossval/03_straight_waveguide_flux.py
+++ b/examples/crossval/03_straight_waveguide_flux.py
@@ -28,14 +28,23 @@ Meep tutorial parameters:
 
 Pass criteria (each must hold):
   - rfx self-transmission T_rfx(f_peak) ∈ [0.95, 1.05]
-  - Meep self-transmission T_meep(f_peak) ∈ [0.95, 1.05]
-  - |T_rfx(f_peak) − T_meep(f_peak)| < 0.05
+  - Meep self-transmission T_meep(f_peak) ∈ [0.95, 1.05]   (only when Meep ran)
+  - |T_rfx(f_peak) − T_meep(f_peak)| < 0.05                 (only when Meep ran)
+
+Exit codes (rfx crossval convention):
+  0 = all PASS including the Meep cross-check
+  1 = rfx self-check failed (broken physics / infra)
+  2 = rfx self-check OK but Meep reference is unavailable — inconclusive
+      crossval, NOT a pass. CI must not treat this as green.
 
 Run:
   JAX_ENABLE_X64=1 python examples/crossval/03_straight_waveguide_flux.py
 """
 
-import os, sys, math, time
+import os
+import sys
+import math
+import time
 os.environ.setdefault("JAX_ENABLE_X64", "1")
 
 import matplotlib; matplotlib.use("Agg")
@@ -100,48 +109,70 @@ print("=" * 70)
 print("PART 1: Meep — two flux monitors, T = flux_out / flux_in")
 print("=" * 70)
 
-import meep as mp
+try:
+    import meep as mp
+except Exception as _e:
+    # Catch ImportError AND any exception during import (a Meep wheel built
+    # against NumPy 1.x crashes under NumPy 2.x with "numpy.core.multiarray
+    # failed to import"). Treat as reference-missing — the rfx self-check
+    # (PART 2) still runs below and the script exits 2, not 0.
+    HAVE_MEEP = False
+    print(f"[SKIP] external reference unavailable (Meep: {type(_e).__name__}: "
+          f"{_e}) — exit 2")
+    print("       rfx self-transmission self-check still runs; "
+          "NOT a crossval PASS.")
+    # rfx still needs a frequency grid + a peak index. Build a Meep-style
+    # frequency band around the carrier and pick the peak from rfx flux_in.
+    meep_freqs = np.linspace(fcen - df / 2, fcen + df / 2, n_freqs)
+    meep_total_t = 400.0  # ~Meep stop_when_fields_decayed wall in time units
+    f_peak_meep = float(fcen)
+    T_meep_peak = float("nan")
+    T_meep = None
+    peak_idx = None  # resolved from rfx flux_in below when Meep is absent
+else:
+    HAVE_MEEP = True
 
-cell_meep = mp.Vector3(sx + 2 * dpml, sy)
-pml_meep = [mp.PML(dpml, direction=mp.X)]
-geo_meep = [mp.Block(size=mp.Vector3(mp.inf, wg_width, mp.inf),
-                     center=mp.Vector3(),
-                     material=mp.Medium(epsilon=eps_wg))]
-src_meep = [mp.Source(mp.GaussianSource(fcen, fwidth=df),
-                      component=mp.Ez,
-                      center=mp.Vector3(src_x_meep, 0),
-                      size=mp.Vector3(0, wg_width))]
+if HAVE_MEEP:
+    cell_meep = mp.Vector3(sx + 2 * dpml, sy)
+    pml_meep = [mp.PML(dpml, direction=mp.X)]
+    geo_meep = [mp.Block(size=mp.Vector3(mp.inf, wg_width, mp.inf),
+                         center=mp.Vector3(),
+                         material=mp.Medium(epsilon=eps_wg))]
+    src_meep = [mp.Source(mp.GaussianSource(fcen, fwidth=df),
+                          component=mp.Ez,
+                          center=mp.Vector3(src_x_meep, 0),
+                          size=mp.Vector3(0, wg_width))]
 
-sim_meep = mp.Simulation(cell_size=cell_meep, boundary_layers=pml_meep,
-                         geometry=geo_meep, sources=src_meep,
-                         resolution=resolution)
+    sim_meep = mp.Simulation(cell_size=cell_meep, boundary_layers=pml_meep,
+                             geometry=geo_meep, sources=src_meep,
+                             resolution=resolution)
 
-flux_in_mon_m = sim_meep.add_flux(fcen, df, n_freqs,
-    mp.FluxRegion(center=mp.Vector3(flux_in_meep, 0),
-                  size=mp.Vector3(0, 2 * wg_width)))
-flux_out_mon_m = sim_meep.add_flux(fcen, df, n_freqs,
-    mp.FluxRegion(center=mp.Vector3(flux_out_meep, 0),
-                  size=mp.Vector3(0, 2 * wg_width)))
+    flux_in_mon_m = sim_meep.add_flux(fcen, df, n_freqs,
+        mp.FluxRegion(center=mp.Vector3(flux_in_meep, 0),
+                      size=mp.Vector3(0, 2 * wg_width)))
+    flux_out_mon_m = sim_meep.add_flux(fcen, df, n_freqs,
+        mp.FluxRegion(center=mp.Vector3(flux_out_meep, 0),
+                      size=mp.Vector3(0, 2 * wg_width)))
 
-sim_meep.run(until_after_sources=mp.stop_when_fields_decayed(
-    50, mp.Ez, mp.Vector3(flux_out_meep, 0), 1e-3))
+    sim_meep.run(until_after_sources=mp.stop_when_fields_decayed(
+        50, mp.Ez, mp.Vector3(flux_out_meep, 0), 1e-3))
 
-meep_flux_in  = np.array(mp.get_fluxes(flux_in_mon_m))
-meep_flux_out = np.array(mp.get_fluxes(flux_out_mon_m))
-meep_freqs = np.array(mp.get_flux_freqs(flux_in_mon_m))
-meep_total_t = sim_meep.meep_time()
+    meep_flux_in  = np.array(mp.get_fluxes(flux_in_mon_m))
+    meep_flux_out = np.array(mp.get_fluxes(flux_out_mon_m))
+    meep_freqs = np.array(mp.get_flux_freqs(flux_in_mon_m))
+    meep_total_t = sim_meep.meep_time()
 
-# Guard against numerical flux-in ≈ 0 near band edges
-eps_flux = float(np.max(np.abs(meep_flux_in))) * 1e-6
-T_meep = meep_flux_out / np.where(np.abs(meep_flux_in) > eps_flux,
-                                   meep_flux_in, eps_flux)
+    # Guard against numerical flux-in ≈ 0 near band edges
+    eps_flux = float(np.max(np.abs(meep_flux_in))) * 1e-6
+    T_meep = meep_flux_out / np.where(np.abs(meep_flux_in) > eps_flux,
+                                       meep_flux_in, eps_flux)
 
-peak_idx = int(np.argmax(np.abs(meep_flux_in)))
-f_peak_meep = float(meep_freqs[peak_idx])
-T_meep_peak = float(T_meep[peak_idx])
-print(f"  Meep: ran {meep_total_t:.0f} time units")
-print(f"  peak frequency (by flux_in magnitude): {f_peak_meep:.4f}")
-print(f"  T_meep(f_peak) = {T_meep_peak:.4f}")
+    peak_idx = int(np.argmax(np.abs(meep_flux_in)))
+    f_peak_meep = float(meep_freqs[peak_idx])
+    T_meep_peak = float(T_meep[peak_idx])
+    print(f"  Meep: ran {meep_total_t:.0f} time units")
+    print(f"  peak frequency (by flux_in magnitude): {f_peak_meep:.4f}")
+    print(f"  T_meep(f_peak) = {T_meep_peak:.4f}")
 
 # =============================================================================
 # PART 2: rfx — same two-monitor measurement
@@ -197,6 +228,10 @@ flux_out_rfx_arr = np.asarray(flux_spectrum(res_rfx.flux_monitors["flux_out"]))
 eps_flux_r = float(np.max(np.abs(flux_in_rfx_arr))) * 1e-6
 T_rfx = flux_out_rfx_arr / np.where(np.abs(flux_in_rfx_arr) > eps_flux_r,
                                      flux_in_rfx_arr, eps_flux_r)
+if peak_idx is None:
+    # Meep absent: pick the peak frequency from rfx's own flux_in magnitude.
+    peak_idx = int(np.argmax(np.abs(flux_in_rfx_arr)))
+    f_peak_meep = float(meep_freqs[peak_idx])
 T_rfx_peak = float(T_rfx[peak_idx])
 print(f"  T_rfx(f_peak) = {T_rfx_peak:.4f}")
 
@@ -210,8 +245,9 @@ print("=" * 70)
 fig, axes = plt.subplots(1, 2, figsize=(14, 4.5))
 
 ax = axes[0]
-ax.plot(meep_freqs, meep_flux_in,  "b-",  lw=2, label="Meep flux_in")
-ax.plot(meep_freqs, meep_flux_out, "b--", lw=2, label="Meep flux_out")
+if HAVE_MEEP:
+    ax.plot(meep_freqs, meep_flux_in,  "b-",  lw=2, label="Meep flux_in")
+    ax.plot(meep_freqs, meep_flux_out, "b--", lw=2, label="Meep flux_out")
 ax.plot(meep_freqs, flux_in_rfx_arr,  "r-",  lw=1.3, label="rfx flux_in")
 ax.plot(meep_freqs, flux_out_rfx_arr, "r--", lw=1.3, label="rfx flux_out")
 ax.axvline(f_peak_meep, color="k", ls=":", alpha=0.5, label=f"f_peak={f_peak_meep:.3f}")
@@ -221,7 +257,8 @@ ax.set_title("Absolute flux spectra")
 ax.legend(fontsize=8); ax.grid(True, alpha=0.3)
 
 ax = axes[1]
-ax.plot(meep_freqs, T_meep, "b-", lw=2, label=f"Meep  T(f_peak)={T_meep_peak:.3f}")
+if HAVE_MEEP:
+    ax.plot(meep_freqs, T_meep, "b-", lw=2, label=f"Meep  T(f_peak)={T_meep_peak:.3f}")
 ax.plot(meep_freqs, T_rfx,  "r--", lw=1.5, label=f"rfx   T(f_peak)={T_rfx_peak:.3f}")
 ax.axhline(1.0, color="k", ls=":", alpha=0.5)
 ax.axvline(f_peak_meep, color="k", ls=":", alpha=0.5)
@@ -250,15 +287,33 @@ def _in_range(x, lo, hi): return lo <= x <= hi
 tol_self  = 0.05        # each sim's own T(f_peak) must be within [0.95, 1.05]
 tol_cross = 0.05        # |T_rfx − T_meep| at peak must be < 0.05
 
-pass_self_rfx  = _in_range(T_rfx_peak,  1.0 - tol_self, 1.0 + tol_self)
-pass_self_meep = _in_range(T_meep_peak, 1.0 - tol_self, 1.0 + tol_self)
-delta_cross    = abs(T_rfx_peak - T_meep_peak)
-pass_cross     = delta_cross < tol_cross
+# rfx self-check (does NOT depend on Meep).
+pass_self_rfx = _in_range(T_rfx_peak, 1.0 - tol_self, 1.0 + tol_self)
+print(f"  rfx self-T  @ f_peak: {T_rfx_peak:.4f}   "
+      f"{'PASS' if pass_self_rfx else 'FAIL'} (gate 1.0 ± {tol_self})")
 
-print(f"  rfx self-T  @ f_peak: {T_rfx_peak:.4f}   {'PASS' if pass_self_rfx  else 'FAIL'} (gate 1.0 ± {tol_self})")
-print(f"  meep self-T @ f_peak: {T_meep_peak:.4f}   {'PASS' if pass_self_meep else 'FAIL'} (gate 1.0 ± {tol_self})")
-print(f"  |T_rfx − T_meep| @ f_peak: {delta_cross:.4f}  {'PASS' if pass_cross     else 'FAIL'} (gate < {tol_cross})")
+if HAVE_MEEP:
+    pass_self_meep = _in_range(T_meep_peak, 1.0 - tol_self, 1.0 + tol_self)
+    delta_cross    = abs(T_rfx_peak - T_meep_peak)
+    pass_cross     = delta_cross < tol_cross
+    print(f"  meep self-T @ f_peak: {T_meep_peak:.4f}   "
+          f"{'PASS' if pass_self_meep else 'FAIL'} (gate 1.0 ± {tol_self})")
+    print(f"  |T_rfx − T_meep| @ f_peak: {delta_cross:.4f}  "
+          f"{'PASS' if pass_cross else 'FAIL'} (gate < {tol_cross})")
+else:
+    print("  meep self-T @ f_peak: SKIP  (Meep reference unavailable)")
+    print("  |T_rfx − T_meep| @ f_peak: SKIP  (Meep reference unavailable)")
 
+# =============================================================================
+# Exit code (rfx crossval convention)
+# =============================================================================
+if not pass_self_rfx:
+    print("\nSOME CHECKS FAILED — rfx self-check failed (exit 1)")
+    sys.exit(1)
+if not HAVE_MEEP:
+    print("\nrfx SELF-CHECK PASSED")
+    print("[SKIP] Meep reference unavailable — crossval inconclusive (exit 2)")
+    sys.exit(2)
 PASS = pass_self_rfx and pass_self_meep and pass_cross
 print("\n" + ("ALL CHECKS PASSED" if PASS else "SOME CHECKS FAILED"))
 sys.exit(0 if PASS else 1)

--- a/examples/crossval/04_multilayer_fresnel.py
+++ b/examples/crossval/04_multilayer_fresnel.py
@@ -9,11 +9,23 @@ Measurement approach (Taflove Ch. 5):
   - 1D auxiliary grid provides exact incident spectrum for normalization
   - Single-run measurement (no reference subtraction needed)
 
+The PRIMARY reference here is the exact transfer-matrix analytic solution
+(always available). Meep is an OPTIONAL secondary FDTD cross-check.
+
+Exit codes (rfx crossval convention):
+  0 = rfx self-check (vs analytic) PASS *and* the Meep secondary cross-check ran
+  1 = rfx self-check failed (broken physics / infra)
+  2 = rfx self-check OK but Meep reference is unavailable — inconclusive
+      crossval, NOT a pass. CI must not treat this as green.
+
 Run:
   python examples/crossval/04_multilayer_fresnel.py
 """
 
-import os, sys, math, time
+import os
+import sys
+import math
+import time
 import matplotlib; matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 import numpy as np
@@ -239,186 +251,223 @@ print(f"  T(f) mean err: {T_err_rfx.mean():.4f}, max: {T_err_rfx.max():.4f}")
 print(f"  R(f) mean err: {R_err_rfx.mean():.4f}, max: {R_err_rfx.max():.4f}")
 print(f"  R+T mean: {np.mean(R_rfx+T_rfx):.4f}, dev max: {cons_rfx.max():.4f}")
 
-# =============================================================================
-# PART 3: Meep simulation (cross-validation reference)
-# =============================================================================
-print(f"\n{'=' * 70}")
-print("PART 3: Meep simulation")
-print("=" * 70)
-
-import meep as mp
-
-# Meep units: 1 length unit = 1 cm = 0.01 m
-a_meep = 0.01  # meters per Meep unit
-fcen_m = f0 * a_meep / C0   # ≈ 0.3336 (10 GHz in cm units)
-# Wide bandwidth so Meep covers full 3-15 GHz range used by rfx comparison.
-# Meep's flux band is [fcen - fwidth/2, fcen + fwidth/2].
-# To cover 3-15 GHz, we need fcen-fwidth/2 ≤ 3 GHz and fcen+fwidth/2 ≥ 15 GHz,
-# so fwidth ≥ 14 GHz. We use fwidth = 1.5*fcen ≈ 15 GHz to comfortably span this.
-fwidth_m = 1.5 * fcen_m
-
-# Convert dimensions to Meep units (cm)
-sx_m = nx_interior * dx / a_meep   # 60 cm
-sy_m = 0.4                          # 0.4 cm transverse (periodic)
-dpml_m = n_cpml * dx / a_meep      # 2 cm PML
-d_slab_m = d_slab / a_meep         # 1 cm slab thickness
-
-# Probe positions (relative to domain center, which is at 0)
-# Match rfx geometry: slab at center, refl probe 30 cells before, trans 30 after
-refl_x_m = -d_slab_m/2 - 30 * dx / a_meep   # -1.5 - 3 = -4.5 cm
-trans_x_m = d_slab_m/2 + 30 * dx / a_meep   # +1.5 + 3 = +4.5 cm
-src_x_m = -d_slab_m/2 - 50 * dx / a_meep    # -1.5 - 5 = -6.5 cm (5 cm before refl probe)
-
-resolution_m = int(round(1.0 / (dx / a_meep)))  # = 10 (10 pixels per cm)
-nfreq_meep = 200
-
-print(f"  Meep units: 1 unit = {a_meep*1e2:.0f} cm")
-print(f"  Domain: {sx_m}x{sy_m} cm, PML={dpml_m} cm, resolution={resolution_m}")
-print(f"  fcen={fcen_m:.4f} (={f0/1e9:.1f} GHz), fwidth={fwidth_m:.4f}")
-print(f"  Slab: thickness {d_slab_m} cm, eps={eps_slab}")
-print(f"  Source: x={src_x_m} cm, refl monitor x={refl_x_m} cm, trans monitor x={trans_x_m} cm")
-
-cell_m = mp.Vector3(sx_m, sy_m, 0)
-pml_m = [mp.PML(dpml_m, direction=mp.X)]
-
-src_meep = [mp.Source(
-    mp.GaussianSource(frequency=fcen_m, fwidth=fwidth_m),
-    component=mp.Ez,
-    center=mp.Vector3(src_x_m, 0),
-    size=mp.Vector3(0, sy_m),  # line source (uniform in y)
-)]
-
-# ---- Reference run: no slab ----
-print("  [Meep ref] no slab...", end=" ", flush=True)
-t0_meep = time.time()
-sim_ref = mp.Simulation(
-    cell_size=cell_m,
-    boundary_layers=pml_m,
-    sources=src_meep,
-    resolution=resolution_m,
-    k_point=mp.Vector3(),  # forces periodic in y
-)
-
-refl_fr = mp.FluxRegion(center=mp.Vector3(refl_x_m, 0), size=mp.Vector3(0, sy_m))
-trans_fr = mp.FluxRegion(center=mp.Vector3(trans_x_m, 0), size=mp.Vector3(0, sy_m))
-refl_ref = sim_ref.add_flux(fcen_m, fwidth_m, nfreq_meep, refl_fr)
-trans_ref = sim_ref.add_flux(fcen_m, fwidth_m, nfreq_meep, trans_fr)
-
-sim_ref.run(until_after_sources=mp.stop_when_fields_decayed(
-    50, mp.Ez, mp.Vector3(trans_x_m, 0), 1e-3))
-
-# Save reflection flux data for subtraction in slab run
-straight_refl_data = sim_ref.get_flux_data(refl_ref)
-straight_tran_flux = mp.get_fluxes(trans_ref)
-flux_freqs_m = np.array(mp.get_flux_freqs(refl_ref))
-print(f"{time.time()-t0_meep:.1f}s")
-
-# ---- Slab run ----
-print("  [Meep slab] with slab...", end=" ", flush=True)
-t0_meep = time.time()
-sim_slab = mp.Simulation(
-    cell_size=cell_m,
-    boundary_layers=pml_m,
-    geometry=[mp.Block(
-        center=mp.Vector3(0, 0),
-        size=mp.Vector3(d_slab_m, mp.inf, mp.inf),
-        material=mp.Medium(epsilon=eps_slab),
-    )],
-    sources=src_meep,
-    resolution=resolution_m,
-    k_point=mp.Vector3(),
-)
-
-refl_slab = sim_slab.add_flux(fcen_m, fwidth_m, nfreq_meep, refl_fr)
-trans_slab = sim_slab.add_flux(fcen_m, fwidth_m, nfreq_meep, trans_fr)
-
-# Subtract reference (incident) flux from refl monitor
-sim_slab.load_minus_flux_data(refl_slab, straight_refl_data)
-
-sim_slab.run(until_after_sources=mp.stop_when_fields_decayed(
-    50, mp.Ez, mp.Vector3(trans_x_m, 0), 1e-3))
-
-slab_refl_flux = mp.get_fluxes(refl_slab)
-slab_tran_flux = mp.get_fluxes(trans_slab)
-print(f"{time.time()-t0_meep:.1f}s")
-
-# T = trans_slab / trans_ref, R = -refl_slab_subtracted / trans_ref
-T_meep_full = np.array(slab_tran_flux) / np.array(straight_tran_flux)
-R_meep_full = -np.array(slab_refl_flux) / np.array(straight_tran_flux)
-freqs_meep_Hz = flux_freqs_m * C0 / a_meep
-
-# Interpolate Meep results onto rfx frequency grid (within Meep's flux band only)
-meep_f_lo = freqs_meep_Hz.min()
-meep_f_hi = freqs_meep_Hz.max()
-print(f"\n  Meep flux band: {meep_f_lo/1e9:.2f}–{meep_f_hi/1e9:.2f} GHz")
-
-T_meep = np.interp(freqs[mask], freqs_meep_Hz, T_meep_full)
-R_meep = np.interp(freqs[mask], freqs_meep_Hz, R_meep_full)
-
-# Only evaluate Meep error inside its valid band (avoid edge garbage)
-freqs_band = freqs[mask]
-in_meep_band = (freqs_band >= meep_f_lo * 1.05) & (freqs_band <= meep_f_hi * 0.95)
-T_err_meep = np.abs(T_meep[in_meep_band] - T_an[in_meep_band])
-R_err_meep = np.abs(R_meep[in_meep_band] - R_an[in_meep_band])
-cons_meep = np.abs(R_meep[in_meep_band] + T_meep[in_meep_band] - 1)
-
-print(f"  Meep T(f) mean err: {T_err_meep.mean():.4f}, max: {T_err_meep.max():.4f}")
-print(f"  Meep R(f) mean err: {R_err_meep.mean():.4f}, max: {R_err_meep.max():.4f}")
-print(f"  Meep R+T mean: {np.mean(R_meep[in_meep_band]+T_meep[in_meep_band]):.4f}, "
-      f"dev max: {cons_meep.max():.4f}")
+# rfx self-check verdict (vs the exact analytic transfer matrix) — this is the
+# primary gate and does NOT depend on Meep. Compute it up front so a missing
+# Meep reference cannot mask an rfx physics failure.
+t_ok = T_err_rfx.mean() < 0.05
+r_ok = R_err_rfx.mean() < 0.05
+c_ok = cons_rfx.mean() < 0.05
+rfx_self_ok = bool(t_ok and r_ok and c_ok)
 
 # =============================================================================
-# PART 4: Three-way comparison table
+# PART 3: Meep simulation (OPTIONAL secondary cross-validation reference)
 # =============================================================================
 print(f"\n{'=' * 70}")
-print("PART 4: Three-way comparison (rfx vs Meep vs Analytic)")
+print("PART 3: Meep simulation (optional secondary cross-check)")
 print("=" * 70)
-print(f"\n  {'f(GHz)':>7} {'T_an':>8} {'T_rfx':>8} {'T_meep':>8} | "
-      f"{'R_an':>8} {'R_rfx':>8} {'R_meep':>8}")
-for fi in [4.0, 5.0, 7.5, 10.0, 11.0, 12.0]:
-    idx = np.argmin(np.abs(f_plot - fi))
-    print(f"  {f_plot[idx]:7.1f} {T_an[idx]:8.4f} {T_rfx[idx]:8.4f} {T_meep[idx]:8.4f} | "
-          f"{R_an[idx]:8.4f} {R_rfx[idx]:8.4f} {R_meep[idx]:8.4f}")
+
+try:
+    import meep as mp
+except Exception as _e:
+    # Catch ImportError AND any exception during import (a Meep wheel built
+    # against NumPy 1.x crashes under NumPy 2.x with "numpy.core.multiarray
+    # failed to import"). Treat as reference-missing, not an rfx failure.
+    HAVE_MEEP = False
+    print(f"[SKIP] external reference unavailable (Meep: {type(_e).__name__}: "
+          f"{_e}) — exit 2")
+    print("       rfx self-check vs analytic still reported; "
+          "NOT a crossval PASS.")
+else:
+    HAVE_MEEP = True
+
+if HAVE_MEEP:
+    # Meep units: 1 length unit = 1 cm = 0.01 m
+    a_meep = 0.01  # meters per Meep unit
+    fcen_m = f0 * a_meep / C0   # ≈ 0.3336 (10 GHz in cm units)
+    # Wide bandwidth so Meep covers full 3-15 GHz range used by rfx comparison.
+    # Meep's flux band is [fcen - fwidth/2, fcen + fwidth/2].
+    # To cover 3-15 GHz, we need fcen-fwidth/2 ≤ 3 GHz and fcen+fwidth/2 ≥ 15 GHz,
+    # so fwidth ≥ 14 GHz. We use fwidth = 1.5*fcen ≈ 15 GHz to comfortably span this.
+    fwidth_m = 1.5 * fcen_m
+
+    # Convert dimensions to Meep units (cm)
+    sx_m = nx_interior * dx / a_meep   # 60 cm
+    sy_m = 0.4                          # 0.4 cm transverse (periodic)
+    dpml_m = n_cpml * dx / a_meep      # 2 cm PML
+    d_slab_m = d_slab / a_meep         # 1 cm slab thickness
+
+    # Probe positions (relative to domain center, which is at 0)
+    # Match rfx geometry: slab at center, refl probe 30 cells before, trans 30 after
+    refl_x_m = -d_slab_m/2 - 30 * dx / a_meep   # -1.5 - 3 = -4.5 cm
+    trans_x_m = d_slab_m/2 + 30 * dx / a_meep   # +1.5 + 3 = +4.5 cm
+    src_x_m = -d_slab_m/2 - 50 * dx / a_meep    # -1.5 - 5 = -6.5 cm (5 cm before refl probe)
+
+    resolution_m = int(round(1.0 / (dx / a_meep)))  # = 10 (10 pixels per cm)
+    nfreq_meep = 200
+
+    print(f"  Meep units: 1 unit = {a_meep*1e2:.0f} cm")
+    print(f"  Domain: {sx_m}x{sy_m} cm, PML={dpml_m} cm, resolution={resolution_m}")
+    print(f"  fcen={fcen_m:.4f} (={f0/1e9:.1f} GHz), fwidth={fwidth_m:.4f}")
+    print(f"  Slab: thickness {d_slab_m} cm, eps={eps_slab}")
+    print(f"  Source: x={src_x_m} cm, refl monitor x={refl_x_m} cm, trans monitor x={trans_x_m} cm")
+
+    cell_m = mp.Vector3(sx_m, sy_m, 0)
+    pml_m = [mp.PML(dpml_m, direction=mp.X)]
+
+    src_meep = [mp.Source(
+        mp.GaussianSource(frequency=fcen_m, fwidth=fwidth_m),
+        component=mp.Ez,
+        center=mp.Vector3(src_x_m, 0),
+        size=mp.Vector3(0, sy_m),  # line source (uniform in y)
+    )]
+
+    # ---- Reference run: no slab ----
+    print("  [Meep ref] no slab...", end=" ", flush=True)
+    t0_meep = time.time()
+    sim_ref = mp.Simulation(
+        cell_size=cell_m,
+        boundary_layers=pml_m,
+        sources=src_meep,
+        resolution=resolution_m,
+        k_point=mp.Vector3(),  # forces periodic in y
+    )
+
+    refl_fr = mp.FluxRegion(center=mp.Vector3(refl_x_m, 0), size=mp.Vector3(0, sy_m))
+    trans_fr = mp.FluxRegion(center=mp.Vector3(trans_x_m, 0), size=mp.Vector3(0, sy_m))
+    refl_ref = sim_ref.add_flux(fcen_m, fwidth_m, nfreq_meep, refl_fr)
+    trans_ref = sim_ref.add_flux(fcen_m, fwidth_m, nfreq_meep, trans_fr)
+
+    sim_ref.run(until_after_sources=mp.stop_when_fields_decayed(
+        50, mp.Ez, mp.Vector3(trans_x_m, 0), 1e-3))
+
+    # Save reflection flux data for subtraction in slab run
+    straight_refl_data = sim_ref.get_flux_data(refl_ref)
+    straight_tran_flux = mp.get_fluxes(trans_ref)
+    flux_freqs_m = np.array(mp.get_flux_freqs(refl_ref))
+    print(f"{time.time()-t0_meep:.1f}s")
+
+    # ---- Slab run ----
+    print("  [Meep slab] with slab...", end=" ", flush=True)
+    t0_meep = time.time()
+    sim_slab = mp.Simulation(
+        cell_size=cell_m,
+        boundary_layers=pml_m,
+        geometry=[mp.Block(
+            center=mp.Vector3(0, 0),
+            size=mp.Vector3(d_slab_m, mp.inf, mp.inf),
+            material=mp.Medium(epsilon=eps_slab),
+        )],
+        sources=src_meep,
+        resolution=resolution_m,
+        k_point=mp.Vector3(),
+    )
+
+    refl_slab = sim_slab.add_flux(fcen_m, fwidth_m, nfreq_meep, refl_fr)
+    trans_slab = sim_slab.add_flux(fcen_m, fwidth_m, nfreq_meep, trans_fr)
+
+    # Subtract reference (incident) flux from refl monitor
+    sim_slab.load_minus_flux_data(refl_slab, straight_refl_data)
+
+    sim_slab.run(until_after_sources=mp.stop_when_fields_decayed(
+        50, mp.Ez, mp.Vector3(trans_x_m, 0), 1e-3))
+
+    slab_refl_flux = mp.get_fluxes(refl_slab)
+    slab_tran_flux = mp.get_fluxes(trans_slab)
+    print(f"{time.time()-t0_meep:.1f}s")
+
+    # T = trans_slab / trans_ref, R = -refl_slab_subtracted / trans_ref
+    T_meep_full = np.array(slab_tran_flux) / np.array(straight_tran_flux)
+    R_meep_full = -np.array(slab_refl_flux) / np.array(straight_tran_flux)
+    freqs_meep_Hz = flux_freqs_m * C0 / a_meep
+
+    # Interpolate Meep results onto rfx frequency grid (within Meep's flux band only)
+    meep_f_lo = freqs_meep_Hz.min()
+    meep_f_hi = freqs_meep_Hz.max()
+    print(f"\n  Meep flux band: {meep_f_lo/1e9:.2f}–{meep_f_hi/1e9:.2f} GHz")
+
+    T_meep = np.interp(freqs[mask], freqs_meep_Hz, T_meep_full)
+    R_meep = np.interp(freqs[mask], freqs_meep_Hz, R_meep_full)
+
+    # Only evaluate Meep error inside its valid band (avoid edge garbage)
+    freqs_band = freqs[mask]
+    in_meep_band = (freqs_band >= meep_f_lo * 1.05) & (freqs_band <= meep_f_hi * 0.95)
+    T_err_meep = np.abs(T_meep[in_meep_band] - T_an[in_meep_band])
+    R_err_meep = np.abs(R_meep[in_meep_band] - R_an[in_meep_band])
+    cons_meep = np.abs(R_meep[in_meep_band] + T_meep[in_meep_band] - 1)
+
+    print(f"  Meep T(f) mean err: {T_err_meep.mean():.4f}, max: {T_err_meep.max():.4f}")
+    print(f"  Meep R(f) mean err: {R_err_meep.mean():.4f}, max: {R_err_meep.max():.4f}")
+    print(f"  Meep R+T mean: {np.mean(R_meep[in_meep_band]+T_meep[in_meep_band]):.4f}, "
+          f"dev max: {cons_meep.max():.4f}")
 
 # =============================================================================
-# PART 5: Three-way comparison plot
+# PART 4: comparison table (three-way if Meep ran, else rfx vs analytic)
+# =============================================================================
+print(f"\n{'=' * 70}")
+if HAVE_MEEP:
+    print("PART 4: Three-way comparison (rfx vs Meep vs Analytic)")
+    print("=" * 70)
+    print(f"\n  {'f(GHz)':>7} {'T_an':>8} {'T_rfx':>8} {'T_meep':>8} | "
+          f"{'R_an':>8} {'R_rfx':>8} {'R_meep':>8}")
+    for fi in [4.0, 5.0, 7.5, 10.0, 11.0, 12.0]:
+        idx = np.argmin(np.abs(f_plot - fi))
+        print(f"  {f_plot[idx]:7.1f} {T_an[idx]:8.4f} {T_rfx[idx]:8.4f} {T_meep[idx]:8.4f} | "
+              f"{R_an[idx]:8.4f} {R_rfx[idx]:8.4f} {R_meep[idx]:8.4f}")
+else:
+    print("PART 4: rfx vs Analytic comparison (Meep reference unavailable)")
+    print("=" * 70)
+    print(f"\n  {'f(GHz)':>7} {'T_an':>8} {'T_rfx':>8} | {'R_an':>8} {'R_rfx':>8}")
+    for fi in [4.0, 5.0, 7.5, 10.0, 11.0, 12.0]:
+        idx = np.argmin(np.abs(f_plot - fi))
+        print(f"  {f_plot[idx]:7.1f} {T_an[idx]:8.4f} {T_rfx[idx]:8.4f} | "
+              f"{R_an[idx]:8.4f} {R_rfx[idx]:8.4f}")
+
+# =============================================================================
+# PART 5: comparison plot
 # =============================================================================
 fig, axes = plt.subplots(2, 2, figsize=(14, 10))
 
-# Mask Meep curves to its valid band (NaN outside, so plot doesn't draw garbage)
-T_meep_plot = T_meep.copy(); T_meep_plot[~in_meep_band] = np.nan
-R_meep_plot = R_meep.copy(); R_meep_plot[~in_meep_band] = np.nan
+if HAVE_MEEP:
+    # Mask Meep curves to its valid band (NaN outside, so plot doesn't draw garbage)
+    T_meep_plot = T_meep.copy(); T_meep_plot[~in_meep_band] = np.nan
+    R_meep_plot = R_meep.copy(); R_meep_plot[~in_meep_band] = np.nan
+    f_meep_band = f_plot[in_meep_band]
 
 axes[0,0].plot(f_plot, T_an, "k-", lw=2.5, label="Analytic", alpha=0.9)
 axes[0,0].plot(f_plot, T_rfx, "r--", lw=1.5, label="rfx")
-axes[0,0].plot(f_plot, T_meep_plot, "b:", lw=2, label="Meep")
+if HAVE_MEEP:
+    axes[0,0].plot(f_plot, T_meep_plot, "b:", lw=2, label="Meep")
 axes[0,0].set_ylabel("T"); axes[0,0].set_title("Transmittance")
 axes[0,0].legend(); axes[0,0].grid(True, alpha=0.3); axes[0,0].set_ylim(-0.05, 1.15)
 
 axes[0,1].plot(f_plot, R_an, "k-", lw=2.5, label="Analytic", alpha=0.9)
 axes[0,1].plot(f_plot, R_rfx, "r--", lw=1.5, label="rfx")
-axes[0,1].plot(f_plot, R_meep_plot, "b:", lw=2, label="Meep")
+if HAVE_MEEP:
+    axes[0,1].plot(f_plot, R_meep_plot, "b:", lw=2, label="Meep")
 axes[0,1].set_ylabel("R"); axes[0,1].set_title("Reflectance")
 axes[0,1].legend(); axes[0,1].grid(True, alpha=0.3); axes[0,1].set_ylim(-0.05, 1.15)
 
-f_meep_band = f_plot[in_meep_band]
 axes[1,0].plot(f_plot, T_err_rfx, "r-", lw=1, label=f"rfx |T err| (mean={T_err_rfx.mean():.3f})")
-axes[1,0].plot(f_meep_band, T_err_meep, "b-", lw=1, label=f"Meep |T err| (mean={T_err_meep.mean():.3f})")
 axes[1,0].plot(f_plot, R_err_rfx, "r--", lw=1, label=f"rfx |R err| (mean={R_err_rfx.mean():.3f})")
-axes[1,0].plot(f_meep_band, R_err_meep, "b--", lw=1, label=f"Meep |R err| (mean={R_err_meep.mean():.3f})")
+if HAVE_MEEP:
+    axes[1,0].plot(f_meep_band, T_err_meep, "b-", lw=1, label=f"Meep |T err| (mean={T_err_meep.mean():.3f})")
+    axes[1,0].plot(f_meep_band, R_err_meep, "b--", lw=1, label=f"Meep |R err| (mean={R_err_meep.mean():.3f})")
 axes[1,0].set_ylabel("Error vs analytic"); axes[1,0].set_title("Errors (vs analytic)")
 axes[1,0].legend(fontsize=8); axes[1,0].grid(True, alpha=0.3)
 
 axes[1,1].plot(f_plot, R_rfx + T_rfx, "r-", lw=1.5, label=f"rfx (mean={np.mean(R_rfx+T_rfx):.4f})")
-axes[1,1].plot(f_meep_band, R_meep[in_meep_band] + T_meep[in_meep_band],
-               "b-", lw=1.5, label=f"Meep (mean={np.mean(R_meep[in_meep_band]+T_meep[in_meep_band]):.4f})")
+if HAVE_MEEP:
+    axes[1,1].plot(f_meep_band, R_meep[in_meep_band] + T_meep[in_meep_band],
+                   "b-", lw=1.5, label=f"Meep (mean={np.mean(R_meep[in_meep_band]+T_meep[in_meep_band]):.4f})")
 axes[1,1].axhline(1, color="gray", ls="--", alpha=0.5)
 axes[1,1].set_ylabel("R+T"); axes[1,1].set_title("Energy Conservation")
 axes[1,1].set_ylim(0.85, 1.15); axes[1,1].grid(True, alpha=0.3); axes[1,1].legend()
 
 for ax in axes[1,:]: ax.set_xlabel("Frequency (GHz)")
+_ref_label = "rfx FDTD vs Meep FDTD vs Exact Transfer Matrix" if HAVE_MEEP \
+    else "rfx FDTD vs Exact Transfer Matrix (Meep reference unavailable)"
 fig.suptitle(f"Fresnel Slab: eps={eps_slab}, d={d_slab*1e3:.0f}mm — Plane wave\n"
-             f"rfx FDTD vs Meep FDTD vs Exact Transfer Matrix",
+             f"{_ref_label}",
              fontsize=13, fontweight="bold")
 plt.tight_layout()
 out = os.path.join(SCRIPT_DIR, "04_fresnel_slab.png")
@@ -431,21 +480,39 @@ print(f"\n  Saved: {out}")
 print(f"\n{'=' * 70}")
 print("SUMMARY")
 print("=" * 70)
-print(f"  {'Metric':<25} {'rfx':>10} {'Meep':>10} {'Limit':>10}")
-print(f"  {'-'*25} {'-'*10} {'-'*10} {'-'*10}")
-print(f"  {'T(f) mean error':<25} {T_err_rfx.mean():>10.4f} {T_err_meep.mean():>10.4f} {0.05:>10.4f}")
-print(f"  {'R(f) mean error':<25} {R_err_rfx.mean():>10.4f} {R_err_meep.mean():>10.4f} {0.05:>10.4f}")
-print(f"  {'R+T mean dev (energy)':<25} {cons_rfx.mean():>10.4f} {cons_meep.mean():>10.4f} {0.05:>10.4f}")
+if HAVE_MEEP:
+    print(f"  {'Metric':<25} {'rfx':>10} {'Meep':>10} {'Limit':>10}")
+    print(f"  {'-'*25} {'-'*10} {'-'*10} {'-'*10}")
+    print(f"  {'T(f) mean error':<25} {T_err_rfx.mean():>10.4f} {T_err_meep.mean():>10.4f} {0.05:>10.4f}")
+    print(f"  {'R(f) mean error':<25} {R_err_rfx.mean():>10.4f} {R_err_meep.mean():>10.4f} {0.05:>10.4f}")
+    print(f"  {'R+T mean dev (energy)':<25} {cons_rfx.mean():>10.4f} {cons_meep.mean():>10.4f} {0.05:>10.4f}")
+else:
+    print(f"  {'Metric':<25} {'rfx':>10} {'Limit':>10}")
+    print(f"  {'-'*25} {'-'*10} {'-'*10}")
+    print(f"  {'T(f) mean error':<25} {T_err_rfx.mean():>10.4f} {0.05:>10.4f}")
+    print(f"  {'R(f) mean error':<25} {R_err_rfx.mean():>10.4f} {0.05:>10.4f}")
+    print(f"  {'R+T mean dev (energy)':<25} {cons_rfx.mean():>10.4f} {0.05:>10.4f}")
 
-t_ok = T_err_rfx.mean() < 0.05
-r_ok = R_err_rfx.mean() < 0.05
-c_ok = cons_rfx.mean() < 0.05
-print(f"\n  rfx accuracy: {'PASS' if (t_ok and r_ok and c_ok) else 'FAIL'}")
+print(f"\n  rfx accuracy: {'PASS' if rfx_self_ok else 'FAIL'}")
 
-# Direct rfx vs Meep comparison (within Meep band)
-T_rfx_meep_diff = np.abs(T_rfx[in_meep_band] - T_meep[in_meep_band])
-R_rfx_meep_diff = np.abs(R_rfx[in_meep_band] - R_meep[in_meep_band])
-print(f"\n  rfx vs Meep direct comparison (in Meep band):")
-print(f"    |T_rfx - T_meep| mean: {T_rfx_meep_diff.mean():.4f}, max: {T_rfx_meep_diff.max():.4f}")
-print(f"    |R_rfx - R_meep| mean: {R_rfx_meep_diff.mean():.4f}, max: {R_rfx_meep_diff.max():.4f}")
-print(f"\n  Output: 04_fresnel_slab.png, 04_time_domain.png")
+if HAVE_MEEP:
+    # Direct rfx vs Meep comparison (within Meep band)
+    T_rfx_meep_diff = np.abs(T_rfx[in_meep_band] - T_meep[in_meep_band])
+    R_rfx_meep_diff = np.abs(R_rfx[in_meep_band] - R_meep[in_meep_band])
+    print("\n  rfx vs Meep direct comparison (in Meep band):")
+    print(f"    |T_rfx - T_meep| mean: {T_rfx_meep_diff.mean():.4f}, max: {T_rfx_meep_diff.max():.4f}")
+    print(f"    |R_rfx - R_meep| mean: {R_rfx_meep_diff.mean():.4f}, max: {R_rfx_meep_diff.max():.4f}")
+print("\n  Output: 04_fresnel_slab.png, 04_time_domain.png")
+
+# =============================================================================
+# Exit code (rfx crossval convention)
+# =============================================================================
+if not rfx_self_ok:
+    print("\nrfx accuracy: FAIL — self-check vs analytic failed (exit 1)")
+    sys.exit(1)
+if not HAVE_MEEP:
+    print("\n[SKIP] Meep secondary reference unavailable — crossval "
+          "inconclusive (exit 2)")
+    sys.exit(2)
+print("\nALL CHECKS PASSED — rfx vs analytic and Meep secondary cross-check (exit 0)")
+sys.exit(0)

--- a/scripts/vessl_crossval_external_monthly.yaml
+++ b/scripts/vessl_crossval_external_monthly.yaml
@@ -1,0 +1,85 @@
+name: rfx-crossval-external-monthly
+description: "W2.5(c) monthly external-crossval lane: cv05 vs a real openEMS source build + cv11 vs committed Meep/Palace references (CPU node)"
+tags: [rfx, crossval-external, ci-trust, w25]
+resources:
+  cluster: remilab-c0
+  cpu: 32
+  memory: 48Gi
+image: pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime
+env:
+  DEBIAN_FRONTEND: noninteractive
+  PYTHONUNBUFFERED: "1"
+  OMP_NUM_THREADS: "4"
+  HDF5_USE_FILE_LOCKING: "FALSE"
+  LANG: "C.UTF-8"
+mount:
+  /root/workspace/: volume://remilab-fs/personal-workspaces/
+run: |-
+  set -eux
+  # pytorch runtime image: dash shell (no bashisms) and git via apt below.
+  echo "=== rfx monthly external crossval (W2.5c) ==="
+  date
+
+  # -- openEMS source build: the PROVEN microwave-energy recipe --
+  # (research/microwave-energy/openems_simulation/jobs/wr90_pec_short_field_dump_20260428.yaml)
+  apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake git \
+    libhdf5-dev libtinyxml-dev \
+    libboost-thread-dev libboost-system-dev libboost-date-time-dev \
+    libboost-serialization-dev \
+    libcgal-dev libvtk7-dev \
+    python3-dev python3-numpy python3-scipy python3-matplotlib \
+    python3-setuptools python3-h5py 2>&1 | tail -3
+  cd /tmp
+  git clone --recursive https://github.com/thliebig/openEMS-Project.git
+  cd openEMS-Project
+  cd fparser && mkdir -p build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release && make -j"$(nproc)" && make install && cd ../..
+  cd CSXCAD && mkdir -p build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DCMAKE_DISABLE_FIND_PACKAGE_MPI=TRUE && make -j"$(nproc)" && make install && cd ../..
+  cd openEMS && mkdir -p build && cd build && cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release -DWITH_MPI=OFF && make -j"$(nproc)" && make install && cd ../..
+  ldconfig
+  export CSXCAD_INSTALL_PATH=/usr/local
+  export OPENEMS_INSTALL_PATH=/usr/local
+  cd CSXCAD/python && /usr/bin/python3 setup.py install 2>&1 | tail -2 && cd ../..
+  cd openEMS/python && /usr/bin/python3 setup.py install 2>&1 | tail -2 && cd ../..
+  /usr/bin/python3 -c "from openEMS.openEMS import openEMS; print('openEMS source build: OK')"
+
+  # -- rfx runtime deps (CPU jax) --
+  cd /root/workspace/byungkwan-workspace/research/rfx
+  git config --global --add safe.directory /root/workspace/byungkwan-workspace/research/rfx || true
+  git rev-parse HEAD || true
+  /usr/bin/python3 -m pip install -q "jax[cpu]==0.4.35" "scipy>=1.11" "h5py>=3.8" "matplotlib>=3.7"
+  export RFX_REPO_ROOT=/root/workspace/byungkwan-workspace/research/rfx
+  export PYTHONPATH="$RFX_REPO_ROOT"
+  /usr/bin/python3 -c "import jax, rfx; print('probe ok', jax.__version__)"
+
+  out=".omx/crossval-external/$(date -u +%Y%m%dT%H%M%SZ)"
+  mkdir -p "$out"
+
+  # -- cv05: patch antenna vs openEMS (exit 0 full pass / 1 fail / 2 ref-missing) --
+  set +e
+  timeout 7200 /usr/bin/python3 examples/crossval/05_patch_antenna.py \
+    > "$out/cv05.log" 2>&1
+  cv05_rc=$?
+  set -e
+  echo "$cv05_rc" > "$out/cv05.rc"
+  tail -n 15 "$out/cv05.log" || true
+  echo "cv05_rc=$cv05_rc"
+
+  # -- cv11: WR-90 vs committed Meep/Palace references --
+  set +e
+  timeout 3600 /usr/bin/python3 examples/crossval/11_waveguide_port_wr90.py \
+    > "$out/cv11.log" 2>&1
+  cv11_rc=$?
+  set -e
+  echo "$cv11_rc" > "$out/cv11.rc"
+  tail -n 15 "$out/cv11.log" || true
+  echo "cv11_rc=$cv11_rc"
+
+  echo "=== verdict (exit-code convention: 0 pass / 1 FAIL / 2 ref-missing) ==="
+  echo "cv05_rc=$cv05_rc cv11_rc=$cv11_rc"
+  # Red iff any script reports a REAL failure (1); ref-missing (2) is visible, not green.
+  fail=0
+  [ "$cv05_rc" = "1" ] && fail=1
+  [ "$cv11_rc" = "1" ] && fail=1
+  [ "$cv05_rc" = "2" ] && echo "WARNING: cv05 reference missing despite source build — investigate"
+  exit "$fail"

--- a/scripts/vessl_gpu_suite.yaml
+++ b/scripts/vessl_gpu_suite.yaml
@@ -32,11 +32,15 @@ run: |-
   # tests — distributed coverage lives in regular test files that set their
   # own XLA --xla_force_host_platform_device_count sentinel and run in the
   # fast suite. Re-add a '-m distributed' step here if the marker gains tests.
+  # POSIX-safe rc capture (the VESSL runner shell is busybox-ash:
+  # ${PIPESTATUS[0]} is a bashism and died with 'bad substitution' on
+  # proof run 369367242339 — pytest itself completed fine).
   set +e
   timeout 13800 python -m pytest -m gpu -q -ra -p no:cacheprovider \
-    2>&1 | tee "$out/gpu_suite.log"
-  rc=${PIPESTATUS[0]}
+    > "$out/gpu_suite.log" 2>&1
+  rc=$?
   set -e
+  tail -n 60 "$out/gpu_suite.log"
   echo "$rc" > "$out/gpu_suite.rc"
   echo "=== summary ==="
   tail -n 30 "$out/gpu_suite.log" | grep -E "passed|failed|error|skipped" || true

--- a/scripts/vessl_gpu_suite.yaml
+++ b/scripts/vessl_gpu_suite.yaml
@@ -1,0 +1,45 @@
+name: rfx-gpu-suite
+description: "W2.4 maintained GPU harness: full gpu-marked pytest suite on current main (run per release tag + after GPU-touching merges)"
+tags: [rfx, gpu-suite, ci-trust, w24]
+resources:
+  cluster: remilab-c0
+  preset: gpu-rtx4090
+image: nvcr.io/nvidia/jax:24.10-py3
+env:
+  PYTHONUNBUFFERED: "1"
+  XLA_PYTHON_CLIENT_PREALLOCATE: "false"
+  HDF5_USE_FILE_LOCKING: "FALSE"
+  LANG: "C.UTF-8"
+mount:
+  /root/workspace/: volume://remilab-fs/personal-workspaces/
+run: |-
+  set -euo pipefail
+  cd /root/workspace/byungkwan-workspace/research/rfx
+  git config --global --add safe.directory /root/workspace/byungkwan-workspace/research/rfx || true
+  echo "=== rfx GPU suite (W2.4 maintained harness) ==="
+  echo "=== provenance ==="
+  git rev-parse HEAD || true
+  git status --short || true
+  echo "=== install runtime dependencies (repo path, no editable install) ==="
+  python -m pip install -q "scipy>=1.11" "h5py>=3.8" "matplotlib>=3.7" pytest
+  export RFX_REPO_ROOT="/root/workspace/byungkwan-workspace/research/rfx"
+  export PYTHONPATH="$RFX_REPO_ROOT:${PYTHONPATH:-}"
+  python -c "import jax, rfx; print('probe ok | jax', jax.__version__, '| devices', jax.devices(), '| rfx', getattr(rfx, '__version__', '?'))"
+  out=".omx/gpu-suite/$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short HEAD)"
+  mkdir -p "$out"
+  echo "=== gpu-marked suite (249 tests at authoring time) ==="
+  # NOTE: the 'distributed' pytest marker is declared but currently has ZERO
+  # tests — distributed coverage lives in regular test files that set their
+  # own XLA --xla_force_host_platform_device_count sentinel and run in the
+  # fast suite. Re-add a '-m distributed' step here if the marker gains tests.
+  set +e
+  timeout 13800 python -m pytest -m gpu -q -ra -p no:cacheprovider \
+    2>&1 | tee "$out/gpu_suite.log"
+  rc=${PIPESTATUS[0]}
+  set -e
+  echo "$rc" > "$out/gpu_suite.rc"
+  echo "=== summary ==="
+  tail -n 30 "$out/gpu_suite.log" | grep -E "passed|failed|error|skipped" || true
+  echo "gpu_suite_rc=$rc"
+  echo "artifacts: $out"
+  exit "$rc"


### PR DESCRIPTION
## Summary

Closes the two VESSL-lane roadmap items (W2.4 + W2.5) in four commits:

**W2.4 (`c6d3b22`)** — `scripts/vessl_gpu_suite.yaml`: THE maintained GPU harness. `pytest -m gpu -q -ra` (~249 tests) on the canonical remilab-c0/gpu-rtx4090 + nvcr jax:24.10 image (JAX in-image → no pin drift), 3h50m budget under the 4h pod limit, per-run rc+log artifacts. The `distributed` marker is declared but has ZERO tests — documented instead of running an empty selection. **Proof run: VESSL 369367242339 in flight — pass/fail counts will be posted as a comment before merge** (the W2.4 gate).

**W2.5(a) (`45e8fc7`)** — exit-2 reference-missing convention retrofitted into cv01–04 (cv09/10 verified already-correct, untouched). cv01's silent exit-0 skip and cv02/03/04's import-crash exit-1s now classify honestly: this env gives cv01/02/04 → **2**, cv09/10 → **0**.
- **R5 finding**: the retrofit unmasked a genuine cv03 self-check failure (T=0.915 vs [0.95,1.05], stable at 3× run length) previously hidden behind the meep import crash → **#160** (left untouched per the one-attempt STOP rule; the weekly lane will honestly show it red until triaged).
- Forced-failure proof: an injected impossible gate exits 1 even with Meep absent.

**W2.5(b) (`2531914`)** — `validation.yml` gains a `crossval-external` job (additions-only, 106 lines; existing jobs untouched): weekly cron + manual dispatch, conda-forge pymeep (the roadmap said "pip-installed Meep" — Meep is conda-forge-only, corrected), strict exit-code mapping (0→PASS, 2→**visible SKIP** in the step-summary table, 1/timeout→RED), per-script log artifacts.

**W2.5(c) (`7b9e77a`)** — `scripts/vessl_crossval_external_monthly.yaml`: monthly lane running cv05 against a **real source-built openEMS** (the proven microwave-energy recipe, dash-safe, sh -n validated) + cv11 against the committed Meep/Palace references.

## Verification
- Per-script exit codes re-verified independently by the reviewing session (cv04→2 with the SKIP banner, cv09→0).
- validation.yml parses; diff additions-only. ruff clean on changed files. Crossval/physics-gate test slice: 52 passed, 1 pre-existing env-sensitive failure verified present on clean HEAD (not a regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)