### PR TITLE
fix(crossval): make the external openEMS lane actually run (conda python + cv05 exit guard)

### DIFF
--- a/examples/crossval/05_patch_antenna.py
+++ b/examples/crossval/05_patch_antenna.py
@@ -776,4 +776,6 @@ if json_out:
 # (CSXCAD/openEMS unavailable); a reference-present run must surface a genuine
 # failure as exit 1 — without this, a real cv05 FAIL falls through to implicit
 # exit 0 and the external-crossval lane would report it GREEN.
-_sys.exit(0 if all_ok else 1)
+# NB: use the SystemExit builtin (no import) — `_sys` is bound only inside the
+# CSXCAD-missing skip branch above, so it is undefined on the success path.
+raise SystemExit(0 if all_ok else 1)

--- a/scripts/vessl_crossval_external.yaml
+++ b/scripts/vessl_crossval_external.yaml
@@ -39,25 +39,38 @@ run: |-
   ldconfig
   export CSXCAD_INSTALL_PATH=/usr/local
   export OPENEMS_INSTALL_PATH=/usr/local
-  cd CSXCAD/python && /usr/bin/python3 setup.py install 2>&1 | tail -2 && cd ../..
-  cd openEMS/python && /usr/bin/python3 setup.py install 2>&1 | tail -2 && cd ../..
-  /usr/bin/python3 -c "from openEMS.openEMS import openEMS; print('openEMS source build: OK')"
+  # Use the image's conda python (>=3.10) for EVERYTHING below. rfx needs
+  # jax>=0.4.20 (Python>=3.9), but the base image's /usr/bin/python3 is 3.8
+  # (its pip resolves jax only up to 0.4.13). cv05 imports the openEMS bindings
+  # AND rfx in the same process, so the bindings must build against this same
+  # conda python. numpy<2 keeps the cython-built bindings ABI-compatible.
+  PY=python
+  command -v "$PY" >/dev/null 2>&1 || PY=/opt/conda/bin/python
+  "$PY" --version
+  # Pre-install the bindings' python deps with pip (wheels, 3.10-compatible
+  # versions) BEFORE setup.py install. Otherwise legacy `setup.py install`
+  # invokes easy_install for unsatisfied install_requires (matplotlib) and
+  # easy_install cannot build a modern meson sdist -> the bindings install dies.
+  "$PY" -m pip install -q --upgrade pip "cython" "numpy<2" "matplotlib" "h5py" "scipy"
+  cd CSXCAD/python && "$PY" setup.py install 2>&1 | tail -2 && cd ../..
+  cd openEMS/python && "$PY" setup.py install 2>&1 | tail -2 && cd ../..
+  "$PY" -c "from openEMS.openEMS import openEMS; print('openEMS source build: OK')"
 
   # -- rfx runtime deps (CPU jax) --
   cd /root/workspace/byungkwan-workspace/research/rfx
   git config --global --add safe.directory /root/workspace/byungkwan-workspace/research/rfx || true
   git rev-parse HEAD || true
-  /usr/bin/python3 -m pip install -q "jax[cpu]==0.6.2" "scipy>=1.11" "h5py>=3.8" "matplotlib>=3.7"
+  "$PY" -m pip install -q "jax[cpu]==0.6.2" "numpy<2" "scipy>=1.11" "h5py>=3.8" "matplotlib>=3.7"
   export RFX_REPO_ROOT=/root/workspace/byungkwan-workspace/research/rfx
   export PYTHONPATH="$RFX_REPO_ROOT"
-  /usr/bin/python3 -c "import jax, rfx; print('probe ok', jax.__version__)"
+  "$PY" -c "import jax, rfx; print('probe ok', jax.__version__)"
 
   out=".omx/crossval-external/$(date -u +%Y%m%dT%H%M%SZ)"
   mkdir -p "$out"
 
   # -- cv05: patch antenna vs openEMS (exit 0 full pass / 1 fail / 2 ref-missing) --
   set +e
-  timeout 7200 /usr/bin/python3 examples/crossval/05_patch_antenna.py \
+  timeout 7200 "$PY" examples/crossval/05_patch_antenna.py \
     > "$out/cv05.log" 2>&1
   cv05_rc=$?
   set -e
@@ -67,7 +80,7 @@ run: |-
 
   # -- cv11: WR-90 vs committed Meep/Palace references --
   set +e
-  timeout 3600 /usr/bin/python3 examples/crossval/11_waveguide_port_wr90.py \
+  timeout 3600 "$PY" examples/crossval/11_waveguide_port_wr90.py \
     > "$out/cv11.log" 2>&1
   cv11_rc=$?
   set -e


### PR DESCRIPTION
Make the external-crossval VESSL lane (`scripts/vessl_crossval_external.yaml`: cv05 patch antenna vs a source-built openEMS + cv11 WR-90 vs committed Meep/Palace refs) **actually run**. It had never executed before; running it on the free `remilab-c0` lab cluster surfaced and fixed the bugs that kept it dead on arrival.

### Two fixes

**1. `cv05` exit guard — `_sys` NameError on the success path**
PR #177 added `_sys.exit(0 if all_ok else 1)` at module end, but `_sys` is bound only inside cv05's CSXCAD-missing skip branch (the exit-2 path). On the success path it's undefined, so a **passing** cv05 raised `NameError` and exited 1 — a genuine PASS reported as FAIL. CI couldn't catch it (cv05 needs a real openEMS). Fixed with `raise SystemExit(...)` (builtin, no import).

**2. Lane environment — use the image's conda python (3.10), not system python3 (3.8)**
Three stacked latent bugs, each blocking the lane:
- apt installed `python3-{numpy,scipy,…}` but not `python3-pip` → `No module named pip`.
- the base image's `/usr/bin/python3` is **Python 3.8**, whose newest jax is `0.4.13`, but rfx needs `jax>=0.4.20` (Python ≥3.9) — system python could never run rfx.
- cv05 imports the openEMS bindings **and** rfx in one process, so they must share an interpreter.

Fix: route everything through the conda python (3.10) — build the CSXCAD/openEMS bindings against it, pip-install jax/rfx deps into it, run the examples with it. Pre-install the bindings' deps (`cython, numpy<2, matplotlib, h5py, scipy`) **before** `setup.py install` so legacy `easy_install` (can't build modern meson sdists) is never invoked.

### Validation — first-ever green run (VESSL `369367242669`, remilab-c0)
```
openEMS source build: OK   →   probe ok 0.6.2
cv05_rc=0   (rfx-vs-openEMS Harminv 2.65% [gate <20%], analytic 5.33%, self-consistency 4.20%, passivity 0.989, Overall PASS)
cv11_rc=0   (CROSSVAL-11 PASS)
exit 0      (status: completed)
```
This is the lane's first real openEMS-class cross-check of cv05, and it passes. Logs archived under `docs/research_notes/vessl_logs/` (gitignored).

Builds on #178 (the on-demand reframe).
