### PR TITLE
test(nonuniform): document PEC-scatterer-on-NU limitation (xfail-strict sentinel)

### DIFF
--- a/docs/guides/support_matrix.json
+++ b/docs/guides/support_matrix.json
@@ -48,7 +48,8 @@
         "lumped_rlc": "hard_fail",
         "lumped_port_sparameters": "hard_fail",
         "msl_s_matrix": "hard_fail",
-        "coaxial_port": "hard_fail"
+        "coaxial_port": "hard_fail",
+        "pec_volume_scatterer": "silent_no_reflection: a volumetric PEC obstacle (iris/post/septum) reflects on the uniform path (|S11|~0.9) but is ABSENT on the NU graded scan (|S11|~0, |S21|~1); NU is dielectric-only for scatterers (pec_mask from rasterize_geometry not effective in the NU scan, root cause not yet isolated); sentinel tests/test_nonuniform_pec_scatterer_limit.py"
       }
     },
     "sbp_sat_subgridding": {

--- a/docs/guides/support_matrix.md
+++ b/docs/guides/support_matrix.md
@@ -96,6 +96,7 @@ Current policy:
 | `compute_msl_s_matrix()` + nonuniform | unsupported | hard-fail |
 | Coaxial port + nonuniform | unsupported | hard-fail |
 | Lumped RLC + nonuniform | unsupported | hard-fail |
+| Volumetric PEC scatterer (iris / post / septum) + nonuniform waveguide | unsupported (**silent**) | reflects on the uniform path (\|S11\|~0.9) but \|S11\|~0 / \|S21\|~1 on the NU graded scan — the metal obstacle silently vanishes; NU is **dielectric-only** for scatterers (`pec_mask` from `rasterize_geometry` not effective in the NU scan, root cause not yet isolated). Sentinel: `tests/test_nonuniform_pec_scatterer_limit.py` (xfail-strict; XPASS = fixed) |
 
 ## Reporting and export artifact rule
 

--- a/tests/test_nonuniform_pec_scatterer_limit.py
+++ b/tests/test_nonuniform_pec_scatterer_limit.py
@@ -1,0 +1,113 @@
+"""Sentinel: volumetric PEC scatterers do NOT reflect on the NU waveguide path.
+
+Discovered 2026-06-25 while scoping a non-uniform external-E4 iris comparison.
+An identical inductive iris (a symmetric pair of PEC fins, ``sigma=1e7`` > the
+1e6 PEC threshold, blocking ~60% of the WR-90 width) reflects strongly on the
+UNIFORM Yee path (``|S11|`` ~ 0.78-0.95) but is effectively ABSENT on the
+non-uniform (graded-``dy``) path (``|S11|`` ~ 0, ``|S21|`` ~ 1 -- the iris
+neither reflects nor blocks transmission). Dielectric Boxes DO rasterize +
+reflect on the NU path (``tests/test_waveguide_nu_flux.py`` and the rung-1
+broad-E5 Airy envelope), so the gap is PEC-scatterer-specific: the
+geometry-derived ``pec_mask`` from ``rasterize_geometry`` on non-uniform coords
+is not taking effect in the NU scan (root cause not yet isolated -- R2-STOP, no
+blind fix).
+
+Consequence: the NU waveguide lane is currently DIELECTRIC-ONLY for scatterers;
+metal obstacles (irises, posts, septa) silently vanish. Documented in
+``docs/guides/support_matrix.{json,md}``.
+
+The uniform witness PASSES (confirms the iris geometry/material is a valid
+strong reflector). The NU sentinel is ``xfail(strict=True)``: when the
+pec_mask-on-NU path is fixed it will XPASS and trip CI, forcing this doc + the
+support-matrix note to be promoted to a hard gate.
+"""
+from __future__ import annotations
+
+import warnings
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from rfx.api import Simulation
+from rfx.auto_config import smooth_grading
+from rfx.boundaries.spec import Boundary, BoundarySpec
+from rfx.geometry.csg import Box
+
+_A, _B, _FMAX = 0.02286, 0.01016, 12e9
+_FREQS = jnp.linspace(8.2e9, 12.4e9, 5)
+_NP = 20
+
+
+def _graded_dy(ratio: float = 2.0, base: float = 0.75e-3):
+    n = int(round(_A / base))
+    x = np.linspace(-1, 1, n)
+    w = 1.0 + (ratio - 1.0) * np.abs(x)
+    return smooth_grading(w / w.sum() * _A, max_ratio=1.3)
+
+
+def _iris_sim(*, nonuniform: bool):
+    """WR-90 with a symmetric inductive PEC iris (~60% width blocked)."""
+    dx = 1.5e-3
+    nx = int(round(0.100 / dx))
+    kw = {"dy_profile": _graded_dy()} if nonuniform else {}
+    sim = Simulation(
+        freq_max=_FMAX, domain=(nx * dx, _A, _B), dx=dx,
+        boundary=BoundarySpec(
+            x=Boundary(lo="cpml", hi="cpml"),
+            y=Boundary(lo="pec", hi="pec"),
+            z=Boundary(lo="pec", hi="pec"),
+        ),
+        cpml_layers=8, **kw,
+    )
+    sim.add_material("metal", eps_r=1.0, sigma=1e7)  # sigma > 1e6 -> PEC
+    xc = 0.5 * nx * dx
+    fin = 0.30 * _A
+    sim.add(Box((xc - 1e-3, 0.0, 0.0), (xc + 1e-3, fin, _B)), material="metal")
+    sim.add(Box((xc - 1e-3, _A - fin, 0.0), (xc + 1e-3, _A, _B)), material="metal")
+    for x0, d, nm in ((0.015, "+x", "left"), (nx * dx - 0.015, "-x", "right")):
+        sim.add_waveguide_port(
+            x0, direction=d, mode=(1, 0), mode_type="TE",
+            freqs=_FREQS, f0=10.3e9, bandwidth=0.5,
+            reference_plane=(0.020 if d == "+x" else nx * dx - 0.020), name=nm,
+        )
+    return sim
+
+
+def _iris_s11_max(*, nonuniform: bool) -> float:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        res = _iris_sim(nonuniform=nonuniform).compute_waveguide_s_matrix(
+            num_periods=_NP, normalize="flux",
+        )
+    return float(np.abs(np.asarray(res.s_params)[0, 0, :]).max())
+
+
+@pytest.mark.slow
+def test_uniform_pec_iris_reflects():
+    """Witness: the inductive iris reflects strongly on the UNIFORM path
+    (confirms the geometry/material is a valid strong reflector)."""
+    s11 = _iris_s11_max(nonuniform=False)
+    assert s11 > 0.5, (
+        f"uniform PEC iris |S11|max={s11:.3f} — expected strong reflection; "
+        "the witness fixture is broken, not the NU path"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Volumetric PEC scatterers do not reflect on the NU waveguide path: "
+        "the same iris that gives |S11|~0.9 on the uniform path gives |S11|~0 "
+        "on the graded-dy path (pec_mask from rasterize_geometry not effective "
+        "in the NU scan; dielectric Boxes DO work). NU is dielectric-only for "
+        "scatterers. XPASS => the PEC-on-NU path was fixed: promote this to a "
+        "hard gate and update docs/guides/support_matrix.* + nu known-limits."
+    ),
+)
+def test_nonuniform_pec_iris_reflects():
+    """Sentinel (xfail-strict): the NU PEC iris SHOULD reflect like the uniform
+    one. It does not today (|S11|~0) — documenting the dielectric-only limit."""
+    s11 = _iris_s11_max(nonuniform=True)
+    assert s11 > 0.2, f"NU PEC iris |S11|max={s11:.3f} <= 0.2 — iris not reflecting"


### PR DESCRIPTION
## Summary

Documents a real, newly-surfaced rfx limitation found while scoping a non-uniform external-E4 comparison: **volumetric PEC scatterers do not reflect on the non-uniform (graded) waveguide path.** This was caught by a cheap de-risk smoke *before* sinking a Meep+VESSL harness into a geometry rfx-NU can't model.

## Evidence (decisive discriminator)

Identical 40%-aperture symmetric inductive iris (PEC fins, `sigma=1e7` > the `1e6` PEC threshold):

| Mesh | `\|S11\|` | `\|S21\|` |
|---|---|---|
| **Uniform** | **0.78 – 0.95** (correct strong reflection) | 0.30 – 0.63 |
| **NU graded-`dy`** | **0.000** | ~1.0 (iris silently vanishes) |

Dielectric Boxes *do* rasterize + reflect on the NU path (`test_waveguide_nu_flux.py` + the rung-1 broad-E5 Airy envelope), so the gap is **PEC-scatterer-specific**: the `pec_mask` from `rasterize_geometry` on non-uniform coords is not effective in the NU scan. **Root cause not yet isolated — R2-STOP, no blind fix in this PR.**

**Consequence:** the NU waveguide lane is currently **dielectric-only** for scatterers; metal obstacles (irises, posts, septa) silently disappear.

## Changes

- **`tests/test_nonuniform_pec_scatterer_limit.py`** — a PASSING uniform witness (confirms the iris is a valid strong reflector, so the gap is the NU path, not the fixture) + an **`xfail(strict=True)`** NU sentinel (`|S11|` should be > 0.2, is ~0). When the PEC-on-NU path is fixed it XPASSes and trips CI → forces promotion to a hard gate + a docs update.
- **`docs/guides/support_matrix.{json,md}`** — records the limitation in the nonuniform lane's unsupported-combinations (silent no-reflection; dielectric-only).

## Context

This is the **checkpoint** of the NU uniform-class promotion ladder: rungs merged so far are the settled-flux gate (#230), committed broad-E5-analytic + graded-dA envelope (#232), and AD-traceability (#233). The external-E4 rung needs either a dielectric-obstacle fallback or a fix to this PEC-on-NU limitation first.

No production code changed — this documents a verified limitation. Tests: uniform witness passes, NU sentinel xfails-strict (12.4s, `@pytest.mark.slow`); `support_matrix.json` consumer contracts (61) pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)