### PR TITLE
fix(preflight): reject periodic axes with lumped/wire run(compute_s_params=True) (#206)

### DIFF
--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -443,6 +443,21 @@ class _PreflightMixin:
                 "reference lane."
             )
 
+        # The lumped/wire S-parameter extractor runs a SEPARATE eager FDTD
+        # re-run that does NOT apply periodic boundaries, so it would silently
+        # ignore set_periodic_axes() and return an S-matrix for the wrong
+        # (non-periodic) boundary-value problem (issue #206). Fail loudly
+        # instead of returning silently-wrong S-parameters.
+        if self._periodic_axes and port_entries:
+            raise NotImplementedError(
+                "run(compute_s_params=True) for lumped/wire add_port(...) does "
+                "not honor periodic axes: the S-parameter extraction re-run uses "
+                "non-periodic boundaries, so the returned S-matrix would silently "
+                f"ignore set_periodic_axes({self._periodic_axes!r}). Remove the "
+                "periodic axes for the S-parameter run, or use a port family that "
+                "supports periodicity (e.g. a Floquet port)."
+            )
+
     def _validate_forward_sparameter_request(self) -> None:
         """Reject ``forward(port_s11_freqs=...)`` outside its narrow path."""
 

--- a/tests/test_periodic_lumped_sparam_guard.py
+++ b/tests/test_periodic_lumped_sparam_guard.py
@@ -1,0 +1,57 @@
+"""Guard: run(compute_s_params=True) for lumped/wire ports rejects periodic axes (#206).
+
+The lumped/wire S-parameter extractor runs a SEPARATE eager FDTD re-run
+(rfx/probes/probes.py extract_s_matrix / extract_s_matrix_wire) that does NOT
+apply periodic boundaries, while the main run does. So a sim with periodic axes
++ a lumped/wire port + compute_s_params=True would silently extract S-parameters
+under the wrong (non-periodic) boundary conditions -- witnessed: setting
+set_periodic_axes() changed the returned |S11| by <1.5e-4 (float32 graph noise),
+i.e. the periodic BC was silently ignored.
+
+Rather than support periodicity in the eager extractor (an unrequested feature),
+the preflight now fails loudly -- mirroring the non-uniform + lumped-port
+NotImplementedError guard. These tests pin that contract and confirm the guard
+does not over-fire on the ordinary non-periodic path.
+"""
+
+import numpy as np
+import pytest
+
+from rfx import Box, Simulation
+from rfx.sources.sources import GaussianPulse
+
+
+def _sim(periodic_axes, extent=None):
+    sim = Simulation(
+        freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1.0e-3,
+        boundary="cpml", cpml_layers=4,
+    )
+    if periodic_axes:
+        sim.set_periodic_axes(periodic_axes)
+    sim.add_port(
+        position=(0.01, 0.01, 0.01), component="ez", impedance=50.0,
+        waveform=GaussianPulse(f0=5e9, bandwidth=0.9), extent=extent,
+    )
+    return sim
+
+
+def test_periodic_lumped_compute_s_params_raises():
+    """Periodic axes + single-cell lumped port + compute_s_params must raise."""
+    sim = _sim("y", extent=None)
+    with pytest.raises(NotImplementedError, match="periodic"):
+        sim.run(n_steps=50, compute_s_params=True)
+
+
+def test_periodic_wire_compute_s_params_raises():
+    """Periodic axes + wire port (extent=) + compute_s_params must raise."""
+    sim = _sim("xy", extent=0.004)
+    with pytest.raises(NotImplementedError, match="periodic"):
+        sim.run(n_steps=50, compute_s_params=True)
+
+
+def test_nonperiodic_lumped_compute_s_params_ok():
+    """Guard must NOT over-fire: the ordinary non-periodic path still runs."""
+    sim = _sim("", extent=None)
+    res = sim.run(n_steps=50, compute_s_params=True)
+    assert res.s_params is not None
+    assert np.all(np.isfinite(np.asarray(res.s_params)))


### PR DESCRIPTION
Fixes #206.

## Bug

The lumped/wire S-parameter extractor (`rfx/probes/probes.py` `extract_s_matrix` / `extract_s_matrix_wire`) runs a **separate eager FDTD re-run** that does **not** apply periodic boundaries, while the main run does (`uniform.py` / `simulation.py` pass `periodic=`). So `run(compute_s_params=True)` for a lumped/wire `add_port` on a sim with `set_periodic_axes()` silently extracted the S-matrix under the **wrong (non-periodic) boundaries**.

**Witnessed:** setting `set_periodic_axes("y"/"xy")` changed the returned |S11| by only **~5e-5 / 1.4e-4** vs non-periodic (float32 graph noise) — the periodic BC was silently *ignored*, not applied (a periodic vs non-periodic structure would differ far more).

## Fix — guard, not feature

Per rfx CLAUDE.md *"correctness > feature sprawl, no new features until requested"*, this **fails loudly** (`NotImplementedError` in `_validate_run_sparameter_request`, mirroring the existing non-uniform + lumped-port guard) rather than adding periodicity support to the eager extractor. Supporting periodic lumped/wire S-params is a deferred feature, not currently requested — refile if needed.

**Floquet ports** (the documented periodic-structure S-param primitive) are unaffected: they live in `self._floquet_ports`, so `port_entries` (`self._port_sparameter_entries`) is empty and the guard stays silent.

## Tests

- `tests/test_periodic_lumped_sparam_guard.py` — lumped+periodic and wire+periodic `compute_s_params` raise; non-periodic still runs (no over-fire). Confirmed the raise-tests **FAIL without** the guard.
- **Invariance: 77 existing tests pass** (`test_floquet` / `test_port_preflight` / `test_run_preflight_parity` / `test_api`); grep confirms no existing test relied on the now-guarded combination.

Independently reviewed: **APPROVE** (bug / guard-scope / no-over-fire / test-validity all verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)