### PR TITLE
fix(sparams): passivity self-check for forward()/run() lumped-wire S11 (item-3 follow-up)

### DIFF
--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -888,6 +888,19 @@ class _ExecuteMixin:
             s_params_out = w_list[0] if len(w_list) == 1 else jnp.stack(w_list, axis=0)
             freqs_out = result.wire_port_sparams[0][0].freqs
 
+        # Passivity self-check (tracer-safe; skipped under jax.grad/jit) — the
+        # eager single-cell lumped/wire extractor can return non-physical
+        # |S11|>1 where the incident wave is weak (spectral band edges), and
+        # forward() previously surfaced no check (unlike compute_*_s_matrix).
+        if s_params_out is not None and (
+            result.lumped_port_sparams or result.wire_port_sparams
+        ):
+            from rfx.probes.probes import warn_if_nonpassive_lumped_s11
+            warn_if_nonpassive_lumped_s11(
+                s_params_out, freqs_out,
+                extractor="forward(port_s11_freqs=...)",
+            )
+
         # Convert tuple → name-keyed dict, mirroring runners/uniform.py:704
         # so consumers can index by the same name they registered with.
         dft_planes_out = None

--- a/rfx/probes/probes.py
+++ b/rfx/probes/probes.py
@@ -974,6 +974,73 @@ def extract_lumped_s11(
     return (v_dft + z0 * i_dft) / safe_denom
 
 
+def warn_if_nonpassive_lumped_s11(s_params, freqs, *, extractor: str,
+                                  passivity_tol: float = 0.10) -> None:
+    """Tracer-safe passivity self-check for lumped/wire port S11 (issue #206 sib).
+
+    ``run(compute_s_params=True)`` and ``forward(port_s11_freqs=...)`` for
+    lumped/wire ports assemble S11 from the eager single-cell extractor, but —
+    unlike ``compute_*_s_matrix`` (which calls
+    :func:`rfx.api._sparams._warn_if_nonpassive_smatrix`) — they previously
+    surfaced no passivity check. A passive one-port cannot have ``|S11| > 1``;
+    a gross violation (measured up to ~1.98 on a high-eps closed cavity) means
+    the extractor is unreliable at that frequency (single-cell curl-of-H
+    current is ill-conditioned where the incident wave is weak, i.e. spectral
+    band edges), NOT that the device is exotic. Surface it so an eager
+    analysis / optimizer setup does not trust or chase those bins.
+
+    ``s_params``: ``(n_freqs,)`` single port, or ``(n_ports, n_freqs)`` per-port
+    diagonal S_ii. ``passivity_tol`` matches the repo standard (0.10) so mild
+    float32 noise just above 1.0 is not flagged.
+
+    Tracer-safe: under ``jax.grad`` / ``jax.jit`` ``s_params`` is an abstract
+    tracer with no concrete value, so the check is skipped entirely — it never
+    perturbs an AD/optimization run, only the eager research call.
+    """
+    import numpy as np
+    import jax as _jax
+    try:
+        if isinstance(s_params, _jax.core.Tracer):
+            return
+    except Exception:
+        pass
+    try:
+        mag = np.abs(np.asarray(s_params))
+        f = np.asarray(freqs)
+    except Exception:
+        return
+    if mag.size == 0:
+        return
+    nonfinite = ~np.isfinite(mag)
+    over = mag > (1.0 + passivity_tol)
+    if not (over.any() or nonfinite.any()):
+        return
+    worst = float(np.nanmax(mag)) if np.isfinite(mag).any() else float("nan")
+    bad_f = []
+    try:
+        bad_cols = np.unique(np.where(over | nonfinite)[-1])
+        bad_f = [f"{float(f[c]) / 1e9:.3f}" for c in bad_cols[:6] if c < f.size]
+    except Exception:
+        pass
+    # Describe the actual trigger accurately: a non-finite bin is its own
+    # failure mode (don't report a misleadingly-small finite max for it).
+    if nonfinite.any():
+        kind = f"non-finite (and max finite|S11|={worst:.3f})"
+    else:
+        kind = f"max|S11|={worst:.3f} > 1+{passivity_tol:g}"
+    import warnings as _w
+    _w.warn(
+        f"{extractor}: lumped/wire port S11 is non-passive ({kind}) "
+        f"at freq(GHz)={bad_f}"
+        f"{' …' if len(bad_f) == 6 else ''}. A passive one-port cannot have "
+        f"|S11|>1; the single-cell extractor is unreliable where the incident "
+        f"wave is weak (spectral band edges). Do not trust or optimize against "
+        f"these bins — restrict the band to where the source has energy, or use "
+        f"run() for a passive analysis curve.",
+        stacklevel=3,
+    )
+
+
 def extract_s11_normalised(probe: SParamProbe, z0: float = 50.0) -> jnp.ndarray:
     """Compute S11 normalised against the incident source DFT.
 

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -647,6 +647,16 @@ def run_uniform(
                 pec_mask=pec_mask,
             )
 
+        # Passivity self-check (tracer-safe) — surface non-physical |S11|>1 from
+        # the eager single-cell lumped/wire extractor, matching forward() and
+        # compute_*_s_matrix (which previously had no such check on this path).
+        if s_params is not None:
+            from rfx.probes.probes import warn_if_nonpassive_lumped_s11
+            warn_if_nonpassive_lumped_s11(
+                s_params, freqs_out,
+                extractor="run(compute_s_params=True)",
+            )
+
     waveguide_ports_result = (
         {
             entry.name: cfg

--- a/tests/test_forward_run_s11_passivity_warn.py
+++ b/tests/test_forward_run_s11_passivity_warn.py
@@ -1,0 +1,118 @@
+"""Passivity self-check for forward()/run() lumped/wire S11 (item-3 follow-up).
+
+The eager single-cell lumped/wire S-parameter extractor can return non-physical
+|S11| > 1 where the incident wave is weak (spectral band edges), because the
+curl-of-H port current is ill-conditioned there (float32). Measured up to ~1.98
+on a high-eps closed cavity. compute_*_s_matrix already runs a passivity
+self-check (_warn_if_nonpassive_smatrix); forward() and run(compute_s_params=True)
+previously surfaced none, so a researcher (or an optimizer's eager setup call)
+could silently trust/chase those bins.
+
+These tests pin that forward()/run() now warn on a gross passivity violation,
+stay silent on a passive sweep and on mild float noise (tol=0.10, the repo
+standard), and — critically — that the check is tracer-safe (skipped under
+jax.grad, so it never perturbs an AD/optimization run).
+"""
+
+import warnings
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from rfx import Box, Simulation
+from rfx.sources.sources import GaussianPulse
+
+_FREQS = np.linspace(1e9, 12e9, 11)
+
+
+def _cavity(eps_r):
+    """PEC cavity; a high-eps dielectric block drives the band-edge |S11|>1."""
+    sim = Simulation(freq_max=12e9, domain=(0.02, 0.02, 0.02), dx=1.0e-3, boundary="pec")
+    if eps_r is not None:
+        sim.add_material("d", eps_r=eps_r)
+        sim.add(Box((0.004, 0.004, 0.004), (0.016, 0.016, 0.016)), material="d")
+    sim.add_port(
+        position=(0.01, 0.01, 0.01), component="ez", impedance=50.0,
+        waveform=GaussianPulse(f0=4e9, bandwidth=0.7),
+    )
+    return sim
+
+
+def _warned_nonpassive(recorded):
+    return any("non-passive" in str(w.message) for w in recorded)
+
+
+def test_forward_lumped_s11_passivity_warns_on_gross_violation():
+    """forward() must warn when the eager extractor returns |S11| >> 1."""
+    sim = _cavity(eps_r=10.0)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        fr = sim.forward(port_s11_freqs=_FREQS)
+    assert float(np.abs(np.asarray(fr.s_params).reshape(-1)).max()) > 1.10
+    assert _warned_nonpassive(rec), "forward() should warn on non-passive |S11|>1"
+
+
+def test_forward_passive_does_not_warn():
+    """A passive (vacuum) sweep must not trigger the passivity warning."""
+    sim = _cavity(eps_r=None)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        fr = sim.forward(port_s11_freqs=_FREQS)
+    assert float(np.abs(np.asarray(fr.s_params).reshape(-1)).max()) <= 1.10
+    assert not _warned_nonpassive(rec), "passive sweep must not warn"
+
+
+def test_passivity_helper_fires_on_gross_silent_otherwise():
+    """Unit-test the shared helper directly (geometry-independent).
+
+    This is the robust proof that the guard FIRES on a gross violation — used
+    on both the forward() and run() paths. (run() happens to be the better-
+    conditioned path and stays passive on the eps cavity above, so its firing
+    cannot be witnessed by geometry; this unit test covers it instead.)
+    """
+    from rfx.probes.probes import warn_if_nonpassive_lumped_s11
+    f = np.array([1e9, 5e9, 9e9])
+    for label, s, expect in [
+        ("gross 1.98", np.array([0.5, 1.98, 0.3]), True),
+        ("mild 1.01 (within tol)", np.array([0.5, 0.9, 1.01]), False),
+        ("passive", np.array([0.5, 0.9, 0.3]), False),
+    ]:
+        with warnings.catch_warnings(record=True) as rec:
+            warnings.simplefilter("always")
+            warn_if_nonpassive_lumped_s11(s, f, extractor="unit")
+        assert _warned_nonpassive(rec) is expect, f"helper {label}: wrong warn state"
+
+
+def test_run_passivity_guard_wired_no_overfire():
+    """run(compute_s_params=True) has the guard wired and does not over-fire.
+
+    run() is the better-conditioned path (item-3): on the eps cavity it stays
+    passive (max|S11|<1), so it correctly does NOT warn. This pins that the
+    guard is present on the run path without false-alarming on a passive run.
+    """
+    sim = _cavity(eps_r=10.0)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        res = sim.run(n_steps=1500, compute_s_params=True, s_param_freqs=_FREQS)
+    assert float(np.abs(np.asarray(res.s_params).reshape(-1)).max()) <= 1.10
+    assert not _warned_nonpassive(rec), "run() passive sweep must not warn"
+
+
+def test_passivity_check_is_tracer_safe_under_grad():
+    """Under jax.grad the check must be skipped (no warn, finite grad, no crash)."""
+    sim = _cavity(eps_r=10.0)
+    g = sim._build_grid()
+    eps_base = jnp.ones(g.shape, dtype=jnp.float32)
+    cell = (g.nx // 2, g.ny // 2, g.nz // 2)
+
+    def objective(alpha):
+        eps = eps_base.at[cell].set(alpha)
+        fr = sim.forward(eps_override=eps, port_s11_freqs=_FREQS[:4])
+        return jnp.sum(jnp.abs(fr.s_params) ** 2)
+
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        grad = float(jax.grad(objective)(jnp.float32(1.0)))
+    assert np.isfinite(grad), "AD grad through forward S11 must be finite"
+    assert not _warned_nonpassive(rec), "passivity check must be skipped under jax.grad"


### PR DESCRIPTION
Follow-up to #207 (run↔forward S11 contract). Item-3 deliverable: surface the non-physical forward/run band-edge |S11|.

## Bug

The eager single-cell lumped/wire S-parameter extractor can return non-physical **|S11| > 1** at spectral band edges, where the curl-of-H port current is ill-conditioned in float32. Measured up to **~1.98** on a high-εr PEC cavity. `compute_*_s_matrix` already runs a passivity self-check (`_warn_if_nonpassive_smatrix`), but `forward(port_s11_freqs=...)` and `run(compute_s_params=True)` surfaced **none** — so an eager analysis (or an optimizer's setup call) could silently trust/chase those bins. (This is the concrete harm behind the closed-cavity-optimization concern from the #207 diagnosis.)

## Fix — diagnostic warning, tracer-safe, no laundering

Add `rfx.probes.probes.warn_if_nonpassive_lumped_s11` (tol=0.10 = repo standard) and wire it into the forward() and run() lumped/wire assembly paths.

- **Diagnostic only** — no numerics change; `s_params` byte-identical (verified by the reviewer with a no-op monkeypatch).
- **Tracer-safe** (load-bearing): under `jax.grad`/`jit`, `s_params` is an abstract tracer → the check early-returns. It **never fires per optimizer iteration** and cannot NaN a gradient — only the eager research call warns. Verified on a real `LinearizeTracer` + `jit` and through a `jax.grad` forward objective (finite grad, no warning).
- **tol=0.10** matches the existing gate: mild float noise (1.01) is ignored, gross violations (~1.98) warn.
- **No clamp/mask** (not laundering): the bin is genuinely unreliable; the message says to restrict the band to where the source has energy, or use `run()` for a passive analysis curve.

`run()` is the better-conditioned path and stays passive on the witness geometry (max|S11|~0.99), so its guard doesn't fire there; the helper's fire-on-violation is covered by a direct unit test.

## Tests / invariance

- `tests/test_forward_run_s11_passivity_warn.py` — forward warns on gross / silent on passive / helper unit (fire+silent) / run no-over-fire / **tracer-safe under jax.grad**.
- **Invariance: 53 S-param/forward/optimize/port tests pass** (no `filterwarnings=error`; no spurious firing in the optimize loop). Reviewer also re-ran `test_sparam_ad_end_to_end` + `test_optimize_s11_wave_decomp` green.

Independently reviewed: **APPROVE** (not-a-no-op / tracer-safety / wiring / byte-identical numerics / all 3 array shapes / invariance verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)