### PR TITLE
feat(msl): NU MSL S-param lane — route compute_msl_s_matrix through the NU runner (laplace feed)

### DIFF
--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1281,11 +1281,16 @@ class _PreflightMixin:
             self._dz_profile is not None
             or self._dx_profile is not None
             or self._dy_profile is not None
+        ) and any(
+            getattr(pe, "mode", "laplace") == "eigenmode"
+            for pe in self._msl_ports
         ):
             raise NotImplementedError(
-                "compute_msl_s_matrix() currently supports the uniform Yee "
-                "lane only. Drop dx_profile/dy_profile/dz_profile or use a "
-                "documented diagnostic path."
+                "compute_msl_s_matrix() on a non-uniform mesh supports "
+                "mode='laplace'/'uniform' (Ez static-Laplace feed) only; the "
+                "eigenmode J+M launch needs the magnetic-source channel that "
+                "the non-uniform runner does not carry. Use mode='laplace' "
+                "(the add_msl_port default) on the graded-mesh lane."
             )
         if self._refinement is not None:
             raise NotImplementedError(

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -913,15 +913,21 @@ class _SparamMixin:
                 "coaxial-port S-parameters need a separate validated V/I "
                 "extraction and calibration contract."
             )
-        if (
+        is_nonuniform = (
             self._dz_profile is not None
             or self._dx_profile is not None
             or self._dy_profile is not None
+        )
+        if is_nonuniform and any(
+            getattr(pe, "mode", "laplace") == "eigenmode"
+            for pe in self._msl_ports
         ):
             raise NotImplementedError(
-                "compute_msl_s_matrix() currently supports the uniform Yee "
-                "lane only. Drop dx_profile/dy_profile/dz_profile or use a "
-                "documented diagnostic path."
+                "compute_msl_s_matrix() on a non-uniform mesh supports "
+                "mode='laplace'/'uniform' (Ez static-Laplace feed) only; the "
+                "eigenmode J+M launch needs the magnetic-source channel that "
+                "the non-uniform runner does not carry. Use mode='laplace' "
+                "(the add_msl_port default) on the graded-mesh lane."
             )
         if self._refinement is not None:
             raise NotImplementedError(
@@ -937,7 +943,34 @@ class _SparamMixin:
         entries = list(self._msl_ports)
         n_ports = len(entries)
 
-        grid = self._build_grid()
+        # Build the grid used for probe placement + the eps anchor. On the
+        # non-uniform lane this MUST be the SAME grid run_nonuniform_path
+        # builds (so probe_xs, port cells, dy/dz arrays and the eps anchor
+        # align with the run's field planes). build_nonuniform_grid needs a
+        # concrete dz_profile — synthesise from dx when absent and mutate
+        # self._dz_profile (restored in the finally) so the subsequent
+        # self.run() reads the same dz and builds a byte-matching grid.
+        _dz_profile_saved = self._dz_profile
+        if is_nonuniform:
+            from rfx.runners.nonuniform import build_nonuniform_grid
+            if self._dz_profile is None:
+                _nz_syn = int(round(float(self._domain[2]) / float(self._dx)))
+                self._dz_profile = np.full(max(_nz_syn, 1), float(self._dx))
+            grid = build_nonuniform_grid(
+                self._freq_max, self._domain, self._dx, self._cpml_layers,
+                self._dz_profile,
+                dx_profile=self._dx_profile, dy_profile=self._dy_profile,
+                pec_faces=self._boundary_spec.pec_faces()
+                    if self._boundary_spec is not None else None,
+                pmc_faces=self._boundary_spec.pmc_faces()
+                    if self._boundary_spec is not None else None,
+                cpml_axes="".join(
+                    ax for ax in "xyz"
+                    if ax not in (self._periodic_axes or "")
+                ),
+            )
+        else:
+            grid = self._build_grid()
 
         if freqs is None:
             freqs_arr = np.asarray(jnp.linspace(self._freq_max / 10, self._freq_max, n_freqs))
@@ -1020,7 +1053,10 @@ class _SparamMixin:
         # land beta outside the scan window for a loaded substrate.
         from rfx.core.yee import EPS_0 as _EPS_0, MU_0 as _MU_0
         _C0_MSL = 1.0 / float(np.sqrt(_MU_0 * _EPS_0))
-        _msl_assembled = self._assemble_materials(grid)
+        _msl_assembled = (
+            self._assemble_materials_nu(grid) if is_nonuniform
+            else self._assemble_materials(grid)
+        )
         _msl_materials = _msl_assembled[0]
         _msl_pec_mask = (
             None if _msl_assembled[3] is None
@@ -1405,6 +1441,7 @@ class _SparamMixin:
             self._dft_planes = saved_dft
             self._msl_ports = saved_msl
             self._ports = saved_ports
+            self._dz_profile = _dz_profile_saved
 
     def compute_coaxial_s_matrix(
         self,

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -947,18 +947,21 @@ class _SparamMixin:
         # non-uniform lane this MUST be the SAME grid run_nonuniform_path
         # builds (so probe_xs, port cells, dy/dz arrays and the eps anchor
         # align with the run's field planes). build_nonuniform_grid needs a
-        # concrete dz_profile — synthesise from dx when absent and mutate
-        # self._dz_profile (restored in the finally) so the subsequent
-        # self.run() reads the same dz and builds a byte-matching grid.
+        # concrete dz_profile — synthesise from dx when absent into a LOCAL.
+        # self._dz_profile is mutated only INSIDE the run try/finally below (so
+        # the restore always runs even if probe placement / the trace-PEC scan
+        # raises) — the subsequent self.run() then reads the same dz and builds
+        # a byte-matching grid.
         _dz_profile_saved = self._dz_profile
+        _dz_for_grid = self._dz_profile
         if is_nonuniform:
             from rfx.runners.nonuniform import build_nonuniform_grid
-            if self._dz_profile is None:
+            if _dz_for_grid is None:
                 _nz_syn = int(round(float(self._domain[2]) / float(self._dx)))
-                self._dz_profile = np.full(max(_nz_syn, 1), float(self._dx))
+                _dz_for_grid = np.full(max(_nz_syn, 1), float(self._dx))
             grid = build_nonuniform_grid(
                 self._freq_max, self._domain, self._dx, self._cpml_layers,
-                self._dz_profile,
+                _dz_for_grid,
                 dx_profile=self._dx_profile, dy_profile=self._dy_profile,
                 pec_faces=self._boundary_spec.pec_faces()
                     if self._boundary_spec is not None else None,
@@ -1115,6 +1118,11 @@ class _SparamMixin:
         saved_msl = list(self._msl_ports)
         saved_ports = list(self._ports)
         try:
+            # Mutate self._dz_profile to the (possibly synthesised) grid dz only
+            # now — inside the try — so the finally always restores it and the
+            # subsequent self.run() builds a grid matching the one above.
+            if is_nonuniform:
+                self._dz_profile = _dz_for_grid
             _complex_dtype = jnp.complex128 if jax.config.x64_enabled else jnp.complex64
             S = jnp.zeros((n_ports, n_ports, n_freqs_used), dtype=_complex_dtype)
             Z0_per_run = jnp.zeros((n_ports, n_freqs_used), dtype=_complex_dtype)

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -203,6 +203,79 @@ def _build_waveguide_port_config_nu(sim, entry, grid: NonUniformGrid,
     )
 
 
+def _setup_msl_ports_nu(sim, grid, materials, materials_concrete, sources,
+                        n_steps, pec_mask):
+    """Set up MSL ports on the non-uniform mesh (Ez static-Laplace feed only).
+
+    Mirrors the uniform MSL block (``rfx/runners/uniform.py``: ``_msl_ports``)
+    but with two NU-specific differences:
+      * the eigenmode J+M launch is FENCED — ``run_nonuniform`` carries no
+        magnetic-source channel, so the Schelkunoff H-source would have
+        nowhere to go; and
+      * the substrate ``eps_r`` is read from ``materials_concrete`` so the
+        value stays concrete under ``jax.grad`` (the same concreteness split
+        ``make_current_source`` uses on this path).
+
+    The Ez point-sources are appended to ``sources`` (they ride the generic
+    NU point-source scan injection). The per-probe DFT planes are registered
+    separately by ``compute_msl_s_matrix`` via ``add_dft_plane_probe`` and
+    flow through the existing NU ``dft_plane_probes`` accumulation. Returns
+    the (possibly σ-updated) ``materials`` and ``pec_mask``.
+    """
+    from rfx.sources.msl_port import (
+        MSLPort,
+        _msl_yz_cells,
+        compute_msl_mode_profile,
+        make_msl_port_sources,
+        setup_msl_port,
+    )
+    for pe in sim._msl_ports:
+        x_feed, y_centre, z_lo = pe.position
+        mp = MSLPort(
+            feed_x=float(x_feed),
+            y_lo=float(y_centre - pe.width / 2),
+            y_hi=float(y_centre + pe.width / 2),
+            z_lo=float(z_lo),
+            z_hi=float(z_lo + pe.height),
+            direction=pe.direction,
+            impedance=pe.impedance,
+            excitation=pe.waveform,
+        )
+        port_mode = getattr(pe, "mode", "laplace")
+        if port_mode == "eigenmode":
+            raise NotImplementedError(
+                "NU MSL S-params support mode='laplace'/'uniform' (Ez feed) "
+                "only: the eigenmode J+M launch needs the magnetic-source "
+                "channel, which run_nonuniform does not carry. Use "
+                "mode='laplace' (the add_msl_port default) on the "
+                "non-uniform lane."
+            )
+        # laplace / uniform: build the static-Laplace Ez mode profile from the
+        # substrate eps_r read concretely under the trace centre.
+        cells = _msl_yz_cells(grid, mp)
+        j_set = sorted({c[1] for c in cells})
+        k_set = sorted({c[2] for c in cells})
+        j_centre = (j_set[0] + j_set[-1]) // 2
+        k_mid = (k_set[0] + k_set[-1]) // 2
+        i_feed = cells[0][0]
+        if pe.eps_r_sub is not None:
+            eps_r_sub = float(pe.eps_r_sub)
+        else:
+            eps_r_sub = float(np.asarray(
+                materials_concrete.eps_r[i_feed, j_centre, k_mid]))
+        mode_profile = compute_msl_mode_profile(grid, mp, eps_r_sub)
+
+        materials = setup_msl_port(grid, mp, materials, mode_profile=mode_profile)
+        if pe.excite and pe.waveform is not None:
+            sources.extend(make_msl_port_sources(
+                grid, mp, materials_concrete, n_steps, mode_profile=mode_profile,
+            ))
+        if pec_mask is not None:
+            for cell in _msl_yz_cells(grid, mp):
+                pec_mask = pec_mask.at[cell[0], cell[1], cell[2]].set(False)
+    return materials, pec_mask
+
+
 def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=None,
                         eps_override=None, sigma_override=None,
                         pec_mask_override=None, pec_occupancy_override=None,
@@ -590,6 +663,14 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
                     sim, pe, grid, wg_freqs, n_steps,
                 )
             )
+
+    # MSL ports — full cross-section distributed Ez feed (NU lane). Sources
+    # ride the generic point-source `sources` list; per-probe DFT planes are
+    # registered by compute_msl_s_matrix via add_dft_plane_probe.
+    if getattr(sim, "_msl_ports", None):
+        materials, pec_mask = _setup_msl_ports_nu(
+            sim, grid, materials, materials_concrete, sources, n_steps, pec_mask,
+        )
 
     # Optional per-waveguide-port Poynting flux monitors at each port's
     # probe plane (issue #88 flux-extractor path). Built from the same

--- a/rfx/sources/msl_port.py
+++ b/rfx/sources/msl_port.py
@@ -75,7 +75,19 @@ def _axis_cell_size(grid, axis: str, idx: int) -> float:
     """Return the cell size at index ``idx`` along ``axis``.
 
     Supports both uniform Grid and NonUniformGrid via duck typing.
+
+    On a ``NonUniformGrid`` the per-cell sizes live in ``dx_arr``/``dy_arr``/
+    ``dz`` (the NamedTuple has NO ``*_profile`` attribute), so the duck-typed
+    ``getattr(grid, "dx_profile")`` path below would fall through to the scalar
+    BOUNDARY ``grid.dx`` for every cell — the wrong-cell bug. Read the real
+    per-cell array first. On a uniform ``Grid`` (not a ``NonUniformGrid``) this
+    branch is skipped and the legacy behaviour is byte-identical.
     """
+    from rfx.nonuniform import NonUniformGrid
+    if isinstance(grid, NonUniformGrid):
+        per_cell = np.asarray({"x": grid.dx_arr, "y": grid.dy_arr, "z": grid.dz}[axis])
+        clamped = max(0, min(int(idx), int(per_cell.shape[0]) - 1))
+        return float(per_cell[clamped])
     profile_attr = {"x": "dx_profile", "y": "dy_profile", "z": "dz_profile"}[axis]
     profile = getattr(grid, profile_attr, None)
     if profile is not None:
@@ -95,8 +107,8 @@ def _msl_yz_cells(grid, port: MSLPort) -> list[tuple[int, int, int]]:
     ``i`` is the feed-plane x index. ``j`` ranges over the y-cells from
     ``port.y_lo`` to ``port.y_hi`` (inclusive); ``k`` likewise over z.
     """
-    i_feed, j_lo, k_lo = grid.position_to_index((port.feed_x, port.y_lo, port.z_lo))
-    _, j_hi, k_hi = grid.position_to_index((port.feed_x, port.y_hi, port.z_hi))
+    i_feed, j_lo, k_lo = _msl_position_to_index(grid, (port.feed_x, port.y_lo, port.z_lo))
+    _, j_hi, k_hi = _msl_position_to_index(grid, (port.feed_x, port.y_hi, port.z_hi))
     j_a, j_b = (j_lo, j_hi) if j_lo <= j_hi else (j_hi, j_lo)
     k_a, k_b = (k_lo, k_hi) if k_lo <= k_hi else (k_hi, k_lo)
     cells = []

--- a/tests/test_msl_nu_abscissa.py
+++ b/tests/test_msl_nu_abscissa.py
@@ -25,6 +25,7 @@ from rfx.sources.msl_port import (
     msl_probe_x_coords,
     msl_probe_x_coords_n,
     _msl_position_to_index,
+    _axis_cell_size,
 )
 from rfx.api._sparams import _msl_cell_profile
 
@@ -209,6 +210,38 @@ def test_cell_profile_uniform_byte_identical():
     for axis, n in (("x", grid.nx), ("y", grid.ny), ("z", grid.nz)):
         np.testing.assert_array_equal(
             _msl_cell_profile(grid, axis, n), np.full(n, float(grid.dx)))
+
+
+# ---------------------------------------------------------------------------
+# 3b. _axis_cell_size (SOURCE-side helper): NU per-cell vs uniform scalar
+# ---------------------------------------------------------------------------
+
+def test_axis_cell_size_nu_reads_per_cell():
+    """setup_msl_port / make_msl_port_sources weight sigma + the Ez feed by
+    _axis_cell_size; on a graded mesh it must return the per-cell size, not the
+    scalar boundary grid.dx."""
+    prof = _tent(_NX, _DX)
+    grid = _nu_grid(prof)
+    # x axis is graded — sizes across interior indices must vary
+    sizes = [_axis_cell_size(grid, "x", i) for i in range(grid.pad_x_lo, grid.nx - grid.pad_x_hi)]
+    assert np.ptp(sizes) > 1e-9, "graded x: _axis_cell_size must not be constant"
+    # each equals the per-cell dx_arr value
+    dx_arr = np.asarray(grid.dx_arr, float)
+    for i in range(grid.pad_x_lo, grid.nx - grid.pad_x_hi):
+        assert abs(_axis_cell_size(grid, "x", i) - dx_arr[i]) < 1e-12
+    # y / z read their own per-cell arrays (not the x boundary cell)
+    assert abs(_axis_cell_size(grid, "y", grid.ny // 2)
+               - float(np.asarray(grid.dy_arr, float)[grid.ny // 2])) < 1e-12
+    assert abs(_axis_cell_size(grid, "z", grid.nz // 2)
+               - float(np.asarray(grid.dz, float)[grid.nz // 2])) < 1e-12
+
+
+def test_axis_cell_size_uniform_byte_identical():
+    """On a uniform Grid (no NonUniformGrid branch) _axis_cell_size returns the
+    legacy scalar grid.dx for every axis."""
+    grid = _uniform_grid()
+    for axis in ("x", "y", "z"):
+        assert _axis_cell_size(grid, axis, 5) == float(grid.dx)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_msl_nu_sparam_gate.py
+++ b/tests/test_msl_nu_sparam_gate.py
@@ -1,0 +1,146 @@
+"""Gate-1 — NU MSL S-param settled-S11 witness (edge-fed patch).
+
+The full fenced NU MSL build (PR-after-#238) routes compute_msl_s_matrix through
+run_nonuniform_path when a *_profile is set: _setup_msl_ports_nu injects the Ez
+static-Laplace feed, the per-probe DFT planes ride the existing NU dft_plane_probe
+accumulation, and the grid-agnostic V·I + N-probe-fit + S-assembly is reused
+verbatim. This gate validates that the NU lane produces the SAME physically-correct
+edge-fed-patch S11 the uniform lane is validated for (the committed issue-80/#118
+gate), against the NU path's own grid.
+
+Validation rationale (R5 / canonical anchor):
+  * We assert the COMMITTED edge-fed physics gate (passivity + edge-fed signature +
+    soft dip-above-band) — NEVER a re-spec to a dip-at-9.3 gate (that is the issue
+    #118 category error). These are the exact assertions from
+    test_issue80_patch_s11_regression.py.
+  * We do NOT gate on NU == uniform bit-for-bit: rfx's uniform Grid and
+    NonUniformGrid constructors differ by ~1 cell per axis for the same domain/dx
+    (verified), so the two rasterise the geometry slightly differently. The NU path
+    is validated against PHYSICS on its own grid, exactly as the waveguide NU lane is
+    (vs analytic/Meep, not vs a uniform-rfx run). A uniform cross-run is printed as an
+    informational witness only.
+  * The mesh here is dz_profile = full(nz, dx) — the NU CODE PATH with uniform cell
+    sizes — so this isolates 'the NU runner reproduces correct MSL physics' from the
+    separate question 'does coarsening the far-air dz preserve the patch resonance'
+    (a graded-z efficiency follow-up; the runner is identical).
+
+Marked gpu + slow: dx=0.197 mm over ~30x18x13 mm with num_periods=200 — GPU-scale,
+run by the VESSL validation harness, excluded from the default CPU suite (mirrors the
+uniform issue-80 gate's resourcing).
+"""
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from rfx import Box, Simulation
+from rfx.sources import GaussianPulse
+
+# --- identical geometry to tests/test_issue80_patch_s11_regression.py ---
+EPS_R = 3.38
+H_SUB = 0.787e-3
+W = 10.129e-3
+L = 8.595e-3
+W_MSL = 1.8e-3
+L_MSL = 8.0e-3
+PORT_MARGIN = 5.0e-3
+DX = 0.197e-3
+DOM_X = 29.747e-3
+DOM_Y = 18.130e-3
+DOM_Z = 12.787e-3
+Y_C = DOM_Y / 2.0
+
+PASSIVE_TOL = 1.05
+RES_BAND_GHZ = (9.0, 9.42)
+RES_BAND_S11_MIN = 0.70
+
+
+def _build_patch_sim_nu() -> Simulation:
+    """The committed edge-fed patch, built on the NON-UNIFORM lane.
+
+    dz_profile = full(nz, DX) drives the NU constructor + NU runner with uniform
+    cell sizes, so any failure is the NU MSL path, not a grading effect.
+    """
+    nz = int(round(DOM_Z / DX))
+    sim = Simulation(
+        freq_max=15e9, domain=(DOM_X, DOM_Y, DOM_Z),
+        dx=DX, cpml_layers=8, boundary="cpml",
+        dz_profile=np.full(nz, DX),
+    )
+    sim.add_material("ro4003c", eps_r=EPS_R, sigma=0.0)
+    sim.add(Box((0, 0, 4e-3), (DOM_X, DOM_Y, 4e-3 + DX)), material="pec")
+    sim.add(Box((0, 0, 4e-3 + DX), (DOM_X, DOM_Y, 4e-3 + DX + H_SUB)),
+            material="ro4003c")
+    sim.add(Box((0, Y_C - W_MSL / 2, 4e-3 + DX + H_SUB + DX),
+                (PORT_MARGIN + L_MSL, Y_C + W_MSL / 2,
+                 4e-3 + DX + H_SUB + 2 * DX)),
+            material="pec")
+    sim.add(Box((PORT_MARGIN + L_MSL, Y_C - W / 2, 4e-3 + DX + H_SUB + DX),
+                (PORT_MARGIN + L_MSL + L, Y_C + W / 2,
+                 4e-3 + DX + H_SUB + 2 * DX)),
+            material="pec")
+    sim.add_msl_port(
+        position=(PORT_MARGIN, Y_C, 4e-3 + DX),
+        width=W_MSL, height=H_SUB, direction="+x", impedance=50.0,
+        waveform=GaussianPulse(f0=8.5e9, bandwidth=1.6),
+    )
+    return sim
+
+
+@pytest.mark.gpu
+@pytest.mark.slow
+def test_nu_msl_patch_s11_passive_and_edge_fed_match():
+    """NU-lane edge-fed patch |S11| is passive AND shows the edge-fed signature,
+    exactly like the validated uniform lane. Gates the full fenced NU MSL build."""
+    sim = _build_patch_sim_nu()
+
+    # R: never ignore preflight — surface any warning before trusting |S| numbers.
+    sim.preflight()
+
+    freqs = np.linspace(6e9, 14e9, 81)
+    res = sim.compute_msl_s_matrix(freqs=jnp.asarray(freqs), num_periods=200.0)
+
+    fr = np.asarray(res.freqs, dtype=float) / 1e9
+    s = np.asarray(res.S)[0, 0, :]
+    z0 = np.asarray(res.Z0)[0, :]
+    zin = z0 * (1.0 + s) / (1.0 - s)
+    s11 = np.abs(s)
+
+    i_dip = int(np.argmin(s11))
+    f_dip = fr[i_dip]
+    s11_max = float(np.max(s11))
+    band = (fr >= RES_BAND_GHZ[0]) & (fr <= RES_BAND_GHZ[1])
+    s11_res_band_min = float(np.min(s11[band]))
+
+    # --- R5 witnesses: full per-frequency trace, never a bare headline ---
+    print(f"\n[NU-MSL-GATE] max|S11| = {s11_max:.4f}  dip @ {f_dip:.3f} GHz "
+          f"(|S11|={s11[i_dip]:.4f}, the off-resonance MATCH point)")
+    print(f"[NU-MSL-GATE] min|S11| over resonance band {RES_BAND_GHZ} GHz = "
+          f"{s11_res_band_min:.4f} (HIGH => edge-fed signature)")
+    print(f"[NU-MSL-GATE] Z0[0] median Re = {np.median(z0.real):.2f} ohm "
+          f"(analytic Hammerstad-Jensen ~50.6 ohm)")
+    for f, a, zr, zi in zip(fr, s11, zin.real, zin.imag):
+        print(f"[NU-MSL-TRACE] {f:7.3f} GHz  |S11|={a:.5f}  "
+              f"Re(Zin)={zr:9.2f}  Im(Zin)={zi:9.2f}")
+
+    # --- (1) passivity (the #80 fix must hold on the NU lane too) ---
+    assert s11_max <= PASSIVE_TOL, (
+        f"non-passive NU patch: max|S11| = {s11_max:.4f} > {PASSIVE_TOL}. "
+        "The NU MSL runner does not reproduce the validated passive patch S11."
+    )
+
+    # --- (2) edge-fed signature: poorly matched at resonance (dip is NOT there) ---
+    assert s11_res_band_min > RES_BAND_S11_MIN, (
+        f"min|S11| = {s11_res_band_min:.4f} over the resonance band "
+        f"{RES_BAND_GHZ} GHz is unexpectedly LOW (<= {RES_BAND_S11_MIN}). "
+        "A directly edge-fed patch must be poorly matched at its TM010 resonance; "
+        "a deep dip there means the NU lane changed the physics."
+    )
+
+    # --- (3) soft: the |S11| minimum (match point) lies ABOVE the resonance band ---
+    assert f_dip > RES_BAND_GHZ[1], (
+        f"|S11| dip at {f_dip:.3f} GHz is inside/below the resonance band — "
+        "expected the off-resonance match point ABOVE it (mesh-limited argmin; "
+        "only the lower bound is asserted)."
+    )

--- a/tests/test_sparameter_support_contract.py
+++ b/tests/test_sparameter_support_contract.py
@@ -175,7 +175,7 @@ def test_preflight_sparameters_rejects_unknown_calculator():
         sim.preflight_sparameters(calculator="not-a-calculator")
 
 
-def test_compute_msl_s_matrix_rejects_nonuniform_profiles():
+def _nu_msl_sim(mode: str = "laplace") -> "Simulation":
     sim = Simulation(
         freq_max=10e9,
         domain=(0.02, 0.006, 0.002),
@@ -188,7 +188,53 @@ def test_compute_msl_s_matrix_rejects_nonuniform_profiles():
         width=0.5e-3,
         height=0.5e-3,
         direction="+x",
+        mode=mode,
     )
+    return sim
 
-    with pytest.raises(NotImplementedError, match="uniform Yee lane only"):
+
+def test_compute_msl_s_matrix_nu_laplace_not_fenced():
+    """The NU MSL lane is OPEN for the Ez static-Laplace feed (PR feat/msl-nu-runner
+    lifted the blanket fence). A laplace port must get PAST the fence — here the
+    minimal geometry has no PEC trace, so it proceeds into the extractor and fails
+    with the trace-PEC RuntimeError, NOT the old 'uniform Yee lane only'
+    NotImplementedError (which would mean the fence still blocks it)."""
+    sim = _nu_msl_sim(mode="laplace")
+    with pytest.raises(RuntimeError, match="no PEC trace conductor"):
         sim.compute_msl_s_matrix(n_steps=1)
+
+
+def test_compute_msl_s_matrix_nu_eigenmode_still_fenced():
+    """The eigenmode J+M launch stays fenced on the NU lane — run_nonuniform has
+    no magnetic-source channel for the Schelkunoff H-source."""
+    sim = _nu_msl_sim(mode="eigenmode")
+    with pytest.raises(NotImplementedError, match="magnetic-source channel"):
+        sim.compute_msl_s_matrix(n_steps=1)
+
+
+def test_msl_nu_fence_message_parity_sparams_vs_preflight():
+    """Contract-test governance: the eigenmode-fence message must be byte-identical
+    between compute_msl_s_matrix (_sparams) and preflight_sparameters (_preflight),
+    so preflight never green-lights a config the method rejects (or vice versa)."""
+    # _sparams raises; _preflight collects the same error into a PreflightReport.
+    sim_a = _nu_msl_sim(mode="eigenmode")
+    try:
+        sim_a.compute_msl_s_matrix(n_steps=1)
+        msg_sparams = None
+    except NotImplementedError as e:
+        msg_sparams = str(e)
+    assert msg_sparams is not None, "_sparams must fence eigenmode-on-NU"
+
+    sim_b = _nu_msl_sim(mode="eigenmode")
+    report = sim_b.preflight_sparameters(calculator="msl")
+    fence_issues = [str(i) for i in report.issues if "magnetic-source channel" in str(i)]
+    assert len(fence_issues) == 1, (
+        f"_preflight must surface the eigenmode fence exactly once; "
+        f"got {[str(i) for i in report.issues]}"
+    )
+    # The _sparams message must appear VERBATIM in the _preflight issue (the
+    # report prefixes it with 'NotImplementedError: '): no fence-message drift.
+    assert msg_sparams in fence_issues[0], (
+        "fence message drift: _sparams vs _preflight must stay byte-identical.\n"
+        f"  _sparams:        {msg_sparams!r}\n  _preflight issue: {fence_issues[0]!r}"
+    )


### PR DESCRIPTION
## What

Lifts the `compute_msl_s_matrix` `NonUniformGrid` `NotImplementedError` fence for the **Ez static-Laplace MSL feed** (`mode='laplace'`/`'uniform'`), routing microstrip S-parameters through the NU runner. The eigenmode J+M launch stays **fenced** (the NU runner has no magnetic-source channel). Builds on #238 (extractor-side NU-awareness); this adds the source-side + runner + dispatch.

**Zero new scan code:** MSL Ez sources ride the generic NU point-source scan injection, and the per-probe ez/hy/hz DFT planes ride the existing NU `dft_plane_probe` accumulation. The entire post-scan V·I + N-probe-fit + S-assembly is reused verbatim (grid-agnostic, NU-safe via #238).

## Changes

- **`_axis_cell_size`** (msl_port.py) — NU branch reads per-cell `dx_arr`/`dy_arr`/`dz` (the 4th NU-readiness gap; #238 fixed only the extractor side). **`_msl_yz_cells`** → `_msl_position_to_index` (fixes `compute_msl_mode_profile`/`setup_msl_port`/`make_msl_port_sources` transitively).
- **`_setup_msl_ports_nu`** (nonuniform.py) — mirrors the uniform MSL block; eigenmode fenced; eps read from `materials_concrete` (concrete under `jax.grad`). Ez sources appended to the generic `sources` list.
- **Dispatch** (`compute_msl_s_matrix`) — builds the *same* NU grid `run_nonuniform_path` builds (probe_xs/port-cells/dy_dz/eps-anchor align with the run's field planes) + `_assemble_materials_nu`; dz synthesised from dx when absent, mutated only inside the try/finally (always restored).
- **Fence → eigenmode-only** in *both* `_sparams.py` and `_preflight.py` (kept byte-aligned per contract-test governance).

## Validation

**Gate-1 (GPU, VESSL run `369367245357`) — PASS.** The canonical edge-fed patch (`tests/test_msl_nu_sparam_gate.py`, gpu+slow) on the NU lane passes the committed issue-80/#118 gate, R5-verified against physics (not a headline):
- passivity **max|S11| = 0.988** ≤ 1.05 (matches the uniform lane's 1.008)
- edge-fed signature **min|S11| over [9.0,9.42] = 0.904** > 0.70 — witnessed by **Re(Zin) peaking to 1398 Ω at the 9.4 GHz TM010 resonance** (high edge resistance → poorly matched → |S11| HIGH, not a dip)
- dip = off-resonance match point: global min |S11|=0.52 at 11.3 GHz (Re(Zin)≈20 Ω, Im(Zin)≈0), above the band
- resonance ~9.3–9.4 GHz matches Balanis 9.21 / Harminv 9.32 / OpenEMS 9.20. **Never a dip-at-9.3 re-spec** (the #118 category error).

**Uniform path byte-identical** (isinstance-gated): 40+ MSL tests green incl. heavy AD + the updated contract suite. ruff clean.

**Scope note:** the mesh here is `dz_profile=full(nz,dx)` (NU code, uniform cells) to isolate runner-correctness from the separate graded-z efficiency question. The actual thin-substrate graded-z win is a documented follow-up — same runner, mesh choice; the NU "3× worse at matched dx" accuracy caveat applies there, not here. Also note: rfx's uniform `Grid` (81³-ish) and `NonUniformGrid` (80³-ish) constructors differ by ~1 cell/axis for the same domain/dx, so Gate-1 validates against physics on the NU grid, NOT a bit-match to a uniform-rfx run (exactly as the waveguide NU lane validates vs analytic/Meep).

## Review

Separate code-review pass: REQUEST-CHANGES → fixed (commit f26b547): updated the contract test that pinned the old fence (was leaving the fast suite red) + added a fence-message-parity governance test; guarded the dz-synth restore against the trace-PEC RuntimeError. Reviewer confirmed sound: fence parity byte-identical, grid-match correct, AD-concreteness correct, uniform byte-identity holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)