### PR TITLE
fix(waveguide): band-centered f0 default + below-cutoff preflight guards (closes #150, fixes #149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — waveguide-port default source spectrum (issue #150, 2026-06-12)
+
+- **`f0=None` now defaults to the center of the requested DFT band** instead
+  of the unrelated `freq_max / 2`. The old fallback could land at or below
+  the port mode's cutoff (canonical WR-90 toy: 6 GHz < fc_TE10 = 6.56 GHz),
+  launching an evanescent near-cutoff crawl whose extracted S-parameters were
+  physically meaningless and **grew with `n_steps`** (max column power
+  20 → 57 → 114 over 600 → 2400 steps on the recorded #150 toy; post-fix
+  1.107, identical at 4800 and 9600 steps). Explicit-`f0` setups unchanged.
+- **New preflight guards** `port_source_below_cutoff` and
+  `port_freqs_below_cutoff`: the resolved source center or any requested
+  measurement bin at/below the excited mode's cutoff is now flagged loudly
+  (below-cutoff bins also NaN gradients under `jax.grad`).
+- `examples/inverse_design/differentiable_s11_design.py` setup corrected
+  (issue #149): ports moved clear of the CPML, measurement band kept inside
+  the TE20 contamination bound, preflight now runs visibly and aborts on
+  issues. AD↔FD relative error after the cleanup: 2.8e-4.
+- New gates: `tests/test_waveguide_port_spectrum_guard.py` (preflight codes,
+  f0-omitted empty-guide transmission |S21|≈1, and the #150 toy's
+  column-power growth signature locked at the measured envelope).
+
 ### Current main status (2026-06-10)
 
 - **Recommended public lane remains uniform Cartesian Yee RF/FDTD.**

--- a/docs/agent/recipe-design-loop.mdx
+++ b/docs/agent/recipe-design-loop.mdx
@@ -47,7 +47,7 @@ physical S11 design objective through `forward()` on every PR.
   `distributed=True` raise).
 - Pass `port_s11_freqs=...` whenever the objective reads port S11.
 
-## Lane B — direct `jax.grad` through the S-matrix API (GRADIENT-VERIFIED, design-blocked)
+## Lane B — direct `jax.grad` through the S-matrix API (waveguide: verified after the #150 fix)
 
 `jax.grad` flows end-to-end through `sim.compute_waveguide_s_matrix(...,
 eps_override=eps(theta))` and `compute_msl_s_matrix` — the gradient itself
@@ -57,15 +57,16 @@ is accurate (AD↔FD relative error ~4.5e-4;
 `rfx.optimize_objectives` compose here too — they accept any result
 exposing `.s_params` / `.freqs`.
 
-**However, closed-loop waveguide design on this lane is currently
-blocked**, verified 2026-06-11: on a preflight-clean dielectric two-slab
-toy, the extracted |S11| grows non-passive with run length under both
-`normalize=False` and `normalize='flux'`
-([#150](https://github.com/bk-squared/rfx/issues/150)) — an optimizer fed
-those numbers chases an extraction artifact, and `validate_port_smatrix`
-on the final design fails passivity. Until #150 is resolved, use Lane B
-for gradient/sensitivity studies, not for trusting the optimized |S11|
-value. MSL Lane B does not have an equivalent verified toy yet.
+**The run-length-growth pathology previously reported here
+([#150](https://github.com/bk-squared/rfx/issues/150)) is resolved**
+(2026-06-12): the root cause was the waveguide source's `f0` default
+(`freq_max/2`) landing below the mode cutoff — an evanescent launch whose
+extracted S grew with `n_steps`. `f0=None` now defaults to the center of
+the requested band, and preflight flags `port_source_below_cutoff` /
+`port_freqs_below_cutoff`. Always pass measurement `freqs` (and ideally an
+explicit in-band `f0`), keep every bin above the mode cutoff, and check
+the final design at 2× `n_steps` (run-length invariance) before trusting
+it. MSL Lane B does not have an equivalent verified toy yet.
 
 ## Validation step (both lanes)
 
@@ -92,7 +93,7 @@ value. MSL Lane B does not have an equivalent verified toy yet.
   once ([#149](https://github.com/bk-squared/rfx/issues/149)).
 - **`compute_waveguide_s_matrix` takes no `freqs` argument** — the result
   carries its own grid (`res.freqs`); select bins from it.
-- **An improving loss is not an improving design.** In the blocked-lane
+- **An improving loss is not an improving design.** In the original #150
   toy, the optimizer "improved" the loss 100× by saturating the design
   variable — the underlying extraction was the thing moving. The
   validation step above is what catches this.

--- a/examples/inverse_design/differentiable_s11_design.py
+++ b/examples/inverse_design/differentiable_s11_design.py
@@ -30,10 +30,19 @@ from rfx import Simulation
 _WR90_A = 22.86e-3    # broad wall (m)
 _WR90_B = 10.16e-3    # narrow wall (m)
 _WR90_DX = 2e-3       # cell size (m)
-_WR90_LX = 0.05       # domain length (m)
+# Domain length: ports must clear the CPML absorber (issue #149 — the
+# original LX=0.05 with cpml_layers=8 x dx=2mm put BOTH port planes inside
+# the 16mm absorber; sim.preflight() flags exactly this).
+_WR90_LX = 0.10       # domain length (m)
 
-# TE10 cutoff for WR-90: c/(2a) ≈ 6.56 GHz; all freqs here are above cutoff.
-_WR90_FREQS = jnp.linspace(8e9, 12e9, 8)
+# TE10 cutoff for WR-90: c/(2a) ≈ 6.56 GHz; all freqs here are above cutoff
+# AND below 0.90 x fc_TE20 = 11.8 GHz (preflight's next-mode contamination
+# bound — the original 8-12 GHz band tripped it at the top edge).
+# f0 is set explicitly at band center — a source centered at/below cutoff
+# launches an evanescent crawl whose extracted S grows with n_steps
+# (issue #150; preflight code "port_source_below_cutoff" now guards this).
+_WR90_FREQS = jnp.linspace(8e9, 11.5e9, 8)
+_WR90_F0 = 9.75e9
 
 
 def _build_sim() -> Simulation:
@@ -47,19 +56,21 @@ def _build_sim() -> Simulation:
     )
     sim.add_waveguide_port(
         direction="+x",
-        x_position=0.01,
+        x_position=0.024,
         y_range=(0.0, _WR90_A),
         z_range=(0.0, _WR90_B),
         n_modes=1,
         freqs=_WR90_FREQS,
+        f0=_WR90_F0,
     )
     sim.add_waveguide_port(
         direction="-x",
-        x_position=_WR90_LX - 0.01,
+        x_position=_WR90_LX - 0.024,
         y_range=(0.0, _WR90_A),
         z_range=(0.0, _WR90_B),
         n_modes=1,
         freqs=_WR90_FREQS,
+        f0=_WR90_F0,
     )
     return sim
 
@@ -96,6 +107,11 @@ if __name__ == "__main__":
     print("=" * 70)
 
     sim = _build_sim()
+    # Preflight runs VISIBLY (never optimize against a setup you have not
+    # preflighted — issues #149/#150 both hid behind suppressed warnings).
+    issues = sim.preflight()
+    if issues:
+        raise SystemExit(f"preflight reported {len(issues)} issue(s) — fix the setup first")
     grid = sim._build_grid()
     eps_base = jnp.ones(grid.shape, dtype=jnp.float32)
     alpha0 = jnp.float32(1.0)

--- a/rfx/api/_compile.py
+++ b/rfx/api/_compile.py
@@ -353,6 +353,24 @@ class _CompileMixin:
             )
         return (lo_idx, hi_idx), actual_span
 
+    def _default_waveguide_f0(self, freqs) -> float:
+        """Default waveguide source center = center of the requested DFT band.
+
+        The old fallback (``freq_max / 2``) had no relation to the port mode
+        and could land below the mode cutoff (issue #150: an evanescent
+        launch whose near-cutoff content crawls at vanishing group velocity,
+        producing junk S-parameters that GROW with run length while the
+        in-band incident reference sits in the source tail). Centering on
+        the band the user asked to measure is the only honest default.
+        """
+        try:
+            f_arr = np.asarray(freqs, dtype=float)
+            if f_arr.size:
+                return float((f_arr.min() + f_arr.max()) / 2.0)
+        except (TypeError, ValueError):
+            pass
+        return self._freq_max / 2.0
+
     def _build_waveguide_port_config(
         self,
         entry: _WaveguidePortEntry,
@@ -414,7 +432,7 @@ class _CompileMixin:
                 grid.dx,
                 freqs,
                 n_modes=entry.n_modes,
-                f0=entry.f0 if entry.f0 is not None else self._freq_max / 2,
+                f0=entry.f0 if entry.f0 is not None else self._default_waveguide_f0(freqs),
                 bandwidth=entry.bandwidth,
                 amplitude=entry.amplitude,
                 probe_offset=entry.probe_offset,
@@ -430,7 +448,7 @@ class _CompileMixin:
             port,
             grid.dx,
             freqs,
-            f0=entry.f0 if entry.f0 is not None else self._freq_max / 2,
+            f0=entry.f0 if entry.f0 is not None else self._default_waveguide_f0(freqs),
             bandwidth=entry.bandwidth,
             amplitude=entry.amplitude,
             probe_offset=entry.probe_offset,

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -855,6 +855,53 @@ class _PreflightMixin:
                 return (C0 / 2.0) * math.sqrt((m / _a) ** 2 + (n / _b) ** 2)
 
             fc_excited = _fc(m0, n0)
+
+            # --- LOWER bound (issue #150): source center / measurement bins
+            # at or below the excited mode's own cutoff. Below fc the launch
+            # is evanescent and near-cutoff content crawls at vanishing group
+            # velocity: the extracted S is junk that GROWS with n_steps (the
+            # in-band incident reference sits in the source spectral tail),
+            # and below-cutoff DFT bins additionally NaN the gradient.
+            if entry.freqs is not None:
+                f_arr = np.asarray(entry.freqs, dtype=float)
+                f_min = float(f_arr.min())
+                band_center = float((f_arr.min() + f_arr.max()) / 2.0)
+            else:
+                f_min = None
+                band_center = self._freq_max / 2.0
+            f0_resolved = entry.f0 if entry.f0 is not None else band_center
+            if f0_resolved <= fc_excited:
+                _w.warn(
+                    PreflightWarning(
+                        f"Waveguide port '{entry.name}': source center "
+                        f"f0={f0_resolved / 1e9:.3f} GHz is at or below the "
+                        f"{entry.mode_type}{m0}{n0} cutoff "
+                        f"fc={fc_excited / 1e9:.3f} GHz"
+                        f"{' (defaulted from the measurement band)' if entry.f0 is None else ''}. "
+                        f"The launch is evanescent — extracted S-parameters are "
+                        f"physically meaningless and grow with n_steps. Set "
+                        f"f0 well above fc (e.g. the center of the measurement "
+                        f"band).",
+                        code="port_source_below_cutoff",
+                        source="_check_waveguide_port_evanescent",
+                    ),
+                    stacklevel=4,
+                )
+            if f_min is not None and f_min <= fc_excited:
+                _w.warn(
+                    PreflightWarning(
+                        f"Waveguide port '{entry.name}': minimum measurement "
+                        f"frequency {f_min / 1e9:.3f} GHz is at or below the "
+                        f"{entry.mode_type}{m0}{n0} cutoff "
+                        f"fc={fc_excited / 1e9:.3f} GHz. Below-cutoff bins "
+                        f"produce junk S-parameters and NaN gradients under "
+                        f"jax.grad. Restrict freqs to f > fc.",
+                        code="port_freqs_below_cutoff",
+                        source="_check_waveguide_port_evanescent",
+                    ),
+                    stacklevel=4,
+                )
+
             fc_next = min(
                 (
                     _fc(m, n)

--- a/tests/test_waveguide_port_spectrum_guard.py
+++ b/tests/test_waveguide_port_spectrum_guard.py
@@ -1,0 +1,136 @@
+"""Issue #150 closure gates: waveguide source-spectrum defaults + guards.
+
+Root cause of #150: with ``f0`` omitted, the waveguide source defaulted to
+``freq_max / 2`` — unrelated to the port mode and, for the canonical WR-90
+toy (freq_max=12 GHz → f0=6 GHz < fc_TE10=6.56 GHz), BELOW the mode cutoff.
+The launch was evanescent, near-cutoff content crawled at vanishing group
+velocity, and the extracted S grew with run length while the in-band
+incident reference sat in the source spectral tail.
+
+Fixes pinned here:
+1. ``f0=None`` now resolves to the center of the requested DFT band.
+2. Preflight emits ``port_source_below_cutoff`` / ``port_freqs_below_cutoff``
+   when the resolved source center or any measurement bin sits at/below the
+   excited mode's cutoff.
+3. Physical acceptance: the f0-omitted empty guide transmits (|S21| ≈ 1)
+   and the recorded #150 two-slab toy is run-length-invariant and passive
+   once the source actually propagates (slow-marked).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from rfx import Simulation, validate_port_smatrix
+
+A_WR90, B_WR90 = 22.86e-3, 10.16e-3
+FC_TE10 = 3e8 / (2 * A_WR90)  # ~6.56 GHz
+
+
+def _build(lx, dx, freqs, *, f0=None, x1=0.024, x2=None):
+    sim = Simulation(freq_max=12e9, domain=(lx, A_WR90, B_WR90), dx=dx,
+                     boundary="cpml", cpml_layers=8)
+    kw = {} if f0 is None else {"f0": f0}
+    sim.add_waveguide_port(x_position=x1, y_range=(0.0, A_WR90),
+                           z_range=(0.0, B_WR90), direction="+x",
+                           n_modes=1, freqs=freqs, **kw)
+    sim.add_waveguide_port(x_position=(x2 if x2 is not None else lx - x1),
+                           y_range=(0.0, A_WR90), z_range=(0.0, B_WR90),
+                           direction="-x", n_modes=1, freqs=freqs, **kw)
+    return sim
+
+
+def _preflight_codes(sim):
+    issues = sim.preflight()
+    return {getattr(i, "code", None) for i in issues}
+
+
+def test_preflight_flags_source_center_below_cutoff():
+    """Explicit f0 below the TE10 cutoff must be flagged."""
+    sim = _build(0.10, 2e-3, jnp.linspace(9e9, 11e9, 3), f0=5e9)
+    codes = _preflight_codes(sim)
+    assert "port_source_below_cutoff" in codes
+
+
+def test_preflight_flags_measurement_bins_below_cutoff():
+    """A DFT bin below cutoff (junk S + NaN gradients) must be flagged."""
+    sim = _build(0.10, 2e-3, jnp.linspace(5e9, 11e9, 4), f0=9e9)
+    codes = _preflight_codes(sim)
+    assert "port_freqs_below_cutoff" in codes
+
+
+def test_preflight_clean_when_band_above_cutoff():
+    """The f0-omitted in-band setup (post-fix default) must NOT be flagged."""
+    sim = _build(0.10, 2e-3, jnp.linspace(9e9, 11e9, 3))
+    codes = _preflight_codes(sim)
+    assert "port_source_below_cutoff" not in codes
+    assert "port_freqs_below_cutoff" not in codes
+
+
+def test_f0_omitted_empty_guide_transmits():
+    """Acceptance smoke (#150): f0-omitted empty WR-90 guide must transmit.
+
+    Pre-fix this exact setup gave |S21| 0.6-1.2 / |S11| 0.5-0.9 garbage
+    (f0 defaulted to 6 GHz < fc=6.56 GHz). Post-fix the default source is
+    centered in the 9-11 GHz measurement band and the guide must look like
+    a guide: |S21| ~ 1, |S11| small at every bin.
+    """
+    freqs = jnp.linspace(9e9, 11e9, 3)
+    sim = _build(0.08, 2e-3, freqs, x1=0.020)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = sim.compute_waveguide_s_matrix(n_steps=1200, normalize=False)
+    s = np.asarray(res.s_params)
+    s21 = np.abs(s[1, 0, :])
+    s11 = np.abs(s[0, 0, :])
+    assert np.all(s21 > 0.9) and np.all(s21 < 1.1), f"|S21|={s21}"
+    assert np.all(s11 < 0.3), f"|S11|={s11}"
+
+
+@pytest.mark.slow
+def test_issue150_two_slab_toy_run_length_invariant_and_passive():
+    """The recorded #150 toy: the run-length GROWTH signature must stay dead.
+
+    Measured calibration (2026-06-12, post-fix, this exact toy):
+      pre-fix : colpow 20.3 (n=600) -> 57.0 -> 113.7 (n=2400)  [GROWING]
+      post-fix: colpow 1.1071 at n=4800 AND n=9600 (identical to 4 dp);
+                max per-entry |S| drift 0.074 (2400->4800), 0.068 (4800->9600).
+    The 1.107 column-power floor is the coarse-toy artifact envelope
+    (dx=2mm staircase on the eps=4 slab + 16mm ~ 0.4*lambda_g port-obstacle
+    clearance), NOT ideal passivity — gated at the measured level, not
+    loosened beyond it. The #150 regression signature is GROWTH of column
+    power with n_steps; that is the primary assertion.
+    """
+    freqs = jnp.linspace(9e9, 11e9, 5)
+    sim = _build(0.10, 2e-3, freqs)
+    grid = sim._build_grid()
+    eps = jnp.ones(grid.shape, dtype=jnp.float32)
+    i = int(round(0.056 / grid.dx))
+    eps = eps.at[i:i + 2].set(4.0)
+    i = int(round(0.040 / grid.dx))
+    eps = eps.at[i:i + 2].set(2.5)
+
+    out = {}
+    for n in (2400, 4800):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            res = sim.compute_waveguide_s_matrix(
+                n_steps=n, normalize=False, eps_override=eps)
+        rep = validate_port_smatrix(res)
+        out[n] = (np.asarray(res.s_params),
+                  float(rep.metrics["max_column_power"]))
+
+    # Primary (#150 signature): column power must NOT grow with run length.
+    growth = out[4800][1] / out[2400][1]
+    assert growth < 1.10, (
+        f"column power GREW with n_steps: {out[2400][1]:.3f} -> "
+        f"{out[4800][1]:.3f} (x{growth:.2f}) — the #150 pathology is back")
+    # Secondary: stay at the measured coarse-toy envelope (1.1071 measured).
+    for n, (_, colpow) in out.items():
+        assert colpow <= 1.15, f"n={n}: max column power {colpow:.3f} > 1.15"
+    d = np.max(np.abs(np.abs(out[2400][0]) - np.abs(out[4800][0])))
+    assert d < 0.15, f"run-length drift max|Delta|S|| = {d:.4f} >= 0.15 (measured 0.074)"


### PR DESCRIPTION
## Root cause (#150)

The reported "extracted S grows non-passive with n_steps" had nothing to do with the extractors themselves: with `f0` omitted, the waveguide source defaulted to **`freq_max / 2`** — unrelated to the port mode and, on the recorded WR-90 toy, **below the TE10 cutoff** (6 GHz < 6.56 GHz). The launch was evanescent; near-cutoff content crawls at vanishing group velocity, so the port DFTs integrated ever-arriving junk while the in-band incident reference sat in the source spectral tail. Sixth confirmation of the repo's R4 pattern: the bug was in setup/defaults, not the FDTD core. (Boundary hypotheses were tested and dissolved along the way: with waveguide ports registered, `_build_grid` already forces x-only CPML + PEC walls for every config.)

## Fix (one attempt, closed decisively)

- `f0=None` → **center of the requested DFT band** (`_default_waveguide_f0`); explicit-f0 setups byte-unchanged.
- **New preflight lower-bound guards** extending the existing evanescent check: `port_source_below_cutoff`, `port_freqs_below_cutoff` (below-cutoff bins also NaN gradients — the trap from the design-loop session).

## Measured closure (R5 ladder, recorded toy)

| | colpow @600 | @2400 | @4800 | @9600 |
|---|---|---|---|---|
| pre-fix | 20.3 | 113.7 | 9.3* | 13.1* |
| post-fix | — | 1.107 | **1.1071** | **1.1071** (identical) |

(*separate pre-fix ladder.) Growth signature dead; the 1.107 floor is the coarse-toy staircase/clearance envelope, gated at the measured level in the new slow test — deliberately not loosened beyond measurement. Empty-guide acceptance: f0-omitted WR-90 now transmits (**|S21| ≈ 1.0**, was 0.6–1.2 garbage).

## #149 flagship cleanup (same cluster)

Ports moved clear of the 16mm CPML, band kept under the TE20 contamination bound (the now-visible preflight caught that third flaw too), preflight aborts on issues. **AD↔FD rel err 2.8e-4** (was 4.5e-4) — and the |S| values are now meaningful measurements, not artifacts.

## Verification

- New gates: `tests/test_waveguide_port_spectrum_guard.py` — 4 fast + 1 slow (growth-signature lock), all green.
- Affected f0-omitting suites (`test_sparam_ad_end_to_end`, `test_waveguide_forward`, `test_normalization`, `test_sparameter_support_contract`, `test_waveguide_sparam_ad`): **32 passed, zero regressions**.
- preflight/waveguide fast slice: **199 passed, 2 skipped, 1 xfailed**; ruff clean.
- `recipe-design-loop.mdx` Lane-B status updated from design-blocked to resolved-with-guards; CHANGELOG entry added.

Remaining in the cluster: #148 (`normalize='flux'` AD tape) — feasibility assessed (two `np.array(flux_spectrum(...))` concretization sites), scheduled separately with its own AD battery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)