### PR TITLE
fix(crossval): bound cv03 flux regions to the Meep-measured window (fixes #160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   resolution including the recipe mesh. Truncation witness: bounded
   resolution-10 T(f_peak) = 0.977 at 3x run length. Gate unchanged.
   Falsifier matrix: `scripts/diagnostics/cv03_flux/sweep_t_deficit.py`.
+- Second comparator defect (same script, surfaced by the lane's first real
+  Meep execution): the rfx integration time was slaved to Meep's
+  `stop_when_fields_decayed` wall clock — when Meep stopped at t=200 the
+  rfx flux DFT was truncated mid-tail and read T=1.155. rfx now runs a
+  fixed 400 a/c0 units (measured band: 0.9736 at 1x, 0.9772 at 3x).
+  `until_decay=1e-5` was tried and rejected for this geometry: the point
+  stopper triggers at ~2200 steps while the eps=12 guide's slow tail is
+  still carrying flux (T=0.745) — point-field decay is not a
+  flux-convergence witness here (filed as a follow-up issue).
 
 ### Fixed — preflight 2D false positive + unit-adaptive warning text (issue #166, 2026-06-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,19 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   `until_decay=1e-5` was tried and rejected for this geometry: the point
   stopper triggers at ~2200 steps while the eps=12 guide's slow tail is
   still carrying flux (T=0.745) — point-field decay is not a
-  flux-convergence witness here (filed as a follow-up issue).
+  flux-convergence witness here (filed as issue #169).
+- Gate statistic re-specified to the **central-band mean** T (fcen ±
+  0.15·df), tolerances unchanged at 1.0 ± 0.05 and cross-diff < 0.05.
+  Measured first (sweep matrix + lane runs 27393931821/27394439174): at
+  the recipe mesh — 11.5 cells/λ_eff at freq_max, below the preflight's
+  own ≥20 floor for flux extraction — rfx's per-bin T(f) carries the
+  preflight-documented ±5-10% coarse-mesh ripple while Meep's curve is
+  smooth, so the old single-bin gate sampled at Meep's peak bin landed
+  in ripple valleys (0.902 at f=0.1510) even at resolutions where the
+  band-energy transmission is clean (band-mean 0.966 / 1.005 / 0.989 at
+  resolution 10/15/20). The band mean is the physically meaningful
+  energy-transmission estimator; peak-bin values remain printed for
+  information.
 
 ### Fixed — preflight 2D false positive + unit-adaptive warning text (issue #166, 2026-06-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — cv03 flux-region congruence (issue #160, 2026-06-12)
+
+- `examples/crossval/03_straight_waveguide_flux.py`: the rfx flux monitors
+  are now bounded to the same `2*wg_width` region the Meep `FluxRegion`
+  measures, instead of the full y-plane (UPML padding included). The
+  full-plane `flux_in` additionally integrated the line source's radiation
+  cone — power that physically exits through the transverse absorber before
+  `flux_out` — so the self-transmission read 0.913 against the [0.95, 1.05]
+  gate with **no flux-normalization bug present**. Measured matrix
+  (resolution 10/15/20): full-plane 0.913 / 0.986 / 0.958 (non-monotonic,
+  not a convergence curve); bounded 0.974 / 1.011 / 0.997 — passing at every
+  resolution including the recipe mesh. Truncation witness: bounded
+  resolution-10 T(f_peak) = 0.977 at 3x run length. Gate unchanged.
+  Falsifier matrix: `scripts/diagnostics/cv03_flux/sweep_t_deficit.py`.
+
 ### Fixed — waveguide-port default source spectrum (issue #150, 2026-06-12)
 
 - **`f0=None` now defaults to the center of the requested DFT band** instead

--- a/examples/crossval/03_straight_waveguide_flux.py
+++ b/examples/crossval/03_straight_waveguide_flux.py
@@ -235,11 +235,22 @@ sim_rfx.add_flux_monitor(axis="x", coordinate=flux_out_rfx,
 
 sim_rfx.preflight(strict=False)
 
-rfx_total_t = meep_total_t * a / C0
+# rfx integration time is a FIXED 400 time units (a/c0), NOT slaved to
+# Meep's stop_when_fields_decayed wall clock. Inheriting Meep's wall time
+# truncated the rfx flux DFT whenever Meep stopped early (lane run
+# 27393931821: Meep stopped at t=200, rfx got 3059 steps and read
+# T(f_peak)=1.155 from truncation aliasing). Measured convergence at this
+# duration: T=0.9736 at 1x (5995 steps), 0.9772 at 3x — a 0.4% band.
+# NOTE: until_decay=1e-5 at flux_out was tried and REJECTED for this
+# geometry: the stopper triggers at ~2200 steps (point ez goes quiet)
+# while the flux DFT is still accumulating the slow low-group-velocity
+# tail of the eps=12 guide — T reads 0.745. Point-field decay is not a
+# flux-convergence witness here.
+rfx_total_t = 400.0 * a / C0
 dt_rfx = dx / (C0 * math.sqrt(2)) * 0.99
 n_steps = int(rfx_total_t / dt_rfx) + 200
 
-print(f"  Running rfx: {n_steps} steps...")
+print(f"  Running rfx: {n_steps} steps (fixed 400 a/c0 units)...")
 t0 = time.time()
 res_rfx = sim_rfx.run(n_steps=n_steps, subpixel_smoothing=True)
 print(f"  Done in {time.time()-t0:.1f}s")

--- a/examples/crossval/03_straight_waveguide_flux.py
+++ b/examples/crossval/03_straight_waveguide_flux.py
@@ -20,6 +20,14 @@ probe as a "flux proxy" and then scaled the result to match the
 Meep peak; that pattern is explicitly forbidden (shape correlation
 of scaled Gaussians always passes) and has been removed.
 
+**Flux-region congruence (issue #160):** the rfx monitors are bounded to
+the same 2*wg_width region the Meep ``FluxRegion`` measures. The earlier
+full-plane monitors also integrated the line source's radiation cone at
+flux_in (radiation that exits transversally before flux_out), reading
+T = 0.913 at resolution 10 with no flux-normalization bug present —
+see scripts/diagnostics/cv03_flux/sweep_t_deficit.py for the
+resolution x monitor-extent falsifier matrix.
+
 Meep tutorial parameters:
   eps = 12, width = 1a, pad = 4, dpml = 2, resolution = 10
   cell = 16 x 8 (plus 2*dpml each side)
@@ -206,10 +214,24 @@ for i in range(int(wg_width * resolution)):
 # Sample the rfx flux on the SAME Meep-normalised frequency grid so the
 # peak-frequency comparison is bin-aligned (no interpolation ambiguity).
 freqs_rfx = jnp.asarray(meep_freqs * C0 / a)
+
+# Flux region bounded to 2*wg_width on the guide axis — the SAME region the
+# Meep part measures (FluxRegion size=(0, 2*wg_width)). A full-plane monitor
+# (the pre-#160 behaviour) additionally integrates the line source's
+# radiation cone at flux_in; that radiation exits through the transverse
+# UPML before flux_out, so T = out/in reads low (0.913 at resolution 10)
+# without any flux-normalization bug. Issue #160 mesh x monitor-extent
+# matrix: bounded T(f_peak) = 0.974 / 1.011 / 0.997 at resolution 10/15/20.
+# The z size is oversized and clamps to the full (degenerate) z extent in
+# 2D mode.
+flux_size = (2 * wg_width * a, 10 * dx)
+flux_center = (OFFSET_Y * a, dx / 2)
 sim_rfx.add_flux_monitor(axis="x", coordinate=flux_in_rfx,
-                          freqs=freqs_rfx, name="flux_in")
+                          freqs=freqs_rfx, name="flux_in",
+                          size=flux_size, center=flux_center)
 sim_rfx.add_flux_monitor(axis="x", coordinate=flux_out_rfx,
-                          freqs=freqs_rfx, name="flux_out")
+                          freqs=freqs_rfx, name="flux_out",
+                          size=flux_size, center=flux_center)
 
 sim_rfx.preflight(strict=False)
 

--- a/examples/crossval/03_straight_waveguide_flux.py
+++ b/examples/crossval/03_straight_waveguide_flux.py
@@ -34,10 +34,16 @@ Meep tutorial parameters:
   fcen = 0.15, fwidth = 0.1
   Source: GaussianSource line source spanning waveguide
 
-Pass criteria (each must hold):
-  - rfx self-transmission T_rfx(f_peak) ∈ [0.95, 1.05]
-  - Meep self-transmission T_meep(f_peak) ∈ [0.95, 1.05]   (only when Meep ran)
-  - |T_rfx(f_peak) − T_meep(f_peak)| < 0.05                 (only when Meep ran)
+Pass criteria (each must hold; gate statistic = MEAN T over the central
+source band fcen ± 0.15*df — re-specified 2026-06-12, issue #160, after
+recording the full T(f) curves: at the recipe mesh rfx's per-bin T
+carries the preflight-documented ±5-10% coarse-mesh ripple, so a
+single-bin gate samples ripple valleys; the band mean is the physically
+meaningful energy-transmission estimator. Peak-bin values are printed
+for information only):
+  - rfx band-mean T ∈ [0.95, 1.05]
+  - Meep band-mean T ∈ [0.95, 1.05]            (only when Meep ran)
+  - |band-mean T_rfx − band-mean T_meep| < 0.05 (only when Meep ran)
 
 Exit codes (rfx crossval convention):
   0 = all PASS including the Meep cross-check
@@ -317,25 +323,46 @@ print("=" * 70)
 
 def _in_range(x, lo, hi): return lo <= x <= hi
 
-tol_self  = 0.05        # each sim's own T(f_peak) must be within [0.95, 1.05]
-tol_cross = 0.05        # |T_rfx − T_meep| at peak must be < 0.05
+tol_self  = 0.05        # each sim's central-band MEAN T within [0.95, 1.05]
+tol_cross = 0.05        # |band-mean T_rfx − band-mean T_meep| < 0.05
+
+# Gate statistic: MEAN T over the central source band (fcen ± 0.15*df,
+# i.e. the central 30% of the Gaussian band, where flux_in is strong and
+# the ratio is well-conditioned). Re-specified 2026-06-12 (issue #160)
+# with the measured curves recorded FIRST (sweep_t_deficit.json + lane
+# runs 27393931821 / 27394439174): at the recipe mesh (11.5 cells/λ_eff
+# at freq_max — below the preflight's own ≥20 floor for flux extraction)
+# rfx's per-bin T(f) carries a ±5-10% ripple, the preflight's documented
+# coarse-mesh |S| error class, while Meep's curve is smooth. A
+# single-bin gate sampled at Meep's peak bin lands in ripple valleys
+# (T=0.902 at f=0.1510) even though the band-energy transmission is
+# clean: band-mean 0.966/1.005/0.989 at resolution 10/15/20. The mean
+# over the source band is the physically meaningful energy-transmission
+# estimator and is robust to the per-bin ripple. Peak-bin values are
+# still printed for information.
+band_mask = np.abs(meep_freqs - fcen) <= 0.15 * df
+T_rfx_band = float(np.mean(T_rfx[band_mask]))
 
 # rfx self-check (does NOT depend on Meep).
-pass_self_rfx = _in_range(T_rfx_peak, 1.0 - tol_self, 1.0 + tol_self)
-print(f"  rfx self-T  @ f_peak: {T_rfx_peak:.4f}   "
+pass_self_rfx = _in_range(T_rfx_band, 1.0 - tol_self, 1.0 + tol_self)
+print(f"  rfx T(f_peak) = {T_rfx_peak:.4f}  [info only]")
+print(f"  rfx band-mean T [{fcen-0.15*df:.3f},{fcen+0.15*df:.3f}]: "
+      f"{T_rfx_band:.4f}   "
       f"{'PASS' if pass_self_rfx else 'FAIL'} (gate 1.0 ± {tol_self})")
 
 if HAVE_MEEP:
-    pass_self_meep = _in_range(T_meep_peak, 1.0 - tol_self, 1.0 + tol_self)
-    delta_cross    = abs(T_rfx_peak - T_meep_peak)
+    T_meep_band = float(np.mean(np.asarray(T_meep)[band_mask]))
+    pass_self_meep = _in_range(T_meep_band, 1.0 - tol_self, 1.0 + tol_self)
+    delta_cross    = abs(T_rfx_band - T_meep_band)
     pass_cross     = delta_cross < tol_cross
-    print(f"  meep self-T @ f_peak: {T_meep_peak:.4f}   "
+    print(f"  meep T(f_peak) = {T_meep_peak:.4f}  [info only]")
+    print(f"  meep band-mean T: {T_meep_band:.4f}   "
           f"{'PASS' if pass_self_meep else 'FAIL'} (gate 1.0 ± {tol_self})")
-    print(f"  |T_rfx − T_meep| @ f_peak: {delta_cross:.4f}  "
+    print(f"  |band-mean T_rfx − T_meep|: {delta_cross:.4f}  "
           f"{'PASS' if pass_cross else 'FAIL'} (gate < {tol_cross})")
 else:
-    print("  meep self-T @ f_peak: SKIP  (Meep reference unavailable)")
-    print("  |T_rfx − T_meep| @ f_peak: SKIP  (Meep reference unavailable)")
+    print("  meep band-mean T: SKIP  (Meep reference unavailable)")
+    print("  |band-mean T_rfx − T_meep|: SKIP  (Meep reference unavailable)")
 
 # =============================================================================
 # Exit code (rfx crossval convention)

--- a/scripts/diagnostics/cv03_flux/sweep_t_deficit.py
+++ b/scripts/diagnostics/cv03_flux/sweep_t_deficit.py
@@ -1,0 +1,177 @@
+"""Issue #160 diagnostic: cv03 straight-waveguide T=0.915 deficit.
+
+One-attempt falsifier matrix (issue #160 acceptance):
+  - resolution in {10, 15, 20}  (mesh-convergence axis: does T -> 1?)
+  - monitor extent in {full-plane (cv03 as-is), bounded 2a (Meep-matched)}
+    (comparator axis: is the deficit radiation captured by the oversized
+    flux_in plane rather than a flux-normalization bug?)
+
+Geometry/source/run-length identical to examples/crossval/03 PART 2,
+parameterized by resolution. Dumps full T(f) curves (R5) to JSON + PNG.
+
+Run: JAX_ENABLE_X64=1 python scripts/diagnostics/cv03_flux/sweep_t_deficit.py
+"""
+
+import os
+import json
+import math
+import time
+
+os.environ.setdefault("JAX_ENABLE_X64", "1")
+
+import matplotlib; matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+C0 = 2.998e8
+
+# ---- cv03 parameters (Meep tutorial) ----
+eps_wg = 12.0
+wg_width = 1.0
+pad = 4.0
+dpml = 2.0
+sx = 16.0
+sy = 2 * (pad + dpml + wg_width / 2)
+a = 1.0e-6
+fcen = 0.15
+df = 0.1
+n_freqs = 50
+
+interior_x = sx
+interior_y = sy - 2 * dpml
+OFFSET_X = interior_x / 2.0
+OFFSET_Y = interior_y / 2.0
+
+bw_rfx = df / (fcen * math.pi * math.sqrt(2))
+fcen_hz = fcen * C0 / a
+
+src_x_meep = -7.0
+flux_in_meep = -5.0
+flux_out_meep = +5.0
+
+freqs_norm = np.linspace(fcen - df / 2, fcen + df / 2, n_freqs)
+meep_total_t = 400.0
+
+
+def run_case(resolution: int, monitor: str) -> dict:
+    from rfx import Simulation, Box, flux_spectrum
+    from rfx.boundaries.spec import BoundarySpec
+    from rfx.sources.sources import ModulatedGaussian
+    import jax.numpy as jnp
+
+    dx = a / resolution
+    cpml_n = int(dpml * resolution)
+    domain_x = interior_x * a
+    domain_y = interior_y * a
+
+    src_x_rfx = (src_x_meep + OFFSET_X) * a
+    flux_in_rfx = (flux_in_meep + OFFSET_X) * a
+    flux_out_rfx = (flux_out_meep + OFFSET_X) * a
+
+    sim = Simulation(freq_max=0.25 * C0 / a,
+                     domain=(domain_x, domain_y, dx), dx=dx,
+                     boundary=BoundarySpec.uniform("upml"),
+                     cpml_layers=cpml_n, mode="2d_tmz")
+    sim.add_material("wg", eps_r=eps_wg)
+
+    wg_y_lo = (OFFSET_Y - wg_width / 2) * a
+    wg_y_hi = (OFFSET_Y + wg_width / 2) * a
+    sim.add(Box((0, wg_y_lo, 0), (domain_x, wg_y_hi, dx)), material="wg")
+
+    n_src = int(wg_width * resolution)
+    for i in range(n_src):
+        y = wg_y_lo + (i + 0.5) * dx
+        sim.add_source(position=(src_x_rfx, y, 0), component="ez",
+                       waveform=ModulatedGaussian(f0=fcen_hz, bandwidth=bw_rfx,
+                                                  amplitude=1.0 / n_src,
+                                                  cutoff=5.0 / math.sqrt(2)))
+
+    freqs_rfx = jnp.asarray(freqs_norm * C0 / a)
+    mon_kwargs = {}
+    if monitor == "bounded2a":
+        # Meep-matched flux region: 2*wg_width tall, centered on the guide.
+        mon_kwargs = dict(size=(2 * wg_width * a, 10 * dx),
+                          center=(OFFSET_Y * a, dx / 2))
+    sim.add_flux_monitor(axis="x", coordinate=flux_in_rfx,
+                         freqs=freqs_rfx, name="flux_in", **mon_kwargs)
+    sim.add_flux_monitor(axis="x", coordinate=flux_out_rfx,
+                         freqs=freqs_rfx, name="flux_out", **mon_kwargs)
+
+    sim.preflight(strict=False)
+
+    rfx_total_t = meep_total_t * a / C0
+    dt = dx / (C0 * math.sqrt(2)) * 0.99
+    n_steps = int(rfx_total_t / dt) + 200
+
+    t0 = time.time()
+    res = sim.run(n_steps=n_steps, subpixel_smoothing=True)
+    wall = time.time() - t0
+
+    flux_in = np.asarray(flux_spectrum(res.flux_monitors["flux_in"]))
+    flux_out = np.asarray(flux_spectrum(res.flux_monitors["flux_out"]))
+    eps_f = float(np.max(np.abs(flux_in))) * 1e-6
+    T = flux_out / np.where(np.abs(flux_in) > eps_f, flux_in, eps_f)
+    peak_idx = int(np.argmax(np.abs(flux_in)))
+
+    out = {
+        "resolution": resolution,
+        "monitor": monitor,
+        "n_steps": n_steps,
+        "wall_s": round(wall, 1),
+        "peak_idx": peak_idx,
+        "f_peak": float(freqs_norm[peak_idx]),
+        "T_peak": float(T[peak_idx]),
+        "freqs_norm": freqs_norm.tolist(),
+        "T": T.tolist(),
+        "flux_in": flux_in.tolist(),
+        "flux_out": flux_out.tolist(),
+    }
+    print(f"[case] res={resolution:3d} monitor={monitor:10s} "
+          f"steps={n_steps} wall={wall:.0f}s  T(f_peak)={T[peak_idx]:.4f}",
+          flush=True)
+    return out
+
+
+def main():
+    cases = []
+    for monitor in ("fullplane", "bounded2a"):
+        for resolution in (10, 15, 20):
+            cases.append(run_case(resolution, monitor))
+
+    out_json = os.path.join(SCRIPT_DIR, "sweep_t_deficit.json")
+    with open(out_json, "w") as f:
+        json.dump(cases, f, indent=1)
+    print(f"saved {out_json}")
+
+    fig, axes = plt.subplots(1, 2, figsize=(13, 4.5))
+    colors = {10: "tab:blue", 15: "tab:orange", 20: "tab:red"}
+    for c in cases:
+        ax = axes[0] if c["monitor"] == "fullplane" else axes[1]
+        ax.plot(c["freqs_norm"], c["T"], color=colors[c["resolution"]],
+                label=f"res={c['resolution']}  T(fp)={c['T_peak']:.3f}")
+    for ax, title in zip(axes, ("full-plane monitor (cv03 as-is)",
+                                "bounded 2a monitor (Meep-matched)")):
+        ax.axhline(1.0, color="k", ls=":", alpha=0.5)
+        ax.axhspan(0.95, 1.05, color="g", alpha=0.08)
+        ax.set_xlabel("Frequency (c/a)")
+        ax.set_ylabel("T(f)")
+        ax.set_title(title)
+        ax.set_ylim(0.7, 1.3)
+        ax.legend(fontsize=8)
+        ax.grid(True, alpha=0.3)
+    plt.suptitle("Issue #160: cv03 T deficit — mesh x monitor-extent matrix",
+                 fontweight="bold")
+    plt.tight_layout()
+    out_png = os.path.join(SCRIPT_DIR, "sweep_t_deficit.png")
+    plt.savefig(out_png, dpi=150)
+    print(f"saved {out_png}")
+
+    print("\nSummary (T at peak bin):")
+    for c in cases:
+        print(f"  res={c['resolution']:3d}  {c['monitor']:10s}  "
+              f"T={c['T_peak']:.4f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

cv03's red gate (#160) turned out to be **three stacked comparator/measurement defects** — no rfx flux-normalization bug at any point. The lane now passes **fully green including the real conda-forge Meep cross-check** (run 27395817036): rfx band-mean T = 0.9657, Meep = 0.9931, cross-diff = 0.0273 < 0.05, `ALL CHECKS PASSED` — the first full cv03 pass in repo history.

## Defect 1 — monitor extent (commit edc2032)

rfx monitors were full-plane (UPML padding included) while the Meep part measures a bounded `2*wg_width` FluxRegion; the full-plane `flux_in` integrated the line source's radiation cone, which physically exits transversally before `flux_out`. Falsifier matrix (res 10/15/20, full curves dumped): full-plane 0.913/0.986/0.958 (non-monotonic); bounded 0.974/1.011/0.997. Truncation witness: 0.977 at 3× run length. Diagnostic committed: `scripts/diagnostics/cv03_flux/sweep_t_deficit.py`.

## Defect 2 — run length slaved to Meep's wall clock (commit d8f6d7c)

Surfaced by the lane's first real Meep execution: Meep's `stop_when_fields_decayed` stopped at t=200, rfx inherited that wall time, got 3059 steps, and read T=1.155 from truncation aliasing. rfx now runs a fixed 400 a/c0 units (measured band 0.9736 at 1×, 0.9772 at 3×). `until_decay=1e-5` was tried and **rejected with evidence**: the point stopper fires at ~2201 steps while the eps=12 guide's slow tail still carries flux (T=0.745) — filed as #169, recipe caveat added.

## Defect 3 — single-bin gate vs coarse-mesh ripple (commit 5fa64a2, user-approved re-spec)

At the recipe mesh (11.5 cells/λ_eff at freq_max, below the preflight's own ≥20 floor for flux extraction) rfx's per-bin T(f) carries the preflight-documented ±5-10% ripple while Meep's curve is smooth; the gate sampled T at Meep's peak bin and landed in a ripple valley (local T@0.1510 = 0.9018 byte-matches the lane — no cross-machine effect; res 20 still reads 0.944, so resolution alone cannot close a single-bin gate). Gate statistic re-specified to the **central-band mean** (fcen ± 0.15·df), tolerances unchanged; curves were recorded before the re-spec per repo discipline.

## Verification

- Lane run 27395817036: 6/6 scripts exit 0 (01, 02, 03, 04, 09, 10) — cv03 PASS including external reference.
- Local: exit 2 path (Meep absent) band-mean 0.9657 PASS.
- Sibling fixes merged separately along the way: #167 (preflight 2D-z false positive + unit-adaptive text, closes #166), #168 (lane errexit + cv02 Meep-path NameError).

Closes #160.

🤖 Generated with [Claude Code](https://claude.com/claude-code)