### PR TITLE
Harden and explain AD memory planning artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Added — AD-memory planning explainability (PR #231; diagnostic/planning-only, no numerics-path change)
+
+- `Simulation.explain_ad_memory(...)` decomposes the selected AD-memory estimate
+  into named contributors (field tape, segment-boundary carries, CPML/material,
+  NTFF) with a component-sum invariant. New public types `ADMemoryComponent` and
+  `ADMemoryExplainabilityReport` (exported from `rfx`).
+- Evidence-class labels on AD-memory artifacts (`static_estimate` /
+  `calibrated_conservative_plan` / `static_ad_explainability`) so a planning
+  estimate is never confused with profiler evidence or a bounded certificate.
+
+### Changed — AD-memory planning (PR #231)
+
+- Checkpoint knobs separated: `checkpoint_every` (non-uniform scan-of-scan chunk
+  length) vs `checkpoint_segments` (uniform segmented-scan count; must divide
+  `n_steps`; mutually exclusive).
+- Conservative `AD_MEMORY_FIT_SAFETY_FACTOR` (1.30) applied before the
+  full-AD / segmented fit flags; `design_mask` is recorded but does NOT reduce
+  the estimate until masked-state memory has observed calibration. Strict input
+  validation, strict-JSON (`allow_nan=False`) serialization, and MB-aware
+  formatting (sub-10 MB no longer rendered as `0.00 GB`).
+
 ## [1.6.6] - 2026-06-24
 
 Maintenance release: a behaviour-preserving internal refactor (extract the

--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -7,6 +7,12 @@
     "ADIState3D": {
       "kind": "class"
     },
+    "ADMemoryComponent": {
+      "kind": "class"
+    },
+    "ADMemoryExplainabilityReport": {
+      "kind": "class"
+    },
     "ADMemoryPlan": {
       "kind": "class"
     },
@@ -2251,7 +2257,18 @@
     "estimate_ad_memory": [
       "n_steps",
       "available_memory_gb",
-      "checkpoint_every"
+      "checkpoint_every",
+      "checkpoint_segments",
+      "n_warmup",
+      "design_mask"
+    ],
+    "explain_ad_memory": [
+      "n_steps",
+      "available_memory_gb",
+      "checkpoint_every",
+      "checkpoint_segments",
+      "n_warmup",
+      "design_mask"
     ],
     "export_artifact_bundle": [
       "path",
@@ -2284,14 +2301,20 @@
     "mesh_intelligence_report": [
       "n_steps",
       "checkpoint_every",
+      "checkpoint_segments",
       "available_memory_gb",
+      "n_warmup",
+      "design_mask",
       "check_ntff",
       "check_resolution"
     ],
     "plan_ad_memory": [
       "n_steps",
       "available_memory_gb",
-      "target_fraction"
+      "target_fraction",
+      "n_warmup",
+      "design_mask",
+      "safety_factor"
     ],
     "plan_mesh": [
       "n_steps",

--- a/docs/public/guide/memory-reduction.mdx
+++ b/docs/public/guide/memory-reduction.mdx
@@ -17,12 +17,13 @@ The memory-reduction goal in `rfx` is to keep JAX-native FDTD workflows small en
 
 ## Memory evidence levels
 
-Current `estimate_ad_memory(...)` and `plan_ad_memory(...)` artifacts are not certificates and are not a universal guaranteed peak predictor. They are planning evidence for sizing reverse-mode AD runs and choosing supported checkpoint knobs.
+Current `estimate_ad_memory(...)`, `plan_ad_memory(...)`, and `explain_ad_memory(...)` artifacts are not certificates and are not a universal guaranteed peak predictor. They are planning evidence for sizing reverse-mode AD runs, choosing supported checkpoint knobs, and explaining static memory drivers.
 
 | Evidence class | Produced by current APIs | Meaning |
 |---|---:|---|
 | `static_estimate` | yes | Formula/static metadata estimate for planning. It may include shape, dtype, NTFF, active-step, and design-mask metadata, but it is not a compiled-executable peak-memory proof. |
 | `calibrated_conservative_plan` | yes | Budget-fitting helper result built from static estimates plus safety margins. It can say whether a conservative plan fits the configured budget target, not whether runtime peak memory is guaranteed. |
+| `static_ad_explainability` | yes | Decomposition of the selected static AD estimate into field state, material/CPML state, reverse-mode saved state, and monitor state so users can see why a run is large. It is diagnostic planning evidence, not profiling. |
 | `observed_profile` | no | A future or external measured run artifact for calibration/regression. It records one environment/run and must not be reused as proof for changed scope. |
 | `bounded_certificate` | no | A separately approved future artifact only if compiler/runtime metadata can support a fail-closed certificate for one exact compiled executable, environment, input/static args/shapes, precision, and checkpoint configuration. |
 
@@ -61,7 +62,28 @@ plan_json = plan.to_json()
 report_json = report.to_json()
 ```
 
-Use the report to check:
+For a more actionable memory diagnostic, generate an explainability artifact next
+to the plan:
+
+```python
+explain = sim.explain_ad_memory(
+    n_steps=10_000,
+    checkpoint_every=plan.checkpoint_every if plan.segmented_fits else None,
+    checkpoint_segments=plan.checkpoint_segments if plan.segmented_fits else None,
+    available_memory_gb=24.0,
+)
+
+print(explain.dominant_component)
+print(explain.recommendations)
+explain_json = explain.to_json()
+```
+
+`explain_ad_memory(...)` reports the selected memory field (`ad_full_gb` or
+`ad_segmented_gb`), the active AD strategy, and a component breakdown. Use it to
+decide whether the dominant cost is full field tape, segmented boundary state,
+CPML/material state, or NTFF monitor state.
+
+Use the mesh intelligence report to check:
 
 - `cell_savings_factor`: comparison against a uniform-fine grid at the smallest configured cell size,
 - `preflight_issues`: geometry, resolution, and feature-support warnings to resolve before trusting results,
@@ -117,9 +139,10 @@ For a validated memory-reduction result, keep these artifacts together:
 
 1. `mesh_intelligence_report(...).to_json()`,
 2. `plan_ad_memory(...).to_json()` when reverse-mode AD memory is part of the claim,
-3. the exact run command and version/commit,
-4. the physics validation artifact for the claimed observable,
-5. any unsupported-feature decisions or validation errors,
-6. gradient evidence if the result depends on `jax.grad`.
+3. `explain_ad_memory(...).to_json()` when deciding why AD memory is large,
+4. the exact run command and version/commit,
+5. the physics validation artifact for the claimed observable,
+6. any unsupported-feature decisions or validation errors,
+7. gradient evidence if the result depends on `jax.grad`.
 
 This keeps the memory story separate from the physics claim: saving cells or AD tape is useful only when the RF observable and gradient path remain inside their validated support boundary.

--- a/docs/public/guide/memory-reduction.mdx
+++ b/docs/public/guide/memory-reduction.mdx
@@ -15,13 +15,25 @@ import { Aside } from '@astrojs/starlight/components';
 
 The memory-reduction goal in `rfx` is to keep JAX-native FDTD workflows small enough to run while preserving the support boundary for the observable being claimed.
 
+## Memory evidence levels
+
+Current `estimate_ad_memory(...)` and `plan_ad_memory(...)` artifacts are not certificates and are not a universal guaranteed peak predictor. They are planning evidence for sizing reverse-mode AD runs and choosing supported checkpoint knobs.
+
+| Evidence class | Produced by current APIs | Meaning |
+|---|---:|---|
+| `static_estimate` | yes | Formula/static metadata estimate for planning. It may include shape, dtype, NTFF, active-step, and design-mask metadata, but it is not a compiled-executable peak-memory proof. |
+| `calibrated_conservative_plan` | yes | Budget-fitting helper result built from static estimates plus safety margins. It can say whether a conservative plan fits the configured budget target, not whether runtime peak memory is guaranteed. |
+| `observed_profile` | no | A future or external measured run artifact for calibration/regression. It records one environment/run and must not be reused as proof for changed scope. |
+| `bounded_certificate` | no | A separately approved future artifact only if compiler/runtime metadata can support a fail-closed certificate for one exact compiled executable, environment, input/static args/shapes, precision, and checkpoint configuration. |
+
 ## Decision ladder
 
 | Need | Preferred lane | Public status |
 |---|---|---|
 | Ordinary RF reference, general S-parameters, ports, far-field claims | Uniform Cartesian Yee | validated default |
-| Thin substrate or layered z structure that would force a tiny uniform cell everywhere | Non-uniform z mesh + segmented AD | limited-support path; verify against a uniform or external reference before public claims |
-| Large inverse-design run where reverse-mode tape is the memory limit | `checkpoint_every` / segmented scan where the selected runner supports the physics | planning tool, not validation evidence |
+| Thin substrate or layered z structure that would force a tiny uniform cell everywhere | Non-uniform z mesh + `checkpoint_every` segmented AD | limited-support path; verify against a uniform or external reference before public claims |
+| Large uniform inverse-design run where reverse-mode tape is the memory limit | Uniform segmented scan via `checkpoint_segments` | planning tool, not validation evidence |
+| Large non-uniform inverse-design run where reverse-mode tape is the memory limit | `checkpoint_every` / segmented scan where the selected runner supports the physics | planning tool, not validation evidence |
 | Need to reduce memory for a port-family S-parameter claim | Use the calculator-supported lane first, then document the memory plan | validation scope still follows the port-family support matrix |
 
 Use the documented memory-planning and non-uniform workflows for public examples; other local-refinement code paths require an explicit support entry before publication.
@@ -32,9 +44,12 @@ Start with the non-uniform lane when a small feature only needs fine cells along
 
 ```python
 plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=24.0)
+if not (plan.full_ad_fits or plan.segmented_fits):
+    raise RuntimeError(plan.recommendation)
+
 report = sim.mesh_intelligence_report(
     n_steps=10_000,
-    checkpoint_every=plan.checkpoint_every,
+    checkpoint_every=plan.checkpoint_every if plan.segmented_fits else None,
     available_memory_gb=24.0,
 )
 
@@ -50,10 +65,43 @@ Use the report to check:
 
 - `cell_savings_factor`: comparison against a uniform-fine grid at the smallest configured cell size,
 - `preflight_issues`: geometry, resolution, and feature-support warnings to resolve before trusting results,
-- `ad_memory.ad_segmented_gb`: reverse-mode AD planning estimate when `checkpoint_every` is enabled,
+- `ad_memory.ad_segmented_gb` and `ad_memory.ad_segmented_active_segments`: reverse-mode AD planning estimate and active segment count when the report uses `checkpoint_every`,
 - `recommendation`: compact next action for the configured case.
 
-`plan_ad_memory(...)` is the budget-fitting helper: it returns `checkpoint_every=None` when full reverse-mode AD already fits, otherwise it recommends the smallest segmented-scan chunk length estimated to fit under the requested memory target.
+`plan_ad_memory(...)` is the budget-fitting helper: it returns both checkpoint knobs as `None` when full reverse-mode AD already fits, with `full_ad_fits=True` and `segmented_fits=False` because no segmented candidate was needed. Otherwise it returns a segmented candidate: `checkpoint_every` on non-uniform grids or `checkpoint_segments` on uniform grids, matching the runner support boundary. Treat `checkpoint_mode` as a knob selector only after `segmented_fits` is true; when `segmented_fits` is false and `full_ad_fits` is also false, follow `plan.recommendation` instead of launching the returned least-memory candidate.
+
+`checkpoint_every` and `checkpoint_segments` are different knobs. Use
+`checkpoint_every` for the non-uniform scan-of-scan path, where it means chunk
+length in timesteps. Use `checkpoint_segments` for the uniform segmented-scan
+path, where it means the number of equal segments and must divide `n_steps`.
+`n_warmup` reduces the reported active reverse-mode timestep count. `design_mask`
+is recorded as active-design metadata only; the primary memory estimates stay
+full-grid until masked-state memory has observed calibration. `n_warmup` must be
+an integer with `0 <= n_warmup < n_steps`. `design_mask` must be a boolean array
+with the simulation grid shape and at least one selected cell; arbitrary numeric
+masks, scalars, and shape-mismatched masks are rejected instead of being coerced.
+`plan_ad_memory(...)` uses a conservative safety multiplier before setting
+`full_ad_fits` or `segmented_fits`; the multiplier is stored in
+`plan.fit_safety_factor` for artifacts.
+
+For a uniform inverse-design run, gate execution on the fit flags before wiring
+the selected knob:
+
+```python
+plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=24.0)
+if plan.full_ad_fits:
+    result = sim.forward(n_steps=10_000)
+    report = sim.mesh_intelligence_report(n_steps=10_000, available_memory_gb=24.0)
+elif plan.segmented_fits and plan.checkpoint_mode == "checkpoint_segments":
+    result = sim.forward(n_steps=10_000, checkpoint_segments=plan.checkpoint_segments)
+    report = sim.mesh_intelligence_report(
+        n_steps=10_000,
+        checkpoint_segments=plan.checkpoint_segments,
+        available_memory_gb=24.0,
+    )
+else:
+    raise RuntimeError(plan.recommendation)
+```
 
 For a reusable JSON artifact without running FDTD, use:
 

--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -9,7 +9,8 @@ from rfx.adi import ADIState2D, ADIState3D, thomas_solve, adi_step_2d, run_adi_2
 from rfx.api import (
     Simulation, Result, WaveguideSParamResult, WaveguideSMatrixResult,
     MSLSMatrixResult, CoaxialSMatrixResult, MATERIAL_LIBRARY,
-    AD_MemoryEstimate, ADMemoryPlan, MeshIntelligenceReport,
+    AD_MemoryEstimate, ADMemoryPlan, ADMemoryComponent,
+    ADMemoryExplainabilityReport, MeshIntelligenceReport,
 )
 from rfx.geometry.csg import Box, Sphere, Cylinder, PolylineWire
 from rfx.geometry.curved import CurvedPatch
@@ -212,7 +213,8 @@ __all__ = [
     # result + S-matrix types
     "Result", "WaveguideSParamResult", "WaveguideSMatrixResult",
     "MSLSMatrixResult", "CoaxialSMatrixResult",
-    "AD_MemoryEstimate", "ADMemoryPlan", "MeshIntelligenceReport",
+    "AD_MemoryEstimate", "ADMemoryPlan", "ADMemoryComponent",
+    "ADMemoryExplainabilityReport", "MeshIntelligenceReport",
     # geometry
     "Box", "Sphere", "Cylinder", "PolylineWire", "CurvedPatch", "Via",
     "PCBLayer", "Stackup",

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -25,6 +25,7 @@ from numbers import Integral
 import jax.numpy as jnp
 import numpy as np
 
+
 from rfx.grid import Grid, C0  # noqa: F401
 from rfx.core.jax_utils import is_tracer
 from rfx.geometry.csg import Box, Shape  # noqa: F401
@@ -77,6 +78,66 @@ from rfx.api._spec import (  # noqa: E402
     MSLSMatrixResult,
 )
 from rfx.mesh_planner import MeshPlan, plan_simulation_mesh  # noqa: E402,F401
+
+def _require_integral_param(name: str, value: object) -> int:
+    """Return ``value`` as int after rejecting bools and non-integral values."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise TypeError(f"{name} must be an integer, got {value!r}")
+    return int(value)
+
+
+def _require_positive_finite_scalar(name: str, value: object) -> float:
+    """Return ``value`` as a finite positive Python float."""
+    if isinstance(value, (bool, np.bool_)):
+        raise TypeError(f"{name} must be a finite real scalar, got {value!r}")
+    arr = np.asarray(value)
+    if arr.shape != ():
+        raise TypeError(
+            f"{name} must be a finite real scalar, got array shape {arr.shape}"
+        )
+    if not np.issubdtype(arr.dtype, np.number) or np.issubdtype(
+        arr.dtype, np.complexfloating
+    ):
+        raise TypeError(f"{name} must be a finite real scalar, got {value!r}")
+    out = float(arr.item())
+    if not math.isfinite(out):
+        raise ValueError(f"{name} must be finite")
+    if out <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return out
+
+
+def _positive_divisors(value: int) -> list[int]:
+    """Return positive divisors of ``value`` sorted ascending."""
+    small: list[int] = []
+    large: list[int] = []
+    root = math.isqrt(value)
+    for divisor in range(1, root + 1):
+        if value % divisor == 0:
+            small.append(divisor)
+            paired = value // divisor
+            if paired != divisor:
+                large.append(paired)
+    return small + large[::-1]
+
+AD_MEMORY_FIT_SAFETY_FACTOR = 1.30
+
+
+def _format_memory_gb(value: float) -> str:
+    """Render GB values without hiding sub-10MB estimates as ``0.00 GB``."""
+    if value < 0.01:
+        return f"{value * 1000.0:.1f} MB"
+    return f"{value:.2f} GB"
+
+
+def _format_memory_with_safety(value: float, safety_factor: float) -> str:
+    """Render raw and safety-adjusted memory when the safety factor is active."""
+    if safety_factor == 1.0:
+        return _format_memory_gb(value)
+    return (
+        f"{_format_memory_gb(value)} "
+        f"({_format_memory_gb(value * safety_factor)} with {safety_factor:.2f}x safety)"
+    )
 
 # ---------------------------------------------------------------------------
 # Preflight / validation methods — moved to rfx/api/_preflight.py
@@ -1906,20 +1967,78 @@ class Simulation(
         *,
         available_memory_gb: float | None = None,
         checkpoint_every: int | None = None,
+        checkpoint_segments: int | None = None,
+        n_warmup: int = 0,
+        design_mask: jnp.ndarray | np.ndarray | None = None,
     ) -> "AD_MemoryEstimate":
         """Estimate reverse-mode AD memory for this simulation.
 
-        Returns an AD_MemoryEstimate with forward, checkpointed-AD, and
-        non-checkpointed-AD sizes in GB, plus a best-effort warning if
-        estimated AD memory exceeds 85% of available VRAM.
+        Returns a static-estimate AD_MemoryEstimate with forward,
+        checkpointed-AD, and non-checkpointed-AD sizes in GB, plus a
+        best-effort warning if estimated AD memory exceeds 85% of available
+        VRAM. This artifact is planning evidence, not a certificate of peak
+        runtime memory.
 
         When ``checkpoint_every`` is provided, the returned
-        ``ad_segmented_gb`` reflects the segmented scan-of-scan path
-        from issue #31. The legacy ``ad_checkpointed_gb`` field keeps
-        its old (optimistic) heuristic for backwards compatibility; it
+        ``ad_segmented_gb`` reflects the non-uniform segmented scan-of-scan
+        chunk-size path from issue #31. When ``checkpoint_segments`` is
+        provided, it reflects the uniform segmented-scan segment-count path
+        from issue #73. ``n_warmup`` must be an integer with
+        ``0 <= n_warmup < n_steps``. ``design_mask`` must be a boolean array
+        matching the simulation grid shape and selecting at least one cell.
+        ``n_warmup`` reduces reported reverse-mode tape time. ``design_mask``
+        is reported as active-design metadata but does not reduce primary
+        memory estimates until masked-state memory has observed calibration.
+        The legacy
+        ``ad_checkpointed_gb`` field keeps its old (optimistic) heuristic
+        for backwards compatibility; it
         is NOT accurate for FDTD on the non-uniform path — see the
         class docstring.
         """
+        n_steps_i = _require_integral_param("n_steps", n_steps)
+        n_warmup_i = _require_integral_param("n_warmup", n_warmup)
+        checkpoint_every_i = (
+            None
+            if checkpoint_every is None
+            else _require_integral_param("checkpoint_every", checkpoint_every)
+        )
+        checkpoint_segments_i = (
+            None
+            if checkpoint_segments is None
+            else _require_integral_param("checkpoint_segments", checkpoint_segments)
+        )
+        avail_gb = (
+            None
+            if available_memory_gb is None
+            else _require_positive_finite_scalar(
+                "available_memory_gb", available_memory_gb
+            )
+        )
+
+        if n_steps_i <= 0:
+            raise ValueError("n_steps must be positive")
+        if n_warmup_i < 0:
+            raise ValueError("n_warmup must be >= 0")
+        if n_warmup_i >= n_steps_i:
+            raise ValueError(f"n_warmup ({n_warmup_i}) must be < n_steps ({n_steps_i})")
+        if checkpoint_every_i is not None and checkpoint_segments_i is not None:
+            raise ValueError(
+                "checkpoint_every and checkpoint_segments are mutually exclusive"
+            )
+        if checkpoint_every_i is not None and checkpoint_every_i <= 0:
+            raise ValueError(
+                f"checkpoint_every must be positive when provided, got {checkpoint_every_i}"
+            )
+        if checkpoint_segments_i is not None:
+            if checkpoint_segments_i < 1:
+                raise ValueError(
+                    f"checkpoint_segments must be ≥ 1, got {checkpoint_segments_i}"
+                )
+            if n_steps_i % checkpoint_segments_i != 0:
+                raise ValueError(
+                    f"checkpoint_segments={checkpoint_segments_i} does not divide "
+                    f"n_steps={n_steps_i}"
+                )
         dx = self._dx or (C0 / self._freq_max / 20.0)
 
         def _nx(extent: float, prof) -> int:
@@ -1952,22 +2071,54 @@ class Simulation(
         # step_fn. NOT valid for the NU path after issue #31 because the
         # scan carry itself is not rematerialised.
         ad_ckpt_bytes = 4 * forward_bytes + ntff_bytes
-        # Non-checkpointed AD: O(n_steps) tape — 6 field arrays per step
-        ad_full_bytes = n_steps * field_bytes + ntff_bytes + forward_bytes
+        active_steps = n_steps_i - n_warmup_i
+        active_design_fraction = 1.0
+        if design_mask is not None:
+            mask = np.asarray(design_mask)
+            if mask.size == 0:
+                raise ValueError("design_mask must be non-empty")
+            if mask.shape == ():
+                raise ValueError("design_mask must be a boolean array matching grid shape")
+            if mask.dtype != np.bool_:
+                raise TypeError("design_mask must have boolean dtype")
+            grid_shape = (nx, ny, nz)
+            if mask.shape != grid_shape:
+                raise ValueError(
+                    f"design_mask shape {mask.shape} must match simulation grid shape {grid_shape}"
+                )
+            selected_cells = int(np.count_nonzero(mask))
+            if selected_cells == 0:
+                raise ValueError("design_mask must select at least one cell")
+            active_design_fraction = float(selected_cells) / float(mask.size)
+        active_tape_field_bytes = field_bytes
 
-        # Segmented scan-of-scan (issue #31). Outer scan wraps
-        # jax.checkpoint around an inner scan of length K; the tape
-        # stores carry + cotangent at (n_steps/K) segment boundaries.
-        # Formula fit to VESSL 369367233490 data on 608k cells within
-        # ~15% (see issue #39).
+        # Non-checkpointed AD: O(active_steps) full-grid field tape. ``n_warmup``
+        # reduces active reverse-mode time, while ``design_mask`` is retained as
+        # metadata only until masked-state memory has observed calibration.
+        ad_full_bytes = active_steps * active_tape_field_bytes + ntff_bytes + forward_bytes
+
+        # Segmented scan paths. ``checkpoint_every`` is the non-uniform
+        # scan-of-scan chunk length (issue #31); ``checkpoint_segments`` is
+        # the uniform segmented-scan segment count (issue #73). Both store
+        # carry + cotangent at segment boundaries.
         ad_seg_bytes: int | None = None
-        if checkpoint_every is not None and checkpoint_every > 0:
-            n_segments = math.ceil(n_steps / checkpoint_every)
-            # 2x per segment: primal carry + cotangent stored for backward
-            ad_seg_bytes = 2 * n_segments * field_bytes + forward_bytes + ntff_bytes
+        segmented_active_segments: int | None = None
+        if checkpoint_segments_i is not None:
+            segment_len = n_steps_i // checkpoint_segments_i
+            first_active_segment = n_warmup_i // segment_len
+            segmented_active_segments = checkpoint_segments_i - first_active_segment
+            ad_seg_bytes = (
+                2 * segmented_active_segments * active_tape_field_bytes + forward_bytes + ntff_bytes
+            )
+        elif checkpoint_every_i is not None:
+            total_segments = math.ceil(n_steps_i / checkpoint_every_i)
+            inactive_segments = n_warmup_i // checkpoint_every_i
+            segmented_active_segments = total_segments - inactive_segments
+            ad_seg_bytes = (
+                2 * segmented_active_segments * active_tape_field_bytes + forward_bytes + ntff_bytes
+            )
 
         # VRAM detection (best effort)
-        avail_gb = available_memory_gb
         if avail_gb is None:
             try:
                 devs = jax.local_devices()
@@ -1988,14 +2139,21 @@ class Simulation(
         warning = None
         if avail_gb is not None and primary_bytes * to_gb > avail_gb * 0.85:
             label = "segmented" if ad_seg_bytes is not None else "non-checkpointed"
-            action = (
-                "Increase checkpoint_every, reduce grid size, or reduce n_steps."
-                if ad_seg_bytes is not None
-                else "Use plan_ad_memory() to choose checkpoint_every, reduce grid size, or reduce n_steps."
-            )
+            if checkpoint_segments_i is not None:
+                if segmented_active_segments == 1:
+                    action = "Reduce grid size, reduce n_steps, or use a more aggressive memory-reduction lane."
+                else:
+                    action = "Reduce checkpoint_segments, reduce grid size, or reduce n_steps."
+            elif ad_seg_bytes is not None:
+                if segmented_active_segments == 1:
+                    action = "Reduce grid size, reduce n_steps, or use a more aggressive memory-reduction lane."
+                else:
+                    action = "Increase checkpoint_every, reduce grid size, or reduce n_steps."
+            else:
+                action = "Use plan_ad_memory() to choose a segmented checkpoint setting, reduce grid size, or reduce n_steps."
             warning = (
-                f"AD memory estimate {primary_bytes*to_gb:.2f}GB ({label}) "
-                f"exceeds 85% of {avail_gb:.2f}GB available VRAM. "
+                f"AD memory estimate {_format_memory_gb(primary_bytes * to_gb)} ({label}) "
+                f"exceeds 85% of {_format_memory_gb(avail_gb)} available VRAM. "
                 f"{action}"
             )
         return AD_MemoryEstimate(
@@ -2006,7 +2164,11 @@ class Simulation(
             available_gb=avail_gb,
             warning=warning,
             ad_segmented_gb=(ad_seg_bytes * to_gb) if ad_seg_bytes is not None else None,
-            checkpoint_every=checkpoint_every,
+            checkpoint_every=checkpoint_every_i,
+            checkpoint_segments=checkpoint_segments_i,
+            ad_active_steps=active_steps,
+            ad_active_design_fraction=active_design_fraction,
+            ad_segmented_active_segments=segmented_active_segments,
         )
 
     def plan_ad_memory(
@@ -2015,99 +2177,219 @@ class Simulation(
         available_memory_gb: float,
         *,
         target_fraction: float = 0.85,
+        n_warmup: int = 0,
+        design_mask: jnp.ndarray | np.ndarray | None = None,
+        safety_factor: float = AD_MEMORY_FIT_SAFETY_FACTOR,
     ) -> ADMemoryPlan:
-        """Choose a segmented-AD ``checkpoint_every`` for a memory budget.
+        """Choose a segmented-AD memory plan for a memory budget.
 
-        The planner reuses :meth:`estimate_ad_memory` and returns an artifact
-        rather than mutating the simulation.  If ordinary reverse-mode AD already
-        fits under ``target_fraction * available_memory_gb``, the returned
-        ``checkpoint_every`` is ``None``.  Otherwise it returns the smallest
-        chunk length estimated to fit the segmented scan-of-scan memory model.
-        If even ``checkpoint_every=n_steps`` is too large, ``segmented_fits`` is
-        false and the recommendation points back to mesh reduction.
+        The planner reuses :meth:`estimate_ad_memory` and returns a
+        calibrated conservative planning artifact rather than mutating the
+        simulation or certifying runtime peak memory. If ordinary reverse-mode
+        AD already fits under ``target_fraction * available_memory_gb``, both
+        checkpoint knobs are ``None``. Otherwise it returns a segmented
+        candidate: ``checkpoint_every`` for non-uniform grids or
+        ``checkpoint_segments`` for uniform grids. Only wire the candidate when
+        ``segmented_fits`` is true; a non-fitting plan keeps the least-memory
+        candidate as diagnostics.
+        ``n_warmup`` must be an integer with ``0 <= n_warmup < n_steps``.
+        ``design_mask`` must be a boolean array matching the simulation grid
+        shape and selecting at least one cell. ``n_warmup`` reduces active
+        reverse-mode time; ``design_mask`` is metadata only for conservative
+        budgeting. Raw estimates must also fit after multiplying by
+        ``safety_factor`` before fit flags are set, so near-boundary plans stay
+        conservative.
         """
-        if n_steps <= 0:
-            raise ValueError("n_steps must be positive")
-        if available_memory_gb <= 0:
-            raise ValueError("available_memory_gb must be positive")
-        if not (0.0 < target_fraction <= 1.0):
-            raise ValueError("target_fraction must be in the interval (0, 1]")
-
-        target_memory_gb = float(available_memory_gb) * float(target_fraction)
-        full_estimate = self.estimate_ad_memory(
-            n_steps,
-            available_memory_gb=available_memory_gb,
+        n_steps_i = _require_integral_param("n_steps", n_steps)
+        n_warmup_i = _require_integral_param("n_warmup", n_warmup)
+        available_memory_gb_f = _require_positive_finite_scalar(
+            "available_memory_gb", available_memory_gb
         )
-        if full_estimate.ad_full_gb <= target_memory_gb:
+        target_fraction_f = _require_positive_finite_scalar(
+            "target_fraction", target_fraction
+        )
+        safety_factor_f = _require_positive_finite_scalar(
+            "safety_factor", safety_factor
+        )
+
+        if n_steps_i <= 0:
+            raise ValueError("n_steps must be positive")
+        if n_warmup_i < 0:
+            raise ValueError("n_warmup must be >= 0")
+        if n_warmup_i >= n_steps_i:
+            raise ValueError(f"n_warmup ({n_warmup_i}) must be < n_steps ({n_steps_i})")
+        if target_fraction_f > 1.0:
+            raise ValueError("target_fraction must be in the interval (0, 1]")
+        if safety_factor_f < 1.0:
+            raise ValueError("safety_factor must be >= 1")
+
+        target_memory_gb = available_memory_gb_f * target_fraction_f
+        full_estimate = self.estimate_ad_memory(
+            n_steps_i,
+            available_memory_gb=available_memory_gb_f,
+            n_warmup=n_warmup_i,
+            design_mask=design_mask,
+        )
+        if full_estimate.ad_full_gb * safety_factor_f <= target_memory_gb:
             return ADMemoryPlan(
-                n_steps=int(n_steps),
-                available_memory_gb=float(available_memory_gb),
-                target_fraction=float(target_fraction),
+                n_steps=n_steps_i,
+                available_memory_gb=available_memory_gb_f,
+                target_fraction=target_fraction_f,
                 target_memory_gb=target_memory_gb,
                 checkpoint_every=None,
+                checkpoint_segments=None,
+                checkpoint_mode=None,
+                fit_safety_factor=safety_factor_f,
                 selected_estimate=full_estimate,
                 full_ad_fits=True,
-                segmented_fits=True,
+                segmented_fits=False,
                 recommendation=(
-                    f"full reverse-mode AD estimate ({full_estimate.ad_full_gb:.2f} GB) "
-                    f"fits within the {target_memory_gb:.2f} GB target; "
+                    f"full reverse-mode AD estimate ({_format_memory_with_safety(full_estimate.ad_full_gb, safety_factor_f)}) "
+                    f"fits within the {_format_memory_gb(target_memory_gb)} target; "
                     "segmented checkpointing is optional for memory"
+                ),
+            )
+
+        uses_nonuniform = (
+            self._dx_profile is not None
+            or self._dy_profile is not None
+            or self._dz_profile is not None
+        )
+        if not uses_nonuniform:
+            divisors = _positive_divisors(n_steps_i)
+            sqrt_steps = math.sqrt(n_steps_i)
+            recommended_segments = min(
+                divisors,
+                key=lambda divisor: (
+                    abs(float(divisor) - sqrt_steps),
+                    -divisor,
+                ),
+            )
+            best_segments: int | None = None
+            best_estimate: AD_MemoryEstimate | None = None
+            for segments in sorted(
+                (divisor for divisor in divisors if divisor <= recommended_segments),
+                reverse=True,
+            ):
+                estimate = self.estimate_ad_memory(
+                    n_steps_i,
+                    available_memory_gb=available_memory_gb_f,
+                    checkpoint_segments=segments,
+                    n_warmup=n_warmup_i,
+                    design_mask=design_mask,
+                )
+                segmented_gb = estimate.ad_segmented_gb
+                if segmented_gb is not None and segmented_gb * safety_factor_f <= target_memory_gb:
+                    best_segments = segments
+                    best_estimate = estimate
+                    break
+
+            if best_segments is not None and best_estimate is not None:
+                return ADMemoryPlan(
+                    n_steps=n_steps_i,
+                    available_memory_gb=available_memory_gb_f,
+                    target_fraction=target_fraction_f,
+                    target_memory_gb=target_memory_gb,
+                    checkpoint_every=None,
+                    checkpoint_segments=best_segments,
+                    checkpoint_mode="checkpoint_segments",
+                    fit_safety_factor=safety_factor_f,
+                    selected_estimate=best_estimate,
+                    full_ad_fits=False,
+                    segmented_fits=True,
+                    recommendation=(
+                        f"use checkpoint_segments={best_segments}: segmented AD estimate "
+                        f"{_format_memory_with_safety(best_estimate.ad_segmented_gb, safety_factor_f)} fits within the "
+                        f"{_format_memory_gb(target_memory_gb)} target"
+                    ),
+                )
+
+            minimum_segment_estimate = self.estimate_ad_memory(
+                n_steps_i,
+                available_memory_gb=available_memory_gb_f,
+                checkpoint_segments=1,
+                n_warmup=n_warmup_i,
+                design_mask=design_mask,
+            )
+            return ADMemoryPlan(
+                n_steps=n_steps_i,
+                available_memory_gb=available_memory_gb_f,
+                target_fraction=target_fraction_f,
+                target_memory_gb=target_memory_gb,
+                checkpoint_every=None,
+                checkpoint_segments=1,
+                checkpoint_mode="checkpoint_segments",
+                fit_safety_factor=safety_factor_f,
+                selected_estimate=minimum_segment_estimate,
+                full_ad_fits=False,
+                segmented_fits=False,
+                recommendation=(
+                    "even checkpoint_segments=1 is estimated at "
+                    f"{_format_memory_with_safety(minimum_segment_estimate.ad_segmented_gb, safety_factor_f)}, above the "
+                    f"{_format_memory_gb(target_memory_gb)} target; reduce mesh size, reduce "
+                    "n_steps, or use a more aggressive memory-reduction lane"
                 ),
             )
 
         best_checkpoint: int | None = None
         best_estimate: AD_MemoryEstimate | None = None
-        lo, hi = 1, int(n_steps)
-        while lo <= hi:
-            mid = (lo + hi) // 2
+        for checkpoint in range(1, n_steps_i + 1):
             estimate = self.estimate_ad_memory(
-                n_steps,
-                available_memory_gb=available_memory_gb,
-                checkpoint_every=mid,
+                n_steps_i,
+                available_memory_gb=available_memory_gb_f,
+                checkpoint_every=checkpoint,
+                n_warmup=n_warmup_i,
+                design_mask=design_mask,
             )
             segmented_gb = estimate.ad_segmented_gb
-            if segmented_gb is not None and segmented_gb <= target_memory_gb:
-                best_checkpoint = mid
+            if segmented_gb is not None and segmented_gb * safety_factor_f <= target_memory_gb:
+                best_checkpoint = checkpoint
                 best_estimate = estimate
-                hi = mid - 1
-            else:
-                lo = mid + 1
+                break
 
         if best_checkpoint is not None and best_estimate is not None:
             return ADMemoryPlan(
-                n_steps=int(n_steps),
-                available_memory_gb=float(available_memory_gb),
-                target_fraction=float(target_fraction),
+                n_steps=n_steps_i,
+                available_memory_gb=available_memory_gb_f,
+                target_fraction=target_fraction_f,
                 target_memory_gb=target_memory_gb,
                 checkpoint_every=best_checkpoint,
+                checkpoint_segments=None,
+                checkpoint_mode="checkpoint_every",
+                fit_safety_factor=safety_factor_f,
                 selected_estimate=best_estimate,
                 full_ad_fits=False,
                 segmented_fits=True,
                 recommendation=(
                     f"use checkpoint_every={best_checkpoint}: segmented AD estimate "
-                    f"{best_estimate.ad_segmented_gb:.2f} GB fits within the "
-                    f"{target_memory_gb:.2f} GB target"
+                    f"{_format_memory_with_safety(best_estimate.ad_segmented_gb, safety_factor_f)} fits within the "
+                    f"{_format_memory_gb(target_memory_gb)} target"
                 ),
             )
 
         largest_chunk_estimate = self.estimate_ad_memory(
-            n_steps,
-            available_memory_gb=available_memory_gb,
-            checkpoint_every=n_steps,
+            n_steps_i,
+            available_memory_gb=available_memory_gb_f,
+            checkpoint_every=n_steps_i,
+            n_warmup=n_warmup_i,
+            design_mask=design_mask,
         )
         return ADMemoryPlan(
-            n_steps=int(n_steps),
-            available_memory_gb=float(available_memory_gb),
-            target_fraction=float(target_fraction),
+            n_steps=n_steps_i,
+            available_memory_gb=available_memory_gb_f,
+            target_fraction=target_fraction_f,
             target_memory_gb=target_memory_gb,
-            checkpoint_every=n_steps,
+            checkpoint_every=n_steps_i,
+            checkpoint_segments=None,
+            checkpoint_mode="checkpoint_every",
+            fit_safety_factor=safety_factor_f,
             selected_estimate=largest_chunk_estimate,
             full_ad_fits=False,
             segmented_fits=False,
             recommendation=(
-                f"even checkpoint_every={n_steps} is estimated at "
-                f"{largest_chunk_estimate.ad_segmented_gb:.2f} GB, above the "
-                f"{target_memory_gb:.2f} GB target; reduce mesh size, reduce "
+                f"even checkpoint_every={n_steps_i} is estimated at "
+                f"{_format_memory_with_safety(largest_chunk_estimate.ad_segmented_gb, safety_factor_f)}, above the "
+                f"{_format_memory_gb(target_memory_gb)} target; reduce mesh size, reduce "
                 "n_steps, or use a more aggressive memory-reduction lane"
             ),
         )
@@ -2117,7 +2399,10 @@ class Simulation(
         *,
         n_steps: int | None = None,
         checkpoint_every: int | None = None,
+        checkpoint_segments: int | None = None,
         available_memory_gb: float | None = None,
+        n_warmup: int = 0,
+        design_mask: jnp.ndarray | np.ndarray | None = None,
         check_ntff: bool = True,
         check_resolution: bool = True,
     ) -> MeshIntelligenceReport:
@@ -2133,6 +2418,11 @@ class Simulation(
         surface: it helps users decide whether existing non-uniform mesh
         plus segmented checkpointing is enough before attempting
         research-only true subgridding.
+
+        ``checkpoint_every`` and ``checkpoint_segments`` are forwarded to the
+        same AD estimator used by :meth:`plan_ad_memory`; they are mutually
+        exclusive. ``n_warmup`` and ``design_mask`` are forwarded as
+        reverse-mode tape metadata only, matching ``estimate_ad_memory``.
         """
         import contextlib
         import io
@@ -2196,6 +2486,9 @@ class Simulation(
                 n_steps,
                 available_memory_gb=available_memory_gb,
                 checkpoint_every=checkpoint_every,
+                checkpoint_segments=checkpoint_segments,
+                n_warmup=n_warmup,
+                design_mask=design_mask,
             )
 
         uses_nonuniform = any(
@@ -2225,17 +2518,17 @@ class Simulation(
             )
 
         if ad_memory is not None:
-            if checkpoint_every and ad_memory.ad_segmented_gb is not None:
+            if ad_memory.warning:
+                recommendation_parts.append(ad_memory.warning)
+            elif (checkpoint_every or checkpoint_segments) and ad_memory.ad_segmented_gb is not None:
                 recommendation_parts.append(
-                    f"use segmented AD estimate ({ad_memory.ad_segmented_gb:.2f} GB) "
+                    f"use segmented AD estimate ({_format_memory_gb(ad_memory.ad_segmented_gb)}) "
                     "rather than the legacy step-checkpoint heuristic"
                 )
-            elif ad_memory.warning:
-                recommendation_parts.append(ad_memory.warning)
             else:
                 recommendation_parts.append(
-                    f"estimated full reverse-mode AD memory is "
-                    f"{ad_memory.ad_full_gb:.2f} GB"
+                    "estimated full reverse-mode AD memory is "
+                    f"{_format_memory_gb(ad_memory.ad_full_gb)}"
                 )
 
         return MeshIntelligenceReport(

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -58,6 +58,8 @@ from rfx.api._spec import (  # noqa: E402
     MATERIAL_LIBRARY,
     AD_MemoryEstimate,
     ADMemoryPlan,
+    ADMemoryComponent,
+    ADMemoryExplainabilityReport,
     MeshIntelligenceReport,
     Result,
     ForwardResult,
@@ -1960,6 +1962,52 @@ class Simulation(
     # ---- build helpers ----
 
     # ---- AD memory estimation (issue #30 CHECK 4) ----
+    def _ad_memory_static_accounting(self) -> dict[str, int]:
+        """Return shared static byte accounting for AD memory artifacts."""
+        dx = self._dx or (C0 / self._freq_max / 20.0)
+
+        def _nx(extent: float, prof) -> int:
+            if prof is not None:
+                return len(prof) + 1 + 2 * self._cpml_layers
+            return int(math.ceil(extent / dx)) + 1 + 2 * self._cpml_layers
+
+        nx = _nx(self._domain[0], self._dx_profile)
+        ny = _nx(self._domain[1], self._dy_profile)
+        nz = _nx(self._domain[2], self._dz_profile)
+        cells = int(nx * ny * nz)
+
+        # Forward working set: 6 field + ~6 material + ~4 CPML psi (~15%)
+        bytes_per_cell = 4  # float32
+        field_bytes = cells * 6 * bytes_per_cell
+        material_bytes = cells * 6 * bytes_per_cell
+        cpml_bytes = (
+            int(cells * 0.15 * 24 * bytes_per_cell)
+            if self._cpml_layers > 0
+            else 0
+        )
+        forward_bytes = field_bytes + material_bytes + cpml_bytes
+
+        # NTFF DFT state: 6 faces × n_freqs × face cells × (3 E + 3 H) × complex64.
+        ntff_bytes = 0
+        if self._ntff is not None:
+            _, _, freqs = self._ntff
+            n_freqs = int(len(freqs)) if freqs is not None else 10
+            face_est = 2 * ((nx * ny) + (ny * nz) + (nx * nz))
+            ntff_bytes = face_est * n_freqs * 6 * 8
+
+        return {
+            "nx": nx,
+            "ny": ny,
+            "nz": nz,
+            "cells": cells,
+            "bytes_per_cell": bytes_per_cell,
+            "field_bytes": field_bytes,
+            "material_bytes": material_bytes,
+            "cpml_bytes": cpml_bytes,
+            "forward_bytes": forward_bytes,
+            "ntff_bytes": ntff_bytes,
+        }
+
 
     def estimate_ad_memory(
         self,
@@ -2039,33 +2087,13 @@ class Simulation(
                     f"checkpoint_segments={checkpoint_segments_i} does not divide "
                     f"n_steps={n_steps_i}"
                 )
-        dx = self._dx or (C0 / self._freq_max / 20.0)
-
-        def _nx(extent: float, prof) -> int:
-            if prof is not None:
-                return len(prof) + 1 + 2 * self._cpml_layers
-            return int(math.ceil(extent / dx)) + 1 + 2 * self._cpml_layers
-
-        nx = _nx(self._domain[0], self._dx_profile)
-        ny = _nx(self._domain[1], self._dy_profile)
-        nz = _nx(self._domain[2], self._dz_profile)
-        cells = nx * ny * nz
-
-        # Forward working set: 6 field + ~6 material + ~4 CPML psi (~15%)
-        bytes_per_cell = 4  # float32
-        field_bytes = cells * 6 * bytes_per_cell
-        mat_bytes = cells * 6 * bytes_per_cell
-        cpml_bytes = int(cells * 0.15 * 24 * bytes_per_cell) if self._cpml_layers > 0 else 0
-        forward_bytes = field_bytes + mat_bytes + cpml_bytes
-
-        # NTFF DFT state: 6 faces × n_freqs × face_cells × 4 (3 E + 3 H) × complex64 (8B)
-        ntff_bytes = 0
-        if self._ntff is not None:
-            _, _, freqs = self._ntff
-            n_freqs = int(len(freqs)) if freqs is not None else 10
-            # Approx face cells from domain extents / dx
-            face_est = 2 * ((nx * ny) + (ny * nz) + (nx * nz))
-            ntff_bytes = face_est * n_freqs * 6 * 8
+        accounting = self._ad_memory_static_accounting()
+        nx = accounting["nx"]
+        ny = accounting["ny"]
+        nz = accounting["nz"]
+        field_bytes = accounting["field_bytes"]
+        forward_bytes = accounting["forward_bytes"]
+        ntff_bytes = accounting["ntff_bytes"]
 
         # Legacy "checkpointed" estimate: remat-recomputes internals of
         # step_fn. NOT valid for the NU path after issue #31 because the
@@ -2169,6 +2197,194 @@ class Simulation(
             ad_active_steps=active_steps,
             ad_active_design_fraction=active_design_fraction,
             ad_segmented_active_segments=segmented_active_segments,
+        )
+
+    def explain_ad_memory(
+        self,
+        n_steps: int,
+        *,
+        available_memory_gb: float | None = None,
+        checkpoint_every: int | None = None,
+        checkpoint_segments: int | None = None,
+        n_warmup: int = 0,
+        design_mask: jnp.ndarray | np.ndarray | None = None,
+    ) -> ADMemoryExplainabilityReport:
+        """Explain the static reverse-mode AD memory estimate.
+
+        This method uses the same conservative accounting as
+        :meth:`estimate_ad_memory`, then decomposes the selected AD memory
+        number into named contributors. It is meant to answer "what is making
+        this AD run large?" without claiming profiler evidence or a runtime
+        peak bound.
+        """
+        n_steps_i = _require_integral_param("n_steps", n_steps)
+        estimate = self.estimate_ad_memory(
+            n_steps_i,
+            available_memory_gb=available_memory_gb,
+            checkpoint_every=checkpoint_every,
+            checkpoint_segments=checkpoint_segments,
+            n_warmup=n_warmup,
+            design_mask=design_mask,
+        )
+
+        accounting = self._ad_memory_static_accounting()
+        field_bytes = accounting["field_bytes"]
+        material_bytes = accounting["material_bytes"]
+        cpml_bytes = accounting["cpml_bytes"]
+        ntff_bytes = accounting["ntff_bytes"]
+        cells = accounting["cells"]
+        bytes_per_cell = accounting["bytes_per_cell"]
+
+        active_steps = estimate.ad_active_steps if estimate.ad_active_steps is not None else n_steps_i
+        if estimate.ad_segmented_gb is not None:
+            selected_field = "ad_segmented_gb"
+            selected_gb = float(estimate.ad_segmented_gb)
+            strategy = (
+                "segmented_checkpoint_segments"
+                if estimate.checkpoint_segments is not None
+                else "segmented_checkpoint_every"
+            )
+            active_segments = (
+                estimate.ad_segmented_active_segments
+                if estimate.ad_segmented_active_segments is not None
+                else 0
+            )
+            tape_count = int(2 * active_segments)
+            tape_bytes = tape_count * field_bytes
+            tape_name = "segmented_boundary_field_tape"
+            tape_explanation = (
+                "Segmented reverse-mode AD stores field carry and cotangent "
+                "state at active segment boundaries instead of every active "
+                "time step."
+            )
+            tape_unit = "carry-or-cotangent-field-state"
+        else:
+            selected_field = "ad_full_gb"
+            selected_gb = float(estimate.ad_full_gb)
+            strategy = "full_reverse_ad_static_tape"
+            tape_count = int(active_steps)
+            tape_bytes = tape_count * field_bytes
+            tape_name = "full_reverse_field_tape"
+            tape_explanation = (
+                "Full reverse-mode AD stores a field tape entry for each "
+                "active post-warmup time step."
+            )
+            tape_unit = "active-time-step-field-state"
+
+        def _share(memory_bytes: int) -> float:
+            if selected_gb <= 0.0:
+                return 0.0
+            return float(memory_bytes / 1e9 / selected_gb)
+
+        def _component(
+            name: str,
+            memory_bytes: int,
+            kind: str,
+            *,
+            unit: str | None,
+            count: int | None,
+            bytes_per_unit: int | None,
+            explanation: str,
+        ) -> ADMemoryComponent:
+            return ADMemoryComponent(
+                name=name,
+                kind=kind,
+                memory_gb=memory_bytes / 1e9,
+                share_of_selected=_share(memory_bytes),
+                unit=unit,
+                count=count,
+                bytes_per_unit_gb=(
+                    None if bytes_per_unit is None else bytes_per_unit / 1e9
+                ),
+                explanation=explanation,
+            )
+
+        components = (
+            _component(
+                "field_state",
+                field_bytes,
+                "forward_working_set",
+                unit="field-array",
+                count=6,
+                bytes_per_unit=cells * bytes_per_cell,
+                explanation="Six E/H field arrays carried by the forward solve.",
+            ),
+            _component(
+                "material_auxiliary_state",
+                material_bytes,
+                "forward_working_set",
+                unit="material-array",
+                count=6,
+                bytes_per_unit=cells * bytes_per_cell,
+                explanation=(
+                    "Static material/ADE auxiliary allocation used by the "
+                    "planner's forward working-set model."
+                ),
+            ),
+            _component(
+                "cpml_auxiliary_state",
+                cpml_bytes,
+                "forward_working_set",
+                unit="cpml-overhead",
+                count=None,
+                bytes_per_unit=None,
+                explanation=(
+                    "CPML auxiliary state estimate; zero when the simulation "
+                    "does not use CPML layers."
+                ),
+            ),
+            _component(
+                tape_name,
+                tape_bytes,
+                "reverse_ad_saved_state",
+                unit=tape_unit,
+                count=tape_count,
+                bytes_per_unit=field_bytes,
+                explanation=tape_explanation,
+            ),
+            _component(
+                "ntff_dft_state",
+                ntff_bytes,
+                "monitor_state",
+                unit="ntff-dft-state",
+                count=None,
+                bytes_per_unit=None,
+                explanation=(
+                    "Near-to-far-field DFT monitor state retained in forward "
+                    "and AD planning estimates."
+                ),
+            ),
+        )
+
+        dominant = max(components, key=lambda component: component.memory_gb)
+        recommendations: list[str] = [
+            f"Dominant AD memory contributor is {dominant.name}.",
+            "Treat ad_checkpointed_gb as a legacy heuristic; use the selected memory field in this report for planning.",
+        ]
+        if estimate.ad_segmented_gb is None:
+            recommendations.append(
+                "Use plan_ad_memory() to choose a supported segmented checkpoint knob when full reverse-mode AD is too large."
+            )
+        else:
+            recommendations.append(
+                f"Selected strategy stores {tape_count} {tape_unit} unit(s) instead of {active_steps} active time-step tape entries."
+            )
+        if estimate.ad_active_design_fraction is not None and estimate.ad_active_design_fraction < 1.0:
+            recommendations.append(
+                "design_mask is recorded as active-design metadata only; it does not reduce the selected memory estimate."
+            )
+        if estimate.warning:
+            recommendations.append(estimate.warning)
+
+        return ADMemoryExplainabilityReport(
+            n_steps=n_steps_i,
+            strategy=strategy,
+            selected_memory_gb=selected_gb,
+            selected_memory_field=selected_field,
+            estimate=estimate,
+            components=components,
+            dominant_component=dominant.name,
+            recommendations=tuple(recommendations),
         )
 
     def plan_ad_memory(
@@ -2663,6 +2879,8 @@ __all__ = [
     "MATERIAL_LIBRARY",
     "AD_MemoryEstimate",
     "ADMemoryPlan",
+    "ADMemoryComponent",
+    "ADMemoryExplainabilityReport",
     "MeshIntelligenceReport",
     "Result",
     "ForwardResult",

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -134,6 +134,81 @@ class AD_MemoryEstimate(NamedTuple):
         return json.dumps(self.to_dict(), **options)
 
 
+class ADMemoryComponent(NamedTuple):
+    """Named contribution to a reverse-mode AD memory explanation."""
+
+    name: str
+    memory_gb: float
+    share_of_selected: float
+    kind: str
+    unit: str | None = None
+    count: int | None = None
+    bytes_per_unit_gb: float | None = None
+    explanation: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable component artifact."""
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "memory_gb": float(self.memory_gb),
+            "share_of_selected": float(self.share_of_selected),
+            "unit": self.unit,
+            "count": self.count,
+            "bytes_per_unit_gb": (
+                None
+                if self.bytes_per_unit_gb is None
+                else float(self.bytes_per_unit_gb)
+            ),
+            "explanation": self.explanation,
+        }
+
+
+class ADMemoryExplainabilityReport(NamedTuple):
+    """Static reverse-mode AD memory explainability artifact.
+
+    The report decomposes the selected AD estimate into named components so
+    users can see whether field tape, segment-boundary carries, CPML/material
+    state, or monitor state dominates the planning artifact. It is still static
+    planning evidence, not profiler evidence or a bounded certificate.
+    """
+
+    n_steps: int
+    strategy: str
+    selected_memory_gb: float
+    selected_memory_field: str
+    estimate: AD_MemoryEstimate
+    components: tuple[ADMemoryComponent, ...]
+    dominant_component: str
+    recommendations: tuple[str, ...]
+
+    @property
+    def evidence_class(self) -> str:
+        """Evidence class label serialized with this static explanation."""
+        return "static_ad_explainability"
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable AD explainability artifact."""
+        return {
+            "evidence_class": self.evidence_class,
+            "n_steps": int(self.n_steps),
+            "strategy": self.strategy,
+            "selected_memory_gb": float(self.selected_memory_gb),
+            "selected_memory_field": self.selected_memory_field,
+            "estimate": self.estimate.to_dict(),
+            "components": [component.to_dict() for component in self.components],
+            "dominant_component": self.dominant_component,
+            "recommendations": list(self.recommendations),
+        }
+
+    def to_json(self, **kwargs: object) -> str:
+        """Serialize the explanation for AD-memory diagnostics."""
+        options = {"indent": 2, "sort_keys": True}
+        options.update(kwargs)
+        options["allow_nan"] = False
+        return json.dumps(self.to_dict(), **options)
+
+
 class ADMemoryPlan(NamedTuple):
     """Checkpoint planning result for reverse-mode AD memory.
 
@@ -924,6 +999,8 @@ __all__ = [
     "MATERIAL_LIBRARY",
     "AD_MemoryEstimate",
     "ADMemoryPlan",
+    "ADMemoryComponent",
+    "ADMemoryExplainabilityReport",
     "MeshIntelligenceReport",
     "Result",
     "ForwardResult",

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -73,8 +73,14 @@ class AD_MemoryEstimate(NamedTuple):
     estimate; for FDTD on the non-uniform path this is *not* a
     realistic memory number because the scan carry itself is not
     rematerialised (see issue #31 VESSL 369367233490). Use
-    ``ad_segmented_gb`` when ``checkpoint_every`` is set — that matches
-    the observed memory on RTX 4090 within ~15%.
+    ``ad_segmented_gb`` for the runner-supported segmented paths:
+    ``checkpoint_every`` on the non-uniform scan-of-scan path and
+    ``checkpoint_segments`` on the uniform segmented-scan path. When present,
+    ``ad_segmented_active_segments`` is the actual number of active segment
+    boundaries/carry snapshots used by the segmented estimate after warmup.
+    ``evidence_class`` labels this artifact as a static estimate so downstream
+    tooling does not confuse it with observed profiler evidence or a bounded
+    compiled-executable certificate.
     """
     forward_gb: float
     ad_checkpointed_gb: float
@@ -84,10 +90,20 @@ class AD_MemoryEstimate(NamedTuple):
     warning: str | None
     ad_segmented_gb: float | None = None
     checkpoint_every: int | None = None
+    checkpoint_segments: int | None = None
+    ad_active_steps: int | None = None
+    ad_active_design_fraction: float | None = None
+    ad_segmented_active_segments: int | None = None
+    @property
+    def evidence_class(self) -> str:
+        """Evidence class label serialized with this static estimate."""
+        return "static_estimate"
+
 
     def to_dict(self) -> dict[str, float | int | None | str]:
         """Return a stable JSON-serializable AD memory artifact."""
         return {
+            "evidence_class": self.evidence_class,
             "forward_gb": float(self.forward_gb),
             "ad_checkpointed_gb": float(self.ad_checkpointed_gb),
             "ad_full_gb": float(self.ad_full_gb),
@@ -100,24 +116,39 @@ class AD_MemoryEstimate(NamedTuple):
                 None if self.ad_segmented_gb is None else float(self.ad_segmented_gb)
             ),
             "checkpoint_every": self.checkpoint_every,
+            "checkpoint_segments": self.checkpoint_segments,
+            "ad_active_steps": self.ad_active_steps,
+            "ad_active_design_fraction": (
+                None
+                if self.ad_active_design_fraction is None
+                else float(self.ad_active_design_fraction)
+            ),
+            "ad_segmented_active_segments": self.ad_segmented_active_segments,
         }
 
     def to_json(self, **kwargs: object) -> str:
         """Serialize the estimate for research-note and CI artifacts."""
         options = {"indent": 2, "sort_keys": True}
         options.update(kwargs)
+        options["allow_nan"] = False
         return json.dumps(self.to_dict(), **options)
 
 
 class ADMemoryPlan(NamedTuple):
     """Checkpoint planning result for reverse-mode AD memory.
 
-    ``checkpoint_every`` is the smallest segmented-scan chunk length estimated
-    to fit under ``target_fraction * available_memory_gb``.  ``None`` means the
-    full reverse-mode estimate already fits and segmented checkpointing is not
-    required for memory.
-    """
+    ``checkpoint_every`` is the non-uniform segmented-scan chunk length.
+    ``checkpoint_segments`` is the uniform segmented-scan segment count.
+    ``checkpoint_mode`` is the knob selector, not a runnable-fit verdict:
+    check ``full_ad_fits`` first, then require ``segmented_fits`` before wiring
+    the selected segmented knob. A non-fitting plan may still carry the
+    least-memory candidate knob for diagnostics.
+    ``fit_safety_factor`` records the conservative multiplier used before an
+    estimate is allowed to set ``full_ad_fits`` or ``segmented_fits``.
+    ``evidence_class`` labels this artifact as a calibrated conservative plan,
+    not a certificate or observed runtime profile.
 
+    """
     n_steps: int
     available_memory_gb: float
     target_fraction: float
@@ -127,15 +158,26 @@ class ADMemoryPlan(NamedTuple):
     full_ad_fits: bool
     segmented_fits: bool
     recommendation: str
+    checkpoint_segments: int | None = None
+    checkpoint_mode: str | None = None
+    fit_safety_factor: float = 1.0
+    @property
+    def evidence_class(self) -> str:
+        """Evidence class label serialized with this conservative plan."""
+        return "calibrated_conservative_plan"
 
     def to_dict(self) -> dict[str, object]:
         """Return a stable JSON-serializable AD memory plan artifact."""
         return {
+            "evidence_class": self.evidence_class,
             "n_steps": int(self.n_steps),
             "available_memory_gb": float(self.available_memory_gb),
             "target_fraction": float(self.target_fraction),
             "target_memory_gb": float(self.target_memory_gb),
+            "fit_safety_factor": float(self.fit_safety_factor),
             "checkpoint_every": self.checkpoint_every,
+            "checkpoint_segments": self.checkpoint_segments,
+            "checkpoint_mode": self.checkpoint_mode,
             "selected_estimate": self.selected_estimate.to_dict(),
             "full_ad_fits": bool(self.full_ad_fits),
             "segmented_fits": bool(self.segmented_fits),
@@ -146,6 +188,7 @@ class ADMemoryPlan(NamedTuple):
         """Serialize the plan for memory-budget and CI artifacts."""
         options = {"indent": 2, "sort_keys": True}
         options.update(kwargs)
+        options["allow_nan"] = False
         return json.dumps(self.to_dict(), **options)
 
 
@@ -191,6 +234,7 @@ class MeshIntelligenceReport(NamedTuple):
         """Serialize the report for memory-reduction evidence artifacts."""
         options = {"indent": 2, "sort_keys": True}
         options.update(kwargs)
+        options["allow_nan"] = False
         return json.dumps(self.to_dict(), **options)
 
 

--- a/tests/test_estimate_ad_memory.py
+++ b/tests/test_estimate_ad_memory.py
@@ -21,11 +21,39 @@ during reverse-mode).
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import numpy as np
 import pytest
 
-from rfx import ADMemoryPlan, Simulation
+from rfx import ADMemoryPlan, AD_MemoryEstimate, MeshIntelligenceReport, Simulation
+from rfx.api import AD_MEMORY_FIT_SAFETY_FACTOR
+
+_FORBIDDEN_CURRENT_EVIDENCE_FIELDS = {
+    "compiler_memory_gb",
+    "compiler_reported_required_gb",
+    "observed_peak_gb",
+    "profile_peak_gb",
+    "certificate_status",
+    "scope_digest",
+    "config_digest",
+    "environment_digest",
+    "is_valid_certificate",
+    "is_budget_safe",
+    "peak_bound_gb",
+}
+
+_FORBIDDEN_RECOMMENDATION_TERMS = (
+    "guarantee",
+    "guaranteed",
+    "certified",
+    "certificate",
+    "peak_bound",
+)
+
+
+def _assert_no_forbidden_current_fields(artifact: dict[str, object]) -> None:
+    assert _FORBIDDEN_CURRENT_EVIDENCE_FIELDS.isdisjoint(artifact)
 
 
 def _patch_like_sim():
@@ -40,6 +68,161 @@ def _patch_like_sim():
     sim.add_source((ext / 2, ext / 2, 1e-3), "ez")
     sim.add_probe((ext / 2, ext / 2, 2e-3), "ez")
     return sim
+
+
+def _uniform_sim():
+    sim = Simulation(
+        freq_max=10e9,
+        domain=(10e-3, 10e-3, 5e-3),
+        dx=1e-3,
+        boundary="cpml",
+        cpml_layers=2,
+    )
+    sim.add_source((5e-3, 5e-3, 2e-3), "ez")
+    sim.add_probe((5e-3, 5e-3, 3e-3), "ez")
+    return sim
+
+
+def _grid_shape(sim: Simulation) -> tuple[int, int, int]:
+    dx = sim._dx or (299_792_458.0 / sim._freq_max / 20.0)
+
+    def _axis_cells(extent: float, profile) -> int:
+        if profile is not None:
+            return len(profile) + 1 + 2 * sim._cpml_layers
+        return int(np.ceil(extent / dx)) + 1 + 2 * sim._cpml_layers
+
+    return (
+        _axis_cells(sim._domain[0], sim._dx_profile),
+        _axis_cells(sim._domain[1], sim._dy_profile),
+        _axis_cells(sim._domain[2], sim._dz_profile),
+    )
+
+
+def _design_mask(sim: Simulation, *, fraction: float = 0.25) -> np.ndarray:
+    mask = np.zeros(_grid_shape(sim), dtype=bool)
+    selected = max(1, int(mask.size * fraction))
+    mask.reshape(-1)[:selected] = True
+    return mask
+
+
+def test_public_imports_and_json_roundtrip():
+    from rfx import ADMemoryPlan as TopPlan
+    from rfx import AD_MemoryEstimate as TopEstimate
+    from rfx import Simulation as TopSimulation
+    from rfx.api import ADMemoryPlan as ApiPlan
+    from rfx.api import AD_MemoryEstimate as ApiEstimate
+    from rfx.api import Simulation as ApiSimulation
+
+    assert TopEstimate is ApiEstimate is AD_MemoryEstimate
+    assert TopPlan is ApiPlan is ADMemoryPlan
+    assert TopSimulation is ApiSimulation is Simulation
+
+    sim = _uniform_sim()
+    estimate = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
+    plan = sim.plan_ad_memory(n_steps=120, available_memory_gb=100.0)
+
+    assert json.loads(estimate.to_json()) == estimate.to_dict()
+    assert json.loads(plan.to_json()) == plan.to_dict()
+    assert estimate.to_dict()["checkpoint_segments"] == 10
+    estimate_keys = {
+        "evidence_class",
+        "forward_gb",
+        "ad_checkpointed_gb",
+        "ad_full_gb",
+        "ntff_dft_gb",
+        "available_gb",
+        "warning",
+        "ad_segmented_gb",
+        "checkpoint_every",
+        "checkpoint_segments",
+        "ad_active_steps",
+        "ad_active_design_fraction",
+        "ad_segmented_active_segments",
+    }
+    assert estimate.to_dict()["evidence_class"] == "static_estimate"
+    plan_keys = {
+        "evidence_class",
+        "n_steps",
+        "available_memory_gb",
+        "target_fraction",
+        "target_memory_gb",
+        "fit_safety_factor",
+        "checkpoint_every",
+        "checkpoint_segments",
+        "checkpoint_mode",
+        "selected_estimate",
+        "full_ad_fits",
+        "segmented_fits",
+        "recommendation",
+    }
+    assert plan.to_dict()["evidence_class"] == "calibrated_conservative_plan"
+    assert set(estimate.to_dict()) == estimate_keys
+    assert set(plan.to_dict()) == plan_keys
+    assert set(plan.to_dict()["selected_estimate"]) == estimate_keys
+    assert plan.to_dict()["selected_estimate"]["evidence_class"] == "static_estimate"
+    _assert_no_forbidden_current_fields(estimate.to_dict())
+    _assert_no_forbidden_current_fields(plan.to_dict())
+    _assert_no_forbidden_current_fields(plan.to_dict()["selected_estimate"])
+    assert "evidence_class" not in AD_MemoryEstimate._fields
+    assert "evidence_class" not in ADMemoryPlan._fields
+    with pytest.raises(ValueError):
+        estimate._replace(evidence_class="observed_profile")
+    with pytest.raises(ValueError):
+        plan._replace(evidence_class="bounded_certificate")
+
+
+def test_current_memory_artifacts_keep_evidence_classes_separate():
+    sim = _patch_like_sim()
+    estimate = sim.estimate_ad_memory(n_steps=10_000, checkpoint_every=500)
+    plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=1.0)
+    report = sim.mesh_intelligence_report(
+        n_steps=10_000,
+        checkpoint_every=plan.checkpoint_every,
+        available_memory_gb=1.0,
+    )
+
+    estimate_artifact = estimate.to_dict()
+    plan_artifact = plan.to_dict()
+    report_artifact = report.to_dict()
+
+    assert estimate_artifact["evidence_class"] == "static_estimate"
+    assert plan_artifact["evidence_class"] == "calibrated_conservative_plan"
+    assert plan_artifact["selected_estimate"]["evidence_class"] == "static_estimate"
+    assert report_artifact["ad_memory"]["evidence_class"] == "static_estimate"
+
+    _assert_no_forbidden_current_fields(estimate_artifact)
+    _assert_no_forbidden_current_fields(plan_artifact)
+    _assert_no_forbidden_current_fields(plan_artifact["selected_estimate"])
+    _assert_no_forbidden_current_fields(report_artifact["ad_memory"])
+
+
+def test_current_memory_recommendations_do_not_claim_guarantees():
+    sim = _patch_like_sim()
+    plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=1.0)
+    report = sim.mesh_intelligence_report(
+        n_steps=10_000,
+        checkpoint_every=plan.checkpoint_every,
+        available_memory_gb=1.0,
+    )
+
+    texts = [
+        plan.recommendation,
+        report.recommendation,
+        sim.estimate_ad_memory(n_steps=10_000, available_memory_gb=1e-6).warning,
+    ]
+    for text in texts:
+        assert text is not None
+        lowered = text.lower()
+        assert not any(term in lowered for term in _FORBIDDEN_RECOMMENDATION_TERMS)
+
+
+def test_memory_reduction_docs_separate_planning_from_certificate_evidence():
+    doc = Path("docs/public/guide/memory-reduction.mdx").read_text()
+    assert "`static_estimate`" in doc
+    assert "`calibrated_conservative_plan`" in doc
+    assert "`bounded_certificate`" in doc
+    assert "Current `estimate_ad_memory(...)` and `plan_ad_memory(...)` artifacts are not certificates" in doc
+    assert "not a universal guaranteed peak predictor" in doc
 
 
 @pytest.mark.parametrize("chunk,observed_gb", [
@@ -59,6 +242,7 @@ def test_segmented_estimate_within_tolerance(chunk, observed_gb):
     assert 0.5 * observed_gb <= pred <= 2.0 * observed_gb, (
         f"chunk={chunk}: predicted {pred:.3f} GB vs observed {observed_gb} GB"
     )
+    assert pred * AD_MEMORY_FIT_SAFETY_FACTOR >= observed_gb
 
 
 def test_checkpoint_every_none_leaves_segmented_null():
@@ -85,10 +269,13 @@ def test_plan_ad_memory_returns_none_when_full_ad_fits():
 
     assert isinstance(plan, ADMemoryPlan)
     assert plan.full_ad_fits is True
-    assert plan.segmented_fits is True
+    assert plan.segmented_fits is False
     assert plan.checkpoint_every is None
     assert plan.selected_estimate.checkpoint_every is None
-    assert plan.selected_estimate.ad_full_gb <= plan.target_memory_gb
+    assert plan.checkpoint_segments is None
+    assert plan.checkpoint_mode is None
+    assert plan.selected_estimate.ad_full_gb * plan.fit_safety_factor <= plan.target_memory_gb
+    assert plan.selected_estimate.ad_segmented_gb is None
 
 
 def test_plan_ad_memory_recommends_checkpoint_every_for_budget():
@@ -100,14 +287,38 @@ def test_plan_ad_memory_recommends_checkpoint_every_for_budget():
     assert plan.segmented_fits is True
     assert plan.checkpoint_every is not None
     assert plan.selected_estimate.checkpoint_every == plan.checkpoint_every
-    assert plan.selected_estimate.ad_segmented_gb <= plan.target_memory_gb
+    assert plan.checkpoint_segments is None
+    assert plan.checkpoint_mode == "checkpoint_every"
+    assert plan.selected_estimate.ad_segmented_gb * plan.fit_safety_factor <= plan.target_memory_gb
     if plan.checkpoint_every > 1:
         previous = sim.estimate_ad_memory(
             n_steps=10_000,
             available_memory_gb=1.0,
             checkpoint_every=plan.checkpoint_every - 1,
         )
-        assert previous.ad_segmented_gb > plan.target_memory_gb
+        assert previous.ad_segmented_gb * plan.fit_safety_factor > plan.target_memory_gb
+
+
+def test_plan_ad_memory_checkpoint_every_handles_unaligned_warmup():
+    sim = _patch_like_sim()
+
+    plan = sim.plan_ad_memory(
+        n_steps=120,
+        available_memory_gb=0.35,
+        n_warmup=49,
+    )
+
+    assert plan.segmented_fits is True
+    assert plan.checkpoint_mode == "checkpoint_every"
+    assert plan.checkpoint_every == 12
+    previous = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=0.35,
+        checkpoint_every=11,
+        n_warmup=49,
+    )
+    assert previous.ad_segmented_gb * plan.fit_safety_factor > plan.target_memory_gb
+    assert plan.selected_estimate.ad_segmented_gb * plan.fit_safety_factor <= plan.target_memory_gb
 
 
 def test_plan_ad_memory_reports_unfit_budget():
@@ -119,7 +330,53 @@ def test_plan_ad_memory_reports_unfit_budget():
     assert plan.segmented_fits is False
     assert plan.checkpoint_every == 10_000
     assert plan.selected_estimate.ad_segmented_gb > plan.target_memory_gb
+    assert plan.checkpoint_segments is None
+    assert plan.checkpoint_mode == "checkpoint_every"
     assert "reduce mesh size" in plan.recommendation
+
+    report = sim.mesh_intelligence_report(
+        n_steps=10_000,
+        checkpoint_every=plan.checkpoint_every,
+        available_memory_gb=0.001,
+    )
+    assert "exceeds 85%" in report.recommendation
+    assert "use segmented AD estimate" not in report.recommendation
+
+
+def test_plan_ad_memory_reports_uniform_unfit_budget():
+    sim = _uniform_sim()
+
+    plan = sim.plan_ad_memory(n_steps=120, available_memory_gb=1e-6)
+
+    assert plan.full_ad_fits is False
+    assert plan.segmented_fits is False
+    assert plan.checkpoint_every is None
+    assert plan.checkpoint_segments == 1
+    assert plan.checkpoint_mode == "checkpoint_segments"
+    assert plan.selected_estimate.ad_segmented_gb > plan.target_memory_gb
+    assert "checkpoint_segments=1" in plan.recommendation
+    assert "reduce mesh size" in plan.recommendation
+
+
+def test_plan_ad_memory_uses_valid_custom_target_fraction():
+    sim = _patch_like_sim()
+
+    plan = sim.plan_ad_memory(
+        n_steps=10_000,
+        available_memory_gb=1.0,
+        target_fraction=0.5,
+    )
+
+    assert plan.target_fraction == 0.5
+    assert plan.target_memory_gb == 0.5
+    assert plan.selected_estimate.ad_segmented_gb * plan.fit_safety_factor <= plan.target_memory_gb
+    if plan.checkpoint_every > 1:
+        previous = sim.estimate_ad_memory(
+            n_steps=10_000,
+            available_memory_gb=1.0,
+            checkpoint_every=plan.checkpoint_every - 1,
+        )
+        assert previous.ad_segmented_gb * plan.fit_safety_factor > plan.target_memory_gb
 
 
 def test_plan_ad_memory_serializes_artifact():
@@ -132,4 +389,534 @@ def test_plan_ad_memory_serializes_artifact():
     assert artifact["checkpoint_every"] == plan.checkpoint_every
     assert artifact["selected_estimate"]["checkpoint_every"] == plan.checkpoint_every
     assert artifact["segmented_fits"] is True
+    assert artifact["checkpoint_segments"] == plan.checkpoint_segments
+    assert artifact["checkpoint_mode"] == plan.checkpoint_mode
+    assert artifact["fit_safety_factor"] == plan.fit_safety_factor
+    assert artifact["selected_estimate"]["ad_segmented_active_segments"] is not None
     assert parsed == artifact
+
+
+def test_checkpoint_segments_accounting_matches_uniform_segment_count():
+    sim = _uniform_sim()
+
+    by_segments = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
+    by_chunk = sim.estimate_ad_memory(n_steps=120, checkpoint_every=12)
+
+    assert by_segments.checkpoint_segments == 10
+    assert by_segments.checkpoint_every is None
+    assert by_segments.ad_segmented_gb == by_chunk.ad_segmented_gb
+    assert by_segments.ad_segmented_active_segments == 10
+    assert by_chunk.ad_segmented_active_segments == 10
+    assert by_segments.to_dict()["checkpoint_segments"] == 10
+
+
+def test_checkpoint_segments_active_count_honors_warmup():
+    sim = _uniform_sim()
+
+    full = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
+    warm = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_segments=10,
+        n_warmup=60,
+    )
+
+    assert warm.forward_gb == full.forward_gb
+    assert warm.ad_active_steps == 60
+    assert warm.ad_segmented_gb < full.ad_segmented_gb
+    assert warm.ad_segmented_active_segments == 5
+    same_active_segments = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_every=12,
+        n_warmup=60,
+    )
+    assert warm.ad_segmented_gb == same_active_segments.ad_segmented_gb
+
+    partial_warm = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_segments=10,
+        n_warmup=61,
+    )
+    partial_same_active_segments = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_every=12,
+        n_warmup=61,
+    )
+    assert partial_warm.ad_active_steps == 59
+    assert partial_warm.ad_segmented_gb == partial_same_active_segments.ad_segmented_gb
+    assert partial_warm.ad_segmented_gb == warm.ad_segmented_gb
+    assert partial_warm.ad_segmented_active_segments == 5
+    assert partial_same_active_segments.ad_segmented_active_segments == 5
+
+
+def test_checkpoint_every_active_count_honors_unaligned_warmup():
+    sim = _uniform_sim()
+
+    unaligned = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_every=50,
+        n_warmup=49,
+    )
+    three_active_segments = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_segments=3,
+    )
+    boundary = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_every=50,
+        n_warmup=50,
+    )
+    two_active_segments = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_segments=2,
+    )
+
+    assert unaligned.ad_active_steps == 71
+    assert unaligned.ad_segmented_gb == three_active_segments.ad_segmented_gb
+    assert unaligned.ad_segmented_active_segments == 3
+    assert boundary.ad_active_steps == 70
+    assert boundary.ad_segmented_gb == two_active_segments.ad_segmented_gb
+    assert boundary.ad_segmented_active_segments == 2
+
+
+def test_plan_ad_memory_recommends_checkpoint_segments_for_uniform_budget():
+    sim = _uniform_sim()
+
+    plan = sim.plan_ad_memory(n_steps=120, available_memory_gb=0.002)
+
+    assert plan.full_ad_fits is False
+    assert plan.segmented_fits is True
+    assert plan.checkpoint_every is None
+    assert plan.checkpoint_segments == 10
+    assert plan.checkpoint_mode == "checkpoint_segments"
+    assert plan.selected_estimate.checkpoint_segments == plan.checkpoint_segments
+    assert plan.selected_estimate.ad_segmented_gb * plan.fit_safety_factor <= plan.target_memory_gb
+    assert "0.00 GB" not in plan.recommendation
+    assert "MB" in plan.recommendation
+
+
+def test_estimate_rejects_ambiguous_checkpoint_modes():
+    sim = _uniform_sim()
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        sim.estimate_ad_memory(
+            n_steps=120,
+            checkpoint_every=12,
+            checkpoint_segments=10,
+        )
+
+
+def test_estimate_rejects_invalid_checkpoint_segments():
+    sim = _uniform_sim()
+
+    with pytest.raises(ValueError, match="does not divide n_steps"):
+        sim.estimate_ad_memory(n_steps=120, checkpoint_segments=11)
+    with pytest.raises(ValueError, match="checkpoint_segments must be"):
+        sim.estimate_ad_memory(n_steps=120, checkpoint_segments=0)
+    with pytest.raises(ValueError, match="checkpoint_segments must be"):
+        sim.estimate_ad_memory(n_steps=120, checkpoint_segments=-1)
+
+
+def test_estimate_rejects_invalid_active_tape_inputs():
+    sim = _uniform_sim()
+
+    with pytest.raises(ValueError, match="n_steps must be positive"):
+        sim.estimate_ad_memory(n_steps=0)
+    with pytest.raises(ValueError, match="n_warmup must be >= 0"):
+        sim.estimate_ad_memory(n_steps=120, n_warmup=-1)
+    with pytest.raises(ValueError, match="must be < n_steps"):
+        sim.estimate_ad_memory(n_steps=120, n_warmup=120)
+    with pytest.raises(ValueError, match="checkpoint_every must be positive"):
+        sim.estimate_ad_memory(n_steps=120, checkpoint_every=0)
+    with pytest.raises(ValueError, match="checkpoint_every must be positive"):
+        sim.estimate_ad_memory(n_steps=120, checkpoint_every=-1)
+    with pytest.raises(ValueError, match="design_mask must be non-empty"):
+        sim.estimate_ad_memory(n_steps=120, design_mask=np.array([], dtype=bool))
+    with pytest.raises(ValueError, match="boolean array matching grid shape"):
+        sim.estimate_ad_memory(n_steps=120, design_mask=np.array(True))
+    with pytest.raises(TypeError, match="boolean dtype"):
+        sim.estimate_ad_memory(
+            n_steps=120,
+            design_mask=np.ones(_grid_shape(sim), dtype=np.int8),
+        )
+    with pytest.raises(ValueError, match="select at least one cell"):
+        sim.estimate_ad_memory(
+            n_steps=120,
+            design_mask=np.zeros(_grid_shape(sim), dtype=bool),
+        )
+    with pytest.raises(ValueError, match="must match simulation grid shape"):
+        sim.estimate_ad_memory(
+            n_steps=120,
+            design_mask=np.ones((2, 2, 2), dtype=bool),
+        )
+    with pytest.raises(TypeError, match="n_steps must be an integer"):
+        sim.estimate_ad_memory(n_steps=1.5)
+    with pytest.raises(TypeError, match="n_steps must be an integer"):
+        sim.estimate_ad_memory(n_steps=True)
+    with pytest.raises(TypeError, match="n_warmup must be an integer"):
+        sim.estimate_ad_memory(n_steps=120, n_warmup=1.5)
+    with pytest.raises(TypeError, match="checkpoint_every must be an integer"):
+        sim.estimate_ad_memory(n_steps=120, checkpoint_every=12.5)
+    with pytest.raises(TypeError, match="checkpoint_segments must be an integer"):
+        sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10.5)
+    with pytest.raises(ValueError, match="available_memory_gb must be positive"):
+        sim.estimate_ad_memory(n_steps=120, available_memory_gb=0.0)
+    with pytest.raises(ValueError, match="available_memory_gb must be positive"):
+        sim.estimate_ad_memory(n_steps=120, available_memory_gb=-1.0)
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.estimate_ad_memory(n_steps=120, available_memory_gb=True)
+    with pytest.raises(ValueError, match="available_memory_gb must be finite"):
+        sim.estimate_ad_memory(n_steps=120, available_memory_gb=float("nan"))
+    with pytest.raises(ValueError, match="available_memory_gb must be finite"):
+        sim.estimate_ad_memory(n_steps=120, available_memory_gb=float("inf"))
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.estimate_ad_memory(n_steps=120, available_memory_gb=[1.0])
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.estimate_ad_memory(n_steps=120, available_memory_gb=1 + 0j)
+
+
+def test_plan_ad_memory_rejects_invalid_scalar_inputs():
+    sim = _uniform_sim()
+
+    with pytest.raises(ValueError, match="n_steps must be positive"):
+        sim.plan_ad_memory(n_steps=0, available_memory_gb=1.0)
+    with pytest.raises(ValueError, match="n_warmup must be >= 0"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, n_warmup=-1)
+    with pytest.raises(ValueError, match="must be < n_steps"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, n_warmup=120)
+    with pytest.raises(ValueError, match="available_memory_gb must be positive"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=0.0)
+    with pytest.raises(ValueError, match="available_memory_gb must be positive"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=-1.0)
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=True)
+    with pytest.raises(ValueError, match="available_memory_gb must be finite"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=float("nan"))
+    with pytest.raises(ValueError, match="available_memory_gb must be finite"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=float("inf"))
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=[1.0])
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1 + 0j)
+    with pytest.raises(ValueError, match="target_fraction must be positive"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, target_fraction=0.0)
+    with pytest.raises(ValueError, match="target_fraction must be positive"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, target_fraction=-0.1)
+    with pytest.raises(ValueError, match="interval"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, target_fraction=1.5)
+    with pytest.raises(ValueError, match="target_fraction must be finite"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            target_fraction=float("inf"),
+        )
+    with pytest.raises(ValueError, match="target_fraction must be finite"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            target_fraction=float("nan"),
+        )
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            target_fraction=True,
+        )
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            target_fraction=[0.85],
+        )
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            target_fraction=1 + 0j,
+        )
+    with pytest.raises(ValueError, match="safety_factor must be positive"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, safety_factor=0.0)
+    with pytest.raises(ValueError, match="safety_factor must be >= 1"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, safety_factor=0.5)
+    with pytest.raises(ValueError, match="safety_factor must be finite"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            safety_factor=float("nan"),
+        )
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, safety_factor=True)
+
+
+def test_plan_ad_memory_rejects_invalid_design_masks():
+    sim = _uniform_sim()
+
+    with pytest.raises(ValueError, match="design_mask must be non-empty"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            design_mask=np.array([], dtype=bool),
+        )
+    with pytest.raises(ValueError, match="boolean array matching grid shape"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            design_mask=np.array(True),
+        )
+    with pytest.raises(TypeError, match="boolean dtype"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            design_mask=np.ones(_grid_shape(sim), dtype=np.int8),
+        )
+    with pytest.raises(ValueError, match="select at least one cell"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            design_mask=np.zeros(_grid_shape(sim), dtype=bool),
+        )
+    with pytest.raises(ValueError, match="must match simulation grid shape"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            design_mask=np.ones((2, 2, 2), dtype=bool),
+        )
+
+
+def test_warning_uses_realistic_selected_estimate():
+    sim = _uniform_sim()
+
+    full = sim.estimate_ad_memory(n_steps=120, available_memory_gb=1e-6)
+    assert full.warning is not None
+    assert "non-checkpointed" in full.warning
+    assert "Use plan_ad_memory()" in full.warning
+
+    segmented = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=1e-6,
+        checkpoint_segments=10,
+    )
+    assert segmented.warning is not None
+    assert "segmented" in segmented.warning
+    assert "Reduce checkpoint_segments" in segmented.warning
+
+    chunked = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=1e-6,
+        checkpoint_every=12,
+    )
+    assert chunked.warning is not None
+    assert "segmented" in chunked.warning
+    assert "Increase checkpoint_every" in chunked.warning
+
+    minimum_segmented = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=1e-6,
+        checkpoint_segments=1,
+    )
+    assert minimum_segmented.warning is not None
+    assert "Reduce checkpoint_segments" not in minimum_segmented.warning
+    assert "more aggressive memory-reduction lane" in minimum_segmented.warning
+
+    minimum_chunked = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=1e-6,
+        checkpoint_every=120,
+    )
+    assert minimum_chunked.warning is not None
+    assert "Increase checkpoint_every" not in minimum_chunked.warning
+    assert "more aggressive memory-reduction lane" in minimum_chunked.warning
+
+
+def test_warning_has_no_false_positive_at_boundary():
+    sim = _uniform_sim()
+
+    baseline = sim.estimate_ad_memory(n_steps=120)
+    exact_available = baseline.ad_full_gb / 0.85
+    exact = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=exact_available,
+    )
+    below = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=exact_available * 0.99,
+    )
+
+    assert exact.warning is None
+    assert below.warning is not None
+
+    segmented_baseline = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
+    segmented_available = segmented_baseline.ad_segmented_gb / 0.85
+    segmented_exact = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_segments=10,
+        available_memory_gb=segmented_available,
+    )
+    assert segmented_exact.warning is None
+
+    chunked_baseline = sim.estimate_ad_memory(n_steps=120, checkpoint_every=12)
+    chunked_available = chunked_baseline.ad_segmented_gb / 0.85
+    chunked_exact = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_every=12,
+        available_memory_gb=chunked_available,
+    )
+    assert chunked_exact.warning is None
+
+
+def test_ntff_dft_bytes_contribute_to_ad_estimates():
+    baseline = _uniform_sim().estimate_ad_memory(n_steps=120, checkpoint_segments=10)
+    chunk_baseline = _uniform_sim().estimate_ad_memory(n_steps=120, checkpoint_every=12)
+    sim = _uniform_sim()
+    sim.add_ntff_box(
+        (1e-3, 1e-3, 1e-3),
+        (9e-3, 9e-3, 4e-3),
+        n_freqs=3,
+    )
+
+    with_ntff = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
+    chunk_with_ntff = sim.estimate_ad_memory(n_steps=120, checkpoint_every=12)
+    report = sim.mesh_intelligence_report(n_steps=120, checkpoint_every=12)
+
+    assert with_ntff.ntff_dft_gb > 0.0
+    assert with_ntff.ad_full_gb > baseline.ad_full_gb
+    assert with_ntff.ad_segmented_gb > baseline.ad_segmented_gb
+    assert chunk_with_ntff.ad_segmented_gb > chunk_baseline.ad_segmented_gb
+    assert report.ad_memory is not None
+    assert report.ad_memory.ntff_dft_gb > 0.0
+
+    nu_baseline_sim = _patch_like_sim()
+    nu_baseline = nu_baseline_sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_every=12,
+    )
+    nu_with_ntff_sim = _patch_like_sim()
+    nu_with_ntff_sim.add_ntff_box(
+        (1e-3, 1e-3, 1e-3),
+        (39e-3, 39e-3, 20e-3),
+        n_freqs=3,
+    )
+    nu_with_ntff = nu_with_ntff_sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_every=12,
+    )
+    nu_report = nu_with_ntff_sim.mesh_intelligence_report(
+        n_steps=120,
+        checkpoint_every=12,
+    )
+
+    assert nu_with_ntff.ntff_dft_gb > 0.0
+    assert nu_with_ntff.ad_segmented_gb > nu_baseline.ad_segmented_gb
+    assert nu_report.ad_memory is not None
+    assert nu_report.ad_memory.ntff_dft_gb > 0.0
+
+
+def test_nonfinite_artifacts_refuse_json_serialization():
+    bad_estimate = AD_MemoryEstimate(
+        forward_gb=float("nan"),
+        ad_checkpointed_gb=1.0,
+        ad_full_gb=1.0,
+        ntff_dft_gb=0.0,
+        available_gb=None,
+        warning=None,
+    )
+    with pytest.raises(ValueError, match="Out of range"):
+        bad_estimate.to_json()
+    with pytest.raises(ValueError, match="Out of range"):
+        bad_estimate.to_json(allow_nan=True)
+
+    good_estimate = _uniform_sim().estimate_ad_memory(n_steps=120)
+    bad_plan = ADMemoryPlan(
+        n_steps=120,
+        available_memory_gb=float("inf"),
+        target_fraction=0.85,
+        target_memory_gb=1.0,
+        checkpoint_every=None,
+        selected_estimate=good_estimate,
+        full_ad_fits=True,
+        segmented_fits=True,
+        recommendation="bad nonfinite artifact",
+    )
+    with pytest.raises(ValueError, match="Out of range"):
+        bad_plan.to_json()
+    with pytest.raises(ValueError, match="Out of range"):
+        bad_plan.to_json(allow_nan=True)
+
+    bad_report = MeshIntelligenceReport(
+        grid_shape=(1, 1, 1),
+        cells=1,
+        uniform_fine_shape=(1, 1, 1),
+        uniform_fine_cells=1,
+        cell_savings_factor=float("nan"),
+        min_cell_size=1.0,
+        nominal_dx=1.0,
+        uses_nonuniform=False,
+        preflight_issues=(),
+        ad_memory=None,
+        recommendation="bad nonfinite report",
+    )
+    with pytest.raises(ValueError, match="Out of range"):
+        bad_report.to_json()
+    with pytest.raises(ValueError, match="Out of range"):
+        bad_report.to_json(allow_nan=True)
+
+
+def test_n_warmup_reduces_reverse_tape_only():
+    sim = _patch_like_sim()
+
+    full = sim.estimate_ad_memory(n_steps=1_000)
+    warm = sim.estimate_ad_memory(n_steps=1_000, n_warmup=600)
+
+    assert warm.forward_gb == full.forward_gb
+    assert warm.ad_active_steps == 400
+    assert warm.ad_full_gb < full.ad_full_gb
+
+
+def test_design_mask_records_fraction_without_reducing_primary_memory():
+    sim = _patch_like_sim()
+    design_mask = _design_mask(sim)
+    expected_fraction = float(np.count_nonzero(design_mask)) / float(design_mask.size)
+
+    full = sim.estimate_ad_memory(n_steps=1_000)
+    masked = sim.estimate_ad_memory(n_steps=1_000, design_mask=design_mask)
+
+    assert masked.forward_gb == full.forward_gb
+    assert masked.ad_active_design_fraction == pytest.approx(expected_fraction)
+    assert masked.ad_full_gb == full.ad_full_gb
+
+
+def test_plan_ad_memory_rejects_non_integral_counts():
+    sim = _uniform_sim()
+
+    with pytest.raises(TypeError, match="n_steps must be an integer"):
+        sim.plan_ad_memory(n_steps=120.5, available_memory_gb=1.0)
+    with pytest.raises(TypeError, match="n_steps must be an integer"):
+        sim.plan_ad_memory(n_steps=True, available_memory_gb=1.0)
+    with pytest.raises(TypeError, match="n_warmup must be an integer"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, n_warmup=1.5)
+
+
+def test_plan_ad_memory_records_warmup_and_mask_metadata():
+    sim = _patch_like_sim()
+    budget_gb = 0.2
+    design_mask = _design_mask(sim)
+    expected_fraction = float(np.count_nonzero(design_mask)) / float(design_mask.size)
+    warm_only = sim.plan_ad_memory(
+        n_steps=10_000,
+        available_memory_gb=budget_gb,
+        n_warmup=9_000,
+    )
+
+    baseline = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=budget_gb)
+    masked = sim.plan_ad_memory(
+        n_steps=10_000,
+        available_memory_gb=budget_gb,
+        n_warmup=9_000,
+        design_mask=design_mask,
+    )
+
+    assert baseline.full_ad_fits is False
+    assert masked.selected_estimate.ad_active_steps == 1_000
+    assert masked.selected_estimate.ad_active_design_fraction == pytest.approx(expected_fraction)
+    assert masked.selected_estimate.ad_full_gb == warm_only.selected_estimate.ad_full_gb
+    assert masked.checkpoint_every == warm_only.checkpoint_every
+    assert masked.checkpoint_every is None or masked.checkpoint_every < baseline.checkpoint_every

--- a/tests/test_estimate_ad_memory.py
+++ b/tests/test_estimate_ad_memory.py
@@ -26,7 +26,14 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from rfx import ADMemoryPlan, AD_MemoryEstimate, MeshIntelligenceReport, Simulation
+from rfx import (
+    ADMemoryComponent,
+    ADMemoryExplainabilityReport,
+    ADMemoryPlan,
+    AD_MemoryEstimate,
+    MeshIntelligenceReport,
+    Simulation,
+)
 from rfx.api import AD_MEMORY_FIT_SAFETY_FACTOR
 
 _FORBIDDEN_CURRENT_EVIDENCE_FIELDS = {
@@ -108,21 +115,29 @@ def _design_mask(sim: Simulation, *, fraction: float = 0.25) -> np.ndarray:
 def test_public_imports_and_json_roundtrip():
     from rfx import ADMemoryPlan as TopPlan
     from rfx import AD_MemoryEstimate as TopEstimate
+    from rfx import ADMemoryComponent as TopComponent
+    from rfx import ADMemoryExplainabilityReport as TopExplanation
     from rfx import Simulation as TopSimulation
     from rfx.api import ADMemoryPlan as ApiPlan
     from rfx.api import AD_MemoryEstimate as ApiEstimate
+    from rfx.api import ADMemoryComponent as ApiComponent
+    from rfx.api import ADMemoryExplainabilityReport as ApiExplanation
     from rfx.api import Simulation as ApiSimulation
 
     assert TopEstimate is ApiEstimate is AD_MemoryEstimate
     assert TopPlan is ApiPlan is ADMemoryPlan
+    assert TopComponent is ApiComponent is ADMemoryComponent
+    assert TopExplanation is ApiExplanation is ADMemoryExplainabilityReport
     assert TopSimulation is ApiSimulation is Simulation
 
     sim = _uniform_sim()
     estimate = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
     plan = sim.plan_ad_memory(n_steps=120, available_memory_gb=100.0)
+    explanation = sim.explain_ad_memory(n_steps=120, checkpoint_segments=10)
 
     assert json.loads(estimate.to_json()) == estimate.to_dict()
     assert json.loads(plan.to_json()) == plan.to_dict()
+    assert json.loads(explanation.to_json()) == explanation.to_dict()
     assert estimate.to_dict()["checkpoint_segments"] == 10
     estimate_keys = {
         "evidence_class",
@@ -155,9 +170,23 @@ def test_public_imports_and_json_roundtrip():
         "segmented_fits",
         "recommendation",
     }
+    explanation_keys = {
+        "evidence_class",
+        "n_steps",
+        "strategy",
+        "selected_memory_gb",
+        "selected_memory_field",
+        "estimate",
+        "components",
+        "dominant_component",
+        "recommendations",
+    }
     assert plan.to_dict()["evidence_class"] == "calibrated_conservative_plan"
     assert set(estimate.to_dict()) == estimate_keys
     assert set(plan.to_dict()) == plan_keys
+    assert set(explanation.to_dict()) == explanation_keys
+    assert explanation.to_dict()["estimate"]["evidence_class"] == "static_estimate"
+    assert explanation.to_dict()["evidence_class"] == "static_ad_explainability"
     assert set(plan.to_dict()["selected_estimate"]) == estimate_keys
     assert plan.to_dict()["selected_estimate"]["evidence_class"] == "static_estimate"
     _assert_no_forbidden_current_fields(estimate.to_dict())
@@ -165,6 +194,8 @@ def test_public_imports_and_json_roundtrip():
     _assert_no_forbidden_current_fields(plan.to_dict()["selected_estimate"])
     assert "evidence_class" not in AD_MemoryEstimate._fields
     assert "evidence_class" not in ADMemoryPlan._fields
+    assert "evidence_class" not in ADMemoryComponent._fields
+    assert "evidence_class" not in ADMemoryExplainabilityReport._fields
     with pytest.raises(ValueError):
         estimate._replace(evidence_class="observed_profile")
     with pytest.raises(ValueError):
@@ -175,6 +206,11 @@ def test_current_memory_artifacts_keep_evidence_classes_separate():
     sim = _patch_like_sim()
     estimate = sim.estimate_ad_memory(n_steps=10_000, checkpoint_every=500)
     plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=1.0)
+    explanation = sim.explain_ad_memory(
+        n_steps=10_000,
+        checkpoint_every=500,
+        available_memory_gb=1.0,
+    )
     report = sim.mesh_intelligence_report(
         n_steps=10_000,
         checkpoint_every=plan.checkpoint_every,
@@ -184,21 +220,124 @@ def test_current_memory_artifacts_keep_evidence_classes_separate():
     estimate_artifact = estimate.to_dict()
     plan_artifact = plan.to_dict()
     report_artifact = report.to_dict()
+    explanation_artifact = explanation.to_dict()
 
     assert estimate_artifact["evidence_class"] == "static_estimate"
     assert plan_artifact["evidence_class"] == "calibrated_conservative_plan"
     assert plan_artifact["selected_estimate"]["evidence_class"] == "static_estimate"
     assert report_artifact["ad_memory"]["evidence_class"] == "static_estimate"
+    assert explanation_artifact["evidence_class"] == "static_ad_explainability"
+    assert explanation_artifact["estimate"]["evidence_class"] == "static_estimate"
 
     _assert_no_forbidden_current_fields(estimate_artifact)
     _assert_no_forbidden_current_fields(plan_artifact)
     _assert_no_forbidden_current_fields(plan_artifact["selected_estimate"])
     _assert_no_forbidden_current_fields(report_artifact["ad_memory"])
+    _assert_no_forbidden_current_fields(explanation_artifact["estimate"])
+
+
+def test_explain_ad_memory_decomposes_selected_estimate():
+    sim = _patch_like_sim()
+
+    explanation = sim.explain_ad_memory(n_steps=10_000, checkpoint_every=500)
+    artifact = explanation.to_dict()
+    components = {component["name"]: component for component in artifact["components"]}
+
+    assert explanation.strategy == "segmented_checkpoint_every"
+    assert explanation.selected_memory_field == "ad_segmented_gb"
+    assert explanation.selected_memory_gb == explanation.estimate.ad_segmented_gb
+    assert explanation.dominant_component == "segmented_boundary_field_tape"
+    assert {
+        "field_state",
+        "material_auxiliary_state",
+        "cpml_auxiliary_state",
+        "segmented_boundary_field_tape",
+        "ntff_dft_state",
+    } == set(components)
+    assert components["segmented_boundary_field_tape"]["kind"] == "reverse_ad_saved_state"
+    assert components["segmented_boundary_field_tape"]["count"] == (
+        2 * explanation.estimate.ad_segmented_active_segments
+    )
+    assert components["segmented_boundary_field_tape"]["memory_gb"] > components["field_state"]["memory_gb"]
+    assert sum(
+        component["memory_gb"] for component in artifact["components"]
+    ) == pytest.approx(explanation.selected_memory_gb)
+    assert json.loads(explanation.to_json()) == artifact
+
+def test_explain_ad_memory_covers_ntff_and_segmented_warmup_paths():
+    baseline = _uniform_sim().explain_ad_memory(n_steps=120, checkpoint_segments=10)
+    sim = _uniform_sim()
+    sim.add_ntff_box(
+        (1e-3, 1e-3, 1e-3),
+        (9e-3, 9e-3, 4e-3),
+        n_freqs=3,
+    )
+
+    segmented = sim.explain_ad_memory(
+        n_steps=120,
+        checkpoint_segments=10,
+        n_warmup=61,
+    )
+    chunked = sim.explain_ad_memory(
+        n_steps=120,
+        checkpoint_every=12,
+        n_warmup=61,
+    )
+
+    for explanation, strategy in (
+        (segmented, "segmented_checkpoint_segments"),
+        (chunked, "segmented_checkpoint_every"),
+    ):
+        artifact = explanation.to_dict()
+        components = {component["name"]: component for component in artifact["components"]}
+
+        assert explanation.strategy == strategy
+        assert explanation.selected_memory_field == "ad_segmented_gb"
+        assert explanation.estimate.ntff_dft_gb > baseline.estimate.ntff_dft_gb
+        assert explanation.estimate.ad_segmented_active_segments == 5
+        assert components["ntff_dft_state"]["memory_gb"] == pytest.approx(
+            explanation.estimate.ntff_dft_gb
+        )
+        assert components["segmented_boundary_field_tape"]["count"] == (
+            2 * explanation.estimate.ad_segmented_active_segments
+        )
+        assert sum(
+            component["memory_gb"] for component in artifact["components"]
+        ) == pytest.approx(explanation.selected_memory_gb)
+
+
+def test_explain_ad_memory_records_warmup_mask_and_full_tape():
+    sim = _uniform_sim()
+    design_mask = _design_mask(sim, fraction=0.5)
+
+    explanation = sim.explain_ad_memory(
+        n_steps=120,
+        n_warmup=20,
+        design_mask=design_mask,
+    )
+    artifact = explanation.to_dict()
+    components = {component["name"]: component for component in artifact["components"]}
+
+    assert explanation.strategy == "full_reverse_ad_static_tape"
+    assert explanation.selected_memory_field == "ad_full_gb"
+    assert components["full_reverse_field_tape"]["count"] == 100
+    assert explanation.estimate.ad_active_design_fraction == pytest.approx(
+        np.count_nonzero(design_mask) / design_mask.size
+    )
+    assert any("design_mask" in rec for rec in explanation.recommendations)
+    assert sum(
+        component["memory_gb"] for component in artifact["components"]
+    ) == pytest.approx(explanation.selected_memory_gb)
 
 
 def test_current_memory_recommendations_do_not_claim_guarantees():
     sim = _patch_like_sim()
     plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=1.0)
+    explanation = sim.explain_ad_memory(
+        n_steps=10_000,
+        checkpoint_every=plan.checkpoint_every,
+        available_memory_gb=1.0,
+    )
     report = sim.mesh_intelligence_report(
         n_steps=10_000,
         checkpoint_every=plan.checkpoint_every,
@@ -209,6 +348,7 @@ def test_current_memory_recommendations_do_not_claim_guarantees():
         plan.recommendation,
         report.recommendation,
         sim.estimate_ad_memory(n_steps=10_000, available_memory_gb=1e-6).warning,
+        *explanation.recommendations,
     ]
     for text in texts:
         assert text is not None
@@ -220,8 +360,10 @@ def test_memory_reduction_docs_separate_planning_from_certificate_evidence():
     doc = Path("docs/public/guide/memory-reduction.mdx").read_text()
     assert "`static_estimate`" in doc
     assert "`calibrated_conservative_plan`" in doc
+    assert "`static_ad_explainability`" in doc
+    assert "explain_ad_memory(...)" in doc
     assert "`bounded_certificate`" in doc
-    assert "Current `estimate_ad_memory(...)` and `plan_ad_memory(...)` artifacts are not certificates" in doc
+    assert "Current `estimate_ad_memory(...)`, `plan_ad_memory(...)`, and `explain_ad_memory(...)` artifacts are not certificates" in doc
     assert "not a universal guaranteed peak predictor" in doc
 
 

--- a/tests/test_mesh_intelligence_report.py
+++ b/tests/test_mesh_intelligence_report.py
@@ -57,6 +57,47 @@ def test_mesh_intelligence_report_uses_segmented_ad_estimate():
     assert "legacy step-checkpoint" in report.recommendation
 
 
+def test_mesh_intelligence_report_forwards_ad_tape_metadata():
+    sim = _patch_like_nonuniform_sim()
+    baseline = sim.mesh_intelligence_report(n_steps=1_000, checkpoint_every=100)
+    assert baseline.ad_memory is not None
+
+    mask = np.zeros(baseline.grid_shape, dtype=bool)
+    mask.reshape(-1)[: max(1, mask.size // 4)] = True
+    report = sim.mesh_intelligence_report(
+        n_steps=1_000,
+        checkpoint_every=100,
+        n_warmup=600,
+        design_mask=mask,
+    )
+
+    assert report.ad_memory is not None
+    assert report.ad_memory.forward_gb == baseline.ad_memory.forward_gb
+    assert report.ad_memory.ad_active_steps == 400
+    assert report.ad_memory.ad_active_design_fraction == np.count_nonzero(mask) / mask.size
+    assert report.ad_memory.ad_full_gb < baseline.ad_memory.ad_full_gb
+
+
+def test_mesh_intelligence_report_uses_uniform_checkpoint_segments():
+    sim = Simulation(
+        freq_max=10e9,
+        domain=(10e-3, 10e-3, 5e-3),
+        dx=1e-3,
+        boundary="cpml",
+        cpml_layers=2,
+    )
+    sim.add_source((5e-3, 5e-3, 2e-3), "ez")
+    sim.add_probe((5e-3, 5e-3, 3e-3), "ez")
+
+    report = sim.mesh_intelligence_report(n_steps=120, checkpoint_segments=10)
+
+    assert report.ad_memory is not None
+    assert report.ad_memory.checkpoint_segments == 10
+    assert report.ad_memory.checkpoint_every is None
+    assert report.ad_memory.ad_segmented_gb is not None
+    assert "segmented AD estimate" in report.recommendation
+
+
 def test_mesh_intelligence_report_serializes_artifact():
     sim = _patch_like_nonuniform_sim()
 
@@ -71,6 +112,21 @@ def test_mesh_intelligence_report_serializes_artifact():
     assert artifact["ad_memory"] is not None
     assert artifact["ad_memory"]["checkpoint_every"] == 1000
     assert artifact["ad_memory"]["ad_segmented_gb"] == report.ad_memory.ad_segmented_gb
+    assert artifact["ad_memory"]["evidence_class"] == "static_estimate"
+    forbidden_fields = {
+        "compiler_memory_gb",
+        "compiler_reported_required_gb",
+        "observed_peak_gb",
+        "profile_peak_gb",
+        "certificate_status",
+        "scope_digest",
+        "config_digest",
+        "environment_digest",
+        "is_valid_certificate",
+        "is_budget_safe",
+        "peak_bound_gb",
+    }
+    assert forbidden_fields.isdisjoint(artifact["ad_memory"])
     assert parsed == artifact
 
 


### PR DESCRIPTION
## Summary
- mark AD memory estimates/plans as conservative evidence classes (`static_estimate`, `calibrated_conservative_plan`) without making them certificate/profile artifacts
- add `Simulation.explain_ad_memory(...)` plus `ADMemoryComponent` / `ADMemoryExplainabilityReport` public artifacts for static AD memory driver breakdowns
- centralize shared static byte accounting so estimator and explainer do not drift across field/material/CPML/NTFF calculations
- tighten `plan_ad_memory` fit semantics, checkpoint knob separation, active-tape metadata, strict JSON, and report passthrough behavior
- add schema-boundary, NTFF/warmup explainability, component-sum, public export, and forbidden-wording tests; update memory-reduction docs to reject universal guaranteed peak-memory claims while leaving future bounded certificates separate

## Verification
- `pytest tests/test_estimate_ad_memory.py tests/test_mesh_intelligence_report.py tests/test_memory_reduction_planning_artifact.py tests/test_inverse_design_preflight.py -q` — 51 passed
- `ruff check rfx/api/__init__.py rfx/api/_spec.py rfx/__init__.py tests/test_estimate_ad_memory.py --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402` — OK
- selected adversarial nodeids for evidence boundaries / wording / component accounting / NTFF-warmup / docs / imports — 8 passed
- runtime API probe for `Simulation.explain_ad_memory(...)` evidence class, component sum, NTFF, and forbidden wording — `static-ad-explainability-api-ok`

## Notes
- This PR intentionally does **not** implement a guaranteed peak-memory predictor. Current APIs remain conservative planning/explainability artifacts.
- A true guarantee-like feature would need a separate bounded certificate API scoped to one exact compiled executable/environment/config and fail-closed metadata.