### PR TITLE
feat(sparams): production-scan lumped/wire S-matrix driver (item-5 Stage 1, pure-add)

### DIFF
--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -478,8 +478,32 @@ class _ExecuteMixin:
         pec_mask: jnp.ndarray | None = None,
         pec_occupancy: jnp.ndarray | None = None,
         port_s11_freqs: object | None = None,
-    ) -> ForwardResult:
-        """Run a minimal differentiable forward path from explicit materials."""
+        _sparam_drive_idx: int | None = None,
+        _return_raw_port_sparams: bool = False,
+    ) -> ForwardResult | dict:
+        """Run a minimal differentiable forward path from explicit materials.
+
+        Internal multi-drive S-matrix hook (item-5 Stage 1, 2026-06-22)
+        --------------------------------------------------------------
+        ``_sparam_drive_idx`` and ``_return_raw_port_sparams`` exist solely
+        for the production-scan S-matrix driver
+        (``rfx.probes.sparam_driver``).  Their defaults preserve the current
+        ``forward()`` / ``run()`` behavior EXACTLY:
+
+        * ``_sparam_drive_idx`` (default ``None``): when set to an integer,
+          build the excitation source for ONLY the sparam-eligible
+          lumped/wire port at that 0-based index (in registration order over
+          the lumped+wire ports), ignoring every port's ``excite`` flag.  All
+          other ports remain matched loads (their impedance is still folded
+          into materials via ``setup_lumped_port`` / ``setup_wire_port``).
+          When ``None``, excitation follows ``pe.excite`` as before.
+        * ``_return_raw_port_sparams`` (default ``False``): when ``True``,
+          return ``{"lumped": result.lumped_port_sparams,
+          "wire": result.wire_port_sparams, "freqs": ...}`` (the all-port
+          ``(v_dft, i_dft)`` accumulators) instead of the diagonal
+          ``ForwardResult``.  When ``False``, the normal ``ForwardResult`` is
+          returned unchanged.
+        """
         if self._solver == "adi":
             return self._run_adi_from_materials(
                 grid,
@@ -522,6 +546,19 @@ class _ExecuteMixin:
         # Collect all port cell indices for Kottke dilation guard (issue #82).
         _port_cleared_cells: list[tuple[int, int, int]] = []
 
+        # Multi-drive S-matrix hook (item-5 Stage 1): 0-based counter over the
+        # sparam-eligible lumped/wire ports (impedance != 0) in registration
+        # order. When ``_sparam_drive_idx`` is set, only the port whose counter
+        # equals it is excited; all others are matched loads regardless of
+        # ``pe.excite``. When ``_sparam_drive_idx`` is None this counter is
+        # inert and excitation follows ``pe.excite`` (current behavior).
+        _sparam_port_idx = -1
+
+        def _excite_this_port(pe) -> bool:
+            if _sparam_drive_idx is None:
+                return pe.excite
+            return _sparam_port_idx == _sparam_drive_idx
+
         for pe in self._ports:
             if pe.impedance == 0.0:
                 from rfx.simulation import make_j_source
@@ -530,6 +567,9 @@ class _ExecuteMixin:
                                   pe.waveform, n_steps, materials)
                 )
                 continue
+
+            # Sparam-eligible lumped/wire port — advance the multi-drive index.
+            _sparam_port_idx += 1
 
             if pe.extent is not None:
                 axis_map = {"ex": 0, "ey": 1, "ez": 2}
@@ -544,7 +584,7 @@ class _ExecuteMixin:
                     excitation=pe.waveform,
                 )
                 materials = setup_wire_port(grid, wp, materials)
-                if pe.excite:
+                if _excite_this_port(pe):
                     sources.extend(make_wire_port_sources(grid, wp, materials, n_steps))
                 wp_cells = _wire_port_cells(grid, wp)
                 for cell in wp_cells:
@@ -578,7 +618,7 @@ class _ExecuteMixin:
                 excitation=pe.waveform,
             )
             materials = setup_lumped_port(grid, lp, materials)
-            if pe.excite:
+            if _excite_this_port(pe):
                 sources.append(make_port_source(grid, lp, materials, n_steps))
             idx = grid.position_to_index(pe.position)
             if pec_mask_local is not None:
@@ -865,6 +905,21 @@ class _ExecuteMixin:
             dft_planes=dft_planes if dft_planes else None,
             return_state=False,
         )
+
+        # Multi-drive S-matrix hook (item-5 Stage 1): return the raw all-port
+        # (v_dft, i_dft) accumulators for off-line wave decomposition by the
+        # production-scan driver, bypassing the diagonal-only extraction below.
+        if _return_raw_port_sparams:
+            _raw_freqs = None
+            if result.lumped_port_sparams:
+                _raw_freqs = result.lumped_port_sparams[0][0].freqs
+            elif result.wire_port_sparams:
+                _raw_freqs = result.wire_port_sparams[0][0].freqs
+            return {
+                "lumped": result.lumped_port_sparams,
+                "wire": result.wire_port_sparams,
+                "freqs": _raw_freqs,
+            }
 
         s_params_out = getattr(result, "s_params", None)
         freqs_out = getattr(result, "freqs", None)

--- a/rfx/probes/probes.py
+++ b/rfx/probes/probes.py
@@ -756,6 +756,115 @@ def update_wire_sparam_probe(
     return probe._replace(v_dft=new_v, i_dft=new_i, v_inc_dft=new_vinc)
 
 
+# ---------------------------------------------------------------------------
+# Pure wave decomposers (single source of truth for the lumped/wire S-matrix)
+# ---------------------------------------------------------------------------
+#
+# These extract the *post-processing* of the eager extractors into reusable,
+# AD-friendly (jnp) module-level functions so that both the eager
+# Python-loop extractor (extract_s_matrix / extract_s_matrix_wire) and the
+# production-scan driver (rfx/probes/sparam_driver.py) decompose V/I phasors
+# with ONE implementation.  The eager extractors call these so the eager path
+# stays bit-identical (item-5 Stage 1, 2026-06-22).
+
+def decompose_lumped_s_matrix(v, i, z0):
+    """Lumped-port N-port S-matrix from accumulated V/I DFTs.
+
+    Wave decomposition with the FDTD sign convention (``V = -E·dx``):
+
+        a_j = (-V[j,j] + Z0[j]·I[j,j]) / (2·√Z0[j])    # incident at driven port j
+        b_i = (-V[j,i] - Z0[i]·I[j,i]) / (2·√Z0[i])    # reflected at receive port i
+        S[i,j] = b_i / a_j
+
+    where the safe-denominator guard replaces a zero incident wave by 1 (so
+    S → 0 / 1 = 0 rather than NaN).  Mirrors ``extract_s_matrix`` exactly.
+
+    Parameters
+    ----------
+    v, i : (n_ports, n_ports, n_freqs) complex
+        ``v[j, i]`` / ``i[j, i]`` are the V/I DFT phasors at receive port *i*
+        when driving port *j* (FDTD sign convention).
+    z0 : (n_ports,) real
+        Per-port reference impedance.
+
+    Returns
+    -------
+    S : (n_ports, n_ports, n_freqs) complex
+        ``S[i, j]`` is the response at receive port *i* when driving port *j*.
+    """
+    v = jnp.asarray(v)
+    i = jnp.asarray(i)
+    z0 = jnp.asarray(z0)
+    n_ports = v.shape[0]
+    n_freqs = v.shape[-1]
+    S = jnp.zeros((n_ports, n_ports, n_freqs), dtype=jnp.complex64)
+    for j in range(n_ports):
+        z0_j = z0[j]
+        a_j = (-v[j, j] + z0_j * i[j, j]) / (2.0 * jnp.sqrt(z0_j))
+        safe_a = jnp.where(jnp.abs(a_j) > 0, a_j, jnp.ones_like(a_j))
+        for ri in range(n_ports):
+            z0_i = z0[ri]
+            b_i = (-v[j, ri] - z0_i * i[j, ri]) / (2.0 * jnp.sqrt(z0_i))
+            S = S.at[ri, j, :].set((b_i / safe_a).astype(jnp.complex64))
+    return S
+
+
+def decompose_wire_s_matrix(v, i, z0, port_cell_counts):
+    """Wire-port N-port S-matrix from accumulated midpoint V/I DFTs.
+
+    Diagonal entries use the measured input impedance reflection
+    (``Z_in = -V/I``; ``S_ii = (Z_in − Z0_i)/(Z_in + Z0_i)``); off-diagonal
+    entries use a *per-cell-normalized* impedance ``Z0/n_cells`` for the wave
+    decomposition.  Mirrors ``extract_s_matrix_wire`` line-for-line.
+
+    Parameters
+    ----------
+    v, i : (n_ports, n_ports, n_freqs) complex
+        ``v[j, i]`` / ``i[j, i]`` are the midpoint-cell V/I DFT phasors at
+        receive port *i* when driving port *j* (FDTD sign convention).
+    z0 : (n_ports,) real
+        Per-port total reference impedance.
+    port_cell_counts : (n_ports,) int
+        Number of wire cells per port (for per-cell impedance normalization).
+
+    Returns
+    -------
+    S : (n_ports, n_ports, n_freqs) complex
+        ``S[i, j]`` is the response at receive port *i* when driving port *j*.
+    """
+    v = jnp.asarray(v)
+    i = jnp.asarray(i)
+    z0 = jnp.asarray(z0)
+    n_ports = v.shape[0]
+    n_freqs = v.shape[-1]
+    S = jnp.zeros((n_ports, n_ports, n_freqs), dtype=jnp.complex64)
+    for j in range(n_ports):
+        z0_j = z0[j]
+        safe_i = jnp.where(
+            jnp.abs(i[j, j]) > 0,
+            i[j, j],
+            jnp.ones_like(i[j, j]) * 1e-30,
+        )
+        z_in_j = -v[j, j] / safe_i  # measured input impedance
+        for ri in range(n_ports):
+            z0_i = z0[ri]
+            if ri == j:
+                S = S.at[ri, j, :].set(
+                    ((z_in_j - z0_i) / (z_in_j + z0_i)).astype(jnp.complex64))
+            else:
+                n_cells_i = max(int(port_cell_counts[ri]), 1)
+                z0_cell_i = z0_i / n_cells_i
+                b_i = (-v[j, ri] - z0_cell_i * i[j, ri]) / (
+                    2.0 * jnp.sqrt(z0_cell_i))
+                n_cells_j = max(int(port_cell_counts[j]), 1)
+                z0_cell_j = z0_j / n_cells_j
+                a_j = (-v[j, j] + z0_cell_j * i[j, j]) / (
+                    2.0 * jnp.sqrt(z0_cell_j))
+                safe_a = jnp.where(jnp.abs(a_j) > 0, a_j, jnp.ones_like(a_j))
+                S = S.at[ri, j, :].set((b_i / safe_a).astype(jnp.complex64))
+    return S
+
+
 def extract_s_matrix(
     grid,
     materials,
@@ -836,7 +945,9 @@ def extract_s_matrix(
         lorentz_poles, lorentz_masks = lorentz_spec
         lorentz = init_lorentz(lorentz_poles, mats, dt, mask=lorentz_masks)
 
-    S = np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex64)
+    # FDTD-sign V/I phasors per (drive j, receive i) for the shared decomposer.
+    v_all = np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex128)
+    i_all = np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex128)
     raw_v = (
         np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex128)
         if return_vi_dump else None
@@ -898,17 +1009,14 @@ def extract_s_matrix(
             # Excite only port j
             state = apply_lumped_port(state, grid, ports[j], t, mats)
 
-        # Wave decomposition with FDTD sign convention (V = -E·dx):
-        #   a = (-V + Z0·I) / (2·√Z0)   # incident
-        #   b = (-V - Z0·I) / (2·√Z0)   # reflected
-        # Incident wave at excitation port j
-        z0_j = ports[j].impedance
-        a_j = (-sprobes[j].v_dft + z0_j * sprobes[j].i_dft) / (
-            2.0 * np.sqrt(z0_j))
-        safe_a = jnp.where(jnp.abs(a_j) > 0, a_j, jnp.ones_like(a_j))
-
-        # Response at each receiving port i
+        # Collect per-(drive j, receive i) V/I DFT phasors for the shared
+        # wave decomposer (``decompose_lumped_s_matrix``) — single source of
+        # truth for the lumped decomposition shared with the production-scan
+        # driver (item-5 Stage 1).  The dump schema stores ``-V`` (voltage
+        # positive into the DUT); the FDTD-sign V is fed to the decomposer.
         for i in range(n_ports):
+            v_all[j, i, :] = np.asarray(sprobes[i].v_dft, dtype=np.complex128)
+            i_all[j, i, :] = np.asarray(sprobes[i].i_dft, dtype=np.complex128)
             if return_vi_dump:
                 # ``port_voltage`` returns the FDTD-sign voltage used by the
                 # legacy extractor (V = -E·dx).  The portable dump schema uses
@@ -918,10 +1026,10 @@ def extract_s_matrix(
                 # decomposition below exactly.
                 raw_v[j, i, :] = np.asarray(-sprobes[i].v_dft, dtype=np.complex128)
                 raw_i[j, i, :] = np.asarray(sprobes[i].i_dft, dtype=np.complex128)
-            z0_i = ports[i].impedance
-            b_i = (-sprobes[i].v_dft - z0_i * sprobes[i].i_dft) / (
-                2.0 * np.sqrt(z0_i))
-            S[i, j, :] = np.array(b_i / safe_a)
+
+    z0_arr = np.asarray([p.impedance for p in ports], dtype=np.float64)
+    S = np.asarray(
+        decompose_lumped_s_matrix(v_all, i_all, z0_arr), dtype=np.complex64)
 
     if return_vi_dump:
         return PortVIReplayBundle(
@@ -1145,7 +1253,10 @@ def extract_s_matrix_wire(
         lorentz_poles, lorentz_masks = lorentz_spec
         lorentz = init_lorentz(lorentz_poles, mats, dt, mask=lorentz_masks)
 
-    S = np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex64)
+    # FDTD-sign midpoint V/I phasors per (drive j, receive i) for the
+    # shared wire decomposer (``decompose_wire_s_matrix``).
+    v_all = np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex128)
+    i_all = np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex128)
     raw_v = (
         np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex128)
         if return_vi_dump else None
@@ -1205,38 +1316,21 @@ def extract_s_matrix_wire(
             # Excite only port j
             state = apply_wire_port(state, grid, ports[j], t, mats)
 
-        # Wave decomposition at the midpoint cell with FDTD sign
-        # convention (V = -E·dx → Z_in = -V/I).
-        z0_j = ports[j].impedance
-        safe_i = jnp.where(
-            jnp.abs(sprobes[j].i_dft) > 0,
-            sprobes[j].i_dft,
-            jnp.ones_like(sprobes[j].i_dft) * 1e-30,
-        )
-        z_in_j = -sprobes[j].v_dft / safe_i  # measured input impedance
-
+        # Collect per-(drive j, receive i) midpoint V/I DFT phasors for the
+        # shared wire wave decomposer (``decompose_wire_s_matrix``) — single
+        # source of truth shared with the production-scan driver.  Wire dump
+        # stores the FDTD-sign V (no negation, unlike lumped).
         for i in range(n_ports):
+            v_all[j, i, :] = np.asarray(sprobes[i].v_dft, dtype=np.complex128)
+            i_all[j, i, :] = np.asarray(sprobes[i].i_dft, dtype=np.complex128)
             if return_vi_dump:
                 raw_v[j, i, :] = np.asarray(sprobes[i].v_dft, dtype=np.complex128)
                 raw_i[j, i, :] = np.asarray(sprobes[i].i_dft, dtype=np.complex128)
-            z0_i = ports[i].impedance
-            if i == j:
-                # S11: reflection from input impedance
-                S[i, j, :] = np.array(
-                    (z_in_j - z0_i) / (z_in_j + z0_i)
-                )
-            else:
-                # Sij: wave decomposition with negated V (FDTD sign)
-                n_cells_i = int(port_cell_counts[i])
-                z0_cell_i = z0_i / max(n_cells_i, 1)
-                b_i = (-sprobes[i].v_dft - z0_cell_i * sprobes[i].i_dft) / (
-                    2.0 * np.sqrt(z0_cell_i))
-                n_cells_j = int(port_cell_counts[j])
-                z0_cell_j = z0_j / max(n_cells_j, 1)
-                a_j = (-sprobes[j].v_dft + z0_cell_j * sprobes[j].i_dft) / (
-                    2.0 * np.sqrt(z0_cell_j))
-                safe_a = jnp.where(jnp.abs(a_j) > 0, a_j, jnp.ones_like(a_j))
-                S[i, j, :] = np.array(b_i / safe_a)
+
+    z0_arr = np.asarray([p.impedance for p in ports], dtype=np.float64)
+    S = np.asarray(
+        decompose_wire_s_matrix(v_all, i_all, z0_arr, port_cell_counts),
+        dtype=np.complex64)
 
     if return_vi_dump:
         return WirePortVIReplayBundle(

--- a/rfx/probes/sparam_driver.py
+++ b/rfx/probes/sparam_driver.py
@@ -1,0 +1,162 @@
+"""Production-scan lumped/wire S-matrix driver (item-5 Stage 1).
+
+This module rebuilds the full N-port lumped/wire S-parameter extraction on
+the **production JIT scan** (``Simulation._forward_from_materials`` →
+``rfx.simulation.run``) instead of the hand-maintained eager Python FDTD
+loops in ``rfx.probes.probes`` (``extract_s_matrix`` /
+``extract_s_matrix_wire``).
+
+It drives one sparam-eligible port at a time via the
+``_sparam_drive_idx`` / ``_return_raw_port_sparams`` hook on
+``_forward_from_materials``, collects the all-port ``(v_dft, i_dft)``
+accumulators, and feeds them to the *shared* pure wave decomposers
+(``decompose_lumped_s_matrix`` / ``decompose_wire_s_matrix`` in
+``rfx.probes.probes``) — the same decomposition the eager path now uses, so
+the driver and the eager extractor agree by construction.
+
+Stage 1 is a PURE ADD: nothing here reroutes ``forward()`` / ``run()``; the
+eager loops are untouched (their removal is Stage 3).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from rfx.probes.probes import (
+    decompose_lumped_s_matrix,
+    decompose_wire_s_matrix,
+)
+
+
+def compute_lumped_wire_s_matrix_via_scan(sim, freqs, *, n_steps=None):
+    """Full lumped/wire N-port S-matrix via the production scan.
+
+    Drives each sparam-eligible lumped/wire port in turn through the
+    production JIT scan, then applies the shared pure decomposers.
+
+    Parameters
+    ----------
+    sim : Simulation
+        A built ``Simulation`` carrying lumped and/or wire ports (added via
+        ``add_port``).  Ports are addressed in registration order over the
+        impedance!=0 lumped/wire ports.
+    freqs : array-like
+        Frequencies (Hz) at which to extract the S-matrix.
+    n_steps : int or None
+        Number of FDTD steps per drive.  Defaults to
+        ``grid.num_timesteps(num_periods=30)`` (matching the eager
+        extractors' default).
+
+    Returns
+    -------
+    (S, freqs) : (np.ndarray, np.ndarray)
+        ``S`` has shape ``(n_ports, n_ports, n_freqs)`` where ``S[i, j]`` is
+        the response at receive port *i* when driving port *j*.
+
+    Notes
+    -----
+    Stage 1 supports a homogeneous all-lumped **or** all-wire port set (the
+    eager ``extract_s_matrix`` / ``extract_s_matrix_wire`` are likewise
+    called per-family).  A mixed lumped+wire set raises ``NotImplementedError``
+    because the lumped and wire off-diagonal wave-decomposition conventions
+    differ (per-cell impedance normalization for wire) and cross-family
+    coupling is out of Stage-1 scope.
+    """
+    freqs = np.asarray(freqs, dtype=np.float64)
+    n_freqs = len(freqs)
+
+    # Build grid + materials exactly as the uniform forward lane does.
+    grid = sim._build_grid()
+    materials, debye_spec, lorentz_spec, pec_mask, _, _, _ = \
+        sim._assemble_materials(grid)
+
+    if n_steps is None:
+        n_steps = grid.num_timesteps(num_periods=30)
+
+    # Ordered sparam-eligible lumped/wire ports (impedance != 0), in
+    # registration order — the same order the multi-drive index counts.
+    eligible = [pe for pe in sim._ports if pe.impedance != 0.0]
+    if not eligible:
+        raise ValueError(
+            "compute_lumped_wire_s_matrix_via_scan: no sparam-eligible "
+            "lumped/wire ports (all ports have impedance 0)."
+        )
+
+    is_wire = [pe.extent is not None for pe in eligible]
+    if any(is_wire) and not all(is_wire):
+        raise NotImplementedError(
+            "compute_lumped_wire_s_matrix_via_scan: mixed lumped + wire port "
+            "sets are not supported in Stage 1 (the off-diagonal wave-"
+            "decomposition conventions differ).  Use a homogeneous all-lumped "
+            "or all-wire port set."
+        )
+    wire_mode = all(is_wire)
+
+    n_ports = len(eligible)
+    z0 = np.asarray([pe.impedance for pe in eligible], dtype=np.float64)
+
+    # Per-port wire cell counts (only needed for the wire decomposer).
+    if wire_mode:
+        from rfx.sources.sources import WirePort, _wire_port_cells
+        axis_map = {"ex": 0, "ey": 1, "ez": 2}
+        port_cell_counts = np.zeros(n_ports, dtype=np.int64)
+        for idx, pe in enumerate(eligible):
+            end = list(pe.position)
+            end[axis_map[pe.component]] += pe.extent
+            wp = WirePort(
+                start=pe.position,
+                end=tuple(end),
+                component=pe.component,
+                impedance=pe.impedance,
+                excitation=pe.waveform,
+            )
+            port_cell_counts[idx] = max(len(_wire_port_cells(grid, wp)), 1)
+
+    # FDTD-sign V/I phasors per (drive j, receive i).
+    v_all = np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex128)
+    i_all = np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex128)
+
+    for j in range(n_ports):
+        raw = sim._forward_from_materials(
+            grid,
+            materials,
+            debye_spec,
+            lorentz_spec,
+            n_steps=n_steps,
+            checkpoint=False,
+            pec_mask=pec_mask,
+            port_s11_freqs=freqs,
+            _sparam_drive_idx=j,
+            _return_raw_port_sparams=True,
+        )
+
+        accs = raw["wire"] if wire_mode else raw["lumped"]
+        if accs is None or len(accs) != n_ports:
+            raise RuntimeError(
+                "compute_lumped_wire_s_matrix_via_scan: production scan "
+                f"returned {0 if accs is None else len(accs)} "
+                f"{'wire' if wire_mode else 'lumped'} accumulators for drive "
+                f"{j}, expected {n_ports}.  The port-spec registration is "
+                "out of sync with the eligible-port list."
+            )
+
+        for i in range(n_ports):
+            spec, vi = accs[i]
+            # Lumped accs are (v_dft, i_dft); wire accs are
+            # (v_dft, i_dft, v_inc_dft) — take the first two either way.
+            v_dft, i_dft = vi[0], vi[1]
+            v_all[j, i, :] = np.asarray(v_dft, dtype=np.complex128)
+            i_all[j, i, :] = np.asarray(i_dft, dtype=np.complex128)
+
+    if wire_mode:
+        S = np.asarray(
+            decompose_wire_s_matrix(v_all, i_all, z0, port_cell_counts),
+            dtype=np.complex64,
+        )
+    else:
+        S = np.asarray(
+            decompose_lumped_s_matrix(v_all, i_all, z0),
+            dtype=np.complex64,
+        )
+
+    return S, freqs

--- a/tests/test_sparam_driver_matches_eager.py
+++ b/tests/test_sparam_driver_matches_eager.py
@@ -1,0 +1,158 @@
+"""Acceptance gate: production-scan S-matrix driver matches the eager extractor.
+
+Item-5 Stage 1 (2026-06-22) rebuilds the lumped/wire N-port S-parameter
+extraction on the production JIT scan
+(``rfx.probes.sparam_driver.compute_lumped_wire_s_matrix_via_scan``) as a PURE
+ADD next to the hand-maintained eager Python-loop extractors
+(``extract_s_matrix`` / ``extract_s_matrix_wire``).
+
+The hard acceptance gate is that the driver reproduces the eager extractor's
+full N-port S-matrix on CPML, where the eager path and the production scan are
+expected byte-identical (cf. ``test_run_forward_s11_contract.py``).  The gate
+tolerances are deliberately tight (atol 2e-3) — a tolerance *bump* to pass is
+a failure, not a fix (R2-STOP).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from rfx.api import Simulation
+from rfx.grid import Grid
+from rfx.core.yee import init_materials
+from rfx.sources.sources import GaussianPulse, LumpedPort, WirePort
+from rfx.probes.probes import extract_s_matrix, extract_s_matrix_wire
+from rfx.probes.sparam_driver import compute_lumped_wire_s_matrix_via_scan
+
+# Small shared geometry (≈0.024 × 0.012 × 0.012, dx = 1 mm, 2–9 GHz).
+_DOMAIN = (0.024, 0.012, 0.012)
+_DX = 1e-3
+_FREQ_MAX = 10e9
+_CPML_LAYERS = 8
+_FREQS = np.linspace(2e9, 9e9, 15)
+_N_STEPS = 1500
+_GATE_ATOL = 2e-3            # CPML byte-closeness
+_RECIPROCITY_REL = 0.05     # |S21 - S12| / max(|S21|, |S12|)
+
+
+def _waveform():
+    return GaussianPulse(f0=5.5e9, bandwidth=4e9)
+
+
+def _eager_grid():
+    return Grid(freq_max=_FREQ_MAX, domain=_DOMAIN, dx=_DX,
+                cpml_layers=_CPML_LAYERS)
+
+
+def _driver_sim():
+    return Simulation(freq_max=_FREQ_MAX, domain=_DOMAIN, dx=_DX,
+                      boundary="cpml", cpml_layers=_CPML_LAYERS)
+
+
+# ---------------------------------------------------------------------------
+# Lumped 1-port (CPML)
+# ---------------------------------------------------------------------------
+
+def test_driver_matches_eager_lumped_1port_cpml():
+    wf = _waveform()
+    pos = (0.012, 0.006, 0.006)
+
+    sim = _driver_sim()
+    sim.add_port(position=pos, component="ez", impedance=50.0, waveform=wf)
+    S_drv, _ = compute_lumped_wire_s_matrix_via_scan(sim, _FREQS, n_steps=_N_STEPS)
+
+    g = _eager_grid()
+    mats = init_materials(g.shape)
+    ports = [LumpedPort(position=pos, component="ez", impedance=50.0,
+                        excitation=wf)]
+    S_eager = np.asarray(extract_s_matrix(
+        g, mats, ports, _FREQS, _N_STEPS, boundary="cpml", cpml_axes="xyz"))
+
+    assert S_drv.shape == S_eager.shape == (1, 1, len(_FREQS))
+    d = float(np.max(np.abs(np.abs(S_drv) - np.abs(S_eager))))
+    assert d < _GATE_ATOL, (
+        f"lumped 1-port CPML |S| diverged: max||S_drv|-|S_eager|| = {d:.3e} "
+        f">= {_GATE_ATOL}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lumped 2-port (CPML) — full matrix incl. off-diagonal S21/S12
+# ---------------------------------------------------------------------------
+
+def test_driver_matches_eager_lumped_2port_cpml():
+    wf = _waveform()
+    pos0 = (0.008, 0.006, 0.006)
+    pos1 = (0.016, 0.006, 0.006)
+
+    sim = _driver_sim()
+    # Drive each port one at a time during extraction — registration order
+    # 0,1.  excite flags are ignored by the driver (it drives by index).
+    sim.add_port(position=pos0, component="ez", impedance=50.0, waveform=wf)
+    sim.add_port(position=pos1, component="ez", impedance=50.0, waveform=wf)
+    S_drv, _ = compute_lumped_wire_s_matrix_via_scan(sim, _FREQS, n_steps=_N_STEPS)
+
+    g = _eager_grid()
+    mats = init_materials(g.shape)
+    ports = [
+        LumpedPort(position=pos0, component="ez", impedance=50.0, excitation=wf),
+        LumpedPort(position=pos1, component="ez", impedance=50.0, excitation=wf),
+    ]
+    S_eager = np.asarray(extract_s_matrix(
+        g, mats, ports, _FREQS, _N_STEPS, boundary="cpml", cpml_axes="xyz"))
+
+    assert S_drv.shape == S_eager.shape == (2, 2, len(_FREQS))
+
+    # Full-matrix byte-closeness (diagonal + off-diagonal).
+    d_full = float(np.max(np.abs(np.abs(S_drv) - np.abs(S_eager))))
+    assert d_full < _GATE_ATOL, (
+        f"lumped 2-port CPML full |S| diverged: {d_full:.3e} >= {_GATE_ATOL}"
+    )
+
+    # Off-diagonal S21 byte-closeness (the production-scan multi-drive proof).
+    d_s21 = float(np.max(np.abs(np.abs(S_drv[1, 0]) - np.abs(S_eager[1, 0]))))
+    assert d_s21 < _GATE_ATOL, (
+        f"lumped 2-port CPML |S21| diverged: {d_s21:.3e} >= {_GATE_ATOL}"
+    )
+
+    # Reciprocity of the driver-reconstructed matrix: |S21 - S12| rel < 5%.
+    s21 = S_drv[1, 0]
+    s12 = S_drv[0, 1]
+    denom = np.maximum(np.abs(s21), np.abs(s12))
+    mask = denom > 1e-6
+    if np.any(mask):
+        rel = float(np.max(np.abs(s21[mask] - s12[mask]) / denom[mask]))
+        assert rel < _RECIPROCITY_REL, (
+            f"lumped 2-port driver reciprocity |S21-S12| rel = {rel:.3e} "
+            f">= {_RECIPROCITY_REL}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Wire 1-port (CPML)
+# ---------------------------------------------------------------------------
+
+def test_driver_matches_eager_wire_1port_cpml():
+    wf = _waveform()
+    start = (0.012, 0.006, 0.005)
+    end = (0.012, 0.006, 0.008)
+    extent = end[2] - start[2]
+
+    sim = _driver_sim()
+    sim.add_port(position=start, component="ez", impedance=50.0,
+                 waveform=wf, extent=extent)
+    S_drv, _ = compute_lumped_wire_s_matrix_via_scan(sim, _FREQS, n_steps=_N_STEPS)
+
+    g = _eager_grid()
+    mats = init_materials(g.shape)
+    wports = [WirePort(start=start, end=end, component="ez", impedance=50.0,
+                       excitation=wf)]
+    S_eager = np.asarray(extract_s_matrix_wire(
+        g, mats, wports, _FREQS, _N_STEPS, boundary="cpml", cpml_axes="xyz"))
+
+    assert S_drv.shape == S_eager.shape == (1, 1, len(_FREQS))
+    d = float(np.max(np.abs(np.abs(S_drv) - np.abs(S_eager))))
+    assert d < _GATE_ATOL, (
+        f"wire 1-port CPML |S| diverged: max||S_drv|-|S_eager|| = {d:.3e} "
+        f">= {_GATE_ATOL}"
+    )


### PR DESCRIPTION
**Item 5, Stage 1 of 3** (consolidate lumped/wire S-param extraction onto the production scan). Scope: `docs/research_notes/20260622_item5_consolidation_scope.md`. This stage is a **PURE ADD** — it builds the replacement driver and gates it against the existing eager extractor, but **deletes nothing and reroutes nothing** (run()/forward() are untouched; the eager extractors stay). Stage 3 will reroute + delete.

## Why
The eager `extract_s_matrix`/`extract_s_matrix_wire` (probes.py) run a hand-maintained FDTD loop that duplicates the production JIT scan and has spawned a bug family (#203/#205/#206/#210). The driver rebuilds extraction on the production scan so config (CPML-materials, periodic, NU) is inherited automatically — killing the drift class at the root.

## What
- **`rfx/probes/probes.py`**: two pure decomposers `decompose_lumped_s_matrix` / `decompose_wire_s_matrix` (single source of truth); the eager extractors **refactored to call them** — eager output **byte-identical** before/after (`np.array_equal`, max|diff|=0.0).
- **`rfx/api/_execute.py::_forward_from_materials`**: two default-preserving kwargs — `_sparam_drive_idx` (drive only the j-th sparam port; others stay matched loads) and `_return_raw_port_sparams` (return raw all-port V/I accumulators). Defaults → current behavior exactly.
- **`rfx/probes/sparam_driver.py`** (new): `compute_lumped_wire_s_matrix_via_scan(sim, freqs)` — loops drives through the production scan, collects all-port V/I, decomposes → full (n,n,n_freqs) matrix incl off-diagonal S21.

## Gate (objective acceptance — driver matches eager)
| case | driver vs eager | gate |
|---|---|---|
| lumped 1p/2p CPML | max‖S‖ **1.07e-6** | 2e-3 |
| lumped 2p \|S21\| | **4.07e-7** | 2e-3 |
| lumped 2p reciprocity | **4.37e-4** | 0.05 |
| wire 1p CPML | **1.13e-6** | 2e-3 |

~1000× inside the gate; **no tolerance loosened**. Test: `tests/test_sparam_driver_matches_eager.py`.

## Pure-add / invariance
`git diff` = 4 files, nothing deleted, run()/forward() not rerouted. Regression: `test_wire_sparam`, `test_lumped_port_sparams_jit`, `test_api`, `test_run_forward_s11_contract`, `test_forward_run_s11_passivity_warn` → **61 passed, 1 skipped**. ruff clean.

## Review
Built by an executor; **independently reviewed by reproduction** (gate re-run, eager byte-identity re-verified on both origin/main and the branch, closure drive-selection verified drive-k→argmax(|V|)==k with no late-binding bug, pure-add diff confirmed). APPROVE. One non-blocking nit: a benign float32 truncation warning (correct choice — keeps byte-identity with the float32 eager path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)