### PR TITLE
T2.5: git-tracked-artifact enforcement (--require-committed)

### DIFF
--- a/scripts/diagnostics/check_port_external_references.py
+++ b/scripts/diagnostics/check_port_external_references.py
@@ -119,34 +119,42 @@ def _read_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-_GIT_TRACKED_CACHE: set[str] | None = None
+_GIT_COMMITTED_CACHE: set[str] | None = None
 
 
-def _git_tracked_paths() -> set[str]:
-    """Repo-relative paths under git version control (T2.5).
+def _reset_git_cache() -> None:
+    """Test hook: clear the committed-path cache (it is process-global)."""
+    global _GIT_COMMITTED_CACHE
+    _GIT_COMMITTED_CACHE = None
 
-    One ``git ls-files`` call, cached. This is the m2 mechanism — version-control
-    membership, NOT ``path.exists()`` — so a gitignored ``.omx`` artifact that is
-    merely present on the author's disk (the coaxial-overclaim root cause, audit
-    #2) is correctly seen as uncommitted.
+
+def _git_committed_paths() -> set[str]:
+    """Repo-relative paths committed to HEAD (T2.5).
+
+    One ``git ls-tree -r HEAD --name-only`` call, cached. Uses HEAD membership —
+    genuinely COMMITTED, not merely ``git ls-files``-staged — and definitely not
+    ``path.exists()``: a gitignored ``.omx`` artifact merely present on the
+    author's disk (the coaxial-overclaim root cause, audit #2) is correctly seen
+    as uncommitted. If git is unavailable the set is empty, which under
+    require_committed BLOCKS everything (fail-closed, the safe direction).
     """
-    global _GIT_TRACKED_CACHE
-    if _GIT_TRACKED_CACHE is None:
+    global _GIT_COMMITTED_CACHE
+    if _GIT_COMMITTED_CACHE is None:
         try:
             r = subprocess.run(
-                ["git", "ls-files"], cwd=REPO_ROOT,
+                ["git", "ls-tree", "-r", "HEAD", "--name-only"], cwd=REPO_ROOT,
                 capture_output=True, text=True,
             )
-            _GIT_TRACKED_CACHE = (
+            _GIT_COMMITTED_CACHE = (
                 set(r.stdout.splitlines()) if r.returncode == 0 else set()
             )
-        except (OSError, FileNotFoundError):
-            _GIT_TRACKED_CACHE = set()
-    return _GIT_TRACKED_CACHE
+        except OSError:
+            _GIT_COMMITTED_CACHE = set()
+    return _GIT_COMMITTED_CACHE
 
 
 def _is_committed(artifact: str) -> bool:
-    return _display(_repo_path(artifact)) in _git_tracked_paths()
+    return _display(_repo_path(artifact)) in _git_committed_paths()
 
 
 def _artifact_check(value: str) -> dict[str, Any]:
@@ -382,37 +390,35 @@ def _requirement_result(
     ]
     ad_test_check = _ad_test_check(entry.get("ad_fd_test"))
     ad_gate_ok = bool(ad_test_check["declared"] and ad_test_check["exists"])
-    # T2.5: annotate every artifact with its git-tracked status. Under
-    # require_committed the GATING artifacts (comparison + envelope) must be
-    # version-controlled, not merely present on disk — closing the gitignored-.omx
-    # overclaim hole (audit #2). git_tracked is reported always (transparency).
+    # T2.5: annotate git-committed status ONLY under require_committed (so the
+    # default path stays a true no-op — no git subprocess). git_tracked is None
+    # when the check was not run.
     for c in artifact_checks + yaml_checks + comparison_checks + envelope_checks:
-        c["git_tracked"] = _is_committed(str(c["artifact"]))
-
-    def _committed_ok(check: dict[str, Any]) -> bool:
-        return (not require_committed) or bool(check["git_tracked"])
+        c["git_tracked"] = _is_committed(str(c["artifact"])) if require_committed else None
 
     missing_artifacts = [a for a in artifact_checks + yaml_checks if not a["exists"]]
     failed_comparison_artifacts = [
         a for a in comparison_checks if not a["is_passed_e4_comparison"]
     ]
+    # Counts are CONTENT-only — a passing-content artifact counts as passing. The
+    # committed requirement is a SEPARATE gate (uncommitted_gating_artifacts +
+    # result_status), so the count-based blockers never contradict the committed
+    # blocker for an artifact that genuinely passes on content (M3).
     passed_comparison_artifact_count = sum(
-        1 for a in comparison_checks
-        if a["is_passed_e4_comparison"] and _committed_ok(a)
+        1 for a in comparison_checks if a["is_passed_e4_comparison"]
     )
     passed_broad_e4_comparison_artifact_count = sum(
-        1 for a in comparison_checks
-        if a["is_passed_broad_e4_comparison"] and _committed_ok(a)
+        1 for a in comparison_checks if a["is_passed_broad_e4_comparison"]
     )
     failed_envelope_artifacts = [
         a for a in envelope_checks if not a["is_passed_broad_e5_envelope"]
     ]
     passed_envelope_artifact_count = sum(
-        1 for a in envelope_checks
-        if a["is_passed_broad_e5_envelope"] and _committed_ok(a)
+        1 for a in envelope_checks if a["is_passed_broad_e5_envelope"]
     )
-    # Gating artifacts that pass on CONTENT but are not committed — the precise
-    # overclaim require_committed exists to catch.
+    # Gating artifacts that pass on CONTENT but are not committed to HEAD — the
+    # precise overclaim require_committed exists to catch (present-but-untracked,
+    # which path.exists() missed; audit #2).
     uncommitted_gating_artifacts = []
     if require_committed:
         uncommitted_gating_artifacts = [
@@ -469,7 +475,7 @@ def _requirement_result(
     if uncommitted_gating_artifacts:
         blockers.append(
             "broad_e5_passed gating artifact(s) pass on content but are NOT "
-            "git-tracked (present on disk only, e.g. gitignored .omx) under "
+            "committed to HEAD (present on disk only, e.g. gitignored .omx) under "
             f"--require-committed: {uncommitted_gating_artifacts} — commit them to "
             "tests/fixtures/ (audit #2, the coaxial-overclaim hole)"
         )
@@ -842,9 +848,10 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help=(
             "T2.5: a broad_e5_passed family's GATING artifacts (comparison + "
-            "envelope) must be git-tracked, not merely present on disk (catches "
-            "gitignored .omx — the coaxial-overclaim hole). On in CI; off for unit "
-            "tests that use tmp_path artifacts."
+            "envelope) must be committed to HEAD, not merely present on disk "
+            "(catches gitignored .omx — the coaxial-overclaim hole). REQUIRES git "
+            "(fail-closed if absent); use in git-having CI, off for unit tests "
+            "that use tmp_path artifacts."
         ),
     )
     args = parser.parse_args(argv)

--- a/scripts/diagnostics/check_port_external_references.py
+++ b/scripts/diagnostics/check_port_external_references.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import ast
 import json
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -116,6 +117,36 @@ def _display(path: Path) -> str:
 
 def _read_json(path: Path) -> dict[str, Any]:
     return json.loads(path.read_text(encoding="utf-8"))
+
+
+_GIT_TRACKED_CACHE: set[str] | None = None
+
+
+def _git_tracked_paths() -> set[str]:
+    """Repo-relative paths under git version control (T2.5).
+
+    One ``git ls-files`` call, cached. This is the m2 mechanism — version-control
+    membership, NOT ``path.exists()`` — so a gitignored ``.omx`` artifact that is
+    merely present on the author's disk (the coaxial-overclaim root cause, audit
+    #2) is correctly seen as uncommitted.
+    """
+    global _GIT_TRACKED_CACHE
+    if _GIT_TRACKED_CACHE is None:
+        try:
+            r = subprocess.run(
+                ["git", "ls-files"], cwd=REPO_ROOT,
+                capture_output=True, text=True,
+            )
+            _GIT_TRACKED_CACHE = (
+                set(r.stdout.splitlines()) if r.returncode == 0 else set()
+            )
+        except (OSError, FileNotFoundError):
+            _GIT_TRACKED_CACHE = set()
+    return _GIT_TRACKED_CACHE
+
+
+def _is_committed(artifact: str) -> bool:
+    return _display(_repo_path(artifact)) in _git_tracked_paths()
 
 
 def _artifact_check(value: str) -> dict[str, Any]:
@@ -333,7 +364,9 @@ def _broad_e5_envelope_artifact_check(value: str) -> dict[str, Any]:
     return check
 
 
-def _requirement_result(entry: dict[str, Any]) -> dict[str, Any]:
+def _requirement_result(
+    entry: dict[str, Any], require_committed: bool = False
+) -> dict[str, Any]:
     required = bool(entry.get("required_for_e5", False))
     status = str(entry.get("current_status", ""))
     scope = str(entry.get("required_scope", ""))
@@ -349,22 +382,48 @@ def _requirement_result(entry: dict[str, Any]) -> dict[str, Any]:
     ]
     ad_test_check = _ad_test_check(entry.get("ad_fd_test"))
     ad_gate_ok = bool(ad_test_check["declared"] and ad_test_check["exists"])
+    # T2.5: annotate every artifact with its git-tracked status. Under
+    # require_committed the GATING artifacts (comparison + envelope) must be
+    # version-controlled, not merely present on disk — closing the gitignored-.omx
+    # overclaim hole (audit #2). git_tracked is reported always (transparency).
+    for c in artifact_checks + yaml_checks + comparison_checks + envelope_checks:
+        c["git_tracked"] = _is_committed(str(c["artifact"]))
+
+    def _committed_ok(check: dict[str, Any]) -> bool:
+        return (not require_committed) or bool(check["git_tracked"])
+
     missing_artifacts = [a for a in artifact_checks + yaml_checks if not a["exists"]]
     failed_comparison_artifacts = [
         a for a in comparison_checks if not a["is_passed_e4_comparison"]
     ]
     passed_comparison_artifact_count = sum(
-        1 for a in comparison_checks if a["is_passed_e4_comparison"]
+        1 for a in comparison_checks
+        if a["is_passed_e4_comparison"] and _committed_ok(a)
     )
     passed_broad_e4_comparison_artifact_count = sum(
-        1 for a in comparison_checks if a["is_passed_broad_e4_comparison"]
+        1 for a in comparison_checks
+        if a["is_passed_broad_e4_comparison"] and _committed_ok(a)
     )
     failed_envelope_artifacts = [
         a for a in envelope_checks if not a["is_passed_broad_e5_envelope"]
     ]
     passed_envelope_artifact_count = sum(
-        1 for a in envelope_checks if a["is_passed_broad_e5_envelope"]
+        1 for a in envelope_checks
+        if a["is_passed_broad_e5_envelope"] and _committed_ok(a)
     )
+    # Gating artifacts that pass on CONTENT but are not committed — the precise
+    # overclaim require_committed exists to catch.
+    uncommitted_gating_artifacts = []
+    if require_committed:
+        uncommitted_gating_artifacts = [
+            a["path_checked"]
+            for a in comparison_checks
+            if a["is_passed_e4_comparison"] and not a["git_tracked"]
+        ] + [
+            a["path_checked"]
+            for a in envelope_checks
+            if a["is_passed_broad_e5_envelope"] and not a["git_tracked"]
+        ]
 
     blockers = []
     if required and status != BROAD_E5_PASS_STATUS:
@@ -407,6 +466,13 @@ def _requirement_result(entry: dict[str, Any]) -> dict[str, Any]:
         blockers.append("listed external comparison artifact is missing, invalid, or not passed")
     if failed_envelope_artifacts:
         blockers.append("listed broad E5 envelope artifact is missing, invalid, or not passed")
+    if uncommitted_gating_artifacts:
+        blockers.append(
+            "broad_e5_passed gating artifact(s) pass on content but are NOT "
+            "git-tracked (present on disk only, e.g. gitignored .omx) under "
+            f"--require-committed: {uncommitted_gating_artifacts} — commit them to "
+            "tests/fixtures/ (audit #2, the coaxial-overclaim hole)"
+        )
 
     result_status = (
         "passed"
@@ -420,6 +486,7 @@ def _requirement_result(entry: dict[str, Any]) -> dict[str, Any]:
         and ad_gate_ok
         and not failed_comparison_artifacts
         and not failed_envelope_artifacts
+        and not uncommitted_gating_artifacts
         else "blocked"
     )
     if not required:
@@ -447,6 +514,8 @@ def _requirement_result(entry: dict[str, Any]) -> dict[str, Any]:
         "passed_broad_e5_envelope_artifact_count": passed_envelope_artifact_count,
         "ad_fd_test_check": ad_test_check,
         "ad_gate_ok": ad_gate_ok,
+        "require_committed": require_committed,
+        "uncommitted_gating_artifacts": uncommitted_gating_artifacts,
         "vessl_yaml_count": len(yaml_checks),
         "missing_artifact_count": len(missing_artifacts),
         "failed_comparison_artifact_count": len(failed_comparison_artifacts),
@@ -507,6 +576,7 @@ def _surface_coverage(
 def build_external_reference_audit(
     manifest_path: Path,
     support_matrix_path: Path | None = None,
+    require_committed: bool = False,
 ) -> dict[str, Any]:
     if support_matrix_path is None:
         support_matrix_path = _repo_path(DEFAULT_SUPPORT_MATRIX)
@@ -518,7 +588,10 @@ def build_external_reference_audit(
     yaml_contract: dict[str, Any] | None = None
     if check_yaml_contract:
         yaml_contract = build_execution_manifest(manifest_path)
-    results = [_requirement_result(entry) for entry in manifest.get("requirements", [])]
+    results = [
+        _requirement_result(entry, require_committed=require_committed)
+        for entry in manifest.get("requirements", [])
+    ]
     coverage = _surface_coverage(results, support_matrix_path)
     required_results = [row for row in results if row["required_for_e5"]]
     missing_vessl_yaml = [
@@ -764,12 +837,23 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Exit 2 unless every required port family has broad E5 external/reference coverage.",
     )
+    parser.add_argument(
+        "--require-committed",
+        action="store_true",
+        help=(
+            "T2.5: a broad_e5_passed family's GATING artifacts (comparison + "
+            "envelope) must be git-tracked, not merely present on disk (catches "
+            "gitignored .omx — the coaxial-overclaim hole). On in CI; off for unit "
+            "tests that use tmp_path artifacts."
+        ),
+    )
     args = parser.parse_args(argv)
 
     manifest_path = _repo_path(args.manifest)
     payload = build_external_reference_audit(
         manifest_path,
         _repo_path(args.support_matrix),
+        require_committed=args.require_committed,
     )
     _write_report(payload, _repo_path(args.output_dir))
     print(f"status={payload['status']} incomplete_count={payload['incomplete_count']}")

--- a/scripts/diagnostics/report_port_external_reference_shard.py
+++ b/scripts/diagnostics/report_port_external_reference_shard.py
@@ -28,8 +28,11 @@ def build_family_reference_shard(
     family: str,
     manifest_path: Path,
     support_matrix_path: Path,
+    require_committed: bool = False,
 ) -> dict[str, Any]:
-    audit = build_external_reference_audit(manifest_path, support_matrix_path)
+    audit = build_external_reference_audit(
+        manifest_path, support_matrix_path, require_committed=require_committed
+    )
     rows = {row["family"]: row for row in audit["requirements"]}
     row = rows.get(family)
     if row is None:
@@ -137,12 +140,22 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Exit 2 unless the selected family is broad-E5 complete.",
     )
+    parser.add_argument(
+        "--require-committed",
+        action="store_true",
+        help=(
+            "T2.5: require the family's gating artifacts to be git-tracked, not "
+            "merely present on disk (catches gitignored .omx). Use on clean-"
+            "checkout CI / VESSL lanes."
+        ),
+    )
     args = parser.parse_args(argv)
 
     payload = build_family_reference_shard(
         args.family,
         _repo_path(args.manifest),
         _repo_path(args.support_matrix),
+        require_committed=args.require_committed,
     )
     _write_report(payload, _repo_path(args.output_dir))
     print(f"status={payload['status']} family={payload['family']}")

--- a/scripts/diagnostics/report_port_external_reference_shard.py
+++ b/scripts/diagnostics/report_port_external_reference_shard.py
@@ -144,9 +144,11 @@ def main(argv: list[str] | None = None) -> int:
         "--require-committed",
         action="store_true",
         help=(
-            "T2.5: require the family's gating artifacts to be git-tracked, not "
-            "merely present on disk (catches gitignored .omx). Use on clean-"
-            "checkout CI / VESSL lanes."
+            "T2.5: require the family's gating artifacts to be committed to HEAD, "
+            "not merely present on disk (catches gitignored .omx). REQUIRES git — "
+            "do NOT use on the git-less VESSL run image (git ls-tree returns empty "
+            "there, which fail-closed would block everything). Use in the fast-"
+            "suite / GitHub-Actions CI lanes that have git."
         ),
     )
     args = parser.parse_args(argv)

--- a/tests/test_physics_gate_reporting.py
+++ b/tests/test_physics_gate_reporting.py
@@ -2160,6 +2160,111 @@ def test_ad_fd_gate_blocks_broad_e5_without_valid_ad_test(
         assert any("ad_fd_test" in b for b in family["blockers"]), family["blockers"]
 
 
+def test_real_manifest_broad_e5_family_survives_require_committed():
+    """T2.5 'on in CI': the real broad_e5_passed family (waveguide) survives the
+    committed-artifact check — its gating evidence is GENUINELY git-tracked, not
+    riding on gitignored .omx. This gates every PR in the fast suite (which has
+    git). Skips only where git is unavailable (the check degrades to empty-set;
+    e.g. the git-less VESSL image), so it never false-fails there.
+    """
+    if not port_external_reference_check._git_tracked_paths():
+        pytest.skip("git ls-files unavailable; require_committed cannot be verified")
+    audit = port_external_reference_check.build_external_reference_audit(
+        REPO_ROOT / "scripts/diagnostics/port_external_reference_requirements.json",
+        REPO_ROOT / "docs/guides/sparameter_support_matrix.json",
+        require_committed=True,
+    )
+    wg = [r for r in audit["requirements"]
+          if r["family"] == "rectangular_waveguide_port"][0]
+    assert wg["status"] == "passed", wg["blockers"]
+    assert not wg["uncommitted_gating_artifacts"], wg["uncommitted_gating_artifacts"]
+
+
+def test_is_committed_distinguishes_tracked_from_present(tmp_path: Path):
+    """T2.5: _is_committed uses git-tracked membership, not path.exists()."""
+    # A real tracked repo file is committed.
+    assert port_external_reference_check._is_committed(
+        "scripts/diagnostics/port_external_reference_requirements.json"
+    )
+    # A present-on-disk-but-untracked file (the .omx-overclaim shape) is NOT.
+    untracked = tmp_path / "present_but_untracked.json"
+    untracked.write_text("{}", encoding="utf-8")
+    assert untracked.exists()  # path.exists() would have passed it (the old bug)
+    assert not port_external_reference_check._is_committed(str(untracked))
+
+
+def test_require_committed_blocks_uncommitted_gating_artifacts(tmp_path: Path):
+    """T2.5 falsifier: under require_committed, present-but-untracked gating
+    artifacts (gitignored .omx) do NOT count -> broad_e5_passed is blocked.
+
+    Everything else passes (broad-E4 comparison + broad-E5 envelope content +
+    YAML + a real AD test); the artifacts live in tmp_path, so they exist on disk
+    but are not git-tracked — exactly the coaxial-overclaim shape (audit #2).
+    """
+    support_matrix = tmp_path / "sparameter_support_matrix.json"
+    support_matrix.write_text(
+        json.dumps({"port_families": [{"family": "lumped_port",
+                                       "primitive": "add_port(extent=None)",
+                                       "is_port": True, "evidence_level": "E5"}],
+                    "future_port_families": []}),
+        encoding="utf-8",
+    )
+    comparison = tmp_path / "broad_comparison.json"
+    comparison.write_text(
+        json.dumps({"status": "passed", "evidence_level": "E4",
+                    "claim_scope": "broad external S-parameter comparison",
+                    "summary": {"geometry_count": 3, "pair_count": 5,
+                                "passed_pair_count": 5, "failed_pair_count": 0}}),
+        encoding="utf-8",
+    )
+    envelope = tmp_path / "broad_envelope.json"
+    envelope.write_text(
+        json.dumps({"status": "passed", "evidence_level": "E5",
+                    "required_scope": "broad_e5",
+                    "claim_scope": "broad mesh/frequency/geometry envelope",
+                    "max_mag_abs_tol": 0.05,
+                    "envelope_summary": {"case_count": 4, "passed_case_count": 4,
+                                         "dx_values_m": [5e-5, 1e-4],
+                                         "eps_r_values": [2.0, 4.0],
+                                         "geometries": ["slab", "notch"],
+                                         "freq_range_hz": [1.0e10, 1.5e10],
+                                         "max_mag_abs_diff_across_cases": 0.02}}),
+        encoding="utf-8",
+    )
+    yaml_path = tmp_path / "physics_gate_port_external_lumped.yaml"
+    yaml_path.write_text("name: unit\n", encoding="utf-8")
+    manifest = tmp_path / "port_external_reference_requirements.json"
+    manifest.write_text(
+        json.dumps({"requirements": [{
+            "family": "lumped_port", "required_for_e5": True,
+            "required_scope": "broad_e5", "current_status": "broad_e5_passed",
+            "ad_fd_test": "tests/test_waveguide_flux_ad.py::test_flux_smatrix_grad_finite_and_fd_consistent",
+            "missing_evidence": [], "existing_artifacts": [],
+            "existing_vessl_yamls": [str(yaml_path)],
+            "external_comparison_artifacts": [str(comparison)],
+            "broad_e5_envelope_artifacts": [str(envelope)],
+        }]}),
+        encoding="utf-8",
+    )
+
+    # Default (require_committed=False): tmp artifacts exist + content-pass -> passed.
+    default = port_external_reference_check.build_external_reference_audit(
+        manifest, support_matrix
+    )
+    assert default["requirements"][0]["status"] == "passed", (
+        default["requirements"][0]["blockers"]
+    )
+
+    # require_committed=True: tmp artifacts are not git-tracked -> blocked.
+    committed = port_external_reference_check.build_external_reference_audit(
+        manifest, support_matrix, require_committed=True
+    )
+    fam = committed["requirements"][0]
+    assert fam["status"] == "blocked"
+    assert fam["uncommitted_gating_artifacts"], "uncommitted gating artifacts not surfaced"
+    assert any("git-tracked" in b for b in fam["blockers"]), fam["blockers"]
+
+
 def test_broad_envelope_rejected_without_numeric_breadth(tmp_path: Path):
     """Single-case prose-'broad' artifact must be rejected (T1 gameability fix)."""
     # Case 1: single-case artifact — fails case_count < 4.

--- a/tests/test_physics_gate_reporting.py
+++ b/tests/test_physics_gate_reporting.py
@@ -2167,8 +2167,8 @@ def test_real_manifest_broad_e5_family_survives_require_committed():
     git). Skips only where git is unavailable (the check degrades to empty-set;
     e.g. the git-less VESSL image), so it never false-fails there.
     """
-    if not port_external_reference_check._git_tracked_paths():
-        pytest.skip("git ls-files unavailable; require_committed cannot be verified")
+    if not port_external_reference_check._git_committed_paths():
+        pytest.skip("git unavailable; require_committed cannot be verified")
     audit = port_external_reference_check.build_external_reference_audit(
         REPO_ROOT / "scripts/diagnostics/port_external_reference_requirements.json",
         REPO_ROOT / "docs/guides/sparameter_support_matrix.json",
@@ -2247,7 +2247,12 @@ def test_require_committed_blocks_uncommitted_gating_artifacts(tmp_path: Path):
         encoding="utf-8",
     )
 
-    # Default (require_committed=False): tmp artifacts exist + content-pass -> passed.
+    # This is the EXACT audit-#2 shape: the gating artifacts are PRESENT on disk
+    # (so the old path.exists() would pass them) but NOT committed to HEAD.
+    assert comparison.exists() and envelope.exists()
+
+    # Default (require_committed=False): present + content-pass -> passed. This is
+    # precisely the overclaim the old path.exists()-based check let through.
     default = port_external_reference_check.build_external_reference_audit(
         manifest, support_matrix
     )
@@ -2255,14 +2260,21 @@ def test_require_committed_blocks_uncommitted_gating_artifacts(tmp_path: Path):
         default["requirements"][0]["blockers"]
     )
 
-    # require_committed=True: tmp artifacts are not git-tracked -> blocked.
+    # require_committed=True: present-but-uncommitted -> blocked, with the gating
+    # artifacts surfaced as uncommitted and marked git_tracked=False (the unique
+    # present-but-untracked path, exercised here in CI — not just the missing-file
+    # path that a clean checkout would hit).
     committed = port_external_reference_check.build_external_reference_audit(
         manifest, support_matrix, require_committed=True
     )
     fam = committed["requirements"][0]
     assert fam["status"] == "blocked"
     assert fam["uncommitted_gating_artifacts"], "uncommitted gating artifacts not surfaced"
-    assert any("git-tracked" in b for b in fam["blockers"]), fam["blockers"]
+    assert any("committed to HEAD" in b for b in fam["blockers"]), fam["blockers"]
+    assert all(
+        c["git_tracked"] is False
+        for c in fam["broad_e5_envelope_artifact_checks"]
+    ), "present-but-untracked envelope artifacts not flagged git_tracked=False"
 
 
 def test_broad_envelope_rejected_without_numeric_breadth(tmp_path: Path):


### PR DESCRIPTION
**Final T2 piece. Stacked on #188** (→ #187 → #186 → #185 → #184).

## What & why
Closes the last audit gap (**#2**): coax published `broad_e5_passed` with its gating evidence in gitignored `.omx` — present on the author's disk, so `path.exists()` passed it locally though it is not in version control. T2.5 makes clean-checkout durability a **designed predicate**.

- **`check_port_external_references.py`**: `_git_committed_paths()` (`git ls-tree -r HEAD --name-only`, cached) + `_is_committed()`; a new `--require-committed`. Under it, a `broad_e5_passed` family's **gating** artifacts (comparison + envelope) must be **committed to HEAD** — present-but-uncommitted no longer counts and surfaces as a dedicated blocker + `uncommitted_gating_artifacts`. Default off (unit tests use tmp_path; true no-op — no git subprocess); the waveguide still passes (its fixtures are HEAD-committed). Fail-closed if git is absent.
- **`report_port_external_reference_shard.py`**: `--require-committed` threaded for the per-family lanes (help warns it requires git).
- **'on in CI'** via the fast suite (which has git): `test_real_manifest_broad_e5_family_survives_require_committed` runs the real auditor with `require_committed=True` and asserts the waveguide survives (skips where git is unavailable, so never false-fails). Plus a falsifier that materializes **present-but-uncommitted** gating artifacts (the exact audit-#2 shape) and asserts blocked-with-flag / passed-without, and a `_is_committed` unit test.

**Deliberately NOT activated in the VESSL YAML** run-blocks — that image is git-less (`sh`/dash, no git), so `git ls-tree` returns empty and fail-closed would falsely block. The fast-suite test is the gating activation.

## Review (the standout points, both fixed)
Independent code review: APPROVE-WITH-CHANGES, 0 CRITICAL/HIGH, 3 MEDIUM. The reviewer reproduced the coax overclaim and confirmed the flip. Fixes: **`git ls-files` → `git ls-tree HEAD`** (ls-files counts *staged*; the flag claims *committed*); **counts made content-only** so a passing-content untracked artifact no longer fires contradictory "needs a passed artifact" blockers alongside the committed blocker; **the falsifier now explicitly exercises the present-but-untracked path** (the unique value `path.exists()` missed).

## Verification
3 T2.5 tests + full gate-reporting + AD-contract green; real auditor `require_committed=True` keeps the waveguide passed; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)