### PR TITLE
Formalize per-port usage rules + physics-set target ceiling

### DIFF
--- a/docs/guides/sparameter_support_matrix.md
+++ b/docs/guides/sparameter_support_matrix.md
@@ -51,7 +51,7 @@ auditor, locked by `tests/test_physics_gate_reporting.py::test_every_family_decl
 | Port | Use it when… | Target ceiling | Status today |
 |---|---|---|---|
 | `add_waveguide_port` | rectangular waveguide TE/TM, uniform Cartesian lane | **broad-E5** | ✅ broad-E5 achieved |
-| `add_msl_port` | matched / thru-line / notch microstrip (quasi-TEM) | broad-E5-regime-restricted | matched-regime only; strong-reflector \|S11\| has a ~0.16 staircase-Z0 floor; eigenmode port is a falsified dead-end |
+| `add_msl_port` | matched / thru-line / notch microstrip (quasi-TEM) | broad-E5-regime-restricted | matched-regime only; strong-reflector \|S11\| has a ~0.16-0.22 staircase-Z0 floor (mesh-conv #183); eigenmode port is a falsified dead-end |
 | `add_coaxial_port` | coax line reflection (forward); **not** in an AD/optimization loop | broad-E5-needs-differentiable-api | physics demonstrated; blocked — evidence uncommitted + numpy extractor fails the AD moat |
 | `add_port(extent=None)` lumped | sub-cell lumped R/L/C/RLC element | **E4-natural-ceiling** | E4 is the ceiling (not a transmission line); validate to E4, do not chase E5 |
 | `add_port(extent=...)` wire | one-cell transverse probe/wire feed (magnitude-only) | **E4-natural-ceiling** | use `add_msl_port` for a real line; E4 is the ceiling |

--- a/docs/guides/sparameter_support_matrix.md
+++ b/docs/guides/sparameter_support_matrix.md
@@ -37,6 +37,27 @@ Hz.
 | `add_tfsf_source(...)` | none | field, flux, NTFF/RCS observables where supported | not a port | plane-wave observables, not port calibration |
 | probes, DFT plane probes, flux monitors | none | field/flux observables | not a port | no port impedance or reference plane |
 
+## Port selection: usage rule & validation ceiling
+
+**`broad-E5` is not a universal goal.** A port's *appropriate* validation level is
+set by its physics, not by a uniform ladder. Single-cell feeds (lumped, wire) are
+not transmission lines, so there is no analytic line oracle to sweep a broad-E5
+envelope against — **E4 is their natural ceiling, and meeting it means "validated
+to ceiling", not "blocked from E5"**. Use each port only where its rule says, and
+read its status against its `target_ceiling` (machine-readable in
+`scripts/diagnostics/port_external_reference_requirements.json`, surfaced by the
+auditor, locked by `tests/test_physics_gate_reporting.py::test_every_family_declares_target_ceiling_and_usage_rule`).
+
+| Port | Use it when… | Target ceiling | Status today |
+|---|---|---|---|
+| `add_waveguide_port` | rectangular waveguide TE/TM, uniform Cartesian lane | **broad-E5** | ✅ broad-E5 achieved |
+| `add_msl_port` | matched / thru-line / notch microstrip (quasi-TEM) | broad-E5-regime-restricted | matched-regime only; strong-reflector \|S11\| has a ~0.16 staircase-Z0 floor; eigenmode port is a falsified dead-end |
+| `add_coaxial_port` | coax line reflection (forward); **not** in an AD/optimization loop | broad-E5-needs-differentiable-api | physics demonstrated; blocked — evidence uncommitted + numpy extractor fails the AD moat |
+| `add_port(extent=None)` lumped | sub-cell lumped R/L/C/RLC element | **E4-natural-ceiling** | E4 is the ceiling (not a transmission line); validate to E4, do not chase E5 |
+| `add_port(extent=...)` wire | one-cell transverse probe/wire feed (magnitude-only) | **E4-natural-ceiling** | use `add_msl_port` for a real line; E4 is the ceiling |
+| `add_floquet_port` | periodic structure, **broadside (θ=0) only** | broad-E5-structural-partial | off-broadside needs a split-field complex-Bloch rewrite (structural ceiling) |
+| generalized planar (stripline/CPW/launch) | — | needs-implementation | no API yet; would inherit the MSL-class ceiling once built |
+
 ## Lane and validation boundaries
 
 ### Lumped `add_port(..., extent=None)`

--- a/scripts/diagnostics/check_port_external_references.py
+++ b/scripts/diagnostics/check_port_external_references.py
@@ -23,6 +23,21 @@ from build_port_external_shard_execution_manifest import build_execution_manifes
 REPO_ROOT = Path(__file__).resolve().parents[2]
 BROAD_E5_PASS_STATUS = "broad_e5_passed"
 DEFAULT_SUPPORT_MATRIX = "docs/guides/sparameter_support_matrix.json"
+
+# Per-port physics-set TARGET ceiling (formalized 2026-06-17). broad-E5 is NOT a
+# universal goal: some ports top out at E4 by their physical nature (single-cell
+# feeds have no transmission-line oracle to sweep an envelope against), so a port
+# meeting its ceiling reads "validated to ceiling", not "blocked from E5". This
+# is descriptive context emitted alongside the broad_e5 verdict — it does NOT
+# change the gate logic.
+VALID_TARGET_CEILINGS = {
+    "broad-E5",                          # full bar reachable (waveguide: achieved)
+    "broad-E5-regime-restricted",        # E5 only in a sub-regime (MSL: matched-only)
+    "broad-E5-needs-differentiable-api", # E5 physics ok, needs a new API (coax)
+    "broad-E5-structural-partial",       # structural ceiling -> sub-case only (floquet broadside)
+    "E4-natural-ceiling",                # E4 IS the physical ceiling (lumped/wire)
+    "needs-implementation",              # no API yet (generalized_planar)
+}
 BROAD_E5_ENVELOPE_BLOCKING_TOKENS = (
     "narrow",
     "enabling",
@@ -527,6 +542,14 @@ def _requirement_result(
         "failed_comparison_artifact_count": len(failed_comparison_artifacts),
         "failed_broad_e5_envelope_artifact_count": len(failed_envelope_artifacts),
         "blockers": blockers,
+        "target_ceiling": str(entry.get("target_ceiling", "")),
+        "usage_rule": str(entry.get("usage_rule", "")),
+        "at_or_below_target_ceiling": (
+            # A family whose physical ceiling is E4 (or needs-impl/structural) is
+            # NOT "failing broad-E5" — broad-E5 is not its goal. This contextualizes
+            # a 'blocked' broad_e5 verdict without changing it.
+            str(entry.get("target_ceiling", "")) != "broad-E5"
+        ),
         "notes": str(entry.get("notes", "")),
     }
 

--- a/scripts/diagnostics/check_port_external_references.py
+++ b/scripts/diagnostics/check_port_external_references.py
@@ -29,7 +29,10 @@ DEFAULT_SUPPORT_MATRIX = "docs/guides/sparameter_support_matrix.json"
 # feeds have no transmission-line oracle to sweep an envelope against), so a port
 # meeting its ceiling reads "validated to ceiling", not "blocked from E5". This
 # is descriptive context emitted alongside the broad_e5 verdict — it does NOT
-# change the gate logic.
+# change the gate logic. The vocab is ENFORCED by the contract test
+# (test_physics_gate_reporting.py::test_every_family_declares_target_ceiling_and_usage_rule),
+# not by this auditor — the emit path passes an unknown ceiling string through
+# unchallenged (it is descriptive, never a gate input).
 VALID_TARGET_CEILINGS = {
     "broad-E5",                          # full bar reachable (waveguide: achieved)
     "broad-E5-regime-restricted",        # E5 only in a sub-regime (MSL: matched-only)
@@ -544,11 +547,16 @@ def _requirement_result(
         "blockers": blockers,
         "target_ceiling": str(entry.get("target_ceiling", "")),
         "usage_rule": str(entry.get("usage_rule", "")),
-        "at_or_below_target_ceiling": (
-            # A family whose physical ceiling is E4 (or needs-impl/structural) is
-            # NOT "failing broad-E5" — broad-E5 is not its goal. This contextualizes
-            # a 'blocked' broad_e5 verdict without changing it.
-            str(entry.get("target_ceiling", "")) != "broad-E5"
+        "broad_e5_is_the_target_ceiling": (
+            # Pure restatement of the declared target_ceiling LABEL — NOT an
+            # achieved-vs-ceiling check (it reads no evidence/status field). It
+            # exists only to contextualize the broad_e5 verdict: when this is
+            # False, the family's physical ceiling is below full broad-E5 (E4,
+            # structural-partial, needs-impl, regime-restricted), so a 'blocked'
+            # broad_e5 verdict is by-design ("validated to ceiling"), not a
+            # failure. Whether the family actually MEETS its ceiling is a
+            # separate question this field does not answer.
+            str(entry.get("target_ceiling", "")) == "broad-E5"
         ),
         "notes": str(entry.get("notes", "")),
     }

--- a/scripts/diagnostics/port_external_reference_requirements.json
+++ b/scripts/diagnostics/port_external_reference_requirements.json
@@ -33,7 +33,9 @@
       ],
       "broad_e5_envelope_artifacts": [],
       "ad_fd_test": null,
-      "ad_fd_test_note": "grad-flow tests exist (test_s11_at_freq, test_minimize_s11_at_freq_physical) but no committed AD-vs-FD CONVERGENCE test yet; required before broad_e5_passed."
+      "ad_fd_test_note": "grad-flow tests exist (test_s11_at_freq, test_minimize_s11_at_freq_physical) but no committed AD-vs-FD CONVERGENCE test yet; required before broad_e5_passed.",
+      "target_ceiling": "E4-natural-ceiling",
+      "usage_rule": "Sub-cell lumped circuit element (R/L/C/RLC) in a uniform Yee cavity. NOT a calibrated transmission-line port (single-cell feed has no analytic line oracle); validated TO ITS CEILING at E4 (analytic RLC/open/short/matched + external PEC-box magnitude). broad-E5 is not a well-posed target for this port."
     },
     {
       "family": "wire_port",
@@ -63,7 +65,9 @@
         ".omx/physics-gate/2026-05-10-m68-wire-openems-broad-envelope/wire_openems_broad_envelope.json"
       ],
       "ad_fd_test": null,
-      "ad_fd_test_note": "grad-flow smoke only (test_wire_port_sparams_forward::test_forward_wire_port_grad_flows); no AD-vs-FD convergence test yet."
+      "ad_fd_test_note": "grad-flow smoke only (test_wire_port_sparams_forward::test_forward_wire_port_grad_flows); no AD-vs-FD convergence test yet.",
+      "target_ceiling": "E4-natural-ceiling",
+      "usage_rule": "One-cell transverse wire/probe feed (e.g. probe-fed patch), magnitude-only. Use add_msl_port for a real microstrip line. E4 (external openEMS magnitude envelope) is the natural ceiling; broad-E5 is not well-posed."
     },
     {
       "family": "microstrip_line_port",
@@ -93,7 +97,9 @@
       ],
       "broad_e5_envelope_artifacts": [],
       "ad_fd_test": "tests/test_msl_ad_fd_converged.py::test_msl_ad_fd_converged_tight",
-      "ad_fd_test_note": "AD-vs-FD converged on the MSL S-matrix; @pytest.mark.gpu (runs on the gpu suite, not CPU CI)."
+      "ad_fd_test_note": "AD-vs-FD converged on the MSL S-matrix; @pytest.mark.gpu (runs on the gpu suite, not CPU CI).",
+      "target_ceiling": "broad-E5-regime-restricted",
+      "usage_rule": "Matched / thru-line / notch-filter microstrip (quasi-TEM, Hammerstad-Jensen oracle). broad-E5 reachable in the MATCHED regime only; strong-reflector |S11| has a ~0.16 Yee-staircase-Z0 floor and the eigenmode port is a falsified dead-end (do not pursue)."
     },
     {
       "family": "rectangular_waveguide_port",
@@ -120,7 +126,9 @@
         "tests/fixtures/waveguide_broad_e5/waveguide_wr10_wband_broad_e5_envelope.json"
       ],
       "ad_fd_test": "tests/test_waveguide_flux_ad.py::test_flux_smatrix_grad_finite_and_fd_consistent",
-      "ad_fd_test_note": "AD-vs-FD consistency on the normalize='flux' S-matrix path (issue #148); CPU, unmarked."
+      "ad_fd_test_note": "AD-vs-FD consistency on the normalize='flux' S-matrix path (issue #148); CPU, unmarked.",
+      "target_ceiling": "broad-E5",
+      "usage_rule": "Rectangular waveguide TE/TM modal ports on the uniform Cartesian lane. broad-E5 ACHIEVED (analytic-Airy envelope + Palace E4 + phase/AD/live/committed gates)."
     },
     {
       "family": "coaxial_port",
@@ -162,7 +170,9 @@
         ".omx/physics-gate/2026-06-07-coaxial-line-broad-e5-envelope/coaxial_line_broad_e5_envelope.json"
       ],
       "ad_fd_test": null,
-      "ad_fd_test_note": "extractor is numpy / not-traceable (test_ad_surface_contract::test_coaxial_reflection_extraction_breaks_tape proves it breaks the tape); no AD-vs-FD test BY DESIGN -> the differentiable moat is unavailable and MUST be resolved (e.g. a differentiable reflection path) before broad_e5_passed."
+      "ad_fd_test_note": "extractor is numpy / not-traceable (test_ad_surface_contract::test_coaxial_reflection_extraction_breaks_tape proves it breaks the tape); no AD-vs-FD test BY DESIGN -> the differentiable moat is unavailable and MUST be resolved (e.g. a differentiable reflection path) before broad_e5_passed.",
+      "target_ceiling": "broad-E5-needs-differentiable-api",
+      "usage_rule": "Coaxial transmission-line reflection (forward). broad-E5 PHYSICS demonstrated but blocked: evidence uncommitted (.omx) AND the numpy matrix-pencil extractor is not-traceable so it cannot satisfy the AD moat. Needs committed artifacts + a differentiable reflection API. Do NOT use in an optimization/AD loop."
     },
     {
       "family": "floquet_port",
@@ -191,7 +201,9 @@
       "external_comparison_artifacts": [],
       "broad_e5_envelope_artifacts": [],
       "ad_fd_test": null,
-      "ad_fd_test_note": "grad-finite smoke only (test_floquet_s_params_contract::test_compute_floquet_s_params_grad_finite); no AD-vs-FD convergence test yet."
+      "ad_fd_test_note": "grad-finite smoke only (test_floquet_s_params_contract::test_compute_floquet_s_params_grad_finite); no AD-vs-FD convergence test yet.",
+      "target_ceiling": "broad-E5-structural-partial",
+      "usage_rule": "Periodic-structure broadside (theta=0) only. Off-broadside scan needs a split-field complex-Bloch BC rewrite (the Bloch BC currently drops the imaginary phase) — a structural ceiling, not a tuning gap."
     },
     {
       "family": "generalized_planar_ports",
@@ -218,7 +230,9 @@
       "external_comparison_artifacts": [],
       "broad_e5_envelope_artifacts": [],
       "ad_fd_test": null,
-      "ad_fd_test_note": "planned only; no AD path yet."
+      "ad_fd_test_note": "planned only; no AD path yet.",
+      "target_ceiling": "needs-implementation",
+      "usage_rule": "NOT IMPLEMENTED — planned stripline/CPW/launch; no promoted S-parameter API. Would inherit the MSL-class quasi-TEM ceiling once built."
     }
   ],
   "next_validation_target_decision": "2026-06-11 (W5.6 backlog decision, recorded NOT started): next port family for external validation = lumped_port (most existing scaffolding: narrow openEMS PEC-box + position-sweep comparisons already in evidence; needs the broad matched/open/short/load external fixture set). wire_port second (blocked_absolute_external_reference, needs an absolute external reference design first). Both are analytic-E5-only effort class."

--- a/scripts/diagnostics/port_external_reference_requirements.json
+++ b/scripts/diagnostics/port_external_reference_requirements.json
@@ -99,7 +99,7 @@
       "ad_fd_test": "tests/test_msl_ad_fd_converged.py::test_msl_ad_fd_converged_tight",
       "ad_fd_test_note": "AD-vs-FD converged on the MSL S-matrix; @pytest.mark.gpu (runs on the gpu suite, not CPU CI).",
       "target_ceiling": "broad-E5-regime-restricted",
-      "usage_rule": "Matched / thru-line / notch-filter microstrip (quasi-TEM, Hammerstad-Jensen oracle). broad-E5 reachable in the MATCHED regime only; strong-reflector |S11| has a ~0.16 Yee-staircase-Z0 floor and the eigenmode port is a falsified dead-end (do not pursue)."
+      "usage_rule": "Matched / thru-line / notch-filter microstrip (quasi-TEM, Hammerstad-Jensen oracle). broad-E5 reachable in the MATCHED regime only; strong-reflector |S11| has a ~0.16-0.22 Yee-staircase-Z0 floor (mesh-conv #183; the earlier 0.118 was a danger-zone artifact) and the eigenmode port is a falsified dead-end (do not pursue)."
     },
     {
       "family": "rectangular_waveguide_port",

--- a/tests/test_physics_gate_reporting.py
+++ b/tests/test_physics_gate_reporting.py
@@ -2188,10 +2188,24 @@ def test_every_family_declares_target_ceiling_and_usage_rule():
     for r in audit["requirements"]:
         assert r["target_ceiling"] in vocab
         assert r["usage_rule"]
+        # broad_e5_is_the_target_ceiling is a PURE LABEL restatement, not an
+        # achieved-vs-ceiling check: it must equal (ceiling == "broad-E5") and
+        # never read evidence/status. Locks the 2026-06-17 rename away from the
+        # earlier misnamed `at_or_below_target_ceiling` (which a reader could
+        # mistake for a real "validated to its ceiling" signal).
+        assert r["broad_e5_is_the_target_ceiling"] == (
+            r["target_ceiling"] == "broad-E5"
+        ), f"{r['family']}: broad_e5_is_the_target_ceiling must restate the label only"
     by = {e["family"]: e["target_ceiling"] for e in manifest["requirements"]}
     assert by["rectangular_waveguide_port"] == "broad-E5"
     assert by["lumped_port"] == "E4-natural-ceiling"
     assert by["wire_port"] == "E4-natural-ceiling"
+    # Concrete value witnesses: only the broad-E5-target family reads True.
+    flag = {r["family"]: r["broad_e5_is_the_target_ceiling"] for r in audit["requirements"]}
+    assert flag["rectangular_waveguide_port"] is True
+    assert flag["lumped_port"] is False
+    assert flag["wire_port"] is False
+    assert flag["coaxial_port"] is False
 
 
 def test_real_manifest_broad_e5_family_survives_require_committed():

--- a/tests/test_physics_gate_reporting.py
+++ b/tests/test_physics_gate_reporting.py
@@ -2160,6 +2160,40 @@ def test_ad_fd_gate_blocks_broad_e5_without_valid_ad_test(
         assert any("ad_fd_test" in b for b in family["blockers"]), family["blockers"]
 
 
+def test_every_family_declares_target_ceiling_and_usage_rule():
+    """Per-port formalization (2026-06-17): broad-E5 is NOT a universal goal.
+
+    Every E5-required family must declare a physics-set `target_ceiling` from the
+    controlled vocab + a `usage_rule` ("use this port when ..."). This locks the
+    rule that single-cell ports top out at E4 (validated-to-ceiling, not blocked),
+    MSL is matched-regime-only, coax needs a differentiable API, floquet is
+    broadside-only, generalized-planar is unimplemented — so a `blocked` broad_e5
+    verdict is contextualized, not read as failure.
+    """
+    manifest = json.loads(
+        (REPO_ROOT / "scripts/diagnostics/port_external_reference_requirements.json").read_text()
+    )
+    vocab = port_external_reference_check.VALID_TARGET_CEILINGS
+    for e in manifest["requirements"]:
+        fam = e["family"]
+        assert e.get("target_ceiling") in vocab, (
+            f"{fam}: target_ceiling {e.get('target_ceiling')!r} not in {sorted(vocab)}"
+        )
+        assert e.get("usage_rule", "").strip(), f"{fam}: missing usage_rule"
+    # The auditor must surface the formalized fields per family.
+    audit = port_external_reference_check.build_external_reference_audit(
+        REPO_ROOT / "scripts/diagnostics/port_external_reference_requirements.json",
+        REPO_ROOT / "docs/guides/sparameter_support_matrix.json",
+    )
+    for r in audit["requirements"]:
+        assert r["target_ceiling"] in vocab
+        assert r["usage_rule"]
+    by = {e["family"]: e["target_ceiling"] for e in manifest["requirements"]}
+    assert by["rectangular_waveguide_port"] == "broad-E5"
+    assert by["lumped_port"] == "E4-natural-ceiling"
+    assert by["wire_port"] == "E4-natural-ceiling"
+
+
 def test_real_manifest_broad_e5_family_survives_require_committed():
     """T2.5 'on in CI': the real broad_e5_passed family (waveguide) survives the
     committed-artifact check — its gating evidence is GENUINELY git-tracked, not


### PR DESCRIPTION
**broad-E5 is not a universal goal.** A port's appropriate validation level is set by its physics (verified this session via the grounded per-family + ceiling assessment). Single-cell feeds (lumped/wire) aren't transmission lines → no analytic line oracle to sweep a broad-E5 envelope against → **E4 is their natural ceiling**, and meeting it = "validated to ceiling", not "blocked from E5".

Codifies the per-port rule, machine-readable + locked:
- **manifest**: each family declares `target_ceiling` (controlled vocab) + `usage_rule`. waveguide `broad-E5` · MSL `broad-E5-regime-restricted` (matched only) · coax `broad-E5-needs-differentiable-api` · lumped/wire `E4-natural-ceiling` · floquet `broad-E5-structural-partial` (broadside) · generalized-planar `needs-implementation`.
- **auditor**: `VALID_TARGET_CEILINGS` vocab + emits `target_ceiling`/`usage_rule`/`at_or_below_target_ceiling`. **Purely descriptive — does NOT change the broad_e5 gate logic**; it contextualizes a `blocked` verdict (E4-natural ≠ failure).
- **contract test** locks the vocab + presence + the waveguide/lumped/wire ceilings.
- **support matrix .md**: user-facing "Port selection: usage rule & validation ceiling" table.

54 gate-reporting tests green; lint clean; JSON valid; auditor surfaces ceilings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)