### PR TITLE
chore(docs): remove dangling internal-doc refs from shipped code + CI guard

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,3 +51,21 @@ jobs:
             exit 1
           fi
           echo "docs/agent/ clean"
+
+      - name: Forbid gitignored-path references in rfx/ and examples/
+        # Shipped code (docstrings, comments, runtime message strings) must not
+        # point a public-clone reader at gitignored internal paths. A public
+        # clone has no docs/agent-memory/, CLAUDE.md, or .claude/. NOTE:
+        # research_notes is intentionally excluded from this scan — two
+        # examples have legitimate functional research_notes file paths
+        # (multilayer_ar_coating optional Meep-reference loader and
+        # 13_subgrid_material_validation ARTIFACT_PATH); the docs/agent/ check
+        # above still forbids research_notes in exported agent pages.
+        run: |
+          hits=$(grep -rn 'agent-memory\|CLAUDE\.md\|\.claude/' rfx/ examples/ || true)
+          if [ -n "$hits" ]; then
+            echo "rfx/ and examples/ must not reference gitignored internal paths:"
+            echo "$hits"
+            exit 1
+          fi
+          echo "rfx/ and examples/ clean"

--- a/examples/crossval/03_straight_waveguide_flux.py
+++ b/examples/crossval/03_straight_waveguide_flux.py
@@ -12,7 +12,7 @@ a few percent.
     the input and output planes
   - Two-run reference subtraction pattern (T = flux_out / flux_in)
 
-**Rule compliance** (.claude/rules/rfx-feature-discovery.md):
+**Rule compliance**:
 This script uses ``add_flux_monitor`` and ``flux_spectrum`` — the
 canonical rfx primitives for R(f) / T(f) measurement. An earlier
 version of this script computed a single-point FFT of a time-series

--- a/examples/crossval/05_patch_antenna.py
+++ b/examples/crossval/05_patch_antenna.py
@@ -34,7 +34,7 @@ Three independent measurements of the patch resonance:
      source inside the substrate, probe Ez at another substrate
      point, extract resonances via filter diagonalization. Clean
      frequency, independent of port calibration.
-     (See `docs/agent-memory/task_recipes/resonance_extraction.md`.)
+     (See `docs/agent/recipe-resonance-extraction.mdx`.)
 
   2. **OpenEMS lumped-port S11** (reference) — full-wave S11 sweep
      with 50 Ω lumped port from ground to patch at the feed inset.
@@ -353,8 +353,7 @@ except ImportError as _e:
     print("\n" + "!" * 70)
     print("!! CROSSVAL 05 SKIPPED — CSXCAD / openEMS not installed")
     print(f"!!   reason: {_e}")
-    print("!!   install recipe: research/microwave-energy/ (see note in")
-    print("!!       docs/agent-memory/index.md)")
+    print("!!   install openEMS / CSXCAD to run the reference comparison.")
     print("!!   this run is NOT a crossval against OpenEMS. Exiting with")
     print("!!   status 2 (SKIPPED) so CI does not treat it as PASS.")
     print("!" * 70)

--- a/examples/crossval/09_half_symmetric_waveguide.py
+++ b/examples/crossval/09_half_symmetric_waveguide.py
@@ -28,8 +28,7 @@ Setup:
     - f_{101}(analytic) = 8.246 GHz.
     - dx = 0.5 mm (uniform), cpml_layers = 0 on both runs.
       Closed cavities with cpml_layers=0 sidestep the PMC+CPML composition
-      architectural gap documented in
-      docs/research_notes/2026-04-19_v175_t10_half_symmetric_pmc.md.
+      architectural gap.
     - Gaussian-pulse E_y source offset from center; E_y probe off-node.
     - Harminv on ringdown (skip first 25 %) to extract the dominant mode.
 

--- a/examples/crossval/11_waveguide_port_wr90.py
+++ b/examples/crossval/11_waveguide_port_wr90.py
@@ -33,14 +33,14 @@ simultaneously before the waveguide port is cleared to Meep-class:
    Geometry: uniform εr=2.0 slab of length L inside WR-90.
    Reference: closed-form using the modal impedances of the two guide
    segments (vacuum-filled + dielectric-filled) and the Airy-formula
-   multi-reflection summation (see ``docs/agent-memory/task_recipes/
-   waveguide_sparams.md``, "Analytic reference" section).
+   multi-reflection summation (see ``docs/agent/recipe-waveguide-sparams.mdx``,
+   "Analytic reference" section).
    Accept: S11 |S| mean diff < 0.10, S21 |S| mean diff < 0.07,
    phase mean diff < 60° with |S_ref| >= 0.30 mask, and complex-S
    envelope max diff <= 0.30. This is a reference-convention-aware
    diagnostic envelope, not a blanket phase-accuracy claim.
 
-**Rule compliance** (`.claude/rules/rfx-feature-discovery.md`):
+**Rule compliance**:
 This crossval uses the canonical ``add_waveguide_port`` +
 ``compute_waveguide_s_matrix`` pipeline. It does NOT compute S-params
 from a time-series FFT or probe-subtraction hacks.
@@ -117,8 +117,7 @@ CPML_LAYERS = 20    # 20 mm physical CPML (was 10 — guided-mode reflection ~12
 # `num_periods` and is independent of scan length once the source pulse
 # has played out — verified byte-identical at np=200/500/1000/2000 for
 # PEC-short. The legacy `dft_window`/`dft_end_step`/`num_periods_dft`
-# magic-number knobs were removed; see
-# docs/research_notes/2026-04-25_port_extractor_principled_refactor_design.md.
+# magic-number knobs were removed.
 NUM_PERIODS_LONG = 200     # uniform scan length, all geometries
 
 # Domain length along propagation axis.

--- a/examples/inverse_design/msl_stub_notch_tuning.py
+++ b/examples/inverse_design/msl_stub_notch_tuning.py
@@ -29,8 +29,7 @@ reproduced on the current composition.  They predate the 2026-05-24
 WI-3 extractor consolidation onto the single ``extract_msl_nprobe``
 plane extractor.  At L = 9.5 mm the current-composition cost is
 ≈ 8.6e-3 (not #965's 0.493).  Kept only as a chronology marker; do
-not cite as current evidence (issue #171; see
-``docs/research_notes/20260612_msl_g2_rerun_nan_session.md``):
+not cite as current evidence (issue #171):
 
   [#965, pre-WI-3, NOT reproduced]
   iter 0  L= 9.500mm  |S21|²=0.493  -3.1dB  grad=+1.015
@@ -115,8 +114,7 @@ Validation chain (the point of this example):
 Three earlier session attempts (2026-05-07/08) shipped band-aids
 (σ-loading via ``materials.sigma += occ × 1e10``, ``apply_pec_occupancy_h``,
 sharper SIGMOID_BETA) that worked on a single mesh but broke at
-others.  All three were reverted.  The closure predicate captured
-in ``docs/agent-memory/rfx-known-issues.md`` (local) gates against
+others.  All three were reverted.  The closure predicate gates against
 repeating that pattern: any future ``pec_occupancy_override`` change
 must (a) descend Adam at dx ∈ {clean, danger}, (b) FD-vs-AD agree
 at L = {min, notch±Δ, notch}, (c) AD descent matches FD with δ=2β,
@@ -295,8 +293,7 @@ def build_sim(freqs: jnp.ndarray) -> tuple[
     # (Hy) per port.  Mirrors the imperative `compute_msl_s_matrix`
     # plane integrals exactly, so the JAX-traceable N-probe extractor
     # in `extract_msl_nprobe` no longer carries the
-    # scalar-Ez bias documented in `docs/agent-memory/rfx-known-issues.md`
-    # (gap #2/#4, closed 2026-05-07).
+    # scalar-Ez bias (gap #2/#4, closed 2026-05-07).
     d_set = register_msl_plane_probes(sim, port_index=0, freqs=freqs,
                                       name_prefix="d")
     p_set = register_msl_plane_probes(sim, port_index=1, freqs=freqs,

--- a/rfx/adi.py
+++ b/rfx/adi.py
@@ -730,8 +730,7 @@ def adi_step_3d(ex, ey, ez, hx, hy, hz,
     but cavity-resonance error reaches ~42% at 5x CFL from the LOD
     splitting (2D LOD by contrast holds <2% to 50x CFL). Only divergence
     /stability tests cover it — there is no physics-accuracy validation.
-    Do not use for quantitative results.
-    See docs/agent-memory/rfx-known-issues.md (OPT-C1).
+    Do not use for quantitative results (known issue OPT-C1).
 
     Parameters
     ----------

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -129,8 +129,8 @@ class _ExecuteMixin:
                 "is not supported on the non-uniform mesh path. "
                 "Drop the dx/dy/dz profile or use the legacy "
                 "``Boundary(conformal=True)`` Stage 1 path on a "
-                "uniform mesh. Tracking: docs/agent-memory/"
-                "stage2_subpixel_pec_unified_design.md §8 Q2."
+                "uniform mesh. Tracked at "
+                "https://github.com/bk-squared/rfx/issues."
             )
         from rfx.runners.nonuniform import run_nonuniform_path
         return run_nonuniform_path(
@@ -744,8 +744,7 @@ class _ExecuteMixin:
         # DFT plane probes — mirror runners/uniform.py:340-359 so the
         # JIT scan body actually accumulates plane-resolved DFT, then
         # carry the result back through ForwardResult.dft_planes for
-        # plane-integrated V/I objectives (gap #4 in
-        # docs/agent-memory/rfx-known-issues.md, 2026-05-05).
+        # plane-integrated V/I objectives (known gap #4, 2026-05-05).
         dft_planes = []
         if self._dft_planes:
             from rfx.probes.probes import init_dft_plane_probe
@@ -847,9 +846,7 @@ class _ExecuteMixin:
         # wiggle near high-Q resonances.  Bypasses the legacy
         # ``apply_pec_occupancy`` E-zeroing path on this branch — the
         # two would double-correct at sigmoid edges (cf. Stage 2
-        # design memo §R9 anti-pattern).  See
-        # ``docs/agent-memory/rfx-known-issues.md`` for the full
-        # diagnosis and the closure predicate.
+        # design memo §R9 anti-pattern).
         aniso_inv_eps_run = None
         pec_occupancy_for_run = pec_occupancy_local
         if (pec_occupancy_local is not None and

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1442,7 +1442,7 @@ class _PreflightMixin:
 
         # CHECK 3: λ/2 (Huygens) and λ/4 (reactive-near-field) gaps to any
         # geometry/source/probe. Issue #77: the λ/2 Huygens-equivalence rule
-        # was documented in papers/rfx-tap/CLAUDE.md but only the λ/4 strong
+        # was documented but only the λ/4 strong
         # tier was enforced; a face at λ/30 above a ground-plane PEC silently
         # ran and produced corrupted directivity. The two-tier check below
         # warns mildly in [λ/4, λ/2) (results may degrade) and strongly in
@@ -1599,8 +1599,7 @@ class _PreflightMixin:
         <= ~2 mm drives the field to NaN. Root cause is a discrete-adjointness
         break (the E-update-only ``eps_eff=eps/w`` makes the update operator
         non-SPSD), NOT a CFL issue — reducing dt does not cure it, and four fix
-        methods are falsified (see docs/agent-memory/rfx-known-issues.md, the
-        conformal-PEC item). ``normalize=False`` is NOT a safe workaround.
+        methods are falsified. ``normalize=False`` is NOT a safe workaround.
         Surfacing this at preflight converts a silent-NaN GPU run into an
         instant redirect. Emitted as a WARNING-severity ``PreflightWarning``
         (code ``conformal_nan``), NOT error — conformal is actively-worked and
@@ -1635,14 +1634,14 @@ class _PreflightMixin:
             # MAINTENANCE: delete this guard when the BCK/USC contour-FIT
             # redesign lands. The strict-xfail tracker
             # tests/test_subpixel_pec.py::test_mesh_convergence_s21_with_conformal_pec
-            # will hard-fail (XPASS) to force this removal. See
-            # docs/agent-memory/rfx-known-issues.md (conformal-PEC item).
+            # will hard-fail (XPASS) to force this removal (conformal-PEC
+            # known issue).
             _w.warn(
                 PreflightWarning(
                     f"conformal PEC is enabled on faces {sorted(cf)} with a min "
                     f"cell size {min_cell * 1e3:.3f} mm <= 2 mm — this is a KNOWN "
                     f"NaN (discrete-adjointness break, not CFL; 4 fix methods "
-                    f"falsified — see docs/agent-memory/rfx-known-issues.md). "
+                    f"falsified — tracked at https://github.com/bk-squared/rfx/issues). "
                     f"normalize=False is NOT a safe workaround at fine dx. Use "
                     f"conformal=False (staircase PEC) or a coarser mesh "
                     f"(dx > 2 mm) until the contour-FIT redesign lands.",
@@ -1888,9 +1887,8 @@ class _PreflightMixin:
             odd-symmetric and must be zero at the plane by image,
             so injecting it fights the mirror.
 
-        See docs/research_notes/2026-04-20_source_on_symmetry_plane_industry_survey.md
-        for the industry survey behind this rule (Meep / OpenEMS /
-        Tidy3D all follow the same convention).
+        This follows the industry convention (Meep / OpenEMS /
+        Tidy3D all follow the same rule).
         """
         _all_reflector_faces = set(self._pec_faces) | set(_pmc_faces_set)
         if _all_reflector_faces:
@@ -2616,8 +2614,7 @@ class _PreflightMixin:
             # biased — typically reading |S11| ≪ 1 even when physics
             # demands full reflection.  Catches the cv06b-vs-Y2-demo
             # divergence (cv06b's L_LINE=30mm passes; Y2's L_LINE=5mm
-            # fails by ~7 dB on |S11|@notch — see
-            # `docs/research_notes/20260506_y2_s11_notch_bias_root_cause.md`).
+            # fails by ~7 dB on |S11|@notch).
             #
             # Conservative ε_eff_proxy = 5.0 → upper bound on β → lower
             # bound on λ_g → most stringent (smallest) recommended

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -51,8 +51,8 @@ def _warn_if_nonpassive_smatrix(
     S-matrix and surface a non-physical result as a warning (or raise when
     ``strict``).
 
-    This operationalizes the R5 "no surface-metric verdict" discipline
-    (CLAUDE.md): a passive structure cannot scatter more power than it
+    This operationalizes the R5 "no surface-metric verdict" discipline:
+    a passive structure cannot scatter more power than it
     receives, so a per-column power > 1 (e.g. ``|S11| > 1`` on a one-port)
     means the *extractor* is wrong — mismeasured current sign/scale or a
     bad reference plane — and the S-parameters are untrustworthy, NOT that
@@ -649,8 +649,8 @@ class _SparamMixin:
         # the asymmetric boundary treatment causes the reference outgoing-wave
         # amplitude to diverge / go unstable, producing NaN |S21|.  Use
         # normalize=False (single-run V/I, no reference run) until the reference
-        # run is updated to carry conformal_weights.  Tracked in
-        # docs/agent-memory/rfx-known-issues.md (cv11 mesh-conv NaN xfail).
+        # run is updated to carry conformal_weights.  Known issue
+        # (cv11 mesh-conv NaN xfail).
         if conformal_weights is not None and normalize:
             import warnings as _w
             _w.warn(
@@ -660,7 +660,7 @@ class _SparamMixin:
                 "empty-guide reference outgoing wave to diverge at fine mesh "
                 "spacings (dx <= 2 mm for WR-90) and produce NaN |S21|.  "
                 "Use normalize=False for conformal=True geometries.  "
-                "Tracked in docs/agent-memory/rfx-known-issues.md.",
+                "Tracked at https://github.com/bk-squared/rfx/issues.",
                 UserWarning,
                 stacklevel=3,
             )
@@ -1199,8 +1199,7 @@ class _SparamMixin:
                         # bounded |S11|<=1, unlike the Fix-C alpha/gamma
                         # spatial fit that blew up to |S11|>1 on a strong
                         # reflector. Z0 is analytic Hammerstad-Jensen; I is
-                        # the closed Ampere loop. See
-                        # docs/agent-memory/port_sparam_review_2026-05-19.md.
+                        # the closed Ampere loop.
                         v0_d = v_per_port[driven][0]
                         z0hj_d = z0_hj_per_port[driven]
                         a_fwd_d = 0.5 * (v0_d + z0hj_d * i_f)
@@ -1258,8 +1257,7 @@ class _SparamMixin:
                         f"f = {freqs_arr[k_s] / 1e9:.4f} GHz — non-physical "
                         "for a passive structure. The closed Ampere-loop "
                         "current is likely mismeasured (sign/scale); the "
-                        "extracted S11/S21 are UNRELIABLE. See "
-                        "docs/agent-memory/port_sparam_review_2026-05-19.md."
+                        "extracted S11/S21 are UNRELIABLE."
                     )
                     if strict_extractor:
                         raise ValueError(msg)

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -220,7 +220,7 @@ def _nonfinite_fields(result) -> list[tuple[str, int]]:
 
 _NONFINITE_CAUSE_HINT = (
     "the FDTD likely diverged. Common causes: dt above CFL, conformal=True "
-    "at fine dx (a known NaN — see docs/agent-memory/rfx-known-issues.md), "
+    "at fine dx (a known NaN), "
     "PEC inside the CPML region, or a sub-cell PEC feature."
 )
 

--- a/rfx/geometry/smoothing.py
+++ b/rfx/geometry/smoothing.py
@@ -595,7 +595,7 @@ def compute_smoothed_eps(
 # `1e-30` epsilon trap that would otherwise produce ε ≈ 1e30 (huge but
 # finite) for ε_inside = ∞.
 #
-# Reference: docs/agent-memory/stage2_ca_cb_derivation.md §4.
+# Reference: subpixel-averaging C_a/C_b derivation.
 
 
 def _kottke_inv_eps_diag(

--- a/rfx/grid.py
+++ b/rfx/grid.py
@@ -102,8 +102,7 @@ class Grid:
         # token is ``pec``/``pmc``/``periodic`` gets ``pad=0`` on that
         # side even when the axis as a whole participates in CPML —
         # this is the Meep / OpenEMS / Tidy3D convention and the
-        # architectural fix for PMC + CPML composition. See
-        # ``docs/research_notes/2026-04-19_v175_t10_half_symmetric_pmc.md``.
+        # architectural fix for PMC + CPML composition.
         def _face_pad(axis: str, side: str) -> int:
             face = f"{axis}_{side}"
             if face in self.pec_faces or face in self.pmc_faces:

--- a/rfx/optimize.py
+++ b/rfx/optimize.py
@@ -251,9 +251,8 @@ def optimize(
             _w.warn(
                 f"optimize: non-finite loss/gradient (NaN or Inf) at iteration "
                 f"{it} — the FDTD forward almost certainly diverged. Common "
-                f"causes: dt above CFL, conformal=True at fine dx (a known NaN, "
-                f"see docs/agent-memory/rfx-known-issues.md), PEC inside the "
-                f"CPML region, or a sub-cell PEC feature. Stopping early and "
+                f"causes: dt above CFL, conformal=True at fine dx (a known NaN), "
+                f"PEC inside the CPML region, or a sub-cell PEC feature. Stopping early and "
                 f"returning the last finite design (from before iteration "
                 f"{it}).",
                 stacklevel=2,

--- a/rfx/ris.py
+++ b/rfx/ris.py
@@ -548,7 +548,7 @@ def _extract_reflection(
     S11. It FFTs the raw probe time series (total field, with no
     incident-field reference subtraction) and peak-normalizes the
     magnitude. This violates the repo rule "never FFT-of-probe for R(f)"
-    (.claude/rules/rfx-feature-discovery.md) and yields a spectrum shaped
+    and yields a spectrum shaped
     by the source, not a reflection coefficient. The fallback is kept
     only so RIS demos run end-to-end; treat its output as a qualitative
     placeholder, not a measured S-parameter.

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -86,8 +86,7 @@ def run_uniform(
     # the Stage 1 (Kottke dielectric + Dey-Mittra weights + per-step
     # apply_conformal_pec) chain with a single inverse-permittivity
     # tensor that encodes both dielectric subpixel smoothing and PEC
-    # behaviour (inv = 0 freezes the field). See
-    # docs/agent-memory/stage2_subpixel_pec_unified_design.md §5.
+    # behaviour (inv = 0 freezes the field).
     aniso_eps = None
     aniso_inv_eps = None
     use_kottke_pec = (subpixel_smoothing == "kottke_pec")

--- a/rfx/sources/msl_eigenmode.py
+++ b/rfx/sources/msl_eigenmode.py
@@ -25,7 +25,6 @@ Failed prior attempts (do not repeat):
 
 * MPB subprocess wrapper (deleted 2026-05-04): boxed-PEC MPB modes do not
   match open-FDTD modes — geometry mismatch, |S11| = 0.61 vs Laplace 0.118.
-  See ``docs/research_notes/20260504_msl_eigenmode_handover.md``.
 * H-only formulation (deleted): cannot self-consistently couple E/H in
   inhomogeneous ε — gave ε_eff = 1.37 instead of ~3 for microstrip.
 * 4-component (Ey,Ez,Hy,Hz) propagation matrix (deleted): redundant DOF +
@@ -185,6 +184,6 @@ def compute_msl_eigenmode_profile(
         "Path B from-scratch FDFD eigenmode solver "
         "(rfx.sources.msl_fdfd_eigenmode) is not yet wired in. "
         "MPB subprocess approach was removed 2026-05-04 — see module "
-        "docstring + docs/research_notes/20260504_msl_eigenmode_handover.md. "
+        "docstring. "
         "Use mode='laplace' for now."
     )

--- a/rfx/sources/msl_port.py
+++ b/rfx/sources/msl_port.py
@@ -898,8 +898,7 @@ def msl_loop_current(
     ``I`` by ~1.5x — it dropped the air-side return Hy and the trace-edge
     Hz — which inflated the de-embedded Z0 to ~74 ohm vs the ~48 ohm
     analytic Hammerstad-Jensen value.  Closing the loop restores Ampere's
-    law.  See ``docs/agent-memory/port_sparam_review_2026-05-19.md``
-    (stage S1).
+    law.
 
     Parameters
     ----------

--- a/rfx/sources/waveguide_port.py
+++ b/rfx/sources/waveguide_port.py
@@ -969,8 +969,7 @@ def init_waveguide_port(
     # Empirically: weight 0.5 (PROD half-weight kludge, used 2026-04-23..27)
     # gives PEC-short min |S11| ≈ 0.94, weight 0.0 (DROP, OpenEMS-equivalent)
     # gives min |S11| = 0.9997. The half-weight was a 2026-04-26 staging
-    # compromise (docs/research_notes/2026-04-26_phase2_aperture_weight_dead_end.md
-    # Phase 2 dead-end) that protected mesh-conv and asymmetric-obstacle
+    # compromise (Phase 2 dead-end) that protected mesh-conv and asymmetric-obstacle
     # reciprocity at the cost of capping PEC-short closure. With DROP,
     # one mesh-conv |S21| test currently regresses (xfail-locked in
     # tests/test_waveguide_port_validation_battery.py); the receive-side
@@ -2440,7 +2439,7 @@ def extract_waveguide_s_params_normalized(
 
     A power-flux (Poynting-vector) extraction analogous to Meep's
     ``add_flux`` would eliminate this limitation for both S11 and S21.
-    Tracked in ``docs/agent-memory/rfx-known-issues.md``.
+    Tracked at https://github.com/bk-squared/rfx/issues.
 
     Parameters
     ----------

--- a/rfx/subgridding/sbp_sat_3d.py
+++ b/rfx/subgridding/sbp_sat_3d.py
@@ -16,8 +16,8 @@ Status: EXPERIMENTAL / NOT physics-validated. An energy-stability check
 at step 1000); the small transient growth (~1.004x) at step 100 is SAT
 penalty equilibration, not instability. That is a stability observation
 only — 3D SBP-SAT subgridding has NOT been validated against a reference
-solver or analytic result, and the repo CLAUDE.md explicitly marks 3D
-subgridding unvalidated. Do not present its output as validated.
+solver or analytic result, and rfx marks 3D subgridding as experimental
+and unvalidated. Do not present its output as validated.
 
 SAT penalty coefficients (Eq. from Cheng et al.)
 -------------------------------------------------

--- a/rfx/topology.py
+++ b/rfx/topology.py
@@ -536,8 +536,7 @@ def topology_optimize(
                 f"topology_optimize: non-finite loss/gradient (NaN or Inf) at "
                 f"iteration {it} — the FDTD forward almost certainly diverged "
                 f"(dt above CFL, conformal=True at fine dx, PEC inside CPML, or "
-                f"a sub-cell PEC feature; see docs/agent-memory/"
-                f"rfx-known-issues.md). Stopping early and returning the last "
+                f"a sub-cell PEC feature). Stopping early and returning the last "
                 f"finite design (from before iteration {it}).",
                 stacklevel=2,
             )


### PR DESCRIPTION
## What

Shipped code (`rfx/`) and `examples/` contained **23 dangling references** to gitignored internal paths (`docs/agent-memory/…`, `docs/research_notes/…`, `.claude/…`, `CLAUDE.md`) in docstrings, comments, and **runtime-visible message strings** (warnings, exceptions, `print()`). Public clones don't have these paths, so each is a dead pointer — surfaced as a public-surface defect in the 2026-06-19 agent-usability review.

This PR removes them (prose-only; no logic/numeric/AD change) and adds a CI guard so the class can't regress.

## Changes

- **Repointed to shipped public recipes** (these exist + are tracked):
  - `examples/crossval/05_patch_antenna.py` → `docs/agent/recipe-resonance-extraction.mdx`
  - `examples/crossval/11_waveguide_port_wr90.py` → `docs/agent/recipe-waveguide-sparams.mdx`
- **Runtime message strings** (warnings/exceptions/print): dropped the dead path; "known/tracked" framing now points at the public issue tracker.
- **Docstrings/comments**: dropped the path, kept the technical prose.
- **CI guard**: extended `.github/workflows/lint.yml` `agent-docs-hygiene` to fail on `agent-memory|CLAUDE.md|.claude/` anywhere in `rfx/` or `examples/`.

## Intentionally left untouched (functional paths, not dangling pointers)

- `examples/inverse_design/multilayer_ar_coating.py` — optional local Meep-reference loader (`research_notes/…`), gracefully returns `None` when absent.
- `examples/crossval/13_subgrid_material_validation.py` — `ARTIFACT_PATH` write target.

`research_notes` is therefore **excluded** from the `rfx/`+`examples/` guard scan (the existing `docs/agent/` check still forbids it in exported agent pages).

## Verification (no behavior change)

- `grep -rn 'agent-memory|CLAUDE.md|.claude/' rfx/ examples/` → empty; guard self-tested (catches an injected ref).
- No test asserts on any changed message substring (grepped `tests/` first).
- No `PreflightIssue` `source=` field or warning category changed.
- `import rfx` + key public symbols clean; `ruff check rfx/ tests/` clean; `pytest` (tier1 + msl_port + waveguide_port batteries) 14 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)