### PR TITLE
T2.2: wire the differentiability moat into broad_e5_passed

### DIFF
--- a/scripts/diagnostics/check_port_external_references.py
+++ b/scripts/diagnostics/check_port_external_references.py
@@ -122,6 +122,50 @@ def _artifact_check(value: str) -> dict[str, Any]:
     return {"artifact": value, "path_checked": _display(path), "exists": path.exists()}
 
 
+def _ad_test_check(value: Any) -> dict[str, Any]:
+    """Static existence check of a family's named AD-vs-FD test (T2.2).
+
+    ``value`` is a ``path::testname`` pytest nodeid, or None when the family has
+    no committed AD-vs-FD test. This is a STATIC check (file + ``def testname``
+    present) — the same level as the artifact checks. The COLLECTION-TIME proof
+    that the test is collected and NOT xfail/skip-marked lives in
+    ``tests/test_ad_surface_contract.py`` (a regex/AST scrape is insufficient,
+    so the dynamic check is done via pytest collection there). Together they
+    enforce: no family reaches broad_e5_passed without a real, non-xfail,
+    collected AD-vs-FD test — wiring the differentiability "moat" into the
+    broad-E5 verdict (framework audit finding #6).
+    """
+    check: dict[str, Any] = {
+        "ad_fd_test": value,
+        "declared": bool(value),
+        "exists": False,
+        "path_checked": "",
+        "testname": "",
+        "error": "",
+    }
+    if not value:
+        check["error"] = "no ad_fd_test declared"
+        return check
+    nodeid = str(value)
+    if "::" not in nodeid:
+        check["error"] = f"ad_fd_test {nodeid!r} is not a path::testname nodeid"
+        return check
+    path_str, testname = nodeid.split("::", 1)
+    # Strip any parametrization suffix for the source-def check.
+    testfunc = testname.split("[", 1)[0]
+    path = _repo_path(path_str)
+    check["path_checked"] = _display(path)
+    check["testname"] = testname
+    if not path.exists():
+        check["error"] = "ad_fd_test file is missing"
+        return check
+    if f"def {testfunc}" not in path.read_text(encoding="utf-8"):
+        check["error"] = f"ad_fd_test {testfunc!r} not defined in {path_str}"
+        return check
+    check["exists"] = True
+    return check
+
+
 def _comparison_artifact_check(value: str) -> dict[str, Any]:
     path = _repo_path(value)
     check: dict[str, Any] = {
@@ -244,6 +288,8 @@ def _requirement_result(entry: dict[str, Any]) -> dict[str, Any]:
         _broad_e5_envelope_artifact_check(str(a))
         for a in entry.get("broad_e5_envelope_artifacts", [])
     ]
+    ad_test_check = _ad_test_check(entry.get("ad_fd_test"))
+    ad_gate_ok = bool(ad_test_check["declared"] and ad_test_check["exists"])
     missing_artifacts = [a for a in artifact_checks + yaml_checks if not a["exists"]]
     failed_comparison_artifacts = [
         a for a in comparison_checks if not a["is_passed_e4_comparison"]
@@ -291,6 +337,13 @@ def _requirement_result(entry: dict[str, Any]) -> dict[str, Any]:
             "broad_e5_passed requires at least one passed broad E5 envelope "
             "artifact covering mesh/frequency/geometry scope"
         )
+    if required and status == BROAD_E5_PASS_STATUS and not ad_gate_ok:
+        blockers.append(
+            "broad_e5_passed requires a named AD-vs-FD test (ad_fd_test) that "
+            f"exists and is collected/non-xfail: {ad_test_check['error'] or 'not satisfied'} "
+            "— the differentiability moat must be wired into the broad-E5 claim "
+            "(framework audit #6)"
+        )
     if failed_comparison_artifacts:
         blockers.append("listed external comparison artifact is missing, invalid, or not passed")
     if failed_envelope_artifacts:
@@ -305,6 +358,7 @@ def _requirement_result(entry: dict[str, Any]) -> dict[str, Any]:
         and passed_comparison_artifact_count > 0
         and passed_broad_e4_comparison_artifact_count > 0
         and passed_envelope_artifact_count > 0
+        and ad_gate_ok
         and not failed_comparison_artifacts
         and not failed_envelope_artifacts
         else "blocked"
@@ -332,6 +386,8 @@ def _requirement_result(entry: dict[str, Any]) -> dict[str, Any]:
         ),
         "broad_e5_envelope_artifact_count": len(envelope_checks),
         "passed_broad_e5_envelope_artifact_count": passed_envelope_artifact_count,
+        "ad_fd_test_check": ad_test_check,
+        "ad_gate_ok": ad_gate_ok,
         "vessl_yaml_count": len(yaml_checks),
         "missing_artifact_count": len(missing_artifacts),
         "failed_comparison_artifact_count": len(failed_comparison_artifacts),

--- a/scripts/diagnostics/check_port_external_references.py
+++ b/scripts/diagnostics/check_port_external_references.py
@@ -10,6 +10,7 @@ external-solver coverage.
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 from datetime import datetime, timezone
 from pathlib import Path
@@ -122,23 +123,57 @@ def _artifact_check(value: str) -> dict[str, Any]:
     return {"artifact": value, "path_checked": _display(path), "exists": path.exists()}
 
 
+_SKIP_XFAIL_MARKERS = {"xfail", "skip", "skipif"}
+
+
+def _decorator_marker_names(node: ast.AST) -> set[str]:
+    """Trailing attribute names of a decorator (``pytest.mark.xfail`` -> {xfail})."""
+    target = node.func if isinstance(node, ast.Call) else node
+    names: set[str] = set()
+    while isinstance(target, ast.Attribute):
+        names.add(target.attr)
+        target = target.value
+    return names
+
+
+def _module_marks_skip_xfail(tree: ast.Module) -> bool:
+    """Detect a module-level ``pytestmark = pytest.mark.{xfail,skip,skipif}``."""
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(t, ast.Name) and t.id == "pytestmark" for t in node.targets
+        ):
+            continue
+        values = node.value.elts if isinstance(node.value, ast.List) else [node.value]
+        for v in values:
+            if _decorator_marker_names(v) & _SKIP_XFAIL_MARKERS:
+                return True
+    return False
+
+
 def _ad_test_check(value: Any) -> dict[str, Any]:
-    """Static existence check of a family's named AD-vs-FD test (T2.2).
+    """Static AST check of a family's named AD-vs-FD test (T2.2).
 
     ``value`` is a ``path::testname`` pytest nodeid, or None when the family has
-    no committed AD-vs-FD test. This is a STATIC check (file + ``def testname``
-    present) — the same level as the artifact checks. The COLLECTION-TIME proof
-    that the test is collected and NOT xfail/skip-marked lives in
-    ``tests/test_ad_surface_contract.py`` (a regex/AST scrape is insufficient,
-    so the dynamic check is done via pytest collection there). Together they
-    enforce: no family reaches broad_e5_passed without a real, non-xfail,
-    collected AD-vs-FD test — wiring the differentiability "moat" into the
-    broad-E5 verdict (framework audit finding #6).
+    no committed AD-vs-FD test. Uses ``ast`` (NOT a naked substring) so it (a)
+    finds the real ``def`` — no comment / ``def test_foo`` ⊂ ``def test_foobar``
+    false positives — and (b) BACKSTOPS the xfail/skip check: a statically
+    xfail/skip/skipif-marked test (on the function or a module ``pytestmark``)
+    fails here too. The AUTHORITATIVE, collection-time proof (catches conditional
+    / parametrize / fixture markers the AST can't see, and dynamic skips it also
+    can't — those remain a documented boundary) lives in
+    ``tests/test_ad_surface_contract.py::test_ad_fd_gate_tests_are_collected_and_not_xfail_skip``.
+    Both gates share this manifest, so they cannot point at different tests, and
+    the static backstop means the release verdict cannot silently diverge from
+    the collection check (reviewer T2.2). Together they wire the differentiability
+    "moat" into the broad-E5 verdict (framework audit finding #6).
     """
     check: dict[str, Any] = {
         "ad_fd_test": value,
         "declared": bool(value),
         "exists": False,
+        "found": False,
         "path_checked": "",
         "testname": "",
         "error": "",
@@ -151,16 +186,40 @@ def _ad_test_check(value: Any) -> dict[str, Any]:
         check["error"] = f"ad_fd_test {nodeid!r} is not a path::testname nodeid"
         return check
     path_str, testname = nodeid.split("::", 1)
-    # Strip any parametrization suffix for the source-def check.
-    testfunc = testname.split("[", 1)[0]
+    # Strip any parametrization suffix and a class qualifier for the def lookup.
+    testfunc = testname.split("[", 1)[0].split("::")[-1]
     path = _repo_path(path_str)
     check["path_checked"] = _display(path)
     check["testname"] = testname
     if not path.exists():
         check["error"] = "ad_fd_test file is missing"
         return check
-    if f"def {testfunc}" not in path.read_text(encoding="utf-8"):
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError as exc:
+        check["error"] = f"ad_fd_test file does not parse: {exc}"
+        return check
+    func = next(
+        (
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and n.name == testfunc
+        ),
+        None,
+    )
+    if func is None:
         check["error"] = f"ad_fd_test {testfunc!r} not defined in {path_str}"
+        return check
+    check["found"] = True
+    marked = any(
+        _decorator_marker_names(d) & _SKIP_XFAIL_MARKERS for d in func.decorator_list
+    ) or _module_marks_skip_xfail(tree)
+    if marked:
+        check["error"] = (
+            f"ad_fd_test {testfunc!r} is statically xfail/skip/skipif-marked — "
+            "cannot prove the differentiability moat"
+        )
         return check
     check["exists"] = True
     return check

--- a/scripts/diagnostics/port_external_reference_requirements.json
+++ b/scripts/diagnostics/port_external_reference_requirements.json
@@ -2,7 +2,7 @@
   "version": 1,
   "created_at": "2026-05-09",
   "purpose": "Machine-readable external-reference backlog for broad E5 RF port/S-parameter validation. This is separate from the release slow-shard manifest: it tracks which port families still need external solver/reference evidence, preferably as independent VESSL jobs.",
-  "completion_rule": "Broad all-port E5 requires every required family to have current_status=broad_e5_passed, required_scope=broad_e5, existing reference/YAML paths present, at least one passed E4/E4-enabling external S-parameter comparison artifact, at least one passed broad E4 external S-parameter comparison artifact that is not merely E4-enabling/narrow, and at least one passed broad-E5 mesh/frequency/geometry envelope artifact.",
+  "completion_rule": "Broad all-port E5 requires every required family to have current_status=broad_e5_passed, required_scope=broad_e5, existing reference/YAML paths present, at least one passed E4/E4-enabling external S-parameter comparison artifact, at least one passed broad E4 external S-parameter comparison artifact that is not merely E4-enabling/narrow, and at least one passed broad-E5 mesh/frequency/geometry envelope artifact. Additionally (T2.2), each family must declare a named AD-vs-FD test (ad_fd_test) that exists, is collected, and is NOT xfail/skip-marked — the differentiability moat is wired into the broad_e5_passed verdict (framework audit #6); families whose extractor is numpy/not-traceable (e.g. coaxial) cannot satisfy this and must resolve it before broad_e5_passed.",
   "requirements": [
     {
       "family": "lumped_port",
@@ -31,7 +31,9 @@
         ".omx/physics-gate/2026-05-10-m47-lumped-openems-sweep-comparison/lumped_openems_sweep_sparameter_comparison.json",
         ".omx/physics-gate/vessl-2026-05-10-lumped-openems-parallel-v5/lumped_openems_sweep_aggregate/lumped_openems_sweep_sparameter_comparison.json"
       ],
-      "broad_e5_envelope_artifacts": []
+      "broad_e5_envelope_artifacts": [],
+      "ad_fd_test": null,
+      "ad_fd_test_note": "grad-flow tests exist (test_s11_at_freq, test_minimize_s11_at_freq_physical) but no committed AD-vs-FD CONVERGENCE test yet; required before broad_e5_passed."
     },
     {
       "family": "wire_port",
@@ -59,7 +61,9 @@
       ],
       "broad_e5_envelope_artifacts": [
         ".omx/physics-gate/2026-05-10-m68-wire-openems-broad-envelope/wire_openems_broad_envelope.json"
-      ]
+      ],
+      "ad_fd_test": null,
+      "ad_fd_test_note": "grad-flow smoke only (test_wire_port_sparams_forward::test_forward_wire_port_grad_flows); no AD-vs-FD convergence test yet."
     },
     {
       "family": "microstrip_line_port",
@@ -87,7 +91,9 @@
       "external_comparison_artifacts": [
         ".omx/physics-gate/2026-05-09-m29-msl-openems-generic-comparison/msl_openems_generic_sparameter_comparison.json"
       ],
-      "broad_e5_envelope_artifacts": []
+      "broad_e5_envelope_artifacts": [],
+      "ad_fd_test": "tests/test_msl_ad_fd_converged.py::test_msl_ad_fd_converged_tight",
+      "ad_fd_test_note": "AD-vs-FD converged on the MSL S-matrix; @pytest.mark.gpu (runs on the gpu suite, not CPU CI)."
     },
     {
       "family": "rectangular_waveguide_port",
@@ -112,7 +118,9 @@
         "tests/fixtures/waveguide_broad_e5/waveguide_wr15_vband_broad_e5_envelope.json",
         "tests/fixtures/waveguide_broad_e5/waveguide_wr340_sband_broad_e5_envelope.json",
         "tests/fixtures/waveguide_broad_e5/waveguide_wr10_wband_broad_e5_envelope.json"
-      ]
+      ],
+      "ad_fd_test": "tests/test_waveguide_flux_ad.py::test_flux_smatrix_grad_finite_and_fd_consistent",
+      "ad_fd_test_note": "AD-vs-FD consistency on the normalize='flux' S-matrix path (issue #148); CPU, unmarked."
     },
     {
       "family": "coaxial_port",
@@ -152,7 +160,9 @@
       ],
       "broad_e5_envelope_artifacts": [
         ".omx/physics-gate/2026-06-07-coaxial-line-broad-e5-envelope/coaxial_line_broad_e5_envelope.json"
-      ]
+      ],
+      "ad_fd_test": null,
+      "ad_fd_test_note": "extractor is numpy / not-traceable (test_ad_surface_contract::test_coaxial_reflection_extraction_breaks_tape proves it breaks the tape); no AD-vs-FD test BY DESIGN -> the differentiable moat is unavailable and MUST be resolved (e.g. a differentiable reflection path) before broad_e5_passed."
     },
     {
       "family": "floquet_port",
@@ -179,7 +189,9 @@
         "scripts/physics_gate_port_external_floquet.yaml"
       ],
       "external_comparison_artifacts": [],
-      "broad_e5_envelope_artifacts": []
+      "broad_e5_envelope_artifacts": [],
+      "ad_fd_test": null,
+      "ad_fd_test_note": "grad-finite smoke only (test_floquet_s_params_contract::test_compute_floquet_s_params_grad_finite); no AD-vs-FD convergence test yet."
     },
     {
       "family": "generalized_planar_ports",
@@ -204,7 +216,9 @@
         "scripts/physics_gate_port_external_generalized_planar.yaml"
       ],
       "external_comparison_artifacts": [],
-      "broad_e5_envelope_artifacts": []
+      "broad_e5_envelope_artifacts": [],
+      "ad_fd_test": null,
+      "ad_fd_test_note": "planned only; no AD path yet."
     }
   ],
   "next_validation_target_decision": "2026-06-11 (W5.6 backlog decision, recorded NOT started): next port family for external validation = lumped_port (most existing scaffolding: narrow openEMS PEC-box + position-sweep comparisons already in evidence; needs the broad matched/open/short/load external fixture set). wire_port second (blocked_absolute_external_reference, needs an absolute external reference design first). Both are analytic-E5-only effort class."

--- a/tests/test_ad_surface_contract.py
+++ b/tests/test_ad_surface_contract.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 import inspect
 import json
 import re
+import subprocess
+import sys
 from pathlib import Path
 
 import jax
@@ -37,6 +39,7 @@ import rfx
 from rfx import Simulation
 
 MATRIX_PATH = Path("docs/guides/sparameter_support_matrix.json")
+MANIFEST_PATH = Path("scripts/diagnostics/port_external_reference_requirements.json")
 
 GRAD_SAFE = "grad-safe"
 NOT_TRACEABLE = "not-traceable"
@@ -205,6 +208,74 @@ def test_coaxial_reflection_extraction_breaks_tape():
     )
     with pytest.raises(jax.errors.TracerArrayConversionError):
         jax.grad(objective)(jnp.asarray(0.7))
+
+
+def _collect_nodeids(paths, marker_filter=None):
+    """COLLECTION-TIME nodeid set for the given test files (T2.2).
+
+    Uses a child ``pytest --collect-only`` (NOT a regex/AST scrape of the
+    source — m1) and clears the repo's default ``addopts`` (which deselects
+    ``gpu``/``slow``) so a gpu-marked AD test is still collected; only the
+    explicit ``marker_filter`` is applied. With ``marker_filter='not (xfail or
+    skip or skipif)'`` an xfail/skip/skipif-marked test is dropped, so comparing
+    the two sets reveals "exists but cannot pass".
+    """
+    args = [sys.executable, "-m", "pytest", "--collect-only", "-q",
+            "-o", "addopts=", "-p", "no:cacheprovider"]
+    if marker_filter:
+        args += ["-m", marker_filter]
+    args += list(paths)
+    proc = subprocess.run(args, capture_output=True, text=True, cwd=Path.cwd())
+    nodeids = set()
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if "::" in line and not line.startswith(("=", "<", "warning")):
+            nodeids.add(line)
+    return nodeids, proc
+
+
+def _nodeid_present(nodeid, collected):
+    return nodeid in collected or any(
+        c == nodeid or c.startswith(nodeid + "[") for c in collected
+    )
+
+
+def test_ad_fd_gate_tests_are_collected_and_not_xfail_skip():
+    """T2.2: every declared `ad_fd_test` must be COLLECTED and NOT xfail/skip.
+
+    The auditor (`check_port_external_references.py`) statically requires a
+    declared+existing `ad_fd_test` for broad_e5_passed; existence is not enough
+    (the framework audit's gameability lesson). This test is the dynamic half:
+    a declared AD-vs-FD test that is xfail/skip-marked CANNOT satisfy the moat,
+    so it must be collected under `not (xfail or skip or skipif)`. gpu-marked
+    tests pass (they run on the gpu lane, not xfail/skip).
+    """
+    manifest = json.loads(MANIFEST_PATH.read_text())
+    declared = [
+        (e["family"], e["ad_fd_test"])
+        for e in manifest["requirements"]
+        if e.get("ad_fd_test")
+    ]
+    assert declared, "no family declares an ad_fd_test — manifest regression"
+
+    paths = sorted({nodeid.split("::", 1)[0] for _, nodeid in declared})
+    all_collected, proc_all = _collect_nodeids(paths)
+    assert all_collected, (
+        "pytest --collect-only returned no nodeids for the AD-vs-FD test files; "
+        f"stderr:\n{proc_all.stderr[-2000:]}"
+    )
+    passable, _ = _collect_nodeids(paths, marker_filter="not (xfail or skip or skipif)")
+
+    for family, nodeid in declared:
+        assert _nodeid_present(nodeid, all_collected), (
+            f"{family}: ad_fd_test {nodeid} is not collected (typo / removed / "
+            f"renamed). Update the manifest or restore the test."
+        )
+        assert _nodeid_present(nodeid, passable), (
+            f"{family}: ad_fd_test {nodeid} is xfail/skip/skipif-marked, so it "
+            f"cannot prove the differentiability moat. An AD-vs-FD gate must be a "
+            f"test expected to PASS (gpu-marked is fine)."
+        )
 
 
 def test_support_matrix_has_ad_traceable_column():

--- a/tests/test_ad_surface_contract.py
+++ b/tests/test_ad_surface_contract.py
@@ -38,8 +38,9 @@ import pytest
 import rfx
 from rfx import Simulation
 
-MATRIX_PATH = Path("docs/guides/sparameter_support_matrix.json")
-MANIFEST_PATH = Path("scripts/diagnostics/port_external_reference_requirements.json")
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+MATRIX_PATH = _REPO_ROOT / "docs/guides/sparameter_support_matrix.json"
+MANIFEST_PATH = _REPO_ROOT / "scripts/diagnostics/port_external_reference_requirements.json"
 
 GRAD_SAFE = "grad-safe"
 NOT_TRACEABLE = "not-traceable"
@@ -225,11 +226,12 @@ def _collect_nodeids(paths, marker_filter=None):
     if marker_filter:
         args += ["-m", marker_filter]
     args += list(paths)
-    proc = subprocess.run(args, capture_output=True, text=True, cwd=Path.cwd())
+    proc = subprocess.run(args, capture_output=True, text=True, cwd=_REPO_ROOT)
     nodeids = set()
     for line in proc.stdout.splitlines():
         line = line.strip()
-        if "::" in line and not line.startswith(("=", "<", "warning")):
+        # pytest -q --collect-only emits one nodeid per line: ``path::name``.
+        if re.match(r"^\S+\.py::\S+$", line):
             nodeids.add(line)
     return nodeids, proc
 
@@ -249,6 +251,14 @@ def test_ad_fd_gate_tests_are_collected_and_not_xfail_skip():
     a declared AD-vs-FD test that is xfail/skip-marked CANNOT satisfy the moat,
     so it must be collected under `not (xfail or skip or skipif)`. gpu-marked
     tests pass (they run on the gpu lane, not xfail/skip).
+
+    Boundary (documented, not enforced here): this proves "collected + not
+    statically xfail/skip/skipif-marked", NOT "executed green". A test that calls
+    `pytest.skip()` in its body, or a gpu-only test whose hardware lane has not
+    run this cycle, is collectable + unmarked yet may not have actually exercised
+    the FD comparison. The gpu lane (e.g. the MSL AD-vs-FD test) is run per the
+    release cadence in CLAUDE.md; this gate guarantees the pointer is real and
+    expected-to-pass, the lane guarantees it did.
     """
     manifest = json.loads(MANIFEST_PATH.read_text())
     declared = [
@@ -260,11 +270,22 @@ def test_ad_fd_gate_tests_are_collected_and_not_xfail_skip():
 
     paths = sorted({nodeid.split("::", 1)[0] for _, nodeid in declared})
     all_collected, proc_all = _collect_nodeids(paths)
+    # pytest --collect-only exit codes: 0 = collected, 5 = none collected.
+    assert proc_all.returncode in (0, 5), (
+        f"pytest --collect-only failed (rc={proc_all.returncode}); "
+        f"stderr:\n{proc_all.stderr[-2000:]}"
+    )
     assert all_collected, (
         "pytest --collect-only returned no nodeids for the AD-vs-FD test files; "
         f"stderr:\n{proc_all.stderr[-2000:]}"
     )
-    passable, _ = _collect_nodeids(paths, marker_filter="not (xfail or skip or skipif)")
+    passable, proc_pass = _collect_nodeids(
+        paths, marker_filter="not (xfail or skip or skipif)"
+    )
+    assert proc_pass.returncode in (0, 5) and passable, (
+        "marker-filtered collection returned nothing — parse/infra error, not a "
+        f"real xfail/skip verdict; stderr:\n{proc_pass.stderr[-2000:]}"
+    )
 
     for family, nodeid in declared:
         assert _nodeid_present(nodeid, all_collected), (

--- a/tests/test_physics_gate_reporting.py
+++ b/tests/test_physics_gate_reporting.py
@@ -8,6 +8,7 @@ import sys
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -852,6 +853,7 @@ def test_port_external_reference_audit_requires_passed_comparison_for_broad_e5(
         "required_for_e5": True,
         "required_scope": "broad_e5",
         "current_status": "broad_e5_passed",
+        "ad_fd_test": "tests/test_waveguide_flux_ad.py::test_flux_smatrix_grad_finite_and_fd_consistent",
         "missing_evidence": [],
         "existing_artifacts": [],
         "existing_vessl_yamls": [],
@@ -1039,6 +1041,7 @@ def test_port_external_reference_shard_requires_comparison_and_envelope(
         "required_for_e5": True,
         "required_scope": "broad_e5",
         "current_status": "broad_e5_passed",
+        "ad_fd_test": "tests/test_waveguide_flux_ad.py::test_flux_smatrix_grad_finite_and_fd_consistent",
         "missing_evidence": [],
         "existing_artifacts": [],
         "existing_vessl_yamls": [str(yaml_path)],
@@ -1897,6 +1900,7 @@ def test_rf_infra_e5_goal_audit_requires_external_manifest_envelope(
         "required_for_e5": True,
         "required_scope": "broad_e5",
         "current_status": "broad_e5_passed",
+        "ad_fd_test": "tests/test_waveguide_flux_ad.py::test_flux_smatrix_grad_finite_and_fd_consistent",
         "missing_evidence": [],
         "existing_artifacts": [],
         "existing_vessl_yamls": [str(yaml_path)],
@@ -2023,6 +2027,7 @@ def test_rf_infra_e5_goal_audit_rejects_failed_json_evidence_artifact(
                         "required_for_e5": True,
                         "required_scope": "broad_e5",
                         "current_status": "broad_e5_passed",
+                        "ad_fd_test": "tests/test_waveguide_flux_ad.py::test_flux_smatrix_grad_finite_and_fd_consistent",
                         "missing_evidence": [],
                         "existing_artifacts": [],
                         "existing_vessl_yamls": [str(yaml_path)],
@@ -2043,6 +2048,116 @@ def test_rf_infra_e5_goal_audit_rejects_failed_json_evidence_artifact(
     assert family["status"] == "partial"
     assert "status=passed" in "; ".join(family["blockers"])
     assert family["artifact_checks"][0]["reported_status"] == "failed"
+
+
+@pytest.mark.parametrize(
+    "ad_fd_test,expect_passed",
+    [
+        # A real, existing, non-xfail AD-vs-FD test -> the AD gate is satisfied.
+        ("tests/test_waveguide_flux_ad.py::test_flux_smatrix_grad_finite_and_fd_consistent", True),
+        # No AD test declared -> the differentiability moat is absent -> blocked.
+        (None, False),
+        # Declared but the file/test does not exist -> dangling pointer -> blocked.
+        ("tests/test_does_not_exist.py::test_nope", False),
+    ],
+)
+def test_ad_fd_gate_blocks_broad_e5_without_valid_ad_test(
+    tmp_path: Path, ad_fd_test, expect_passed
+):
+    """T2.2 falsifier: broad_e5_passed requires a valid named AD-vs-FD test.
+
+    Everything else (broad E4 comparison + broad E5 envelope + YAML) passes; the
+    ONLY differentiator is `ad_fd_test`. Removing/dangling it must flip the
+    family GREEN->blocked — wiring the differentiability moat into the verdict
+    (framework audit #6). The companion collection-time check (a declared test
+    that is xfail/skip cannot satisfy the gate) lives in
+    tests/test_ad_surface_contract.py::test_ad_fd_gate_tests_are_collected_and_not_xfail_skip.
+    """
+    support_matrix = tmp_path / "sparameter_support_matrix.json"
+    support_matrix.write_text(
+        json.dumps(
+            {
+                "port_families": [
+                    {
+                        "family": "lumped_port",
+                        "primitive": "add_port(extent=None)",
+                        "is_port": True,
+                        "evidence_level": "E5",
+                    }
+                ],
+                "future_port_families": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    comparison = tmp_path / "broad_comparison.json"
+    comparison.write_text(
+        json.dumps(
+            {
+                "status": "passed",
+                "evidence_level": "E4",
+                "claim_scope": "broad external S-parameter comparison",
+                "summary": {
+                    "geometry_count": 3,
+                    "pair_count": 5,
+                    "passed_pair_count": 5,
+                    "failed_pair_count": 0,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    envelope = tmp_path / "broad_envelope.json"
+    envelope.write_text(
+        json.dumps(
+            {
+                "status": "passed",
+                "evidence_level": "E5",
+                "required_scope": "broad_e5",
+                "claim_scope": "broad mesh/frequency/geometry envelope",
+                "max_mag_abs_tol": 0.05,
+                "envelope_summary": {
+                    "case_count": 4,
+                    "passed_case_count": 4,
+                    "dx_values_m": [5e-5, 1e-4],
+                    "eps_r_values": [2.0, 4.0],
+                    "geometries": ["slab", "notch"],
+                    "freq_range_hz": [1.0e10, 1.5e10],
+                    "max_mag_abs_diff_across_cases": 0.02,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    yaml_path = tmp_path / "physics_gate_port_external_lumped.yaml"
+    yaml_path.write_text("name: unit\n", encoding="utf-8")
+    entry = {
+        "family": "lumped_port",
+        "required_for_e5": True,
+        "required_scope": "broad_e5",
+        "current_status": "broad_e5_passed",
+        "missing_evidence": [],
+        "existing_artifacts": [],
+        "existing_vessl_yamls": [str(yaml_path)],
+        "external_comparison_artifacts": [str(comparison)],
+        "broad_e5_envelope_artifacts": [str(envelope)],
+    }
+    if ad_fd_test is not None:
+        entry["ad_fd_test"] = ad_fd_test
+    manifest = tmp_path / "port_external_reference_requirements.json"
+    manifest.write_text(json.dumps({"requirements": [entry]}), encoding="utf-8")
+
+    audit = port_external_reference_check.build_external_reference_audit(
+        manifest, support_matrix
+    )
+    family = audit["requirements"][0]
+    if expect_passed:
+        assert family["status"] == "passed", family["blockers"]
+        assert family["ad_gate_ok"] is True
+    else:
+        assert family["status"] == "blocked"
+        assert family["ad_gate_ok"] is False
+        assert any("ad_fd_test" in b for b in family["blockers"]), family["blockers"]
 
 
 def test_broad_envelope_rejected_without_numeric_breadth(tmp_path: Path):


### PR DESCRIPTION
**Stacked on #185** (which is stacked on #184). Base = `feat/t2.1-waveguide-phase-gate`; merge #184 → #185 → this in order, then the diff is just the 2 T2.2 commits.

## What & why
Framework audit **finding #6**: the differentiability "moat" (AD↔FD consistency) was gated in *separate* tests, structurally disconnected from the `broad_e5_passed` verdict — a user reading GREEN learned nothing about gradient trustworthiness (the headline claim). T2.2 wires it in.

- **manifest** (`port_external_reference_requirements.json`): each family declares `ad_fd_test` (named AD-vs-FD test nodeid) + `ad_fd_test_note`. Waveguide → `test_flux_smatrix_grad_finite_and_fd_consistent` (CPU, passes 16s); MSL → `test_msl_ad_fd_converged_tight` (gpu). **Coaxial = null** — its extractor is numpy/`not-traceable` (proven by `test_coaxial_reflection_extraction_breaks_tape`), so it cannot satisfy the moat and is correctly blocked from `broad_e5_passed`.
- **auditor** (`check_port_external_references.py`): `_ad_test_check` + `ad_gate_ok` ANDed into `result_status`; a `broad_e5_passed` family without a declared+existing+non-xfail AD test is **blocked**. Uses `ast` (not a substring) → exact `def` match + a static xfail/skip backstop. Verified: waveguide still passes (0 blockers), coax blocked on AD.
- **collection-time contract test** (`test_ad_surface_contract.py`): the authoritative "existence ≠ passing" half (m1) — a child `pytest --collect-only` with `addopts` cleared (so gpu tests still collect) and `-m "not (xfail or skip or skipif)"` proves each declared `ad_fd_test` is collected AND not xfail/skip. Verified discriminating (drops 2 known xfail tests on a probe file); gpu passes, xfail fails.
- **falsifier self-test**: a fully-passing `broad_e5` entry flips GREEN→blocked when `ad_fd_test` is null or dangling.

## Review
Independent code review (`oh-my-claudecode:code-reviewer`): APPROVE-WITH-CHANGES, 0 CRITICAL/HIGH, 3 MEDIUM + 3 LOW — all addressed (AST rewrite closed the auditor↔contract-test xfail-blindness + the substring false-positive; subprocess parse/returncode hardening; repo-root path anchoring; documented the dynamic-skip / gpu-lane boundary).

## Verification
55 gate-reporting + AD-contract tests green; the load-bearing waveguide AD-vs-FD test passes (16s); full suite (1458) collects clean; lint clean; JSON valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)