### PR TITLE
fix(msl): NaN gradient in extract_msl_nprobe β refinement at tiny field scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — MSL N-probe extractor NaN gradient at tiny field scales (2026-06-12)
+
+- `extract_msl_nprobe`'s β-refinement (`_estimate_beta`) produced `nan`
+  gradients when the plane-integrated probe voltages were very small
+  (|V| ~ 1e-14, measured on the density-PEC/Kottke forward path): the
+  float32 residual curve over the β scan went numerically flat, the
+  parabolic second-difference collapsed below its 1e-20 guard, and the
+  **single-where** division guard leaked `0 * nan = nan` through the
+  backward pass — the exact trap class the module's `_solve_q`
+  custom-JVP comment documents, reintroduced by the lstsq rewrite.
+  Forward values were always finite (the failure was invisible to
+  value-level checks and to unit-scale AD tests — composition-level
+  only). Fixed with the double-where idiom plus scale-normalizing the
+  β-estimate input (`v/max|v|`; α/γ/Z0 keep absolute scale via the raw
+  final lstsq). Found by the msl_stub G2 re-run (VESSL 369367242390:
+  Adam grad=nan from iter 0 while the 17-point brute scan stayed
+  finite). Regression-locked by
+  `test_nprobe_grad_finite_and_scale_invariant_at_tiny_v` (fails on the
+  old code; locks finiteness at scale 1e-14 + scale-invariance + FD
+  match).
+
 ### Fixed — cv03 flux-region congruence (issue #160, 2026-06-12)
 
 - `examples/crossval/03_straight_waveguide_flux.py`: the rfx flux monitors

--- a/rfx/probes/msl_wave_decomp.py
+++ b/rfx/probes/msl_wave_decomp.py
@@ -426,8 +426,20 @@ def _estimate_beta(
     hi = beta0 * (1.0 + _BETA_SCAN_FRAC)
     grid = jnp.linspace(lo, hi, _BETA_SCAN_NODES)
 
+    # Scale-normalize the probe vector for the β estimate.  β is
+    # scale-invariant, but the residuals below scale with ‖v‖: on the
+    # Kottke density-PEC path the plane-integrated V can be ~1e-14
+    # (2026-06-12 G2 NaN session), which makes the residual curve
+    # numerically flat in float32 and collapses the parabolic
+    # second-difference `denom` to ~1e-21 — far below the 1e-20 guard
+    # the threshold was designed around.  Normalizing restores the
+    # threshold's meaning.  (α/γ/Z0 keep absolute scale — the final
+    # lstsq in `extract_msl_nprobe` runs on the RAW v.)
+    v_scale = jnp.max(jnp.abs(v))
+    v_n = v / jnp.where(v_scale > 0.0, v_scale, 1.0)
+
     def _resid(b):
-        _, _, r = _lstsq_alpha_gamma(v, x, b.astype(jnp.complex64))
+        _, _, r = _lstsq_alpha_gamma(v_n, x, b.astype(jnp.complex64))
         return r
 
     resids = jax.vmap(_resid)(grid)
@@ -437,9 +449,19 @@ def _estimate_beta(
     b_lo, b_mid, _ = grid[k - 1], grid[k], grid[k + 1]
     r_lo, r_mid, r_hi = resids[k - 1], resids[k], resids[k + 1]
     # Parabolic vertex offset (in grid-step units), clamped to [-1, 1].
+    # Double-where idiom: the single-where form computed `num / denom`
+    # in the untaken branch, and when catastrophic cancellation drives
+    # denom to ~0 the untaken branch's backward pass produces inf/nan
+    # that `0 * nan = nan` leaks through the mask (the exact trap class
+    # the _solve_q custom-JVP comment above documents; reintroduced
+    # here by the lstsq rewrite and caught 2026-06-12 as the G2
+    # grad=nan).  `safe_denom` keeps the untaken branch finite in both
+    # the primal and the cotangent.
     denom = (r_lo - 2.0 * r_mid + r_hi)
     num = 0.5 * (r_lo - r_hi)
-    frac = jnp.where(jnp.abs(denom) > 1e-20, num / denom, 0.0)
+    ok = jnp.abs(denom) > 1e-20
+    safe_denom = jnp.where(ok, denom, 1.0)
+    frac = jnp.where(ok, num / safe_denom, 0.0)
     frac = jnp.clip(frac, -1.0, 1.0)
     step = b_mid - b_lo
     return (b_mid + frac * step).astype(jnp.complex64)

--- a/scripts/diagnostics/msl_g2_nan/grad_probe.py
+++ b/scripts/diagnostics/msl_g2_nan/grad_probe.py
@@ -1,0 +1,119 @@
+"""G2 NaN-grad triage probe (2026-06-12, VESSL run 369367242390).
+
+Reproduces ONLY iter-0 value_and_grad of msl_stub_notch_tuning at
+L=9.5mm, with toggles to localize the NaN:
+
+  RFX_PEC_OCC_KOTTKE=0|1   (set outside)  Kottke vs legacy occupancy
+  PROBE_CKPT=seg|plain     segmented checkpointing vs checkpoint=True
+  PROBE_PERIODS=<float>    NUM_PERIODS (default 4 for cheap CPU triage)
+  PROBE_GRAD=1|0           0 = forward value only
+
+Observed on GPU (full config): value finite (8.59e-3), grad nan.
+"""
+
+import importlib.util
+import math
+import os
+import sys
+import time
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+
+REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+EX = os.path.join(REPO, "examples", "inverse_design", "msl_stub_notch_tuning.py")
+spec = importlib.util.spec_from_file_location("msl_demo", EX)
+m = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(m)
+
+from rfx.probes.msl_wave_decomp import _v_from_plane, _i_from_plane, extract_msl_nprobe  # noqa: E402
+
+PERIODS = float(os.environ.get("PROBE_PERIODS", 4.0))
+CKPT = os.environ.get("PROBE_CKPT", "seg")
+DO_GRAD = os.environ.get("PROBE_GRAD", "1") not in ("0", "false")
+
+f_target_arr = jnp.asarray([m.F_TARGET], dtype=jnp.float32)
+sim, y_trace, trace_y_hi, d_set, p_set = m.build_sim(f_target_arr)
+grid = sim._build_grid()
+
+period = 1.0 / float(sim._freq_max)
+n_raw = int(math.ceil(PERIODS * period / float(grid.dt)))
+K = max(8, int(math.isqrt(n_raw)))
+n_steps = ((n_raw + K - 1) // K) * K
+ck_kwargs = {"checkpoint_segments": K} if CKPT == "seg" else {}
+print(f"[probe] kottke={os.environ.get('RFX_PEC_OCC_KOTTKE','0')} ckpt={CKPT} "
+      f"periods={PERIODS} n_steps={n_steps} (K={K}) grad={DO_GRAD}", flush=True)
+
+
+def s21_at_f_target(L_stub):
+    occ = m.build_stub_occ(grid, trace_y_hi, L_stub)
+    fr = sim.forward(pec_occupancy_override=occ, n_steps=n_steps,
+                     skip_preflight=True, **ck_kwargs)
+    freqs_arr = f_target_arr
+    beta0 = (2.0 * jnp.pi * freqs_arr * jnp.sqrt(jnp.asarray(m.EPS_EFF, dtype=jnp.float32))
+             / jnp.asarray(m.C0, dtype=jnp.float32))
+    x_probes = jnp.array([0.0, d_set.delta, 2.0 * d_set.delta], dtype=jnp.float32)
+    v_d = jnp.stack([_v_from_plane(fr, d_set.ez1_name, d_set),
+                     _v_from_plane(fr, d_set.ez2_name, d_set),
+                     _v_from_plane(fr, d_set.ez3_name, d_set)], axis=-1)
+    i1_d = _i_from_plane(fr, d_set.hy_name, d_set)
+    v_p = jnp.stack([_v_from_plane(fr, p_set.ez1_name, p_set),
+                     _v_from_plane(fr, p_set.ez2_name, p_set),
+                     _v_from_plane(fr, p_set.ez3_name, p_set)], axis=-1)
+    i1_p = _i_from_plane(fr, p_set.hy_name, p_set)
+    res_d = extract_msl_nprobe(v_d, x_probes, i1_d, beta0)
+    res_p = extract_msl_nprobe(v_p, x_probes, i1_p, beta0)
+    s21 = res_p["alpha"] / (res_d["alpha"] + 1e-30)
+    return s21[0]
+
+
+TARGET = os.environ.get("PROBE_TARGET", "cost")
+
+
+def _intermediates(L_stub):
+    occ = m.build_stub_occ(grid, trace_y_hi, L_stub)
+    fr = sim.forward(pec_occupancy_override=occ, n_steps=n_steps,
+                     skip_preflight=True, **ck_kwargs)
+    freqs_arr = f_target_arr
+    beta0 = (2.0 * jnp.pi * freqs_arr * jnp.sqrt(jnp.asarray(m.EPS_EFF, dtype=jnp.float32))
+             / jnp.asarray(m.C0, dtype=jnp.float32))
+    x_probes = jnp.array([0.0, d_set.delta, 2.0 * d_set.delta], dtype=jnp.float32)
+    v_d = jnp.stack([_v_from_plane(fr, d_set.ez1_name, d_set),
+                     _v_from_plane(fr, d_set.ez2_name, d_set),
+                     _v_from_plane(fr, d_set.ez3_name, d_set)], axis=-1)
+    i1_d = _i_from_plane(fr, d_set.hy_name, d_set)
+    return v_d, i1_d, x_probes, beta0
+
+
+def cost(L_stub):
+    if TARGET == "cost":
+        return jnp.abs(s21_at_f_target(L_stub)) ** 2
+    v_d, i1_d, x_probes, beta0 = _intermediates(L_stub)
+    if TARGET == "v_plane":
+        # Chain cut BEFORE the extractor: plane-integrated V magnitude.
+        return jnp.sum(jnp.abs(v_d) ** 2)
+    if TARGET == "alpha_fixedbeta":
+        # Extractor WITHOUT the beta scan: single lstsq at analytic beta0.
+        from rfx.probes.msl_wave_decomp import _lstsq_alpha_gamma
+        a, _, _ = _lstsq_alpha_gamma(v_d[0], x_probes,
+                                     beta0[0].astype(jnp.complex64))
+        return jnp.abs(a) ** 2
+    if TARGET == "alpha_d":
+        # Full extractor (beta scan + refine + lstsq), driven port only.
+        res_d = extract_msl_nprobe(v_d, x_probes, i1_d, beta0)
+        return jnp.abs(res_d["alpha"][0]) ** 2
+    raise SystemExit(f"unknown PROBE_TARGET={TARGET}")
+
+
+L0 = jnp.asarray(9.5e-3, dtype=jnp.float32)
+t0 = time.time()
+if DO_GRAD:
+    val, g = jax.value_and_grad(cost)(L0)
+    print(f"[probe] value={float(val):.6e}  grad={float(g):+.6e}  "
+          f"({time.time()-t0:.0f}s)", flush=True)
+    sys.exit(2 if not np.isfinite(float(g)) else 0)
+else:
+    val = cost(L0)
+    print(f"[probe] value={float(val):.6e}  ({time.time()-t0:.0f}s)", flush=True)
+    sys.exit(2 if not np.isfinite(float(val)) else 0)

--- a/tests/test_msl_wave_decomp_jvp.py
+++ b/tests/test_msl_wave_decomp_jvp.py
@@ -108,3 +108,52 @@ def test_solve_q_jvp_w_r_t_v3():
     assert jnp.allclose(fd, ad, atol=2e-3, rtol=1e-2), (
         f"FD={fd}  AD={ad}  diff={fd - ad}"
     )
+
+
+# ---------------------------------------------------------------- issue: G2 NaN
+def _nprobe_cost(g, scale):
+    """|S11| from extract_msl_nprobe for a synthetic 2-wave field whose
+    backward amplitude is parameterized by the real latent ``g``."""
+    from rfx.probes.msl_wave_decomp import extract_msl_nprobe
+    delta = 381e-6
+    x = jnp.array([0.0, delta, 2.0 * delta], dtype=jnp.float32)
+    beta_true = jnp.asarray(213.0, dtype=jnp.float32)   # ~6 GHz MSL class
+    alpha = scale * jnp.asarray(1.0 + 0.2j, dtype=jnp.complex64)
+    gamma = scale * g * jnp.asarray(0.3 + 0.1j, dtype=jnp.complex64)
+    ph = (beta_true * x).astype(jnp.complex64)
+    v = (alpha * jnp.exp(-1j * ph) + gamma * jnp.exp(+1j * ph))[None, :]
+    i1 = jnp.asarray([scale / 50.0 + 0j], dtype=jnp.complex64)
+    res = extract_msl_nprobe(v, x, i1, beta_true[None])
+    return jnp.abs(res["s11"][0])
+
+
+def test_nprobe_grad_finite_and_scale_invariant_at_tiny_v():
+    """2026-06-12 G2 regression lock (grad=nan on the Kottke path).
+
+    With |V| ~ 1e-14 (measured on the density-PEC/Kottke path) the
+    beta-scan residual curve is numerically flat in float32; the
+    parabolic second-difference collapses below the 1e-20 guard and the
+    OLD single-where division leaked nan through the backward pass
+    (0 * nan = nan).  Lock three properties:
+
+      1. grad is finite at scale 1e-14 (was nan),
+      2. grad matches the scale=1.0 grad (s11 and d|s11|/dg are
+         scale-invariant by construction),
+      3. grad matches central finite differences.
+    """
+    g0 = 0.7
+
+    grad_tiny = jax.grad(_nprobe_cost)(g0, 1e-14)
+    assert jnp.isfinite(grad_tiny), f"grad at scale 1e-14 is {grad_tiny}"
+
+    grad_unit = jax.grad(_nprobe_cost)(g0, 1.0)
+    assert jnp.isfinite(grad_unit)
+    assert jnp.allclose(grad_tiny, grad_unit, rtol=5e-2), (
+        f"scale invariance broken: tiny={grad_tiny} unit={grad_unit}"
+    )
+
+    h = 1e-3
+    fd = (_nprobe_cost(g0 + h, 1.0) - _nprobe_cost(g0 - h, 1.0)) / (2 * h)
+    assert jnp.allclose(grad_unit, fd, rtol=2e-2, atol=1e-4), (
+        f"AD={grad_unit} FD={fd}"
+    )


### PR DESCRIPTION
## Symptom

First full execution of the WI-3-rewired msl_stub composition (VESSL G2 re-run 369367242390, `RFX_Y2B_SCAN=17`): **Adam `grad=nan` from iter 0**, while the 17-point brute scan — same JAX extractor, forward-only — stayed finite and found a clean convex minimum at L_ref=7.000 mm (-45.9 dB). Forward values finite everywhere; the failure is gradient-only and composition-only (all 17 MSL AD unit gates were green throughout).

## Localization (CPU repro, measured)

| probe (periods=10, Kottke=1) | grad |
|---|---|
| plane-V only (no extractor) | finite |
| single lstsq at analytic β (no scan) | finite |
| full extractor with β scan | **nan** |
| full cost, Kottke OFF | finite |

Confirmation probe: plane-integrated |V| ≈ 1.6e-14 on the Kottke path; β-scan residuals 1.574e-16–1.849e-16 over 41 nodes (spread 2.7e-18) — numerically flat in float32. The parabolic second-difference `denom = r_lo − 2r_mid + r_hi` collapses below its `1e-20` guard, and the **single-where** division `where(|denom|>1e-20, num/denom, 0)` leaks `0·nan = nan` through the backward pass — the exact trap class documented at `_solve_q`'s custom JVP, reintroduced by the lstsq rewrite. Length/config dependence (periods=4 finite, Kottke-off finite) is just the V-scale crossing the collapse threshold.

## Fix

- Double-where idiom (`safe_denom`) in `_estimate_beta`.
- Scale-normalize the β-estimate input (`v/max|v|`) — β is scale-invariant, and normalization restores the meaning of the 1e-20 threshold. α/γ/Z0 keep absolute scale (final lstsq runs on raw `v`).

## Verification

- New regression `test_nprobe_grad_finite_and_scale_invariant_at_tiny_v`: **fails on old code**, passes on fix; locks grad finiteness at scale 1e-14 + scale-invariance vs unit scale + FD match.
- Original failing composition: grad −137.2 finite (value unchanged 8.632e-3); `alpha_d` chain probe finite.
- MSL AD gates: 18 passed (`test_msl_sparam_ad`, `test_msl_ad_fd_converged`, `test_msl_wave_decomp_jvp`, `test_kottke_inv_eps_from_occupancy`).
- Diagnostic driver committed: `scripts/diagnostics/msl_g2_nan/grad_probe.py`.

Falsifier: VESSL G2 re-run (N_SCAN=17) will be re-dispatched on this branch — G2 gate (Adam L_opt ≈ brute L_ref ≤1%) is the end-to-end verdict.

Open follow-up (separate): WHY the Kottke path's plane-V absolute scale is ~1e-14 (ratios are consistent, so forward physics is self-consistent; absolute calibration deserves one look).

🤖 Generated with [Claude Code](https://claude.com/claude-code)