### PR TITLE
fix(ci): crossval-external lane errexit defeated exit-code classification + cv02 Meep-path NameError

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -93,6 +93,13 @@ jobs:
       - name: Run external-reference crossval scripts (per-script exit codes)
         run: |
           set -uo pipefail
+          # The job default shell is `bash -el` — the -e (errexit) survives
+          # `set -uo pipefail`, so any nonzero script exit killed the step
+          # BEFORE the `code=$?` classification below could run. That defeats
+          # the whole W2.5 design (exit 2 = visible SKIP, exit 1 = red with
+          # a per-script verdict table). Disable errexit explicitly; this
+          # loop classifies every exit code itself and sets `fail`.
+          set +e
           mkdir -p crossval_logs
           export PYTHONPATH="$PWD"
           export MPLBACKEND=Agg

--- a/examples/crossval/02_ring_resonator.py
+++ b/examples/crossval/02_ring_resonator.py
@@ -125,6 +125,10 @@ if HAVE_MEEP:
 
     print("\n  Meep Harminv results:")
     print(f"  {'freq':>10} {'Q':>10} {'amp':>12}")
+    # NOTE: the [] init must live on THIS branch too — it used to exist only
+    # in the Meep-missing except branch, so the first lane run with a real
+    # conda-forge Meep died here with NameError (2026-06-12, run 27392475256).
+    meep_modes = []
     for m in h.modes:
         meep_modes.append(m)
         print(f"  {m.freq:>10.6f} {m.Q:>10.1f} {abs(m.amp):>12.6f}")


### PR DESCRIPTION
## Context

Dispatched the `crossval-external` lane on the PR #165 branch to get the Meep cross-verdict for the cv03 fix (#160). The run (27392475256) was the lane's **first real execution with a working conda-forge Meep**, and it failed before reaching cv03 — exposing two latent defects, both unrelated to #165's change:

## 1. Lane shell: errexit defeats the W2.5 exit-code design

The job default shell is `bash -el`; `-e` survives the step's `set -uo pipefail`, so the first nonzero script exit aborted the step **before** `code=$?` could classify it. Consequences: no exit-2 SKIP rows, no per-script verdict table, all later scripts skipped silently. In run 27392475256 the step died 2 seconds into script 2 of 6. Fixed with an explicit `set +e` (the loop classifies every exit itself and sets `fail`).

## 2. cv02: `meep_modes` initialized only in the Meep-MISSING branch

`meep_modes = []` lived in the `except` (reference-missing) branch, so the first run ever to actually import Meep crashed with `NameError` at the Harminv result loop — the exact failure in run 27392475256's log artifact. Init added to the Meep-present path.

## Verification

- `bash -elc 'set -uo pipefail; set +e; false; code=$?; ...'` → classification reachable, code=1.
- YAML parses; cv02 local run (Meep absent): exit 2, rfx self-check PASS — except-path behaviour unchanged.
- 01/04 audited for the same except-branch-only init pattern: clean (01 already passed with real Meep in the failed run).
- Real-Meep verdict: will re-dispatch the lane after merge (also unblocks the #165 cv03 cross-gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)