### PR TITLE
fix(preflight): 2D collapsed-z absorber_overlap false positive + unit-adaptive warning text (fixes #166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — preflight 2D false positive + unit-adaptive warning text (issue #166, 2026-06-12)
+
+- **`absorber_overlap` no longer false-trips on the collapsed z axis in 2D
+  modes.** The preflight thickness mirror assumed an absorber on every
+  non-PEC/PMC/periodic axis, but 2D grids collapse z to a single cell with
+  no absorber at all (`Grid` sets `pad_z = 0` and strips z from
+  `cpml_axes`) — so every 2D source/probe, necessarily at z=0, warned
+  "near/inside UPML region" (cv03: one line per line-source point, 20 lines
+  of spam per preflight). Real x/y overlap in 2D and all 3D behaviour are
+  regression-locked unchanged.
+- **Scale-sensitive preflight messages now pick units adaptively**
+  (`_fmt_len` / `_fmt_freq`): the mesh-resolution and absorber-placement
+  warnings printed fixed mm/GHz, rendering optical-scale setups as
+  `dx=0.000mm`, `lo=0.0mm`, and `freq_max=74950.00GHz` — values that read
+  like bugs while being correct (cv03: 100nm, 2µm, 74.95THz). Remaining
+  RF-lane messages (NTFF, MSL, ports) keep mm/GHz, which is correct at
+  their scale, and can migrate incrementally.
+- New gates in `tests/test_preflight_structured_and_guards.py` (2D-z no
+  false positive, 2D-x/y still fires, formatter units, optical-scale
+  mesh-warning text).
+
 ### Fixed — waveguide-port default source spectrum (issue #150, 2026-06-12)
 
 - **`f0=None` now defaults to the center of the requested DFT band** instead

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -26,6 +26,43 @@ from rfx.core.yee import MaterialArrays
 from rfx.core.jax_utils import is_tracer
 
 
+def _fmt_len(meters: float) -> str:
+    """Unit-adaptive length for warning text (issue #166).
+
+    Fixed-mm formatting rendered µm-scale setups as ``0.0mm`` / ``0.000mm``
+    and misled optical-scale users into reading a routine value as a bug;
+    pick the unit that keeps the digits visible.
+    """
+    m = abs(meters)
+    if m == 0.0:
+        return "0mm"
+    if m >= 1.0:
+        return f"{meters:.4g}m"
+    if m >= 1e-3:
+        return f"{meters*1e3:.4g}mm"
+    if m >= 1e-6:
+        return f"{meters*1e6:.4g}µm"
+    return f"{meters*1e9:.4g}nm"
+
+
+def _fmt_freq(hz: float) -> str:
+    """Unit-adaptive frequency for warning text (issue #166).
+
+    Fixed-GHz formatting printed optical-scale ``freq_max`` as
+    ``74950.00GHz`` instead of ``74.95THz``.
+    """
+    h = abs(hz)
+    if h == 0.0:
+        return "0Hz"
+    if h >= 1e12:
+        return f"{hz/1e12:.4g}THz"
+    if h >= 1e9:
+        return f"{hz/1e9:.4g}GHz"
+    if h >= 1e6:
+        return f"{hz/1e6:.4g}MHz"
+    return f"{hz:.4g}Hz"
+
+
 class PreflightWarning(UserWarning):
     """Base for structured preflight findings carried on the warning instance.
 
@@ -534,7 +571,7 @@ class _PreflightMixin:
                             f"Zero-thickness geometry '{mat_name}' along "
                             f"{axis_name}-axis. On non-uniform mesh this may "
                             f"produce empty rasterization. Consider giving it "
-                            f"at least one cell of thickness ({cell*1e3:.2f}mm).",
+                            f"at least one cell of thickness ({_fmt_len(cell)}).",
                             code="mesh_resolution",
                             source="_validate_mesh_quality",
                         ),
@@ -553,7 +590,7 @@ class _PreflightMixin:
                     )
                     _w.warn(
                         PreflightWarning(
-                            f"'{mat_name}' {axis_name}-extent {dim*1e3:.2f}mm = "
+                            f"'{mat_name}' {axis_name}-extent {_fmt_len(dim)} = "
                             f"{cells_count:.1f} cells — below 1 cell resolution."
                             + hint,
                             code="mesh_resolution",
@@ -578,7 +615,7 @@ class _PreflightMixin:
                             _w.warn(
                                 PreflightWarning(
                                     f"PEC '{mat_name}' {axis_name}-extent "
-                                    f"{dim*1e3:.2f}mm = {cells:.1f} cells — "
+                                    f"{_fmt_len(dim)} = {cells:.1f} cells — "
                                     "volume under-resolved (PEC volume needs "
                                     "≥5 cells; thin sheets <3 cells are fine).",
                                     code="mesh_resolution",
@@ -628,8 +665,8 @@ class _PreflightMixin:
                                     f"dielectric '{mat_name}' on {axis_name}: "
                                     f"{cells_per_lam:.1f} cells per λ_eff "
                                     f"(eps_r={eps_r:.2f}, freq_max="
-                                    f"{self._freq_max/1e9:.2f}GHz, "
-                                    f"dx={cell*1e3:.3f}mm). Need ≥"
+                                    f"{_fmt_freq(self._freq_max)}, "
+                                    f"dx={_fmt_len(cell)}). Need ≥"
                                     f"{threshold:.0f} cells/λ_eff for "
                                     f"phase-accurate propagation."
                                     f"{suffix}",
@@ -655,7 +692,7 @@ class _PreflightMixin:
                                 _w.warn(
                                     PreflightWarning(
                                         f"Gap between PEC structures: "
-                                        f"{gap*1e3:.2f}mm = {gap/cell:.1f} cells "
+                                        f"{_fmt_len(gap)} = {gap/cell:.1f} cells "
                                         f"along {'xyz'[ax]} — coupling may be "
                                         f"under-resolved.",
                                         code="mesh_resolution",
@@ -1694,6 +1731,14 @@ class _PreflightMixin:
             face = f"{ax_name}_{side}"
             if self._boundary not in ("cpml", "upml"):
                 return 0.0
+            if ax_name == "z" and self._mode.startswith("2d"):
+                # 2D modes collapse z to a single cell with NO absorber
+                # (Grid sets pad_z_lo = pad_z_hi = 0 and strips z from
+                # cpml_axes — rfx/grid.py). Without this mirror rule the
+                # z thickness is the full cpml budget and every 2D
+                # source/probe at z=0 false-trips absorber_overlap
+                # (issue #166).
+                return 0.0
             if face in self._pec_faces or face in _pmc_faces_set:
                 return 0.0
             if ax_name in self._periodic_axes:
@@ -1775,7 +1820,7 @@ class _PreflightMixin:
                             PreflightWarning(
                                 f"Probe at {pos} is near/inside {absorber_label} region "
                                 f"({absorber_label} {'xyz'[ax]}-thickness: "
-                                f"lo={ct_lo*1e3:.1f}mm, hi={ct_hi*1e3:.1f}mm). "
+                                f"lo={_fmt_len(ct_lo)}, hi={_fmt_len(ct_hi)}). "
                                 f"Signal will be attenuated. Move probe to interior.",
                                 code="absorber_overlap",
                                 source="_validate_cfg_absorber_placement",
@@ -1796,7 +1841,7 @@ class _PreflightMixin:
                             PreflightWarning(
                                 f"Source/port at {pos} is near/inside {absorber_label} region "
                                 f"({absorber_label} {'xyz'[ax]}-thickness: "
-                                f"lo={ct_lo*1e3:.1f}mm, hi={ct_hi*1e3:.1f}mm). "
+                                f"lo={_fmt_len(ct_lo)}, hi={_fmt_len(ct_hi)}). "
                                 f"Energy will be absorbed. Move source to interior.",
                                 code="absorber_overlap",
                                 source="_validate_cfg_absorber_placement",

--- a/tests/test_preflight_structured_and_guards.py
+++ b/tests/test_preflight_structured_and_guards.py
@@ -337,3 +337,66 @@ def test_run_hard_fails_on_error_severity_and_skip_bypasses():
     with _w.catch_warnings():
         _w.simplefilter("error")  # no preflight warning/raise should fire
         sim.run(n_steps=5, skip_preflight=True)
+
+
+# ------------------------------------------------- issue #166: 2D z + units
+def test_absorber_overlap_no_false_positive_on_2d_collapsed_z():
+    """2D modes collapse z to a single cell with NO absorber (Grid strips z
+    from cpml_axes and sets pad_z=0). Every 2D source/probe necessarily sits
+    at z=0, so the z-axis proximity check must not fire (issue #166: cv03
+    emitted one absorber_overlap line per line-source point)."""
+    sim = Simulation(domain=(16e-6, 9e-6, 1e-7), freq_max=7.5e13, dx=1e-7,
+                     boundary="upml", cpml_layers=20, mode="2d_tmz")
+    # mid-domain in x and y — only the collapsed z coordinate (0) is "near"
+    # the phantom z absorber the old mirror logic assumed.
+    sim.add_source((8e-6, 4.5e-6, 0), component="ez")
+    sim.add_probe((9e-6, 4.5e-6, 0), component="ez")
+    report = sim.preflight()
+    overlap = report.by_code("absorber_overlap")
+    assert not overlap, f"false positive on collapsed z axis: {list(overlap)}"
+
+
+def test_absorber_overlap_still_fires_on_2d_xy():
+    """The 2D-z exemption must not silence real x/y absorber overlap."""
+    sim = Simulation(domain=(16e-6, 9e-6, 1e-7), freq_max=7.5e13, dx=1e-7,
+                     boundary="upml", cpml_layers=20, mode="2d_tmz")
+    sim.add_source((1e-7, 4.5e-6, 0), component="ez")   # deep in x_lo absorber
+    report = sim.preflight()
+    overlap = report.by_code("absorber_overlap")
+    assert overlap, "expected absorber_overlap for a source at the x_lo edge"
+    assert any("x-thickness" in str(i) for i in overlap)
+
+
+def test_unit_adaptive_formatting_helpers():
+    """_fmt_len/_fmt_freq pick units that keep digits visible at any scale
+    (issue #166: fixed mm/GHz rendered 0.1µm as 0.000mm and 74.95THz as
+    74950.00GHz)."""
+    from rfx.api._preflight import _fmt_len, _fmt_freq
+    assert _fmt_len(1e-7) == "100nm"
+    assert _fmt_len(2e-6) == "2µm"
+    assert _fmt_len(0.002) == "2mm"
+    assert _fmt_len(0.02286) == "22.86mm"
+    assert _fmt_len(1.5) == "1.5m"
+    assert _fmt_len(5e-10) == "0.5nm"
+    assert _fmt_len(0.0) == "0mm"
+    assert _fmt_freq(7.495e13) == "74.95THz"
+    assert _fmt_freq(10e9) == "10GHz"
+    assert _fmt_freq(9.322e9) == "9.322GHz"
+    assert _fmt_freq(2.45e6) == "2.45MHz"
+
+
+def test_mesh_warning_uses_adaptive_units_at_optical_scale():
+    """The cv03-class mesh-resolution warning must print THz/µm, not
+    0.000mm / five-digit GHz, at optical scale."""
+    sim = Simulation(domain=(16e-6, 9e-6, 1e-7), freq_max=7.495e13, dx=1e-7,
+                     boundary="upml", cpml_layers=20, mode="2d_tmz")
+    sim.add_material("wg", eps_r=12.0)
+    sim.add(Box((0, 4e-6, 0), (16e-6, 5e-6, 1e-7)), material="wg")
+    sim.add_source((8e-6, 4.5e-6, 0), component="ez")
+    report = sim.preflight()
+    mesh = [str(i) for i in report.by_code("mesh_resolution")
+            if "cells per λ_eff" in str(i)]
+    assert mesh, "expected the cells-per-λ_eff warning at 11.5 cells/λ_eff"
+    assert any("74.95THz" in m for m in mesh), mesh
+    assert any("100nm" in m for m in mesh), mesh
+    assert not any("0.000mm" in m for m in mesh), mesh


### PR DESCRIPTION
## What

Two defects from #166, found during the #160 cv03 session:

**1. `absorber_overlap` false positive on the collapsed z axis in 2D modes.**
`_validate_cfg_compute_cpml_thickness` claims to "mirror `Grid._face_pad`" but missed the 2D rule: `Grid` sets `pad_z_lo = pad_z_hi = 0` and strips z from `cpml_axes` in 2D modes (`rfx/grid.py`), while the preflight mirror assigned the full CPML budget to z — a phantom absorber thicker than the entire one-cell z domain. Every 2D source/probe (necessarily at z=0) tripped the proximity check; cv03 emitted 20 identical spam lines per preflight. The mirror now applies the same 2D-z rule.

**2. Fixed mm/GHz formatting rendered correct optical-scale values as bugs.**
`dx=0.000mm`, `lo=0.0mm, hi=0.0mm`, `freq_max=74950.00GHz` — all correct values (100nm, 2µm, 74.95THz) that prompted a "is this a bug?" review (it briefly misled the #160 session into a zero-thickness-absorber reading). Added `_fmt_len` / `_fmt_freq` unit-adaptive helpers, applied to the scale-sensitive messages (mesh-resolution family + absorber placement). RF-lane messages (NTFF/MSL/ports) keep mm/GHz — correct at their scale — and can migrate incrementally.

## Verification

- 4 new gates in `tests/test_preflight_structured_and_guards.py`: 2D-z no false positive, 2D x/y still fires, formatter unit table, optical-scale mesh-warning text (THz/nm present, `0.000mm` absent).
- Guard suite 22 passed; affected slices (`preflight_physics_thresholds`, `mesh_intelligence_report`, `inverse_design_preflight`, `waveguide_port_spectrum_guard`, `preflight_false_positives`, `preflight_thin_metal_nu`) 32 passed.
- 3D z-proximity behaviour regression-locked by the existing `test_codes_set_at_check_site` (source at z=0.018/0.02 still warns).
- cv03-shape repro: `absorber_overlap` count 20 → 0; message now `freq_max=74.95THz, dx=100nm`.
- Contract tests assert on codes/substrings, not number formatting — no text-matching fallout.

Independent of PR #165 (branched off main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)