### PR TITLE
chore(gitignore): ignore PyPI credential files (.pypi/.pypirc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ examples/*.json
 # VESSL cluster log mirrors (operational; not physics evidence)
 docs/vessl-logs/
 scripts/diagnostics/_artifacts/*.npz
+
+# PyPI upload credentials — never commit
+.pypi
+.pypirc


### PR DESCRIPTION
Durable guard so a release-time token file (e.g. `./.pypi` for `twine upload`) can never be accidentally committed. 2-line, zero-risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)