### PR TITLE
fix(validation): close vacuous MSL comparator gate + add harminv estimator test

### DIFF
--- a/examples/crossval/05_patch_antenna.py
+++ b/examples/crossval/05_patch_antenna.py
@@ -47,7 +47,12 @@ Three independent measurements of the patch resonance:
      appears as a small local dip rather than a deep -20 dB match.
      Pattern-match `tests/test_crossval_comprehensive.py::TestLumpedPortCavity`.
 
-Primary PASS metric: rfx Harminv vs OpenEMS S11 < 5 %.
+Primary PASS gate: rfx Harminv vs OpenEMS Harminv (resonance frequency) < 20 %
+(`pass_vs_openems`); rfx internal self-consistency < 5 % (`pass_internal`).
+(NOTE: the vs-OpenEMS number is a Harminv-vs-Harminv RESONANCE-FREQUENCY
+agreement, not an S11-vs-S11 magnitude match — the OpenEMS S11 dip itself sits
+~10 % off analytic and is used only as a fallback when the OpenEMS port-V(t)
+Harminv fails. See the "primary metric" print near the end of this script.)
 
 Analytic reference (Balanis, *Antenna Theory*, Ch. 14):
   εr_eff = (εr+1)/2 + (εr-1)/2 · (1 + 12·h/W)^(-1/2)

--- a/scripts/diagnostics/compare_msl_thru_openems_reference.py
+++ b/scripts/diagnostics/compare_msl_thru_openems_reference.py
@@ -5,6 +5,15 @@ This is an M3 external-reference smoke check, not a claims-bearing MSL-port
 promotion.  It uses a stored openEMS artifact generated outside rfx and reruns
 rfx on the same core microstrip dimensions, then compares S11/S21 magnitudes in
 the 3.0--4.5 GHz quasi-TEM gate window.
+
+Validation-honesty note: on a MATCHED thru-line |S11| is intrinsically small
+(reference mean ~0.12), comparable to the comparison tolerance (0.15), so the
+S11 channel cannot discriminate rfx physics from a constant (a degenerate
+``S11==0`` would "pass" it).  The S11 channel is therefore reported as
+INFORMATIONAL (``s11_gate_discriminating=False``) and does NOT gate; the status
+then reads ``passed_transmission_only_s11_nondiscriminating`` so a green result
+is never mis-read as an S11 validation.  Transmission (|S21|~1) is the real
+discriminator here.
 """
 
 from __future__ import annotations
@@ -112,6 +121,17 @@ def run_rfx_msl_thru(
     }
 
 
+def is_pass_status(status: str) -> bool:
+    """True for any PASS status, for exit-code purposes.
+
+    Includes ``passed_transmission_only_s11_nondiscriminating`` — a GREEN result on
+    a matched line where the |S11| channel is informational (too small to
+    discriminate). That is a pass and must NOT turn the M3 VESSL lane red; the
+    exit code keys off this helper, not an exact ``== "passed"`` match.
+    """
+    return status.startswith("passed")
+
+
 def compare_magnitudes(
     freqs_hz: np.ndarray,
     rfx_s11: np.ndarray,
@@ -139,9 +159,27 @@ def compare_magnitudes(
     s11_mean_ref = float(np.mean(ref_s11_mag))
     s21_mean_rfx = float(np.mean(rfx_s21_mag))
     s21_mean_ref = float(np.mean(ref_s21_mag))
-    pass_s11 = s11_mean_abs_diff <= 0.15
-    pass_s21 = s21_mean_abs_diff <= 0.15
+    mag_tol = 0.15
+    # Validation-honesty guard: on a MATCHED thru-line |S11| is intrinsically tiny
+    # (here ref mean ~0.12), so an absolute |S11| tolerance of 0.15 is LARGER than the
+    # signal it is supposed to check — a degenerate rfx output (S11==0) would pass it,
+    # i.e. the gate cannot distinguish rfx physics from a constant. The S11 channel is a
+    # real discriminator ONLY when the reference |S11| comfortably exceeds the tolerance.
+    # When it does not, we mark S11 INFORMATIONAL and let the gate rest on transmission,
+    # so a green status is never mis-read as "rfx S11 validated".
+    s11_gate_discriminating = s11_mean_ref >= 2.0 * mag_tol
+    pass_s11 = (s11_mean_abs_diff <= mag_tol) if s11_gate_discriminating else None
+    pass_s21 = s21_mean_abs_diff <= mag_tol
     pass_transmission = 0.85 <= s21_mean_rfx <= 1.10 and 0.85 <= s21_mean_ref <= 1.10
+
+    if s11_gate_discriminating:
+        status = "passed" if (pass_s11 and pass_s21 and pass_transmission) else "failed"
+    else:
+        status = (
+            "passed_transmission_only_s11_nondiscriminating"
+            if (pass_s21 and pass_transmission)
+            else "failed"
+        )
 
     return {
         "frequency_window_hz": [float(f_lo_hz), float(f_hi_hz)],
@@ -155,7 +193,19 @@ def compare_magnitudes(
         "pass_s11_mean_abs_diff_le_0p15": pass_s11,
         "pass_s21_mean_abs_diff_le_0p15": pass_s21,
         "pass_transmission_magnitude_window": pass_transmission,
-        "status": "passed" if (pass_s11 and pass_s21 and pass_transmission) else "failed",
+        "s11_gate_discriminating": bool(s11_gate_discriminating),
+        "s11_discrimination_note": (
+            "S11 channel discriminating (ref |S11| mean "
+            f"{s11_mean_ref:.3f} >= 2x tol {2.0 * mag_tol:.2f})"
+            if s11_gate_discriminating
+            else (
+                f"S11 channel NON-discriminating: ref |S11| mean {s11_mean_ref:.3f} < 2x "
+                f"tol {2.0 * mag_tol:.2f}; a degenerate rfx S11 would pass it, so S11 is "
+                "INFORMATIONAL only and does NOT gate. This is a transmission smoke "
+                "check, not an S11 validation."
+            )
+        ),
+        "status": status,
     }
 
 
@@ -242,7 +292,7 @@ def main(argv: list[str] | None = None) -> int:
     out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
     print(json.dumps({"status": payload["status"], "metrics": metrics}, indent=2))
     print(f"wrote {out_path.relative_to(REPO_ROOT)}")
-    return 0 if payload["status"] == "passed" else 1
+    return 0 if is_pass_status(payload["status"]) else 1
 
 
 if __name__ == "__main__":

--- a/tests/test_harminv_estimator.py
+++ b/tests/test_harminv_estimator.py
@@ -1,0 +1,124 @@
+"""Estimator-level unit tests for ``rfx.harminv`` (Matrix Pencil).
+
+Until now ``rfx.harminv`` had NO committed estimator-level test — its only
+validation was indirect, through physics cross-vals (cv05) and the slow
+issue-80 patch resonance gate (``tests/test_issue80_patch_resonance_harminv.py``).
+The 2026-06-17 reference-verification confirmed (in throwaway scratch scripts)
+that the issue-80 9.32 GHz witness is window-stable, estimator-parameter-stable,
+and float32-insensitive — but those findings were not regression-locked.
+
+This module locks the estimator's core contract against a SYNTHETIC
+sum-of-decaying-exponentials with KNOWN frequencies, so a regression in the
+Matrix-Pencil core (or a float32 precision surprise) is caught directly, not
+only via an expensive FDTD run. CPU, fast.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rfx.harminv import HarminvMode, harminv
+
+# A synthetic ring-down that mirrors the issue-80 spectrum shape: a dominant
+# patch-mode tone with a couple of weaker neighbours, all decaying. The 9.30 GHz
+# tone is given the largest amplitude so it must come out as the dominant mode.
+_DT = 1.0e-12  # 1 ps -> fs = 1 THz, Nyquist 500 GHz >> 12 GHz
+_N = 4000      # 4 ns record
+_TONES = (
+    # (freq_hz, amplitude, Q, phase)
+    (8.80e9, 0.50, 35.0, 0.3),
+    (9.30e9, 1.00, 44.0, 0.0),  # dominant
+    (11.90e9, 0.60, 18.0, 1.1),
+)
+
+
+def _synthetic_ringdown(dtype=np.float64) -> np.ndarray:
+    t = np.arange(_N) * _DT
+    sig = np.zeros(_N, dtype=np.float64)
+    for f, a, q, phi in _TONES:
+        decay = np.pi * f / q  # 1/s, from Q = pi f / decay
+        sig += a * np.exp(-decay * t) * np.cos(2 * np.pi * f * t + phi)
+    return sig.astype(dtype)
+
+
+def _freqs_ghz(modes: list[HarminvMode]) -> list[float]:
+    return sorted(m.freq / 1e9 for m in modes)
+
+
+def test_harminv_recovers_known_synthetic_frequencies():
+    """Matrix Pencil recovers all three planted tones to <0.5% on a clean signal."""
+    modes = harminv(_synthetic_ringdown(), _DT, 7.0e9, 14.0e9)
+    got = _freqs_ghz(modes)
+    for f_true_hz, _, _, _ in _TONES:
+        f_true = f_true_hz / 1e9
+        nearest = min(got, key=lambda g: abs(g - f_true))
+        assert abs(nearest - f_true) < 0.05, (  # < 50 MHz (~0.5%)
+            f"planted {f_true:.3f} GHz not recovered; got {got}"
+        )
+
+
+def test_harminv_dominant_is_largest_amplitude_tone():
+    """The returned list is amplitude-sorted; the dominant must be the 9.30 GHz tone.
+
+    This is exactly the selection the issue-80 gate relies on (max-by-amplitude,
+    no analytic-nearest bias) — locks that 9.30 is dominant by ENERGY, not by
+    proximity to an expected value.
+    """
+    modes = harminv(_synthetic_ringdown(), _DT, 7.0e9, 14.0e9)
+    assert modes, "no modes recovered"
+    # API contract: sorted by amplitude, strongest first.
+    amps = [m.amplitude for m in modes]
+    assert amps == sorted(amps, reverse=True), "modes not amplitude-sorted"
+    assert abs(modes[0].freq / 1e9 - 9.30) < 0.05, (
+        f"dominant mode {modes[0].freq/1e9:.3f} GHz is not the planted 9.30 GHz tone"
+    )
+
+
+def test_harminv_float32_roundtrip_is_frequency_stable():
+    """Storing the signal as float32 (the FDTD field dtype) must not move the estimate.
+
+    rfx FDTD fields are float32; ``harminv`` upcasts the signal to complex128
+    internally. This locks that a float32 round-trip of the input leaves the
+    dominant frequency essentially unchanged (the verification measured 9.3000
+    under both float64 and float32-roundtrip).
+    """
+    dom_f64 = harminv(_synthetic_ringdown(np.float64), _DT, 7.0e9, 14.0e9)[0].freq
+    dom_f32 = harminv(
+        _synthetic_ringdown(np.float32).astype(np.float64), _DT, 7.0e9, 14.0e9
+    )[0].freq
+    assert abs(dom_f64 - dom_f32) / dom_f64 < 1e-3, (
+        f"float32 roundtrip moved dominant {dom_f64/1e9:.4f} -> {dom_f32/1e9:.4f} GHz"
+    )
+
+
+def test_harminv_dominant_is_window_stable():
+    """Dropping the first quarter of the record must not change the dominant tone.
+
+    Window-stability is the property the issue-80 verification leaned on but had
+    not regression-locked; a transient early-window artifact must not flip the
+    dominant mode.
+    """
+    sig = _synthetic_ringdown()
+    full = harminv(sig, _DT, 7.0e9, 14.0e9)[0].freq / 1e9
+    tail = harminv(sig[_N // 4:], _DT, 7.0e9, 14.0e9)[0].freq / 1e9
+    assert abs(full - 9.30) < 0.05 and abs(tail - 9.30) < 0.05, (
+        f"dominant not window-stable: full={full:.3f}, tail={tail:.3f} GHz"
+    )
+
+
+def test_harminv_recovers_q_within_band():
+    """Recovered Q of the dominant tone is in the right ballpark (planted Q=44)."""
+    modes = harminv(_synthetic_ringdown(), _DT, 7.0e9, 14.0e9)
+    dom = modes[0]
+    # Matrix Pencil on a clean 3-tone signal recovers Q to a few %.
+    assert 0.7 * 44.0 < dom.Q < 1.3 * 44.0, f"dominant Q={dom.Q:.1f} far from planted 44"
+
+
+def test_harminv_modest_noise_does_not_move_dominant():
+    """At a realistic SNR the dominant frequency is unchanged (seeded, deterministic)."""
+    rng = np.random.default_rng(20260617)
+    sig = _synthetic_ringdown()
+    noise = rng.standard_normal(_N) * 0.01 * np.max(np.abs(sig))  # ~40 dB SNR
+    dom = harminv(sig + noise, _DT, 7.0e9, 14.0e9)[0].freq / 1e9
+    assert abs(dom - 9.30) < 0.05, f"noise moved dominant to {dom:.3f} GHz"

--- a/tests/test_physics_gate_reporting.py
+++ b/tests/test_physics_gate_reporting.py
@@ -282,6 +282,9 @@ def test_aggregate_refuses_required_skip_as_full_claim(tmp_path: Path):
 
 
 def test_msl_openems_magnitude_comparison_metrics_pass_for_close_curves():
+    """Matched thru-line: |S11| is intrinsically small (~0.12), so the S11 channel is
+    NON-discriminating (a degenerate rfx S11 would 'pass' the 0.15 tol). The honest
+    status is transmission-only; S11 is informational, not a gate."""
     np = msl_openems_compare.np
     freqs = np.linspace(3.0e9, 4.5e9, 5)
     ref_s11 = np.full(freqs.shape, 0.12 + 0.01j, dtype=complex)
@@ -300,9 +303,62 @@ def test_msl_openems_magnitude_comparison_metrics_pass_for_close_curves():
         f_hi_hz=4.5e9,
     )
 
-    assert metrics["status"] == "passed"
+    # ref |S11| ~0.12 < 2x tol (0.30) -> S11 channel cannot discriminate -> informational.
+    assert metrics["s11_gate_discriminating"] is False
+    assert metrics["pass_s11_mean_abs_diff_le_0p15"] is None
+    assert metrics["status"] == "passed_transmission_only_s11_nondiscriminating"
     assert metrics["s11_mean_abs_diff"] < 0.15
     assert metrics["s21_mean_abs_diff"] < 0.15
+
+
+def test_msl_openems_comparison_s11_channel_is_not_vacuous():
+    """Validation-honesty lock (2026-06-17): the comparator must NOT report a bare
+    'passed' for a degenerate rfx output on a matched line (the bug the reference-
+    verification found: |S11| tol 0.15 exceeded the reference |S11| ~0.12, so a
+    degenerate rfx S11=0 'passed'). It must flag the S11 channel non-discriminating.
+    A genuinely strong-reflector reference (|S11| >= 2x tol) must still gate on S11."""
+    np = msl_openems_compare.np
+    freqs = np.linspace(3.0e9, 4.5e9, 5)
+    ref_s11 = np.full(freqs.shape, 0.12 + 0.01j, dtype=complex)
+    ref_s21 = np.full(freqs.shape, 0.98 - 0.02j, dtype=complex)
+
+    # Degenerate rfx (zero reflection physics, ideal transmission): must NOT bare-pass.
+    degenerate = msl_openems_compare.compare_magnitudes(
+        freqs, np.zeros(freqs.shape, complex), np.ones(freqs.shape, complex),
+        freqs, ref_s11, ref_s21, f_lo_hz=3.0e9, f_hi_hz=4.5e9,
+    )
+    assert degenerate["status"] != "passed"
+    assert degenerate["s11_gate_discriminating"] is False
+
+    # Strong reflector (ref |S11| = 0.5 >= 2x tol): the S11 channel IS a real gate,
+    # and a mismatched rfx S11 (=0) must FAIL it.
+    strong_ref = np.full(freqs.shape, 0.5 + 0.0j, dtype=complex)
+    strong_s21 = np.full(freqs.shape, 0.86 + 0.0j, dtype=complex)
+    far = msl_openems_compare.compare_magnitudes(
+        freqs, np.zeros(freqs.shape, complex), strong_s21,
+        freqs, strong_ref, strong_s21, f_lo_hz=3.0e9, f_hi_hz=4.5e9,
+    )
+    assert far["s11_gate_discriminating"] is True
+    assert far["pass_s11_mean_abs_diff_le_0p15"] is False
+    assert far["status"] == "failed"
+
+
+def test_msl_openems_comparison_pass_status_maps_to_success_exit_code():
+    """Exit-code regression lock: the transmission-only PASS must map to success.
+
+    The honesty fix added a new success status; an exact ``== "passed"`` exit-code
+    check would turn a GREEN M3 VESSL lane RED on a matched line — the exact
+    harness false-negative the fix must NOT introduce. ``main()`` keys its exit
+    code off ``is_pass_status``.
+    """
+    assert msl_openems_compare.is_pass_status("passed") is True
+    assert (
+        msl_openems_compare.is_pass_status(
+            "passed_transmission_only_s11_nondiscriminating"
+        )
+        is True
+    )
+    assert msl_openems_compare.is_pass_status("failed") is False
 
 
 def test_waveguide_report_parser_captures_cv11_gates_and_refs():


### PR DESCRIPTION
## Context
From the 2026-06-17 adversarial reference+comparator verification (prompted by "could the OpenEMS/Meep gates be wrong, or did WE write the validation code wrong?"). The **resonance science was confirmed SOUND** (~9.3 GHz, three independent witnesses — rfx-internal Harminv 9.32, analytic Balanis 9.19, OpenEMS graded 9.15–9.20; the 11.9 GHz is a feed-line λ/2 mode, **retired**), so **no MSL extractor redesign is justified**. But the verification found real weaknesses in our **own** comparison/gate code — the canonical rfx "4/4 the bug was in the comparator" pattern. This PR fixes those (validation-hygiene only; the extractor is untouched).

## Changes
- **`compare_msl_thru_openems_reference.py` — vacuous S11 gate.** On a matched thru-line the reference |S11| (~0.12) is *below* the 0.15 pass tolerance, so a degenerate rfx output (S11=0) "passed". Tightening would false-fail *legitimate* rfx (|S11| is intrinsically small on a matched line), so instead the S11 channel is flagged `s11_gate_discriminating=False`, reported **informational**, and `status="passed_transmission_only_s11_nondiscriminating"` — a green is never mis-read as S11 validation. Exit code keys off `is_pass_status()` (not exact `== "passed"`) so the new success status does **not** turn the M3 VESSL lane red.
- **`tests/test_harminv_estimator.py` (NEW).** rfx.harminv had no estimator-level test (only indirect cv05 / slow issue-80). Locks synthetic known-frequency recovery, dominant-by-amplitude, float32-roundtrip stability, window-stability, Q recovery, seeded noise robustness.
- **`test_physics_gate_reporting.py`.** Updated the comparator test (it asserted the OLD vacuous status) to the honest behavior + a vacuity lock (degenerate input must not bare-pass; a strong-reflector ref still gates on S11) + an exit-code lock.
- **cv05 docstring.** Header said "rfx Harminv vs OpenEMS **S11**" but it is Harminv-vs-Harminv resonance agreement (the code already printed that); also corrected the stale "< 5 %" → real gates (vs-OpenEMS **< 20 %**, self-consistency < 5 %).

## Not in scope (deliberate)
The MSL S11 extractor is **not** touched — the resonance is read correctly by the port-independent Harminv; the de-embed is a documented *narrow* open defect, not a redesign target (both adversarial critics returned reject-redesign / HIGH loop-reentry). The 6 pre-existing F541 lint warnings in cv05 are out of CI lint scope (`ruff check rfx/ tests/`) and left untouched.

## Verification
- 62 physics-gate + harminv tests pass; lint clean on in-scope files.
- Degenerate-input probe: a matched-line degenerate rfx no longer bare-passes; exit-code mapping confirmed (green stays green).
- Independent `code-reviewer`: **REQUEST-CHANGES** (1 HIGH exit-code regression, 1 MEDIUM docstring threshold, 1 LOW rename) → **all three fixed**, HIGH regression-locked with a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)