### PR TITLE
chore(release): 1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+## [1.6.4] - 2026-06-16
+
+Highlights: the rectangular-waveguide-port **broad-E5 close** (committed
+analytic-Airy band envelopes + an rfx-vs-Palace-FEM external comparison, with the
+port-external-reference audit GREEN for `rectangular_waveguide_port` on a clean
+checkout) and removal of the orphaned legacy 3-probe MSL extractor — on top of the
+accumulated correctness, preflight, AD-tape, and validation-lane work since 1.6.3.
+
+### Added — rectangular waveguide port broad-E5 evidence, committed (PR #181, 2026-06-16)
+
+- `compute_waveguide_s_matrix(normalize='flux')` broad-E5 evidence now survives a
+  clean checkout: five WR-band (WR-28/62/15/340/10, eps_r 2 & 4) analytic-Airy flux
+  envelopes (20/20 cases, max |S| diff ≤ 0.0414) committed under
+  `tests/fixtures/waveguide_broad_e5/`, plus an rfx-vs-Palace-FEM broad-E4 external
+  comparison across the empty / PEC-short / dielectric-slab geometry axis (max |S|
+  diff 0.0707, gate 0.10). Previously this evidence lived only in gitignored
+  `.omx/` outputs, so `scripts/diagnostics/check_port_external_references.py`
+  reported the family `blocked` on a clean checkout while the manifest claimed
+  `broad_e5_passed`; the auditor now reports `rectangular_waveguide_port` passed.
+  New gate `tests/test_waveguide_broad_e5_envelope_gates.py` re-derives both
+  verdicts from the committed fixtures and mirrors the auditor's broad-E5/E4
+  acceptance. R5 note: coarse Meep (res 3/4) gives a non-physical PEC-short
+  |S11|>1, so the converged Palace high-order FEM reference is used for that
+  geometry; rfx itself is exact (|S11|=1.0000).
+
 ### Removed — orphaned legacy 3-probe MSL extractor (2026-06-15)
 
 - Deleted the pre-issue-#80 closed-form 3-probe MSL de-embedding helpers

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -7,7 +7,7 @@ authors:
     given-names: "Byungkwan"
     email: "byungkwan.kim@cnu.ac.kr"
     affiliation: "REMI Lab, Chungnam National University"
-version: "1.6.3"
+version: "1.6.4"
 date-released: "2026-04-17"
 license: MIT
 repository-code: "https://github.com/bk-squared/rfx"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 **Differentiable 3D FDTD electromagnetic simulator for RF and microwave engineering — powered by JAX.**
 
-**v1.6.3 package; current `main` after v1.6.3** — JAX-based RF/FDTD workflows, GPU-oriented execution, practical examples, structured setup guards, and port-family validation envelopes.
+**v1.6.4 package** — JAX-based RF/FDTD workflows, GPU-oriented execution, practical examples, structured setup guards, and port-family validation envelopes.
 
 > **Project status (June 2026):** `rfx` remains an actively validated research/product simulator. Use the uniform Cartesian Yee RF lane first; advanced lanes are promoted only inside explicitly documented evidence envelopes rather than as blanket simulator guarantees.
 
@@ -298,7 +298,7 @@ Gitops-side snapshot/build CI lives in the deploy repo:
   title        = {rfx: JAX-based differentiable 3D FDTD simulator for RF engineering},
   institution  = {REMI Lab, Chungnam National University},
   year         = {2026},
-  version      = {1.6.3},
+  version      = {1.6.4},
   url          = {https://github.com/bk-squared/rfx}
 }
 ```

--- a/docs/public/guide/changelog.mdx
+++ b/docs/public/guide/changelog.mdx
@@ -11,8 +11,9 @@ This page summarizes user-visible changes without internal run logs or diagnosti
 
 The recommended starting point remains the **uniform Cartesian Yee RF/FDTD lane**. Non-uniform mesh, distributed execution, Floquet/Bloch, general SBP-SAT subgridding, generalized planar ports, and broad inverse-design extensions stay lane-scoped. Rectangular waveguide S-matrices and coaxial transmission-line reflection have stronger port-family evidence envelopes, but those envelopes are not blanket S-parameter guarantees.
 
-## Current main after v1.6.3 — June 2026
+## v1.6.4 — June 2026
 
+- Rectangular waveguide-port **broad-E5** evidence is now committed and passes the port-external-reference audit on a clean checkout: five WR-band power-flux envelopes versus analytic Airy plus an rfx-vs-Palace-FEM external comparison across the empty / PEC-short / dielectric-slab geometry axis. The orphaned legacy 3-probe microstrip extractor was removed (no public-surface change).
 - `preflight()` and `preflight_sparameters()` now expose coded report objects for automation while preserving older list/string behaviour.
 - Run/forward results, S-matrix calculators, sweeps, and optimizers now surface finite-data, passivity, setup, and NaN-gradient issues earlier.
 - `compute_coaxial_line_reflection(...)` is the current coaxial line-reflection path inside its documented transmission-line envelope. The older `compute_coaxial_s_matrix(...)` single-plane path is deprecated/experimental.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfx-fdtd"
-version = "1.6.3"
+version = "1.6.4"
 description = "JAX-native 3D FDTD electromagnetic simulator for RF engineering"
 readme = "README.md"
 license = {text = "MIT"}

--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -1,7 +1,7 @@
 """rfx — JAX-based RF FDTD electromagnetic simulator."""
 # ruff: noqa: F401
 
-__version__ = "1.6.3"
+__version__ = "1.6.4"
 
 from rfx.grid import Grid
 from rfx.simulation import run, run_until_decay, make_source, make_probe, make_port_source, SimResult


### PR DESCRIPTION
Cuts **1.6.4** after #180 (orphaned legacy 3-probe MSL extractor removed) and #181 (rectangular_waveguide_port broad-E5 close) merged to main.

## Version bump (1.6.3 → 1.6.4)
`pyproject.toml`, `rfx.__version__`, `CITATION.cff`, `README.md` (status line + BibTeX), and the public `changelog.mdx` header. Historical markers (`.. deprecated:: 1.6.3`, "Periodic × CPML (v1.6.3)") left intact — they record when those landed.

## CHANGELOG
Rolled the accumulated `[Unreleased]` into `[1.6.4] - 2026-06-16` with a Highlights lead + a new committed-waveguide-broad-E5 entry; opened a fresh empty `[Unreleased]`. The public `changelog.mdx` gains a matching v1.6.4 bullet.

## Packaging
`pyproject` was already clean (deps / classifiers / urls / `py.typed`) — no change beyond the version.

## Verification
- `rfx.__version__` == `pyproject` == `CITATION` == **1.6.4**
- CHANGELOG parses (`[Unreleased]` empty, `[1.6.4]` present)
- `ruff` clean; api-reference inventory unaffected by a version bump

After merge: tag `v1.6.4` on main (and the on-demand external openEMS + GPU suite lanes can be run per the release cadence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)