### PR TITLE
fix(sparams): material-aware CPML in lumped/wire S-param extractors (#203)

### DIFF
--- a/rfx/probes/probes.py
+++ b/rfx/probes/probes.py
@@ -858,7 +858,8 @@ def extract_s_matrix(
             state = update_h(state, mats, dt, dx)
             if use_cpml:
                 state, cpml_state = apply_cpml_h(
-                    state, cpml_params, cpml_state, grid, cpml_axes)
+                    state, cpml_params, cpml_state, grid, cpml_axes,
+                    materials=mats)
 
             state, debye_state, lorentz_state = _update_e_with_optional_dispersion(
                 state,
@@ -871,7 +872,8 @@ def extract_s_matrix(
 
             if use_cpml:
                 state, cpml_state = apply_cpml_e(
-                    state, cpml_params, cpml_state, grid, cpml_axes)
+                    state, cpml_params, cpml_state, grid, cpml_axes,
+                    materials=mats)
             state = apply_pec(state)
 
             # Apply interior PEC mask (e.g. ground plane, scatterers
@@ -1105,7 +1107,8 @@ def extract_s_matrix_wire(
             state = update_h(state, mats, dt, dx)
             if use_cpml:
                 state, cpml_state = apply_cpml_h(
-                    state, cpml_params, cpml_state, grid, cpml_axes)
+                    state, cpml_params, cpml_state, grid, cpml_axes,
+                    materials=mats)
 
             state, debye_state, lorentz_state = _update_e_with_optional_dispersion(
                 state,
@@ -1118,7 +1121,8 @@ def extract_s_matrix_wire(
 
             if use_cpml:
                 state, cpml_state = apply_cpml_e(
-                    state, cpml_params, cpml_state, grid, cpml_axes)
+                    state, cpml_params, cpml_state, grid, cpml_axes,
+                    materials=mats)
             state = apply_pec(state)
 
             if pec_mask is not None:

--- a/tests/test_lumped_wire_sparam_cpml_dielectric.py
+++ b/tests/test_lumped_wire_sparam_cpml_dielectric.py
@@ -1,0 +1,104 @@
+"""Regression: lumped/wire S-parameter extraction must be CPML-material-aware.
+
+Issue #203. ``run(compute_s_params=True)`` for a single-cell lumped port (or a
+wire port) runs a *separate* eager FDTD re-run inside
+``rfx.probes.probes.extract_s_matrix`` / ``extract_s_matrix_wire`` to accumulate
+the port V/I DFTs. Those re-runs called ``apply_cpml_h`` / ``apply_cpml_e``
+WITHOUT the ``materials=`` argument, so the CPML fell back to free-space eps_0
+coefficients. Inside a dielectric (eps_r > 1) the absorber update is then
+unstable, the field diverges exponentially to float32 overflow (first NaN
+~step 300-400), the V/I DFTs are poisoned, and every S-parameter comes back NaN.
+
+The production JIT scan body passes ``materials=materials`` to both CPML calls
+and is stable — which is why the *same* run with ``compute_s_params=False`` is
+healthy. The fix threads ``materials=mats`` into the CPML calls of BOTH
+``extract_s_matrix`` (lumped) and ``extract_s_matrix_wire`` (wire), so the
+extractor and the production scan handle dielectric-in-CPML identically.
+
+``test_lumped_...`` is the strict #203 regression: it triggers the divergence
+deterministically (dielectric spanning the full transverse cross-section so its
+y/z faces sit in the CPML, run ~700 steps so the pre-fix field blow-up reaches
+NaN), and was confirmed to FAIL on the pre-fix code and pass after.
+``test_wire_...`` exercises the sibling wire extractor — which carried the same
+missing-``materials=`` omission — on the same geometry; empirically this case
+stayed finite even pre-fix (the single-cell lumped excitation is what seeded the
+instability), so it is a forward-looking finiteness/passivity guard, not a
+proven before/after regression. Both assert only finiteness and passivity
+(|S| <= 1); the absolute |S11| of a lossless dielectric block on an open domain
+is a near-total reflector and is not a validated number.
+"""
+
+import numpy as np
+import pytest
+
+from rfx import Box, Simulation
+from rfx.sources.sources import GaussianPulse
+
+# Enough steps for the pre-fix CPML divergence to reach NaN (it first appears
+# ~step 300-400; fewer steps would let the buggy code pass spuriously).
+_N_STEPS = 700
+
+
+def _dielectric_in_cpml_sim():
+    """Small open-domain sim with an eps_r=4 block spanning the transverse
+    cross-section, so the dielectric occupies CPML cells (the #203 trigger)."""
+    sim = Simulation(
+        freq_max=5e9,
+        domain=(0.06, 0.03, 0.02),
+        dx=1.5e-3,
+        boundary="cpml",
+        cpml_layers=8,
+    )
+    sim.add_material("diel", eps_r=4.0)
+    # Spans full y/z extent -> the block's transverse faces sit in the CPML.
+    sim.add(Box((0.02, 0.0, 0.0), (0.04, 0.03, 0.02)), material="diel")
+    return sim
+
+
+def test_lumped_port_sparam_cpml_dielectric_finite_passive():
+    """Single-cell lumped port + CPML + dielectric must give finite, passive S11.
+
+    Pre-fix this returned all-NaN s_params (issue #203 as-filed symptom).
+    """
+    sim = _dielectric_in_cpml_sim()
+    # Single-cell lumped port (extent=None), interior in x (clear of x-CPML).
+    sim.add_port(
+        position=(0.03, 0.015, 0.01),
+        component="ez",
+        impedance=50.0,
+        waveform=GaussianPulse(f0=3e9, bandwidth=0.8),
+    )
+    result = sim.run(n_steps=_N_STEPS, compute_s_params=True)
+
+    assert result.s_params is not None
+    s = np.asarray(result.s_params)
+    assert s.shape == (1, 1, result.freqs.shape[0])
+    assert np.all(np.isfinite(s)), "lumped S-params must be finite (issue #203)"
+    max_s11 = float(np.max(np.abs(s[0, 0, :])))
+    assert max_s11 <= 1.0 + 1e-3, f"passivity: max|S11|={max_s11:.4f} > 1"
+
+
+def test_wire_port_sparam_cpml_dielectric_finite_passive():
+    """Wire port (extent=) + CPML + dielectric stays finite and passive.
+
+    ``extract_s_matrix_wire`` carried the identical missing-``materials=`` CPML
+    omission and is fixed alongside the lumped extractor. This geometry did not
+    by itself reproduce the pre-fix lumped divergence (the wire excitation does
+    not seed it the same way), so this is a forward-looking finiteness/passivity
+    guard on the wire S-param path rather than a proven before/after regression.
+    """
+    sim = _dielectric_in_cpml_sim()
+    sim.add_port(
+        position=(0.03, 0.015, 0.01),
+        component="ez",
+        impedance=50.0,
+        waveform=GaussianPulse(f0=3e9, bandwidth=0.8),
+        extent=0.006,
+    )
+    result = sim.run(n_steps=_N_STEPS, compute_s_params=True)
+
+    assert result.s_params is not None
+    s = np.asarray(result.s_params)
+    assert np.all(np.isfinite(s)), "wire S-params must be finite (issue #203)"
+    max_s11 = float(np.max(np.abs(s[0, 0, :])))
+    assert max_s11 <= 1.0 + 1e-3, f"passivity: max|S11|={max_s11:.4f} > 1"


### PR DESCRIPTION
Fixes #203.

## Root cause

`run(compute_s_params=True)` with a single-cell lumped port returned **all-NaN `s11`** whenever a dielectric overlapped the CPML region (the quickstart §2 geometry).

The lumped/wire S-parameter extractors in `rfx/probes/probes.py` run a **separate eager FDTD re-run** to accumulate port V/I DFTs, and their CPML calls omitted the `materials=` argument. Per `rfx/boundaries/cpml.py`, `materials=None` makes CPML fall back to free-space ε₀/μ₀ coefficients. Inside a dielectric (ε_r>1) the absorber is then unstable → field diverges exponentially to float32 overflow (first NaN ~step 300–400) → V/I DFTs poisoned → every `s_param` NaN. The production JIT scan body passes `materials=materials` and is stable — which is exactly why the same run with `compute_s_params=False` is healthy.

The issue's "port-in-CPML / single-cell lumped is broken" framing was **falsified** during diagnosis: an interior-placed port is equally all-NaN; the discriminator is CPML **+** dielectric, not port position.

## Fix

Thread `materials=mats` into the 4 CPML calls in `extract_s_matrix` (lumped) and `extract_s_matrix_wire` (wire), matching the production scan. `mats` is the run materials with port impedances folded in (`setup_*_port` changes only `sigma`, not `eps_r`), so CPML reads the correct local `eps_r`.

## Scope

Lumped + wire are the **only** S-param extractors that run their own eager CPML loop reachable via `compute_s_params=True`; waveguide/MSL/coax forward to the production scan and are unaffected. The same `materials=` omission exists on the non-uniform / vmap / subgrid scan bodies, but `compute_s_params=True` is gated off those paths — tracked as a separate follow-up (see #203 comment), **not** expanded here.

## Tests (`tests/test_lumped_wire_sparam_cpml_dielectric.py`)

- **lumped** — strict #203 regression: proven to **fail all-NaN pre-fix and pass after** (git-stash round-trip).
- **wire** — forward-looking finiteness/passivity guard. The wire excitation did **not** reproduce the divergence even at ε_r=9 / 1500 steps, so it is honestly **not** labeled a before/after regression; the wire code fix is kept for material-aware-CPML consistency with the production scan.

## Verification

- §2 repro: all-NaN → finite 50/50, max|S11|=0.9995 ✓
- **Invariance**: vacuum/PEC paths byte-identical (ε_r=1 array == scalar fallback); the existing CPML+dielectric test `test_twoport_wire_port` unchanged to all digits; full S-param suite **32 passed**.
- The ~0.99 |S11| of a lossless dielectric block on an open domain is *"finite and passive"*, **not** a validated number.
- Independently reviewed (correctness / scope / test-validity+invariance) — all lenses approve, no must-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)