### PR TITLE
feat(microstrip): Hammerstad-Jensen impedance/width synthesis + substrate presets

### DIFF
--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -1188,6 +1188,30 @@
         "output_probe_idx"
       ]
     },
+    "microstrip_eps_eff": {
+      "kind": "function",
+      "params": [
+        "width",
+        "height",
+        "eps_r"
+      ]
+    },
+    "microstrip_impedance": {
+      "kind": "function",
+      "params": [
+        "width",
+        "height",
+        "eps_r"
+      ]
+    },
+    "microstrip_width": {
+      "kind": "function",
+      "params": [
+        "z0",
+        "height",
+        "eps_r"
+      ]
+    },
     "minimize_reflected_energy": {
       "kind": "function",
       "params": [

--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -148,6 +148,9 @@ from rfx.probes.probes import (
 from rfx.sweep import parametric_sweep, SweepResult, plot_sweep
 from rfx.vmap_sweep import vmap_material_sweep, VmapSweepResult
 from rfx.pcb import PCBLayer, Stackup
+from rfx.microstrip import (
+    microstrip_impedance, microstrip_eps_eff, microstrip_width,
+)
 from rfx.floquet import (
     FloquetPort,
     floquet_phase_shift,
@@ -213,6 +216,8 @@ __all__ = [
     # geometry
     "Box", "Sphere", "Cylinder", "PolylineWire", "CurvedPatch", "Via",
     "PCBLayer", "Stackup",
+    # microstrip closed-form synthesis / analysis
+    "microstrip_impedance", "microstrip_eps_eff", "microstrip_width",
     # sources / waveforms / ports (builder classes; not per-step kernels)
     "GaussianPulse", "ModulatedGaussian", "CWSource", "CustomWaveform",
     "WaveguidePort", "WaveguidePortConfig", "CoaxialPort",

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -39,7 +39,13 @@ MATERIAL_LIBRARY: dict[str, dict] = {
     "vacuum":      {"eps_r": 1.0, "sigma": 0.0},
     "air":         {"eps_r": 1.0006, "sigma": 0.0},
     "fr4":         {"eps_r": 4.4, "sigma": 0.025},
+    # RO4003C: this entry uses the *process* Dk 3.55; for 50-ohm impedance
+    # synthesis most designs use the *design* Dk 3.38 (Rogers RO4000 datasheet).
     "rogers4003c": {"eps_r": 3.55, "sigma": 0.0027 * 2 * np.pi * 5e9 * 3.55 * EPS_0},
+    # RO4350B: Dk(design) 3.48, Df 0.0037 @ 10 GHz (Rogers RO4000 datasheet).
+    "rogers4350b": {"eps_r": 3.48, "sigma": 0.0037 * 2 * np.pi * 10e9 * 3.48 * EPS_0},
+    # RT/duroid 5880: Dk 2.20, Df 0.0009 @ 10 GHz (Rogers RT/duroid datasheet).
+    "rt_duroid_5880": {"eps_r": 2.20, "sigma": 0.0009 * 2 * np.pi * 10e9 * 2.20 * EPS_0},
     "alumina":     {"eps_r": 9.8, "sigma": 0.0},
     "silicon":     {"eps_r": 11.9, "sigma": 0.01},
     "ptfe":        {"eps_r": 2.1, "sigma": 0.0},

--- a/rfx/microstrip.py
+++ b/rfx/microstrip.py
@@ -1,0 +1,197 @@
+"""Closed-form microstrip transmission-line synthesis and analysis.
+
+Host-side (numpy/math) analytical helpers for the single most common RF
+design task: *what trace width gives a target characteristic impedance on
+a given substrate?* These are pure closed-form functions — they do **not**
+run a simulation and are intentionally decoupled from JAX.
+
+Formula source
+--------------
+Characteristic impedance and effective permittivity use the
+**Hammerstad–Jensen** quasi-static synthesis/analysis equations as
+presented in:
+
+    E. Hammerstad and O. Jensen, "Accurate Models for Microstrip
+    Computer-Aided Design," IEEE MTT-S International Microwave Symposium
+    Digest, 1980, pp. 407-409.
+
+and reproduced in standard references (e.g. Pozar, *Microwave
+Engineering*, 4th ed., §3.8; Wadell, *Transmission Line Design
+Handbook*). The effective-permittivity term uses the Hammerstad form
+
+    eps_eff = (eps_r + 1)/2 + (eps_r - 1)/2 * (1 + 12 h / w)^(-1/2)
+
+with the thin-line ``(w/h < 1)`` correction term, and the impedance is
+the standard two-regime Wheeler/Hammerstad expression. Width synthesis
+uses the closed-form Wheeler inversion (Pozar eqs. 3.197).
+
+Accuracy
+--------
+The quasi-static Hammerstad–Jensen model is accurate to roughly **1 %**
+for ``0.05 <= w/h <= 20`` and ``eps_r <= ~13`` at low frequency. It
+ignores conductor thickness, dispersion (frequency dependence of
+``eps_eff``), and surface roughness, so it is a starting-point synthesis
+tool — not a substitute for a full-wave solve. All lengths are in metres.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+
+# Free-space wave impedance, eta_0 = sqrt(mu_0 / eps_0)  (ohm).
+_ETA_0 = 376.730313668
+
+
+def _validate_geometry(height: float, eps_r: float, *, width: float | None = None) -> None:
+    """Validate common microstrip inputs, raising ValueError on bad input."""
+    if width is not None and not (width > 0.0):
+        raise ValueError(f"width must be positive (metres), got {width!r}")
+    if not (height > 0.0):
+        raise ValueError(f"height must be positive (metres), got {height!r}")
+    if not (eps_r >= 1.0):
+        raise ValueError(f"eps_r must be >= 1.0, got {eps_r!r}")
+
+
+def microstrip_eps_eff(width: float, height: float, eps_r: float) -> float:
+    """Effective relative permittivity of a microstrip line (Hammerstad).
+
+    Parameters
+    ----------
+    width : float
+        Conductor (trace) width in metres.
+    height : float
+        Substrate (dielectric) thickness in metres.
+    eps_r : float
+        Substrate relative permittivity (dimensionless, >= 1).
+
+    Returns
+    -------
+    float
+        Effective relative permittivity ``eps_eff`` seen by the quasi-TEM
+        mode (``1 <= eps_eff <= eps_r``).
+
+    Notes
+    -----
+    Uses the Hammerstad form (Pozar §3.8, eq. 3.195); the
+    ``(w/h < 1)`` branch adds the ``(1 - w/h)^2`` thin-line correction.
+    """
+    _validate_geometry(height, eps_r, width=width)
+    u = width / height  # w/h ratio
+    if u >= 1.0:
+        f = (1.0 + 12.0 / u) ** -0.5
+    else:
+        f = (1.0 + 12.0 / u) ** -0.5 + 0.04 * (1.0 - u) ** 2
+    return (eps_r + 1.0) / 2.0 + (eps_r - 1.0) / 2.0 * f
+
+
+def microstrip_impedance(
+    width: float, height: float, eps_r: float
+) -> tuple[float, float]:
+    """Characteristic impedance and eps_eff of a microstrip line (analysis).
+
+    Parameters
+    ----------
+    width : float
+        Conductor (trace) width in metres.
+    height : float
+        Substrate (dielectric) thickness in metres.
+    eps_r : float
+        Substrate relative permittivity (dimensionless, >= 1).
+
+    Returns
+    -------
+    (z0, eps_eff) : tuple of float
+        ``z0`` is the characteristic impedance in ohms; ``eps_eff`` is the
+        effective relative permittivity.
+
+    Notes
+    -----
+    Two-regime Wheeler/Hammerstad expression (Pozar §3.8, eq. 3.196):
+
+    * ``w/h <= 1``: ``z0 = eta_0 / (2*pi*sqrt(eps_eff))
+      * ln(8 h/w + w/(4 h))``
+    * ``w/h >= 1``: ``z0 = eta_0 / (sqrt(eps_eff)
+      * (w/h + 1.393 + 0.667 ln(w/h + 1.444)))``
+    """
+    _validate_geometry(height, eps_r, width=width)
+    eps_eff = microstrip_eps_eff(width, height, eps_r)
+    u = width / height
+    sqrt_eff = math.sqrt(eps_eff)
+    if u <= 1.0:
+        z0 = _ETA_0 / (2.0 * math.pi * sqrt_eff) * math.log(8.0 / u + u / 4.0)
+    else:
+        z0 = _ETA_0 / (sqrt_eff * (u + 1.393 + 0.667 * math.log(u + 1.444)))
+    return z0, eps_eff
+
+
+def microstrip_width(z0: float, height: float, eps_r: float) -> float:
+    """Trace width that yields a target characteristic impedance (synthesis).
+
+    Solves the inverse problem: *given* a desired ``z0`` (e.g. 50 ohm), a
+    substrate thickness, and a substrate permittivity, return the
+    microstrip conductor width.
+
+    Parameters
+    ----------
+    z0 : float
+        Target characteristic impedance in ohms (> 0).
+    height : float
+        Substrate (dielectric) thickness in metres.
+    eps_r : float
+        Substrate relative permittivity (dimensionless, >= 1).
+
+    Returns
+    -------
+    float
+        Conductor (trace) width in metres.
+
+    Notes
+    -----
+    Closed-form Wheeler/Hammerstad synthesis (Pozar §3.8, eq. 3.197).
+    A trial ``w/h`` is computed for both the narrow and wide regimes and
+    the branch consistent with its own validity condition is selected.
+    """
+    if not (z0 > 0.0):
+        raise ValueError(f"z0 must be positive (ohm), got {z0!r}")
+    _validate_geometry(height, eps_r)
+
+    # Wide-strip trial (w/h > 2): B-based form. Its logarithms are only real
+    # for b > 1 (low-to-moderate z0); for high-impedance lines on high-eps_r
+    # substrates b <= 1 and the wide form does not apply — mark it invalid and
+    # fall through to the narrow branch instead of raising a bare
+    # "math domain error".
+    b = _ETA_0 * math.pi / (2.0 * z0 * math.sqrt(eps_r))
+    if b > 1.0:
+        u_wide = (2.0 / math.pi) * (
+            b - 1.0 - math.log(2.0 * b - 1.0)
+            + (eps_r - 1.0) / (2.0 * eps_r)
+            * (math.log(b - 1.0) + 0.39 - 0.61 / eps_r)
+        )
+    else:
+        u_wide = float("-inf")  # wide form invalid here; use the narrow branch
+
+    # Narrow-strip trial (w/h < 2): A-based form.
+    a = (
+        z0 / 60.0 * math.sqrt((eps_r + 1.0) / 2.0)
+        + (eps_r - 1.0) / (eps_r + 1.0) * (0.23 + 0.11 / eps_r)
+    )
+    u_narrow = 8.0 * math.exp(a) / (math.exp(2.0 * a) - 2.0)
+
+    # Each closed form is valid on one side of w/h = 2: use the wide form when
+    # its own trial comes out >= 2, otherwise the narrow form (Pozar rule).
+    u = u_wide if u_wide >= 2.0 else u_narrow
+
+    # The Hammerstad-Jensen fit is only ~1% accurate for 0.05 <= w/h <= 20;
+    # outside that the returned width is an extrapolation — warn rather than
+    # silently hand back a degraded value.
+    if not (0.05 <= u <= 20.0):
+        warnings.warn(
+            f"microstrip_width: resulting w/h={u:.3g} is outside the "
+            f"Hammerstad-Jensen validated range [0.05, 20]; the returned "
+            f"width is an extrapolation with degraded accuracy "
+            f"(z0={z0!r} ohm, eps_r={eps_r!r}).",
+            stacklevel=2,
+        )
+
+    return u * height

--- a/rfx/pcb.py
+++ b/rfx/pcb.py
@@ -38,6 +38,12 @@ PCB_MATERIAL_ALIASES: dict[str, str] = {
     # object; the alias simply lets the stackup builder pass a valid
     # library name downstream.
     "prepreg": "fr4",
+    # Natural-name aliases for common RF laminates whose canonical
+    # MATERIAL_LIBRARY keys are spelled differently.
+    "ro4003c": "rogers4003c",
+    "ro4350b": "rogers4350b",
+    "rt5880": "rt_duroid_5880",
+    "duroid5880": "rt_duroid_5880",
 }
 
 

--- a/tests/test_microstrip.py
+++ b/tests/test_microstrip.py
@@ -1,0 +1,181 @@
+"""Tests for closed-form microstrip synthesis/analysis (rfx.microstrip).
+
+Reference points are taken from the standard Hammerstad-Jensen quasi-static
+model (Pozar, *Microwave Engineering*, 4th ed., §3.8). The model is ~1%
+accurate, so tolerances are a few percent.
+"""
+
+import math
+
+import pytest
+
+from rfx.microstrip import (
+    microstrip_impedance,
+    microstrip_eps_eff,
+    microstrip_width,
+)
+
+
+# ---------------------------------------------------------------------------
+# Analysis vs published reference points
+# ---------------------------------------------------------------------------
+
+class TestAnalysisReference:
+    def test_fr4_50ohm_geometry(self):
+        # 50 ohm microstrip on FR4 (eps_r=4.4, h=1.6 mm): standard textbook
+        # result is w ~ 3.0-3.1 mm and eps_eff ~ 3.3.
+        w = 3.06e-3
+        z0, eps_eff = microstrip_impedance(w, 1.6e-3, 4.4)
+        assert z0 == pytest.approx(50.0, abs=1.0)  # within ~2%
+        assert eps_eff == pytest.approx(3.3, abs=0.1)
+
+    def test_ro4003c_50ohm_geometry(self):
+        # Rogers RO4003C (eps_r=3.38), h=0.508 mm (20 mil): a 50 ohm line is
+        # ~1.15 mm wide with eps_eff ~ 2.65 (Rogers app notes / TX-line tools).
+        w = 1.17e-3
+        z0, eps_eff = microstrip_impedance(w, 0.508e-3, 3.38)
+        assert z0 == pytest.approx(50.0, abs=1.5)  # within ~3%
+        assert eps_eff == pytest.approx(2.67, abs=0.1)
+
+    def test_eps_eff_bounds(self):
+        # eps_eff is always between 1 and eps_r.
+        eps_r = 4.4
+        eps_eff = microstrip_eps_eff(3.0e-3, 1.6e-3, eps_r)
+        assert 1.0 < eps_eff < eps_r
+
+    def test_eps_eff_matches_impedance_call(self):
+        # microstrip_impedance must return the same eps_eff as the standalone.
+        _, eps_eff_from_z = microstrip_impedance(2.0e-3, 1.0e-3, 3.55)
+        eps_eff_direct = microstrip_eps_eff(2.0e-3, 1.0e-3, 3.55)
+        assert eps_eff_from_z == pytest.approx(eps_eff_direct, rel=1e-12)
+
+    def test_wider_trace_lowers_impedance(self):
+        # Monotonicity sanity: wider trace -> lower Z0.
+        z_narrow, _ = microstrip_impedance(0.5e-3, 1.6e-3, 4.4)
+        z_wide, _ = microstrip_impedance(5.0e-3, 1.6e-3, 4.4)
+        assert z_narrow > z_wide
+
+
+# ---------------------------------------------------------------------------
+# Synthesis <-> analysis roundtrip
+# ---------------------------------------------------------------------------
+
+class TestRoundtrip:
+    @pytest.mark.parametrize("eps_r", [4.4, 3.38, 2.2, 9.8])
+    @pytest.mark.parametrize("z0_target", [50.0, 75.0])
+    def test_roundtrip_recovers_z0(self, eps_r, z0_target):
+        h = 1.6e-3
+        w = microstrip_width(z0_target, h, eps_r)
+        assert w > 0.0
+        z0_back, _ = microstrip_impedance(w, h, eps_r)
+        # Synthesis and analysis are different closed forms; HJ accuracy ~1%.
+        assert z0_back == pytest.approx(z0_target, rel=0.03)
+
+    def test_roundtrip_straddles_wh_boundary(self):
+        # Low eps_r + high Z0 lands in the narrow (w/h < 1) regime; high
+        # eps_r + low Z0 lands in the wide (w/h > 1) regime. Exercise both.
+        h = 1.0e-3
+        # Narrow regime case (high-Z line on a low-eps_r substrate).
+        w_narrow = microstrip_width(120.0, h, 2.2)
+        assert w_narrow / h < 1.0
+        z_narrow, _ = microstrip_impedance(w_narrow, h, 2.2)
+        assert z_narrow == pytest.approx(120.0, rel=0.03)
+        # Wide regime case.
+        w_wide = microstrip_width(40.0, h, 9.8)
+        assert w_wide / h > 1.0
+        z_wide, _ = microstrip_impedance(w_wide, h, 9.8)
+        assert z_wide == pytest.approx(40.0, rel=0.03)
+
+    def test_fr4_50ohm_width_value(self):
+        # The headline number: 50 ohm on FR4 (h=1.6 mm) -> ~3.0-3.1 mm.
+        w = microstrip_width(50.0, 1.6e-3, 4.4)
+        assert 3.0e-3 <= w <= 3.1e-3
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+class TestValidation:
+    def test_impedance_rejects_nonpositive_width(self):
+        with pytest.raises(ValueError):
+            microstrip_impedance(0.0, 1.6e-3, 4.4)
+        with pytest.raises(ValueError):
+            microstrip_impedance(-1e-3, 1.6e-3, 4.4)
+
+    def test_impedance_rejects_nonpositive_height(self):
+        with pytest.raises(ValueError):
+            microstrip_impedance(3.0e-3, 0.0, 4.4)
+
+    def test_impedance_rejects_eps_below_one(self):
+        with pytest.raises(ValueError):
+            microstrip_impedance(3.0e-3, 1.6e-3, 0.9)
+
+    def test_eps_eff_rejects_bad_inputs(self):
+        with pytest.raises(ValueError):
+            microstrip_eps_eff(-1.0, 1.6e-3, 4.4)
+        with pytest.raises(ValueError):
+            microstrip_eps_eff(3.0e-3, 1.6e-3, 0.5)
+
+    def test_width_rejects_nonpositive_z0(self):
+        with pytest.raises(ValueError):
+            microstrip_width(0.0, 1.6e-3, 4.4)
+        with pytest.raises(ValueError):
+            microstrip_width(-50.0, 1.6e-3, 4.4)
+
+    def test_width_rejects_bad_substrate(self):
+        with pytest.raises(ValueError):
+            microstrip_width(50.0, -1.6e-3, 4.4)
+        with pytest.raises(ValueError):
+            microstrip_width(50.0, 1.6e-3, 0.5)
+
+
+# ---------------------------------------------------------------------------
+# Substrate presets (added in this change)
+# ---------------------------------------------------------------------------
+
+class TestSubstratePresets:
+    def test_new_presets_in_library(self):
+        from rfx import MATERIAL_LIBRARY
+        assert "rogers4350b" in MATERIAL_LIBRARY
+        assert "rt_duroid_5880" in MATERIAL_LIBRARY
+
+    def test_ro4350b_eps_r(self):
+        from rfx import MATERIAL_LIBRARY
+        assert MATERIAL_LIBRARY["rogers4350b"]["eps_r"] == pytest.approx(3.48, abs=0.02)
+        assert MATERIAL_LIBRARY["rogers4350b"]["sigma"] > 0.0  # lossy dielectric
+
+    def test_rt_duroid_5880_eps_r(self):
+        from rfx import MATERIAL_LIBRARY
+        assert MATERIAL_LIBRARY["rt_duroid_5880"]["eps_r"] == pytest.approx(2.20, abs=0.02)
+        assert MATERIAL_LIBRARY["rt_duroid_5880"]["sigma"] > 0.0
+
+    def test_presets_resolvable_via_real_api(self):
+        # Resolve through the actual Simulation material-resolution path.
+        from rfx import Simulation
+        sim = Simulation(freq_max=10e9, domain=(0.01, 0.01, 0.01))
+        for name, expected in (("rogers4350b", 3.48), ("rt_duroid_5880", 2.20)):
+            spec = sim._resolve_material(name)
+            assert spec.eps_r == pytest.approx(expected, abs=0.02)
+
+    def test_pcb_aliases_resolve(self):
+        # Natural-name aliases map to canonical library keys.
+        from rfx.pcb import resolve_pcb_material
+        from rfx import MATERIAL_LIBRARY
+        assert resolve_pcb_material("ro4350b") == "rogers4350b"
+        assert resolve_pcb_material("rt5880") == "rt_duroid_5880"
+        assert resolve_pcb_material("duroid5880") == "rt_duroid_5880"
+        # Aliased canonical names exist in the library.
+        assert resolve_pcb_material("ro4350b") in MATERIAL_LIBRARY
+        assert resolve_pcb_material("rt5880") in MATERIAL_LIBRARY
+
+
+class TestSynthesisRobustness:
+    def test_high_z_high_eps_no_crash_and_warns(self):
+        # A high-impedance line on a high-eps_r substrate drives the wide-form
+        # argument b <= 1 (its logs would be complex). The synthesis must fall
+        # through to the narrow branch and return a finite width — not raise a
+        # bare math-domain error — while warning that w/h is extrapolated.
+        with pytest.warns(UserWarning, match="validated range"):
+            w = microstrip_width(200.0, 1.6e-3, 9.8)
+        assert math.isfinite(w) and w > 0.0


### PR DESCRIPTION
## What
Closed-form **microstrip synthesis** — the #1 thing an RF engineer reaches for ("what trace width gives 50 Ω on this substrate?") — plus two missing substrate presets. The verifiable, no-new-dependency slice of the toolchain-interop theme.

```python
from rfx import microstrip_width, microstrip_impedance
w = microstrip_width(50, 1.6e-3, 4.4)        # 50 Ω on FR4 (h=1.6mm) -> 3.059 mm
z0, eps_eff = microstrip_impedance(w, 1.6e-3, 4.4)   # -> 50.2 Ω, 3.330
```

## Design
- New `rfx/microstrip.py` — pure host-side `math` (no JAX coupling), Hammerstad–Jensen quasi-static model (Hammerstad & Jensen 1980; Pozar §3.8, eqs 3.195–3.197): `microstrip_eps_eff`, `microstrip_impedance` (two w/h regimes), `microstrip_width` (closed-form Wheeler inversion). Inputs validated (positive w/h, eps_r≥1, z0>0); accuracy envelope (~1% for 0.05≤w/h≤20) documented. Exported from `rfx/__init__.py`.
- `MATERIAL_LIBRARY` (in `rfx/api/_spec.py`) gains **RO4350B** (Dk 3.48, Df 0.0037 @10GHz) and **RT/duroid 5880** (Dk 2.20, Df 0.0009 @10GHz) — datasheet-accurate, same `sigma = tanδ·2π·f·eps_r·ε0` form as the existing `rogers4003c` entry. Natural-name aliases (`ro4350b`, `rt5880`, `duroid5880`) added to `resolve_pcb_material`. **No existing preset changed** (added a clarifying comment that `rogers4003c` carries process Dk 3.55 vs design Dk 3.38).

## Verification
- `ruff` clean
- 27 tests pass — analysis vs ≥2 published reference points (50 Ω FR4 → w=3.059 mm/eps_eff=3.330; RO4003C case), synthesis↔analysis roundtrip within tolerance across eps_r∈{2.2,3.38,4.4,9.8}, narrow/wide regime straddle, input-validation errors, presets resolvable via the real `Simulation._resolve_material` path, and a robustness case (high-Z on high-eps_r no longer raises a bare math-domain error — falls through to the narrow branch and warns on out-of-range extrapolation)
- regression: `tests/test_pcb.py` + `tests/test_material_fit.py` green

## Deferred (noted, not built)
- **scikit-rf Network bridge** — `scikit-rf` isn't installed in this env, so it can't be honestly verified here; land it as a thin optional-dependency wrapper in an env/CI where `scikit-rf` is a confirmed extra.
- **CAD import (GDS/STEP/STL)** — weeks-scale, separate effort.

## Merge note
Touches `rfx/api/_spec.py` (`MATERIAL_LIBRARY` dict). PR #215 (Result accessors) also edits `_spec.py` but a different region (the `Result` class), so they should merge without conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
