### PR TITLE
Keep public changelog focused on supported workflows

### DIFF
--- a/docs/public/guide/changelog.mdx
+++ b/docs/public/guide/changelog.mdx
@@ -13,11 +13,11 @@ The recommended starting point remains the **uniform Cartesian Yee RF/FDTD lane*
 
 ## v1.6.5 — June 2026
 
-- The port-external-reference validation verdict was **reframed**: `broad_e5_passed` now means a magnitude envelope **plus** an (approximately) convention-free phase witness, an AD-vs-FD differentiability gate wired into the verdict, a live-physics anchor (not only a frozen replay), physics-derived tolerances, and committed-artifact enforcement — not a magnitude-only checkmark.
-- Per-port **physics-set validation ceilings** + usage rules are now declared (machine-readable): broad-E5 is not a universal goal — single-cell lumped/wire feeds top out at E4 by their nature, MSL is matched-regime-only, Floquet is broadside-only, generalized-planar is unimplemented. Only `rectangular_waveguide_port` passes the clean-checkout audit; coaxial is reported BLOCKED (its broad-E5 evidence is uncommitted and its extractor is not differentiable).
-- `compute_msl_s_matrix` now reports a positive characteristic impedance on **both** ports (a reported-Z0 sign fix that is S-parameter-invariant — the reported Z0 never enters S11/S21).
-- New validation coverage: a Floquet AD-vs-FD agreement test, and an analytic-gated non-uniform-mesh accuracy test against a mode whose resonance frequency depends on the graded axis (an air-cavity TM111 resonance).
-- Documentation-honesty corrections across the changelog, support matrix, and reference-lane docs; the public documentation surface was narrowed to maintained workflows; the multi-GPU distributed tests are device-count-adaptive and skip cleanly on a single-GPU pod.
+- Validation reporting is stricter: promoted port-family results now require magnitude evidence, phase-consistency evidence, differentiability checks where gradients are part of the claim, and reproducible artifact checks.
+- Port-family support wording is clearer: users should match each source or port family to its documented calculator and evidence envelope instead of treating any S-parameter helper as universal.
+- `compute_msl_s_matrix` now reports a positive characteristic impedance on both ports. This fixes reported metadata while leaving the S-parameter calculation invariant.
+- Non-uniform mesh accuracy coverage now includes an analytic gated cavity case whose resonance frequency depends on the graded axis.
+- Public guides and support pages were tightened around maintained workflows, validation boundaries, and device-count-adaptive test behaviour.
 
 ## v1.6.4 — June 2026
 


### PR DESCRIPTION
## Summary
- reword the v1.6.5 public changelog as user-facing release guidance
- remove maintainer-facing labels/details about unsupported or incomplete surfaces from the public changelog
- preserve the validation-boundary and port-family guidance in official-doc language

## Validation
- `python3 scripts/check_public_docs_manifest.py`
- public changelog maintainer-term scan
- full `docs/public` CJK scan
- full `docs/public` excluded-term scan
- `git diff --cached --check`
