### PR TITLE
fix(cpml): material-aware CPML on the distributed (uniform) scan body (#205)

### DIFF
--- a/rfx/runners/distributed.py
+++ b/rfx/runners/distributed.py
@@ -712,7 +712,7 @@ def _init_cpml_distributed(grid, nx_local, n_devices):
 
 def _apply_cpml_e_distributed(
     state, cpml_params, cpml_state, n_cpml, dt, dx,
-    n_devices, ghost=1, axis_name="devices",
+    n_devices, ghost=1, axis_name="devices", eps_r=None,
 ):
     """Apply CPML E-field correction on a distributed slab.
 
@@ -739,10 +739,29 @@ def _apply_cpml_e_distributed(
     ghost : int
         Number of ghost cells on each side of x (default 1).
     axis_name : str
+    eps_r : jnp.ndarray or None
+        Per-cell relative permittivity slab (nx_local+2*ghost, ny, nz),
+        same ghost layout as the field slab.  When provided, the CPML
+        E-coefficient is the material-aware ``dt / (eps_r * eps_0)`` so the
+        absorber stays impedance-matched inside a dielectric (mirrors the
+        single-device ``apply_cpml_e``).  ``None`` falls back to the vacuum
+        scalar ``dt / eps_0`` (bit-identical to the pre-#205 behaviour).
     """
     n = n_cpml
     g = ghost
-    coeff_e = cpml_coeff_e_vacuum(dt)  # dt / eps_0 (vacuum)
+    # Per-face E-coefficient (material-aware when eps_r is supplied).
+    # Each face slice broadcasts element-wise against its correction array
+    # (x faces account for the ghost offset; y/z faces have no x-ghost).
+    if eps_r is not None:
+        _ce = dt / (eps_r * EPS_0)  # (nx_local+2g, ny, nz)
+        ce_xlo = _ce[g:g + n, :, :]
+        ce_xhi = _ce[-(g + n):-g, :, :] if g > 0 else _ce[-n:, :, :]
+        ce_ylo = _ce[:, :n, :]
+        ce_yhi = _ce[:, -n:, :]
+        ce_zlo = _ce[:, :, :n]
+        ce_zhi = _ce[:, :, -n:]
+    else:
+        ce_xlo = ce_xhi = ce_ylo = ce_yhi = ce_zlo = ce_zhi = cpml_coeff_e_vacuum(dt)
 
     b = cpml_params.b
     c = cpml_params.c
@@ -779,7 +798,7 @@ def _apply_cpml_e_distributed(
     curl_hz_dx_xlo = (hz_xlo - hz_shifted_xlo) / dx
 
     new_psi_ey_xlo = b_x * cpml_state.psi_ey_xlo + c_x * curl_hz_dx_xlo
-    ey_corr_xlo = -coeff_e * new_psi_ey_xlo - coeff_e * (1.0 / k_x - 1.0) * curl_hz_dx_xlo
+    ey_corr_xlo = -ce_xlo * new_psi_ey_xlo - ce_xlo * (1.0 / k_x - 1.0) * curl_hz_dx_xlo
     # Mask: only device 0
     ey_corr_xlo = jnp.where(is_first, ey_corr_xlo, 0.0)
     ey = ey.at[xlo, :, :].add(ey_corr_xlo)
@@ -791,7 +810,7 @@ def _apply_cpml_e_distributed(
     curl_hz_dx_xhi = (hz_xhi - hz_shifted_xhi) / dx
 
     new_psi_ey_xhi = b_xr * cpml_state.psi_ey_xhi + c_xr * curl_hz_dx_xhi
-    ey_corr_xhi = -coeff_e * new_psi_ey_xhi - coeff_e * (1.0 / k_xr - 1.0) * curl_hz_dx_xhi
+    ey_corr_xhi = -ce_xhi * new_psi_ey_xhi - ce_xhi * (1.0 / k_xr - 1.0) * curl_hz_dx_xhi
     ey_corr_xhi = jnp.where(is_last, ey_corr_xhi, 0.0)
     ey = ey.at[xhi, :, :].add(ey_corr_xhi)
     new_psi_ey_xhi = jnp.where(is_last, new_psi_ey_xhi, cpml_state.psi_ey_xhi)
@@ -804,7 +823,7 @@ def _apply_cpml_e_distributed(
 
     new_psi_ez_xlo = b_x * cpml_state.psi_ez_xlo + c_x * curl_hy_dx_xlo_t
     correction_ez_xlo = jnp.transpose(new_psi_ez_xlo, (0, 2, 1))
-    ez_corr_xlo = coeff_e * correction_ez_xlo + coeff_e * (1.0 / k_x - 1.0) * curl_hy_dx_xlo
+    ez_corr_xlo = ce_xlo * correction_ez_xlo + ce_xlo * (1.0 / k_x - 1.0) * curl_hy_dx_xlo
     ez_corr_xlo = jnp.where(is_first, ez_corr_xlo, 0.0)
     ez = ez.at[xlo, :, :].add(ez_corr_xlo)
     new_psi_ez_xlo = jnp.where(is_first, new_psi_ez_xlo, cpml_state.psi_ez_xlo)
@@ -817,7 +836,7 @@ def _apply_cpml_e_distributed(
 
     new_psi_ez_xhi = b_xr * cpml_state.psi_ez_xhi + c_xr * curl_hy_dx_xhi_t
     correction_ez_xhi = jnp.transpose(new_psi_ez_xhi, (0, 2, 1))
-    ez_corr_xhi = coeff_e * correction_ez_xhi + coeff_e * (1.0 / k_xr - 1.0) * curl_hy_dx_xhi
+    ez_corr_xhi = ce_xhi * correction_ez_xhi + ce_xhi * (1.0 / k_xr - 1.0) * curl_hy_dx_xhi
     ez_corr_xhi = jnp.where(is_last, ez_corr_xhi, 0.0)
     ez = ez.at[xhi, :, :].add(ez_corr_xhi)
     new_psi_ez_xhi = jnp.where(is_last, new_psi_ez_xhi, cpml_state.psi_ez_xhi)
@@ -840,9 +859,9 @@ def _apply_cpml_e_distributed(
 
     new_psi_ex_ylo = b_yn * cpml_state.psi_ex_ylo + c_yn * curl_hz_dy_ylo_t
     correction_ex_ylo = jnp.transpose(new_psi_ex_ylo, (1, 0, 2))
-    ex = ex.at[:, :n, :].add(coeff_e * correction_ex_ylo)
+    ex = ex.at[:, :n, :].add(ce_ylo * correction_ex_ylo)
     kappa_corr_ylo = jnp.transpose((1.0 / k_yn - 1.0) * curl_hz_dy_ylo_t, (1, 0, 2))
-    ex = ex.at[:, :n, :].add(coeff_e * kappa_corr_ylo)
+    ex = ex.at[:, :n, :].add(ce_ylo * kappa_corr_ylo)
 
     # --- Y-hi: Ex correction from dHz/dy ---
     hz_yhi = state.hz[:, -n:, :]
@@ -852,9 +871,9 @@ def _apply_cpml_e_distributed(
 
     new_psi_ex_yhi = b_yrn * cpml_state.psi_ex_yhi + c_yrn * curl_hz_dy_yhi_t
     correction_ex_yhi = jnp.transpose(new_psi_ex_yhi, (1, 0, 2))
-    ex = ex.at[:, -n:, :].add(coeff_e * correction_ex_yhi)
+    ex = ex.at[:, -n:, :].add(ce_yhi * correction_ex_yhi)
     kappa_corr_yhi = jnp.transpose((1.0 / k_yrn - 1.0) * curl_hz_dy_yhi_t, (1, 0, 2))
-    ex = ex.at[:, -n:, :].add(coeff_e * kappa_corr_yhi)
+    ex = ex.at[:, -n:, :].add(ce_yhi * kappa_corr_yhi)
 
     # --- Y-lo: Ez correction from dHx/dy ---
     hx_ylo = state.hx[:, :n, :]
@@ -864,9 +883,9 @@ def _apply_cpml_e_distributed(
 
     new_psi_ez_ylo = b_yn * cpml_state.psi_ez_ylo + c_yn * curl_hx_dy_ylo_t
     correction_ez_ylo = jnp.transpose(new_psi_ez_ylo, (2, 0, 1))
-    ez = ez.at[:, :n, :].add(-coeff_e * correction_ez_ylo)
+    ez = ez.at[:, :n, :].add(-ce_ylo * correction_ez_ylo)
     kappa_corr_ez_ylo = jnp.transpose((1.0 / k_yn - 1.0) * curl_hx_dy_ylo_t, (2, 0, 1))
-    ez = ez.at[:, :n, :].add(-coeff_e * kappa_corr_ez_ylo)
+    ez = ez.at[:, :n, :].add(-ce_ylo * kappa_corr_ez_ylo)
 
     # --- Y-hi: Ez correction from dHx/dy ---
     hx_yhi = state.hx[:, -n:, :]
@@ -876,9 +895,9 @@ def _apply_cpml_e_distributed(
 
     new_psi_ez_yhi = b_yrn * cpml_state.psi_ez_yhi + c_yrn * curl_hx_dy_yhi_t
     correction_ez_yhi = jnp.transpose(new_psi_ez_yhi, (2, 0, 1))
-    ez = ez.at[:, -n:, :].add(-coeff_e * correction_ez_yhi)
+    ez = ez.at[:, -n:, :].add(-ce_yhi * correction_ez_yhi)
     kappa_corr_ez_yhi = jnp.transpose((1.0 / k_yrn - 1.0) * curl_hx_dy_yhi_t, (2, 0, 1))
-    ez = ez.at[:, -n:, :].add(-coeff_e * kappa_corr_ez_yhi)
+    ez = ez.at[:, -n:, :].add(-ce_yhi * kappa_corr_ez_yhi)
 
     # =======================================================================
     # Z-axis CPML (all devices)
@@ -892,9 +911,9 @@ def _apply_cpml_e_distributed(
 
     new_psi_ex_zlo = b_yn * cpml_state.psi_ex_zlo + c_yn * curl_hy_dz_zlo_t
     correction_ex_zlo = jnp.transpose(new_psi_ex_zlo, (1, 2, 0))
-    ex = ex.at[:, :, :n].add(-coeff_e * correction_ex_zlo)
+    ex = ex.at[:, :, :n].add(-ce_zlo * correction_ex_zlo)
     kappa_corr_ex_zlo = jnp.transpose((1.0 / k_yn - 1.0) * curl_hy_dz_zlo_t, (1, 2, 0))
-    ex = ex.at[:, :, :n].add(-coeff_e * kappa_corr_ex_zlo)
+    ex = ex.at[:, :, :n].add(-ce_zlo * kappa_corr_ex_zlo)
 
     # --- Z-hi: Ex correction from dHy/dz ---
     hy_zhi = state.hy[:, :, -n:]
@@ -904,9 +923,9 @@ def _apply_cpml_e_distributed(
 
     new_psi_ex_zhi = b_yrn * cpml_state.psi_ex_zhi + c_yrn * curl_hy_dz_zhi_t
     correction_ex_zhi = jnp.transpose(new_psi_ex_zhi, (1, 2, 0))
-    ex = ex.at[:, :, -n:].add(-coeff_e * correction_ex_zhi)
+    ex = ex.at[:, :, -n:].add(-ce_zhi * correction_ex_zhi)
     kappa_corr_ex_zhi = jnp.transpose((1.0 / k_yrn - 1.0) * curl_hy_dz_zhi_t, (1, 2, 0))
-    ex = ex.at[:, :, -n:].add(-coeff_e * kappa_corr_ex_zhi)
+    ex = ex.at[:, :, -n:].add(-ce_zhi * kappa_corr_ex_zhi)
 
     # --- Z-lo: Ey correction from dHx/dz ---
     hx_zlo = state.hx[:, :, :n]
@@ -916,9 +935,9 @@ def _apply_cpml_e_distributed(
 
     new_psi_ey_zlo = b_yn * cpml_state.psi_ey_zlo + c_yn * curl_hx_dz_zlo_t
     correction_ey_zlo = jnp.transpose(new_psi_ey_zlo, (2, 1, 0))
-    ey = ey.at[:, :, :n].add(coeff_e * correction_ey_zlo)
+    ey = ey.at[:, :, :n].add(ce_zlo * correction_ey_zlo)
     kappa_corr_ey_zlo = jnp.transpose((1.0 / k_yn - 1.0) * curl_hx_dz_zlo_t, (2, 1, 0))
-    ey = ey.at[:, :, :n].add(coeff_e * kappa_corr_ey_zlo)
+    ey = ey.at[:, :, :n].add(ce_zlo * kappa_corr_ey_zlo)
 
     # --- Z-hi: Ey correction from dHx/dz ---
     hx_zhi = state.hx[:, :, -n:]
@@ -928,9 +947,9 @@ def _apply_cpml_e_distributed(
 
     new_psi_ey_zhi = b_yrn * cpml_state.psi_ey_zhi + c_yrn * curl_hx_dz_zhi_t
     correction_ey_zhi = jnp.transpose(new_psi_ey_zhi, (2, 1, 0))
-    ey = ey.at[:, :, -n:].add(coeff_e * correction_ey_zhi)
+    ey = ey.at[:, :, -n:].add(ce_zhi * correction_ey_zhi)
     kappa_corr_ey_zhi = jnp.transpose((1.0 / k_yrn - 1.0) * curl_hx_dz_zhi_t, (2, 1, 0))
-    ey = ey.at[:, :, -n:].add(coeff_e * kappa_corr_ey_zhi)
+    ey = ey.at[:, :, -n:].add(ce_zhi * kappa_corr_ey_zhi)
 
     state = state._replace(ex=ex, ey=ey, ez=ez)
     cpml_state = cpml_state._replace(
@@ -956,7 +975,7 @@ def _apply_cpml_e_distributed(
 
 def _apply_cpml_h_distributed(
     state, cpml_params, cpml_state, n_cpml, dt, dx,
-    n_devices, ghost=1, axis_name="devices",
+    n_devices, ghost=1, axis_name="devices", mu_r=None,
 ):
     """Apply CPML H-field correction on a distributed slab.
 
@@ -981,10 +1000,26 @@ def _apply_cpml_h_distributed(
     ghost : int
         Number of ghost cells on each side of x (default 1).
     axis_name : str
+    mu_r : jnp.ndarray or None
+        Per-cell relative permeability slab (nx_local+2*ghost, ny, nz),
+        same ghost layout as the field slab.  When provided, the CPML
+        H-coefficient is the material-aware ``dt / (mu_r * mu_0)`` (mirrors
+        the single-device ``apply_cpml_h``).  ``None`` falls back to the
+        vacuum scalar ``dt / mu_0`` (bit-identical to pre-#205 behaviour).
     """
     n = n_cpml
     g = ghost
-    coeff_h = cpml_coeff_h_vacuum(dt)  # dt / mu_0 (vacuum)
+    # Per-face H-coefficient (material-aware when mu_r is supplied).
+    if mu_r is not None:
+        _ch = dt / (mu_r * MU_0)  # (nx_local+2g, ny, nz)
+        ch_xlo = _ch[g:g + n, :, :]
+        ch_xhi = _ch[-(g + n):-g, :, :] if g > 0 else _ch[-n:, :, :]
+        ch_ylo = _ch[:, :n, :]
+        ch_yhi = _ch[:, -n:, :]
+        ch_zlo = _ch[:, :, :n]
+        ch_zhi = _ch[:, :, -n:]
+    else:
+        ch_xlo = ch_xhi = ch_ylo = ch_yhi = ch_zlo = ch_zhi = cpml_coeff_h_vacuum(dt)
 
     b = cpml_params.b
     c = cpml_params.c
@@ -1021,7 +1056,7 @@ def _apply_cpml_h_distributed(
     curl_ez_dx_xlo = (ez_shifted_xlo - ez_xlo) / dx
 
     new_psi_hy_xlo = b_x * cpml_state.psi_hy_xlo + c_x * curl_ez_dx_xlo
-    hy_corr_xlo = coeff_h * new_psi_hy_xlo + coeff_h * (1.0 / k_x - 1.0) * curl_ez_dx_xlo
+    hy_corr_xlo = ch_xlo * new_psi_hy_xlo + ch_xlo * (1.0 / k_x - 1.0) * curl_ez_dx_xlo
     hy_corr_xlo = jnp.where(is_first, hy_corr_xlo, 0.0)
     hy = hy.at[xlo, :, :].add(hy_corr_xlo)
     new_psi_hy_xlo = jnp.where(is_first, new_psi_hy_xlo, cpml_state.psi_hy_xlo)
@@ -1032,7 +1067,7 @@ def _apply_cpml_h_distributed(
     curl_ez_dx_xhi = (ez_shifted_xhi - ez_xhi) / dx
 
     new_psi_hy_xhi = b_xr * cpml_state.psi_hy_xhi + c_xr * curl_ez_dx_xhi
-    hy_corr_xhi = coeff_h * new_psi_hy_xhi + coeff_h * (1.0 / k_xr - 1.0) * curl_ez_dx_xhi
+    hy_corr_xhi = ch_xhi * new_psi_hy_xhi + ch_xhi * (1.0 / k_xr - 1.0) * curl_ez_dx_xhi
     hy_corr_xhi = jnp.where(is_last, hy_corr_xhi, 0.0)
     hy = hy.at[xhi, :, :].add(hy_corr_xhi)
     new_psi_hy_xhi = jnp.where(is_last, new_psi_hy_xhi, cpml_state.psi_hy_xhi)
@@ -1045,7 +1080,7 @@ def _apply_cpml_h_distributed(
 
     new_psi_hz_xlo = b_x * cpml_state.psi_hz_xlo + c_x * curl_ey_dx_xlo_t
     correction_hz_xlo = jnp.transpose(new_psi_hz_xlo, (0, 2, 1))
-    hz_corr_xlo = -coeff_h * correction_hz_xlo - coeff_h * (1.0 / k_x - 1.0) * curl_ey_dx_xlo
+    hz_corr_xlo = -ch_xlo * correction_hz_xlo - ch_xlo * (1.0 / k_x - 1.0) * curl_ey_dx_xlo
     hz_corr_xlo = jnp.where(is_first, hz_corr_xlo, 0.0)
     hz = hz.at[xlo, :, :].add(hz_corr_xlo)
     new_psi_hz_xlo = jnp.where(is_first, new_psi_hz_xlo, cpml_state.psi_hz_xlo)
@@ -1058,7 +1093,7 @@ def _apply_cpml_h_distributed(
 
     new_psi_hz_xhi = b_xr * cpml_state.psi_hz_xhi + c_xr * curl_ey_dx_xhi_t
     correction_hz_xhi = jnp.transpose(new_psi_hz_xhi, (0, 2, 1))
-    hz_corr_xhi = -coeff_h * correction_hz_xhi - coeff_h * (1.0 / k_xr - 1.0) * curl_ey_dx_xhi
+    hz_corr_xhi = -ch_xhi * correction_hz_xhi - ch_xhi * (1.0 / k_xr - 1.0) * curl_ey_dx_xhi
     hz_corr_xhi = jnp.where(is_last, hz_corr_xhi, 0.0)
     hz = hz.at[xhi, :, :].add(hz_corr_xhi)
     new_psi_hz_xhi = jnp.where(is_last, new_psi_hz_xhi, cpml_state.psi_hz_xhi)
@@ -1081,9 +1116,9 @@ def _apply_cpml_h_distributed(
 
     new_psi_hx_ylo = b_yn * cpml_state.psi_hx_ylo + c_yn * curl_ez_dy_ylo_t
     correction_hx_ylo = jnp.transpose(new_psi_hx_ylo, (1, 0, 2))
-    hx = hx.at[:, :n, :].add(-coeff_h * correction_hx_ylo)
+    hx = hx.at[:, :n, :].add(-ch_ylo * correction_hx_ylo)
     kappa_corr_hx_ylo = jnp.transpose((1.0 / k_yn - 1.0) * curl_ez_dy_ylo_t, (1, 0, 2))
-    hx = hx.at[:, :n, :].add(-coeff_h * kappa_corr_hx_ylo)
+    hx = hx.at[:, :n, :].add(-ch_ylo * kappa_corr_hx_ylo)
 
     # --- Y-hi: Hx correction from dEz/dy ---
     ez_yhi = state.ez[:, -n:, :]
@@ -1093,9 +1128,9 @@ def _apply_cpml_h_distributed(
 
     new_psi_hx_yhi = b_yrn * cpml_state.psi_hx_yhi + c_yrn * curl_ez_dy_yhi_t
     correction_hx_yhi = jnp.transpose(new_psi_hx_yhi, (1, 0, 2))
-    hx = hx.at[:, -n:, :].add(-coeff_h * correction_hx_yhi)
+    hx = hx.at[:, -n:, :].add(-ch_yhi * correction_hx_yhi)
     kappa_corr_hx_yhi = jnp.transpose((1.0 / k_yrn - 1.0) * curl_ez_dy_yhi_t, (1, 0, 2))
-    hx = hx.at[:, -n:, :].add(-coeff_h * kappa_corr_hx_yhi)
+    hx = hx.at[:, -n:, :].add(-ch_yhi * kappa_corr_hx_yhi)
 
     # --- Y-lo: Hz correction from dEx/dy ---
     ex_ylo = state.ex[:, :n, :]
@@ -1105,9 +1140,9 @@ def _apply_cpml_h_distributed(
 
     new_psi_hz_ylo = b_yn * cpml_state.psi_hz_ylo + c_yn * curl_ex_dy_ylo_t
     correction_hz_ylo = jnp.transpose(new_psi_hz_ylo, (2, 0, 1))
-    hz = hz.at[:, :n, :].add(coeff_h * correction_hz_ylo)
+    hz = hz.at[:, :n, :].add(ch_ylo * correction_hz_ylo)
     kappa_corr_hz_ylo = jnp.transpose((1.0 / k_yn - 1.0) * curl_ex_dy_ylo_t, (2, 0, 1))
-    hz = hz.at[:, :n, :].add(coeff_h * kappa_corr_hz_ylo)
+    hz = hz.at[:, :n, :].add(ch_ylo * kappa_corr_hz_ylo)
 
     # --- Y-hi: Hz correction from dEx/dy ---
     ex_yhi = state.ex[:, -n:, :]
@@ -1117,9 +1152,9 @@ def _apply_cpml_h_distributed(
 
     new_psi_hz_yhi = b_yrn * cpml_state.psi_hz_yhi + c_yrn * curl_ex_dy_yhi_t
     correction_hz_yhi = jnp.transpose(new_psi_hz_yhi, (2, 0, 1))
-    hz = hz.at[:, -n:, :].add(coeff_h * correction_hz_yhi)
+    hz = hz.at[:, -n:, :].add(ch_yhi * correction_hz_yhi)
     kappa_corr_hz_yhi = jnp.transpose((1.0 / k_yrn - 1.0) * curl_ex_dy_yhi_t, (2, 0, 1))
-    hz = hz.at[:, -n:, :].add(coeff_h * kappa_corr_hz_yhi)
+    hz = hz.at[:, -n:, :].add(ch_yhi * kappa_corr_hz_yhi)
 
     # =======================================================================
     # Z-axis CPML (all devices)
@@ -1133,9 +1168,9 @@ def _apply_cpml_h_distributed(
 
     new_psi_hx_zlo = b_yn * cpml_state.psi_hx_zlo + c_yn * curl_ey_dz_zlo_t
     correction_hx_zlo = jnp.transpose(new_psi_hx_zlo, (1, 2, 0))
-    hx = hx.at[:, :, :n].add(coeff_h * correction_hx_zlo)
+    hx = hx.at[:, :, :n].add(ch_zlo * correction_hx_zlo)
     kappa_corr_hx_zlo = jnp.transpose((1.0 / k_yn - 1.0) * curl_ey_dz_zlo_t, (1, 2, 0))
-    hx = hx.at[:, :, :n].add(coeff_h * kappa_corr_hx_zlo)
+    hx = hx.at[:, :, :n].add(ch_zlo * kappa_corr_hx_zlo)
 
     # --- Z-hi: Hx correction from dEy/dz ---
     ey_zhi = state.ey[:, :, -n:]
@@ -1145,9 +1180,9 @@ def _apply_cpml_h_distributed(
 
     new_psi_hx_zhi = b_yrn * cpml_state.psi_hx_zhi + c_yrn * curl_ey_dz_zhi_t
     correction_hx_zhi = jnp.transpose(new_psi_hx_zhi, (1, 2, 0))
-    hx = hx.at[:, :, -n:].add(coeff_h * correction_hx_zhi)
+    hx = hx.at[:, :, -n:].add(ch_zhi * correction_hx_zhi)
     kappa_corr_hx_zhi = jnp.transpose((1.0 / k_yrn - 1.0) * curl_ey_dz_zhi_t, (1, 2, 0))
-    hx = hx.at[:, :, -n:].add(coeff_h * kappa_corr_hx_zhi)
+    hx = hx.at[:, :, -n:].add(ch_zhi * kappa_corr_hx_zhi)
 
     # --- Z-lo: Hy correction from dEx/dz ---
     ex_zlo = state.ex[:, :, :n]
@@ -1157,9 +1192,9 @@ def _apply_cpml_h_distributed(
 
     new_psi_hy_zlo = b_yn * cpml_state.psi_hy_zlo + c_yn * curl_ex_dz_zlo_t
     correction_hy_zlo = jnp.transpose(new_psi_hy_zlo, (2, 1, 0))
-    hy = hy.at[:, :, :n].add(-coeff_h * correction_hy_zlo)
+    hy = hy.at[:, :, :n].add(-ch_zlo * correction_hy_zlo)
     kappa_corr_hy_zlo = jnp.transpose((1.0 / k_yn - 1.0) * curl_ex_dz_zlo_t, (2, 1, 0))
-    hy = hy.at[:, :, :n].add(-coeff_h * kappa_corr_hy_zlo)
+    hy = hy.at[:, :, :n].add(-ch_zlo * kappa_corr_hy_zlo)
 
     # --- Z-hi: Hy correction from dEx/dz ---
     ex_zhi = state.ex[:, :, -n:]
@@ -1169,9 +1204,9 @@ def _apply_cpml_h_distributed(
 
     new_psi_hy_zhi = b_yrn * cpml_state.psi_hy_zhi + c_yrn * curl_ex_dz_zhi_t
     correction_hy_zhi = jnp.transpose(new_psi_hy_zhi, (2, 1, 0))
-    hy = hy.at[:, :, -n:].add(-coeff_h * correction_hy_zhi)
+    hy = hy.at[:, :, -n:].add(-ch_zhi * correction_hy_zhi)
     kappa_corr_hy_zhi = jnp.transpose((1.0 / k_yrn - 1.0) * curl_ex_dz_zhi_t, (2, 1, 0))
-    hy = hy.at[:, :, -n:].add(-coeff_h * kappa_corr_hy_zhi)
+    hy = hy.at[:, :, -n:].add(-ch_zhi * kappa_corr_hy_zhi)
 
     state = state._replace(hx=hx, hy=hy, hz=hz)
     cpml_state = cpml_state._replace(

--- a/rfx/runners/distributed_v2.py
+++ b/rfx/runners/distributed_v2.py
@@ -279,8 +279,15 @@ def _apply_pmc_shmap(state: FDTDState, mesh: Mesh, n_devices: int,
 # ---------------------------------------------------------------------------
 
 def _apply_cpml_e_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
-                         mesh, n_devices, ghost=1):
-    """Apply CPML E-field correction using shard_map."""
+                         mesh, n_devices, ghost=1, eps_r=None):
+    """Apply CPML E-field correction using shard_map.
+
+    ``eps_r`` (the x-sharded per-cell relative permittivity slab) is a new
+    READ-ONLY input: it is threaded into the inner shard so the CPML
+    correction is material-aware (#205).  It is NOT returned, so it gets an
+    extra ``P("x")`` entry in ``in_specs`` only.  ``None`` reproduces the
+    vacuum (pre-#205) coefficient bit-identically.
+    """
 
     @partial(
         shard_map,
@@ -296,6 +303,7 @@ def _apply_cpml_e_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
             P("x"), P("x"), P("x"), P("x"),  # ey_xlo/xhi, ez_xlo/xhi
             P("x"), P("x"), P("x"), P("x"),  # ex_ylo/yhi, ez_ylo/yhi
             P("x"), P("x"), P("x"), P("x"),  # ex_zlo/zhi, ey_zlo/zhi
+            P("x"),  # eps_r (read-only, material-aware coefficient)
         ),
         out_specs=(
             P("x"), P("x"), P("x"),           # ex, ey, ez
@@ -308,7 +316,8 @@ def _apply_cpml_e_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
     def _cpml_e(ex, ey, ez, hx, hy, hz,
                 psi_ey_xlo, psi_ey_xhi, psi_ez_xlo, psi_ez_xhi,
                 psi_ex_ylo, psi_ex_yhi, psi_ez_ylo, psi_ez_yhi,
-                psi_ex_zlo, psi_ex_zhi, psi_ey_zlo, psi_ey_zhi):
+                psi_ex_zlo, psi_ex_zhi, psi_ey_zlo, psi_ey_zhi,
+                eps_r_slab):
         # Reconstruct minimal state and cpml_state objects
         from rfx.core.yee import FDTDState as _FS
         _st = _FS(ex=ex, ey=ey, ez=ez, hx=hx, hy=hy, hz=hz, step=jnp.int32(0))
@@ -322,7 +331,7 @@ def _apply_cpml_e_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
         )
         new_st, new_cs = _apply_cpml_e_distributed(
             _st, cpml_params, _cs, n_cpml, dt, dx,
-            n_devices, ghost=ghost, axis_name="x")
+            n_devices, ghost=ghost, axis_name="x", eps_r=eps_r_slab)
         return (
             new_st.ex, new_st.ey, new_st.ez,
             new_cs.psi_ey_xlo, new_cs.psi_ey_xhi,
@@ -345,6 +354,7 @@ def _apply_cpml_e_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
         cpml_state.psi_ez_ylo, cpml_state.psi_ez_yhi,
         cpml_state.psi_ex_zlo, cpml_state.psi_ex_zhi,
         cpml_state.psi_ey_zlo, cpml_state.psi_ey_zhi,
+        eps_r,
     )
     new_state = state._replace(ex=ex, ey=ey, ez=ez)
     new_cpml = cpml_state._replace(
@@ -359,8 +369,15 @@ def _apply_cpml_e_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
 
 
 def _apply_cpml_h_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
-                         mesh, n_devices, ghost=1):
-    """Apply CPML H-field correction using shard_map."""
+                         mesh, n_devices, ghost=1, mu_r=None):
+    """Apply CPML H-field correction using shard_map.
+
+    ``mu_r`` (the x-sharded per-cell relative permeability slab) is a new
+    READ-ONLY input threaded into the inner shard for material-aware CPML
+    (#205).  Like ``eps_r`` in the E-variant it gets one extra ``P("x")``
+    in ``in_specs`` only and is not returned.  ``None`` reproduces the
+    vacuum (pre-#205) coefficient bit-identically.
+    """
 
     @partial(
         shard_map,
@@ -375,6 +392,7 @@ def _apply_cpml_h_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
             P("x"), P("x"), P("x"), P("x"),  # hy_xlo/xhi, hz_xlo/xhi
             P("x"), P("x"), P("x"), P("x"),  # hx_ylo/yhi, hz_ylo/yhi
             P("x"), P("x"), P("x"), P("x"),  # hx_zlo/zhi, hy_zlo/zhi
+            P("x"),  # mu_r (read-only, material-aware coefficient)
         ),
         out_specs=(
             P("x"), P("x"), P("x"),           # hx, hy, hz
@@ -387,7 +405,8 @@ def _apply_cpml_h_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
     def _cpml_h(ex, ey, ez, hx, hy, hz,
                 psi_hy_xlo, psi_hy_xhi, psi_hz_xlo, psi_hz_xhi,
                 psi_hx_ylo, psi_hx_yhi, psi_hz_ylo, psi_hz_yhi,
-                psi_hx_zlo, psi_hx_zhi, psi_hy_zlo, psi_hy_zhi):
+                psi_hx_zlo, psi_hx_zhi, psi_hy_zlo, psi_hy_zhi,
+                mu_r_slab):
         from rfx.core.yee import FDTDState as _FS
         _st = _FS(ex=ex, ey=ey, ez=ez, hx=hx, hy=hy, hz=hz, step=jnp.int32(0))
         _cs = cpml_state._replace(
@@ -400,7 +419,7 @@ def _apply_cpml_h_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
         )
         new_st, new_cs = _apply_cpml_h_distributed(
             _st, cpml_params, _cs, n_cpml, dt, dx,
-            n_devices, ghost=ghost, axis_name="x")
+            n_devices, ghost=ghost, axis_name="x", mu_r=mu_r_slab)
         return (
             new_st.hx, new_st.hy, new_st.hz,
             new_cs.psi_hy_xlo, new_cs.psi_hy_xhi,
@@ -423,6 +442,7 @@ def _apply_cpml_h_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
         cpml_state.psi_hz_ylo, cpml_state.psi_hz_yhi,
         cpml_state.psi_hx_zlo, cpml_state.psi_hx_zhi,
         cpml_state.psi_hy_zlo, cpml_state.psi_hy_zhi,
+        mu_r,
     )
     new_state = state._replace(hx=hx, hy=hy, hz=hz)
     new_cpml = cpml_state._replace(
@@ -1232,10 +1252,10 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
         # 1. H update
         st = _update_h_shmap(st, sharded_materials)
 
-        # 2. CPML H correction
+        # 2. CPML H correction (material-aware, #205)
         st, cpml_st = _apply_cpml_h_shmap(
             st, cpml_params, cpml_st, n_cpml, dt, dx,
-            mesh, n_devices, ghost=ghost)
+            mesh, n_devices, ghost=ghost, mu_r=sharded_materials.mu_r)
 
         # 3. Exchange H ghost cells (conditionally skip)
         do_exchange = (_step_idx % _exchange_interval == 0)
@@ -1258,10 +1278,10 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
             debye_coeffs_sharded, db_st,
             lorentz_coeffs_sharded, lr_st)
 
-        # 5. CPML E correction
+        # 5. CPML E correction (material-aware, #205)
         st, cpml_st = _apply_cpml_e_shmap(
             st, cpml_params, cpml_st, n_cpml, dt, dx,
-            mesh, n_devices, ghost=ghost)
+            mesh, n_devices, ghost=ghost, eps_r=sharded_materials.eps_r)
 
         # 6. Exchange E ghost cells
         st = lax.cond(

--- a/tests/test_distributed_cpml_dielectric.py
+++ b/tests/test_distributed_cpml_dielectric.py
@@ -1,0 +1,116 @@
+"""Distributed-CPML material-awareness regression (#205).
+
+Before this fix the distributed FDTD runners applied the CPML correction
+with a HARDCODED VACUUM coefficient ``dt/eps_0`` (E) / ``dt/mu_0`` (H),
+ignoring the local material.  Inside a dielectric of ``eps_r`` the correct
+E-coefficient is ``dt/(eps_r*eps_0)`` -- the vacuum value is ``eps_r`` x too
+large, so the distributed absorber over-corrects and the field DIVERGES once
+the wave reaches the absorber (witnessed: a 2-device eps_r=9 sim blows up to
+inf at step ~75 while single-device stays finite at ~3.3e-3).
+
+The single-device path (``rfx/boundaries/cpml.py``) has been material-aware
+since #204, so ``sim.run(...)`` is the correct reference and the distributed
+path must agree with it.  This test pins that agreement.
+
+Fast-suite (NOT gpu-marked) but multi-device: it sets the CPU host-device
+sentinel before importing jax and SKIPS cleanly when <2 devices are
+available (e.g. a single-GPU pod, or a shared pytest process where another
+module initialised jax first -- the XLA_FLAGS sentinel is process-global and
+first-init-wins).  It runs correctly in an isolated invocation.
+"""
+
+import os
+# Must be set before importing jax so we get >=2 host CPU devices.
+os.environ.setdefault("XLA_FLAGS", "--xla_force_host_platform_device_count=2")
+
+import numpy as np
+import jax
+import pytest
+
+from rfx import Box, GaussianPulse, Simulation
+
+requires_multidevice = pytest.mark.skipif(
+    jax.device_count() < 2,
+    reason=(
+        f"distributed CPML test needs >=2 JAX devices (got "
+        f"{jax.device_count()}); the XLA host-device-count sentinel only adds "
+        "virtual devices on the CPU backend and is ignored if jax was already "
+        "initialised by another module first."
+    ),
+)
+
+# --- run parameters (mirrors the #205 witness) ---
+_DOMAIN = (0.02, 0.02, 0.02)   # 10 x 10 x 10 interior cells at dx=2mm
+_DX = 0.002
+_CPML_LAYERS = 6
+_FREQ_MAX = 5e9
+_F0 = 3e9
+_N_STEPS = 200
+_EPS_DIELECTRIC = 9.0
+
+
+def _build_sim(eps_r: float) -> Simulation:
+    """Open CPML cube whose dielectric (eps_r) fills the ENTIRE domain,
+    including every CPML face, with a central source radiating outward so
+    energy is absorbed THROUGH the dielectric-filled absorber."""
+    sim = Simulation(
+        freq_max=_FREQ_MAX, domain=_DOMAIN,
+        boundary="cpml", cpml_layers=_CPML_LAYERS, dx=_DX,
+    )
+    sim.add_material("d", eps_r=eps_r)
+    sim.add(Box((-1.0, -1.0, -1.0), (1.0, 1.0, 1.0)), material="d")
+    cx, cy, cz = _DOMAIN[0] / 2, _DOMAIN[1] / 2, _DOMAIN[2] / 2
+    sim.add_source((cx, cy, cz), "ez", waveform=GaussianPulse(f0=_F0))
+    return sim
+
+
+def _max_abs_e(result) -> float:
+    """max|E| over all three E components at the final step (inf if any
+    NaN/inf is present so divergence reports as non-finite)."""
+    st = result.state
+    m = 0.0
+    for comp in ("ex", "ey", "ez"):
+        arr = np.asarray(getattr(st, comp))
+        if not np.isfinite(arr).all():
+            return np.inf
+        m = max(m, float(np.abs(arr).max()))
+    return m
+
+
+@requires_multidevice
+def test_distributed_cpml_dielectric_finite_and_matches_single():
+    """eps_r=9 filling the CPML: distributed must be finite AND match
+    single-device (pre-#205 the distributed path diverged to inf)."""
+    devices = jax.devices()[:2]
+
+    single = _max_abs_e(_build_sim(_EPS_DIELECTRIC).run(n_steps=_N_STEPS))
+    multi = _max_abs_e(
+        _build_sim(_EPS_DIELECTRIC).run(n_steps=_N_STEPS, devices=devices))
+
+    # (a) distributed result is finite / bounded (the bug produced inf).
+    assert np.isfinite(multi), (
+        f"distributed dielectric max|E| not finite ({multi}) -- the #205 "
+        "vacuum-coefficient divergence has regressed")
+    assert multi < 1e3, f"distributed dielectric max|E|={multi} grossly large"
+
+    # (b) distributed ~= single-device (the correct material-aware reference).
+    rel = abs(multi - single) / max(abs(single), 1e-30)
+    assert rel < 1e-2, (
+        f"distributed dielectric max|E|={multi:.6e} disagrees with single "
+        f"max|E|={single:.6e} (rel-diff {rel:.3e} >= 1e-2)")
+
+
+@requires_multidevice
+def test_distributed_cpml_responds_to_eps():
+    """Sanity: the distributed CPML coefficient actually depends on eps_r --
+    a vacuum vs a dielectric fill give distinguishable bounded responses
+    (guards against the coefficient being silently constant again)."""
+    devices = jax.devices()[:2]
+    vac = _max_abs_e(_build_sim(1.0).run(n_steps=_N_STEPS, devices=devices))
+    diel = _max_abs_e(
+        _build_sim(_EPS_DIELECTRIC).run(n_steps=_N_STEPS, devices=devices))
+    assert np.isfinite(vac) and np.isfinite(diel)
+    # Different permittivity -> different field magnitude at the same step.
+    assert abs(vac - diel) / max(vac, 1e-30) > 1e-3, (
+        f"vacuum ({vac:.6e}) and dielectric ({diel:.6e}) responses are "
+        "indistinguishable -- eps_r is not influencing the distributed run")


### PR DESCRIPTION
## What

Makes the **uniform distributed** FDTD CPML correction material-aware, the next piece of #205 (after #204 uniform, #208 non-uniform, #224 vmap).

The distributed CPML kernels applied the absorber correction with a **hardcoded vacuum coefficient** `dt/ε₀` (E) / `dt/μ₀` (H), ignoring the local material. Inside a dielectric of `eps_r` the correct E-coefficient is `dt/(eps_r·ε₀)` — the vacuum value is `eps_r`× too strong, so the distributed absorber over-corrects and the field **diverges** once the wave reaches a dielectric-filled CPML face.

## Witness (the bug, on clean `main`)

A 2-device sim with `eps_r=9` filling the whole domain (so every CPML face sits inside the dielectric), central source radiating outward:

| step | single max\|E\| | distributed max\|E\| |
|---|---|---|
| 50 | 1.09e-2 | 1.09e-2 (agree, energy still interior) |
| 75 | 5.82e-2 | **1.61e+2** (wave hits CPML — distributed explodes) |
| 100 | 2.08e-1 | 7.55e+8 |
| 150 | 7.99e-1 | 1.67e+26 |
| 300 | 3.31e-3 (absorbs cleanly) | **inf** |

The single-device path (`rfx/boundaries/cpml.py`, material-aware since #204) stays finite — it is the correct reference. After the fix, distributed dielectric `max|E|` = **3.32e-3 ≈ single 3.31e-3 (ratio 1.003)**.

## Fix

Per-face material-aware coefficients mirroring the validated single-device `apply_cpml_e/h`:
- `rfx/runners/distributed.py` — `_apply_cpml_{e,h}_distributed` gain `eps_r=None`/`mu_r=None`; the scalar `coeff_e/h` becomes per-face slices `dt/(eps_r·ε₀)` / `dt/(mu_r·μ₀)`. **x-faces use the ghost offset** `[g:g+n]`/`[-(g+n):-g]`; **y/z-faces span the full slab x-extent**. `None` → exact vacuum scalar (bit-identical to pre-#205).
- `rfx/runners/distributed_v2.py` (the live `sim.run(devices=...)` shard_map runner) — threads `sharded_materials.eps_r/.mu_r` as one new **read-only `P("x")`** `shard_map` input (in_specs only; not returned).

## Scope

**Uniform distributed only** — fully witnessed. `distributed_nu.py` (non-uniform distributed, `_apply_cpml_{e,h}_local_nu`) carries the same vacuum-coefficient pattern and is a **separate follow-up** that needs its own NU witness before shipping (per the repo's "no surface-metric verdict" rule — won't ship it on "same pattern" plausibility).

## Verification (independent reproduction + read-only audit)

- **Witness flip**: dielectric distributed inf → finite 3.32e-3, matches single to ~5 sig figs across the full trace.
- **New regression test** `tests/test_distributed_cpml_dielectric.py` (fast-suite, CPU 2-device sentinel): finite + matches single-device + responds-to-eps anti-regression. `2 passed` in 8.5s, genuinely runs (no silent skip).
- **Bit-identity guard** `test_cpml_axis_params_refactor_bit_identical.py`: 9/9 (single-device scan body untouched).
- **Existing distributed suite** (`-m gpu`): 30/30 incl. the vacuum `test_distributed_cpml_matches_single` gate.
- **Vacuum**: now computes `dt/(1·ε₀)` in float32 like the single-device reference (was a float64 scalar) — a ~6e-8 *consistency* shift that makes distributed-vacuum match single-device-vacuum, not a regression.
- **AD**: uniform distributed has no grad path (`forward(distributed=True)` is NU-only); no tape impact.
- ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)