### PR TITLE
feat(sparams): wire AD-traceability into the NU waveguide flux S-matrix (rung 5)

### DIFF
--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -275,16 +275,23 @@ class _SparamMixin:
                 unsupported.append("normalize=True or normalize='flux' is required")
             if any(entry.n_modes > 1 for entry in entries):
                 unsupported.append("multi-mode ports (n_modes>1) are not supported")
-            # The NU extractor has no eps/sigma/subpixel inputs; accepting
-            # these kwargs and forwarding nothing would silently break the
-            # documented differentiable channel (G-AD-WIRE-WG2).
-            if eps_override is not None:
+            # The differentiable eps/sigma AD channel is wired on the NU
+            # path only for normalize='flux' (mirrors the uniform PR #172
+            # flux-AD fix): the flux extractor is now jnp-native end-to-end
+            # so a traced eps_override flows into the device Yee update and
+            # back through the S-matrix. normalize=True is kept out of scope
+            # — its diagonal a_inc_ref denominator carries the #88 band-edge
+            # fragility, so accepting eps_override there could yield
+            # silently-wrong gradients.
+            if eps_override is not None and normalize != "flux":
                 unsupported.append(
-                    "eps_override (differentiable AD channel) is not wired on the NU path"
+                    "eps_override (differentiable AD channel) on the NU path "
+                    "requires normalize='flux'"
                 )
-            if sigma_override is not None:
+            if sigma_override is not None and normalize != "flux":
                 unsupported.append(
-                    "sigma_override (differentiable AD channel) is not wired on the NU path"
+                    "sigma_override (differentiable AD channel) on the NU path "
+                    "requires normalize='flux'"
                 )
             if subpixel_smoothing:
                 unsupported.append("subpixel_smoothing is not supported")
@@ -300,6 +307,8 @@ class _SparamMixin:
                 n_steps=n_steps,
                 num_periods=num_periods,
                 normalize=normalize,
+                eps_override=eps_override,
+                sigma_override=sigma_override,
             )
             return _finalize_sparam_result(
                 _res_nu,
@@ -1894,6 +1903,8 @@ class _SparamMixin:
         n_steps: int | None,
         num_periods: float,
         normalize: bool,
+        eps_override=None,
+        sigma_override=None,
     ) -> WaveguideSMatrixResult:
         """Non-uniform-mesh two-run S-matrix extraction.
 
@@ -1907,8 +1918,15 @@ class _SparamMixin:
         vacuum before the scan launches.
 
         Current scope (matches the uniform path minus a few niceties):
-          - ``normalize=True`` only.
+          - ``normalize=True`` or ``normalize='flux'``.
           - Single-mode ports (``n_modes == 1``) only.
+          - ``eps_override`` / ``sigma_override`` (the differentiable AD
+            design variable) are wired only for ``normalize='flux'``: they
+            are threaded into the *device* run so the traced eps flows
+            through the jnp-native flux extraction and back to the
+            S-matrix gradient. The *reference* run stays vacuum. They are
+            rejected for ``normalize=True`` (its diagonal a_inc_ref
+            denominator carries the #88 band-edge fragility).
 
         Extracts ``a_inc`` / ``b_out`` via the same
         ``extract_waveguide_port_waves`` helper as the uniform path and
@@ -2036,10 +2054,22 @@ class _SparamMixin:
                     for idx, e in enumerate(original_entries)
                 ]
 
+                # Device run: thread the public eps/sigma override (the
+                # traced design variable) into the device Yee update so the
+                # gradient flows from eps_override -> device fields -> flux
+                # -> S-matrix (mirrors the uniform PR #172 flux-AD wiring).
+                # When eps_override is None the assembled device materials
+                # are used unchanged (device fields identical); the np->jnp
+                # flux extraction below matches the prior np path to
+                # rtol<=1e-5 (float reassociation only, per uniform PR #172).
                 dev_result = run_nonuniform_path(
                     self, n_steps=n_steps,
+                    eps_override=eps_override,
+                    sigma_override=sigma_override,
                     attach_waveguide_flux=_flux_mode,
                 )
+                # Reference run stays vacuum (incident-power reference) and is
+                # independent of the design variable.
                 ref_result = run_nonuniform_path(
                     self,
                     n_steps=n_steps,
@@ -2099,27 +2129,52 @@ class _SparamMixin:
                             "per-port flux spectra; run_nonuniform_path did "
                             "not return waveguide_port_flux."
                         )
-                    P_inc = np.abs(np.asarray(F_ref[drive_idx]))
-                    safe_P_inc = np.where(P_inc > 1e-60, P_inc, 1.0)
+                    # jnp-native (mirrors the uniform PR #172 flux-AD fix):
+                    # no np.asarray() concretization — keeps the whole flux
+                    # extraction on the AD tape so an eps_override-traced
+                    # device run yields finite gradients through the
+                    # S-matrix. Uses the DOUBLE-WHERE trick at sqrt(0) /
+                    # angle(0) (guard the INPUT, not just the output): a
+                    # single jnp.where still leaks NaN grad through the dead
+                    # branch (#171/#172/#148). Forward values are identical
+                    # to the prior np version for P_inc / P > 0.
+                    P_inc = jnp.abs(F_ref[drive_idx])
+                    safe_P_inc = jnp.where(
+                        P_inc > 1e-60, P_inc, jnp.ones_like(P_inc)
+                    )
                     recv_col = []
                     for recv_idx in range(n_ports):
                         recv_name = original_entries[recv_idx].name
                         _, b_recv_dev = extract_waveguide_port_waves(
                             dev_wg[recv_name], ref_shift=ref_shifts[recv_idx],
                         )
-                        phase = np.angle(
-                            np.asarray(b_recv_dev) / np.asarray(safe_a_inc)
+                        # AD-safe angle (double-where): angle() has an
+                        # undefined gradient at 0; angle(1)=0 matches
+                        # np.angle(0)=0 so the primal is unchanged.
+                        ratio = b_recv_dev / safe_a_inc
+                        ratio_ok = jnp.abs(ratio) > 0.0
+                        phase = jnp.angle(
+                            jnp.where(ratio_ok, ratio, jnp.ones_like(ratio))
                         )
                         if recv_idx == drive_idx:
-                            P_refl = np.abs(
-                                np.asarray(F_ref[drive_idx])
-                                - np.asarray(F_dev[drive_idx])
-                            )
-                            mag = np.sqrt(P_refl / safe_P_inc)
+                            P_num = jnp.abs(F_ref[drive_idx] - F_dev[drive_idx])
                         else:
-                            P_trans = np.abs(np.asarray(F_dev[recv_idx]))
-                            mag = np.sqrt(P_trans / safe_P_inc)
-                        recv_col.append(jnp.asarray(mag * np.exp(1j * phase)))
+                            P_num = jnp.abs(F_dev[recv_idx])
+                        # AD-safe sqrt (double-where): a perfect match/null
+                        # makes the power ratio exactly 0, where
+                        # d(sqrt)/dx = inf would leak 0*inf=nan through the
+                        # backward pass; primal stays exactly sqrt(x) for
+                        # x>0 and exactly 0 at x=0.
+                        p_ratio = P_num / safe_P_inc
+                        p_ok = p_ratio > 0.0
+                        mag = jnp.where(
+                            p_ok,
+                            jnp.sqrt(
+                                jnp.where(p_ok, p_ratio, jnp.ones_like(p_ratio))
+                            ),
+                            0.0,
+                        )
+                        recv_col.append(mag * jnp.exp(1j * phase))
                     s_columns.append(recv_col)
                     continue
 

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -735,10 +735,18 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
                 ref_shift=reference_plane - measured_reference_plane,
                 probe_shift=probe_plane - measured_probe_plane,
             )
+            # jnp-native (NU flux-AD): this per-port diagnostic is a SIDE
+            # output the normalize='flux' S-matrix path does not consume, but
+            # run_nonuniform_path always assembles it. np.array(tracer) here
+            # detaches / crashes the eps_override-traced device run (the same
+            # concretization class as issue #70 / #148). Keeping these as
+            # jnp arrays is forward bit-identical for concrete consumers
+            # (np.asarray accepts jnp transparently — test_nonuniform_api /
+            # test_api read .s11 via np.abs / np.isfinite).
             waveguide_sparams_result[entry.name] = WaveguideSParamResult(
-                freqs=np.array(cfg.freqs),
-                s11=np.array(s11),
-                s21=np.array(s21),
+                freqs=cfg.freqs,
+                s11=s11,
+                s21=s21,
                 calibration_preset=calibration_preset,
                 source_plane=float(source_plane),
                 measured_reference_plane=measured_reference_plane,
@@ -772,8 +780,14 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         from rfx.probes.probes import flux_spectrum
         n_sim_flux = len(flux_monitor_objs)
         wg_final = r["flux_monitors"][n_sim_flux:]
+        # jnp-native (NU flux-AD, mirrors the uniform PR #172 fix): keep
+        # flux_spectrum on the AD tape — np.array() here would detach the
+        # eps_override-traced gradient (the issue #148 concretization bug).
+        # The sole consumer (compute_waveguide_s_matrix_nu, normalize='flux')
+        # is jnp-native; np.asarray(...) downstream still accepts these for
+        # any concrete-path numpy reader, so forward values are unchanged.
         waveguide_port_flux_result = tuple(
-            np.array(flux_spectrum(m)) for m in wg_final
+            flux_spectrum(m) for m in wg_final
         )
 
     return Result(

--- a/tests/test_waveguide_nu_flux_ad.py
+++ b/tests/test_waveguide_nu_flux_ad.py
@@ -1,0 +1,209 @@
+"""NU waveguide ``normalize='flux'`` S-matrix on the AD tape (rung 5).
+
+Mirror of ``tests/test_waveguide_flux_ad.py`` (the uniform PR #172 flux-AD
+gate) for the NON-UNIFORM mesh path. Before the fix the NU dispatch
+rejected ``eps_override`` outright on every normalize mode, and the NU
+flux branch concretized the flux/phase/mag assembly through ``np.*``
+(plus ``run_nonuniform_path`` wrapped ``waveguide_port_flux`` in
+``np.array(...)``), so ``compute_waveguide_s_matrix(normalize='flux',
+eps_override=<traced>)`` on a graded mesh could not be optimized through.
+
+After the fix the device run threads the traced ``eps_override`` into the
+Yee update, the flux extraction is jnp-native end-to-end (double-where at
+sqrt(0)/angle(0) per #171/#172/#148), and the reference run stays vacuum.
+
+Gates (composition-level, per the G2 lesson — unit AD tests do not
+protect compositions):
+  1+2. grad(|S21(f0)|^2) w.r.t. a substrate-eps scalar through the FULL
+       NU flux extraction is finite AND matches central finite
+       differences to <=5% rel (fixture has real sensitivity: FD != 0).
+  3.   Forward S-matrix with a no-op (deps=0) eps_override == the
+       no-override NU flux forward (rtol<=1e-5) — proves the np->jnp
+       rewrite + threading did not change forward values.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+import jax
+import jax.numpy as jnp
+
+from rfx import Simulation
+from rfx.auto_config import smooth_grading
+from rfx.boundaries.spec import Boundary, BoundarySpec
+from rfx.geometry.csg import Box
+
+NUM_PERIODS = 8.0
+
+_A_WG = 0.02286
+_B_WG = 0.01016
+_F_MAX = 12e9
+_FREQS = jnp.linspace(8.2e9, 12.4e9, 4)
+_SLAB_X_LO = 0.045
+_SLAB_X_HI = 0.049
+_SLAB_EPS_R = 4.0
+
+
+def _wr90_nu_sim():
+    """Graded-mesh (dx_profile) WR-90 with a dielectric slab mid-guide.
+
+    Same geometry as ``tests/test_waveguide_nu_flux.py`` so the fixture is
+    a known-good NU flux witness; the slab gives the eps_override a real
+    |S21| sensitivity for the FD gate.
+    """
+    dx_coarse = 1.5e-3
+    dx_fine = 0.75e-3
+    n_pre = int(round(0.030 / dx_coarse))
+    n_fine = int(round(0.040 / dx_fine))
+    n_post = int(round(0.030 / dx_coarse))
+    raw = np.concatenate([
+        np.full(n_pre, dx_coarse),
+        np.full(n_fine, dx_fine),
+        np.full(n_post, dx_coarse),
+    ])
+    dx_profile = smooth_grading(raw, max_ratio=1.3)
+    domain_x = float(np.sum(dx_profile))
+
+    sim = Simulation(
+        freq_max=_F_MAX,
+        domain=(domain_x, _A_WG, _B_WG),
+        dx=dx_coarse,
+        boundary=BoundarySpec(
+            x=Boundary(lo="cpml", hi="cpml"),
+            y=Boundary(lo="pec", hi="pec"),
+            z=Boundary(lo="pec", hi="pec"),
+        ),
+        cpml_layers=8,
+        dx_profile=dx_profile,
+    )
+    sim.add_material("diel_slab", eps_r=_SLAB_EPS_R, sigma=0.0)
+    sim.add(
+        Box((_SLAB_X_LO, 0.0, 0.0), (_SLAB_X_HI, _A_WG, _B_WG)),
+        material="diel_slab",
+    )
+    sim.add_waveguide_port(
+        0.015, direction="+x", mode=(1, 0), mode_type="TE",
+        freqs=_FREQS, f0=10.3e9, bandwidth=0.5,
+        reference_plane=0.020, name="left",
+    )
+    sim.add_waveguide_port(
+        domain_x - 0.015, direction="-x", mode=(1, 0), mode_type="TE",
+        freqs=_FREQS, f0=10.3e9, bandwidth=0.5,
+        reference_plane=domain_x - 0.020, name="right",
+    )
+    return sim, domain_x
+
+
+def _eps_override_for(sim, domain_x, deps):
+    """NU-grid eps override 1.0 + deps inside the slab region (traced).
+
+    Sized to the NU grid the flux extractor builds (``_build_nonuniform_grid``
+    synthesises the same scalar-dx dz_profile and the same x-cpml pad the
+    NU S-matrix path uses, so the shape matches the device materials array).
+    """
+    from rfx.runners.nonuniform import pos_to_nu_index
+    grid = sim._build_nonuniform_grid()
+    eps = jnp.ones(grid.shape, dtype=jnp.float32)
+    i_lo = pos_to_nu_index(grid, (_SLAB_X_LO, _A_WG / 2, _B_WG / 2))[0]
+    i_hi = pos_to_nu_index(grid, (_SLAB_X_HI, _A_WG / 2, _B_WG / 2))[0]
+    # Perturb the slab region: base slab eps (=4) + deps so deps=0 is a
+    # no-op vs the assembled materials (gate 3) and deps>0 changes S21.
+    return eps.at[i_lo:i_hi, :, :].set(_SLAB_EPS_R + deps)
+
+
+def _s21_mag2(deps):
+    sim, domain_x = _wr90_nu_sim()
+    eps = _eps_override_for(sim, domain_x, deps)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = sim.compute_waveguide_s_matrix(
+            num_periods=NUM_PERIODS, normalize="flux", eps_override=eps,
+        )
+    # |S21|^2 at the band-center bin (index 2 of the 4-point grid)
+    return jnp.abs(res.s_params[1, 0, 2]) ** 2
+
+
+@pytest.mark.slow
+def test_nu_flux_smatrix_grad_finite_and_fd_consistent():
+    """Gates 1+2: traced NU flux extraction yields a finite, FD-consistent
+    grad w.r.t. a substrate-eps scalar."""
+    deps0 = jnp.asarray(0.5, dtype=jnp.float32)
+    val, g = jax.value_and_grad(_s21_mag2)(deps0)
+    assert np.isfinite(float(val)), f"value is {val}"
+    assert np.isfinite(float(g)), f"grad is {g}"
+
+    h = 0.1
+    fd = (float(_s21_mag2(deps0 + h)) - float(_s21_mag2(deps0 - h))) / (2 * h)
+    assert fd != 0.0, "FD slope is zero — fixture has no sensitivity; rebuild it"
+    rel = abs(float(g) - fd) / max(abs(fd), 1e-12)
+    print(f"\n[NU-FLUX-AD] AD={float(g):+.6e} FD={fd:+.6e} rel={rel:.4f}")
+    assert rel <= 0.05, (
+        f"AD={float(g):+.6e} vs FD={fd:+.6e} (rel diff {rel:.3f} > 5%)"
+    )
+
+
+@pytest.mark.slow
+def test_nu_flux_smatrix_forward_matches_untraced():
+    """Gate 3: the np->jnp rewrite + eps_override threading did not change
+    forward values — compare normalize='flux' against itself with a no-op
+    (deps=0) override that reproduces the assembled slab eps."""
+    sim_a, _ = _wr90_nu_sim()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res_a = sim_a.compute_waveguide_s_matrix(
+            num_periods=NUM_PERIODS, normalize="flux")
+    sim_b, domain_x_b = _wr90_nu_sim()
+    eps = _eps_override_for(sim_b, domain_x_b, jnp.asarray(0.0, dtype=jnp.float32))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res_b = sim_b.compute_waveguide_s_matrix(
+            num_periods=NUM_PERIODS, normalize="flux", eps_override=eps)
+    sa = np.asarray(res_a.s_params)
+    sb = np.asarray(res_b.s_params)
+    assert np.all(np.isfinite(sa)) and np.all(np.isfinite(sb))
+    np.testing.assert_allclose(sb, sa, rtol=1e-5, atol=1e-7)
+
+
+def _s11_mag2_at_vacuum(deps):
+    """|S11|^2 with a pure-vacuum device override (eps = 1 + deps everywhere).
+
+    At deps=0 the device run is identical to the vacuum reference run, so
+    P_refl = |F_ref - F_dev| = 0 exactly -> the diagonal sqrt(P_refl/P_inc)
+    (and the abs() feeding it) hit their zero argument. This is the DEAD
+    branch the FD gate's reflective slab never reaches.
+    """
+    sim, _ = _wr90_nu_sim()
+    grid = sim._build_nonuniform_grid()
+    eps = jnp.ones(grid.shape, dtype=jnp.float32) + deps
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = sim.compute_waveguide_s_matrix(
+            num_periods=NUM_PERIODS, normalize="flux", eps_override=eps,
+        )
+    return jnp.abs(res.s_params[0, 0, 2]) ** 2
+
+
+@pytest.mark.slow
+def test_nu_flux_smatrix_grad_finite_at_perfect_null():
+    """Dead-branch NaN-safety (the double-where guard the live FD gate misses).
+
+    At deps=0 the traced device override is pure vacuum == the reference run,
+    so the diagonal reflected power P_refl = |F_ref - F_dev| = 0. A single
+    output-only ``jnp.where`` would leak a NaN gradient through ``sqrt(0)`` /
+    ``abs(0)`` here; the input-guarded double-where must keep the grad finite.
+    Locks the protection in CI so a future single-where simplification trips.
+    """
+    deps0 = jnp.asarray(0.0, dtype=jnp.float32)
+    val, g = jax.value_and_grad(_s11_mag2_at_vacuum)(deps0)
+    assert np.isfinite(float(val)), f"value is {val}"
+    assert np.isfinite(float(g)), (
+        f"grad is {g} at the perfect-null (P_refl=0) — dead-branch NaN leak; "
+        "the sqrt(0)/abs(0) double-where guard has regressed"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q"])


### PR DESCRIPTION
## Summary

Rung 5 of the NU-lane uniform-class ladder: makes `compute_waveguide_s_matrix(normalize='flux', eps_override=<traced>)` on a **graded mesh** differentiable end-to-end — the AD-traceability the auditor requires for `broad_e5_passed`. Mirrors the uniform `#172`/`#148` flux-AD fix on the non-uniform path.

## Changes

**`rfx/api/_sparams.py`**
- Dispatch: allow `eps_override`/`sigma_override` when `normalize=='flux'` on the NU path; **keep rejecting** them for `normalize=True` (its diagonal `a_inc_ref` denominator carries the #88 band-edge fragility — out of scope, fence kept).
- `_compute_waveguide_s_matrix_nu`: thread the traced override into the **device run only** (the design variable); reference run stays vacuum.
- Rewrite the `_flux_mode` branch `np → jnp` (`P_inc / phase / P_refl / P_trans / mag / S`) with the **double-where** trick at `sqrt(0)`/`angle(0)` (guard the *input*, not just the output — the recurring rfx NaN-grad lesson). Forward unchanged for `P > 0`.

**`rfx/runners/nonuniform.py`**
- Drop `np.array()` on `waveguide_port_flux` + the per-port `waveguide_sparams` side-output (`np.array(tracer)` detached/crashed the tape). Concrete consumers value-unchanged.

## Verification

- **AD vs FD**: `grad(|S21|²)` through the full NU flux extraction on a graded mesh = **−4.497e‑04** vs central FD **−4.389e‑04**, **rel 2.47% ≤ 5%**, finite.
- **Forward preserved**: no-op (`deps=0`) override == no-override flux forward, **rtol≤1e-5** (max abs diff 1.67e‑8 = np→jnp reassociation, same class as uniform #172 gate 3).
- **Dead-branch NaN-safety**: a perfect-null gate (`deps=0` → device==reference → `P_refl=0`) asserts the grad stays finite — locks the `sqrt(0)/abs(0)` double-where in CI (a single output-only `where` would NaN here).
- **No regression**: NU flux / nontrivial / sparam / api / grad-sparams + uniform flux-AD suites green; ruff clean.
- **Fence intact**: `eps_override` + `normalize=True` on NU still raises.
- Independent code review: **trust-with-caveats** (0 blocker/major).

## Scope (honest)

This is the **AD-traceability** rung. It does **not** by itself promote the NU lane — the remaining blocker is rung 6 (a broad-E4 external Meep/OpenEMS cross-check on a graded mesh). The lane stays `shadow` until both land and the auditor PASSes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)