### PR TITLE
diag(msl): matched-thru |S11| mesh-convergence — eigenmode-push premise test (R2-STOP)

### DIFF
--- a/scripts/diagnostics/msl_thru_mesh_convergence.py
+++ b/scripts/diagnostics/msl_thru_mesh_convergence.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""MSL matched-thru |S11| mesh-convergence — the mode-vs-mesh bottleneck test.
+
+Premise-validation for the MSL *eigenmode-source* push (R1/R2): durable memory
+(project_msl_eigenmode_path_b_failed) says the matched-thru |S11|~=0.118 floor
+"appears to be mesh discretization, not source mode shape" — across 4 prior
+eigensolver attempts, a better source mode never beat that floor. Before
+committing to a 1-2 week Helmholtz-projected eigensolver, test that claim with
+the EXISTING static-Laplace source by refining the mesh:
+
+  * |S11| converges DOWN toward 0 as dx shrinks  -> MESH-limited; an eigenmode
+    source cannot beat the floor -> the eigenmode push is futile (R2-STOP).
+  * |S11| plateaus near ~0.11 regardless of dx   -> SOURCE-MODE-limited; NEW
+    evidence justifying the eigenmode build.
+
+Replicates tests/test_msl_port_integration.py::test_msl_thru_line_passive_gate
+exactly (RO4350B, h_sub=254um, W=600um, mode='laplace'), parameterized over dx.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+
+from rfx.api import Simulation  # noqa: E402
+from rfx.boundaries.spec import Boundary, BoundarySpec  # noqa: E402
+from rfx.geometry.csg import Box  # noqa: E402
+
+# --- thru-line constants (verbatim from the gate test) ---
+EPS_R = 3.66
+H_SUB = 254e-6
+W_TRACE = 600e-6
+L_LINE = 10e-3
+PORT_MARGIN = 2e-3
+F_MAX = 5e9
+GATE_F_LO, GATE_F_HI = 3.0e9, 4.5e9
+
+
+def run_one(dx: float) -> dict:
+    lx = L_LINE + 2 * PORT_MARGIN
+    ly = W_TRACE + 2 * (2 * H_SUB + 8 * dx)   # same fixed-clearance formula
+    lz = H_SUB + 1.5e-3
+    sim = Simulation(
+        freq_max=F_MAX, domain=(lx, ly, lz), dx=dx, cpml_layers=8,
+        boundary=BoundarySpec(x="cpml", y="cpml",
+                              z=Boundary(lo="pec", hi="cpml")),
+    )
+    sim.add_material("ro4350b", eps_r=EPS_R)
+    sim.add(Box((0.0, 0.0, 0.0), (lx, ly, H_SUB)), material="ro4350b")
+    yc = ly / 2.0
+    sim.add(Box((0.0, yc - W_TRACE / 2.0, H_SUB),
+                (lx, yc + W_TRACE / 2.0, H_SUB + dx)), material="pec")
+    sim.add_msl_port(position=(PORT_MARGIN, yc, 0.0), width=W_TRACE,
+                     height=H_SUB, direction="+x", impedance=50.0)
+    sim.add_msl_port(position=(PORT_MARGIN + L_LINE, yc, 0.0), width=W_TRACE,
+                     height=H_SUB, direction="-x", impedance=50.0)
+    t0 = time.time()
+    res = sim.compute_msl_s_matrix(n_freqs=30, num_periods=12)
+    dt = time.time() - t0
+    S = np.asarray(res.S)
+    Z0 = np.asarray(res.Z0)
+    f = np.asarray(res.freqs)
+    m = (f >= GATE_F_LO) & (f <= GATE_F_HI)
+    s11 = np.abs(S[0, 0, m]); s21 = np.abs(S[1, 0, m]); z0 = Z0[0, m].real
+    return {
+        "dx_um": round(dx * 1e6, 2),
+        "nz_sub": int(round(H_SUB / dx)),
+        "mean_s11": float(s11.mean()),
+        "max_s11": float(s11.max()),
+        "mean_s21": float(s21.mean()),
+        "mean_re_z0": float(z0.mean()),
+        "wallclock_s": round(dt, 1),
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--dx-list-um", default="80,60,40,30,20")
+    p.add_argument("--output", default=".omx/physics-gate/2026-06-16-msl-thru-mesh-conv/msl_thru_mesh_convergence.json")
+    args = p.parse_args()
+    dxs = [float(v) * 1e-6 for v in args.dx_list_um.split(",")]
+    rows = []
+    for dx in dxs:
+        r = run_one(dx)
+        rows.append(r)
+        print(f"dx={r['dx_um']:5.1f}um nz_sub={r['nz_sub']:2d}  mean|S11|={r['mean_s11']:.4f} "
+              f"max|S11|={r['max_s11']:.4f}  mean|S21|={r['mean_s21']:.4f}  "
+              f"Re(Z0)={r['mean_re_z0']:.1f}ohm  ({r['wallclock_s']}s)", flush=True)
+    # verdict
+    s11s = [r["mean_s11"] for r in rows]
+    trend = "DECREASING(mesh-limited)" if s11s[-1] < 0.6 * s11s[0] else "PLATEAU(mode-limited)"
+    print(f"\nVERDICT: mean|S11| {s11s[0]:.4f} (dx={rows[0]['dx_um']}um) -> {s11s[-1]:.4f} "
+          f"(dx={rows[-1]['dx_um']}um)  => {trend}", flush=True)
+    out = REPO / args.output
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps({"rows": rows, "trend": trend}, indent=2) + "\n")
+    print(f"wrote {out}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vessl_msl_thru_mesh_conv.yaml
+++ b/scripts/vessl_msl_thru_mesh_conv.yaml
@@ -1,0 +1,31 @@
+name: rfx-msl-thru-mesh-conv
+description: "MSL eigenmode push, premise test: matched-thru |S11| vs dx (80->20um, static-Laplace source) to decide MESH-limited (eigenmode futile, R2-STOP) vs MODE-limited (eigenmode justified). vessl run create -f scripts/vessl_msl_thru_mesh_conv.yaml"
+tags: [rfx, msl, eigenmode, mesh-convergence, sparameter-validation]
+resources:
+  cluster: remilab-c0
+  preset: gpu-rtx4090
+image: nvcr.io/nvidia/jax:24.10-py3
+env:
+  PYTHONUNBUFFERED: "1"
+  XLA_PYTHON_CLIENT_PREALLOCATE: "false"
+  HDF5_USE_FILE_LOCKING: "FALSE"
+  LANG: "C.UTF-8"
+mount:
+  /root/workspace/: volume://remilab-fs/personal-workspaces/
+run: |-
+  set -eu
+  cd /root/workspace/byungkwan-workspace/research/rfx
+  command -v git >/dev/null 2>&1 || { apt-get update -qq && apt-get install -y -qq git; }
+  git config --global --add safe.directory "$(pwd)" || true
+  echo "=== MSL matched-thru |S11| mesh-convergence (mode-vs-mesh bottleneck test) ==="
+  date
+  python -m pip install -q "scipy>=1.11" "h5py>=3.8" "matplotlib>=3.7"
+  export PYTHONPATH="$(pwd):${PYTHONPATH:-}"
+  python -c "import jax, rfx; print('jax_backend', jax.default_backend(), 'rfx', getattr(rfx,'__version__','unknown'))"
+  # dx = h_sub/n (n = 3,4,6,8,10,12 substrate cells) so h_sub/dx is INTEGER --
+  # avoids the [0.10,0.40] mixed-cell danger zone that would confound the mesh
+  # trend with a cell-alignment artifact (preflight-flagged). h_sub=254um.
+  python scripts/diagnostics/msl_thru_mesh_convergence.py \
+    --dx-list-um 84.667,63.5,42.333,31.75,25.4,21.167 \
+    --output .omx/physics-gate/2026-06-16-msl-thru-mesh-conv/msl_thru_mesh_convergence.json
+  echo "=== DONE ==="


### PR DESCRIPTION
Disciplined start of the **MSL eigenmode-source push**: a premise test before any 1–2 week Helmholtz-eigensolver build. Does the matched-thru `|S11|≈0.118` floor converge **down** with mesh refinement (mesh-limited → eigenmode can't beat it) or **plateau** (mode-limited → solver justified)?

`scripts/diagnostics/msl_thru_mesh_convergence.py` replicates the thru-line gate at clean integer-`h_sub/dx` alignments (3/4/6/8/10/12 substrate cells — avoiding the `[0.10,0.40]` mixed-cell danger zone the preflight flags). Run on gpu-rtx4090 (VESSL `369367243079`):

| cells | mean \|S11\| | Re(Z0) Ω |
|---|---|---|
| 3 | 0.224 | 38.8 |
| 4 | 0.205 | 41.7 |
| 6 | 0.121 | 53.1 (outlier) |
| 8 | 0.164 | 45.3 |
| 10 | 0.161 | 45.5 |
| 12 | 0.161 | 45.5 |

**Findings (R5):**
1. `|S11|` does **not** converge to 0 → **not purely mesh-limited** (refines the prior "mesh is the bottleneck").
2. But the ~0.16 residual is **confounded**: `Re(Z0)→45.5 Ω` (~9% below 50) is a Yee-staircase **Z0-reference** bias (a V·I-extraction-reference issue a source mode wouldn't fix), tangled with numerical dispersion + Laplace launch.
3. The documented "0.118 floor" was a **fortuitous artifact** — measured at dx=80µm (`h_sub/dx=3.175`, the danger zone); clean alignments give 0.16–0.22 (*higher*).

**Verdict: R2-STOP.** The new evidence is real but ambiguous/confounded — not solid enough (R1.4) to overturn the memory + the MPB precedent (a correct boxed mode made `|S11|` *worse*, 0.61). A 1–2 week eigensolver build is not justified (R2/R4, fidelity-over-cost). This diagnostic + the VESSL YAML are the stop-with-evidence deliverable (§2.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)