### PR TITLE
feat(onboarding): rfx-diagnose install checker + 10s hello-world quickstart

### DIFF
--- a/docs/public/guide/installation.mdx
+++ b/docs/public/guide/installation.mdx
@@ -20,6 +20,31 @@ The package name on PyPI is `rfx-fdtd`, while the Python import remains:
 import rfx
 ```
 
+## Verify your install
+
+After installing, confirm the environment can actually run a simulation.
+
+First run the bundled diagnostics command:
+
+```bash
+rfx-diagnose
+```
+
+It prints a PASS / WARN / FAIL report (Python and rfx versions, the JAX
+backend and devices, core dependencies, optional extras) and finishes with a
+tiny end-to-end FDTD smoke run. It exits `0` only when every critical check
+passes; WARN lines (CPU-only backend, x64 disabled) are informational.
+
+Then run the quick hello-world example (a second or two) to see a real
+simulation step:
+
+```bash
+python examples/quickstart/hello_world.py
+```
+
+It builds a tiny box, injects one pulse, records one field probe, and prints
+a short summary. If you see finite numbers, rfx is working.
+
 ## GPU support
 
 ```bash

--- a/examples/quickstart/hello_world.py
+++ b/examples/quickstart/hello_world.py
@@ -1,0 +1,91 @@
+"""hello_world.py — the simplest possible rfx simulation.
+
+Run it::
+
+    python examples/quickstart/hello_world.py
+
+This is the canonical first thing to run after installing rfx. It builds a
+tiny empty box, drops a pulse source in the middle, watches one field point,
+steps the simulation a few dozen times, and prints a short summary. It is
+deliberately small so it finishes in well under ten seconds on a laptop CPU —
+the point is to see rfx actually run, not to model a real device.
+
+Everything below uses only the stable public API
+(``rfx.Simulation`` + ``GaussianPulse``).
+"""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from rfx import Simulation
+from rfx.sources.sources import GaussianPulse
+
+
+def main() -> None:
+    t_start = time.time()
+
+    # 1. Build the domain.
+    #    A 20 mm cube of empty space (vacuum). `freq_max` tells rfx the
+    #    highest frequency we care about; here 10 GHz. `dx` is the cell size
+    #    (2 mm), so the box is about 10 cells on each side — tiny on purpose.
+    #    `boundary="pec"` wraps the box in perfect electric conductor walls
+    #    (a closed metal box), which is the cheapest boundary to simulate.
+    sim = Simulation(
+        freq_max=10e9,            # 10 GHz upper frequency of interest
+        domain=(0.02, 0.02, 0.02),  # 20 mm x 20 mm x 20 mm, in metres
+        dx=2e-3,                  # 2 mm cells -> ~10 cells per axis
+        boundary="pec",           # closed perfectly-conducting box
+    )
+
+    # 2. Add a source.
+    #    A soft point source at the centre of the box that injects an Ez
+    #    (vertical electric field) pulse. The `GaussianPulse` is a short
+    #    broadband "ping" centred at 5 GHz — like tapping the box to see how
+    #    it rings.
+    sim.add_source(
+        (0.01, 0.01, 0.01),                  # centre of the box, in metres
+        "ez",                                # drive the z-component of E
+        waveform=GaussianPulse(f0=5e9, bandwidth=0.8),
+    )
+
+    # 3. Add a probe.
+    #    A point "microphone" that records the Ez field at one location over
+    #    time, two cells away from the source so we see the pulse arrive.
+    sim.add_probe((0.014, 0.01, 0.01), "ez")
+
+    # 4. Run the time-stepping.
+    #    Step the FDTD update enough times for the pulse to reach the probe
+    #    and ring inside the little PEC box, so the trace shows a peak that is
+    #    distinct from its final value. We pass `compute_s_params=False`
+    #    because this toy run has no ports — we just want raw field data.
+    n_steps = 120
+    result = sim.run(n_steps=n_steps, compute_s_params=False)
+
+    # 5. Look at the result.
+    #    `result.time_series` has shape (n_steps, n_probes). We have one
+    #    probe, so column 0 is its recorded Ez trace.
+    trace = np.asarray(result.time_series)[:, 0]
+    grid_shape = result.grid.shape  # (nx, ny, nz) including boundary padding
+
+    elapsed = time.time() - t_start
+
+    # 6. Print a short, human-readable summary.
+    print("rfx hello world")
+    print("-" * 40)
+    print(f"grid size      : {tuple(int(n) for n in grid_shape)} cells")
+    print(f"time steps     : {n_steps}")
+    print(f"probe samples  : {trace.shape[0]}")
+    print(f"peak |Ez|      : {float(np.max(np.abs(trace))):.4e}")
+    print(f"final Ez       : {float(trace[-1]):+.4e}")
+    print(f"all finite     : {bool(np.all(np.isfinite(trace)))}")
+    print(f"wall time      : {elapsed:.2f} s")
+    print("-" * 40)
+    print("If you see finite numbers above, rfx is working. Next: try")
+    print("examples/crossval/ for real RF device validation cases.")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 [project.scripts]
 rfx = "rfx.cli:main"
 rfx-dashboard = "rfx.dashboard.cli:main"
+rfx-diagnose = "rfx.diagnostics:main"
 
 [project.optional-dependencies]
 optimization = ["optax>=0.1.7"]

--- a/rfx/diagnostics.py
+++ b/rfx/diagnostics.py
@@ -1,0 +1,322 @@
+"""``rfx-diagnose`` — a one-command install / environment checker for rfx.
+
+Run it after installing rfx to confirm the environment can actually run a
+simulation::
+
+    rfx-diagnose
+
+(or ``python -m rfx.diagnostics``). It prints a readable PASS / WARN / FAIL
+report and exits ``0`` only when every *critical* check passes. WARN-level
+findings (missing optional extras, CPU-only backend, x64 disabled) are
+informational and never change the exit code.
+
+The final check is a tiny end-to-end FDTD smoke run — the real "can rfx
+actually step a grid on this machine" gate — kept well under ~2 seconds.
+"""
+
+from __future__ import annotations
+
+import importlib
+import platform
+import sys
+from importlib import metadata
+
+# ---------------------------------------------------------------------------
+# Report primitives
+# ---------------------------------------------------------------------------
+
+# Status levels. CRITICAL governs the exit code; WARN/INFO never do.
+PASS = "PASS"
+WARN = "WARN"
+FAIL = "FAIL"
+INFO = "INFO"
+
+
+class _Report:
+    """Accumulates check lines and tracks whether any critical check failed."""
+
+    def __init__(self) -> None:
+        self.lines: list[str] = []
+        self.critical_failures = 0
+
+    def record(self, status: str, label: str, detail: str, *, critical: bool) -> None:
+        if status == FAIL and critical:
+            self.critical_failures += 1
+        # Right-pad the status so the labels line up in the printed report.
+        self.lines.append(f"  [{status:<4}] {label}: {detail}")
+
+    def __str__(self) -> str:
+        return "\n".join(self.lines)
+
+
+def _version_of(dist: str) -> str:
+    """Best-effort installed-distribution version string ("?" if unknown)."""
+    try:
+        return metadata.version(dist)
+    except Exception:
+        return "?"
+
+
+# ---------------------------------------------------------------------------
+# Individual checks. Each is wrapped so one failure never aborts the rest:
+# a check that raises is reported as a FAIL line, not a traceback.
+# ---------------------------------------------------------------------------
+
+def _check_python(report: _Report) -> None:
+    v = sys.version_info
+    detail = f"{v.major}.{v.minor}.{v.micro} ({platform.python_implementation()})"
+    # pyproject requires-python = ">=3.10".
+    if (v.major, v.minor) >= (3, 10):
+        report.record(PASS, "Python version", detail, critical=True)
+    else:
+        report.record(
+            FAIL,
+            "Python version",
+            f"{detail} — rfx requires Python >= 3.10",
+            critical=True,
+        )
+
+
+def _check_rfx_import(report: _Report) -> None:
+    try:
+        import rfx
+
+        version = getattr(rfx, "__version__", "?")
+        location = getattr(rfx, "__file__", "?")
+        report.record(
+            PASS,
+            "import rfx",
+            f"rfx {version} (from {location})",
+            critical=True,
+        )
+    except Exception as exc:  # pragma: no cover - exercised via monkeypatch
+        report.record(
+            FAIL,
+            "import rfx",
+            f"could not import rfx: {exc!r}",
+            critical=True,
+        )
+
+
+def _check_jax(report: _Report) -> None:
+    try:
+        import jax
+
+        jax_v = _version_of("jax")
+        jaxlib_v = _version_of("jaxlib")
+        report.record(
+            PASS,
+            "jax / jaxlib",
+            f"jax {jax_v}, jaxlib {jaxlib_v}",
+            critical=True,
+        )
+    except Exception as exc:
+        report.record(
+            FAIL,
+            "jax / jaxlib",
+            f"could not import jax: {exc!r}",
+            critical=True,
+        )
+        return
+
+    # Backend / devices. A GPU backend is reported as PASS; CPU-only is a WARN
+    # (large 3D runs will be slow) but never a failure.
+    try:
+        devices = jax.devices()
+        platforms = sorted({d.platform for d in devices})
+        device_repr = ", ".join(str(d) for d in devices)
+        if any(p in ("gpu", "cuda", "rocm") for p in platforms):
+            report.record(
+                PASS,
+                "jax backend",
+                f"GPU backend present: {device_repr}",
+                critical=False,
+            )
+        else:
+            report.record(
+                WARN,
+                "jax backend",
+                f"CPU-only ({device_repr}); large 3D runs will be slow "
+                f"(not a failure)",
+                critical=False,
+            )
+    except Exception as exc:
+        report.record(
+            WARN,
+            "jax backend",
+            f"could not query jax.devices(): {exc!r}",
+            critical=False,
+        )
+
+    # x64 precision. rfx's S-parameter DFT accumulators run at reduced
+    # precision when x64 is disabled — a real rfx caveat, so WARN if off.
+    try:
+        x64 = bool(jax.config.read("jax_enable_x64"))
+        if x64:
+            report.record(PASS, "jax x64", "enabled (float64 available)", critical=False)
+        else:
+            report.record(
+                WARN,
+                "jax x64",
+                "disabled — S-parameter DFT runs reduced precision; "
+                "enable with JAX_ENABLE_X64=1 or "
+                "jax.config.update('jax_enable_x64', True)",
+                critical=False,
+            )
+    except Exception as exc:
+        report.record(WARN, "jax x64", f"could not read config: {exc!r}", critical=False)
+
+
+def _check_core_deps(report: _Report) -> None:
+    # (import name, distribution name). All are hard rfx dependencies, so a
+    # missing one is CRITICAL.
+    core = [
+        ("numpy", "numpy"),
+        ("scipy", "scipy"),
+        ("matplotlib", "matplotlib"),
+        ("h5py", "h5py"),
+    ]
+    for import_name, dist_name in core:
+        try:
+            importlib.import_module(import_name)
+            report.record(
+                PASS,
+                f"core dep {import_name}",
+                _version_of(dist_name),
+                critical=True,
+            )
+        except Exception as exc:
+            report.record(
+                FAIL,
+                f"core dep {import_name}",
+                f"missing or broken: {exc!r}",
+                critical=True,
+            )
+
+
+def _check_optional_extras(report: _Report) -> None:
+    # Optional extras: report presence only, never fail. These back the
+    # [optimization] / [dashboard] / [visualization] extras.
+    optional = [
+        ("optax", "optax", "inverse-design / gradient optimisation"),
+        ("streamlit", "streamlit", "dashboard UI"),
+        ("pandas", "pandas", "tabular post-processing"),
+        ("PIL", "pillow", "image export"),
+    ]
+    for import_name, dist_name, purpose in optional:
+        try:
+            importlib.import_module(import_name)
+            report.record(
+                INFO,
+                f"optional {dist_name}",
+                f"{_version_of(dist_name)} ({purpose})",
+                critical=False,
+            )
+        except Exception:
+            report.record(
+                INFO,
+                f"optional {dist_name}",
+                f"not installed ({purpose}) — install only if needed",
+                critical=False,
+            )
+
+
+def _check_smoke(report: _Report) -> None:
+    """Tiny end-to-end FDTD run — the real "can rfx run here" gate.
+
+    Builds a few-cell uniform PEC box, adds one point source and one point
+    probe, steps a handful of timesteps, and asserts the probe time series is
+    finite. CRITICAL. Kept well under ~2 s.
+    """
+    try:
+        import numpy as np
+
+        from rfx import Simulation
+        from rfx.sources.sources import GaussianPulse
+
+        # ~10-cell-per-axis box (dx = 2 mm over a 20 mm domain). PEC boundary
+        # keeps it cheap — no CPML profiles to build.
+        sim = Simulation(
+            freq_max=10e9,
+            domain=(0.02, 0.02, 0.02),
+            dx=2e-3,
+            boundary="pec",
+        )
+        sim.add_source(
+            (0.01, 0.01, 0.01),
+            "ez",
+            waveform=GaussianPulse(f0=5e9, bandwidth=0.8),
+        )
+        sim.add_probe((0.012, 0.01, 0.01), "ez")
+
+        result = sim.run(n_steps=40, compute_s_params=False, skip_preflight=True)
+        ts = np.asarray(result.time_series)
+        finite = bool(np.all(np.isfinite(ts)))
+        grid_repr = (
+            tuple(int(n) for n in result.grid.shape)
+            if result.grid is not None
+            else "n/a"
+        )
+
+        if finite:
+            report.record(
+                PASS,
+                "FDTD smoke run",
+                f"grid {grid_repr}, 40 steps, "
+                f"finite probe trace (peak |Ez|={float(np.max(np.abs(ts))):.3e})",
+                critical=True,
+            )
+        else:
+            report.record(
+                FAIL,
+                "FDTD smoke run",
+                "probe time series contained NaN/Inf — the run diverged",
+                critical=True,
+            )
+    except Exception as exc:  # pragma: no cover - exercised via monkeypatch
+        report.record(
+            FAIL,
+            "FDTD smoke run",
+            f"simulation failed to run: {exc!r}",
+            critical=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str] | None = None) -> int:
+    """Run all diagnostics and return 0 iff every critical check passed."""
+    # argv is accepted for the console-script / test contract; there are no
+    # options to parse yet, so it is intentionally unused.
+    del argv
+
+    report = _Report()
+
+    print("rfx environment diagnostics")
+    print("=" * 60)
+
+    # Order matters: import rfx and core deps before the smoke run so a
+    # missing dependency is reported as its own clean FAIL line rather than
+    # surfacing only as a smoke-run traceback.
+    _check_python(report)
+    _check_rfx_import(report)
+    _check_jax(report)
+    _check_core_deps(report)
+    _check_optional_extras(report)
+    _check_smoke(report)
+
+    print(report)
+    print("=" * 60)
+
+    if report.critical_failures == 0:
+        print("Summary: All critical checks passed.")
+        return 0
+    n = report.critical_failures
+    print(f"Summary: {n} critical check(s) failed.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,124 @@
+"""Tests for the onboarding code spine: rfx-diagnose + the hello-world example.
+
+These exercise the two things a brand-new user runs first, so they must stay
+fast and headless.
+"""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+import numpy as np
+
+from rfx import diagnostics
+
+
+# ---------------------------------------------------------------------------
+# rfx-diagnose
+# ---------------------------------------------------------------------------
+
+def test_diagnose_passes_in_this_environment(capsys):
+    """In a working install (rfx importable, jax + core deps present, smoke
+    runs) main([]) returns 0 and prints the expected section labels."""
+    rc = diagnostics.main([])
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "rfx environment diagnostics" in out
+    assert "Python version" in out
+    assert "import rfx" in out
+    assert "jax / jaxlib" in out
+    assert "FDTD smoke run" in out
+    assert "All critical checks passed" in out
+
+
+def test_diagnose_critical_failure_returns_nonzero_without_traceback(
+    monkeypatch, capsys
+):
+    """A forced critical failure (the smoke run blows up) returns non-zero,
+    prints a FAIL line, and does NOT propagate a traceback."""
+
+    def _boom(*_args, **_kwargs):
+        raise RuntimeError("forced smoke failure")
+
+    # Make the FDTD smoke run fail at the Simulation.run() call. The check is
+    # wrapped in try/except, so this must surface as a FAIL line, not a raise.
+    import rfx.api as rfx_api
+
+    monkeypatch.setattr(rfx_api.Simulation, "run", _boom)
+
+    rc = diagnostics.main([])
+    out = capsys.readouterr().out
+
+    assert rc != 0
+    assert "[FAIL] FDTD smoke run" in out
+    assert "critical check(s) failed" in out
+
+
+def test_diagnose_missing_core_dep_fails_without_aborting(monkeypatch, capsys):
+    """A missing core dependency surfaces as a clean [FAIL] + non-zero exit,
+    and does NOT abort the later checks (fault isolation)."""
+    import importlib as _il
+
+    real_import = _il.import_module
+
+    def _fake_import(name, *args, **kwargs):
+        if name == "h5py":
+            raise ImportError("simulated missing h5py")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(diagnostics.importlib, "import_module", _fake_import)
+
+    rc = diagnostics.main([])
+    out = capsys.readouterr().out
+
+    assert rc != 0
+    assert "[FAIL]" in out and "h5py" in out
+    # fault isolation: a check after the core-dep stage still ran.
+    assert "FDTD smoke run" in out
+
+
+# ---------------------------------------------------------------------------
+# hello-world example
+# ---------------------------------------------------------------------------
+
+def _example_path() -> Path:
+    # tests/ -> repo root -> examples/quickstart/hello_world.py
+    return (
+        Path(__file__).resolve().parent.parent
+        / "examples"
+        / "quickstart"
+        / "hello_world.py"
+    )
+
+
+def test_hello_world_example_runs(capsys):
+    """The hello-world example executes end-to-end and prints a finite
+    probe summary. It is already tiny (~50 steps on a ~10-cell box)."""
+    path = _example_path()
+    assert path.exists(), f"missing example: {path}"
+
+    runpy.run_path(str(path), run_name="__main__")
+    out = capsys.readouterr().out
+
+    assert "rfx hello world" in out
+    assert "grid size" in out
+    assert "peak |Ez|" in out
+    assert "all finite     : True" in out
+
+
+def test_hello_world_main_produces_finite_trace():
+    """Directly drive the example's builder via the same public API it uses
+    and assert the probe trace is finite (independent of stdout parsing)."""
+    from rfx import Simulation
+    from rfx.sources.sources import GaussianPulse
+
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=2e-3, boundary="pec")
+    sim.add_source((0.01, 0.01, 0.01), "ez", waveform=GaussianPulse(f0=5e9, bandwidth=0.8))
+    sim.add_probe((0.014, 0.01, 0.01), "ez")
+    result = sim.run(n_steps=50, compute_s_params=False)
+
+    trace = np.asarray(result.time_series)[:, 0]
+    assert trace.shape[0] == 50
+    assert bool(np.all(np.isfinite(trace)))


### PR DESCRIPTION
## What
The verifiable code spine of an external-user onboarding funnel: an install checker + a first-run example + a docs pointer tying them together.

- **`rfx-diagnose`** (`rfx/diagnostics.py`) — one command that checks Python/rfx versions, JAX backend + devices, x64 status, core deps, optional extras, and runs a tiny end-to-end **FDTD smoke** ("can rfx actually run here?"). Prints PASS/WARN/FAIL and exits 0 iff all critical checks pass.
- **`examples/quickstart/hello_world.py`** — the simplest possible sim (tiny PEC box, one source, one probe), heavily commented, finishes in ~1 s on CPU. A new user's first "rfx works" moment.
- **`docs/public/guide/installation.mdx`** — a "Verify your install" section pointing at both.

## Design
`rfx-diagnose` isolates every check in try/except (one failure can't abort the rest), assigns honest severities (missing optional extra = INFO; CPU-only / x64-off = WARN; missing core dep / failed import / failed smoke = CRITICAL → non-zero). The x64-off WARN ("S-parameter DFT runs reduced precision") maps to a real dtype gate at `rfx/api/_sparams.py` (complex128 only when x64 enabled). The smoke + hello-world use the real public builder API (`Simulation`/`add_source`/`add_probe`/`run`) — verified by running them. No physics code touched.

## Verification
- `ruff` clean
- 5 tests pass — healthy-env exit 0 with expected labels; a forced **smoke-run** failure and a forced **missing-core-dep** (h5py) failure both return non-zero with a clean `[FAIL]` line, no traceback, and later checks still run (fault isolation); the hello-world runs to a finite probe trace
- `rfx-diagnose` exits 0 here (CPU-only + x64-off → two accurate WARNs); `hello_world.py` runs in ~1 s

## Notes
- The GPU-PASS and x64-enabled-PASS report branches are simple format branches unexercised on this CPU/x64-off box (low defect risk).
- Adds to `[project.scripts]` — collides (both-add) with PR #211 (config-cli) and PR #216 (dashboard-cli); union all entries under one header at merge.
- Pure-docs onboarding pieces (filling the 3 empty tutorial mdx files, `ONBOARDING.md`, a FAQ) are **deliberately deferred** to a separate docs pass — this PR is the verifiable code spine only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
