### PR TITLE
T2.3: live-physics anchor for the waveguide broad-E5 claim

### DIFF
--- a/tests/test_waveguide_broad_e5_envelope_gates.py
+++ b/tests/test_waveguide_broad_e5_envelope_gates.py
@@ -14,7 +14,12 @@ Two layers, mirroring ``tests/test_msl_broad_e5_envelope_gates.py``:
    perturbed S-parameters, asserting the magnitude-diff gate fires exactly at
    the threshold (ideal slab passes; a +0.1 |S| perturbation fails).
 
-These are pure-Python contracts (no FDTD).
+These are pure-Python contracts (no FDTD). Because both layers REPLAY frozen
+numbers, a regression in the live ``compute_waveguide_s_matrix`` would not flip
+them red — that gap is closed by the LIVE-physics anchor
+``tests/test_waveguide_broad_e5_live_anchor.py`` (T2.3), which runs the
+production extractor at CI time on non-trivial geometries (PEC-short, empty-guide
+transmission) and checks it against analytic physics.
 """
 from __future__ import annotations
 

--- a/tests/test_waveguide_broad_e5_live_anchor.py
+++ b/tests/test_waveguide_broad_e5_live_anchor.py
@@ -1,0 +1,168 @@
+"""T2.3 — LIVE-physics anchor for the waveguide broad-E5 claim.
+
+The committed broad-E5 gate (``test_waveguide_broad_e5_envelope_gates.py``) is a
+FROZEN replay: it re-derives a verdict from per-case JSON regenerated on VESSL.
+A real regression in the production ``compute_waveguide_s_matrix`` would NOT flip
+it red (the rfx_npz is gitignored — framework audit, finding "frozen replay").
+
+This file RUNS ``compute_waveguide_s_matrix`` at CI time on NON-TRIVIAL
+geometries and checks the live output against analytic physics, so an extractor
+regression turns it red. Per the T2.3 design + review:
+
+- PEC-short (``|S11|=1`` total reflection, ``|S21|=0``): the primary regression
+  witness. ``normalize=False`` — the two-run ``normalize=True`` has standing-wave
+  node artifacts on strong reflectors (battery ``test_pec_short_s11_magnitude``);
+  bare ``normalize=True`` is also the ±10–20 % non-convergent mode the audit
+  flagged (#12). |S11|=1 is the NON-trivial anchor the review asked for — NOT the
+  empty-guide |S11|=0 (too forgiving).
+- empty matched guide (``|S21|≈1`` full transmission): the live TRANSMISSION /
+  S21 path witness (PEC-short alone checks only reflection). ``normalize='flux'``
+  — the documented-convergent mode, not bare ``normalize=True``. Used here as a
+  secondary S21 witness + passivity check, NOT as the S11 regression witness.
+- boundary is CPML on both: ``run_until_decay`` / flux convergence assume an
+  absorbing boundary (#169); the test asserts the CPML boundary explicitly.
+- falsifier: a perturbed live S-matrix must breach the gate — proving the anchor
+  catches what the frozen replay cannot.
+- R5: full per-frequency dump on every run.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import jax.numpy as jnp
+
+from rfx.api import Simulation
+from rfx.geometry.csg import Box
+
+# Canonical 40 mm x 20 mm guide, TE10 cutoff 3.75 GHz (matches the validation
+# battery so the live numbers are directly comparable). Single-mode band.
+DOMAIN = (0.12, 0.04, 0.02)
+PORT_LEFT_X = 0.01
+PORT_RIGHT_X = 0.09
+BAND_HZ = (5.0e9, 7.0e9)
+N_FREQS = 6
+
+
+def _build_sim(freqs_hz, *, pec_short_x=None):
+    """Two-port WR-style guide; optional full-cross-section PEC short.
+
+    Compact local builder (mirrors the validation battery's ``_build_sim``) so
+    this live anchor is self-contained.
+    """
+    freqs = np.asarray(freqs_hz, dtype=float)
+    f0 = float(freqs.mean())
+    bandwidth = max(0.2, min(0.8, (freqs[-1] - freqs[0]) / max(f0, 1.0)))
+    sim = Simulation(
+        freq_max=max(float(freqs[-1]), f0),
+        domain=DOMAIN,
+        boundary="cpml",
+        cpml_layers=10,
+    )
+    if pec_short_x is not None:
+        thickness = 0.002
+        sim.add(
+            Box((pec_short_x, 0.0, 0.0),
+                (pec_short_x + thickness, DOMAIN[1], DOMAIN[2])),
+            material="pec",
+        )
+    port_freqs = jnp.asarray(freqs)
+    for x, direction, name in ((PORT_LEFT_X, "+x", "left"),
+                               (PORT_RIGHT_X, "-x", "right")):
+        sim.add_waveguide_port(
+            x, direction=direction, mode=(1, 0), mode_type="TE",
+            freqs=port_freqs, f0=f0, bandwidth=bandwidth,
+            waveform="modulated_gaussian", n_modes=1, name=name,
+        )
+    return sim
+
+
+def _s_matrix(sim, *, normalize, num_periods=40):
+    result = sim.compute_waveguide_s_matrix(num_periods=num_periods, normalize=normalize)
+    s = np.asarray(result.s_params)
+    idx = {name: i for i, name in enumerate(result.port_names)}
+    return s, np.asarray(result.freqs), idx
+
+
+def _assert_cpml(sim):
+    # m3: the flux / decay convergence assumes an absorbing boundary.
+    assert sim._boundary == "cpml", (
+        f"live anchor requires a CPML (absorbing) boundary, got {sim._boundary!r}"
+    )
+
+
+def test_live_pec_short_s11_anchor():
+    """LIVE compute_waveguide_s_matrix: PEC-short total reflection, |S11|≈1.
+
+    The primary regression witness. Non-trivial (|S11|=1, NOT 0). A real
+    extractor regression (ghost-cell contamination, wrong modal V/I integral)
+    drops |S11| below the Meep-class 0.99 gate — exactly what the frozen replay
+    cannot see.
+    """
+    freqs = np.linspace(*BAND_HZ, N_FREQS)
+    sim = _build_sim(freqs, pec_short_x=0.085)
+    _assert_cpml(sim)
+    s, _, idx = _s_matrix(sim, normalize=False)
+    s11 = np.abs(s[idx["left"], idx["left"], :])
+    s21 = np.abs(s[idx["right"], idx["left"], :])
+    print(f"\n[live pec-short] |S11|={np.array2string(s11, precision=4)}")
+    # NOTE: |S21| is NOT asserted here. With normalize=False (single-run wave
+    # decomposition) the off-diagonal S21 is convention-dependent — the source
+    # spectrum is not cancelled without the two-run normalization, so the raw
+    # right-port ratio is ~1 even behind the short. PEC-short's validated,
+    # Meep-class quantity is |S11| (battery test_pec_short_s11_magnitude); the
+    # live transmission/S21 path is checked separately on the empty guide with
+    # normalize='flux'. (R5: the |S21|≈0 expectation was an extraction-convention
+    # misdiagnosis, surfaced here; not chased — R2.)
+    print(f"[live pec-short] |S21|(normalize=False, NOT asserted)={np.array2string(s21, precision=4)}")
+    assert s11.min() >= 0.99, (
+        f"LIVE PEC-short min|S11|={s11.min():.4f} < 0.99 — compute_waveguide_s_matrix "
+        f"regression (the frozen broad-E5 replay would NOT catch this)"
+    )
+    assert s11.max() < 1.03, f"LIVE PEC-short max|S11|={s11.max():.4f} non-passive"
+
+
+def test_live_empty_guide_s21_anchor():
+    """LIVE compute_waveguide_s_matrix: empty matched guide transmits, |S21|≈1.
+
+    Secondary witness covering the TRANSMISSION / S21 extraction path (PEC-short
+    checks only reflection). ``normalize='flux'`` (documented-convergent), plus a
+    live passivity check |S11|²+|S21|² ≤ 1. Empty-guide |S11|≈0 is used only as a
+    sanity bound here, NOT as the S11 regression witness (that is PEC-short).
+    """
+    freqs = np.linspace(*BAND_HZ, N_FREQS)
+    sim = _build_sim(freqs)
+    _assert_cpml(sim)
+    s, _, idx = _s_matrix(sim, normalize="flux")
+    s11 = np.abs(s[idx["left"], idx["left"], :])
+    s21 = np.abs(s[idx["right"], idx["left"], :])
+    power = s11**2 + s21**2
+    print(f"\n[live empty] |S21|={np.array2string(s21, precision=4)}  (ideal 1)")
+    print(f"[live empty] |S11|={np.array2string(s11, precision=4)}  passivity={np.array2string(power, precision=4)}")
+    assert s21.min() >= 0.9, (
+        f"LIVE empty-guide min|S21|={s21.min():.4f} < 0.9 — transmission "
+        f"extraction regression in compute_waveguide_s_matrix"
+    )
+    assert power.max() <= 1.05, (
+        f"LIVE empty-guide max(|S11|²+|S21|²)={power.max():.4f} > 1.05 — "
+        f"non-passive (energy-injection) extractor bug"
+    )
+
+
+def test_live_anchor_catches_extractor_perturbation():
+    """Falsifier: the live anchor flips red under an extractor regression.
+
+    Runs PEC-short live, then perturbs the live |S11| by −10 % (a stand-in for a
+    compute_waveguide_s_matrix regression) and asserts the gate predicate fails.
+    This is the property the FROZEN replay lacks: it would keep passing against
+    its committed answer key. Lightweight (no second FDTD run).
+    """
+    freqs = np.linspace(*BAND_HZ, N_FREQS)
+    sim = _build_sim(freqs, pec_short_x=0.085)
+    s, _, idx = _s_matrix(sim, normalize=False)
+    s11 = np.abs(s[idx["left"], idx["left"], :])
+    assert s11.min() >= 0.99  # healthy live baseline
+    perturbed = s11 * 0.90  # simulate a 10% extractor regression
+    assert perturbed.min() < 0.99, (
+        "a −10 % extractor regression did not breach the 0.99 gate — the live "
+        "anchor would be too loose to catch a real regression"
+    )

--- a/tests/test_waveguide_broad_e5_live_anchor.py
+++ b/tests/test_waveguide_broad_e5_live_anchor.py
@@ -21,8 +21,10 @@ regression turns it red. Per the T2.3 design + review:
   secondary S21 witness + passivity check, NOT as the S11 regression witness.
 - boundary is CPML on both: ``run_until_decay`` / flux convergence assume an
   absorbing boundary (#169); the test asserts the CPML boundary explicitly.
-- falsifier: a perturbed live S-matrix must breach the gate — proving the anchor
-  catches what the frozen replay cannot.
+- discrimination is STRUCTURAL: these tests run the production extractor, so a
+  real regression flips them red; the frozen replay reads a fixed JSON answer key
+  and cannot. The PEC-short test also asserts the gate margin is tight (healthy
+  values sit ~1% above the 0.99 floor), so the gate is not slack.
 - R5: full per-frequency dump on every run.
 """
 
@@ -84,7 +86,10 @@ def _s_matrix(sim, *, normalize, num_periods=40):
 
 
 def _assert_cpml(sim):
-    # m3: the flux / decay convergence assumes an absorbing boundary.
+    # Cheap constructor guard (echoes the boundary kwarg). The REAL absorbing-
+    # boundary witness (m3 / #169) is downstream: the empty-guide |S11|≈0 in
+    # test_live_empty_guide_s21_anchor — a non-absorbing boundary could not give
+    # a matched-load reflection near zero.
     assert sim._boundary == "cpml", (
         f"live anchor requires a CPML (absorbing) boundary, got {sim._boundary!r}"
     )
@@ -118,7 +123,17 @@ def test_live_pec_short_s11_anchor():
         f"LIVE PEC-short min|S11|={s11.min():.4f} < 0.99 — compute_waveguide_s_matrix "
         f"regression (the frozen broad-E5 replay would NOT catch this)"
     )
+    # 1.03 matches the battery's validated near-cutoff ceiling (the 5 GHz bin at
+    # f/fc=1.33 carries a small over-unity discrete-Yee Z_TE residual).
     assert s11.max() < 1.03, f"LIVE PEC-short max|S11|={s11.max():.4f} non-passive"
+    # Gate-tightness witness (non-vacuous): the live healthy values sit close to
+    # the 0.99 floor, so the gate catches a regression of ~1%, not a slack one.
+    # This is what makes the LIVE anchor discriminating where the frozen replay
+    # (a fixed JSON answer key, blind to the live extractor) is not.
+    assert s11.min() - 0.99 < 0.02, (
+        f"PEC-short gate is slack: healthy min|S11|={s11.min():.4f} is >0.02 above "
+        f"the 0.99 floor, so a real regression could hide under it"
+    )
 
 
 def test_live_empty_guide_s21_anchor():
@@ -138,31 +153,21 @@ def test_live_empty_guide_s21_anchor():
     power = s11**2 + s21**2
     print(f"\n[live empty] |S21|={np.array2string(s21, precision=4)}  (ideal 1)")
     print(f"[live empty] |S11|={np.array2string(s11, precision=4)}  passivity={np.array2string(power, precision=4)}")
-    assert s21.min() >= 0.9, (
-        f"LIVE empty-guide min|S21|={s21.min():.4f} < 0.9 — transmission "
+    # Tight transmission witness (measured ~0.999; the battery's matched-load
+    # gates are ratcheted to their values, so this is too — 0.98 keeps ~2%
+    # cross-machine float margin, far tighter than the prior slack 0.9).
+    assert s21.min() >= 0.98, (
+        f"LIVE empty-guide min|S21|={s21.min():.4f} < 0.98 — transmission "
         f"extraction regression in compute_waveguide_s_matrix"
+    )
+    # Absorbing-boundary witness (m3 / #169): a matched empty guide reflects ~0
+    # ONLY because the boundary is genuinely absorbing — this is the real
+    # downstream CPML check (vs the constructor-echo in _assert_cpml).
+    assert s11.max() < 0.05, (
+        f"LIVE empty-guide max|S11|={s11.max():.4f} >= 0.05 — boundary is not "
+        f"absorbing as expected (or matched-load extraction regressed)"
     )
     assert power.max() <= 1.05, (
         f"LIVE empty-guide max(|S11|²+|S21|²)={power.max():.4f} > 1.05 — "
         f"non-passive (energy-injection) extractor bug"
-    )
-
-
-def test_live_anchor_catches_extractor_perturbation():
-    """Falsifier: the live anchor flips red under an extractor regression.
-
-    Runs PEC-short live, then perturbs the live |S11| by −10 % (a stand-in for a
-    compute_waveguide_s_matrix regression) and asserts the gate predicate fails.
-    This is the property the FROZEN replay lacks: it would keep passing against
-    its committed answer key. Lightweight (no second FDTD run).
-    """
-    freqs = np.linspace(*BAND_HZ, N_FREQS)
-    sim = _build_sim(freqs, pec_short_x=0.085)
-    s, _, idx = _s_matrix(sim, normalize=False)
-    s11 = np.abs(s[idx["left"], idx["left"], :])
-    assert s11.min() >= 0.99  # healthy live baseline
-    perturbed = s11 * 0.90  # simulate a 10% extractor regression
-    assert perturbed.min() < 0.99, (
-        "a −10 % extractor regression did not breach the 0.99 gate — the live "
-        "anchor would be too loose to catch a real regression"
     )


### PR DESCRIPTION
**Stacked on #186** (→ #185 → #184). Base = `feat/t2.2-differentiability-gate`.

## What & why
The committed broad-E5 gate (`test_waveguide_broad_e5_envelope_gates.py`) is a **frozen replay** of VESSL-regenerated per-case JSON — a regression in the live `compute_waveguide_s_matrix` would NOT flip it red (audit). T2.3 adds a **live anchor** that runs the production extractor at CI time on non-trivial geometries and checks it against analytic physics.

- **`test_live_pec_short_s11_anchor`** — PEC-short total reflection, `|S11|≥0.99` (`normalize=False`, the proven battery convention; bare `normalize=True` is the ±10-20% non-convergent mode, audit #12). Non-trivial (`|S11|=1`, **not** the too-forgiving empty-guide `|S11|=0`). Primary regression witness + a gate-tightness assertion (healthy values sit <0.02 above the 0.99 floor → gate not slack).
- **`test_live_empty_guide_s21_anchor`** — empty matched guide transmits, `|S21|≥0.98` + passivity, `normalize='flux'` (documented-convergent). Covers the live S21/transmission path PEC-short can't, and asserts `|S11|<0.05` as the real **absorbing-boundary witness** (m3/#169).

## R5/R2 note (the most-scrutinized decision)
Initial run showed PEC-short `|S21|≈1` under `normalize=False`. This is a known extraction-convention artifact (single-run S21 doesn't cancel the source spectrum — the production code documents it at `_sparams.py:227-229`), **not** a transmission bug. Per R2 I did not chase it; per R5 I surfaced it in the docstring and dropped the unvalidated `|S21|≈0` assertion (PEC-short's validated quantity is `|S11|`; transmission is checked on the empty guide). The independent reviewer traced the extractor math and confirmed this call.

## Review
Independent code review (`oh-my-claudecode:code-reviewer`): APPROVE-WITH-CHANGES, 0 CRITICAL/HIGH, 3 MEDIUM + 3 LOW — all addressed (tightened the slack `|S21|` 0.9→0.98; replaced the tautological falsifier with a real gate-tightness assertion + structural-discrimination docstring; added the genuine downstream absorbing-boundary witness instead of the constructor-echo).

## Verification
2 live FDTD tests pass (9.4s, unmarked — CI-time liveness is the point); frozen gate (11 tests) still green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)