### PR TITLE
docs(agent-usability): fix public-docs punch list (runnable sims from docs alone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ modes = result.find_resonances(freq_range=(1.5e9, 3.5e9))
 print(f"Resonance: {modes[0].freq/1e9:.4f} GHz  Q={modes[0].Q:.0f}")
 ```
 
+> This compact snippet favours brevity over a production-clean mesh, so `run()`
+> prints a few non-fatal preflight advisories (thin PEC sheets; substrate/feed
+> near the CPML absorber) and the reported resonance is only approximate (this
+> coarse mesh lands ~10–15% high). For a
+> properly resolved patch — PEC ground, non-uniform z-mesh, lossy FR4, and a
+> cross-checked resonance — follow the
+> [First Patch tutorial](docs/public/guide/first-patch.mdx).
+
 ## Differentiable S-Parameters
 
 `jax.grad` flows end-to-end through the **public S-parameter API** — the
@@ -232,6 +240,13 @@ Gitops-side snapshot/build CI lives in the deploy repo:
 - [Public landing page](docs/public/index.mdx)
 - [Validation hub](docs/public/validation/index.mdx) — support overview and lane labels
 - [Examples hub](docs/public/examples/index.mdx) — current runnable entry points
+
+### For AI coding agents
+Working from a fresh clone with an LLM agent? Start with the purpose-built agent docs:
+- [Agent overview & operating rules](docs/agent/overview.mdx) — start here; includes a safe prompt skeleton
+- [Repo map & feature discovery](docs/agent/repo-map.mdx) — how the code is organized + the grep map for finding existing primitives before writing new code
+- [Port selection](docs/agent/port-selection.mdx) — pick the right port family / S-parameter calculator
+- Task recipes: [waveguide S-params](docs/agent/recipe-waveguide-sparams.mdx) · [R(f)/T(f) measurement](docs/agent/recipe-rt-measurement.mdx) · [resonance extraction](docs/agent/recipe-resonance-extraction.mdx) · [differentiable design loop](docs/agent/recipe-design-loop.mdx) · [parameter sweeps](docs/agent/recipe-parameter-sweeps.mdx) · [failed-gate triage](docs/agent/recipe-failed-gate-triage.mdx)
 
 ### Tutorials
 - [Patch Antenna Design](docs/public/guide/tutorial-patch-antenna.mdx) — practical patch workflow from local resonance run to external cross-check

--- a/docs/agent/recipe-rt-measurement.mdx
+++ b/docs/agent/recipe-rt-measurement.mdx
@@ -139,6 +139,13 @@ corners: `Box((x_lo, -1, -1), (x_hi, 1, 1))`.
 `d`-thick slab can map to `d + dx` cells. Nudge the upper x-corner down by
 `dx/2` to hit the last interior cell: `slab_x_hi = center + d/2 - dx/2`.
 
+### (e) dtype-truncation warnings are expected, not errors
+
+Under the default `precision="float32"`, the flux DFT accumulators emit benign
+`complex128 → complex64` truncation `UserWarning`s (from `rfx/probes/probes.py`)
+on every run. They are expected and do not affect the R/T result — do **not**
+enable `jax_enable_x64` globally to silence them.
+
 ## Do NOT use
 
 **`add_probe` (time-series) + `np.fft.rfft`** for dispersive media.
@@ -179,6 +186,10 @@ necessarily a usage error in either tool.
 
 ## Canonical examples
 
+- `examples/slab_rt_flux_monitor.py` — **the recommended path**: `add_flux_monitor`
+  + two-run field-level reference subtraction via the `Simulation` API, with an
+  analytic Fresnel witness and an energy-conservation readout (on the coarse demo
+  grid R+T sits slightly above 1; refine `dx` to tighten it). Start here.
 - `examples/crossval/04_multilayer_fresnel.py` — dispersionless Fresnel slab,
   analytic comparison. Note: this script uses a raw Yee loop (`update_e` /
   `update_h`) rather than the `Simulation` API. The raw-loop approach works for

--- a/docs/agent/recipe-waveguide-sparams.mdx
+++ b/docs/agent/recipe-waveguide-sparams.mdx
@@ -48,6 +48,7 @@ bw = 0.4                       # fractional bandwidth
 freqs = jnp.linspace(f_c * 1.3, f_c * 1.9, 50)
 
 sim = Simulation(
+    freq_max=f_c * 1.9,   # required first argument: top of the measurement band
     domain=(length, a_wg, b_wg),
     dx=dx,
     boundary="cpml",
@@ -100,6 +101,12 @@ S21 = S[1, 0, :]
 | `probe_offset` | Distance in Yee cells from the port plane to the probe plane. Must be far enough from any obstacle to avoid source-plane artifacts. Typical value: 10 cells. |
 | `ref_offset` | Distance in cells from the port plane to the reference plane. Must be consistent across compared ports. Typical value: 3 cells. |
 | Band edges | Keep `f_min > 1.3 · f_cutoff` (TE10 cutoff is `c / (2a)`) to stay away from evanescent-mode contamination. Keep `f_max` below the TE20 cutoff (`c / a`) for single-mode operation. |
+
+> **Expected warnings (not errors).** Under the default `precision="float32"`, the
+> flux DFT accumulators used by `normalize="flux"` emit benign
+> `complex128 → complex64` truncation `UserWarning`s (from `rfx/probes/probes.py`).
+> They are expected and do not affect results — do **not** enable `jax_enable_x64`
+> globally to silence them.
 
 ## Baseline accuracy
 

--- a/docs/public/guide/first-patch.mdx
+++ b/docs/public/guide/first-patch.mdx
@@ -149,12 +149,12 @@ sim.add_probe((feed_x, feed_y, feed_z), "ez")
 ## 5. Run the simulation
 
 ```python
-# Build grid to get dt, then set n_steps for ~10 ns simulation time
-grid    = sim._build_grid()
-n_steps = int(np.ceil(10e-9 / grid.dt))
-print(f"Grid: {grid.shape}, dt={grid.dt*1e12:.2f} ps, n_steps={n_steps}")
-
-result = sim.run(n_steps=n_steps)
+# run() sizes the time stepping for you. num_periods counts cycles of the
+# resolved band (freq_max = 4 GHz here), so 40 periods ≈ 10 ns. The realized
+# dt and step count are reported on the result — no private grid access needed.
+result = sim.run(num_periods=40)
+n_steps = result.time_series.shape[0]   # realized number of timesteps
+print(f"dt={result.dt*1e12:.2f} ps, n_steps={n_steps}")
 ```
 
 ---
@@ -184,6 +184,14 @@ if modes:
 
 If you want a quick diagnostic S-parameter run, you can re-run with a lumped
 port instead of a soft source:
+
+!!! warning
+    This single-cell lumped-port `compute_s_params=True` snippet is illustrative.
+    It raises `NotImplementedError` on the non-uniform `dz_profile` mesh built in
+    §2 — single-cell lumped-port S-parameters are not wired for the non-uniform
+    path. For calibrated S-parameters use a multi-cell `add_port(..., extent=...)`
+    WirePort, or a dedicated port workflow (see the waveguide/MSL S-parameter
+    recipes).
 
 ```python
 sim2 = Simulation(

--- a/docs/public/guide/quickstart.mdx
+++ b/docs/public/guide/quickstart.mdx
@@ -15,22 +15,27 @@ from rfx import Simulation, Box, GaussianPulse
 
 sim = Simulation(
     freq_max=5e9,
-    domain=(0.10, 0.04, 0.02),
+    domain=(0.14, 0.06, 0.05),
+    dx=2e-3,
     boundary="cpml",
+    cpml_layers=8,
 )
 
-sim.add_material("slab", eps_r=2.2)
-sim.add(Box((0.03, 0.0, 0.0), (0.05, 0.04, 0.02)), material="slab")
+# A small loss keeps the open-domain Q finite (a lossless dielectric in an open
+# CPML domain reports an artificially infinite Q).
+sim.add_material("slab", eps_r=2.2, sigma=0.01)
+sim.add(Box((0.07, 0.0, 0.0), (0.09, 0.06, 0.05)), material="slab")
 
+# Source and probe sit in the interior, clear of the CPML absorber.
 sim.add_source(
-    (0.01, 0.02, 0.01),
+    (0.03, 0.03, 0.025),
     "ez",
     waveform=GaussianPulse(f0=3e9, bandwidth=0.8),
 )
-sim.add_probe((0.08, 0.02, 0.01), "ez")
+sim.add_probe((0.11, 0.03, 0.025), "ez")
 
 result = sim.run(until_decay=1e-3)
-modes = result.find_resonances(freq_range=(1e9, 4e9))
+modes = result.find_resonances(freq_range=(1e9, 4e9))  # mode.freq, mode.Q — see Probes & S-params guide
 ```
 
 Use `add_source()` for **unloaded resonance studies**.  
@@ -92,6 +97,7 @@ When `auto_configure()` detects a thin z-feature, it can switch to a
 ## 4. Common next steps
 
 - [Simulation API](/rfx/guide/api-reference/) — current method signatures and result fields
+- [Probes & S-parameters](/rfx/guide/probes-sparams/) — resonance fields (`mode.freq`, `mode.Q`), the S-matrix shape `(n_ports, n_ports, n_freqs)`, and flux monitors
 - [Sources & Ports](/rfx/guide/sources-ports/) — when to use `add_source()` vs `add_port()`
 - [Non-Uniform Mesh](/rfx/guide/nonuniform-mesh/) — `dz_profile` and thin-substrate workflow
 - [Validation](/rfx/guide/validation/) — what is strongly benchmarked today

--- a/examples/slab_rt_flux_monitor.py
+++ b/examples/slab_rt_flux_monitor.py
@@ -1,0 +1,157 @@
+"""Broadband R(f)/T(f) of a dielectric slab — the recommended flux-monitor path.
+
+This is the runnable companion to ``docs/agent/recipe-rt-measurement.mdx``. It
+demonstrates the *correct* way to measure broadband reflection and transmission
+spectra in rfx:
+
+    add_flux_monitor  +  two-run reference subtraction (field-level)
+
+and deliberately avoids the documented footgun (``add_probe`` time series +
+``np.fft.rfft``), which suffers a resolution-independent window-bias for
+dispersive media.
+
+Why two runs?
+  Run 1 (reference, no slab) gives the incident flux. Run 2 (sample, with slab)
+  gives the total flux. For *reflection* the scattered field is recovered by
+  subtracting the reference E/H DFT accumulators from the sample ones *before*
+  computing the Poynting flux (flux is bilinear in E and H, so subtracting the
+  already-computed fluxes would leave cross terms — see recipe detail (a)).
+
+The slab here is dispersionless (eps_r = 4), so an analytic Fresnel
+transfer-matrix result is available as a sanity witness. The grid is kept coarse
+for speed; halving ``dx`` reduces the error toward the analytic curve. Preflight
+will flag the under-resolution and the lossless slab — both are expected here:
+this is a fast method demo, we measure R/T (not Q), and a lossless slab is what
+matches the lossless analytic Fresnel reference.
+
+Public docs:
+  - docs/agent/recipe-rt-measurement.mdx   (canonical two-run pattern)
+  - docs/public/guide/probes-sparams.mdx   (flux monitors as non-port observables)
+  - docs/public/api/results-observables.mdx (add_flux_monitor -> Result.flux_monitors)
+
+Run:  python examples/slab_rt_flux_monitor.py
+"""
+
+import numpy as np
+
+from rfx import Box, Simulation
+from rfx.probes.probes import flux_spectrum
+
+C0 = 299_792_458.0
+
+# ----- problem definition (kept small/fast; refine dx for accuracy) -----
+EPS_SLAB = 4.0
+D_SLAB = 10.0e-3  # 10 mm slab
+DX = 1.0e-3  # 1 mm cells (coarse demo)
+FREQ_MAX = 16e9
+F0 = 9e9
+BW = 0.9
+
+DOM_X = 200e-3  # propagation axis -> 200 cells in x
+DOM_Y = 8e-3  # transverse (TFSF forces the transverse axes periodic)
+
+FREQS_RT = np.linspace(4e9, 14e9, 21)  # R/T evaluation band
+
+# slab centred in x; nudge the upper x-corner down by dx/2 so an inclusive-bounds
+# Box maps to exactly D_SLAB of interior cells (recipe detail (d)).
+CENTER_X = DOM_X / 2.0
+SLAB_X_LO = CENTER_X - D_SLAB / 2.0
+SLAB_X_HI = CENTER_X + D_SLAB / 2.0 - DX / 2.0
+
+# flux planes: reflection monitor before the slab, transmission monitor after it
+REFL_X = CENTER_X - 40e-3
+TRANS_X = CENTER_X + 40e-3
+Y_CENTER = DOM_Y / 2.0
+
+
+def build_sim(with_slab: bool) -> Simulation:
+    sim = Simulation(
+        freq_max=FREQ_MAX,
+        domain=(DOM_X, DOM_Y, DX),
+        dx=DX,
+        boundary="cpml",
+        cpml_layers=10,
+        mode="2d_tmz",
+    )
+    if with_slab:
+        sim.add_material("slab", eps_r=EPS_SLAB)
+        # The material Box must span the full transverse extent (incl. CPML
+        # padding): with TFSF the transverse axes are periodic, so any cell
+        # outside the material mask breaks the plane-wave assumption (detail (c)).
+        sim.add(Box((SLAB_X_LO, -1.0, -1.0), (SLAB_X_HI, 1.0, 1.0)), material="slab")
+    sim.add_tfsf_source(f0=F0, bandwidth=BW, polarization="ez", direction="+x")
+    sim.add_flux_monitor(axis="x", coordinate=REFL_X, freqs=FREQS_RT, name="refl")
+    sim.add_flux_monitor(axis="x", coordinate=TRANS_X, freqs=FREQS_RT, name="trans")
+    return sim
+
+
+def run_one(with_slab: bool):
+    sim = build_sim(with_slab)
+    # run() auto-runs preflight; advisories are printed, never suppressed.
+    return sim.run(
+        n_steps=4000,
+        until_decay=1e-3,  # dispersionless slab -> 1e-3 is sufficient
+        decay_monitor_component="ez",
+        decay_monitor_position=(TRANS_X, Y_CENTER, 0.0),
+    )
+
+
+def fresnel_slab_rt(freqs, eps_r, d):
+    """Analytic lossless-slab |r|^2, |t|^2 via the 1-D transfer matrix."""
+    n = np.sqrt(eps_r)
+    ra = np.zeros_like(freqs)
+    ta = np.zeros_like(freqs)
+    for i, f in enumerate(freqs):
+        delta = 2 * np.pi * f * n * d / C0
+        cd, sd = np.cos(delta), np.sin(delta)
+        m00, m01, m10, m11 = cd, 1j * sd / n, 1j * n * sd, cd
+        r = (m00 + m01 - m10 - m11) / (m00 + m01 + m10 + m11)
+        t = 2.0 / (m00 + m01 + m10 + m11)
+        ra[i] = abs(r) ** 2
+        ta[i] = abs(t) ** 2
+    return ra, ta
+
+
+def main():
+    print("RUN 1: reference (no slab)")
+    res_ref = run_one(with_slab=False)
+    ref_refl_fm = res_ref.flux_monitors["refl"]
+    ref_trans_flux = np.asarray(flux_spectrum(res_ref.flux_monitors["trans"]))
+
+    print("RUN 2: sample (with slab)")
+    res_slab = run_one(with_slab=True)
+    slab_refl_fm = res_slab.flux_monitors["refl"]
+    slab_trans_flux = np.asarray(flux_spectrum(res_slab.flux_monitors["trans"]))
+
+    # Field-level subtraction for the reflected (scattered) flux — recipe detail (a).
+    # FluxMonitor is a NamedTuple; the accumulated DFT fields are e1_dft, e2_dft,
+    # h1_dft, h2_dft.
+    scat_refl_fm = slab_refl_fm._replace(
+        e1_dft=slab_refl_fm.e1_dft - ref_refl_fm.e1_dft,
+        e2_dft=slab_refl_fm.e2_dft - ref_refl_fm.e2_dft,
+        h1_dft=slab_refl_fm.h1_dft - ref_refl_fm.h1_dft,
+        h2_dft=slab_refl_fm.h2_dft - ref_refl_fm.h2_dft,
+    )
+    scat_refl_flux = np.asarray(flux_spectrum(scat_refl_fm))
+
+    transmittance = slab_trans_flux / ref_trans_flux
+    reflectance = -scat_refl_flux / ref_trans_flux  # reflection travels -x
+
+    r_an, t_an = fresnel_slab_rt(FREQS_RT, EPS_SLAB, D_SLAB)
+
+    print("\n  f(GHz)    R       T      R+T   |   R_an    T_an")
+    for i, f in enumerate(FREQS_RT):
+        print(
+            f"  {f / 1e9:5.1f}  {reflectance[i]:6.3f}  {transmittance[i]:6.3f}  "
+            f"{reflectance[i] + transmittance[i]:5.3f}  |  {r_an[i]:6.3f}  {t_an[i]:6.3f}"
+        )
+
+    finite = np.all(np.isfinite(reflectance)) and np.all(np.isfinite(transmittance))
+    print(f"\n  R+T max = {np.max(reflectance + transmittance):.3f} (energy: expect <= ~1)")
+    print(f"  mean |T - T_analytic| = {np.mean(np.abs(transmittance - t_an)):.3f}")
+    print(f"  mean |R - R_analytic| = {np.mean(np.abs(reflectance - r_an)):.3f}")
+    print(f"  all finite: {finite}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

An empirical agent-usability review (2026-06-19) gave each of 5 simulation tasks **only the public-shipping docs + package** and had an independent verifier clean-reproduce every script. Result: **5/5 ran from public docs alone, zero source-diving**. The docs are good — but a short list of real gaps survived adversarial audit (most *claimed* gaps were downgraded to "docs already cover it"; these are the ones that held up). This PR fixes them.

## What

| # | Gap | Fix |
|---|-----|-----|
| 1 | `recipe-waveguide-sparams.mdx` canonical block omitted required `freq_max` → `TypeError` on copy-paste (only **blocking** gap) | added `freq_max=f_c * 1.9` |
| 2 | `first-patch.mdx` §5 used a **private** `sim._build_grid()` in flagship tutorial code | → public `run(num_periods=40)` + `result.dt` / `result.time_series` |
| 3 | benign `complex128→complex64` truncation warnings (float32) were undocumented | "expected, not errors" note in both recipes |
| 4 | `quickstart.mdx` §1 + README patch placed source/probe/geometry **inside the CPML** → preflight warned on the docs' own code | §1 rewritten clean (**preflight now `[]`**) + cross-link; README honest note (advisories are non-fatal; resonance approximate → First Patch tutorial) |
| 5 | no shipped example of the **recommended** R/T path (recipe pointed only at the raw-loop+FFT `cv04`) | new `examples/slab_rt_flux_monitor.py` (`add_flux_monitor` + two-run field-level reference subtraction + analytic Fresnel witness) |
| meta | `docs/agent/` was not linked from the README (an agent couldn't discover it) | added a **"For AI coding agents"** entry-point section |

## Scope notes (honest)

- The reported "stale `cv01` cite in `repo-map.mdx`" sub-item was **dropped** — verified `repo-map.mdx` does not actually cite the missing file (it correctly points to `cv03`).
- **Discovered but deferred (pre-existing, out of scope):** single-cell lumped-port `run(compute_s_params=True)` is broken on this path — `quickstart.mdx §2` returns all-NaN `s11` (uniform mesh) and `first-patch.mdx §7` raises `NotImplementedError` (non-uniform mesh). Neither was introduced here. §7 now carries a caveat; both warrant a separate follow-up to wire the supported lumped S-parameter path (`add_port(..., extent=...)` WirePort / two-run subtraction).

## Verification

Author/reviewer separation: implemented by one pass, independently reviewed by another (runnability / doc-link integrity / scope-honesty). All changed code blocks execute on **rfx 1.6.5**; quickstart §1 preflight is clean; the new example exits 0 with finite R/T tracking the analytic Fresnel curve; every added link resolves to a tracked file (zero internal-path references); public-docs manifest validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)