### PR TITLE
Explain rfx gradients with Meep adjoint context

### DIFF
--- a/docs/public/guide/autodiff-adjoint.mdx
+++ b/docs/public/guide/autodiff-adjoint.mdx
@@ -1,0 +1,181 @@
+---
+title: "Autodiff and Adjoint Background"
+sidebar:
+  order: 13
+---
+
+This guide explains the gradient language used by rfx for microwave engineers
+who already think in terms of fields, ports, S-parameters, and design tuning.
+It uses Meep's adjoint-solver documentation as the comparison point, then maps
+those ideas to the JAX-native rfx workflow.
+
+## The engineering problem
+
+A conventional RF design loop is easy to state:
+
+1. choose geometry and materials,
+2. run the electromagnetic solver,
+3. extract an observable such as `|S11|`, `|S21|`, input impedance, radiated
+   power, or field intensity,
+4. change the design and run again.
+
+For one or two scalar variables, a sweep or finite-difference derivative is often
+sufficient. For a design region with hundreds or millions of material degrees of
+freedom, finite differences become too expensive because each variable requires
+additional solver runs.
+
+Gradient methods answer a different question: if the current design is fixed,
+which direction in the design-variable space most quickly improves a scalar
+objective?
+
+```text
+design variables -> FDTD fields -> probes / ports / far-field data -> scalar loss
+       eps_r(x)        E,H(t)              S11, S21, power             J
+```
+
+The output of autodiff or an adjoint calculation is the sensitivity of that
+scalar loss with respect to the design variables, for example `dJ / d eps_r` in
+a dielectric tuning region.
+
+## Finite difference, adjoint, and autodiff
+
+| Method | What it does | Cost shape | When it is useful |
+|---|---|---|---|
+| Parameter sweep | Evaluate a grid of candidate designs | many full simulations | low-dimensional engineering trade studies |
+| Finite difference | Perturb one variable at a time and re-run | one or two runs per variable | sanity checks and small parameter sets |
+| Adjoint method | Solve a forward problem and an adjoint sensitivity problem | roughly independent of design-variable count for one scalar objective family | large design regions and topology-style optimization |
+| Reverse-mode automatic differentiation | Apply the chain rule to the implemented discrete program | one differentiated program, with memory/recompute tradeoffs | JAX-native differentiable workflows in rfx |
+
+Meep's current adjoint-solver documentation describes a dedicated adjoint module
+for gradients of functions of mode coefficients, S-parameters, DFT fields, LDOS,
+and far fields with respect to a `MaterialGrid`. In that formulation, Meep runs a
+forward calculation to obtain the objective and design-region fields, then an
+adjoint calculation with a special current-source distribution; the gradient is
+assembled from the forward and adjoint fields. Meep highlights that this is why a
+large number of design variables can be handled without one simulation per
+variable.
+
+rfx uses a different implementation route. rfx writes the solver and supported
+objective paths in JAX, then uses JAX reverse-mode automatic differentiation to
+compute gradients of the implemented discrete computation. This is closely
+related to a discrete adjoint at the linear-algebra level: both are efficient
+ways to compute vector-Jacobian products for a scalar objective. The practical
+interface, however, is `jax.grad(loss_fn)(params)`, not a separate Meep-style
+adjoint run object.
+
+## What to carry over from Meep's adjoint model
+
+Meep's adjoint documentation is a useful mental model because it keeps four
+ideas explicit:
+
+1. **The objective must be explicit.** A solver does not optimize an antenna,
+   filter, or waveguide by itself. You must define a scalar loss such as
+   reflected energy, transmitted energy, directivity at an angle, or mismatch to
+   a target impedance.
+2. **The design variables must be continuous.** Gradients are natural for
+   permittivity, material-density, shape-parameter, or other continuous
+   variables. They do not make an integer grid size, a boolean topology switch,
+   or an arbitrary CAD operation differentiable.
+3. **The gradient is tied to the implemented observable.** A proxy loss such as
+   reflected probe energy is not automatically the same claim as a calibrated
+   S-parameter benchmark. Use the support matrix for the physical claim you want
+   to make.
+4. **Optimization still needs constraints and validation.** Filters,
+   projection, minimum feature-size rules, mesh convergence, passivity checks,
+   and final independent verification remain engineering requirements.
+
+Those rules are the same whether the gradient comes from a hand-derived adjoint
+solver, an automated adjoint module, or JAX autodiff.
+
+## rfx interpretation
+
+In rfx, the public gradient story is:
+
+- `jax.grad` can differentiate scalar losses through supported JAX-traced FDTD
+  workflows.
+- The result is a gradient of the implemented discrete simulation, not a
+  guarantee that the chosen observable is the right RF metric.
+- `checkpoint=True` or segmented checkpointing can reduce reverse-mode memory by
+  recomputing parts of the forward pass during the backward pass.
+- New problem setups should start with finite-difference checks on a few cells or
+  parameters before trusting the gradient for optimization.
+- Final RF claims should be verified by the relevant public workflow: port-family
+  S-parameter checks, convergence studies, far-field checks, or benchmarked
+  validation cases.
+
+This distinction matters for microwave work. A gradient can correctly optimize a
+proxy loss while the final design still fails a stricter measurement definition,
+for example a calibrated de-embedded `S11` envelope or a far-field directivity
+metric.
+
+## Practical microwave examples
+
+| Task | Good gradient variable | Good first objective | Validation after optimization |
+|---|---|---|---|
+| Dielectric matching block | continuous `eps_r` in a bounded design region | reflected probe energy or `forward(port_s11_freqs=...)` where supported | compare to the documented port-family S-parameter path |
+| Waveguide taper | dielectric profile or smooth shape parameters | transmitted modal energy or waveguide-port metric inside the guide envelope | run `compute_waveguide_s_matrix()` with convergence checks |
+| Patch-style tuning | substrate or feed-region continuous parameters | resonance/probe proxy during iteration | re-run resonance extraction and documented patch workflow checks |
+| Far-field shaping | continuous dielectric or layout-density field away from CPML | NTFF/directivity objective where configured | re-run far-field workflow and mesh/convergence checks |
+
+Avoid using gradients for cells inside CPML, boolean geometry insertion/removal,
+unsupported mixed-port combinations, or workflows that do not have a public guide
+and support entry.
+
+## Minimal gradient-check pattern
+
+Use this kind of check before a new optimization setup:
+
+```python
+import jax
+
+ad_grad = jax.grad(loss_fn)(params)
+
+idx = (10, 5, 3)
+h = 1e-2
+params_p = params.at[idx].add(h)
+params_m = params.at[idx].add(-h)
+fd_grad = (loss_fn(params_p) - loss_fn(params_m)) / (2 * h)
+
+rel_err = abs(ad_grad[idx] - fd_grad) / max(abs(fd_grad), 1e-30)
+print(rel_err)
+```
+
+For float32 FDTD workflows, very small finite-difference steps can be dominated
+by cancellation. Start with `h = 1e-2` for permittivity-like variables, then
+adjust based on the scale of the loss and the design variable.
+
+## Reading map
+
+- [Meep Adjoint Solver](https://meep.readthedocs.io/en/latest/Python_Tutorials/Adjoint_Solver/)
+  introduces the forward/adjoint two-run structure, MaterialGrid design
+  variables, broad-bandwidth objectives, and implementation references.
+- A. M. Hammond, A. Oskooi, M. Chen, Z. Lin, S. G. Johnson, and S. E. Ralph,
+  ["High-performance hybrid time/frequency-domain topology optimization for
+  large-scale photonics inverse design"](https://doi.org/10.1364/OE.442074),
+  *Optics Express* 30, 4467-4491 (2022), is the main Meep adjoint-solver
+  reference cited by the Meep documentation.
+- M. B. Giles and N. A. Pierce,
+  ["An Introduction to the Adjoint Approach to Design"](https://doi.org/10.1023/A:1011430410075),
+  *Flow, Turbulence and Combustion* 65, 393-415 (2000), is a classic
+  engineering introduction to adjoint design sensitivities.
+- S. Molesky, Z. Lin, A. Y. Piggott, W. Jin, J. Vuckovic, and A. W. Rodriguez,
+  ["Outlook for inverse design in nanophotonics"](https://doi.org/10.1038/s41566-018-0246-9),
+  *Nature Photonics* 12, 659-670 (2018), surveys inverse-design concepts and
+  motivation in photonics.
+- The [JAX automatic differentiation guide](https://docs.jax.dev/en/latest/automatic-differentiation.html)
+  and [Autodiff Cookbook](https://docs.jax.dev/en/latest/notebooks/autodiff_cookbook.html)
+  explain `jax.grad`, `value_and_grad`, JVPs, VJPs, and finite-difference checks
+  from the programming side.
+- A. Taflove and S. C. Hagness,
+  [*Computational Electrodynamics: The Finite-Difference Time-Domain Method*,
+  3rd ed.](https://us.artechhouse.com/Computational-Electrodynamics-The-Finite-Difference-Time-Domain-Method-Third-Edition-P2342.aspx),
+  Artech House (2005), is the standard FDTD background reference.
+
+## Next steps in rfx
+
+- Use [Inverse Design](/rfx/guide/inverse-design/) for the rfx optimization API
+  and objective families.
+- Use [Gradient Behavior](/rfx/guide/gradient-behavior/) for known stable,
+  noisy, and non-differentiable paths.
+- Use [Memory Reduction](/rfx/guide/memory-reduction/) when reverse-mode memory,
+  checkpointing, or run size is the limiting factor.

--- a/docs/public/guide/gradient-behavior.md
+++ b/docs/public/guide/gradient-behavior.md
@@ -4,15 +4,16 @@ sidebar:
   order: 14
 ---
 
-rfx guarantees that `jax.grad` flows correctly through the entire FDTD
-simulation. This guide documents where gradients are reliable, where they
-are noisy, and best practices for using them.
+rfx gradient workflows use JAX reverse-mode automatic differentiation through
+the implemented discrete FDTD calculation. This guide documents where gradients
+are reliable, where they are noisy, and best practices for using them. For the
+conceptual background, see [Autodiff and Adjoint Background](/rfx/guide/autodiff-adjoint/).
 
 ## How It Works
 
-JAX traces the entire FDTD time-stepping loop as a computation graph.
-`jax.checkpoint` (rematerialization) reduces memory from O(n_steps) to
-O(sqrt(n_steps)) by recomputing forward states during backpropagation.
+JAX traces the supported FDTD time-stepping and objective path as a computation
+graph. `jax.checkpoint` (rematerialization) reduces reverse-mode memory by
+recomputing forward states during backpropagation.
 
 ```python
 import jax
@@ -24,7 +25,7 @@ def objective(eps_r):
                  checkpoint=True)
     return jnp.sum(result.time_series ** 2)
 
-grad = jax.grad(objective)(eps_r)  # exact gradient via reverse-mode AD
+grad = jax.grad(objective)(eps_r)  # discrete reverse-mode AD gradient
 ```
 
 ## Where Gradients Work Well
@@ -86,7 +87,7 @@ JAX defaults to float32. For very small perturbations, finite-difference
 validation may show large disagreement with AD due to cancellation.
 
 **Mitigation**: When validating with FD, use h >= 1e-2 (not 1e-4).
-The AD gradient is correct; the FD estimate is imprecise at small h.
+A too-small FD step can be imprecise even when the AD path is stable.
 
 ## What Is NOT Differentiable
 
@@ -134,7 +135,7 @@ def fd_check(objective, eps_r, cell=(10, 5, 5), h=1e-2):
 5. **Average over frequencies** — broadband objectives are smoother
 6. **Exclude CPML from design region** — gradients there are artifacts
 7. **Use `until_decay`** — don't run longer than needed
-8. **GPU for speed** — same code, 10-50x faster, identical gradients
+8. **GPU for speed** — same differentiated program, faster execution when JAX has CUDA devices
 
 ## Supported Gradient Paths
 

--- a/docs/public/guide/index.md
+++ b/docs/public/guide/index.md
@@ -50,6 +50,7 @@ Start with the recommended default lane unless a public guide explicitly routes 
 
 | Guide | Description |
 |---|---|
+| [Autodiff and Adjoint Background](/rfx/guide/autodiff-adjoint/) | Gradient concepts for microwave engineers, mapped from Meep adjoint terminology to rfx autodiff workflows |
 | [Inverse Design](/rfx/guide/inverse-design/) | Gradient-based optimization with proxy objectives and validation caveats |
 | [Gradient Behavior](/rfx/guide/gradient-behavior/) | Where gradients are strong, weak, or noisy |
 | [Parametric Sweeps](/rfx/guide/parametric-sweeps/) | Sequential sweeps and `jax.vmap` batch evaluation |

--- a/docs/public/guide/inverse-design.md
+++ b/docs/public/guide/inverse-design.md
@@ -4,14 +4,16 @@ sidebar:
   order: 16
 ---
 
-rfx is fully differentiable — `jax.grad` computes gradients through the entire
-FDTD simulation, enabling gradient-based inverse design of RF structures.
+rfx exposes JAX-differentiable FDTD workflows: `jax.grad` computes reverse-mode
+gradients of a scalar loss through the implemented discrete time-domain
+calculation. If you are coming from Meep's adjoint terminology, start with
+[Autodiff and Adjoint Background](/rfx/guide/autodiff-adjoint/).
 
 ## How it works
 
-JAX traces the computation graph through all FDTD time steps.
-`jax.checkpoint` reduces memory from `O(n_steps)` to `O(sqrt(n_steps))` by
-recomputing forward states during backpropagation.
+JAX traces the supported solver and objective path as a computation graph.
+`jax.checkpoint` reduces reverse-mode memory by recomputing forward states
+during backpropagation.
 
 ```text
 Forward:  eps_r → FDTD steps → probes / NTFF / loss

--- a/docs/public/guide/migration.md
+++ b/docs/public/guide/migration.md
@@ -24,8 +24,8 @@ concepts are familiar -- the API surface is different.
 | PEC | `PerfectElectricalConductor` | `AddMetal` | `material="pec"` |
 | PML / ABC | `PML(thickness)` | `AddPML` | `boundary="cpml"` |
 | Dispersive media | `LorentzianSusceptibility` | `AddLorentzMaterial` | `DebyePole`, `LorentzPole`, `drude_pole()` |
-| Differentiable | Not available | Not available | `jax.grad(loss_fn)(params)` |
-| Inverse design | Not native (adjoint plugin) | Not native | `rfx.optimize(sim, design_region, objective)` |
+| Differentiable | adjoint-solver workflows for selected design-region objectives | not native | `jax.grad(loss_fn)(params)` on supported JAX-traced workflows |
+| Inverse design | `meep.adjoint` / `OptimizationProblem` | not native | `rfx.optimize(sim, design_region, objective)` |
 | Non-uniform mesh | Not native | `SmoothMeshLines` | `dz_profile` or `auto_configure()` |
 
 ---
@@ -94,10 +94,10 @@ rectangular-guide gates. Do not treat `run(compute_s_params=True)` as a
 universal OpenEMS `CalcPort` equivalent; it is the lumped/wire `add_port(...)`
 calculator only.
 
-### Meep Adjoint -> rfx Inverse Design
+### Meep Adjoint Solver -> rfx Inverse Design
 
 ```python
-# Meep (requires meep.adjoint plugin)
+# Meep (uses the meep.adjoint module)
 opt = mpa.OptimizationProblem(...)
 opt.update_design([design_params])
 f, g = opt()  # forward + adjoint
@@ -128,12 +128,12 @@ file-based I/O between the Python front-end and a C++ solver. The full
 time-stepping loop is JIT-compiled and executes on GPU (~3,000 Mcells/s on
 RTX 4090).
 
-### Differentiable by Default
+### JAX-Native Differentiation
 
-Every rfx simulation is differentiable with `jax.grad`. Gradients propagate
-through the entire FDTD time-stepping, sources, probes, and post-processing.
-This enables gradient-based inverse design without adjoint plugins or
-finite-difference approximations.
+Supported rfx optimization workflows are written so `jax.grad` can propagate
+through the implemented discrete time-stepping, sources, probes, and objective
+post-processing. This enables gradient-based inverse design from ordinary Python
+loss functions, while final RF claims still need the relevant validation path.
 
 ### Declarative Builder API
 
@@ -178,4 +178,5 @@ one globally fine uniform mesh.
 - [Quick Start](/rfx/guide/quickstart/) -- first simulation in 15 minutes
 - [Simulation API](/rfx/guide/api-reference/) -- current builder reference
 - [Sources & Ports](/rfx/guide/sources-ports/) -- source vs. port workflows
+- [Autodiff and Adjoint Background](/rfx/guide/autodiff-adjoint/) -- Meep-informed gradient concepts
 - [Inverse Design](/rfx/guide/inverse-design/) -- gradient-based optimization

--- a/docs/public/index.mdx
+++ b/docs/public/index.mdx
@@ -19,7 +19,7 @@ Use the **uniform Cartesian Yee RF/FDTD lane** first. The public docs highlight 
 | **Rectangular waveguide S-matrices** | validated inside the documented rectangular-guide envelope |
 | **Lumped, wire, and microstrip-line port workflows** | available through their matching calculators; validation scope follows the support matrix |
 | **Coaxial line reflection** | bounded one-port transmission-line workflow only; not a general coaxial S-matrix promise |
-| **Differentiable design loops** | use proxy objectives and documented validation checks before treating a design result as evidence |
+| **Differentiable design loops** | use proxy objectives, gradient checks, and documented validation before treating a design result as evidence |
 
 If a capability is not listed here or in the support-boundary page, treat it as outside the documented public support scope until the support matrix lists it.
 
@@ -98,6 +98,7 @@ print(f"Resonance: {modes[0].freq/1e9:.4f} GHz")
 
 ### Design & Optimization
 
+- [Autodiff and Adjoint Background](guide/autodiff-adjoint/) — Meep-informed gradient concepts for microwave engineers
 - [Inverse Design](guide/inverse-design/) — autodiff-driven optimization with documented proxy objectives
 - [Gradient Behavior](guide/gradient-behavior/) — where gradients are reliable vs noisy
 - [Parametric Sweeps](guide/parametric-sweeps/) — sequential sweep and `jax.vmap` design-space exploration

--- a/docs/public/site_map.json
+++ b/docs/public/site_map.json
@@ -33,6 +33,7 @@
     {
       "label": "Design & Optimization",
       "items": [
+        "rfx/guide/autodiff-adjoint",
         "rfx/guide/inverse-design",
         "rfx/guide/gradient-behavior",
         "rfx/guide/parametric-sweeps",


### PR DESCRIPTION
## Summary
- add a public `Autodiff and Adjoint Background` guide for microwave engineers
- map Meep's adjoint-solver concepts to rfx's JAX-native reverse-mode autodiff workflow
- add navigation links and tighten nearby gradient wording so gradients are not framed as standalone physics validation

## Validation
- `python3 scripts/check_public_docs_manifest.py`
- changed-doc internal `/rfx/guide` link scan
- full `docs/public` CJK scan
- full `docs/public` excluded-term scan for SBP-SAT/subgridding/research-decision leakage
- `git diff --cached --check`

## Source references
- Meep Adjoint Solver documentation
- Hammond et al., Optics Express 2022
- Giles & Pierce, Flow, Turbulence and Combustion 2000
- JAX automatic differentiation documentation
