### PR TITLE
test(nonuniform): commit + gate the NU graded-dy flux broad-E5 Airy envelope (scoped, lane stays shadow)

### DIFF
--- a/docs/guides/support_matrix.json
+++ b/docs/guides/support_matrix.json
@@ -44,7 +44,7 @@
         "ntff": "hard_fail",
         "dft_plane": "hard_fail",
         "tfsf": "hard_fail",
-        "waveguide_port": "restricted_shadow_normalize_true_single_mode_otherwise_hard_fail",
+        "waveguide_port": "shadow_te10_single_mode: normalize=True/'flux' validated at settled num_periods; broad-E5-ANALYTIC envelope committed+gated (graded-dy 1-3x, eps_r 2/4, vs analytic Airy, 16/16<=0.0157); NOT claims-bearing (broad-E4 external cross-solver + AD-traceability pending); other combinations hard_fail",
         "lumped_rlc": "hard_fail",
         "lumped_port_sparameters": "hard_fail",
         "msl_s_matrix": "hard_fail",

--- a/docs/guides/support_matrix.md
+++ b/docs/guides/support_matrix.md
@@ -63,6 +63,19 @@ Current retained subset:
 - graded-z thin-substrate workflows with probes and current-style excitation
 - smoke/convergence coverage in `tests/test_nonuniform_api.py` and `tests/test_nonuniform_convergence.py`
 - selected dispersive-material smoke coverage
+- NU waveguide-port flux (TE10, single-mode, forward-only): **broad-E5-analytic
+  evidence committed + gated** vs independent analytic Airy across the graded-`dy`
+  transverse mesh axis (grading 1-3x, eps_r {2,4}, 16/16 ≤0.0157; gpu-rtx4090
+  VESSL 369367244527 @ `ff9bfcb`). Lives in
+  `tests/fixtures/waveguide_nu_broad_e5/` + `tests/test_waveguide_nu_broad_e5_envelope_gates.py`
+  and the np=40 power/reciprocity live gate `tests/test_waveguide_nu_nontrivial.py`.
+  This is a **broad-E5-analytic tier (analytic-oracle, no external solver / no AD),
+  NOT a claims-bearing promotion** — the lane stays
+  shadow. Remaining ladder rungs before any uniform-class flip: (1) a broad-E4
+  external-solver (Meep/OpenEMS) cross-check on a graded mesh, and (2)
+  AD-traceability of the NU waveguide S-matrix (`eps_override`/`sigma_override`
+  are currently `NotImplementedError` on the NU path). `check_port_external_references.py`
+  correctly blocks `broad_e5_passed` until both exist.
 
 Current policy:
 - preserved for continuity and qualification work
@@ -78,7 +91,7 @@ Current policy:
 | NTFF + nonuniform | unsupported | hard-fail |
 | DFT planes + nonuniform | unsupported | hard-fail |
 | TFSF + nonuniform | unsupported | hard-fail |
-| Waveguide ports + nonuniform | shadow / restricted | only documented `compute_waveguide_s_matrix(normalize=True)` single-mode path; otherwise hard-fail |
+| Waveguide ports + nonuniform | shadow / restricted | `compute_waveguide_s_matrix(normalize=True/'flux')` single-mode TE10 validated at settled `num_periods`; **broad-E5-analytic envelope committed + gated** (graded-`dy` 1-3x, eps_r 2/4, vs analytic Airy, `tests/test_waveguide_nu_broad_e5_envelope_gates.py`); still **shadow / not claims-bearing** pending broad-E4 external cross-solver + AD-traceability; otherwise hard-fail |
 | Lumped-port S-parameters + nonuniform | unsupported | hard-fail |
 | `compute_msl_s_matrix()` + nonuniform | unsupported | hard-fail |
 | Coaxial port + nonuniform | unsupported | hard-fail |

--- a/tests/fixtures/waveguide_nu_broad_e5/waveguide_wr90_nu_flux_broad_e5_envelope.json
+++ b/tests/fixtures/waveguide_nu_broad_e5/waveguide_wr90_nu_flux_broad_e5_envelope.json
@@ -1,0 +1,279 @@
+{
+  "schema": "rfx.waveguide_wr90_nu_flux_broad_e5_envelope",
+  "schema_version": 1,
+  "status": "passed",
+  "evidence_level": "E5-broad-mesh-frequency-geometry-nonuniform-flux",
+  "claim": "rfx WR-90 nonuniform graded-dy compute_waveguide_s_matrix(normalize='flux') vs analytic Airy across 4 grading ratios and 2 eps_r geometries (incl. strong eps_r=4) over X-band passes broad-E5 0.05.",
+  "claim_scope": "broad rfx WR-90 rectangular_waveguide_port nonuniform-mesh compute_waveguide_s_matrix(normalize='flux') Poynting power-flux extraction versus analytic Airy reference envelope spanning the graded-dy mesh refinement axis (grading_ratio 1-3, adjacent-cell ratio up to 3.00), the frequency axis (8.2-12.4 GHz X-band single-mode TE10), and the geometry axis (eps_r in [2.0, 4.0] centered slabs including the strong eps_r=4 reflector that the normalize=True path floors at ~0.077). The graded-mesh discrete TE10 mode profile uses the Galerkin symmetric generalized eigensolve (commit 13c9651) and the flux S-matrix branch (issue #88 Step B). Truth source is independent analytic Airy, not a same-class FDTD reference.",
+  "commit_hash": "ff9bfcb",
+  "generated_at": "2026-06-24T16:13:21.303022+00:00",
+  "max_mag_abs_tol": 0.05,
+  "ratio_spread_floor": 0.005,
+  "noise_floor_baseline": 0.0021,
+  "primary_reference": {
+    "label": "analytic_airy",
+    "truth_key": "airy_slab_closed_form",
+    "path": "internal_closed_form",
+    "meta": {
+      "eps_r_values": [
+        2.0,
+        4.0
+      ]
+    }
+  },
+  "cross_check_references": [],
+  "envelope_summary": {
+    "case_count": 16,
+    "passed_case_count": 16,
+    "failed_case_count": 0,
+    "freq_range_hz": [
+      8200000000.0,
+      12400000000.0
+    ],
+    "cutoff_te10_hz": 6557140376.202975,
+    "grading_ratios": [
+      1.0,
+      1.5,
+      2.0,
+      3.0
+    ],
+    "eps_r_values": [
+      2.0,
+      4.0
+    ],
+    "max_adjacent_ratio": 2.9999999999999996,
+    "max_mag_abs_diff_across_cases": 0.015609204769134521,
+    "mean_max_mag_abs_diff_across_cases": 0.012635523453354836,
+    "ratio_spread": 0.4257214209615891,
+    "primary_reference_label": "analytic_airy",
+    "mesh_axis_kind": "nonuniform_dy_profile_ratio",
+    "setup_recipe": {
+      "cpml_layers": 24,
+      "normalize": "flux",
+      "num_periods": 60,
+      "base_dx_m": 0.00025,
+      "domain_m": [
+        0.2,
+        0.02286,
+        0.01016
+      ]
+    },
+    "runtime_env": {
+      "jax_default_backend": "gpu",
+      "jax_version": "0.4.33.dev20241023+e3c6d6430",
+      "numpy_version": "1.26.4"
+    }
+  },
+  "diagnostic_note": "max_mag_abs_diff_across_cases 0.0156 (tol 0.05); graded-mesh TE10 via Galerkin eigensolve (13c9651); normalize='flux' NU path (issue #88 Step B). eps_r=4 cases test strong-reflector extension past the normalize=True 0.077 floor.",
+  "rfx_manifest_path": "/root/workspace/byungkwan-workspace/research/rfx/.omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/rfx_wr90_nu_flux_sweep_manifest.json",
+  "cases": [
+    {
+      "tag": "ratio1_er2_L4mm",
+      "grading_ratio": 1.0,
+      "adjacent_ratio": 1.0,
+      "n_cells_y": 91,
+      "eps_r": 2.0,
+      "geometry": "slab_er2_L4mm",
+      "s11_max_mag_abs_diff": 0.012687206268310547,
+      "s21_max_mag_abs_diff": 0.005950868129730225,
+      "max_mag_abs_diff": 0.012687206268310547,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio1_er2_L4mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio1_er2_L2mm",
+      "grading_ratio": 1.0,
+      "adjacent_ratio": 1.0,
+      "n_cells_y": 91,
+      "eps_r": 2.0,
+      "geometry": "slab_er2_L2mm",
+      "s11_max_mag_abs_diff": 0.00896403193473816,
+      "s21_max_mag_abs_diff": 0.002487778663635254,
+      "max_mag_abs_diff": 0.00896403193473816,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio1_er2_L2mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio1_er4_L4mm",
+      "grading_ratio": 1.0,
+      "adjacent_ratio": 1.0,
+      "n_cells_y": 91,
+      "eps_r": 4.0,
+      "geometry": "slab_er4_L4mm",
+      "s11_max_mag_abs_diff": 0.009904861450195312,
+      "s21_max_mag_abs_diff": 0.010992646217346191,
+      "max_mag_abs_diff": 0.010992646217346191,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio1_er4_L4mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio1_er4_L2mm",
+      "grading_ratio": 1.0,
+      "adjacent_ratio": 1.0,
+      "n_cells_y": 91,
+      "eps_r": 4.0,
+      "geometry": "slab_er4_L2mm",
+      "s11_max_mag_abs_diff": 0.01277017593383789,
+      "s21_max_mag_abs_diff": 0.008968651294708252,
+      "max_mag_abs_diff": 0.01277017593383789,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio1_er4_L2mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio1.5_er2_L4mm",
+      "grading_ratio": 1.5,
+      "adjacent_ratio": 1.5,
+      "n_cells_y": 91,
+      "eps_r": 2.0,
+      "geometry": "slab_er2_L4mm",
+      "s11_max_mag_abs_diff": 0.013668656349182129,
+      "s21_max_mag_abs_diff": 0.0066266655921936035,
+      "max_mag_abs_diff": 0.013668656349182129,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio1.5_er2_L4mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio1.5_er2_L2mm",
+      "grading_ratio": 1.5,
+      "adjacent_ratio": 1.5,
+      "n_cells_y": 91,
+      "eps_r": 2.0,
+      "geometry": "slab_er2_L2mm",
+      "s11_max_mag_abs_diff": 0.009210765361785889,
+      "s21_max_mag_abs_diff": 0.002675652503967285,
+      "max_mag_abs_diff": 0.009210765361785889,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio1.5_er2_L2mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio1.5_er4_L4mm",
+      "grading_ratio": 1.5,
+      "adjacent_ratio": 1.5,
+      "n_cells_y": 91,
+      "eps_r": 4.0,
+      "geometry": "slab_er4_L4mm",
+      "s11_max_mag_abs_diff": 0.011177897453308105,
+      "s21_max_mag_abs_diff": 0.012625277042388916,
+      "max_mag_abs_diff": 0.012625277042388916,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio1.5_er4_L4mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio1.5_er4_L2mm",
+      "grading_ratio": 1.5,
+      "adjacent_ratio": 1.5,
+      "n_cells_y": 91,
+      "eps_r": 4.0,
+      "geometry": "slab_er4_L2mm",
+      "s11_max_mag_abs_diff": 0.014034509658813477,
+      "s21_max_mag_abs_diff": 0.010134458541870117,
+      "max_mag_abs_diff": 0.014034509658813477,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio1.5_er4_L2mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio2_er2_L4mm",
+      "grading_ratio": 2.0,
+      "adjacent_ratio": 2.0,
+      "n_cells_y": 91,
+      "eps_r": 2.0,
+      "geometry": "slab_er2_L4mm",
+      "s11_max_mag_abs_diff": 0.01434352993965149,
+      "s21_max_mag_abs_diff": 0.007036387920379639,
+      "max_mag_abs_diff": 0.01434352993965149,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio2_er2_L4mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio2_er2_L2mm",
+      "grading_ratio": 2.0,
+      "adjacent_ratio": 2.0,
+      "n_cells_y": 91,
+      "eps_r": 2.0,
+      "geometry": "slab_er2_L2mm",
+      "s11_max_mag_abs_diff": 0.009434342384338379,
+      "s21_max_mag_abs_diff": 0.002773284912109375,
+      "max_mag_abs_diff": 0.009434342384338379,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio2_er2_L2mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio2_er4_L4mm",
+      "grading_ratio": 2.0,
+      "adjacent_ratio": 2.0,
+      "n_cells_y": 91,
+      "eps_r": 4.0,
+      "geometry": "slab_er4_L4mm",
+      "s11_max_mag_abs_diff": 0.012028038501739502,
+      "s21_max_mag_abs_diff": 0.013658642768859863,
+      "max_mag_abs_diff": 0.013658642768859863,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio2_er4_L4mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio2_er4_L2mm",
+      "grading_ratio": 2.0,
+      "adjacent_ratio": 2.0,
+      "n_cells_y": 91,
+      "eps_r": 4.0,
+      "geometry": "slab_er4_L2mm",
+      "s11_max_mag_abs_diff": 0.0148848295211792,
+      "s21_max_mag_abs_diff": 0.010865271091461182,
+      "max_mag_abs_diff": 0.0148848295211792,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio2_er4_L2mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio3_er2_L4mm",
+      "grading_ratio": 3.0,
+      "adjacent_ratio": 2.9999999999999996,
+      "n_cells_y": 91,
+      "eps_r": 2.0,
+      "geometry": "slab_er2_L4mm",
+      "s11_max_mag_abs_diff": 0.014874488115310669,
+      "s21_max_mag_abs_diff": 0.007620632648468018,
+      "max_mag_abs_diff": 0.014874488115310669,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio3_er2_L4mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio3_er2_L2mm",
+      "grading_ratio": 3.0,
+      "adjacent_ratio": 2.9999999999999996,
+      "n_cells_y": 91,
+      "eps_r": 2.0,
+      "geometry": "slab_er2_L2mm",
+      "s11_max_mag_abs_diff": 0.009405970573425293,
+      "s21_max_mag_abs_diff": 0.002978503704071045,
+      "max_mag_abs_diff": 0.009405970573425293,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio3_er2_L2mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio3_er4_L4mm",
+      "grading_ratio": 3.0,
+      "adjacent_ratio": 2.9999999999999996,
+      "n_cells_y": 91,
+      "eps_r": 4.0,
+      "geometry": "slab_er4_L4mm",
+      "s11_max_mag_abs_diff": 0.012785613536834717,
+      "s21_max_mag_abs_diff": 0.015004098415374756,
+      "max_mag_abs_diff": 0.015004098415374756,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio3_er4_L4mm.npz",
+      "status": "passed"
+    },
+    {
+      "tag": "ratio3_er4_L2mm",
+      "grading_ratio": 3.0,
+      "adjacent_ratio": 2.9999999999999996,
+      "n_cells_y": 91,
+      "eps_r": 4.0,
+      "geometry": "slab_er4_L2mm",
+      "s11_max_mag_abs_diff": 0.015609204769134521,
+      "s21_max_mag_abs_diff": 0.011837482452392578,
+      "max_mag_abs_diff": 0.015609204769134521,
+      "rfx_npz": ".omx/physics-gate/2026-05-29-waveguide-wr90-nu-flux-broad-e5/rfx-sweep/ratio3_er4_L2mm.npz",
+      "status": "passed"
+    }
+  ]
+}

--- a/tests/test_waveguide_nu_broad_e5_envelope_gates.py
+++ b/tests/test_waveguide_nu_broad_e5_envelope_gates.py
@@ -1,0 +1,134 @@
+"""Committed gate for the WR-90 nonuniform graded-dy FLUX broad-E5 envelope.
+
+Mirrors ``tests/test_waveguide_broad_e5_envelope_gates.py`` for the NONUNIFORM
+(graded transverse ``dy``) waveguide-port flux lane. It closes the
+"uncommitted ``.omx``" defect for the NU broad-E5-analytic evidence: the envelope
+JSON (``tests/fixtures/waveguide_nu_broad_e5/``, regenerated on gpu-rtx4090,
+VESSL 369367244527 at commit ff9bfcb, 16/16 cases <= 0.0157 vs analytic Airy) is
+replayed on a CLEAN CHECKOUT, so the claim no longer rides on a gitignored
+artifact (the coaxial-overclaim hole this lane was at risk of).
+
+SCOPE / honesty -- this gate is **broad-E5-analytic (analytic-oracle, no external
+solver / no AD), NOT a claims-bearing uniform-class PASS**. It locks the NU flux S-matrix against the independent analytic Airy
+reference across the graded-TRANSVERSE ``dy`` mesh axis (grading ratio 1-3,
+adjacent-cell ratio up to 3:1), eps_r {2, 4} (incl. the strong eps_r=4 reflector
+the ``normalize=True`` path floors at ~0.077), over X-band single-mode TE10,
+forward-only, single-slab. It deliberately does NOT establish (a) a broad-E4
+external-solver (Meep/OpenEMS) cross-check, nor (b) AD-traceability of the NU
+S-matrix -- both are REQUIRED by ``check_port_external_references.py`` for
+``broad_e5_passed`` and remain the open ladder rungs that keep the nonuniform
+lane SHADOW (not claims-bearing).
+
+Layer 2 drives the producer's own ``airy()`` formula + ``MAX_TOL`` with synthetic
+ideal / perturbed S-parameters to lock the gate semantics. Pure-Python (no FDTD);
+both layers replay frozen numbers, so a regression in the live
+``compute_waveguide_s_matrix`` does not flip them -- that live anchor is the
+np=40 power/reciprocity gate in ``tests/test_waveguide_nu_nontrivial.py``.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "scripts" / "diagnostics"))
+from build_waveguide_wr90_nu_flux_broad_e5_envelope import (  # type: ignore  # noqa: E402
+    MAX_TOL,
+    airy,
+)
+
+FIXTURE = (
+    REPO / "tests" / "fixtures" / "waveguide_nu_broad_e5"
+    / "waveguide_wr90_nu_flux_broad_e5_envelope.json"
+)
+
+MIN_GRADING_RATIOS = 2   # mesh-refinement axis (NU uses grading ratio, not dx)
+MIN_EPS_R = 2            # geometry axis
+MIN_CASES = 4
+_A_WG = 22.86e-3
+_FC_TE10 = 299_792_458.0 / (2 * _A_WG)
+
+
+def test_nu_flux_envelope_present() -> None:
+    assert FIXTURE.exists(), f"missing committed NU flux envelope: {FIXTURE}"
+
+
+def test_committed_nu_flux_envelope_passes_broad_e5() -> None:
+    """Re-derive the broad-E5 verdict from the committed per-case numbers."""
+    env = json.loads(FIXTURE.read_text())
+    summ = env["envelope_summary"]
+
+    assert env["status"] == "passed", f"status={env['status']}"
+    assert env["evidence_level"].startswith("E5-broad"), env["evidence_level"]
+    # Mesh axis = grading ratio (NU), geometry axis = eps_r.
+    assert len(summ["grading_ratios"]) >= MIN_GRADING_RATIOS, summ["grading_ratios"]
+    assert len(summ["eps_r_values"]) >= MIN_EPS_R, summ["eps_r_values"]
+    assert summ["mesh_axis_kind"] == "nonuniform_dy_profile_ratio", summ["mesh_axis_kind"]
+    # The graded TRANSVERSE axis is genuinely exercised (adjacent-cell ratio > 1):
+    # this envelope drives the per-cell graded-dA port-plane weighting the
+    # dx-graded production tests do not reach.
+    assert summ["max_adjacent_ratio"] > 1.0, summ["max_adjacent_ratio"]
+
+    cases = env["cases"]
+    assert len(cases) >= MIN_CASES, cases
+    per_case_max = []
+    for c in cases:
+        assert c["status"] == "passed", c
+        assert c["max_mag_abs_diff"] <= MAX_TOL, c
+        per_case_max.append(c["max_mag_abs_diff"])
+    assert summ["passed_case_count"] == summ["case_count"] == len(cases)
+    assert summ["max_mag_abs_diff_across_cases"] == pytest.approx(
+        max(per_case_max), abs=1e-9
+    )
+    assert summ["max_mag_abs_diff_across_cases"] <= MAX_TOL
+    # The strong eps_r=4 reflector (normalize=True 0.077-floor breaker) is covered.
+    assert 4.0 in [float(x) for x in summ["eps_r_values"]], summ["eps_r_values"]
+
+
+def test_primary_reference_is_independent_analytic_no_external_yet() -> None:
+    """Truth is the independent analytic Airy; NU has no external E4 cross-check
+    yet (honest: the external-solver leg is an open ladder rung, lane = shadow)."""
+    env = json.loads(FIXTURE.read_text())
+    assert env["primary_reference"]["label"] == "analytic_airy", env["primary_reference"]
+    assert env["cross_check_references"] == [], env["cross_check_references"]
+
+
+def _synthetic_airy(eps_r: float = 4.0, slab_L: float = 4.0e-3):
+    f = np.linspace(8.2e9, 12.4e9, 11)
+    s11, s21 = airy(f, eps_r, slab_L, _FC_TE10)
+    return f, np.asarray(s11), np.asarray(s21)
+
+
+def _case_max_diff(rfx_s11, rfx_s21, ref_s11, ref_s21) -> float:
+    """Replicate the producer's magnitude-diff gate metric."""
+    s11d = np.abs(np.abs(rfx_s11) - np.abs(ref_s11))
+    s21d = np.abs(np.abs(rfx_s21) - np.abs(ref_s21))
+    return max(float(s11d.max()), float(s21d.max()))
+
+
+def test_gate_passes_when_rfx_equals_airy() -> None:
+    """An ideal slab (rfx == analytic Airy) clears the gate with ~zero diff."""
+    _, s11, s21 = _synthetic_airy()
+    case_max = _case_max_diff(s11, s21, s11, s21)
+    assert case_max <= MAX_TOL
+    assert case_max < 1e-12
+
+
+def test_gate_fails_on_magnitude_perturbation() -> None:
+    """A +0.1 |S11| offset (well above MAX_TOL=0.05) must fail the gate."""
+    _, s11, s21 = _synthetic_airy()
+    perturbed = np.abs(s11) + 0.1
+    case_max = _case_max_diff(perturbed, s21, s11, s21)
+    assert case_max > MAX_TOL
+    assert case_max == pytest.approx(0.1, abs=1e-9)
+
+
+def test_lossless_slab_airy_is_unitary() -> None:
+    """Independent witness: the analytic Airy reference itself conserves power."""
+    _, s11, s21 = _synthetic_airy(eps_r=4.0)
+    unit = np.abs(s11) ** 2 + np.abs(s21) ** 2
+    assert np.allclose(unit, 1.0, atol=1e-6)


### PR DESCRIPTION
## Summary

Honest **scoped** step of the non-uniform (NU) lane promotion ladder. The user asked to promote NU to uniform-class; a multi-agent assessment + the repo auditor (`check_port_external_references.py`) found full uniform-class is **blocked** (needs a broad-E4 external cross-solver + AD-traceability). This PR ships only what the evidence supports — and **keeps the NU lane `shadow` / not claims-bearing**.

A GPU re-run on **current main** (`gpu-rtx4090`, VESSL `369367244527` @ `ff9bfcb`) reproduced the WR-90 NU graded-`dy` flux broad-E5 sweep: **16/16 cases ≤ 0.0157 vs analytic Airy**, refreshing the previously frozen/gitignored `.omx` artifact (`e867975`).

## What landed

- **Committed evidence** — `tests/fixtures/waveguide_nu_broad_e5/waveguide_wr90_nu_flux_broad_e5_envelope.json`. The broad-E5-analytic envelope now survives a clean checkout (closes the gitignored-`.omx` hole, the coaxial-overclaim pattern).
- **Non-vacuous gate** — `tests/test_waveguide_nu_broad_e5_envelope_gates.py`: replays the committed per-case diffs (fails on a doctored status / a case > `MAX_TOL` / a summary that disagrees with its cases / a dropped eps_r=4) **plus** a gate-semantics lock driving the producer's own `airy()` + `MAX_TOL` (ideal slab passes, +0.1 |S| perturbation fails) + an Airy unitarity witness.
- **Honest matrix update** — `support_matrix.{json,md}`: NU waveguide-port flux now has committed+gated broad-E5-analytic evidence, but the lane **stays shadow**, with the two remaining ladder rungs named: (1) broad-E4 external-solver (Meep/OpenEMS) cross-check on a graded mesh, (2) AD-traceability of the NU S-matrix.

## Why this is not an over-claim

- The sweep grades `dy_profile` (the y-axis), which is **transverse** to the x-normal port plane — so it genuinely exercises the per-cell **graded-dA** weighting the dx-graded production tests miss. Real, non-redundant coverage.
- It is an **analytic-oracle (E5-broad-analytic)** tier, single-mode TE10, forward-only, single-slab — explicitly **NOT** a uniform-class flip.
- The auditor still returns `status=blocked` (unchanged) — NU was **not** slipped into a false `broad_e5_passed`. Its inputs (`sparameter_support_matrix.json`, the requirements manifest) are untouched.

## Validation

- New gate: 6 passed; co-run with the uniform gate: 17 passed (no glob collision — separate fixture dir).
- `support_matrix.json` consumers (`test_ad_surface_contract.py`, `test_physics_gate_reporting.py`): 61 passed.
- `check_port_external_references.py --require-committed`: `status=blocked` (unchanged).
- ruff clean. No production simulator code changed (`tests/` + `docs/` only).
- Independent code review: **APPROVE** (0 blocker/major).

🤖 Generated with [Claude Code](https://claude.com/claude-code)