### PR TITLE
feat(sparams): reroute run()-lumped onto production-scan driver (item-5 Stage 3 / 3a)

### DIFF
--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -638,13 +638,20 @@ def run_uniform(
                 pec_mask=pec_mask,
             )
         else:
-            s_params = extract_s_matrix(
-                grid, base_materials, lumped_ports, s_param_freqs,
-                n_steps=sp_n_steps,
-                boundary=sim._boundary,
-                debye_spec=debye_spec,
-                lorentz_spec=lorentz_spec,
-                pec_mask=pec_mask,
+            # item-5 Stage 3 (reroute-only): the LUMPED run() path now goes
+            # through the production-scan driver (= forward()'s graph) instead
+            # of the eager extract_s_matrix loop. The eager extractors are KEPT
+            # (diagnostics / openEMS-crossval tooling) but are no longer on the
+            # run() hot path. Consequence: run()-lumped now inherits forward()'s
+            # band-edge non-physical |S11|>1 on lossless PEC cavities (it was
+            # better-conditioned on the old eager path); the #210 passivity
+            # warning below correctly surfaces those unreliable band-edge bins.
+            # CPML run()-lumped stays byte-close (driver↔eager ~1e-6..1.5e-3).
+            from rfx.probes.sparam_driver import (
+                compute_lumped_wire_s_matrix_via_scan,
+            )
+            s_params, _ = compute_lumped_wire_s_matrix_via_scan(
+                sim, s_param_freqs, n_steps=sp_n_steps,
             )
 
         # Passivity self-check (tracer-safe) — surface non-physical |S11|>1 from

--- a/tests/test_forward_run_s11_passivity_warn.py
+++ b/tests/test_forward_run_s11_passivity_warn.py
@@ -67,9 +67,11 @@ def test_passivity_helper_fires_on_gross_silent_otherwise():
     """Unit-test the shared helper directly (geometry-independent).
 
     This is the robust proof that the guard FIRES on a gross violation — used
-    on both the forward() and run() paths. (run() happens to be the better-
-    conditioned path and stays passive on the eps cavity above, so its firing
-    cannot be witnessed by geometry; this unit test covers it instead.)
+    on both the forward() and run() paths. It is geometry-independent, so it
+    pins the helper's firing/silence regardless of which extractor path feeds
+    it (since item-5 Stage 3, run()-lumped shares forward()'s scan path and the
+    band-edge firing is now witnessable on geometry too — see
+    ``test_run_passivity_warns_on_band_edge_after_consolidation``).
     """
     from rfx.probes.probes import warn_if_nonpassive_lumped_s11
     f = np.array([1e9, 5e9, 9e9])
@@ -84,19 +86,26 @@ def test_passivity_helper_fires_on_gross_silent_otherwise():
         assert _warned_nonpassive(rec) is expect, f"helper {label}: wrong warn state"
 
 
-def test_run_passivity_guard_wired_no_overfire():
-    """run(compute_s_params=True) has the guard wired and does not over-fire.
+def test_run_passivity_warns_on_band_edge_after_consolidation():
+    """run(compute_s_params=True) warns on the eps-cavity band-edge.
 
-    run() is the better-conditioned path (item-3): on the eps cavity it stays
-    passive (max|S11|<1), so it correctly does NOT warn. This pins that the
-    guard is present on the run path without false-alarming on a passive run.
+    As of item-5 Stage 3, run()-lumped routes its S-parameter extraction
+    through the production-scan driver (the SAME graph as forward()), not the
+    old eager extract_s_matrix loop. It therefore shares forward()'s band-edge
+    behavior: the lossless eps cavity produces a non-physical |S11| > 1 at a
+    spectral band edge, and the #210 passivity guard correctly surfaces it.
+
+    This supersedes the pre-consolidation premise (run() was the better-
+    conditioned path and stayed passive on this cavity). The forward() analog
+    is ``test_forward_lumped_s11_passivity_warns_on_gross_violation`` above;
+    run() now mirrors it because they are one path.
     """
     sim = _cavity(eps_r=10.0)
     with warnings.catch_warnings(record=True) as rec:
         warnings.simplefilter("always")
         res = sim.run(n_steps=1500, compute_s_params=True, s_param_freqs=_FREQS)
-    assert float(np.abs(np.asarray(res.s_params).reshape(-1)).max()) <= 1.10
-    assert not _warned_nonpassive(rec), "run() passive sweep must not warn"
+    assert float(np.abs(np.asarray(res.s_params).reshape(-1)).max()) > 1.10
+    assert _warned_nonpassive(rec), "run()-lumped should warn on the band-edge |S11|>1"
 
 
 def test_passivity_check_is_tracer_safe_under_grad():


### PR DESCRIPTION
**Item 5, Stage 3 (variant 3a = reroute-only) — completes the user-facing consolidation.** Scope: `docs/research_notes/20260622_item5_consolidation_scope.md`. run()'s **lumped** `compute_s_params` path now routes through the production-scan driver (Stages 1+2), so the user-facing path inherits CPML-materials / periodic / NU config — **retiring the eager-loop drift class (#203/#205/#206/#210) for users**. The eager extractors are **kept** (public API intact) for the openEMS-crossval diagnostic tooling; the **wire** path is untouched (already JIT). Full-delete (3b) was deliberately not done — it'd break public API + re-point 6 openEMS scripts, disproportionate once production no longer uses the loop.

## What
`rfx/runners/uniform.py` lumped branch: `extract_s_matrix(...)` → `compute_lumped_wire_s_matrix_via_scan(sim, s_param_freqs, n_steps=sp_n_steps)`. The `warn_if_nonpassive_lumped_s11` post-call is kept; s_params shape `(n,n,nf)` preserved. Nothing else changed.

## Perf — a 25× win
Driver vs eager on a lumped 2-port: **4.2 s vs 102 s (0.04×)**. The eager Python step-loop was slow; the JIT scan is far faster. R2 perf falsifier (>2×) not just passed — strongly inverted.

## Behavior change (accepted under 3a) + the one honest re-baseline
run()-lumped is now the same path as forward(). CPML: byte-close (in-band ~1e-6, band-edge ≤~8.5e-4, within the 2e-3 gate). PEC lossless-cavity band-edge: run()-lumped now inherits forward()'s non-physical |S11|>1 (was 0.99 on the better-conditioned eager path) — and the **#210 passivity warning correctly fires**. Exactly one test re-baselined to this reality: `test_run_passivity_guard_wired_no_overfire` → `test_run_passivity_warns_on_band_edge_after_consolidation` (eps10 cavity: run() now max|S11|=2.25 + warns, mirroring the forward() analog). Not laundering — it asserts the genuine new behavior.

## Invariance / review
Keystone `test_run_s11_is_passive_both_boundaries` green **legitimately** (wire port; wire run() path untouched). **86 passed, 1 skipped** across the lumped/wire/driver/dump/contract/api/nonuniform S-param suite; eager extractors + 6 openEMS scripts + `test_port_dump_replay` untouched; ruff clean. Executor-built; **independently reviewed by reproduction** — the 1.46e-3 CPML diff was specifically traced to inherent E4 band-edge conditioning (n_steps + grid/materials byte-identical), not a mismatch. APPROVE, no must-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)