### PR TITLE
feat(dashboard): rfx-dashboard console entry point + README GUI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,29 @@ git clone https://github.com/bk-squared/rfx.git
 cd rfx && pip install -e ".[all]"
 ```
 
+### Interactive dashboard (GUI)
+
+rfx ships an experimental Streamlit dashboard — a browser GUI for assembling a
+simulation (geometry, materials, sources/ports, probes), running it, and
+inspecting the results (S-parameter magnitude (dB) plots, Smith chart, field
+slices, probe time series, and Touchstone export) without writing Python. It is
+a convenience front end for quick exploration, not a replacement for the
+scripted API used in the validation lanes.
+
+Install the optional dependency and launch the bundled console command:
+
+```bash
+pip install "rfx-fdtd[dashboard]"
+rfx-dashboard
+```
+
+`rfx-dashboard` forwards any extra arguments straight to `streamlit run`, so you
+can override Streamlit options as usual:
+
+```bash
+rfx-dashboard --server.port 8502
+```
+
 ## Quick Start
 
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,12 @@ dependencies = [
 [project.optional-dependencies]
 optimization = ["optax>=0.1.7"]
 visualization = ["matplotlib>=3.7", "pillow"]
-dashboard = ["streamlit>=1.30"]
+dashboard = ["streamlit>=1.30", "pandas"]
 dev = ["pytest>=7.0", "pytest-xdist", "pytest-split", "ruff"]
 all = ["rfx[optimization,visualization,dashboard,dev]"]
+
+[project.scripts]
+rfx-dashboard = "rfx.dashboard.cli:main"
 
 [project.urls]
 Homepage = "https://remilab.ai/rfx/"

--- a/rfx/dashboard/cli.py
+++ b/rfx/dashboard/cli.py
@@ -1,0 +1,90 @@
+"""Console entry point for the rfx Streamlit dashboard.
+
+Exposes ``rfx-dashboard`` (see ``[project.scripts]`` in ``pyproject.toml``),
+a thin launcher that runs the Streamlit app shipped at
+``rfx/dashboard/app.py`` via ``streamlit run``.
+
+Usage::
+
+    rfx-dashboard                       # launch on the default port (8501)
+    rfx-dashboard --server.port 8502    # forward extra flags to streamlit
+    rfx-dashboard --help                # show this usage (no streamlit needed)
+
+The dashboard is an experimental convenience GUI; install it with::
+
+    pip install "rfx-fdtd[dashboard]"
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+_USAGE = """\
+usage: rfx-dashboard [streamlit options]
+
+Launch the rfx Streamlit dashboard — an experimental browser GUI for building
+and running FDTD simulations and viewing S-parameters, Smith charts, field
+slices, and Touchstone exports without writing code.
+
+Any extra arguments are forwarded verbatim to `streamlit run`, e.g.:
+
+    rfx-dashboard --server.port 8502
+    rfx-dashboard --server.address 0.0.0.0 --server.headless true
+
+Requires the dashboard extra:
+
+    pip install "rfx-fdtd[dashboard]"
+"""
+
+_MISSING_STREAMLIT_MSG = (
+    'Streamlit is not installed. Install the dashboard extra:  '
+    'pip install "rfx-fdtd[dashboard]"'
+)
+
+
+def _app_path() -> Path:
+    """Absolute path to the Streamlit app, resolved from the package location."""
+    return Path(__file__).parent / "app.py"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Launch the rfx Streamlit dashboard.
+
+    Args:
+        argv: Arguments after the program name. Defaults to ``sys.argv[1:]``.
+            Any arguments are forwarded to ``streamlit run`` unchanged, except
+            ``-h``/``--help`` which print local usage without importing
+            streamlit.
+
+    Returns:
+        Process exit code (streamlit's exit code, or non-zero on error).
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+
+    if "-h" in argv or "--help" in argv:
+        sys.stdout.write(_USAGE)
+        return 0
+
+    if importlib.util.find_spec("streamlit") is None:
+        sys.stderr.write(_MISSING_STREAMLIT_MSG + "\n")
+        return 1
+
+    app_path = _app_path()
+    cmd = ["streamlit", "run", str(app_path), *argv]
+
+    try:
+        completed = subprocess.run(cmd, check=False)
+    except FileNotFoundError:
+        # streamlit importable but console script absent: run via the module.
+        cmd = [sys.executable, "-m", "streamlit", "run", str(app_path), *argv]
+        completed = subprocess.run(cmd, check=False)
+
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dashboard_cli.py
+++ b/tests/test_dashboard_cli.py
@@ -1,0 +1,146 @@
+"""Tests for the ``rfx-dashboard`` console entry point.
+
+These tests never launch Streamlit or open a browser: ``subprocess.run`` and
+``importlib.util.find_spec`` are monkeypatched so we only assert on the command
+that *would* be invoked.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from rfx.dashboard import cli
+
+
+def test_help_returns_zero_and_prints_usage(capsys, monkeypatch):
+    """--help prints usage and never touches streamlit or subprocess."""
+
+    def _boom(*_args, **_kwargs):  # pragma: no cover - must not be called
+        raise AssertionError("streamlit must not be probed for --help")
+
+    monkeypatch.setattr(cli.importlib.util, "find_spec", _boom)
+    monkeypatch.setattr(cli.subprocess, "run", _boom)
+
+    rc = cli.main(["--help"])
+    assert rc == 0
+
+    out = capsys.readouterr().out
+    assert "usage: rfx-dashboard" in out
+    assert "streamlit" in out
+
+
+def test_short_help_flag(capsys, monkeypatch):
+    monkeypatch.setattr(
+        cli.subprocess,
+        "run",
+        lambda *a, **k: pytest.fail("subprocess.run called on -h"),
+    )
+    assert cli.main(["-h"]) == 0
+    assert "usage: rfx-dashboard" in capsys.readouterr().out
+
+
+def test_app_path_exists():
+    """The resolved app.py path must point at a real file."""
+    app_path = cli._app_path()
+    assert app_path.is_file()
+    assert app_path.name == "app.py"
+    assert app_path.parent.name == "dashboard"
+
+
+def test_launch_builds_streamlit_run_command(monkeypatch):
+    """main([]) invokes `streamlit run <abs app.py>` and returns its code."""
+    captured: dict[str, list[str]] = {}
+
+    monkeypatch.setattr(cli.importlib.util, "find_spec", lambda _name: object())
+
+    def _fake_run(cmd, **_kwargs):
+        captured["cmd"] = cmd
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(cli.subprocess, "run", _fake_run)
+
+    rc = cli.main([])
+    assert rc == 0
+
+    cmd = captured["cmd"]
+    assert cmd[:2] == ["streamlit", "run"]
+    app_arg = Path(cmd[2])
+    assert app_arg.is_absolute()
+    assert app_arg.is_file()
+    assert app_arg.name == "app.py"
+
+
+def test_extra_args_are_forwarded(monkeypatch):
+    """Extra flags like --server.port are passed through to streamlit."""
+    captured: dict[str, list[str]] = {}
+
+    monkeypatch.setattr(cli.importlib.util, "find_spec", lambda _name: object())
+
+    def _fake_run(cmd, **_kwargs):
+        captured["cmd"] = cmd
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(cli.subprocess, "run", _fake_run)
+
+    cli.main(["--server.port", "8502"])
+
+    cmd = captured["cmd"]
+    assert cmd[-2:] == ["--server.port", "8502"]
+    assert cmd[:2] == ["streamlit", "run"]
+
+
+def test_propagates_streamlit_exit_code(monkeypatch):
+    monkeypatch.setattr(cli.importlib.util, "find_spec", lambda _name: object())
+    monkeypatch.setattr(
+        cli.subprocess, "run", lambda *a, **k: SimpleNamespace(returncode=7)
+    )
+    assert cli.main([]) == 7
+
+
+def test_missing_streamlit_returns_nonzero_with_actionable_message(capsys, monkeypatch):
+    """When streamlit is absent, exit non-zero and name the dashboard extra."""
+
+    monkeypatch.setattr(cli.importlib.util, "find_spec", lambda _name: None)
+
+    def _must_not_run(*_a, **_k):  # pragma: no cover - must not be called
+        raise AssertionError("subprocess.run must not run without streamlit")
+
+    monkeypatch.setattr(cli.subprocess, "run", _must_not_run)
+
+    rc = cli.main([])
+    assert rc != 0
+
+    err = capsys.readouterr().err
+    assert "rfx-fdtd[dashboard]" in err
+    assert "not installed" in err
+
+
+def test_console_script_fallback_to_module(monkeypatch):
+    """If the `streamlit` script is missing, fall back to `python -m streamlit`."""
+    calls: list[list[str]] = []
+
+    monkeypatch.setattr(cli.importlib.util, "find_spec", lambda _name: object())
+
+    def _fake_run(cmd, **_kwargs):
+        calls.append(cmd)
+        if cmd[0] == "streamlit":
+            raise FileNotFoundError("no streamlit on PATH")
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr(cli.subprocess, "run", _fake_run)
+
+    rc = cli.main([])
+    assert rc == 0
+    assert len(calls) == 2
+    assert calls[0][0] == "streamlit"
+    assert calls[1][1:3] == ["-m", "streamlit"]
+    assert "run" in calls[1]
+
+
+def test_subprocess_module_is_the_real_one():
+    """Sanity: cli references the stdlib subprocess (monkeypatch target check)."""
+    assert cli.subprocess is subprocess


### PR DESCRIPTION
## What
A console entry point + documentation for the Streamlit dashboard that rfx **already ships** (`rfx/dashboard/app.py`, ~780 lines) but that was undiscoverable — users had to memorize `streamlit run rfx/dashboard/app.py`.

```bash
pip install "rfx-fdtd[dashboard]"
rfx-dashboard                       # launches the browser GUI
rfx-dashboard --server.port 8502    # extra args forwarded verbatim to `streamlit run`
```

## Design
- `rfx/dashboard/cli.py` — `main(argv=None) -> int`. Resolves `app.py` **package-relative** (`Path(__file__).parent`), so it works from any CWD and from an installed wheel. Forwards extra argv to `streamlit run` and propagates streamlit's exit code. Falls back to `python -m streamlit` if the `streamlit` console script isn't on PATH.
- **Fail-loud**: if streamlit is absent, exits non-zero with `pip install "rfx-fdtd[dashboard]"` (no traceback). `-h/--help` prints local usage **without** importing streamlit (so help works even without the extra).
- `[project.scripts] rfx-dashboard = "rfx.dashboard.cli:main"`.
- README gains an "Interactive dashboard (GUI)" section (honest about it being a convenience front end, not a validation-lane replacement).
- `dashboard` extra now also pulls `pandas` (used by the dashboard's result tables; matplotlib is already a core dep).

No dashboard-app logic or physics code touched.

## Verification
- `ruff` clean
- 9 tests pass — all monkeypatch subprocess/`find_spec` so **no browser/server ever launches**, yet assert command shape, verbatim arg passthrough, exit-code propagation, the missing-streamlit message, and the `python -m streamlit` fallback
- `rfx-dashboard --help` exits 0 with usage text

## Merge note
Adds a `[project.scripts]` block. Sibling PR #211 (config-CLI) also adds one — trivial both-add conflict; union the two entries (`rfx` + `rfx-dashboard`) under one header at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
