### PR TITLE
chore(crossval): external openEMS lane on-demand, not monthly (free lab cluster)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The recommended starting point is the **uniform Cartesian Yee RF/FDTD lane**. No
 - **Periodic × CPML correctness (v1.6.3)**: `set_periodic_axes("xy")` + `boundary="cpml"` only allocates CPML on non-periodic faces. Required for normal-incidence absorber / FSS / RIS setups.
 - **Current practical anchors**: `examples/crossval/05_patch_antenna.py` for the patch cross-check and `examples/nonuniform_patch_demo.py` for a quick repo-local thin-substrate demo.
 - **Curated star-import surface (current `main`)**: `rfx.__all__` exposes the supported public API (176 names); per-step kernels and internal bookkeeping stay importable for back-compat but are no longer part of the star-import surface.
-- **Maintained validation lanes (current `main`)**: a full-suite PR gate (4-shard fast suite + API-reference drift gate + agent-docs hygiene), a maintained GPU suite harness (`scripts/vessl_gpu_suite.yaml`), a weekly external-crossval CI lane with real Meep, and a monthly source-built-OpenEMS lane — all using the honest exit-code convention (reference-missing is a visible SKIP, never a silent pass).
+- **Maintained validation lanes (current `main`)**: a full-suite PR gate (4-shard fast suite + API-reference drift gate + agent-docs hygiene), a maintained GPU suite harness (`scripts/vessl_gpu_suite.yaml`), a weekly external-crossval CI lane with real Meep, and an on-demand source-built-OpenEMS lane (run per release) — all using the honest exit-code convention (reference-missing is a visible SKIP, never a silent pass).
 - **Public docs separate lanes**: start with the uniform Yee RF lane; treat advanced features as experimental unless a guide or support matrix gives a narrower claims-bearing envelope.
 
 ## Installation

--- a/examples/crossval/05_patch_antenna.py
+++ b/examples/crossval/05_patch_antenna.py
@@ -775,5 +775,5 @@ if json_out:
 # 2 = external reference missing). The ref-missing path already exited 2 above
 # (CSXCAD/openEMS unavailable); a reference-present run must surface a genuine
 # failure as exit 1 — without this, a real cv05 FAIL falls through to implicit
-# exit 0 and the monthly external-crossval lane would report it GREEN.
+# exit 0 and the external-crossval lane would report it GREEN.
 _sys.exit(0 if all_ok else 1)

--- a/scripts/vessl_crossval_external.yaml
+++ b/scripts/vessl_crossval_external.yaml
@@ -1,5 +1,5 @@
-name: rfx-crossval-external-monthly
-description: "W2.5(c) monthly external-crossval lane: cv05 vs a real openEMS source build + cv11 vs committed Meep/Palace references (CPU node)"
+name: rfx-crossval-external
+description: "W2.5(c) on-demand external-crossval lane: cv05 vs a real openEMS source build + cv11 vs committed Meep/Palace references (CPU node, remilab-c0 lab cluster). No fixed cadence -- run per release tag and whenever the cv05/cv11 physics paths change; free on the lab cluster, so submit as needed: vessl run create -f scripts/vessl_crossval_external.yaml"
 tags: [rfx, crossval-external, ci-trust, w25]
 resources:
   cluster: remilab-c0
@@ -47,7 +47,7 @@ run: |-
   cd /root/workspace/byungkwan-workspace/research/rfx
   git config --global --add safe.directory /root/workspace/byungkwan-workspace/research/rfx || true
   git rev-parse HEAD || true
-  /usr/bin/python3 -m pip install -q "jax[cpu]==0.4.35" "scipy>=1.11" "h5py>=3.8" "matplotlib>=3.7"
+  /usr/bin/python3 -m pip install -q "jax[cpu]==0.6.2" "scipy>=1.11" "h5py>=3.8" "matplotlib>=3.7"
   export RFX_REPO_ROOT=/root/workspace/byungkwan-workspace/research/rfx
   export PYTHONPATH="$RFX_REPO_ROOT"
   /usr/bin/python3 -c "import jax, rfx; print('probe ok', jax.__version__)"


### PR DESCRIPTION
Reframe the source-built-OpenEMS external-crossval lane from a nominal **monthly calendar** to **on-demand / per-release**.

### Why
The lane (`cv05` patch antenna vs a real openEMS source build + `cv11` WR-90 port vs committed Meep/Palace refs) already runs on the **free `remilab-c0` lab cluster**, so rationing it to "monthly" buys nothing. Run it when it's actually useful instead — per release tag, and whenever the cv05/cv11 physics paths change.

### Changes
- **Rename** `scripts/vessl_crossval_external_monthly.yaml` → `scripts/vessl_crossval_external.yaml`; `name`/`description` reframed to on-demand (no fixed cadence).
- **Bump** the stale CPU jax pin `0.4.35` → `0.6.2` (parity with the tested env; pyproject floor is `>=0.4.20`).
- **README** + repo-local CLAUDE.md (gitignored, local-only): "monthly" → "on-demand (run per release)".
- **cv05 comment**: drop the stale "monthly" qualifier on the exit-code guard.

### Not changed
- Compute/resources: `cluster: remilab-c0`, cpu/memory, and the entire `run:` block are untouched (verified the block is still dash/`sh -n`-clean).

The lane has never actually been submitted; the first run is a separate step (now trivially on-demand on the free cluster).
