### PR TITLE
refactor(msl): drop orphaned legacy 3-probe extractor (NEW-1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Removed — orphaned legacy 3-probe MSL extractor (2026-06-15)
+
+- Deleted the pre-issue-#80 closed-form 3-probe MSL de-embedding helpers
+  from `rfx/sources/msl_port.py`: `_solve_3probe`, `msl_forward_amplitude`,
+  `compute_s21`, and the unused `_integrate_v` / `_integrate_i` line
+  integrals.  They had **zero callers in `rfx/`** — the production MSL
+  S-matrix path uses the closed Ampère-loop current (`msl_loop_current`,
+  retained) plus the SVD N-probe wave decomposition (`extract_msl_nprobe`)
+  — and were only kept alive by one unit test
+  (`tests/test_msl_port.py::test_compute_s21_round_trip`), removed with its
+  imports.  None were exported (no `__all__`; absent from top-level `rfx`),
+  so the public surface and the api-reference inventory are unchanged.
+  Closes architect-review item NEW-1.
+
 ### Fixed — normalize='flux' waveguide S-matrix joins the AD tape (issue #148, 2026-06-12)
 
 - `extract_waveguide_s_matrix_flux` is now jnp-native end to end: the

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -925,8 +925,8 @@ class _SparamMixin:
         # ``-x`` ports; the extractor anchors the model at probe 0 and
         # only uses coordinate differences, so feeding raw physical x
         # keeps alpha = the +x-travelling wave for BOTH port directions
-        # — matching the legacy 3-probe convention that compute_s21 and
-        # the S11 sign were validated against.
+        # — matching the legacy 3-probe sign convention the S11 sign
+        # was validated against.
 
         # Per-axis cell-size arrays for V/I integration. Both uniform
         # and non-uniform grids are supported.

--- a/rfx/sources/msl_port.py
+++ b/rfx/sources/msl_port.py
@@ -854,26 +854,8 @@ def msl_probe_x_coords_n(
 
 
 # ---------------------------------------------------------------------------
-# 3-probe S-parameter extraction
+# Closed Ampère-loop current (∮H·dl) for S-parameter extraction
 # ---------------------------------------------------------------------------
-
-
-def _integrate_v(ez_plane: np.ndarray, j_center: int, z_lo_idx: int, z_hi_idx: int,
-                 dz_arr: np.ndarray) -> np.ndarray:
-    """V(f) = ∫ Ez dz along the substrate height at y = j_center."""
-    total = np.zeros(ez_plane.shape[0], dtype=complex)
-    for k in range(z_lo_idx, z_hi_idx + 1):
-        total = total + ez_plane[:, j_center, k] * float(dz_arr[k])
-    return total
-
-
-def _integrate_i(hy_plane: np.ndarray, y_lo_idx: int, y_hi_idx: int, z_top_idx: int,
-                 dy_arr: np.ndarray) -> np.ndarray:
-    """I(f) = ∫ Hy dy across the trace width at z = z_top_idx."""
-    total = np.zeros(hy_plane.shape[0], dtype=complex)
-    for j in range(y_lo_idx, y_hi_idx + 1):
-        total = total + hy_plane[:, j, z_top_idx] * float(dy_arr[j])
-    return total
 
 
 def msl_loop_current(
@@ -912,8 +894,7 @@ def msl_loop_current(
     the top face.  ``Hz[i,j,k]`` sits at ``y=(j+½)dy``, so
     ``Hz[·,j_hi,·]`` / ``Hz[·,j_lo-1,·]`` are the right / left side edges.
 
-    The pre-issue-#80 current (``_integrate_i`` / the inline integral in
-    ``compute_msl_s_matrix``) used the bottom leg only, undercounting
+    The pre-issue-#80 current (a bottom-leg-only Hy integral) undercounted
     ``I`` by ~1.5x — it dropped the air-side return Hy and the trace-edge
     Hz — which inflated the de-embedded Z0 to ~74 ohm vs the ~48 ohm
     analytic Hammerstad-Jensen value.  Closing the loop restores Ampere's
@@ -966,68 +947,3 @@ def msl_loop_current(
     if direction == "+x":
         i_loop = -i_loop
     return i_loop
-
-
-
-def _solve_3probe(v1, v2, v3, i1, eps):
-    """Closed-form 3-probe solver used by msl_forward_amplitude."""
-    # q + 1/q = (V1 + V3) / V2  →  q² − coeff·q + 1 = 0
-    coeff = (v1 + v3) / (v2 + eps)
-    disc = coeff**2 - 4.0 + 0j
-    sqrt_disc = np.sqrt(disc)
-    q_plus = (coeff + sqrt_disc) / 2.0
-    q_minus = (coeff - sqrt_disc) / 2.0
-
-    # Both roots are reciprocals (q_minus = 1/q_plus), so on a lossless
-    # line they have |q|=1 exactly and the |q|≤1 selector becomes
-    # ambiguous.  The physical forward root must reproduce the observed
-    # forward step ratio V2/V1 in the absence of strong reflection; we
-    # therefore pick the root whose phase is closer to V2/V1.
-    ratio = v2 / (v1 + eps)
-    err_plus = np.abs(q_plus - ratio)
-    err_minus = np.abs(q_minus - ratio)
-    # Tie-breaker: |q| ≤ 1 (decaying) is preferred when both errors match.
-    use_plus = (err_plus < err_minus) | (
-        (np.isclose(err_plus, err_minus)) & (np.abs(q_plus) <= np.abs(q_minus))
-    )
-    q = np.where(use_plus, q_plus, q_minus)
-
-    # Forward (alpha) and backward (gamma) wave amplitudes at probe 1
-    denom = (q * q - 1.0) + eps
-    alpha = (q * v2 - v1) / denom
-    gamma = q * (v1 * q - v2) / denom
-
-    z0 = (alpha - gamma) / (i1 + eps)
-    s11 = gamma / (alpha + eps)
-    return s11, z0, q
-
-
-def msl_forward_amplitude(
-    v1: np.ndarray,
-    v2: np.ndarray,
-    v3: np.ndarray,
-    *,
-    eps: float = 1e-30,
-) -> tuple[np.ndarray, np.ndarray]:
-    """Return ``(alpha, q)``: forward amplitude at probe 1 and per-Δ phasor.
-
-    Useful on the passive (non-driven) port where only the voltage triple
-    is needed to recover the transmitted forward wave.
-    """
-    v1 = np.asarray(v1, dtype=complex)
-    v2 = np.asarray(v2, dtype=complex)
-    v3 = np.asarray(v3, dtype=complex)
-    # Reuse the shared solver (i1 unused for q/alpha — pass v1 as a
-    # placeholder; z0/s11 outputs are discarded).
-    _, _, q = _solve_3probe(v1, v2, v3, v1, eps)
-    denom = (q * q - 1.0) + eps
-    alpha = (q * v2 - v1) / denom
-    return alpha, q
-
-
-def compute_s21(alpha_passive: np.ndarray, alpha_driven: np.ndarray,
-                *, eps: float = 1e-30) -> np.ndarray:
-    """S21 from forward amplitudes on driven (port 1) and passive (port 2)."""
-    return np.asarray(alpha_passive, dtype=complex) / (
-        np.asarray(alpha_driven, dtype=complex) + eps
-    )

--- a/tests/test_msl_port.py
+++ b/tests/test_msl_port.py
@@ -1,7 +1,7 @@
 """Unit tests for the MSL (microstrip line) port primitive.
 
-These tests exercise the geometry/material setup and the closed-form
-3-probe de-embedding math without running an FDTD scan.
+These tests exercise the geometry/material setup and the closed
+Ampère-loop current / wave-decomposition math without running an FDTD scan.
 """
 
 from __future__ import annotations
@@ -16,8 +16,6 @@ from rfx.core.yee import MaterialArrays
 from rfx.sources.msl_port import (
     MSLPort,
     _msl_yz_cells,
-    compute_s21,
-    msl_forward_amplitude,
     msl_loop_current,
     msl_probe_x_coords,
     setup_msl_port,
@@ -260,29 +258,6 @@ def test_add_msl_port_api():
     with pytest.raises(ValueError):
         sim.add_msl_port(position=(2e-3, 1.5e-3, 0.0),
                          width=1e-3, height=2.54e-4, n_probe_offset=2)
-
-
-# ---------------------------------------------------------------------------
-# Test 7: msl_forward_amplitude + compute_s21 sanity
-# ---------------------------------------------------------------------------
-
-
-def test_compute_s21_round_trip():
-    beta = 200.0
-    Delta = 0.5e-3
-    x1 = 5e-3
-    V_plus = 1.0
-    V1 = np.array([V_plus * np.exp(-1j * beta * x1)])
-    V2 = np.array([V_plus * np.exp(-1j * beta * (x1 + Delta))])
-    V3 = np.array([V_plus * np.exp(-1j * beta * (x1 + 2 * Delta))])
-    alpha_drv, _ = msl_forward_amplitude(V1, V2, V3)
-    # Passive port sees half the forward amplitude (lossy line).
-    V1p = 0.5 * V1
-    V2p = 0.5 * V2
-    V3p = 0.5 * V3
-    alpha_pas, _ = msl_forward_amplitude(V1p, V2p, V3p)
-    s21 = compute_s21(alpha_pas, alpha_drv)
-    assert abs(s21[0] - 0.5) < 1e-3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Deletes the dead pre-issue-#80 closed-form 3-probe MSL de-embedding helpers from `rfx/sources/msl_port.py`: `_solve_3probe`, `msl_forward_amplitude`, `compute_s21`, and the unused `_integrate_v` / `_integrate_i` line integrals.

They had **zero callers in `rfx/`** — the production MSL S-matrix path (`compute_msl_s_matrix`) uses the closed Ampère-loop current `msl_loop_current` + the SVD N-probe wave decomposition `extract_msl_nprobe`. The helpers were kept alive only by `tests/test_msl_port.py::test_compute_s21_round_trip`, removed here with its imports.

`msl_loop_current` (the **live** production current, called at `_sparams.py:1154`) is **retained** — the 2026-05-26 architect review's "delete 861–1032" range wrongly swept it in.

## Why

Closes architect-review item **NEW-1** (port/S-param infra debt). Premise-verification on current main found the other three review items are stale specs already resolved by the S1 redesign + AD-wiring, so they are closed with evidence and **no code change**:

- **NEW-3** (promote the Z0-deviation warn to a gate) — *superseded*: post-S1, `|S11|≤1` rides the V·I split + closed Ampère-loop current with a hard `strict_extractor` raise at `_sparams.py:1240`; the Z0-deviation is a deliberately soft, separate caveat (a flat gate would false-fail on coarse-mesh Yee-staircase bias).
- **NEW-4** (reported `.Z0`/`.beta` stale under `eps_override`) — *refuted*: they come from the AD-traced N-probe fit on the measured fields, not the base-materials anchor. Gradient witness `d|z0|/d(field)=39.97` (finite, nonzero); `z0`/`beta` identical across `z0_hj` = 47.89 vs 999.

(NEW-2 was already done — `tests/test_issue80_patch_s11_regression.py`.)

## Surface impact

None. The deleted symbols were not exported (no `__all__`, absent from top-level `rfx`); the api-reference inventory and public surface are unchanged. The `docs/api` pdoc snapshot is gitignored.

## Verification

- `ruff check rfx/sources/msl_port.py rfx/api/_sparams.py tests/test_msl_port.py --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402` → clean
- `python scripts/check_api_reference.py` → OK
- full-suite collection clean (no stray references to the deleted symbols)
- `tests/test_msl_port.py` → 6 passed / 1 xfailed (was 7 — removed the dead test)
- live consumers `tests/test_msl_wave_decomp_jvp.py` + `tests/test_msl_port_integration.py` → 10 passed
- independent code-reviewer pass: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)