### PR TITLE
release: v1.6.6 — waveguide mode-solver extraction + repo hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+## [1.6.6] - 2026-06-24
+
+Maintenance release: a behaviour-preserving internal refactor (extract the
+waveguide mode solver into its own module — byte-identical, GPU-suite-confirmed)
+plus repo hygiene (remove dangling internal-doc references from shipped code and
+add a CI guard). **No user-visible behaviour or public-API change.** Per-release
+GPU gate green: `pytest -m gpu` on the release commit = 187 passed / 62 skipped /
+2 xfailed (VESSL gpu-rtx4090).
+
 ### Internal — refactor + repo hygiene (no user-visible behaviour change; PRs #218, #219)
 
 - Extracted the rectangular-waveguide transverse mode solver and mode-profile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfx-fdtd"
-version = "1.6.5"
+version = "1.6.6"
 description = "JAX-native 3D FDTD electromagnetic simulator for RF engineering"
 readme = "README.md"
 license = {text = "MIT"}

--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -1,7 +1,7 @@
 """rfx — JAX-based RF FDTD electromagnetic simulator."""
 # ruff: noqa: F401
 
-__version__ = "1.6.5"
+__version__ = "1.6.6"
 
 from rfx.grid import Grid
 from rfx.simulation import run, run_until_decay, make_source, make_probe, make_port_source, SimResult


### PR DESCRIPTION
Patch release. **No user-visible behaviour or public-API change.**

Bumps `pyproject.toml` + `rfx.__version__` 1.6.5 → 1.6.6 and promotes the `CHANGELOG` `[Unreleased]` section to `[1.6.6] - 2026-06-24`.

### Included (already merged to main)
- **#219** — extract the waveguide transverse mode solver + profile algebra (10 pure-NumPy helpers) from `waveguide_port.py` (3364→3090 LOC) into `rfx/sources/_waveguide_modes.py`; verbatim/byte-identical, AD tape unaffected, **GPU suite unchanged (187/62/2)**.
- **#218** — remove 23 dangling internal-doc references from shipped code/examples + CI guard.

### Release gate
- Per-release GPU suite (CLAUDE.md cadence): `pytest -m gpu` on the release content = **187 passed / 62 skipped / 2 xfailed** (VESSL gpu-rtx4090, run 369367244324).
- External crossval (cv05/cv11) not required — no cv05/cv11 physics-path changes.
- PyPI: not part of recent cadence (v1.6.4/v1.6.5 were tag-only; PyPI latest = 1.6.3). This release is git-tag + GitHub-release only unless a PyPI publish is requested separately.

After merge: annotated tag `v1.6.6` on the merge commit + a GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)