### PR TITLE
fix(waveguide): normalize='flux' S-matrix extraction joins the AD tape (fixes #148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — normalize='flux' waveguide S-matrix joins the AD tape (issue #148, 2026-06-12)
+
+- `extract_waveguide_s_matrix_flux` is now jnp-native end to end: the
+  `np.array(flux_spectrum(...))` concretizations and the in-place numpy
+  S-matrix assembly are gone, so
+  `compute_waveguide_s_matrix(normalize='flux', eps_override=<traced>)`
+  works under `jax.grad` (previously: `TracerArrayConversionError`) —
+  design loops can optimize directly through the production-recommended
+  power-flux extraction instead of the normalize=False-then-validate
+  workaround.
+- The rewrite adds double-where guards at the two genuine gradient
+  singularities (sqrt of a zero power ratio at a perfect match/null,
+  angle of a zero modal ratio); primal values are preserved exactly.
+- Forward regression: S-matrix unchanged vs the numpy path within the
+  float-reassociation envelope (measured max|diff| 1.1e-7 on the WR-90
+  fixture). New CI gates in `tests/test_waveguide_flux_ad.py`
+  (composition-level grad finite + central-FD agreement ≤5% + forward
+  no-op-override equivalence); support matrix `ad_evidence` updated.
+
 ### Fixed — MSL N-probe extractor NaN gradient at tiny field scales (2026-06-12)
 
 - `extract_msl_nprobe`'s β-refinement (`_estimate_beta`) produced `nan`

--- a/docs/agent/recipe-design-loop.mdx
+++ b/docs/agent/recipe-design-loop.mdx
@@ -23,9 +23,12 @@ design today.
    `ad_evidence`. Two verified nuances:
    - Coaxial is `no` — `compute_coaxial_line_reflection` breaks the tape
      by construction (numpy matrix-pencil).
-   - Waveguide `yes` covers the default extraction (`normalize=False`);
-     `normalize='flux'` breaks the tape
-     ([#148](https://github.com/bk-squared/rfx/issues/148)).
+   - Waveguide `yes` covers BOTH the default extraction
+     (`normalize=False`) and, since the
+     [#148](https://github.com/bk-squared/rfx/issues/148) fix, the
+     power-flux extraction (`normalize='flux'`) — you can now optimize
+     directly through the production-recommended flux path
+     (evidence: `tests/test_waveguide_flux_ad.py`).
 3. **Pick the design lane.**
 4. **Validate the final design — never ship the loss number alone.**
 

--- a/docs/guides/sparameter_support_matrix.json
+++ b/docs/guides/sparameter_support_matrix.json
@@ -249,7 +249,7 @@
         "broad nonuniform waveguide S-parameters remain shadow/blocked"
       ],
       "ad_traceable": "yes",
-      "ad_evidence": "tests/test_sparam_ad_end_to_end.py::test_waveguide_s_matrix_ad_end_to_end, tests/test_waveguide_sparam_ad.py::test_wg_smatrix_assembly_ad_traceable"
+      "ad_evidence": "tests/test_sparam_ad_end_to_end.py::test_waveguide_s_matrix_ad_end_to_end, tests/test_waveguide_sparam_ad.py::test_wg_smatrix_assembly_ad_traceable (normalize=False V/I path); tests/test_waveguide_flux_ad.py::test_flux_smatrix_grad_finite_and_fd_consistent (normalize='flux' power-flux path, issue #148 — previously raised TracerArrayConversionError)"
     },
     {
       "primitive": "add_coaxial_port(...)",

--- a/rfx/sources/waveguide_port.py
+++ b/rfx/sources/waveguide_port.py
@@ -2238,9 +2238,11 @@ def extract_waveguide_s_matrix_flux(
 
     template_cfgs = tuple(port_cfgs)
     n_ports = len(template_cfgs)
-    n_freqs = len(template_cfgs[0].freqs)
     freqs = template_cfgs[0].freqs
-    s_matrix = np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex64)
+    # jnp-native assembly (issue #148): columns are collected per drive
+    # port and stacked at the end — no in-place np mutation, so traced
+    # values flow through to the returned S-matrix.
+    s_columns: list = []
 
     def _reset_cfg(cfg: WaveguidePortConfig, drive_enabled: bool) -> WaveguidePortConfig:
         zeros_t = jnp.zeros_like(cfg.v_probe_t)
@@ -2309,9 +2311,12 @@ def extract_waveguide_s_matrix_flux(
 
         # Incident power: signed flux at driven port in the reference guide.
         # |F_ref| = P_inc regardless of port direction (+x vs −x).
-        F_ref_drive = np.array(flux_spectrum(ref_final_mons[drive_idx]))  # (n_freqs,)
-        P_inc = np.abs(F_ref_drive)
-        safe_P_inc = np.where(P_inc > 1e-60, P_inc, np.ones_like(P_inc))
+        # jnp-native (issue #148): no np.array() concretization — keeps
+        # the whole flux extraction on the AD tape for
+        # eps_override-traced gradients.
+        F_ref_drive = flux_spectrum(ref_final_mons[drive_idx])  # (n_freqs,)
+        P_inc = jnp.abs(F_ref_drive)
+        safe_P_inc = jnp.where(P_inc > 1e-60, P_inc, jnp.ones_like(P_inc))
 
         # Modal incident wave (reference run) — used to determine phase reference
         a_inc_ref, _ = extract_waveguide_port_waves(
@@ -2340,29 +2345,45 @@ def extract_waveguide_s_matrix_flux(
         if len(dev_final_cfgs) != n_ports:
             raise RuntimeError("waveguide S-matrix extraction expected one final config per port")
 
-        F_dev_drive = np.array(flux_spectrum(dev_final_mons[drive_idx]))
+        F_dev_drive = flux_spectrum(dev_final_mons[drive_idx])
 
+        col_entries = []
         for recv_idx, dev_cfg in enumerate(dev_final_cfgs):
             # Phase from modal V/I decomposition of device run
             _, b_recv_dev = extract_waveguide_port_waves(
                 dev_cfg, ref_shift=ref_shifts[recv_idx]
             )
             safe_a = jnp.where(jnp.abs(a_inc_ref) > 1e-60, a_inc_ref, jnp.ones_like(a_inc_ref))
-            phase = np.angle(np.array(b_recv_dev / safe_a))
+            # AD-safe angle (double-where): angle() has an undefined
+            # gradient at 0; angle(1)=0 matches np.angle(0)=0 so the
+            # primal is unchanged.
+            ratio = b_recv_dev / safe_a
+            ratio_ok = jnp.abs(ratio) > 0.0
+            phase = jnp.angle(jnp.where(ratio_ok, ratio, jnp.ones_like(ratio)))
 
             if recv_idx == drive_idx:
                 # Reflection: ref_flux − dev_flux = power that turned around
-                P_refl = np.abs(F_ref_drive - F_dev_drive)
-                mag = np.sqrt(P_refl / safe_P_inc)
+                P_num = jnp.abs(F_ref_drive - F_dev_drive)
             else:
                 # Transmission: net flux through receiving port's probe plane
-                F_dev_recv = np.array(flux_spectrum(dev_final_mons[recv_idx]))
-                P_trans = np.abs(F_dev_recv)
-                mag = np.sqrt(P_trans / safe_P_inc)
+                P_num = jnp.abs(flux_spectrum(dev_final_mons[recv_idx]))
+            # AD-safe sqrt (double-where): a perfect match/null makes the
+            # power ratio exactly 0, where d(sqrt)/dx = inf would leak
+            # 0*inf=nan through the backward pass; primal stays exactly
+            # sqrt(x) for x>0 and exactly 0 at x=0.
+            p_ratio = P_num / safe_P_inc
+            p_ok = p_ratio > 0.0
+            mag = jnp.where(
+                p_ok, jnp.sqrt(jnp.where(p_ok, p_ratio, jnp.ones_like(p_ratio))), 0.0
+            )
 
-            s_matrix[recv_idx, drive_idx, :] = mag * np.exp(1j * phase)
+            col_entries.append((mag * jnp.exp(1j * phase)).astype(jnp.complex64))
 
-    return jnp.asarray(s_matrix)
+        # (n_ports, n_freqs) column for this drive port
+        s_columns.append(jnp.stack(col_entries, axis=0))
+
+    # Stack drive columns on axis 1 -> (recv, drive, n_freqs)
+    return jnp.stack(s_columns, axis=1)
 
 
 def extract_waveguide_s_params_normalized(

--- a/tests/test_waveguide_flux_ad.py
+++ b/tests/test_waveguide_flux_ad.py
@@ -1,0 +1,108 @@
+"""Issue #148: ``normalize='flux'`` waveguide S-matrix on the AD tape.
+
+Before the fix, ``extract_waveguide_s_matrix_flux`` concretized traced
+arrays (``np.array(flux_spectrum(...))`` at the old waveguide_port.py:2307
+plus np in-place S-matrix assembly), so
+``compute_waveguide_s_matrix(normalize='flux', eps_override=<traced>)``
+under ``jax.grad`` raised ``TracerArrayConversionError`` — the
+production-recommended power-flux path was the one extraction that
+could NOT be optimized through.
+
+Gates here (composition-level, per the G2 lesson: unit AD tests do not
+protect compositions):
+  1. grad(|S21(f0)|^2) w.r.t. a substrate-eps scalar through the FULL
+     flux extraction is finite (was: raise).
+  2. AD matches central finite differences.
+  3. Forward S-matrix is unchanged vs the pre-fix path (regression for
+     the np->jnp rewrite; tolerance covers float reassociation only).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import jax
+import jax.numpy as jnp
+
+from rfx import Simulation
+from rfx.boundaries.spec import BoundarySpec, Boundary
+
+NUM_PERIODS = 8.0
+
+
+def _wr90_sim():
+    sim = Simulation(
+        freq_max=10e9,
+        domain=(0.12, 0.04, 0.02),
+        dx=0.003,
+        boundary=BoundarySpec(
+            x="cpml",
+            y=Boundary(lo="pec", hi="pec"),
+            z=Boundary(lo="pec", hi="pec"),
+        ),
+        cpml_layers=8,
+    )
+    freqs = jnp.linspace(5e9, 6.5e9, 4)
+    sim.add_waveguide_port(0.010, direction="+x", mode=(1, 0), mode_type="TE",
+                           freqs=freqs, f0=6e9, bandwidth=0.5, name="left")
+    sim.add_waveguide_port(0.090, direction="-x", mode=(1, 0), mode_type="TE",
+                           freqs=freqs, f0=6e9, bandwidth=0.5, name="right")
+    return sim
+
+
+def _eps_override_for(sim, deps):
+    """Uniform-eps grid override 1.0 + deps in a slab mid-guide (traced)."""
+    grid = sim._build_grid()
+    eps = jnp.ones(grid.shape, dtype=jnp.float32)
+    # slab x in [0.054, 0.066] m -> a 4-cell perturbation region
+    i_lo = grid.position_to_index((0.054, 0.0, 0.0))[0]
+    i_hi = grid.position_to_index((0.066, 0.0, 0.0))[0]
+    return eps.at[i_lo:i_hi, :, :].add(deps)
+
+
+def _s21_mag2(deps):
+    sim = _wr90_sim()
+    eps = _eps_override_for(sim, deps)
+    res = sim.compute_waveguide_s_matrix(
+        num_periods=NUM_PERIODS, normalize="flux", eps_override=eps,
+    )
+    # |S21|^2 at the band-center bin (index 2 of the 4-point grid)
+    return jnp.abs(res.s_params[1, 0, 2]) ** 2
+
+
+def test_flux_smatrix_grad_finite_and_fd_consistent():
+    """Gates 1+2: traced flux extraction yields a finite, FD-consistent grad."""
+    deps0 = jnp.asarray(0.5, dtype=jnp.float32)
+    val, g = jax.value_and_grad(_s21_mag2)(deps0)
+    assert np.isfinite(float(val))
+    assert np.isfinite(float(g)), f"grad is {g}"
+
+    h = 0.05
+    fd = (float(_s21_mag2(deps0 + h)) - float(_s21_mag2(deps0 - h))) / (2 * h)
+    assert fd != 0.0, "FD slope is zero — fixture has no sensitivity; rebuild it"
+    rel = abs(float(g) - fd) / max(abs(fd), 1e-12)
+    assert rel <= 0.05, (
+        f"AD={float(g):+.6e} vs FD={fd:+.6e} (rel diff {rel:.3f} > 5%)"
+    )
+
+
+def test_flux_smatrix_forward_matches_untraced():
+    """Gate 3: the jnp rewrite did not change forward values — the traced
+    and untraced (no eps_override) paths share the assembly, so compare
+    normalize='flux' against itself with a no-op override."""
+    sim_a = _wr90_sim()
+    res_a = sim_a.compute_waveguide_s_matrix(num_periods=NUM_PERIODS,
+                                             normalize="flux")
+    sim_b = _wr90_sim()
+    eps = _eps_override_for(sim_b, jnp.asarray(0.0, dtype=jnp.float32))
+    res_b = sim_b.compute_waveguide_s_matrix(num_periods=NUM_PERIODS,
+                                             normalize="flux",
+                                             eps_override=eps)
+    sa = np.asarray(res_a.s_params)
+    sb = np.asarray(res_b.s_params)
+    assert np.all(np.isfinite(sa)) and np.all(np.isfinite(sb))
+    np.testing.assert_allclose(sb, sa, rtol=1e-5, atol=1e-7)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q"])


### PR DESCRIPTION
## What

`extract_waveguide_s_matrix_flux` broke the AD tape (`np.array` on tracer at the old waveguide_port.py:2307 + in-place numpy S-matrix assembly), so the production-recommended power-flux extraction couldn't be optimized through — design loops had to optimize `normalize=False` and validate flux outside the tape (documented workaround in recipe-design-loop). This implements the issue's option (a): jnp-native flux extraction.

## How

- Flux spectra stay traced end to end; per-drive S-matrix columns are collected and `jnp.stack`ed (no in-place mutation).
- Double-where guards at the two genuine gradient singularities: `sqrt` of a zero power ratio (perfect match/null) and `angle` of a zero modal ratio — same catalog idiom as the G2 NaN fix (6efcba9). Primals preserved exactly (`angle(1)=0` matches `np.angle(0)=0`; `sqrt` branch untaken at exactly 0).

## Verification

- **Forward regression**: stash-baseline captured BEFORE the rewrite on the WR-90 2-port fixture; post-rewrite max|diff| = **1.075e-7** (float32 reassociation envelope, max|S| 0.571).
- **New composition-level CI gates** (`tests/test_waveguide_flux_ad.py`): `jax.grad(|S21(f0)|²)` w.r.t. a traced `eps_override` slab — finite (was: raise) + central-FD agreement ≤5% + no-op-override forward equivalence (rtol 1e-5).
- Affected suites: `test_normalize_flux` (incl. PEC-short |S11|≥0.99 physics gate), `test_waveguide_nu_flux`, `test_waveguide_smatrix_checkpoint` — **12 passed** total.
- Docs: support-matrix `ad_evidence` extended for the flux path; `recipe-design-loop.mdx` Lane-B caveat replaced (flux now directly optimizable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)