### PR TITLE
feat(msl): NonUniformGrid-aware MSL S-param extractor math (no fence flip)

### DIFF
--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -30,6 +30,8 @@ from rfx.sources.waveguide_port import (
     waveguide_plane_positions,
 )
 
+from rfx.nonuniform import NonUniformGrid
+
 from rfx.api._spec import (
     WaveguideSMatrixResult,
     CoaxialSMatrixResult,
@@ -38,6 +40,40 @@ from rfx.api._spec import (
     _WaveguidePortEntry,
     _MSLPortEntry,
 )
+
+
+def _msl_cell_profile(grid, axis: str, n: int) -> np.ndarray:
+    """Per-cell size array (length ``n``, full/padded) along ``axis`` for
+    MSL V/I integration. Graded-mesh aware.
+
+    ``NonUniformGrid`` (a NamedTuple) stores per-cell spacings as
+    ``dx_arr`` / ``dy_arr`` / ``dz`` and exposes NO ``*_profile``
+    attributes — so the legacy ``getattr(grid, "dy_profile", None)``
+    fell through to ``np.full(n, grid.dx)``, i.e. the SCALAR boundary-x
+    cell for every transverse cell (wrong axis AND scalar-not-per-cell).
+    This reads the real per-cell array on a NU grid. On a uniform
+    ``Grid`` it is byte-identical to the legacy path (``Grid`` is not a
+    ``NonUniformGrid``, so the per-cell branch is never taken): the
+    ``*_profile`` attr if present, else ``np.full(n, grid.dx)`` — the
+    legacy behaviour of using ``grid.dx`` for every axis is preserved.
+    """
+    if isinstance(grid, NonUniformGrid):
+        per_cell = {"x": grid.dx_arr, "y": grid.dy_arr, "z": grid.dz}[axis]
+        a = np.asarray(per_cell, dtype=float)
+        if a.shape != (n,):
+            # The NU branch is authoritative — never silently fall back to a
+            # scalar boundary-dx fill (that is the exact wrong-number bug this
+            # helper exists to fix). A shape mismatch is a wiring error.
+            raise ValueError(
+                f"NonUniformGrid {axis} per-cell profile shape {a.shape} "
+                f"!= expected ({n},)."
+            )
+        return a
+    attr = {"x": "dx_profile", "y": "dy_profile", "z": "dz_profile"}[axis]
+    prof = getattr(grid, attr, None)
+    if prof is not None:
+        return np.asarray(prof, dtype=float)
+    return np.full(n, float(grid.dx), dtype=float)
 
 
 def _warn_if_nonpassive_smatrix(
@@ -946,17 +982,11 @@ class _SparamMixin:
         # — matching the legacy 3-probe sign convention the S11 sign
         # was validated against.
 
-        # Per-axis cell-size arrays for V/I integration. Both uniform
-        # and non-uniform grids are supported.
-        def _profile(axis: str, n: int) -> np.ndarray:
-            attr = {"x": "dx_profile", "y": "dy_profile", "z": "dz_profile"}[axis]
-            prof = getattr(grid, attr, None)
-            if prof is not None:
-                return np.asarray(prof, dtype=float)
-            return np.full(n, float(grid.dx), dtype=float)
-
-        dy_arr = _profile("y", grid.ny)
-        dz_arr = _profile("z", grid.nz)
+        # Per-axis cell-size arrays for V/I integration. Both uniform and
+        # non-uniform grids are supported — NonUniformGrid exposes per-cell
+        # dx_arr/dy_arr/dz (NOT *_profile); see _msl_cell_profile.
+        dy_arr = _msl_cell_profile(grid, "y", grid.ny)
+        dz_arr = _msl_cell_profile(grid, "z", grid.nz)
 
         # Fixed cross-section indices per port (same across all runs).
         port_idx_meta = []

--- a/rfx/sources/msl_port.py
+++ b/rfx/sources/msl_port.py
@@ -791,6 +791,50 @@ def make_msl_port_sources_jm(
 # ---------------------------------------------------------------------------
 
 
+def _msl_position_to_index(grid, pos):
+    """Grid-agnostic physical-position -> index lookup.
+
+    ``rfx.grid.Grid`` exposes ``position_to_index`` as a method; the
+    ``NonUniformGrid`` NamedTuple does NOT — its lookup is the free
+    function ``rfx.nonuniform.position_to_index`` (cumulative cell-edge,
+    so it is graded-aware). Duck-types over both.
+    """
+    method = getattr(grid, "position_to_index", None)
+    if callable(method):
+        return method(pos)
+    from rfx.nonuniform import position_to_index as _nu_position_to_index
+    return _nu_position_to_index(grid, pos)
+
+
+def _msl_x_for_index(grid, target_i: int) -> float:
+    """Physical x-coordinate of a (clamped) grid index, graded-aware.
+
+    On a uniform ``Grid`` this is the legacy ``(clamped - pad_x_lo) *
+    grid.dx`` and is byte-identical (``Grid`` has no ``dx_arr``). On a
+    ``NonUniformGrid`` ``grid.dx`` is ONLY the boundary cell, so the index
+    must be converted to a physical coordinate via the cumulative
+    cell-edge sum of the interior ``dx_arr`` profile (mirroring
+    ``_range_to_slice_nu`` in ``rfx/runners/nonuniform.py``). Indices are
+    clamped into the in-domain range. (In the leading-CPML region ``u<0``
+    the uniform branch returns a negative coord while the NU branch clamps
+    to ``edges[0]=0``; valid probe placement never targets that region.)
+    """
+    nx = int(grid.nx)
+    pad = int(getattr(grid, "pad_x_lo", 0))
+    clamped = max(0, min(int(target_i), nx - 1))
+    u = clamped - pad  # user-domain (non-CPML) interior index
+    dx_arr = getattr(grid, "dx_arr", None)
+    if dx_arr is None:
+        # Uniform Grid — legacy scalar spacing (byte-identical).
+        return float(u * grid.dx)
+    # NonUniformGrid — cumulative interior cell-edge positions.
+    pad_hi = int(getattr(grid, "pad_x_hi", 0))
+    interior = np.asarray(dx_arr, dtype=float)[pad : nx - pad_hi]
+    edges = np.insert(np.cumsum(interior), 0, 0.0)
+    u_c = max(0, min(u, len(edges) - 1))
+    return float(edges[u_c])
+
+
 def msl_probe_x_coords(
     grid,
     port: MSLPort,
@@ -803,22 +847,18 @@ def msl_probe_x_coords(
     remaining two are spaced by ``n_spacing_cells`` further along the
     propagation direction.  Indices are clamped into the valid grid
     range so callers always receive in-domain physical coordinates.
+    Graded-mesh aware (see :func:`_msl_x_for_index`).
     """
-    i_feed, _, _ = grid.position_to_index((port.feed_x, port.y_lo, port.z_lo))
+    i_feed, _, _ = _msl_position_to_index(grid, (port.feed_x, port.y_lo, port.z_lo))
     sign = 1 if port.direction == "+x" else -1
-    nx = grid.nx
-
-    def _x_for_index(target_i: int) -> float:
-        clamped = max(0, min(target_i, nx - 1))
-        # User-domain physical x-coord. position_to_index adds pad_x_lo, so
-        # subtract it back when rebuilding the coordinate.
-        pad = getattr(grid, "pad_x_lo", 0)
-        return float((clamped - pad) * grid.dx)
-
     i1 = i_feed + sign * n_offset_cells
     i2 = i1 + sign * n_spacing_cells
     i3 = i2 + sign * n_spacing_cells
-    return _x_for_index(i1), _x_for_index(i2), _x_for_index(i3)
+    return (
+        _msl_x_for_index(grid, i1),
+        _msl_x_for_index(grid, i2),
+        _msl_x_for_index(grid, i3),
+    )
 
 
 def msl_probe_x_coords_n(
@@ -838,17 +878,10 @@ def msl_probe_x_coords_n(
     """
     if n_probes < 3:
         raise ValueError(f"n_probes must be >= 3, got {n_probes}")
-    i_feed, _, _ = grid.position_to_index((port.feed_x, port.y_lo, port.z_lo))
+    i_feed, _, _ = _msl_position_to_index(grid, (port.feed_x, port.y_lo, port.z_lo))
     sign = 1 if port.direction == "+x" else -1
-    nx = grid.nx
-    pad = getattr(grid, "pad_x_lo", 0)
-
-    def _x_for_index(target_i: int) -> float:
-        clamped = max(0, min(target_i, nx - 1))
-        return float((clamped - pad) * grid.dx)
-
     return tuple(
-        _x_for_index(i_feed + sign * (n_offset_cells + n * n_spacing_cells))
+        _msl_x_for_index(grid, i_feed + sign * (n_offset_cells + n * n_spacing_cells))
         for n in range(n_probes)
     )
 

--- a/tests/test_msl_nu_abscissa.py
+++ b/tests/test_msl_nu_abscissa.py
@@ -1,0 +1,226 @@
+"""Contract tests: MSL probe-abscissa + V/I cell-profile are graded-mesh aware.
+
+Promotes the Gate-0 falsifier
+(docs/research_notes/experiments/msl_nu_gate0/gate0_abscissa.py).
+
+The fix makes ``msl_probe_x_coords{,_n}`` and the transverse V/I cell-profile
+helper read the ``NonUniformGrid`` per-cell arrays (``dx_arr``/``dy_arr``/
+``dz``) instead of the scalar BOUNDARY ``grid.dx``, WITHOUT flipping the
+``compute_msl_s_matrix`` NU fence (the full NU MSL runner path is a separate
+track). On a uniform ``Grid`` every path here is byte-identical to the legacy
+scalar formula.
+
+Scope: extractor-math NU-readiness only. ``compute_msl_s_matrix`` on a NU mesh
+still raises ``NotImplementedError`` (the fence is intact); this is unit-level
+coverage of the probe-placement + transverse-profile helpers, not an
+end-to-end NU MSL S-parameter validation.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from rfx.nonuniform import make_nonuniform_grid, position_to_index
+from rfx.sources.msl_port import (
+    MSLPort,
+    msl_probe_x_coords,
+    msl_probe_x_coords_n,
+    _msl_position_to_index,
+)
+from rfx.api._sparams import _msl_cell_profile
+
+
+_DX = 0.0005
+_NX = 80
+_NZ = 24
+_DZ = 0.0005
+_LY = 0.020
+_PEC = {"y_lo", "y_hi", "z_lo", "z_hi"}
+
+
+def _tent(n: int, dx: float, peak: float = 2.0) -> np.ndarray:
+    """Symmetric graded interior: dx at both ends, peak*dx in the middle."""
+    t = np.linspace(0.0, 1.0, n)
+    prof = dx * (1.0 + (peak - 1.0) * (1.0 - np.abs(2.0 * t - 1.0)))
+    prof[0] = dx
+    prof[-1] = dx
+    return prof
+
+
+def _nu_grid(dx_profile: np.ndarray):
+    return make_nonuniform_grid(
+        domain_xy=(float(np.sum(dx_profile)), _LY),
+        dz_profile=np.full(_NZ, _DZ),
+        dx=float(dx_profile[0]),
+        cpml_layers=8,
+        dx_profile=dx_profile,
+        pec_faces=_PEC,
+        cpml_axes="x",
+    )
+
+
+def _uniform_grid():
+    from rfx import Simulation
+    from rfx.boundaries.spec import BoundarySpec, Boundary
+
+    s = Simulation(
+        freq_max=10e9,
+        domain=(_DX * _NX, _LY, _NZ * _DZ),
+        dx=_DX,
+        boundary=BoundarySpec(
+            x="cpml",
+            y=Boundary(lo="pec", hi="pec"),
+            z=Boundary(lo="pec", hi="pec"),
+        ),
+        cpml_layers=8,
+    )
+    return s._build_grid()
+
+
+def _port(Lx: float) -> MSLPort:
+    return MSLPort(
+        feed_x=0.10 * Lx, y_lo=0.008, y_hi=0.012,
+        z_lo=0.0, z_hi=0.001, direction="+x", impedance=50.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. NU mesh: probe coords now RUN (no AttributeError) and are cumsum-correct
+# ---------------------------------------------------------------------------
+
+def test_probe_coords_n_runs_on_nu_and_is_cumsum_correct():
+    prof = _tent(_NX, _DX)
+    grid = _nu_grid(prof)
+    port = _port(float(np.sum(prof)))
+
+    xs = np.asarray(
+        msl_probe_x_coords_n(grid, port, 6, n_offset_cells=5, n_spacing_cells=3)
+    )
+    assert xs.shape == (6,)
+    assert np.all(np.isfinite(xs))
+    assert np.all(np.diff(xs) > 0), "+x probes must be physically increasing"
+
+    # Independent cumsum cell-edge reference at the same clamped indices.
+    i_feed, _, _ = position_to_index(grid, (port.feed_x, port.y_lo, port.z_lo))
+    pad, pad_hi = int(grid.pad_x_lo), int(grid.pad_x_hi)
+    interior = np.asarray(grid.dx_arr, float)[pad : grid.nx - pad_hi]
+    edges = np.insert(np.cumsum(interior), 0, 0.0)
+
+    ref, legacy = [], []
+    for n in range(6):
+        clamped = max(0, min(i_feed + (5 + n * 3), grid.nx - 1))
+        u = clamped - pad
+        ref.append(edges[max(0, min(u, len(edges) - 1))])
+        legacy.append(u * float(grid.dx))   # the OLD scalar-grid.dx abscissa
+
+    np.testing.assert_allclose(xs, ref, rtol=0, atol=1e-12)
+    # The fix is real: the cumsum abscissa departs from the legacy scalar one
+    # by mm-scale on this 2x-graded mesh (Gate-0 measured up to 5.9 mm).
+    assert np.max(np.abs(xs - np.asarray(legacy))) > 1e-3
+
+
+def test_probe_coords_n_runs_on_nu_minus_x():
+    """-x port: graded-mesh probes must be physically DECREASING and match an
+    independent reverse-direction cumsum reference."""
+    prof = _tent(_NX, _DX)
+    grid = _nu_grid(prof)
+    Lx = float(np.sum(prof))
+    port = MSLPort(
+        feed_x=0.90 * Lx, y_lo=0.008, y_hi=0.012,
+        z_lo=0.0, z_hi=0.001, direction="-x", impedance=50.0,
+    )
+    xs = np.asarray(
+        msl_probe_x_coords_n(grid, port, 6, n_offset_cells=5, n_spacing_cells=3)
+    )
+    assert xs.shape == (6,) and np.all(np.isfinite(xs))
+    assert np.all(np.diff(xs) < 0), "-x probes must be physically decreasing"
+
+    i_feed, _, _ = position_to_index(grid, (port.feed_x, port.y_lo, port.z_lo))
+    pad, pad_hi = int(grid.pad_x_lo), int(grid.pad_x_hi)
+    interior = np.asarray(grid.dx_arr, float)[pad : grid.nx - pad_hi]
+    edges = np.insert(np.cumsum(interior), 0, 0.0)
+    ref = []
+    for n in range(6):
+        clamped = max(0, min(i_feed - (5 + n * 3), grid.nx - 1))
+        u = clamped - pad
+        ref.append(edges[max(0, min(u, len(edges) - 1))])
+    np.testing.assert_allclose(xs, ref, rtol=0, atol=1e-12)
+
+
+def test_cell_profile_nu_shape_mismatch_raises():
+    """The NU branch is authoritative: a wrong-length request must RAISE,
+    never silently fall back to a scalar boundary-dx fill."""
+    import pytest
+
+    prof = _tent(_NX, _DX)
+    grid = _nu_grid(prof)
+    with pytest.raises(ValueError, match="per-cell profile shape"):
+        _msl_cell_profile(grid, "y", grid.ny + 5)
+
+
+def test_probe_coords_3_runs_on_nu():
+    prof = _tent(_NX, _DX)
+    grid = _nu_grid(prof)
+    port = _port(float(np.sum(prof)))
+    xs = msl_probe_x_coords(grid, port, n_offset_cells=5, n_spacing_cells=3)
+    assert len(xs) == 3 and all(np.isfinite(xs))
+    assert xs[0] < xs[1] < xs[2]
+
+
+# ---------------------------------------------------------------------------
+# 2. Uniform Grid: byte-identical to the legacy scalar formula
+# ---------------------------------------------------------------------------
+
+def test_probe_coords_uniform_byte_identical():
+    grid = _uniform_grid()
+    port = _port(_DX * _NX)
+    i_feed, _, _ = grid.position_to_index((port.feed_x, port.y_lo, port.z_lo))
+    pad = int(getattr(grid, "pad_x_lo", 0))
+    nx = grid.nx
+
+    def legacy(target: int) -> float:
+        c = max(0, min(target, nx - 1))
+        return float((c - pad) * grid.dx)
+
+    xs = msl_probe_x_coords_n(grid, port, 6, n_offset_cells=5, n_spacing_cells=3)
+    assert list(xs) == [legacy(i_feed + (5 + n * 3)) for n in range(6)]
+
+    x3 = msl_probe_x_coords(grid, port, n_offset_cells=5, n_spacing_cells=3)
+    assert x3 == (legacy(i_feed + 5), legacy(i_feed + 8), legacy(i_feed + 11))
+
+
+# ---------------------------------------------------------------------------
+# 3. _msl_cell_profile: NU per-cell arrays vs uniform scalar fill
+# ---------------------------------------------------------------------------
+
+def test_cell_profile_nu_reads_per_cell_arrays():
+    prof = _tent(_NX, _DX)
+    grid = _nu_grid(prof)
+    np.testing.assert_array_equal(
+        _msl_cell_profile(grid, "y", grid.ny), np.asarray(grid.dy_arr, float))
+    np.testing.assert_array_equal(
+        _msl_cell_profile(grid, "z", grid.nz), np.asarray(grid.dz, float))
+    dx = _msl_cell_profile(grid, "x", grid.nx)
+    np.testing.assert_array_equal(dx, np.asarray(grid.dx_arr, float))
+    assert np.ptp(dx) > 1e-9, "graded x profile must not be constant grid.dx"
+
+
+def test_cell_profile_uniform_byte_identical():
+    grid = _uniform_grid()
+    for axis, n in (("x", grid.nx), ("y", grid.ny), ("z", grid.nz)):
+        np.testing.assert_array_equal(
+            _msl_cell_profile(grid, axis, n), np.full(n, float(grid.dx)))
+
+
+# ---------------------------------------------------------------------------
+# 4. _msl_position_to_index duck-types over both grid types
+# ---------------------------------------------------------------------------
+
+def test_position_to_index_ducktypes_both_grids():
+    prof = _tent(_NX, _DX)
+    nu = _nu_grid(prof)
+    port = _port(float(np.sum(prof)))
+    pos = (port.feed_x, port.y_lo, port.z_lo)
+    assert _msl_position_to_index(nu, pos) == position_to_index(nu, pos)
+
+    uni = _uniform_grid()
+    assert _msl_position_to_index(uni, pos) == uni.position_to_index(pos)


### PR DESCRIPTION
## What

Makes the microstrip-line (MSL) S-parameter **extractor math** graded-mesh (`NonUniformGrid`) aware. Three index→physical helpers silently assumed a uniform mesh and would return wrong numbers on a graded mesh. This fixes them **without lifting** the `compute_msl_s_matrix` NU `NotImplementedError` fence — the full NU MSL runner path (port injection + DFT-plane accumulation + dispatch) is a **separate track**. On a uniform `Grid` every path here is **byte-identical** to the legacy scalar formula.

## Why

Investigating the differentiable thin-substrate memory lever surfaced the MSL-S-param-on-NU extractor as the one remaining gap (the waveguide-flux S-matrix already works on NU, #237). A pure-Python Gate-0 falsifier (no FDTD) showed the legacy longitudinal probe abscissa `(idx − pad)·grid.dx` mis-places probes by up to **27.5% (5.9 mm)** on a 2×-graded mesh — multiple radians of phase error that would wreck the `α·e^{−jβx}+γ·e^{+jβx}` least-squares fit. A second witness: the production helper `AttributeError`'d on a NU grid (the `NonUniformGrid` NamedTuple has no `.position_to_index`), so the extractor had **never run** on NU.

## Fixes

- **`msl_probe_x_coords{,_n}`** — longitudinal abscissa via cumulative cell-edge sum of the interior `dx_arr` profile (mirrors `_range_to_slice_nu`), not the scalar boundary `grid.dx`. `i_feed` lookup duck-types `grid.position_to_index` (uniform `Grid`) vs the free `rfx.nonuniform.position_to_index` (NU).
- **`_sparams._msl_cell_profile`** (extracted from a closure) — on a `NonUniformGrid` reads per-cell `dx_arr`/`dy_arr`/`dz`. The old closure fell through `getattr(grid,"dy_profile")→None` to `np.full(n, grid.dx)` — the scalar boundary-x cell for **every** transverse cell. The NU branch is authoritative (**raises** on shape mismatch, never silently scalar-fills).

## Scope / safety

- **Fence intact:** `compute_msl_s_matrix` on a NU mesh still raises `NotImplementedError` (verified). This is extractor-math NU-readiness only, not an end-to-end NU MSL S-param validation.
- **Uniform byte-identity:** uniform `Grid` is gated out by `isinstance(grid, NonUniformGrid)` / `dx_arr` absence → strict no-op on the production path.

## Tests

- New `tests/test_msl_nu_abscissa.py` (promotes the Gate-0 falsifier): NU probe coords run + cumsum-correct (`+x` and `−x`) + depart from legacy; uniform **exact-equality** byte-identity; `_msl_cell_profile` NU per-cell vs uniform scalar + shape-mismatch raise; `position_to_index` duck-typing. **8/8 green.**
- Existing MSL suite green with the change: 31 fast + 20 heavy AD/S-param + 8 broad-E5/eigenmode (3 documented xfails). ruff clean.
- Separate code-review pass: **APPROVE**, byte-identity empirically re-derived on all three paths, round-trip exact, no circular import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)