### PR TITLE
fix(cpml): material-aware CPML on the non-uniform distributed scan body (#205)

### DIFF
--- a/rfx/runners/distributed_nu.py
+++ b/rfx/runners/distributed_nu.py
@@ -1438,7 +1438,7 @@ def _update_e_dispersive_local_nu(
 
 def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
                            n_cpml: int, dt: float, ghost: int,
-                           n_devices: int):
+                           n_devices: int, eps_r=None):
     """Per-rank slab-aware CPML E-field correction with NU per-axis dx.
 
     Mirrors :func:`rfx.boundaries.cpml.apply_cpml_e` but operates on a
@@ -1448,10 +1448,19 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
 
     Must be called inside ``shard_map`` so ``lax.axis_index("x")`` is
     available.
+
+    Parameters
+    ----------
+    eps_r : jnp.ndarray or None
+        Per-cell relative permittivity slab
+        ``(nx_local + 2*ghost, ny, nz)``, the same ghost layout as the
+        field slab.  When provided, the CPML E-coefficient is the
+        material-aware ``dt / (eps_r * eps_0)`` so the absorber stays
+        impedance-matched inside a dielectric (mirrors the single-device,
+        material-aware NU path, #208).  ``None`` falls back to the vacuum
+        scalar ``dt / eps_0`` (bit-identical to the pre-#205 behaviour).
     """
     from rfx.boundaries.cpml import CPMLAxisParams
-
-    coeff_e = cpml_coeff_e_vacuum(dt)  # vacuum coefficient (matches uniform path)
 
     if isinstance(cpml_params, CPMLAxisParams):
         # T7 PR1: read lo-face profile; scan body synthesises the hi-face
@@ -1493,6 +1502,22 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
     xlo = slice(g, g + n)
     xhi = slice(-(g + n), -g) if g > 0 else slice(-n, None)
 
+    # Per-face E-coefficient (material-aware when eps_r is supplied, #205).
+    # Each face slice broadcasts element-wise against its correction array:
+    # x faces account for the ghost offset (reuse xlo/xhi); y/z faces have
+    # no x-ghost so they slice the full local x extent.  When eps_r is None
+    # every face is the vacuum scalar dt/eps_0 (bit-identical to pre-#205).
+    if eps_r is not None:
+        _ce = dt / (eps_r * EPS_0)  # (nx_local + 2*ghost, ny, nz)
+        ce_xlo = _ce[xlo, :, :]
+        ce_xhi = _ce[xhi, :, :]
+        ce_ylo = _ce[:, :n, :]
+        ce_yhi = _ce[:, -n:, :]
+        ce_zlo = _ce[:, :, :n]
+        ce_zhi = _ce[:, :, -n:]
+    else:
+        ce_xlo = ce_xhi = ce_ylo = ce_yhi = ce_zlo = ce_zhi = cpml_coeff_e_vacuum(dt)
+
     device_idx = lax.axis_index("x")
     is_first = (device_idx == 0)
     is_last = (device_idx == n_devices - 1)
@@ -1514,8 +1539,8 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_hz_dx_xlo = (hz_xlo - hz_shifted_xlo) / dx_x
     new_psi_ey_xlo = b_x * cpml_state.psi_ey_xlo + c_x * curl_hz_dx_xlo
     ey_corr_xlo = (
-        -coeff_e * new_psi_ey_xlo
-        - coeff_e * (1.0 / k_x - 1.0) * curl_hz_dx_xlo
+        -ce_xlo * new_psi_ey_xlo
+        - ce_xlo * (1.0 / k_x - 1.0) * curl_hz_dx_xlo
     )
     ey_corr_xlo = jnp.where(is_first, ey_corr_xlo, 0.0)
     ey = ey.at[xlo, :, :].add(ey_corr_xlo)
@@ -1527,8 +1552,8 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_hz_dx_xhi = (hz_xhi - hz_shifted_xhi) / dx_x
     new_psi_ey_xhi = b_xr * cpml_state.psi_ey_xhi + c_xr * curl_hz_dx_xhi
     ey_corr_xhi = (
-        -coeff_e * new_psi_ey_xhi
-        - coeff_e * (1.0 / k_xr - 1.0) * curl_hz_dx_xhi
+        -ce_xhi * new_psi_ey_xhi
+        - ce_xhi * (1.0 / k_xr - 1.0) * curl_hz_dx_xhi
     )
     ey_corr_xhi = jnp.where(is_last, ey_corr_xhi, 0.0)
     ey = ey.at[xhi, :, :].add(ey_corr_xhi)
@@ -1542,8 +1567,8 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
     new_psi_ez_xlo = b_x * cpml_state.psi_ez_xlo + c_x * curl_hy_dx_xlo_t
     correction_ez_xlo = jnp.transpose(new_psi_ez_xlo, (0, 2, 1))
     ez_corr_xlo = (
-        coeff_e * correction_ez_xlo
-        + coeff_e * (1.0 / k_x - 1.0) * curl_hy_dx_xlo
+        ce_xlo * correction_ez_xlo
+        + ce_xlo * (1.0 / k_x - 1.0) * curl_hy_dx_xlo
     )
     ez_corr_xlo = jnp.where(is_first, ez_corr_xlo, 0.0)
     ez = ez.at[xlo, :, :].add(ez_corr_xlo)
@@ -1557,8 +1582,8 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
     new_psi_ez_xhi = b_xr * cpml_state.psi_ez_xhi + c_xr * curl_hy_dx_xhi_t
     correction_ez_xhi = jnp.transpose(new_psi_ez_xhi, (0, 2, 1))
     ez_corr_xhi = (
-        coeff_e * correction_ez_xhi
-        + coeff_e * (1.0 / k_xr - 1.0) * curl_hy_dx_xhi
+        ce_xhi * correction_ez_xhi
+        + ce_xhi * (1.0 / k_xr - 1.0) * curl_hy_dx_xhi
     )
     ez_corr_xhi = jnp.where(is_last, ez_corr_xhi, 0.0)
     ez = ez.at[xhi, :, :].add(ez_corr_xhi)
@@ -1574,9 +1599,9 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_hz_dy_ylo_t = jnp.transpose(curl_hz_dy_ylo, (1, 0, 2))
     new_psi_ex_ylo = b_y * cpml_state.psi_ex_ylo + c_y * curl_hz_dy_ylo_t
     correction_ex_ylo = jnp.transpose(new_psi_ex_ylo, (1, 0, 2))
-    ex = ex.at[:, :n, :].add(coeff_e * correction_ex_ylo)
+    ex = ex.at[:, :n, :].add(ce_ylo * correction_ex_ylo)
     kappa_corr_ylo = jnp.transpose((1.0 / k_y - 1.0) * curl_hz_dy_ylo_t, (1, 0, 2))
-    ex = ex.at[:, :n, :].add(coeff_e * kappa_corr_ylo)
+    ex = ex.at[:, :n, :].add(ce_ylo * kappa_corr_ylo)
 
     # --- Y-hi: Ex from dHz/dy ---
     hz_yhi = state.hz[:, -n:, :]
@@ -1585,9 +1610,9 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_hz_dy_yhi_t = jnp.transpose(curl_hz_dy_yhi, (1, 0, 2))
     new_psi_ex_yhi = b_yr * cpml_state.psi_ex_yhi + c_yr * curl_hz_dy_yhi_t
     correction_ex_yhi = jnp.transpose(new_psi_ex_yhi, (1, 0, 2))
-    ex = ex.at[:, -n:, :].add(coeff_e * correction_ex_yhi)
+    ex = ex.at[:, -n:, :].add(ce_yhi * correction_ex_yhi)
     kappa_corr_yhi = jnp.transpose((1.0 / k_yr - 1.0) * curl_hz_dy_yhi_t, (1, 0, 2))
-    ex = ex.at[:, -n:, :].add(coeff_e * kappa_corr_yhi)
+    ex = ex.at[:, -n:, :].add(ce_yhi * kappa_corr_yhi)
 
     # --- Y-lo: Ez from dHx/dy ---
     hx_ylo = state.hx[:, :n, :]
@@ -1596,9 +1621,9 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_hx_dy_ylo_t = jnp.transpose(curl_hx_dy_ylo, (1, 2, 0))
     new_psi_ez_ylo = b_y * cpml_state.psi_ez_ylo + c_y * curl_hx_dy_ylo_t
     correction_ez_ylo = jnp.transpose(new_psi_ez_ylo, (2, 0, 1))
-    ez = ez.at[:, :n, :].add(-coeff_e * correction_ez_ylo)
+    ez = ez.at[:, :n, :].add(-ce_ylo * correction_ez_ylo)
     kappa_corr_ez_ylo = jnp.transpose((1.0 / k_y - 1.0) * curl_hx_dy_ylo_t, (2, 0, 1))
-    ez = ez.at[:, :n, :].add(-coeff_e * kappa_corr_ez_ylo)
+    ez = ez.at[:, :n, :].add(-ce_ylo * kappa_corr_ez_ylo)
 
     # --- Y-hi: Ez from dHx/dy ---
     hx_yhi = state.hx[:, -n:, :]
@@ -1607,9 +1632,9 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_hx_dy_yhi_t = jnp.transpose(curl_hx_dy_yhi, (1, 2, 0))
     new_psi_ez_yhi = b_yr * cpml_state.psi_ez_yhi + c_yr * curl_hx_dy_yhi_t
     correction_ez_yhi = jnp.transpose(new_psi_ez_yhi, (2, 0, 1))
-    ez = ez.at[:, -n:, :].add(-coeff_e * correction_ez_yhi)
+    ez = ez.at[:, -n:, :].add(-ce_yhi * correction_ez_yhi)
     kappa_corr_ez_yhi = jnp.transpose((1.0 / k_yr - 1.0) * curl_hx_dy_yhi_t, (2, 0, 1))
-    ez = ez.at[:, -n:, :].add(-coeff_e * kappa_corr_ez_yhi)
+    ez = ez.at[:, -n:, :].add(-ce_yhi * kappa_corr_ez_yhi)
 
     # =========================================================
     # Z-axis CPML — every rank, sliced over local x extent.
@@ -1621,9 +1646,9 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_hy_dz_zlo_t = jnp.transpose(curl_hy_dz_zlo, (2, 0, 1))
     new_psi_ex_zlo = b_zl * cpml_state.psi_ex_zlo + c_zl * curl_hy_dz_zlo_t
     correction_ex_zlo = jnp.transpose(new_psi_ex_zlo, (1, 2, 0))
-    ex = ex.at[:, :, :n].add(-coeff_e * correction_ex_zlo)
+    ex = ex.at[:, :, :n].add(-ce_zlo * correction_ex_zlo)
     kappa_corr_ex_zlo = jnp.transpose((1.0 / k_zl - 1.0) * curl_hy_dz_zlo_t, (1, 2, 0))
-    ex = ex.at[:, :, :n].add(-coeff_e * kappa_corr_ex_zlo)
+    ex = ex.at[:, :, :n].add(-ce_zlo * kappa_corr_ex_zlo)
 
     # --- Z-hi: Ex from dHy/dz ---
     hy_zhi = state.hy[:, :, -n:]
@@ -1632,9 +1657,9 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_hy_dz_zhi_t = jnp.transpose(curl_hy_dz_zhi, (2, 0, 1))
     new_psi_ex_zhi = b_zh * cpml_state.psi_ex_zhi + c_zh * curl_hy_dz_zhi_t
     correction_ex_zhi = jnp.transpose(new_psi_ex_zhi, (1, 2, 0))
-    ex = ex.at[:, :, -n:].add(-coeff_e * correction_ex_zhi)
+    ex = ex.at[:, :, -n:].add(-ce_zhi * correction_ex_zhi)
     kappa_corr_ex_zhi = jnp.transpose((1.0 / k_zh - 1.0) * curl_hy_dz_zhi_t, (1, 2, 0))
-    ex = ex.at[:, :, -n:].add(-coeff_e * kappa_corr_ex_zhi)
+    ex = ex.at[:, :, -n:].add(-ce_zhi * kappa_corr_ex_zhi)
 
     # --- Z-lo: Ey from dHx/dz ---
     hx_zlo = state.hx[:, :, :n]
@@ -1643,9 +1668,9 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_hx_dz_zlo_t = jnp.transpose(curl_hx_dz_zlo, (2, 1, 0))
     new_psi_ey_zlo = b_zl * cpml_state.psi_ey_zlo + c_zl * curl_hx_dz_zlo_t
     correction_ey_zlo = jnp.transpose(new_psi_ey_zlo, (2, 1, 0))
-    ey = ey.at[:, :, :n].add(coeff_e * correction_ey_zlo)
+    ey = ey.at[:, :, :n].add(ce_zlo * correction_ey_zlo)
     kappa_corr_ey_zlo = jnp.transpose((1.0 / k_zl - 1.0) * curl_hx_dz_zlo_t, (2, 1, 0))
-    ey = ey.at[:, :, :n].add(coeff_e * kappa_corr_ey_zlo)
+    ey = ey.at[:, :, :n].add(ce_zlo * kappa_corr_ey_zlo)
 
     # --- Z-hi: Ey from dHx/dz ---
     hx_zhi = state.hx[:, :, -n:]
@@ -1654,9 +1679,9 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_hx_dz_zhi_t = jnp.transpose(curl_hx_dz_zhi, (2, 1, 0))
     new_psi_ey_zhi = b_zh * cpml_state.psi_ey_zhi + c_zh * curl_hx_dz_zhi_t
     correction_ey_zhi = jnp.transpose(new_psi_ey_zhi, (2, 1, 0))
-    ey = ey.at[:, :, -n:].add(coeff_e * correction_ey_zhi)
+    ey = ey.at[:, :, -n:].add(ce_zhi * correction_ey_zhi)
     kappa_corr_ey_zhi = jnp.transpose((1.0 / k_zh - 1.0) * curl_hx_dz_zhi_t, (2, 1, 0))
-    ey = ey.at[:, :, -n:].add(coeff_e * kappa_corr_ey_zhi)
+    ey = ey.at[:, :, -n:].add(ce_zhi * kappa_corr_ey_zhi)
 
     new_state = state._replace(ex=ex, ey=ey, ez=ez)
     new_cpml = cpml_state._replace(
@@ -1672,15 +1697,23 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
 
 def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
                            n_cpml: int, dt: float, ghost: int,
-                           n_devices: int):
+                           n_devices: int, mu_r=None):
     """Per-rank slab-aware CPML H-field correction with NU per-axis dx.
 
     Mirror of :func:`_apply_cpml_e_local_nu` for the H field.  Same
     ghost-aware slicing, same x-face rank-conditional gating.
+
+    Parameters
+    ----------
+    mu_r : jnp.ndarray or None
+        Per-cell relative permeability slab
+        ``(nx_local + 2*ghost, ny, nz)``, the same ghost layout as the
+        field slab.  When provided, the CPML H-coefficient is the
+        material-aware ``dt / (mu_r * mu_0)`` (mirrors the single-device,
+        material-aware NU path, #208).  ``None`` falls back to the vacuum
+        scalar ``dt / mu_0`` (bit-identical to the pre-#205 behaviour).
     """
     from rfx.boundaries.cpml import CPMLAxisParams
-
-    coeff_h = cpml_coeff_h_vacuum(dt)  # vacuum coefficient (matches uniform path)
 
     if isinstance(cpml_params, CPMLAxisParams):
         # T7 PR1: read lo-face; scan body jnp.flip(px.b) preserves bit-identity.
@@ -1719,6 +1752,20 @@ def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
     xlo = slice(g, g + n)
     xhi = slice(-(g + n), -g) if g > 0 else slice(-n, None)
 
+    # Per-face H-coefficient (material-aware when mu_r is supplied, #205).
+    # Same per-face slicing as the E kernel; vacuum scalar dt/mu_0 when
+    # mu_r is None (bit-identical to pre-#205).
+    if mu_r is not None:
+        _ch = dt / (mu_r * MU_0)  # (nx_local + 2*ghost, ny, nz)
+        ch_xlo = _ch[xlo, :, :]
+        ch_xhi = _ch[xhi, :, :]
+        ch_ylo = _ch[:, :n, :]
+        ch_yhi = _ch[:, -n:, :]
+        ch_zlo = _ch[:, :, :n]
+        ch_zhi = _ch[:, :, -n:]
+    else:
+        ch_xlo = ch_xhi = ch_ylo = ch_yhi = ch_zlo = ch_zhi = cpml_coeff_h_vacuum(dt)
+
     device_idx = lax.axis_index("x")
     is_first = (device_idx == 0)
     is_last = (device_idx == n_devices - 1)
@@ -1734,8 +1781,8 @@ def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_ez_dx_xlo = (ez_shifted_xlo - ez_xlo) / dx_x
     new_psi_hy_xlo = b_x * cpml_state.psi_hy_xlo + c_x * curl_ez_dx_xlo
     hy_corr_xlo = (
-        coeff_h * new_psi_hy_xlo
-        + coeff_h * (1.0 / k_x - 1.0) * curl_ez_dx_xlo
+        ch_xlo * new_psi_hy_xlo
+        + ch_xlo * (1.0 / k_x - 1.0) * curl_ez_dx_xlo
     )
     hy_corr_xlo = jnp.where(is_first, hy_corr_xlo, 0.0)
     hy = hy.at[xlo, :, :].add(hy_corr_xlo)
@@ -1747,8 +1794,8 @@ def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_ez_dx_xhi = (ez_shifted_xhi - ez_xhi) / dx_x
     new_psi_hy_xhi = b_xr * cpml_state.psi_hy_xhi + c_xr * curl_ez_dx_xhi
     hy_corr_xhi = (
-        coeff_h * new_psi_hy_xhi
-        + coeff_h * (1.0 / k_xr - 1.0) * curl_ez_dx_xhi
+        ch_xhi * new_psi_hy_xhi
+        + ch_xhi * (1.0 / k_xr - 1.0) * curl_ez_dx_xhi
     )
     hy_corr_xhi = jnp.where(is_last, hy_corr_xhi, 0.0)
     hy = hy.at[xhi, :, :].add(hy_corr_xhi)
@@ -1762,8 +1809,8 @@ def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
     new_psi_hz_xlo = b_x * cpml_state.psi_hz_xlo + c_x * curl_ey_dx_xlo_t
     correction_hz_xlo = jnp.transpose(new_psi_hz_xlo, (0, 2, 1))
     hz_corr_xlo = (
-        -coeff_h * correction_hz_xlo
-        - coeff_h * (1.0 / k_x - 1.0) * curl_ey_dx_xlo
+        -ch_xlo * correction_hz_xlo
+        - ch_xlo * (1.0 / k_x - 1.0) * curl_ey_dx_xlo
     )
     hz_corr_xlo = jnp.where(is_first, hz_corr_xlo, 0.0)
     hz = hz.at[xlo, :, :].add(hz_corr_xlo)
@@ -1777,8 +1824,8 @@ def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
     new_psi_hz_xhi = b_xr * cpml_state.psi_hz_xhi + c_xr * curl_ey_dx_xhi_t
     correction_hz_xhi = jnp.transpose(new_psi_hz_xhi, (0, 2, 1))
     hz_corr_xhi = (
-        -coeff_h * correction_hz_xhi
-        - coeff_h * (1.0 / k_xr - 1.0) * curl_ey_dx_xhi
+        -ch_xhi * correction_hz_xhi
+        - ch_xhi * (1.0 / k_xr - 1.0) * curl_ey_dx_xhi
     )
     hz_corr_xhi = jnp.where(is_last, hz_corr_xhi, 0.0)
     hz = hz.at[xhi, :, :].add(hz_corr_xhi)
@@ -1792,9 +1839,9 @@ def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_ez_dy_ylo_t = jnp.transpose(curl_ez_dy_ylo, (1, 0, 2))
     new_psi_hx_ylo = b_y * cpml_state.psi_hx_ylo + c_y * curl_ez_dy_ylo_t
     correction_hx_ylo = jnp.transpose(new_psi_hx_ylo, (1, 0, 2))
-    hx = hx.at[:, :n, :].add(-coeff_h * correction_hx_ylo)
+    hx = hx.at[:, :n, :].add(-ch_ylo * correction_hx_ylo)
     kappa_corr_hx_ylo = jnp.transpose((1.0 / k_y - 1.0) * curl_ez_dy_ylo_t, (1, 0, 2))
-    hx = hx.at[:, :n, :].add(-coeff_h * kappa_corr_hx_ylo)
+    hx = hx.at[:, :n, :].add(-ch_ylo * kappa_corr_hx_ylo)
 
     # --- Y-hi: Hx from dEz/dy ---
     ez_yhi = state.ez[:, -n:, :]
@@ -1803,9 +1850,9 @@ def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_ez_dy_yhi_t = jnp.transpose(curl_ez_dy_yhi, (1, 0, 2))
     new_psi_hx_yhi = b_yr * cpml_state.psi_hx_yhi + c_yr * curl_ez_dy_yhi_t
     correction_hx_yhi = jnp.transpose(new_psi_hx_yhi, (1, 0, 2))
-    hx = hx.at[:, -n:, :].add(-coeff_h * correction_hx_yhi)
+    hx = hx.at[:, -n:, :].add(-ch_yhi * correction_hx_yhi)
     kappa_corr_hx_yhi = jnp.transpose((1.0 / k_yr - 1.0) * curl_ez_dy_yhi_t, (1, 0, 2))
-    hx = hx.at[:, -n:, :].add(-coeff_h * kappa_corr_hx_yhi)
+    hx = hx.at[:, -n:, :].add(-ch_yhi * kappa_corr_hx_yhi)
 
     # --- Y-lo: Hz from dEx/dy ---
     ex_ylo = state.ex[:, :n, :]
@@ -1814,9 +1861,9 @@ def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_ex_dy_ylo_t = jnp.transpose(curl_ex_dy_ylo, (1, 2, 0))
     new_psi_hz_ylo = b_y * cpml_state.psi_hz_ylo + c_y * curl_ex_dy_ylo_t
     correction_hz_ylo = jnp.transpose(new_psi_hz_ylo, (2, 0, 1))
-    hz = hz.at[:, :n, :].add(coeff_h * correction_hz_ylo)
+    hz = hz.at[:, :n, :].add(ch_ylo * correction_hz_ylo)
     kappa_corr_hz_ylo = jnp.transpose((1.0 / k_y - 1.0) * curl_ex_dy_ylo_t, (2, 0, 1))
-    hz = hz.at[:, :n, :].add(coeff_h * kappa_corr_hz_ylo)
+    hz = hz.at[:, :n, :].add(ch_ylo * kappa_corr_hz_ylo)
 
     # --- Y-hi: Hz from dEx/dy ---
     ex_yhi = state.ex[:, -n:, :]
@@ -1825,9 +1872,9 @@ def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_ex_dy_yhi_t = jnp.transpose(curl_ex_dy_yhi, (1, 2, 0))
     new_psi_hz_yhi = b_yr * cpml_state.psi_hz_yhi + c_yr * curl_ex_dy_yhi_t
     correction_hz_yhi = jnp.transpose(new_psi_hz_yhi, (2, 0, 1))
-    hz = hz.at[:, -n:, :].add(coeff_h * correction_hz_yhi)
+    hz = hz.at[:, -n:, :].add(ch_yhi * correction_hz_yhi)
     kappa_corr_hz_yhi = jnp.transpose((1.0 / k_yr - 1.0) * curl_ex_dy_yhi_t, (2, 0, 1))
-    hz = hz.at[:, -n:, :].add(coeff_h * kappa_corr_hz_yhi)
+    hz = hz.at[:, -n:, :].add(ch_yhi * kappa_corr_hz_yhi)
 
     # Z-axis (every rank)
     # --- Z-lo: Hx from dEy/dz ---
@@ -1837,9 +1884,9 @@ def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_ey_dz_zlo_t = jnp.transpose(curl_ey_dz_zlo, (2, 0, 1))
     new_psi_hx_zlo = b_zl * cpml_state.psi_hx_zlo + c_zl * curl_ey_dz_zlo_t
     correction_hx_zlo = jnp.transpose(new_psi_hx_zlo, (1, 2, 0))
-    hx = hx.at[:, :, :n].add(coeff_h * correction_hx_zlo)
+    hx = hx.at[:, :, :n].add(ch_zlo * correction_hx_zlo)
     kappa_corr_hx_zlo = jnp.transpose((1.0 / k_zl - 1.0) * curl_ey_dz_zlo_t, (1, 2, 0))
-    hx = hx.at[:, :, :n].add(coeff_h * kappa_corr_hx_zlo)
+    hx = hx.at[:, :, :n].add(ch_zlo * kappa_corr_hx_zlo)
 
     # --- Z-hi: Hx from dEy/dz ---
     ey_zhi = state.ey[:, :, -n:]
@@ -1848,9 +1895,9 @@ def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_ey_dz_zhi_t = jnp.transpose(curl_ey_dz_zhi, (2, 0, 1))
     new_psi_hx_zhi = b_zh * cpml_state.psi_hx_zhi + c_zh * curl_ey_dz_zhi_t
     correction_hx_zhi = jnp.transpose(new_psi_hx_zhi, (1, 2, 0))
-    hx = hx.at[:, :, -n:].add(coeff_h * correction_hx_zhi)
+    hx = hx.at[:, :, -n:].add(ch_zhi * correction_hx_zhi)
     kappa_corr_hx_zhi = jnp.transpose((1.0 / k_zh - 1.0) * curl_ey_dz_zhi_t, (1, 2, 0))
-    hx = hx.at[:, :, -n:].add(coeff_h * kappa_corr_hx_zhi)
+    hx = hx.at[:, :, -n:].add(ch_zhi * kappa_corr_hx_zhi)
 
     # --- Z-lo: Hy from dEx/dz ---
     ex_zlo = state.ex[:, :, :n]
@@ -1859,9 +1906,9 @@ def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_ex_dz_zlo_t = jnp.transpose(curl_ex_dz_zlo, (2, 1, 0))
     new_psi_hy_zlo = b_zl * cpml_state.psi_hy_zlo + c_zl * curl_ex_dz_zlo_t
     correction_hy_zlo = jnp.transpose(new_psi_hy_zlo, (2, 1, 0))
-    hy = hy.at[:, :, :n].add(-coeff_h * correction_hy_zlo)
+    hy = hy.at[:, :, :n].add(-ch_zlo * correction_hy_zlo)
     kappa_corr_hy_zlo = jnp.transpose((1.0 / k_zl - 1.0) * curl_ex_dz_zlo_t, (2, 1, 0))
-    hy = hy.at[:, :, :n].add(-coeff_h * kappa_corr_hy_zlo)
+    hy = hy.at[:, :, :n].add(-ch_zlo * kappa_corr_hy_zlo)
 
     # --- Z-hi: Hy from dEx/dz ---
     ex_zhi = state.ex[:, :, -n:]
@@ -1870,9 +1917,9 @@ def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
     curl_ex_dz_zhi_t = jnp.transpose(curl_ex_dz_zhi, (2, 1, 0))
     new_psi_hy_zhi = b_zh * cpml_state.psi_hy_zhi + c_zh * curl_ex_dz_zhi_t
     correction_hy_zhi = jnp.transpose(new_psi_hy_zhi, (2, 1, 0))
-    hy = hy.at[:, :, -n:].add(-coeff_h * correction_hy_zhi)
+    hy = hy.at[:, :, -n:].add(-ch_zhi * correction_hy_zhi)
     kappa_corr_hy_zhi = jnp.transpose((1.0 / k_zh - 1.0) * curl_ex_dz_zhi_t, (2, 1, 0))
-    hy = hy.at[:, :, -n:].add(-coeff_h * kappa_corr_hy_zhi)
+    hy = hy.at[:, :, -n:].add(-ch_zhi * kappa_corr_hy_zhi)
 
     new_state = state._replace(hx=hx, hy=hy, hz=hz)
     new_cpml = cpml_state._replace(
@@ -2615,6 +2662,7 @@ def run_nonuniform_distributed_pec(
                 P("x"), P("x"), P("x"), P("x"),
                 # z-face psi (sliced per rank)
                 P("x"), P("x"), P("x"), P("x"),
+                P("x"),  # mu_r slab (material-aware CPML coeff, #205)
             ),
             out_specs=(
                 P("x"), P("x"), P("x"),               # hx, hy, hz
@@ -2627,7 +2675,8 @@ def run_nonuniform_distributed_pec(
         def _h(ex, ey, ez, hx, hy, hz,
                psi_hy_xlo, psi_hy_xhi, psi_hz_xlo, psi_hz_xhi,
                psi_hx_ylo, psi_hx_yhi, psi_hz_ylo, psi_hz_yhi,
-               psi_hx_zlo, psi_hx_zhi, psi_hy_zlo, psi_hy_zhi):
+               psi_hx_zlo, psi_hx_zhi, psi_hy_zlo, psi_hy_zhi,
+               mu_r_slab):
             _st = FDTDState(ex=ex, ey=ey, ez=ez,
                             hx=hx, hy=hy, hz=hz, step=jnp.int32(0))
             _cs = cs._replace(
@@ -2640,6 +2689,7 @@ def run_nonuniform_distributed_pec(
             )
             new_st, new_cs = _apply_cpml_h_local_nu(
                 _st, cpml_params, _cs, n_cpml_local, dt, ghost, n_devices,
+                mu_r=mu_r_slab,
             )
             return (new_st.hx, new_st.hy, new_st.hz,
                     new_cs.psi_hy_xlo, new_cs.psi_hy_xhi,
@@ -2657,6 +2707,7 @@ def run_nonuniform_distributed_pec(
             cs.psi_hy_xlo, cs.psi_hy_xhi, cs.psi_hz_xlo, cs.psi_hz_xhi,
             cs.psi_hx_ylo, cs.psi_hx_yhi, cs.psi_hz_ylo, cs.psi_hz_yhi,
             cs.psi_hx_zlo, cs.psi_hx_zhi, cs.psi_hy_zlo, cs.psi_hy_zhi,
+            sharded_materials.mu_r,
         )
         new_st = st._replace(hx=hx, hy=hy, hz=hz)
         new_cs = cs._replace(
@@ -2679,6 +2730,7 @@ def run_nonuniform_distributed_pec(
                 P("x"), P("x"), P("x"), P("x"),  # x-face psi
                 P("x"), P("x"), P("x"), P("x"),  # y-face psi
                 P("x"), P("x"), P("x"), P("x"),  # z-face psi
+                P("x"),  # eps_r slab (material-aware CPML coeff, #205)
             ),
             out_specs=(
                 P("x"), P("x"), P("x"),               # ex, ey, ez
@@ -2691,7 +2743,8 @@ def run_nonuniform_distributed_pec(
         def _e(ex, ey, ez, hx, hy, hz,
                psi_ey_xlo, psi_ey_xhi, psi_ez_xlo, psi_ez_xhi,
                psi_ex_ylo, psi_ex_yhi, psi_ez_ylo, psi_ez_yhi,
-               psi_ex_zlo, psi_ex_zhi, psi_ey_zlo, psi_ey_zhi):
+               psi_ex_zlo, psi_ex_zhi, psi_ey_zlo, psi_ey_zhi,
+               eps_r_slab):
             _st = FDTDState(ex=ex, ey=ey, ez=ez,
                             hx=hx, hy=hy, hz=hz, step=jnp.int32(0))
             _cs = cs._replace(
@@ -2704,6 +2757,7 @@ def run_nonuniform_distributed_pec(
             )
             new_st, new_cs = _apply_cpml_e_local_nu(
                 _st, cpml_params, _cs, n_cpml_local, dt, ghost, n_devices,
+                eps_r=eps_r_slab,
             )
             return (new_st.ex, new_st.ey, new_st.ez,
                     new_cs.psi_ey_xlo, new_cs.psi_ey_xhi,
@@ -2721,6 +2775,7 @@ def run_nonuniform_distributed_pec(
             cs.psi_ey_xlo, cs.psi_ey_xhi, cs.psi_ez_xlo, cs.psi_ez_xhi,
             cs.psi_ex_ylo, cs.psi_ex_yhi, cs.psi_ez_ylo, cs.psi_ez_yhi,
             cs.psi_ex_zlo, cs.psi_ex_zhi, cs.psi_ey_zlo, cs.psi_ey_zhi,
+            sharded_materials.eps_r,
         )
         new_st = st._replace(ex=ex, ey=ey, ez=ez)
         new_cs = cs._replace(

--- a/tests/test_distributed_nu_cpml_dielectric.py
+++ b/tests/test_distributed_nu_cpml_dielectric.py
@@ -1,0 +1,226 @@
+"""Distributed NON-UNIFORM CPML material-awareness regression (#205, NU lane).
+
+Before this fix ``rfx/runners/distributed_nu.py`` applied its CPML correction
+with a HARDCODED VACUUM coefficient ``dt/eps_0`` (E) / ``dt/mu_0`` (H),
+ignoring the local material (``_apply_cpml_e_local_nu`` /
+``_apply_cpml_h_local_nu``).  Inside a dielectric of ``eps_r`` the correct
+E-coefficient is ``dt/(eps_r*eps_0)`` -- the vacuum value is ``eps_r`` x too
+large, so the NON-UNIFORM distributed absorber over-corrects and the field
+DIVERGES once an outgoing wave is absorbed THROUGH the dielectric-filled CPML
+faces.
+
+WITNESS (origin/main, captured field-level via the runner's ``final_state``):
+a small genuinely-non-uniform cube (10 interior cells, cpml=6) fully filled
+with eps_r=9 and a Gaussian source near the absorber blows the 2-device
+distributed forward to ``inf`` while the single-device NU forward (which has
+been material-aware since #208) stays finite (~4.6e7).  After the fix the
+distributed result is finite and matches the single-device reference to
+< 1e-6 (witnessed rel-diff ~8.8e-8).
+
+REACHABILITY (an important finding in itself): the NU-distributed CPML
+kernels are reached ONLY via ``Simulation.forward(distributed=True,
+devices=[...], boundary='cpml')`` -- the *differentiable* lane.
+``run(devices=...)`` on a non-uniform + CPML grid hard-raises
+``NotImplementedError`` (Phase C fence) in ``distributed_v2.py`` before ever
+touching ``distributed_nu.py``.  So this test exercises ``forward`` (not
+``run``) and ALSO asserts the lane is AD-safe -- the gradient through the
+fixed per-face ``eps_r`` slicing must stay finite (the uniform fix in
+``distributed.py`` did not need this gate; this lane is differentiated).
+
+Multi-device but CPU-only: it sets the host-device sentinel before importing
+jax and SKIPS cleanly when < 2 devices are available (the sentinel is
+process-global and first-init-wins).  NOT ``gpu``-marked: like its sibling
+material-aware-CPML regression guards (``test_vmap_cpml_dielectric.py``,
+``test_nonuniform_cpml_dielectric.py``, ``test_lumped_wire_sparam_cpml_dielectric.py``)
+it runs in the fast suite via the conftest CPU 2-device sentinel, so the
+regression actually executes on every PR.  (A ``gpu`` mark would deselect it
+from the fast suite AND skip it on the single-GPU release suite, i.e. run in
+no CI lane.)  ~11 s wall-clock.
+"""
+
+import os
+# Must be set before importing jax so we get >=2 host CPU devices.
+os.environ.setdefault("XLA_FLAGS", "--xla_force_host_platform_device_count=2")
+
+import numpy as np
+import jax
+import jax.numpy as jnp
+import pytest
+
+from rfx import Box, GaussianPulse, Simulation
+import rfx.runners.distributed_nu as _dnu
+import rfx.runners.nonuniform as _rnu
+
+requires_multidevice = pytest.mark.skipif(
+    jax.device_count() < 2,
+    reason=(
+        f"distributed NU CPML test needs >=2 JAX devices (got "
+        f"{jax.device_count()}); the XLA host-device-count sentinel only adds "
+        "virtual devices on the CPU backend and is ignored if jax was already "
+        "initialised by another module first."
+    ),
+)
+
+# --- run parameters (mirror the #205 NU witness: small genuinely-NU cube, ---
+# --- source near the absorber so energy is absorbed THROUGH the dielectric) -
+_DX0 = 2e-3
+_CPML = 6
+_RATIO = 1.1            # mild grading -> genuinely non-uniform, ratio <= 5
+_NX = 22               # 22 total = ~10 interior + 2*6 CPML
+_FREQ_MAX = 5e9
+_F0 = 3e9
+_N_STEPS = 200
+_EPS_DIELECTRIC = 9.0
+
+
+def _graded(n: int, ratio: float) -> np.ndarray:
+    """Symmetric cosine-bump graded cell-size profile (edges = _DX0, centre =
+    ratio*_DX0) -> grid is genuinely non-uniform so the NU lane is taken."""
+    x = np.linspace(-1.0, 1.0, n)
+    s = 1.0 + (ratio - 1.0) * (0.5 * (1.0 + np.cos(np.pi * x)))
+    return (_DX0 * s).astype(np.float64)
+
+
+_DXP = _graded(_NX, _RATIO)
+_DYP = _graded(_NX, _RATIO)
+_DZP = _graded(_NX, _RATIO)
+_LX = float(_DXP.sum())
+_LY = float(_DYP.sum())
+_LZ = float(_DZP.sum())
+
+
+def _build_sim(eps_r: float) -> Simulation:
+    """Open CPML cube on a genuinely non-uniform mesh whose dielectric
+    (eps_r) fills the ENTIRE domain, including every CPML face, with a
+    central Gaussian source radiating outward so energy is absorbed THROUGH
+    the dielectric-filled absorber."""
+    sim = Simulation(
+        freq_max=_FREQ_MAX, domain=(_LX, _LY, _LZ), dx=_DX0,
+        boundary="cpml", cpml_layers=_CPML,
+        dx_profile=_DXP, dy_profile=_DYP, dz_profile=_DZP,
+    )
+    sim.add_material("d", eps_r=eps_r)
+    sim.add(Box((-1.0, -1.0, -1.0), (1.0, 1.0, 1.0)), material="d")
+    cx, cy, cz = _LX / 2, _LY / 2, _LZ / 2
+    sim.add_source((cx, cy, cz), "ez", waveform=GaussianPulse(f0=_F0))
+    sim.add_probe((cx, cy, cz), "ez")
+    return sim
+
+
+def _max_abs_E(state) -> float:
+    """max|E| over all three E components of a gathered FDTDState (inf if any
+    NaN/inf is present so divergence reports as non-finite)."""
+    m = 0.0
+    for comp in ("ex", "ey", "ez"):
+        arr = np.asarray(getattr(state, comp))
+        if not np.isfinite(arr).all():
+            return np.inf
+        m = max(m, float(np.abs(arr).max()))
+    return m
+
+
+def _capture_distributed_final_state(eps_r: float, devices) -> object:
+    """Run the 2-device NU forward and capture the runner's gathered
+    ``final_state`` (forward() itself surfaces only the probe time-series).
+    """
+    cap = {}
+    orig = _dnu.run_nonuniform_distributed_pec
+
+    def _wrap(*a, **kw):
+        out = orig(*a, **kw)
+        cap["state"] = out.get("final_state")
+        return out
+
+    _dnu.run_nonuniform_distributed_pec = _wrap
+    try:
+        _build_sim(eps_r).forward(
+            distributed=True, devices=devices, n_steps=_N_STEPS,
+            checkpoint=False, skip_preflight=True)
+    finally:
+        _dnu.run_nonuniform_distributed_pec = orig
+    return cap["state"]
+
+
+def _capture_single_final_state(eps_r: float) -> object:
+    """Run the single-device NU forward (material-aware reference, #208) and
+    capture its gathered ``state`` (``run_nonuniform`` returns a dict)."""
+    cap = {}
+    orig = _rnu.run_nonuniform
+
+    def _wrap(*a, **kw):
+        r = orig(*a, **kw)
+        cap["state"] = r["state"] if isinstance(r, dict) else None
+        return r
+
+    _rnu.run_nonuniform = _wrap
+    try:
+        _build_sim(eps_r).forward(
+            distributed=False, n_steps=_N_STEPS,
+            checkpoint=False, skip_preflight=True)
+    finally:
+        _rnu.run_nonuniform = orig
+    return cap["state"]
+
+
+@requires_multidevice
+def test_distributed_nu_cpml_dielectric_finite_and_matches_single():
+    """eps_r=9 filling the NU CPML: the distributed-NU forward must be finite
+    AND match the material-aware single-device NU reference (pre-#205 the
+    distributed-NU path diverged to inf)."""
+    devices = jax.devices()[:2]
+
+    single = _max_abs_E(_capture_single_final_state(_EPS_DIELECTRIC))
+    multi = _max_abs_E(_capture_distributed_final_state(_EPS_DIELECTRIC, devices))
+
+    # (a) distributed result is finite (the pre-#205 bug produced inf).
+    assert np.isfinite(multi), (
+        f"distributed-NU dielectric max|E| not finite ({multi}) -- the #205 "
+        "vacuum-coefficient divergence has regressed in distributed_nu.py")
+
+    # (b) distributed ~= material-aware single-device reference.
+    rel = abs(multi - single) / max(abs(single), 1e-30)
+    assert rel < 1e-2, (
+        f"distributed-NU dielectric max|E|={multi:.6e} disagrees with the "
+        f"single-device material-aware reference max|E|={single:.6e} "
+        f"(rel-diff {rel:.3e} >= 1e-2)")
+
+
+@requires_multidevice
+def test_distributed_nu_cpml_forward_is_ad_finite():
+    """The NU-distributed CPML lane is differentiable (it is reached ONLY via
+    forward(distributed=True)); the gradient through the fixed per-face eps_r
+    slicing must stay finite and non-trivial (no NaN/inf from the new
+    dt/(eps_r*eps_0) coefficient path)."""
+    devices = jax.devices()[:2]
+
+    # Offset the probe from the source so the recorded field depends on the
+    # propagation through the (eps_r-dependent) medium + absorber.
+    def _build_offset():
+        sim = Simulation(
+            freq_max=_FREQ_MAX, domain=(_LX, _LY, _LZ), dx=_DX0,
+            boundary="cpml", cpml_layers=_CPML,
+            dx_profile=_DXP, dy_profile=_DYP, dz_profile=_DZP,
+        )
+        sim.add_source((_LX * 0.45, _LY / 2, _LZ / 2), "ez")
+        sim.add_probe((_LX * 0.60, _LY / 2, _LZ / 2), "ez")
+        return sim
+
+    shp = _build_offset()._build_nonuniform_grid().shape
+    eps0 = jnp.full(shp, _EPS_DIELECTRIC)
+
+    def loss(eps_val):
+        res = _build_offset().forward(
+            n_steps=120, eps_override=eps_val,
+            distributed=True, devices=devices,
+            checkpoint=False, skip_preflight=True)
+        return jnp.sum(res.time_series ** 2)
+
+    grad = np.asarray(jax.grad(loss)(eps0))
+    assert np.isfinite(grad).all(), (
+        "gradient through distributed-NU CPML forward is non-finite -- the "
+        "#205 per-face eps_r slicing broke AD traceability")
+    # Non-trivial: the eps_r-dependent coefficient must actually influence
+    # the loss (guards against a silently-detached / zeroed gradient).
+    assert float(np.abs(grad).max()) > 0.0, (
+        "gradient through distributed-NU CPML forward is identically zero -- "
+        "eps_r is not influencing the differentiable distributed run")


### PR DESCRIPTION
## What

Completes the distributed corner of #205 (after #204 uniform, #208 single-device NU, #224 vmap, **#227 uniform-distributed**): makes the **non-uniform distributed** CPML correction material-aware.

`rfx/runners/distributed_nu.py` kernels `_apply_cpml_{e,h}_local_nu` applied the absorber with a **hardcoded vacuum coefficient** `dt/ε₀`(E)/`dt/μ₀`(H). Inside a dielectric of `eps_r` the correct E-coefficient is `dt/(eps_r·ε₀)` (vacuum is `eps_r`× too strong) → the NU-distributed absorber over-corrects and **diverges to inf** once an outgoing wave is absorbed through a dielectric-filled CPML face. The single-device NU path has been material-aware since #208; this mirrors it onto the shard_map kernels.

## Reachability (important)

The NU-distributed CPML kernels are reached **only** via `sim.forward(distributed=True, boundary="cpml")` — the **differentiable** lane (an opt-in, experimental/scaling lane per `docs/guides/support_matrix.md`). `run(devices=...)` on an NU+CPML grid hard-raises `NotImplementedError` (Phase C fence) before reaching `distributed_nu.py`. So unlike the uniform fix, this lane **is differentiated → AD-safety is a required gate** (verified below).

## Witness (independently reproduced on `origin/main` vs branch)

Genuinely non-uniform grid, `eps_r=9` filling all CPML faces, source driven into the absorber:

| | single-device (correct, #208) | 2-device distributed |
|---|---|---|
| **origin/main** | 5.91e7 (finite) | **inf — diverges** |
| **this branch** | 5.91e7 | **5.91e7** (finite, matches, rel 6.8e-8) |

## Fix

Per-face material-aware coefficients (same pattern as the merged uniform fix #227, face-for-face):
- `_apply_cpml_{e,h}_local_nu` gain `eps_r=None`/`mu_r=None`; the scalar `coeff_e/h` becomes per-face slices `dt/(eps_r·ε₀)` / `dt/(mu_r·μ₀)` — x-faces reuse the kernel's existing ghost-aware `xlo`/`xhi` slices, y/z-faces slice the full local x-extent. All 24 multiply sites per kernel (psi + (1/κ−1) terms × 6 faces) replaced (AST-verified). `None` → exact vacuum scalar (bit-identical to pre-#205 for direct callers).
- Nested shard_map wrappers `_apply_cpml_{e,h}_shmap` thread `sharded_materials.eps_r/.mu_r` as a new read-only `P("x")` `in_specs` input (out_specs/return arity unchanged).

## Verification (independent reproduction + read-only audit)

- **Witness flip**: inf → finite + matches single-device (rel 6.8e-8) — reproduced main-vs-branch in a clean worktree.
- **AD-safe** (the required gate for this lane): `jax.grad` through `forward(distributed=True, boundary="cpml")` is finite + nonzero (verified at eps_r=9 and eps_r=2; magnitude is unnormalized-loss-scaled, not a near-divergence artifact).
- **New regression test** `tests/test_distributed_nu_cpml_dielectric.py` — **not** gpu-marked, so it runs in the fast suite on every PR via the conftest CPU 2-device sentinel (matching the sibling material-CPML guards). 2 passed in ~12s; asserts finite + matches single + AD-finite.
- **Vacuum**: now computes `dt/(1·ε₀)` in float32 like the single-device reference — a ~2e-7 float-reassociation shift (same class as #227), a consistency match, **not** a regression. (The `None` fallback path remains exactly bit-identical.)
- **Existing NU distributed suite** green (29 gpu / 20 non-gpu); ruff clean.
- Audit: all 12 faces' slice↔write-region alignment correct, shard_map arity balanced (19-in/15-out), no leftover scalar coeff.

## Scope / remaining

This + #227 cover the **production** distributed CPML lanes. Still latent (lower priority): `distributed.py`'s pmap `run_distributed` scan body (non-production, direct-import only — the kernel now supports `eps_r` but its scan still passes `None`) and subgrid (experimental, PR #90).

🤖 Generated with [Claude Code](https://claude.com/claude-code)