### PR TITLE
Add AD residual diagnostics and bounded memory certificates

### DIFF
--- a/docs/public/guide/memory-reduction.mdx
+++ b/docs/public/guide/memory-reduction.mdx
@@ -24,8 +24,12 @@ Current `estimate_ad_memory(...)`, `plan_ad_memory(...)`, and `explain_ad_memory
 | `static_estimate` | yes | Formula/static metadata estimate for planning. It may include shape, dtype, NTFF, active-step, and design-mask metadata, but it is not a compiled-executable peak-memory proof. |
 | `calibrated_conservative_plan` | yes | Budget-fitting helper result built from static estimates plus safety margins. It can say whether a conservative plan fits the configured budget target, not whether runtime peak memory is guaranteed. |
 | `static_ad_explainability` | yes | Decomposition of the selected static AD estimate into field state, material/CPML state, reverse-mode saved state, and monitor state so users can see why a run is large. It is diagnostic planning evidence, not profiling. |
+| `jax_saved_residuals_inspection` | yes | Low-level JAX trace-time saved-residual listing from `inspect_ad_saved_residuals(...)`. It preserves what JAX says reverse-mode AD would save for one function and sample argument set; it is not an XLA memory report or runtime peak-memory profile. |
+| `rfx_ad_saved_residuals_diagnostic` | yes | rfx-owned report from `diagnose_ad_saved_residuals(...)` that adds JAX version, parser health, top residuals, grouped summaries, optional artifact snapshots, and deterministic recommendations over the low-level listing. It is still trace-time explainability, not a certificate. |
+| `composite_ad_memory_preflight` | yes | One-call planning bundle from `ad_memory_preflight(...)`: budget-fit status, the selected supported checkpoint knob, static explainability, optional mesh report, optional saved-residual diagnostic, and action hints. |
+| `static_action_hint` | yes | Deterministic next-action row attached to the preflight bundle. It is a planning instruction such as `use_checkpoint_every`, not proof that a run will fit at runtime. |
 | `observed_profile` | no | A future or external measured run artifact for calibration/regression. It records one environment/run and must not be reused as proof for changed scope. |
-| `bounded_certificate` | no | A separately approved future artifact only if compiler/runtime metadata can support a fail-closed certificate for one exact compiled executable, environment, input/static args/shapes, precision, and checkpoint configuration. |
+| `bounded_certificate` | yes | A fail-closed compiler-memory certificate from `ad_memory_compiled_certificate(...)` for one exact caller-supplied JAX compiled executable, complete exact-scope metadata, and `Compiled.memory_analysis()` byte fields. It is not a universal runtime peak-memory guarantee. |
 
 ## Decision ladder
 
@@ -38,6 +42,107 @@ Current `estimate_ad_memory(...)`, `plan_ad_memory(...)`, and `explain_ad_memory
 | Need to reduce memory for a port-family S-parameter claim | Use the calculator-supported lane first, then document the memory plan | validation scope still follows the port-family support matrix |
 
 Use the documented memory-planning and non-uniform workflows for public examples; other local-refinement code paths require an explicit support entry before publication.
+
+## One-call AD memory preflight
+
+Use `ad_memory_preflight(...)` before launching memory-heavy AD or inverse-design work. It composes `plan_ad_memory(...)`, `explain_ad_memory(...)`, `mesh_intelligence_report(...)`, and optionally `diagnose_ad_saved_residuals(...)` into one deterministic JSON artifact without running FDTD.
+
+```python
+preflight = sim.ad_memory_preflight(
+    n_steps=10_000,
+    available_memory_gb=24.0,
+)
+
+if preflight.full_ad_fits:
+    checkpoint_kwargs = {}
+elif (
+    preflight.checkpointing_fits
+    and preflight.supported_checkpoint_mode == "checkpoint_every"
+):
+    checkpoint_kwargs = {"checkpoint_every": preflight.checkpoint_every}
+elif (
+    preflight.checkpointing_fits
+    and preflight.supported_checkpoint_mode == "checkpoint_segments"
+):
+    checkpoint_kwargs = {"checkpoint_segments": preflight.checkpoint_segments}
+else:
+    # The returned least-memory checkpoint candidate is diagnostic-only here.
+    raise RuntimeError(preflight.recommendation)
+
+print(preflight.status)
+print(preflight.recommendation)
+print([hint.to_dict() for hint in preflight.action_hints])
+preflight_json = preflight.to_json()
+
+# After choosing a supported lane and running the required physics checks,
+# pass the selected knob into the launch path:
+# result = sim.forward(n_steps=10_000, **checkpoint_kwargs)
+```
+
+For JAX-level trace context, pass a small representative objective through `residual_fun`. `residual_context` is snapshotted before the diagnostic runs: JSON primitives, mappings, sequences, NumPy/JAX scalar or array `.tolist()` values, and valid `to_dict()` / `to_json()` outputs are accepted; unsupported objects raise `TypeError`, and non-finite JSON values raise `ValueError`.
+
+```python
+import jax.numpy as jnp
+
+def reduced_loss(params):
+    return jnp.sum(jnp.sin(params) ** 2)
+
+preflight = sim.ad_memory_preflight(
+    n_steps=10_000,
+    available_memory_gb=24.0,
+    residual_fun=reduced_loss,
+    residual_args=(jnp.ones((32,)),),
+    residual_workflow="reduced-inverse-design-loss",
+    residual_context={"case": "notch-filter-demo"},
+)
+```
+
+Canonical `ad_memory_preflight(...)` evidence boundaries are:
+
+- `static memory planning only`
+- `trace-time JAX saved-residual explainability only when residual_diagnostic is present`
+- `not a runtime peak-memory guarantee`
+- `not XLA memory analysis`
+- `not profiler evidence`
+- `not a certificate`
+- `not RF validation`
+
+The preflight bundle is the preferred UX when deciding whether to use full AD, `checkpoint_every`, or `checkpoint_segments`. It still does not replace physics validation, gradient checks, profiler measurement, or XLA/compiler memory analysis; use the compiled certificate below only after compiling the exact executable you want to bound.
+
+## Compiled executable memory certificate
+
+After `ad_memory_preflight(...)` chooses a candidate lane, compile the exact AD objective or runner you intend to launch and pass that already-compiled object to `ad_memory_compiled_certificate(...)`. Reuse the same selected checkpoint kwargs from the preflight decision so the supplied preflight scope and certificate scope match. The certificate reads `Compiled.memory_analysis()` once and fails closed unless the exact scope and compiler byte fields are complete.
+
+```python
+certificate = sim.ad_memory_compiled_certificate(
+    compiled_loss,
+    n_steps=10_000,
+    available_memory_gb=24.0,
+    target_fraction=0.85,
+    **checkpoint_kwargs,
+    precision="float32",
+    input_signature={
+        "eps_r": {"shape": [128, 64, 16], "dtype": "float32", "role": "design"}
+    },
+    static_signature={"dx": 0.0005, "boundary": "pml"},
+    compiled_object_id="notch-filter-loss-v1",
+    runner_or_objective="notch-filter-reduced-loss",
+    preflight=preflight,
+)
+
+You may provide compact signature dictionaries as above or pass representative NumPy/JAX arrays / `jax.ShapeDtypeStruct` leaves inside `input_signature` and `static_signature`; rfx records only shape, dtype, and weak-type metadata for array-like leaves, not full array values. Keep semantic labels such as `"role": "design"` in explicit dictionaries when they matter for audit readability.
+
+if certificate.status == "certified_budget_fit":
+    launch()
+else:
+    raise RuntimeError(certificate.recommendations[0])
+```
+
+A green certificate is bounded to the supplied compiled object, backend/device metadata, input/static signatures, precision, `n_steps`, warmup count, checkpoint mode, and target budget. Missing or non-JSON-safe exact-scope metadata returns `scope_incomplete`; contradictions with supplied preflight metadata or compiled-object introspection return `scope_mismatch`; missing `memory_analysis()`, a raised call, or a `None` result returns `analysis_unavailable`; missing or invalid byte fields return `analysis_incomplete`.
+
+The required compiler byte fields are `temp_size_in_bytes`, `argument_size_in_bytes`, `output_size_in_bytes`, and `alias_size_in_bytes`. rfx computes required bytes exactly as `temp + argument + output - alias` and compares that value with `available_memory_gb * target_fraction`.
+
+`scope_digest`, `config_digest`, and `environment_digest` are audit identities over canonical JSON. They are not proof that source code, Python callables, or simulation configuration correspond to the opaque compiled executable unless separate introspection establishes that relationship. JAX documents memory analysis as estimated/debugging-oriented compiler metadata; it is version/backend dependent and may be unavailable. Treat `bounded_certificate` as compiler evidence for one exact scope, not profiler evidence, RF validation, or a universal guaranteed peak predictor.
 
 ## Non-uniform + segmented AD workflow
 
@@ -82,6 +187,55 @@ explain_json = explain.to_json()
 `ad_segmented_gb`), the active AD strategy, and a component breakdown. Use it to
 decide whether the dominant cost is full field tape, segmented boundary state,
 CPML/material state, or NTFF monitor state.
+
+For a JAX-level saved-residual diagnostic on a small loss function or reduced
+problem, use `diagnose_ad_saved_residuals(...)`:
+
+```python
+import jax.numpy as jnp
+from rfx import diagnose_ad_saved_residuals
+
+def loss(x):
+    return jnp.sum(jnp.sin(x) ** 2)
+
+diagnostic = diagnose_ad_saved_residuals(
+    loss,
+    jnp.ones((32,)),
+    workflow="reduced-inverse-design-loss",
+    context={"n_steps": 10_000},
+    artifacts={"memory_plan": plan_json},
+)
+print(diagnostic.parser_health)
+print(diagnostic.top_residuals)
+print(diagnostic.recommendations)
+```
+
+This wraps `jax.ad_checkpoint.print_saved_residuals(...)`, preserves the raw
+JAX lines, and adds parsed dtype/shape/byte estimates, original line indices,
+JAX version, top residuals, grouped summaries, parser health, optional context
+and memory-artifact snapshots, and deterministic recommendations. Use
+`inspect_ad_saved_residuals(...)` when you need the low-level adapter output
+only. Treat both artifacts as trace-time AD explainability, not profiling,
+compiler memory analysis, RF validation, or a certificate.
+
+For compiled invariant checks inside reduced AD examples, wrap a function with
+`checkify_invariants(...)` and place checks in the traced body:
+
+```python
+import jax.numpy as jnp
+from rfx import check_bounds, checkify_invariants
+
+def loss(eps_r):
+    check_bounds(eps_r, lower=1.0, upper=12.0, name="eps_r")
+    return jnp.sum(eps_r)
+
+checked_loss = checkify_invariants(loss)
+err, value = checked_loss(jnp.ones((16,)))
+assert err.get() is None
+```
+
+These checks are runtime diagnostics that survive JAX transforms; they are not
+physics validation and do not replace a convergence or external-reference check.
 
 Use the mesh intelligence report to check:
 

--- a/docs/public/guide/memory-reduction.mdx
+++ b/docs/public/guide/memory-reduction.mdx
@@ -17,12 +17,13 @@ The memory-reduction goal in `rfx` is to keep JAX-native FDTD workflows small en
 
 ## Memory evidence levels
 
-Current `estimate_ad_memory(...)` and `plan_ad_memory(...)` artifacts are not certificates and are not a universal guaranteed peak predictor. They are planning evidence for sizing reverse-mode AD runs and choosing supported checkpoint knobs.
+Current `estimate_ad_memory(...)`, `plan_ad_memory(...)`, and `explain_ad_memory(...)` artifacts are not certificates and are not a universal guaranteed peak predictor. They are planning evidence for sizing reverse-mode AD runs, choosing supported checkpoint knobs, and explaining static memory drivers.
 
 | Evidence class | Produced by current APIs | Meaning |
 |---|---:|---|
 | `static_estimate` | yes | Formula/static metadata estimate for planning. It may include shape, dtype, NTFF, active-step, and design-mask metadata, but it is not a compiled-executable peak-memory proof. |
 | `calibrated_conservative_plan` | yes | Budget-fitting helper result built from static estimates plus safety margins. It can say whether a conservative plan fits the configured budget target, not whether runtime peak memory is guaranteed. |
+| `static_ad_explainability` | yes | Decomposition of the selected static AD estimate into field state, material/CPML state, reverse-mode saved state, and monitor state so users can see why a run is large. It is diagnostic planning evidence, not profiling. |
 | `observed_profile` | no | A future or external measured run artifact for calibration/regression. It records one environment/run and must not be reused as proof for changed scope. |
 | `bounded_certificate` | no | A separately approved future artifact only if compiler/runtime metadata can support a fail-closed certificate for one exact compiled executable, environment, input/static args/shapes, precision, and checkpoint configuration. |
 
@@ -61,7 +62,28 @@ plan_json = plan.to_json()
 report_json = report.to_json()
 ```
 
-Use the report to check:
+For a more actionable memory diagnostic, generate an explainability artifact next
+to the plan:
+
+```python
+explain = sim.explain_ad_memory(
+    n_steps=10_000,
+    checkpoint_every=plan.checkpoint_every if plan.segmented_fits else None,
+    checkpoint_segments=plan.checkpoint_segments if plan.segmented_fits else None,
+    available_memory_gb=24.0,
+)
+
+print(explain.dominant_component)
+print(explain.recommendations)
+explain_json = explain.to_json()
+```
+
+`explain_ad_memory(...)` reports the selected memory field (`ad_full_gb` or
+`ad_segmented_gb`), the active AD strategy, and a component breakdown. Use it to
+decide whether the dominant cost is full field tape, segmented boundary state,
+CPML/material state, or NTFF monitor state.
+
+Use the mesh intelligence report to check:
 
 - `cell_savings_factor`: comparison against a uniform-fine grid at the smallest configured cell size,
 - `preflight_issues`: geometry, resolution, and feature-support warnings to resolve before trusting results,
@@ -117,9 +139,10 @@ For a validated memory-reduction result, keep these artifacts together:
 
 1. `mesh_intelligence_report(...).to_json()`,
 2. `plan_ad_memory(...).to_json()` when reverse-mode AD memory is part of the claim,
-3. the exact run command and version/commit,
-4. the physics validation artifact for the claimed observable,
-5. any unsupported-feature decisions or validation errors,
-6. gradient evidence if the result depends on `jax.grad`.
+3. `explain_ad_memory(...).to_json()` when deciding why AD memory is large,
+4. the exact run command and version/commit,
+5. the physics validation artifact for the claimed observable,
+6. any unsupported-feature decisions or validation errors,
+7. gradient evidence if the result depends on `jax.grad`.
 
 This keeps the memory story separate from the physics claim: saving cells or AD tape is useful only when the RF observable and gradient path remain inside their validated support boundary.

--- a/docs/public/guide/memory-reduction.mdx
+++ b/docs/public/guide/memory-reduction.mdx
@@ -15,13 +15,25 @@ import { Aside } from '@astrojs/starlight/components';
 
 The memory-reduction goal in `rfx` is to keep JAX-native FDTD workflows small enough to run while preserving the support boundary for the observable being claimed.
 
+## Memory evidence levels
+
+Current `estimate_ad_memory(...)` and `plan_ad_memory(...)` artifacts are not certificates and are not a universal guaranteed peak predictor. They are planning evidence for sizing reverse-mode AD runs and choosing supported checkpoint knobs.
+
+| Evidence class | Produced by current APIs | Meaning |
+|---|---:|---|
+| `static_estimate` | yes | Formula/static metadata estimate for planning. It may include shape, dtype, NTFF, active-step, and design-mask metadata, but it is not a compiled-executable peak-memory proof. |
+| `calibrated_conservative_plan` | yes | Budget-fitting helper result built from static estimates plus safety margins. It can say whether a conservative plan fits the configured budget target, not whether runtime peak memory is guaranteed. |
+| `observed_profile` | no | A future or external measured run artifact for calibration/regression. It records one environment/run and must not be reused as proof for changed scope. |
+| `bounded_certificate` | no | A separately approved future artifact only if compiler/runtime metadata can support a fail-closed certificate for one exact compiled executable, environment, input/static args/shapes, precision, and checkpoint configuration. |
+
 ## Decision ladder
 
 | Need | Preferred lane | Public status |
 |---|---|---|
 | Ordinary RF reference, general S-parameters, ports, far-field claims | Uniform Cartesian Yee | validated default |
-| Thin substrate or layered z structure that would force a tiny uniform cell everywhere | Non-uniform z mesh + segmented AD | limited-support path; verify against a uniform or external reference before public claims |
-| Large inverse-design run where reverse-mode tape is the memory limit | `checkpoint_every` / segmented scan where the selected runner supports the physics | planning tool, not validation evidence |
+| Thin substrate or layered z structure that would force a tiny uniform cell everywhere | Non-uniform z mesh + `checkpoint_every` segmented AD | limited-support path; verify against a uniform or external reference before public claims |
+| Large uniform inverse-design run where reverse-mode tape is the memory limit | Uniform segmented scan via `checkpoint_segments` | planning tool, not validation evidence |
+| Large non-uniform inverse-design run where reverse-mode tape is the memory limit | `checkpoint_every` / segmented scan where the selected runner supports the physics | planning tool, not validation evidence |
 | Need to reduce memory for a port-family S-parameter claim | Use the calculator-supported lane first, then document the memory plan | validation scope still follows the port-family support matrix |
 
 Use the documented memory-planning and non-uniform workflows for public examples; other local-refinement code paths require an explicit support entry before publication.
@@ -32,9 +44,12 @@ Start with the non-uniform lane when a small feature only needs fine cells along
 
 ```python
 plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=24.0)
+if not (plan.full_ad_fits or plan.segmented_fits):
+    raise RuntimeError(plan.recommendation)
+
 report = sim.mesh_intelligence_report(
     n_steps=10_000,
-    checkpoint_every=plan.checkpoint_every,
+    checkpoint_every=plan.checkpoint_every if plan.segmented_fits else None,
     available_memory_gb=24.0,
 )
 
@@ -50,10 +65,43 @@ Use the report to check:
 
 - `cell_savings_factor`: comparison against a uniform-fine grid at the smallest configured cell size,
 - `preflight_issues`: geometry, resolution, and feature-support warnings to resolve before trusting results,
-- `ad_memory.ad_segmented_gb`: reverse-mode AD planning estimate when `checkpoint_every` is enabled,
+- `ad_memory.ad_segmented_gb` and `ad_memory.ad_segmented_active_segments`: reverse-mode AD planning estimate and active segment count when the report uses `checkpoint_every`,
 - `recommendation`: compact next action for the configured case.
 
-`plan_ad_memory(...)` is the budget-fitting helper: it returns `checkpoint_every=None` when full reverse-mode AD already fits, otherwise it recommends the smallest segmented-scan chunk length estimated to fit under the requested memory target.
+`plan_ad_memory(...)` is the budget-fitting helper: it returns both checkpoint knobs as `None` when full reverse-mode AD already fits, with `full_ad_fits=True` and `segmented_fits=False` because no segmented candidate was needed. Otherwise it returns a segmented candidate: `checkpoint_every` on non-uniform grids or `checkpoint_segments` on uniform grids, matching the runner support boundary. Treat `checkpoint_mode` as a knob selector only after `segmented_fits` is true; when `segmented_fits` is false and `full_ad_fits` is also false, follow `plan.recommendation` instead of launching the returned least-memory candidate.
+
+`checkpoint_every` and `checkpoint_segments` are different knobs. Use
+`checkpoint_every` for the non-uniform scan-of-scan path, where it means chunk
+length in timesteps. Use `checkpoint_segments` for the uniform segmented-scan
+path, where it means the number of equal segments and must divide `n_steps`.
+`n_warmup` reduces the reported active reverse-mode timestep count. `design_mask`
+is recorded as active-design metadata only; the primary memory estimates stay
+full-grid until masked-state memory has observed calibration. `n_warmup` must be
+an integer with `0 <= n_warmup < n_steps`. `design_mask` must be a boolean array
+with the simulation grid shape and at least one selected cell; arbitrary numeric
+masks, scalars, and shape-mismatched masks are rejected instead of being coerced.
+`plan_ad_memory(...)` uses a conservative safety multiplier before setting
+`full_ad_fits` or `segmented_fits`; the multiplier is stored in
+`plan.fit_safety_factor` for artifacts.
+
+For a uniform inverse-design run, gate execution on the fit flags before wiring
+the selected knob:
+
+```python
+plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=24.0)
+if plan.full_ad_fits:
+    result = sim.forward(n_steps=10_000)
+    report = sim.mesh_intelligence_report(n_steps=10_000, available_memory_gb=24.0)
+elif plan.segmented_fits and plan.checkpoint_mode == "checkpoint_segments":
+    result = sim.forward(n_steps=10_000, checkpoint_segments=plan.checkpoint_segments)
+    report = sim.mesh_intelligence_report(
+        n_steps=10_000,
+        checkpoint_segments=plan.checkpoint_segments,
+        available_memory_gb=24.0,
+    )
+else:
+    raise RuntimeError(plan.recommendation)
+```
 
 For a reusable JSON artifact without running FDTD, use:
 

--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -9,7 +9,8 @@ from rfx.adi import ADIState2D, ADIState3D, thomas_solve, adi_step_2d, run_adi_2
 from rfx.api import (
     Simulation, Result, WaveguideSParamResult, WaveguideSMatrixResult,
     MSLSMatrixResult, CoaxialSMatrixResult, MATERIAL_LIBRARY,
-    AD_MemoryEstimate, ADMemoryPlan, MeshIntelligenceReport,
+    AD_MemoryEstimate, ADMemoryPlan, ADMemoryComponent,
+    ADMemoryExplainabilityReport, MeshIntelligenceReport,
 )
 from rfx.geometry.csg import Box, Sphere, Cylinder, PolylineWire
 from rfx.geometry.curved import CurvedPatch
@@ -212,7 +213,8 @@ __all__ = [
     # result + S-matrix types
     "Result", "WaveguideSParamResult", "WaveguideSMatrixResult",
     "MSLSMatrixResult", "CoaxialSMatrixResult",
-    "AD_MemoryEstimate", "ADMemoryPlan", "MeshIntelligenceReport",
+    "AD_MemoryEstimate", "ADMemoryPlan", "ADMemoryComponent",
+    "ADMemoryExplainabilityReport", "MeshIntelligenceReport",
     # geometry
     "Box", "Sphere", "Cylinder", "PolylineWire", "CurvedPatch", "Via",
     "PCBLayer", "Stackup",

--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -10,7 +10,35 @@ from rfx.api import (
     Simulation, Result, WaveguideSParamResult, WaveguideSMatrixResult,
     MSLSMatrixResult, CoaxialSMatrixResult, MATERIAL_LIBRARY,
     AD_MemoryEstimate, ADMemoryPlan, ADMemoryComponent,
-    ADMemoryExplainabilityReport, MeshIntelligenceReport,
+    ADMemoryActionHint, ADMemoryExplainabilityReport,
+    ADMemoryPreflightReport, ADCompiledMemoryCertificate,
+    MeshIntelligenceReport,
+)
+from rfx.ad_diagnostics import (
+    ADParserHealth,
+    ADResidualGroup,
+    ADResidualInspection,
+    ADResidualRecord,
+    ADSavedResidualDiagnosticReport,
+    diagnose_ad_saved_residuals,
+    inspect_ad_saved_residuals,
+    parse_saved_residual_line,
+)
+from rfx.pareto import (
+    ParetoFront,
+    ParetoPoint,
+    epsilon_constraint_mask,
+    pareto_front,
+    pareto_mask,
+    select_epsilon_constrained,
+    weighted_scalarization,
+)
+from rfx.jax_checks import (
+    check_bounds,
+    check_courant_number,
+    check_finite,
+    check_positive,
+    checkify_invariants,
 )
 from rfx.geometry.csg import Box, Sphere, Cylinder, PolylineWire
 from rfx.geometry.curved import CurvedPatch
@@ -214,7 +242,19 @@ __all__ = [
     "Result", "WaveguideSParamResult", "WaveguideSMatrixResult",
     "MSLSMatrixResult", "CoaxialSMatrixResult",
     "AD_MemoryEstimate", "ADMemoryPlan", "ADMemoryComponent",
+    "ADMemoryActionHint",
     "ADMemoryExplainabilityReport", "MeshIntelligenceReport",
+    "ADMemoryPreflightReport",
+    "ADCompiledMemoryCertificate",
+    "ADParserHealth", "ADResidualGroup",
+    "ADResidualInspection", "ADResidualRecord",
+    "ADSavedResidualDiagnosticReport", "diagnose_ad_saved_residuals",
+    "inspect_ad_saved_residuals", "parse_saved_residual_line",
+    "ParetoFront", "ParetoPoint", "pareto_front", "pareto_mask",
+    "weighted_scalarization", "epsilon_constraint_mask",
+    "select_epsilon_constrained",
+    "checkify_invariants", "check_finite", "check_positive",
+    "check_bounds", "check_courant_number",
     # geometry
     "Box", "Sphere", "Cylinder", "PolylineWire", "CurvedPatch", "Via",
     "PCBLayer", "Stackup",

--- a/rfx/ad_diagnostics.py
+++ b/rfx/ad_diagnostics.py
@@ -1,0 +1,562 @@
+"""JAX autodiff diagnostic helpers for rfx.
+
+These helpers expose JAX's saved-residual inspection as structured JSON
+artifacts. They are diagnostics for AD tape explainability, not runtime memory
+profiles or peak-memory certificates.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import math
+import re
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any, NamedTuple
+
+import jax
+import jax.ad_checkpoint as ad_checkpoint
+
+
+_AVAL_RE = re.compile(r"^(?P<dtype>[A-Za-z][A-Za-z0-9]*)(?:\[(?P<shape>[^\]]*)\])?$")
+_NAMED_RE = re.compile(r"named '([^']+)'")
+_DTYPE_BYTES = {
+    "bool": 1,
+    "i8": 1,
+    "u8": 1,
+    "i16": 2,
+    "u16": 2,
+    "f16": 2,
+    "bf16": 2,
+    "i32": 4,
+    "u32": 4,
+    "f32": 4,
+    "i64": 8,
+    "u64": 8,
+    "f64": 8,
+    "c64": 8,
+    "c128": 16,
+}
+
+
+def _json_safe(value: object) -> object:
+    """Return common metadata values as JSON-native containers."""
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_json_safe(item) for item in value]
+    if hasattr(value, "tolist") and callable(value.tolist):
+        return _json_safe(value.tolist())
+    return value
+
+
+def _snapshot_artifact(value: object) -> object:
+    """Snapshot a caller-provided artifact without importing rfx API types."""
+    if hasattr(value, "to_dict") and callable(value.to_dict):
+        return _json_safe(value.to_dict())
+    if hasattr(value, "to_json") and callable(value.to_json):
+        return _json_safe(json.loads(value.to_json()))
+    return _json_safe(value)
+
+
+class ADResidualRecord(NamedTuple):
+    """One line from JAX saved-residual inspection.
+
+    ``estimated_bytes`` is derived from the printed abstract value when shape
+    and dtype are parseable. It is a static byte count for the residual value,
+    not allocator overhead, fragmentation, or measured peak memory.
+    """
+
+    aval: str
+    source: str
+    dtype: str | None = None
+    shape: tuple[int, ...] | None = None
+    size: int | None = None
+    estimated_bytes: int | None = None
+    source_kind: str = "unknown"
+    name: str | None = None
+    raw_line: str = ""
+    line_index: int | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable residual record."""
+        return {
+            "aval": self.aval,
+            "source": self.source,
+            "dtype": self.dtype,
+            "shape": None if self.shape is None else list(self.shape),
+            "size": self.size,
+            "estimated_bytes": self.estimated_bytes,
+            "estimated_gb": (
+                None if self.estimated_bytes is None else self.estimated_bytes / 1e9
+            ),
+            "source_kind": self.source_kind,
+            "name": self.name,
+            "raw_line": self.raw_line,
+            "line_index": self.line_index,
+        }
+
+
+class ADResidualInspection(NamedTuple):
+    """Structured artifact for JAX saved-residual inspection.
+
+    This artifact is produced from ``jax.ad_checkpoint.print_saved_residuals``.
+    It explains what JAX says would be saved for reverse-mode AD under the given
+    Python function and sample arguments. It is not a runtime profile, not an
+    XLA memory report, and not a peak-memory certificate.
+    """
+
+    records: tuple[ADResidualRecord, ...]
+    raw_lines: tuple[str, ...]
+    total_estimated_bytes: int | None
+    total_estimated_gb: float | None
+    unknown_estimate_count: int
+
+    @property
+    def evidence_class(self) -> str:
+        """Evidence class label serialized with this diagnostic artifact."""
+        return "jax_saved_residuals_inspection"
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable saved-residual artifact."""
+        return {
+            "evidence_class": self.evidence_class,
+            "records": [record.to_dict() for record in self.records],
+            "raw_lines": list(self.raw_lines),
+            "total_estimated_bytes": self.total_estimated_bytes,
+            "total_estimated_gb": self.total_estimated_gb,
+            "unknown_estimate_count": self.unknown_estimate_count,
+        }
+
+    def to_json(self, **kwargs: object) -> str:
+        """Serialize the inspection artifact with non-finite floats rejected."""
+        options = {"indent": 2, "sort_keys": True}
+        options.update(kwargs)
+        options["allow_nan"] = False
+        return json.dumps(self.to_dict(), **options)
+
+
+class ADResidualGroup(NamedTuple):
+    """Grouped summary of saved residual records."""
+
+    key: str
+    source_kind: str
+    name: str | None
+    dtype: str | None
+    record_count: int
+    known_count: int
+    unknown_count: int
+    known_estimated_bytes: int
+    line_indices: tuple[int, ...]
+
+    @property
+    def known_estimated_gb(self) -> float:
+        """Known static byte estimate in GB for parseable records in the group."""
+        return self.known_estimated_bytes / 1e9
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable group artifact."""
+        return {
+            "key": self.key,
+            "source_kind": self.source_kind,
+            "name": self.name,
+            "dtype": self.dtype,
+            "record_count": self.record_count,
+            "known_count": self.known_count,
+            "unknown_count": self.unknown_count,
+            "known_estimated_bytes": self.known_estimated_bytes,
+            "known_estimated_gb": self.known_estimated_gb,
+            "line_indices": list(self.line_indices),
+        }
+
+
+class ADParserHealth(NamedTuple):
+    """Parser health summary for saved-residual diagnostics."""
+
+    record_count: int
+    known_count: int
+    unknown_count: int
+    unknown_fraction: float
+    warnings: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable parser-health artifact."""
+        return {
+            "record_count": self.record_count,
+            "known_count": self.known_count,
+            "unknown_count": self.unknown_count,
+            "unknown_fraction": self.unknown_fraction,
+            "warnings": list(self.warnings),
+        }
+
+
+class ADSavedResidualDiagnosticReport(NamedTuple):
+    """rfx saved-residual diagnostic report.
+
+    The report summarizes JAX saved-residual evidence for one differentiated
+    callable and sample argument set. It is trace-time explainability, not a
+    runtime profiler, XLA memory report, peak-memory guarantee, certificate, or
+    RF/gradient validation artifact.
+    """
+
+    inspection: ADResidualInspection
+    top_residuals: tuple[ADResidualRecord, ...]
+    groups: tuple[ADResidualGroup, ...]
+    parser_health: ADParserHealth
+    known_estimated_bytes: int
+    known_estimated_gb: float
+    total_estimated_bytes: int | None
+    total_estimated_gb: float | None
+    jax_version: str
+    workflow: str | None
+    context: Mapping[str, object] | None
+    artifact_snapshots: Mapping[str, object]
+    recommendations: tuple[str, ...]
+
+    @property
+    def evidence_class(self) -> str:
+        """Evidence class label serialized with this rfx diagnostic report."""
+        return "rfx_ad_saved_residuals_diagnostic"
+
+    @property
+    def known_only_bytes(self) -> int:
+        """Known-byte subtotal excluding parser-unknown residual lines."""
+        return self.known_estimated_bytes
+
+    @property
+    def source_evidence_class(self) -> str:
+        """Evidence class of the underlying JAX saved-residual adapter."""
+        return self.inspection.evidence_class
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable diagnostic report."""
+        return {
+            "evidence_class": self.evidence_class,
+            "source_evidence_class": self.source_evidence_class,
+            "jax_version": self.jax_version,
+            "workflow": self.workflow,
+            "context": None if self.context is None else _json_safe(self.context),
+            "artifact_snapshots": _json_safe(self.artifact_snapshots),
+            "inspection": self.inspection.to_dict(),
+            "raw_lines": list(self.inspection.raw_lines),
+            "records": [record.to_dict() for record in self.inspection.records],
+            "top_residuals": [record.to_dict() for record in self.top_residuals],
+            "groups": [group.to_dict() for group in self.groups],
+            "parser_health": self.parser_health.to_dict(),
+            "known_estimated_bytes": self.known_estimated_bytes,
+            "known_only_bytes": self.known_only_bytes,
+            "known_estimated_gb": self.known_estimated_gb,
+            "total_estimated_bytes": self.total_estimated_bytes,
+            "total_estimated_gb": self.total_estimated_gb,
+            "recommendations": list(self.recommendations),
+        }
+
+    def to_json(self, **kwargs: object) -> str:
+        """Serialize the diagnostic report with non-finite floats rejected."""
+        options = {"indent": 2, "sort_keys": True}
+        options.update(kwargs)
+        options["allow_nan"] = False
+        return json.dumps(self.to_dict(), **options)
+
+
+def _parse_aval(aval: str) -> tuple[str | None, tuple[int, ...] | None, int | None, int | None]:
+    match = _AVAL_RE.match(aval)
+    if match is None:
+        return None, None, None, None
+
+    dtype = match.group("dtype")
+    shape_text = match.group("shape")
+    if shape_text is None:
+        shape: tuple[int, ...] = ()
+    elif shape_text.strip() == "":
+        shape = ()
+    else:
+        dims: list[int] = []
+        for item in shape_text.split(","):
+            item = item.strip()
+            if not item.isdigit():
+                return dtype, None, None, None
+            dims.append(int(item))
+        shape = tuple(dims)
+
+    size = math.prod(shape) if shape else 1
+    dtype_bytes = _DTYPE_BYTES.get(dtype)
+    estimated_bytes = None if dtype_bytes is None else int(size * dtype_bytes)
+    return dtype, shape, int(size), estimated_bytes
+
+
+def _source_kind(source: str) -> str:
+    if source.startswith("from the argument"):
+        return "argument"
+    if _NAMED_RE.search(source):
+        return "named"
+    if source.startswith("output of"):
+        return "intermediate"
+    return "unknown"
+
+
+def parse_saved_residual_line(line: str, *, line_index: int | None = None) -> ADResidualRecord:
+    """Parse one line printed by JAX saved-residual inspection.
+
+    Unknown future JAX formats are preserved as raw text with parseable fields
+    set to ``None`` instead of being silently discarded.
+    """
+    stripped = line.strip()
+    if not stripped:
+        return ADResidualRecord(aval="", source="", raw_line=line, line_index=line_index)
+
+    aval, _, source = stripped.partition(" ")
+    dtype, shape, size, estimated_bytes = _parse_aval(aval)
+    name_match = _NAMED_RE.search(source)
+    return ADResidualRecord(
+        aval=aval,
+        source=source,
+        dtype=dtype,
+        shape=shape,
+        size=size,
+        estimated_bytes=estimated_bytes,
+        source_kind=_source_kind(source),
+        name=None if name_match is None else name_match.group(1),
+        raw_line=line,
+        line_index=line_index,
+    )
+
+
+def inspect_ad_saved_residuals(
+    fun: Callable[..., Any],
+    *args: Any,
+    **kwargs: Any,
+) -> ADResidualInspection:
+    """Inspect JAX saved residuals for ``fun(*args, **kwargs)``.
+
+    The implementation captures ``jax.ad_checkpoint.print_saved_residuals`` and
+    parses the printed abstract values into a structured, JSON-serializable
+    artifact. Exceptions from tracing ``fun`` propagate to the caller.
+    """
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        ad_checkpoint.print_saved_residuals(fun, *args, **kwargs)
+
+    raw_lines = tuple(
+        line for line in buffer.getvalue().splitlines() if line.strip()
+    )
+    records = tuple(
+        parse_saved_residual_line(line, line_index=index)
+        for index, line in enumerate(raw_lines)
+    )
+    known_bytes = [
+        record.estimated_bytes
+        for record in records
+        if record.estimated_bytes is not None
+    ]
+    unknown_count = len(records) - len(known_bytes)
+    total_bytes = None if unknown_count else int(sum(known_bytes))
+    return ADResidualInspection(
+        records=records,
+        raw_lines=raw_lines,
+        total_estimated_bytes=total_bytes,
+        total_estimated_gb=None if total_bytes is None else total_bytes / 1e9,
+        unknown_estimate_count=unknown_count,
+    )
+
+
+def _known_estimated_bytes(records: Sequence[ADResidualRecord]) -> int:
+    return int(sum(record.estimated_bytes or 0 for record in records))
+
+
+def _group_key(record: ADResidualRecord) -> tuple[str, str | None, str | None]:
+    return record.source_kind, record.name, record.dtype
+
+
+def _make_group(records: Sequence[ADResidualRecord]) -> ADResidualGroup:
+    first = records[0]
+    source_kind, name, dtype = _group_key(first)
+    known_count = sum(record.estimated_bytes is not None for record in records)
+    unknown_count = len(records) - known_count
+    key_parts = [source_kind]
+    if name is not None:
+        key_parts.append(f"name={name}")
+    if dtype is not None:
+        key_parts.append(f"dtype={dtype}")
+    return ADResidualGroup(
+        key="|".join(key_parts),
+        source_kind=source_kind,
+        name=name,
+        dtype=dtype,
+        record_count=len(records),
+        known_count=known_count,
+        unknown_count=unknown_count,
+        known_estimated_bytes=_known_estimated_bytes(records),
+        line_indices=tuple(
+            record.line_index for record in records if record.line_index is not None
+        ),
+    )
+
+
+def _build_groups(records: Sequence[ADResidualRecord]) -> tuple[ADResidualGroup, ...]:
+    buckets: dict[tuple[str, str | None, str | None], list[ADResidualRecord]] = {}
+    for record in records:
+        buckets.setdefault(_group_key(record), []).append(record)
+    groups = [_make_group(group_records) for group_records in buckets.values()]
+    return tuple(
+        sorted(
+            groups,
+            key=lambda group: (
+                -group.known_estimated_bytes,
+                -group.record_count,
+                group.key,
+            ),
+        )
+    )
+
+
+def _parser_health(inspection: ADResidualInspection) -> ADParserHealth:
+    record_count = len(inspection.records)
+    unknown_count = inspection.unknown_estimate_count
+    known_count = record_count - unknown_count
+    unknown_fraction = 0.0 if record_count == 0 else unknown_count / record_count
+    warnings: list[str] = []
+    if record_count == 0:
+        warnings.append("JAX printed no saved residual lines for this callable and sample args.")
+    if unknown_count:
+        warnings.append(
+            "Some saved residual lines could not be byte-estimated; known byte totals are partial and raw_lines must be inspected."
+        )
+    return ADParserHealth(
+        record_count=record_count,
+        known_count=known_count,
+        unknown_count=unknown_count,
+        unknown_fraction=unknown_fraction,
+        warnings=tuple(warnings),
+    )
+
+
+def _top_residuals(
+    records: Sequence[ADResidualRecord],
+    top_n: int,
+) -> tuple[ADResidualRecord, ...]:
+    if top_n < 0:
+        raise ValueError("top_n must be non-negative")
+    known = [record for record in records if record.estimated_bytes is not None]
+    return tuple(
+        sorted(
+            known,
+            key=lambda record: (
+                -(record.estimated_bytes or 0),
+                record.line_index if record.line_index is not None else 10**9,
+                record.raw_line,
+            ),
+        )[:top_n]
+    )
+
+
+def _recommendations(
+    *,
+    inspection: ADResidualInspection,
+    top_residuals: Sequence[ADResidualRecord],
+    groups: Sequence[ADResidualGroup],
+    parser_health: ADParserHealth,
+    artifact_snapshots: Mapping[str, object],
+) -> tuple[str, ...]:
+    recs: list[str] = [
+        "Treat this report as trace-time JAX saved-residual explainability, not runtime profiling, XLA memory analysis, a peak-memory certificate, or RF validation."
+    ]
+    if parser_health.unknown_count:
+        recs.append(
+            "Inspect raw_lines before comparing byte totals because some residual lines were not parseable by the current rfx parser."
+        )
+    if top_residuals:
+        largest = top_residuals[0]
+        label = largest.name or largest.source_kind or largest.aval
+        recs.append(
+            f"Largest parseable saved residual is {label!r} at line {largest.line_index} with {largest.estimated_bytes} known static bytes; consider checkpoint naming/remat policy around that value."
+        )
+    elif inspection.records:
+        recs.append(
+            "No parseable residual byte estimates were available; use raw_lines and JAX version metadata for manual inspection."
+        )
+    else:
+        recs.append(
+            "No saved residual lines were printed; confirm the inspected callable matches the differentiated objective of interest."
+        )
+    if groups:
+        dominant_group = groups[0]
+        recs.append(
+            f"Dominant parseable residual group is {dominant_group.key!r}; compare this group with static AD memory planning artifacts before changing checkpoint policy."
+        )
+    if artifact_snapshots:
+        recs.append(
+            "Passed memory-planning artifacts are included as snapshots for comparison only; residual bytes do not prove budget fit."
+        )
+    else:
+        recs.append(
+            "For grid-level memory planning, compare this report with sim.explain_ad_memory(...), plan_ad_memory(...), or mesh_intelligence_report(...)."
+        )
+    recs.append(
+        "Run separate gradient checks, convergence tests, or RF reference validation before making physics claims."
+    )
+    return tuple(recs)
+
+
+def diagnose_ad_saved_residuals(
+    fun: Callable[..., Any],
+    *args: Any,
+    top_n: int = 10,
+    workflow: str | None = None,
+    context: Mapping[str, object] | None = None,
+    artifacts: Mapping[str, object] | None = None,
+    **kwargs: Any,
+) -> ADSavedResidualDiagnosticReport:
+    """Return an rfx diagnostic report for JAX saved residuals.
+
+    The report layers rfx-owned summaries and recommendations on top of
+    ``inspect_ad_saved_residuals``. It inspects ``fun(*args, **kwargs)`` and
+    preserves exceptions from tracing the callable. Optional ``context`` and
+    ``artifacts`` are serialized as snapshots only; they are not used to infer
+    runtime memory fit or physics validity.
+    """
+    inspection = inspect_ad_saved_residuals(fun, *args, **kwargs)
+    top = _top_residuals(inspection.records, top_n)
+    groups = _build_groups(inspection.records)
+    health = _parser_health(inspection)
+    snapshots = {
+        str(key): _snapshot_artifact(value)
+        for key, value in (artifacts or {}).items()
+    }
+    known_bytes = _known_estimated_bytes(inspection.records)
+    return ADSavedResidualDiagnosticReport(
+        inspection=inspection,
+        top_residuals=top,
+        groups=groups,
+        parser_health=health,
+        known_estimated_bytes=known_bytes,
+        known_estimated_gb=known_bytes / 1e9,
+        total_estimated_bytes=inspection.total_estimated_bytes,
+        total_estimated_gb=inspection.total_estimated_gb,
+        jax_version=jax.__version__,
+        workflow=workflow,
+        context=None if context is None else _json_safe(context),
+        artifact_snapshots=snapshots,
+        recommendations=_recommendations(
+            inspection=inspection,
+            top_residuals=top,
+            groups=groups,
+            parser_health=health,
+            artifact_snapshots=snapshots,
+        ),
+    )
+
+
+__all__ = [
+    "ADParserHealth",
+    "ADResidualGroup",
+    "ADResidualInspection",
+    "ADResidualRecord",
+    "ADSavedResidualDiagnosticReport",
+    "diagnose_ad_saved_residuals",
+    "inspect_ad_saved_residuals",
+    "parse_saved_residual_line",
+]

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -25,6 +25,7 @@ from numbers import Integral
 import jax.numpy as jnp
 import numpy as np
 
+
 from rfx.grid import Grid, C0  # noqa: F401
 from rfx.core.jax_utils import is_tracer
 from rfx.geometry.csg import Box, Shape  # noqa: F401
@@ -77,6 +78,66 @@ from rfx.api._spec import (  # noqa: E402
     MSLSMatrixResult,
 )
 from rfx.mesh_planner import MeshPlan, plan_simulation_mesh  # noqa: E402,F401
+
+def _require_integral_param(name: str, value: object) -> int:
+    """Return ``value`` as int after rejecting bools and non-integral values."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise TypeError(f"{name} must be an integer, got {value!r}")
+    return int(value)
+
+
+def _require_positive_finite_scalar(name: str, value: object) -> float:
+    """Return ``value`` as a finite positive Python float."""
+    if isinstance(value, (bool, np.bool_)):
+        raise TypeError(f"{name} must be a finite real scalar, got {value!r}")
+    arr = np.asarray(value)
+    if arr.shape != ():
+        raise TypeError(
+            f"{name} must be a finite real scalar, got array shape {arr.shape}"
+        )
+    if not np.issubdtype(arr.dtype, np.number) or np.issubdtype(
+        arr.dtype, np.complexfloating
+    ):
+        raise TypeError(f"{name} must be a finite real scalar, got {value!r}")
+    out = float(arr.item())
+    if not math.isfinite(out):
+        raise ValueError(f"{name} must be finite")
+    if out <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return out
+
+
+def _positive_divisors(value: int) -> list[int]:
+    """Return positive divisors of ``value`` sorted ascending."""
+    small: list[int] = []
+    large: list[int] = []
+    root = math.isqrt(value)
+    for divisor in range(1, root + 1):
+        if value % divisor == 0:
+            small.append(divisor)
+            paired = value // divisor
+            if paired != divisor:
+                large.append(paired)
+    return small + large[::-1]
+
+AD_MEMORY_FIT_SAFETY_FACTOR = 1.30
+
+
+def _format_memory_gb(value: float) -> str:
+    """Render GB values without hiding sub-10MB estimates as ``0.00 GB``."""
+    if value < 0.01:
+        return f"{value * 1000.0:.1f} MB"
+    return f"{value:.2f} GB"
+
+
+def _format_memory_with_safety(value: float, safety_factor: float) -> str:
+    """Render raw and safety-adjusted memory when the safety factor is active."""
+    if safety_factor == 1.0:
+        return _format_memory_gb(value)
+    return (
+        f"{_format_memory_gb(value)} "
+        f"({_format_memory_gb(value * safety_factor)} with {safety_factor:.2f}x safety)"
+    )
 
 # ---------------------------------------------------------------------------
 # Preflight / validation methods — moved to rfx/api/_preflight.py
@@ -1887,20 +1948,78 @@ class Simulation(
         *,
         available_memory_gb: float | None = None,
         checkpoint_every: int | None = None,
+        checkpoint_segments: int | None = None,
+        n_warmup: int = 0,
+        design_mask: jnp.ndarray | np.ndarray | None = None,
     ) -> "AD_MemoryEstimate":
         """Estimate reverse-mode AD memory for this simulation.
 
-        Returns an AD_MemoryEstimate with forward, checkpointed-AD, and
-        non-checkpointed-AD sizes in GB, plus a best-effort warning if
-        estimated AD memory exceeds 85% of available VRAM.
+        Returns a static-estimate AD_MemoryEstimate with forward,
+        checkpointed-AD, and non-checkpointed-AD sizes in GB, plus a
+        best-effort warning if estimated AD memory exceeds 85% of available
+        VRAM. This artifact is planning evidence, not a certificate of peak
+        runtime memory.
 
         When ``checkpoint_every`` is provided, the returned
-        ``ad_segmented_gb`` reflects the segmented scan-of-scan path
-        from issue #31. The legacy ``ad_checkpointed_gb`` field keeps
-        its old (optimistic) heuristic for backwards compatibility; it
+        ``ad_segmented_gb`` reflects the non-uniform segmented scan-of-scan
+        chunk-size path from issue #31. When ``checkpoint_segments`` is
+        provided, it reflects the uniform segmented-scan segment-count path
+        from issue #73. ``n_warmup`` must be an integer with
+        ``0 <= n_warmup < n_steps``. ``design_mask`` must be a boolean array
+        matching the simulation grid shape and selecting at least one cell.
+        ``n_warmup`` reduces reported reverse-mode tape time. ``design_mask``
+        is reported as active-design metadata but does not reduce primary
+        memory estimates until masked-state memory has observed calibration.
+        The legacy
+        ``ad_checkpointed_gb`` field keeps its old (optimistic) heuristic
+        for backwards compatibility; it
         is NOT accurate for FDTD on the non-uniform path — see the
         class docstring.
         """
+        n_steps_i = _require_integral_param("n_steps", n_steps)
+        n_warmup_i = _require_integral_param("n_warmup", n_warmup)
+        checkpoint_every_i = (
+            None
+            if checkpoint_every is None
+            else _require_integral_param("checkpoint_every", checkpoint_every)
+        )
+        checkpoint_segments_i = (
+            None
+            if checkpoint_segments is None
+            else _require_integral_param("checkpoint_segments", checkpoint_segments)
+        )
+        avail_gb = (
+            None
+            if available_memory_gb is None
+            else _require_positive_finite_scalar(
+                "available_memory_gb", available_memory_gb
+            )
+        )
+
+        if n_steps_i <= 0:
+            raise ValueError("n_steps must be positive")
+        if n_warmup_i < 0:
+            raise ValueError("n_warmup must be >= 0")
+        if n_warmup_i >= n_steps_i:
+            raise ValueError(f"n_warmup ({n_warmup_i}) must be < n_steps ({n_steps_i})")
+        if checkpoint_every_i is not None and checkpoint_segments_i is not None:
+            raise ValueError(
+                "checkpoint_every and checkpoint_segments are mutually exclusive"
+            )
+        if checkpoint_every_i is not None and checkpoint_every_i <= 0:
+            raise ValueError(
+                f"checkpoint_every must be positive when provided, got {checkpoint_every_i}"
+            )
+        if checkpoint_segments_i is not None:
+            if checkpoint_segments_i < 1:
+                raise ValueError(
+                    f"checkpoint_segments must be ≥ 1, got {checkpoint_segments_i}"
+                )
+            if n_steps_i % checkpoint_segments_i != 0:
+                raise ValueError(
+                    f"checkpoint_segments={checkpoint_segments_i} does not divide "
+                    f"n_steps={n_steps_i}"
+                )
         dx = self._dx or (C0 / self._freq_max / 20.0)
 
         def _nx(extent: float, prof) -> int:
@@ -1933,22 +2052,54 @@ class Simulation(
         # step_fn. NOT valid for the NU path after issue #31 because the
         # scan carry itself is not rematerialised.
         ad_ckpt_bytes = 4 * forward_bytes + ntff_bytes
-        # Non-checkpointed AD: O(n_steps) tape — 6 field arrays per step
-        ad_full_bytes = n_steps * field_bytes + ntff_bytes + forward_bytes
+        active_steps = n_steps_i - n_warmup_i
+        active_design_fraction = 1.0
+        if design_mask is not None:
+            mask = np.asarray(design_mask)
+            if mask.size == 0:
+                raise ValueError("design_mask must be non-empty")
+            if mask.shape == ():
+                raise ValueError("design_mask must be a boolean array matching grid shape")
+            if mask.dtype != np.bool_:
+                raise TypeError("design_mask must have boolean dtype")
+            grid_shape = (nx, ny, nz)
+            if mask.shape != grid_shape:
+                raise ValueError(
+                    f"design_mask shape {mask.shape} must match simulation grid shape {grid_shape}"
+                )
+            selected_cells = int(np.count_nonzero(mask))
+            if selected_cells == 0:
+                raise ValueError("design_mask must select at least one cell")
+            active_design_fraction = float(selected_cells) / float(mask.size)
+        active_tape_field_bytes = field_bytes
 
-        # Segmented scan-of-scan (issue #31). Outer scan wraps
-        # jax.checkpoint around an inner scan of length K; the tape
-        # stores carry + cotangent at (n_steps/K) segment boundaries.
-        # Formula fit to VESSL 369367233490 data on 608k cells within
-        # ~15% (see issue #39).
+        # Non-checkpointed AD: O(active_steps) full-grid field tape. ``n_warmup``
+        # reduces active reverse-mode time, while ``design_mask`` is retained as
+        # metadata only until masked-state memory has observed calibration.
+        ad_full_bytes = active_steps * active_tape_field_bytes + ntff_bytes + forward_bytes
+
+        # Segmented scan paths. ``checkpoint_every`` is the non-uniform
+        # scan-of-scan chunk length (issue #31); ``checkpoint_segments`` is
+        # the uniform segmented-scan segment count (issue #73). Both store
+        # carry + cotangent at segment boundaries.
         ad_seg_bytes: int | None = None
-        if checkpoint_every is not None and checkpoint_every > 0:
-            n_segments = math.ceil(n_steps / checkpoint_every)
-            # 2x per segment: primal carry + cotangent stored for backward
-            ad_seg_bytes = 2 * n_segments * field_bytes + forward_bytes + ntff_bytes
+        segmented_active_segments: int | None = None
+        if checkpoint_segments_i is not None:
+            segment_len = n_steps_i // checkpoint_segments_i
+            first_active_segment = n_warmup_i // segment_len
+            segmented_active_segments = checkpoint_segments_i - first_active_segment
+            ad_seg_bytes = (
+                2 * segmented_active_segments * active_tape_field_bytes + forward_bytes + ntff_bytes
+            )
+        elif checkpoint_every_i is not None:
+            total_segments = math.ceil(n_steps_i / checkpoint_every_i)
+            inactive_segments = n_warmup_i // checkpoint_every_i
+            segmented_active_segments = total_segments - inactive_segments
+            ad_seg_bytes = (
+                2 * segmented_active_segments * active_tape_field_bytes + forward_bytes + ntff_bytes
+            )
 
         # VRAM detection (best effort)
-        avail_gb = available_memory_gb
         if avail_gb is None:
             try:
                 devs = jax.local_devices()
@@ -1969,14 +2120,21 @@ class Simulation(
         warning = None
         if avail_gb is not None and primary_bytes * to_gb > avail_gb * 0.85:
             label = "segmented" if ad_seg_bytes is not None else "non-checkpointed"
-            action = (
-                "Increase checkpoint_every, reduce grid size, or reduce n_steps."
-                if ad_seg_bytes is not None
-                else "Use plan_ad_memory() to choose checkpoint_every, reduce grid size, or reduce n_steps."
-            )
+            if checkpoint_segments_i is not None:
+                if segmented_active_segments == 1:
+                    action = "Reduce grid size, reduce n_steps, or use a more aggressive memory-reduction lane."
+                else:
+                    action = "Reduce checkpoint_segments, reduce grid size, or reduce n_steps."
+            elif ad_seg_bytes is not None:
+                if segmented_active_segments == 1:
+                    action = "Reduce grid size, reduce n_steps, or use a more aggressive memory-reduction lane."
+                else:
+                    action = "Increase checkpoint_every, reduce grid size, or reduce n_steps."
+            else:
+                action = "Use plan_ad_memory() to choose a segmented checkpoint setting, reduce grid size, or reduce n_steps."
             warning = (
-                f"AD memory estimate {primary_bytes*to_gb:.2f}GB ({label}) "
-                f"exceeds 85% of {avail_gb:.2f}GB available VRAM. "
+                f"AD memory estimate {_format_memory_gb(primary_bytes * to_gb)} ({label}) "
+                f"exceeds 85% of {_format_memory_gb(avail_gb)} available VRAM. "
                 f"{action}"
             )
         return AD_MemoryEstimate(
@@ -1987,7 +2145,11 @@ class Simulation(
             available_gb=avail_gb,
             warning=warning,
             ad_segmented_gb=(ad_seg_bytes * to_gb) if ad_seg_bytes is not None else None,
-            checkpoint_every=checkpoint_every,
+            checkpoint_every=checkpoint_every_i,
+            checkpoint_segments=checkpoint_segments_i,
+            ad_active_steps=active_steps,
+            ad_active_design_fraction=active_design_fraction,
+            ad_segmented_active_segments=segmented_active_segments,
         )
 
     def plan_ad_memory(
@@ -1996,99 +2158,219 @@ class Simulation(
         available_memory_gb: float,
         *,
         target_fraction: float = 0.85,
+        n_warmup: int = 0,
+        design_mask: jnp.ndarray | np.ndarray | None = None,
+        safety_factor: float = AD_MEMORY_FIT_SAFETY_FACTOR,
     ) -> ADMemoryPlan:
-        """Choose a segmented-AD ``checkpoint_every`` for a memory budget.
+        """Choose a segmented-AD memory plan for a memory budget.
 
-        The planner reuses :meth:`estimate_ad_memory` and returns an artifact
-        rather than mutating the simulation.  If ordinary reverse-mode AD already
-        fits under ``target_fraction * available_memory_gb``, the returned
-        ``checkpoint_every`` is ``None``.  Otherwise it returns the smallest
-        chunk length estimated to fit the segmented scan-of-scan memory model.
-        If even ``checkpoint_every=n_steps`` is too large, ``segmented_fits`` is
-        false and the recommendation points back to mesh reduction.
+        The planner reuses :meth:`estimate_ad_memory` and returns a
+        calibrated conservative planning artifact rather than mutating the
+        simulation or certifying runtime peak memory. If ordinary reverse-mode
+        AD already fits under ``target_fraction * available_memory_gb``, both
+        checkpoint knobs are ``None``. Otherwise it returns a segmented
+        candidate: ``checkpoint_every`` for non-uniform grids or
+        ``checkpoint_segments`` for uniform grids. Only wire the candidate when
+        ``segmented_fits`` is true; a non-fitting plan keeps the least-memory
+        candidate as diagnostics.
+        ``n_warmup`` must be an integer with ``0 <= n_warmup < n_steps``.
+        ``design_mask`` must be a boolean array matching the simulation grid
+        shape and selecting at least one cell. ``n_warmup`` reduces active
+        reverse-mode time; ``design_mask`` is metadata only for conservative
+        budgeting. Raw estimates must also fit after multiplying by
+        ``safety_factor`` before fit flags are set, so near-boundary plans stay
+        conservative.
         """
-        if n_steps <= 0:
-            raise ValueError("n_steps must be positive")
-        if available_memory_gb <= 0:
-            raise ValueError("available_memory_gb must be positive")
-        if not (0.0 < target_fraction <= 1.0):
-            raise ValueError("target_fraction must be in the interval (0, 1]")
-
-        target_memory_gb = float(available_memory_gb) * float(target_fraction)
-        full_estimate = self.estimate_ad_memory(
-            n_steps,
-            available_memory_gb=available_memory_gb,
+        n_steps_i = _require_integral_param("n_steps", n_steps)
+        n_warmup_i = _require_integral_param("n_warmup", n_warmup)
+        available_memory_gb_f = _require_positive_finite_scalar(
+            "available_memory_gb", available_memory_gb
         )
-        if full_estimate.ad_full_gb <= target_memory_gb:
+        target_fraction_f = _require_positive_finite_scalar(
+            "target_fraction", target_fraction
+        )
+        safety_factor_f = _require_positive_finite_scalar(
+            "safety_factor", safety_factor
+        )
+
+        if n_steps_i <= 0:
+            raise ValueError("n_steps must be positive")
+        if n_warmup_i < 0:
+            raise ValueError("n_warmup must be >= 0")
+        if n_warmup_i >= n_steps_i:
+            raise ValueError(f"n_warmup ({n_warmup_i}) must be < n_steps ({n_steps_i})")
+        if target_fraction_f > 1.0:
+            raise ValueError("target_fraction must be in the interval (0, 1]")
+        if safety_factor_f < 1.0:
+            raise ValueError("safety_factor must be >= 1")
+
+        target_memory_gb = available_memory_gb_f * target_fraction_f
+        full_estimate = self.estimate_ad_memory(
+            n_steps_i,
+            available_memory_gb=available_memory_gb_f,
+            n_warmup=n_warmup_i,
+            design_mask=design_mask,
+        )
+        if full_estimate.ad_full_gb * safety_factor_f <= target_memory_gb:
             return ADMemoryPlan(
-                n_steps=int(n_steps),
-                available_memory_gb=float(available_memory_gb),
-                target_fraction=float(target_fraction),
+                n_steps=n_steps_i,
+                available_memory_gb=available_memory_gb_f,
+                target_fraction=target_fraction_f,
                 target_memory_gb=target_memory_gb,
                 checkpoint_every=None,
+                checkpoint_segments=None,
+                checkpoint_mode=None,
+                fit_safety_factor=safety_factor_f,
                 selected_estimate=full_estimate,
                 full_ad_fits=True,
-                segmented_fits=True,
+                segmented_fits=False,
                 recommendation=(
-                    f"full reverse-mode AD estimate ({full_estimate.ad_full_gb:.2f} GB) "
-                    f"fits within the {target_memory_gb:.2f} GB target; "
+                    f"full reverse-mode AD estimate ({_format_memory_with_safety(full_estimate.ad_full_gb, safety_factor_f)}) "
+                    f"fits within the {_format_memory_gb(target_memory_gb)} target; "
                     "segmented checkpointing is optional for memory"
+                ),
+            )
+
+        uses_nonuniform = (
+            self._dx_profile is not None
+            or self._dy_profile is not None
+            or self._dz_profile is not None
+        )
+        if not uses_nonuniform:
+            divisors = _positive_divisors(n_steps_i)
+            sqrt_steps = math.sqrt(n_steps_i)
+            recommended_segments = min(
+                divisors,
+                key=lambda divisor: (
+                    abs(float(divisor) - sqrt_steps),
+                    -divisor,
+                ),
+            )
+            best_segments: int | None = None
+            best_estimate: AD_MemoryEstimate | None = None
+            for segments in sorted(
+                (divisor for divisor in divisors if divisor <= recommended_segments),
+                reverse=True,
+            ):
+                estimate = self.estimate_ad_memory(
+                    n_steps_i,
+                    available_memory_gb=available_memory_gb_f,
+                    checkpoint_segments=segments,
+                    n_warmup=n_warmup_i,
+                    design_mask=design_mask,
+                )
+                segmented_gb = estimate.ad_segmented_gb
+                if segmented_gb is not None and segmented_gb * safety_factor_f <= target_memory_gb:
+                    best_segments = segments
+                    best_estimate = estimate
+                    break
+
+            if best_segments is not None and best_estimate is not None:
+                return ADMemoryPlan(
+                    n_steps=n_steps_i,
+                    available_memory_gb=available_memory_gb_f,
+                    target_fraction=target_fraction_f,
+                    target_memory_gb=target_memory_gb,
+                    checkpoint_every=None,
+                    checkpoint_segments=best_segments,
+                    checkpoint_mode="checkpoint_segments",
+                    fit_safety_factor=safety_factor_f,
+                    selected_estimate=best_estimate,
+                    full_ad_fits=False,
+                    segmented_fits=True,
+                    recommendation=(
+                        f"use checkpoint_segments={best_segments}: segmented AD estimate "
+                        f"{_format_memory_with_safety(best_estimate.ad_segmented_gb, safety_factor_f)} fits within the "
+                        f"{_format_memory_gb(target_memory_gb)} target"
+                    ),
+                )
+
+            minimum_segment_estimate = self.estimate_ad_memory(
+                n_steps_i,
+                available_memory_gb=available_memory_gb_f,
+                checkpoint_segments=1,
+                n_warmup=n_warmup_i,
+                design_mask=design_mask,
+            )
+            return ADMemoryPlan(
+                n_steps=n_steps_i,
+                available_memory_gb=available_memory_gb_f,
+                target_fraction=target_fraction_f,
+                target_memory_gb=target_memory_gb,
+                checkpoint_every=None,
+                checkpoint_segments=1,
+                checkpoint_mode="checkpoint_segments",
+                fit_safety_factor=safety_factor_f,
+                selected_estimate=minimum_segment_estimate,
+                full_ad_fits=False,
+                segmented_fits=False,
+                recommendation=(
+                    "even checkpoint_segments=1 is estimated at "
+                    f"{_format_memory_with_safety(minimum_segment_estimate.ad_segmented_gb, safety_factor_f)}, above the "
+                    f"{_format_memory_gb(target_memory_gb)} target; reduce mesh size, reduce "
+                    "n_steps, or use a more aggressive memory-reduction lane"
                 ),
             )
 
         best_checkpoint: int | None = None
         best_estimate: AD_MemoryEstimate | None = None
-        lo, hi = 1, int(n_steps)
-        while lo <= hi:
-            mid = (lo + hi) // 2
+        for checkpoint in range(1, n_steps_i + 1):
             estimate = self.estimate_ad_memory(
-                n_steps,
-                available_memory_gb=available_memory_gb,
-                checkpoint_every=mid,
+                n_steps_i,
+                available_memory_gb=available_memory_gb_f,
+                checkpoint_every=checkpoint,
+                n_warmup=n_warmup_i,
+                design_mask=design_mask,
             )
             segmented_gb = estimate.ad_segmented_gb
-            if segmented_gb is not None and segmented_gb <= target_memory_gb:
-                best_checkpoint = mid
+            if segmented_gb is not None and segmented_gb * safety_factor_f <= target_memory_gb:
+                best_checkpoint = checkpoint
                 best_estimate = estimate
-                hi = mid - 1
-            else:
-                lo = mid + 1
+                break
 
         if best_checkpoint is not None and best_estimate is not None:
             return ADMemoryPlan(
-                n_steps=int(n_steps),
-                available_memory_gb=float(available_memory_gb),
-                target_fraction=float(target_fraction),
+                n_steps=n_steps_i,
+                available_memory_gb=available_memory_gb_f,
+                target_fraction=target_fraction_f,
                 target_memory_gb=target_memory_gb,
                 checkpoint_every=best_checkpoint,
+                checkpoint_segments=None,
+                checkpoint_mode="checkpoint_every",
+                fit_safety_factor=safety_factor_f,
                 selected_estimate=best_estimate,
                 full_ad_fits=False,
                 segmented_fits=True,
                 recommendation=(
                     f"use checkpoint_every={best_checkpoint}: segmented AD estimate "
-                    f"{best_estimate.ad_segmented_gb:.2f} GB fits within the "
-                    f"{target_memory_gb:.2f} GB target"
+                    f"{_format_memory_with_safety(best_estimate.ad_segmented_gb, safety_factor_f)} fits within the "
+                    f"{_format_memory_gb(target_memory_gb)} target"
                 ),
             )
 
         largest_chunk_estimate = self.estimate_ad_memory(
-            n_steps,
-            available_memory_gb=available_memory_gb,
-            checkpoint_every=n_steps,
+            n_steps_i,
+            available_memory_gb=available_memory_gb_f,
+            checkpoint_every=n_steps_i,
+            n_warmup=n_warmup_i,
+            design_mask=design_mask,
         )
         return ADMemoryPlan(
-            n_steps=int(n_steps),
-            available_memory_gb=float(available_memory_gb),
-            target_fraction=float(target_fraction),
+            n_steps=n_steps_i,
+            available_memory_gb=available_memory_gb_f,
+            target_fraction=target_fraction_f,
             target_memory_gb=target_memory_gb,
-            checkpoint_every=n_steps,
+            checkpoint_every=n_steps_i,
+            checkpoint_segments=None,
+            checkpoint_mode="checkpoint_every",
+            fit_safety_factor=safety_factor_f,
             selected_estimate=largest_chunk_estimate,
             full_ad_fits=False,
             segmented_fits=False,
             recommendation=(
-                f"even checkpoint_every={n_steps} is estimated at "
-                f"{largest_chunk_estimate.ad_segmented_gb:.2f} GB, above the "
-                f"{target_memory_gb:.2f} GB target; reduce mesh size, reduce "
+                f"even checkpoint_every={n_steps_i} is estimated at "
+                f"{_format_memory_with_safety(largest_chunk_estimate.ad_segmented_gb, safety_factor_f)}, above the "
+                f"{_format_memory_gb(target_memory_gb)} target; reduce mesh size, reduce "
                 "n_steps, or use a more aggressive memory-reduction lane"
             ),
         )
@@ -2098,7 +2380,10 @@ class Simulation(
         *,
         n_steps: int | None = None,
         checkpoint_every: int | None = None,
+        checkpoint_segments: int | None = None,
         available_memory_gb: float | None = None,
+        n_warmup: int = 0,
+        design_mask: jnp.ndarray | np.ndarray | None = None,
         check_ntff: bool = True,
         check_resolution: bool = True,
     ) -> MeshIntelligenceReport:
@@ -2114,6 +2399,11 @@ class Simulation(
         surface: it helps users decide whether existing non-uniform mesh
         plus segmented checkpointing is enough before attempting
         research-only true subgridding.
+
+        ``checkpoint_every`` and ``checkpoint_segments`` are forwarded to the
+        same AD estimator used by :meth:`plan_ad_memory`; they are mutually
+        exclusive. ``n_warmup`` and ``design_mask`` are forwarded as
+        reverse-mode tape metadata only, matching ``estimate_ad_memory``.
         """
         import contextlib
         import io
@@ -2177,6 +2467,9 @@ class Simulation(
                 n_steps,
                 available_memory_gb=available_memory_gb,
                 checkpoint_every=checkpoint_every,
+                checkpoint_segments=checkpoint_segments,
+                n_warmup=n_warmup,
+                design_mask=design_mask,
             )
 
         uses_nonuniform = any(
@@ -2206,17 +2499,17 @@ class Simulation(
             )
 
         if ad_memory is not None:
-            if checkpoint_every and ad_memory.ad_segmented_gb is not None:
+            if ad_memory.warning:
+                recommendation_parts.append(ad_memory.warning)
+            elif (checkpoint_every or checkpoint_segments) and ad_memory.ad_segmented_gb is not None:
                 recommendation_parts.append(
-                    f"use segmented AD estimate ({ad_memory.ad_segmented_gb:.2f} GB) "
+                    f"use segmented AD estimate ({_format_memory_gb(ad_memory.ad_segmented_gb)}) "
                     "rather than the legacy step-checkpoint heuristic"
                 )
-            elif ad_memory.warning:
-                recommendation_parts.append(ad_memory.warning)
             else:
                 recommendation_parts.append(
-                    f"estimated full reverse-mode AD memory is "
-                    f"{ad_memory.ad_full_gb:.2f} GB"
+                    "estimated full reverse-mode AD memory is "
+                    f"{_format_memory_gb(ad_memory.ad_full_gb)}"
                 )
 
         return MeshIntelligenceReport(

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -58,6 +58,8 @@ from rfx.api._spec import (  # noqa: E402
     MATERIAL_LIBRARY,
     AD_MemoryEstimate,
     ADMemoryPlan,
+    ADMemoryComponent,
+    ADMemoryExplainabilityReport,
     MeshIntelligenceReport,
     Result,
     ForwardResult,
@@ -1941,6 +1943,52 @@ class Simulation(
     # ---- build helpers ----
 
     # ---- AD memory estimation (issue #30 CHECK 4) ----
+    def _ad_memory_static_accounting(self) -> dict[str, int]:
+        """Return shared static byte accounting for AD memory artifacts."""
+        dx = self._dx or (C0 / self._freq_max / 20.0)
+
+        def _nx(extent: float, prof) -> int:
+            if prof is not None:
+                return len(prof) + 1 + 2 * self._cpml_layers
+            return int(math.ceil(extent / dx)) + 1 + 2 * self._cpml_layers
+
+        nx = _nx(self._domain[0], self._dx_profile)
+        ny = _nx(self._domain[1], self._dy_profile)
+        nz = _nx(self._domain[2], self._dz_profile)
+        cells = int(nx * ny * nz)
+
+        # Forward working set: 6 field + ~6 material + ~4 CPML psi (~15%)
+        bytes_per_cell = 4  # float32
+        field_bytes = cells * 6 * bytes_per_cell
+        material_bytes = cells * 6 * bytes_per_cell
+        cpml_bytes = (
+            int(cells * 0.15 * 24 * bytes_per_cell)
+            if self._cpml_layers > 0
+            else 0
+        )
+        forward_bytes = field_bytes + material_bytes + cpml_bytes
+
+        # NTFF DFT state: 6 faces × n_freqs × face cells × (3 E + 3 H) × complex64.
+        ntff_bytes = 0
+        if self._ntff is not None:
+            _, _, freqs = self._ntff
+            n_freqs = int(len(freqs)) if freqs is not None else 10
+            face_est = 2 * ((nx * ny) + (ny * nz) + (nx * nz))
+            ntff_bytes = face_est * n_freqs * 6 * 8
+
+        return {
+            "nx": nx,
+            "ny": ny,
+            "nz": nz,
+            "cells": cells,
+            "bytes_per_cell": bytes_per_cell,
+            "field_bytes": field_bytes,
+            "material_bytes": material_bytes,
+            "cpml_bytes": cpml_bytes,
+            "forward_bytes": forward_bytes,
+            "ntff_bytes": ntff_bytes,
+        }
+
 
     def estimate_ad_memory(
         self,
@@ -2020,33 +2068,13 @@ class Simulation(
                     f"checkpoint_segments={checkpoint_segments_i} does not divide "
                     f"n_steps={n_steps_i}"
                 )
-        dx = self._dx or (C0 / self._freq_max / 20.0)
-
-        def _nx(extent: float, prof) -> int:
-            if prof is not None:
-                return len(prof) + 1 + 2 * self._cpml_layers
-            return int(math.ceil(extent / dx)) + 1 + 2 * self._cpml_layers
-
-        nx = _nx(self._domain[0], self._dx_profile)
-        ny = _nx(self._domain[1], self._dy_profile)
-        nz = _nx(self._domain[2], self._dz_profile)
-        cells = nx * ny * nz
-
-        # Forward working set: 6 field + ~6 material + ~4 CPML psi (~15%)
-        bytes_per_cell = 4  # float32
-        field_bytes = cells * 6 * bytes_per_cell
-        mat_bytes = cells * 6 * bytes_per_cell
-        cpml_bytes = int(cells * 0.15 * 24 * bytes_per_cell) if self._cpml_layers > 0 else 0
-        forward_bytes = field_bytes + mat_bytes + cpml_bytes
-
-        # NTFF DFT state: 6 faces × n_freqs × face_cells × 4 (3 E + 3 H) × complex64 (8B)
-        ntff_bytes = 0
-        if self._ntff is not None:
-            _, _, freqs = self._ntff
-            n_freqs = int(len(freqs)) if freqs is not None else 10
-            # Approx face cells from domain extents / dx
-            face_est = 2 * ((nx * ny) + (ny * nz) + (nx * nz))
-            ntff_bytes = face_est * n_freqs * 6 * 8
+        accounting = self._ad_memory_static_accounting()
+        nx = accounting["nx"]
+        ny = accounting["ny"]
+        nz = accounting["nz"]
+        field_bytes = accounting["field_bytes"]
+        forward_bytes = accounting["forward_bytes"]
+        ntff_bytes = accounting["ntff_bytes"]
 
         # Legacy "checkpointed" estimate: remat-recomputes internals of
         # step_fn. NOT valid for the NU path after issue #31 because the
@@ -2150,6 +2178,194 @@ class Simulation(
             ad_active_steps=active_steps,
             ad_active_design_fraction=active_design_fraction,
             ad_segmented_active_segments=segmented_active_segments,
+        )
+
+    def explain_ad_memory(
+        self,
+        n_steps: int,
+        *,
+        available_memory_gb: float | None = None,
+        checkpoint_every: int | None = None,
+        checkpoint_segments: int | None = None,
+        n_warmup: int = 0,
+        design_mask: jnp.ndarray | np.ndarray | None = None,
+    ) -> ADMemoryExplainabilityReport:
+        """Explain the static reverse-mode AD memory estimate.
+
+        This method uses the same conservative accounting as
+        :meth:`estimate_ad_memory`, then decomposes the selected AD memory
+        number into named contributors. It is meant to answer "what is making
+        this AD run large?" without claiming profiler evidence or a runtime
+        peak bound.
+        """
+        n_steps_i = _require_integral_param("n_steps", n_steps)
+        estimate = self.estimate_ad_memory(
+            n_steps_i,
+            available_memory_gb=available_memory_gb,
+            checkpoint_every=checkpoint_every,
+            checkpoint_segments=checkpoint_segments,
+            n_warmup=n_warmup,
+            design_mask=design_mask,
+        )
+
+        accounting = self._ad_memory_static_accounting()
+        field_bytes = accounting["field_bytes"]
+        material_bytes = accounting["material_bytes"]
+        cpml_bytes = accounting["cpml_bytes"]
+        ntff_bytes = accounting["ntff_bytes"]
+        cells = accounting["cells"]
+        bytes_per_cell = accounting["bytes_per_cell"]
+
+        active_steps = estimate.ad_active_steps if estimate.ad_active_steps is not None else n_steps_i
+        if estimate.ad_segmented_gb is not None:
+            selected_field = "ad_segmented_gb"
+            selected_gb = float(estimate.ad_segmented_gb)
+            strategy = (
+                "segmented_checkpoint_segments"
+                if estimate.checkpoint_segments is not None
+                else "segmented_checkpoint_every"
+            )
+            active_segments = (
+                estimate.ad_segmented_active_segments
+                if estimate.ad_segmented_active_segments is not None
+                else 0
+            )
+            tape_count = int(2 * active_segments)
+            tape_bytes = tape_count * field_bytes
+            tape_name = "segmented_boundary_field_tape"
+            tape_explanation = (
+                "Segmented reverse-mode AD stores field carry and cotangent "
+                "state at active segment boundaries instead of every active "
+                "time step."
+            )
+            tape_unit = "carry-or-cotangent-field-state"
+        else:
+            selected_field = "ad_full_gb"
+            selected_gb = float(estimate.ad_full_gb)
+            strategy = "full_reverse_ad_static_tape"
+            tape_count = int(active_steps)
+            tape_bytes = tape_count * field_bytes
+            tape_name = "full_reverse_field_tape"
+            tape_explanation = (
+                "Full reverse-mode AD stores a field tape entry for each "
+                "active post-warmup time step."
+            )
+            tape_unit = "active-time-step-field-state"
+
+        def _share(memory_bytes: int) -> float:
+            if selected_gb <= 0.0:
+                return 0.0
+            return float(memory_bytes / 1e9 / selected_gb)
+
+        def _component(
+            name: str,
+            memory_bytes: int,
+            kind: str,
+            *,
+            unit: str | None,
+            count: int | None,
+            bytes_per_unit: int | None,
+            explanation: str,
+        ) -> ADMemoryComponent:
+            return ADMemoryComponent(
+                name=name,
+                kind=kind,
+                memory_gb=memory_bytes / 1e9,
+                share_of_selected=_share(memory_bytes),
+                unit=unit,
+                count=count,
+                bytes_per_unit_gb=(
+                    None if bytes_per_unit is None else bytes_per_unit / 1e9
+                ),
+                explanation=explanation,
+            )
+
+        components = (
+            _component(
+                "field_state",
+                field_bytes,
+                "forward_working_set",
+                unit="field-array",
+                count=6,
+                bytes_per_unit=cells * bytes_per_cell,
+                explanation="Six E/H field arrays carried by the forward solve.",
+            ),
+            _component(
+                "material_auxiliary_state",
+                material_bytes,
+                "forward_working_set",
+                unit="material-array",
+                count=6,
+                bytes_per_unit=cells * bytes_per_cell,
+                explanation=(
+                    "Static material/ADE auxiliary allocation used by the "
+                    "planner's forward working-set model."
+                ),
+            ),
+            _component(
+                "cpml_auxiliary_state",
+                cpml_bytes,
+                "forward_working_set",
+                unit="cpml-overhead",
+                count=None,
+                bytes_per_unit=None,
+                explanation=(
+                    "CPML auxiliary state estimate; zero when the simulation "
+                    "does not use CPML layers."
+                ),
+            ),
+            _component(
+                tape_name,
+                tape_bytes,
+                "reverse_ad_saved_state",
+                unit=tape_unit,
+                count=tape_count,
+                bytes_per_unit=field_bytes,
+                explanation=tape_explanation,
+            ),
+            _component(
+                "ntff_dft_state",
+                ntff_bytes,
+                "monitor_state",
+                unit="ntff-dft-state",
+                count=None,
+                bytes_per_unit=None,
+                explanation=(
+                    "Near-to-far-field DFT monitor state retained in forward "
+                    "and AD planning estimates."
+                ),
+            ),
+        )
+
+        dominant = max(components, key=lambda component: component.memory_gb)
+        recommendations: list[str] = [
+            f"Dominant AD memory contributor is {dominant.name}.",
+            "Treat ad_checkpointed_gb as a legacy heuristic; use the selected memory field in this report for planning.",
+        ]
+        if estimate.ad_segmented_gb is None:
+            recommendations.append(
+                "Use plan_ad_memory() to choose a supported segmented checkpoint knob when full reverse-mode AD is too large."
+            )
+        else:
+            recommendations.append(
+                f"Selected strategy stores {tape_count} {tape_unit} unit(s) instead of {active_steps} active time-step tape entries."
+            )
+        if estimate.ad_active_design_fraction is not None and estimate.ad_active_design_fraction < 1.0:
+            recommendations.append(
+                "design_mask is recorded as active-design metadata only; it does not reduce the selected memory estimate."
+            )
+        if estimate.warning:
+            recommendations.append(estimate.warning)
+
+        return ADMemoryExplainabilityReport(
+            n_steps=n_steps_i,
+            strategy=strategy,
+            selected_memory_gb=selected_gb,
+            selected_memory_field=selected_field,
+            estimate=estimate,
+            components=components,
+            dominant_component=dominant.name,
+            recommendations=tuple(recommendations),
         )
 
     def plan_ad_memory(
@@ -2644,6 +2860,8 @@ __all__ = [
     "MATERIAL_LIBRARY",
     "AD_MemoryEstimate",
     "ADMemoryPlan",
+    "ADMemoryComponent",
+    "ADMemoryExplainabilityReport",
     "MeshIntelligenceReport",
     "Result",
     "ForwardResult",

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -19,8 +19,11 @@ Usage
 from __future__ import annotations
 
 import math
+import json
 import jax
+from collections.abc import Callable, Mapping, Sequence
 from numbers import Integral
+from typing import Any
 
 import jax.numpy as jnp
 import numpy as np
@@ -59,7 +62,10 @@ from rfx.api._spec import (  # noqa: E402
     AD_MemoryEstimate,
     ADMemoryPlan,
     ADMemoryComponent,
+    ADMemoryActionHint,
     ADMemoryExplainabilityReport,
+    ADMemoryPreflightReport,
+    ADCompiledMemoryCertificate,
     MeshIntelligenceReport,
     Result,
     ForwardResult,
@@ -140,6 +146,92 @@ def _format_memory_with_safety(value: float, safety_factor: float) -> str:
         f"{_format_memory_gb(value)} "
         f"({_format_memory_gb(value * safety_factor)} with {safety_factor:.2f}x safety)"
     )
+
+
+AD_MEMORY_PREFLIGHT_EVIDENCE_BOUNDARIES = (
+    "static memory planning only",
+    "trace-time JAX saved-residual explainability only when residual_diagnostic is present",
+    "not a runtime peak-memory guarantee",
+    "not XLA memory analysis",
+    "not profiler evidence",
+    "not a certificate",
+    "not RF validation",
+)
+
+AD_COMPILED_MEMORY_CERTIFICATE_EVIDENCE_BOUNDARIES = (
+    "bounded to one caller-supplied compiled executable",
+    "uses JAX Compiled.memory_analysis() estimates",
+    "not a universal guaranteed peak-memory predictor",
+    "not profiler evidence",
+    "not RF validation",
+    "digests are audit identities, not executable correspondence proof",
+)
+
+
+def _preflight_json_safe(value: object, *, path: str = "residual_context") -> object:
+    """Return ``value`` as JSON-native data or raise a residual-context error."""
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{path} contains non-finite JSON value")
+        return value
+    if hasattr(value, "to_dict") and callable(value.to_dict):
+        return _preflight_json_safe(value.to_dict(), path=path)
+    if hasattr(value, "to_json") and callable(value.to_json):
+        try:
+            parsed = json.loads(value.to_json())
+        except Exception as exc:
+            raise TypeError(f"{path} to_json() did not return JSON data") from exc
+        return _preflight_json_safe(parsed, path=path)
+    if hasattr(value, "tolist") and callable(value.tolist):
+        return _preflight_json_safe(value.tolist(), path=path)
+    if isinstance(value, Mapping):
+        return {
+            str(key): _preflight_json_safe(item, path=f"{path}.{key}")
+            for key, item in value.items()
+        }
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [
+            _preflight_json_safe(item, path=f"{path}[{index}]")
+            for index, item in enumerate(value)
+        ]
+    raise TypeError(f"{path} contains unsupported value {type(value).__name__}")
+
+
+def _validate_residual_context(
+    context: Mapping[str, object] | None,
+    *,
+    owned_fields: Mapping[str, object],
+) -> dict[str, object]:
+    """Merge and validate caller residual context before returning a report."""
+    caller_context = (
+        {}
+        if context is None
+        else _preflight_json_safe(context, path="residual_context")
+    )
+    if not isinstance(caller_context, dict):
+        raise TypeError("residual_context must be a mapping")
+    merged = dict(caller_context)
+    merged.update(
+        {
+            key: _preflight_json_safe(value, path=f"residual_context.{key}")
+            for key, value in owned_fields.items()
+        }
+    )
+    try:
+        json.dumps(merged, allow_nan=False)
+    except ValueError as exc:
+        raise ValueError("residual_context contains non-finite JSON value") from exc
+    except TypeError as exc:
+        raise TypeError("residual_context contains unsupported JSON value") from exc
+    return merged
+
+from rfx.api._compiled_memory import (  # noqa: E402
+    _canonicalize_exact_scope,
+    _environment_summary,
+    _normalize_compiled_memory_analysis,
+)
 
 # ---------------------------------------------------------------------------
 # Preflight / validation methods — moved to rfx/api/_preflight.py
@@ -2591,6 +2683,404 @@ class Simulation(
             ),
         )
 
+    def ad_memory_preflight(
+        self,
+        n_steps: int,
+        available_memory_gb: float,
+        *,
+        target_fraction: float = 0.85,
+        n_warmup: int = 0,
+        design_mask: jnp.ndarray | np.ndarray | None = None,
+        safety_factor: float = AD_MEMORY_FIT_SAFETY_FACTOR,
+        include_mesh_report: bool = True,
+        check_ntff: bool = True,
+        check_resolution: bool = True,
+        residual_fun: Callable[..., Any] | None = None,
+        residual_args: tuple[Any, ...] = (),
+        residual_kwargs: Mapping[str, Any] | None = None,
+        residual_top_n: int = 10,
+        residual_workflow: str | None = None,
+        residual_context: Mapping[str, object] | None = None,
+    ) -> ADMemoryPreflightReport:
+        """Return a one-call AD-memory preflight planning artifact.
+
+        The report composes existing static memory planning, static
+        explainability, optional mesh advisories, and optional trace-time JAX
+        saved-residual diagnostics. It does not run FDTD and does not upgrade
+        static planning evidence into runtime memory proof.
+        """
+        plan = self.plan_ad_memory(
+            n_steps,
+            available_memory_gb,
+            target_fraction=target_fraction,
+            n_warmup=n_warmup,
+            design_mask=design_mask,
+            safety_factor=safety_factor,
+        )
+
+        if plan.full_ad_fits:
+            status = "full_ad_fits"
+            selected_checkpoint_every = None
+            selected_checkpoint_segments = None
+            supported_checkpoint_mode = None
+        else:
+            selected_checkpoint_every = plan.checkpoint_every
+            selected_checkpoint_segments = plan.checkpoint_segments
+            supported_checkpoint_mode = plan.checkpoint_mode
+            status = "checkpointing_fits" if plan.segmented_fits else "does_not_fit"
+
+        explanation = self.explain_ad_memory(
+            n_steps,
+            available_memory_gb=available_memory_gb,
+            checkpoint_every=selected_checkpoint_every,
+            checkpoint_segments=selected_checkpoint_segments,
+            n_warmup=n_warmup,
+            design_mask=design_mask,
+        )
+
+        mesh_report = (
+            self.mesh_intelligence_report(
+                n_steps=n_steps,
+                checkpoint_every=selected_checkpoint_every,
+                checkpoint_segments=selected_checkpoint_segments,
+                available_memory_gb=available_memory_gb,
+                n_warmup=n_warmup,
+                design_mask=design_mask,
+                check_ntff=check_ntff,
+                check_resolution=check_resolution,
+            )
+            if include_mesh_report
+            else None
+        )
+
+        action_hints: list[ADMemoryActionHint] = []
+        if plan.full_ad_fits:
+            recommendation = "Full reverse-mode AD fits the conservative memory target; checkpointing is optional for memory."
+            action_hints.append(
+                ADMemoryActionHint(
+                    code="full_ad_fits",
+                    severity="info",
+                    message="Full reverse-mode AD fits the configured conservative memory target.",
+                    action="Run full reverse-mode AD or still choose checkpointing for extra margin.",
+                )
+            )
+        elif plan.segmented_fits:
+            if plan.checkpoint_mode == "checkpoint_every":
+                code = "use_checkpoint_every"
+                action = (
+                    f"Wire checkpoint_every={plan.checkpoint_every} into the supported non-uniform runner."
+                )
+            else:
+                code = "use_checkpoint_segments"
+                action = (
+                    f"Wire checkpoint_segments={plan.checkpoint_segments} into the supported uniform runner."
+                )
+            recommendation = plan.recommendation
+            action_hints.append(
+                ADMemoryActionHint(
+                    code=code,
+                    severity="warning",
+                    message="Supported segmented checkpointing fits the configured conservative memory target.",
+                    action=action,
+                    checkpoint_mode=plan.checkpoint_mode,
+                    checkpoint_every=plan.checkpoint_every,
+                    checkpoint_segments=plan.checkpoint_segments,
+                )
+            )
+        else:
+            recommendation = (
+                f"{plan.recommendation}; do not launch the returned checkpoint "
+                "candidate as a fit. It is diagnostic-only."
+            )
+            action_hints.append(
+                ADMemoryActionHint(
+                    code="memory_budget_unfit",
+                    severity="blocker",
+                    message="Neither full reverse-mode AD nor the least-memory supported checkpoint candidate fits the configured conservative memory target.",
+                    action=(
+                        "Do not launch the returned checkpoint candidate as a fit; "
+                        "reduce mesh size, reduce n_steps, increase memory, or choose a stronger memory-reduction lane."
+                    ),
+                    checkpoint_mode=plan.checkpoint_mode,
+                    checkpoint_every=plan.checkpoint_every,
+                    checkpoint_segments=plan.checkpoint_segments,
+                    blocking=True,
+                )
+            )
+
+        owned_residual_context = {
+            "n_steps": int(plan.n_steps),
+            "available_memory_gb": float(plan.available_memory_gb),
+            "target_fraction": float(plan.target_fraction),
+            "target_memory_gb": float(plan.target_memory_gb),
+            "fit_safety_factor": float(plan.fit_safety_factor),
+            "checkpoint_mode": supported_checkpoint_mode,
+            "checkpoint_every": selected_checkpoint_every,
+            "checkpoint_segments": selected_checkpoint_segments,
+            "preflight_status": status,
+        }
+        merged_residual_context = (
+            _validate_residual_context(
+                residual_context,
+                owned_fields=owned_residual_context,
+            )
+            if residual_fun is not None or residual_context is not None
+            else None
+        )
+        residual_diagnostic = None
+        if residual_fun is not None:
+            from rfx.ad_diagnostics import diagnose_ad_saved_residuals
+            artifact_snapshots: dict[str, object] = {
+                "memory_plan": plan,
+                "explainability": explanation,
+            }
+            if mesh_report is not None:
+                artifact_snapshots["mesh_report"] = mesh_report
+            residual_diagnostic = diagnose_ad_saved_residuals(
+                residual_fun,
+                *residual_args,
+                top_n=residual_top_n,
+                workflow=residual_workflow,
+                context=merged_residual_context,
+                artifacts=artifact_snapshots,
+                **(dict(residual_kwargs) if residual_kwargs is not None else {}),
+            )
+            action_hints.append(
+                ADMemoryActionHint(
+                    code="inspect_saved_residuals",
+                    severity="info",
+                    message="JAX saved-residual trace context is attached for comparison with static memory artifacts.",
+                    action="Compare top residuals and groups with the static explanation before changing checkpoint policy.",
+                )
+            )
+
+        action_hints.append(
+            ADMemoryActionHint(
+                code="validate_physics_separately",
+                severity="info",
+                message="Memory preflight is separate from electromagnetic correctness checks.",
+                action="Run convergence, reference, or observable checks before making physics claims.",
+            )
+        )
+
+        return ADMemoryPreflightReport(
+            n_steps=plan.n_steps,
+            available_memory_gb=plan.available_memory_gb,
+            target_fraction=plan.target_fraction,
+            target_memory_gb=plan.target_memory_gb,
+            fit_safety_factor=plan.fit_safety_factor,
+            status=status,
+            supported_checkpoint_mode=supported_checkpoint_mode,
+            checkpoint_every=selected_checkpoint_every,
+            checkpoint_segments=selected_checkpoint_segments,
+            full_ad_fits=plan.full_ad_fits,
+            checkpointing_fits=plan.segmented_fits,
+            memory_plan=plan,
+            explainability=explanation,
+            mesh_report=mesh_report,
+            residual_diagnostic=residual_diagnostic,
+            action_hints=tuple(action_hints),
+            evidence_boundaries=AD_MEMORY_PREFLIGHT_EVIDENCE_BOUNDARIES,
+            recommendation=recommendation,
+        )
+
+    def ad_memory_compiled_certificate(
+        self,
+        compiled: object,
+        *,
+        n_steps: int,
+        available_memory_gb: float,
+        target_fraction: float = 0.85,
+        checkpoint_every: int | None = None,
+        checkpoint_segments: int | None = None,
+        n_warmup: int = 0,
+        design_mask: jnp.ndarray | np.ndarray | None = None,
+        precision: str | None = None,
+        input_signature: object | None = None,
+        static_signature: object | None = None,
+        compiled_object_id: str | None = None,
+        runner_or_objective: str | None = None,
+        preflight: ADMemoryPreflightReport | None = None,
+        scope_context: Mapping[str, object] | None = None,
+    ) -> ADCompiledMemoryCertificate:
+        """Return a fail-closed compiler-memory certificate for one executable.
+
+        This method accepts an already-compiled JAX object and reads only its
+        ``memory_analysis()`` output. It does not compile callables, run FDTD,
+        profile runtime memory, or convert static memory plans into guarantees.
+        Green statuses are bounded to the supplied compiled object and complete
+        exact-scope metadata.
+        """
+        n_steps_i = _require_integral_param("n_steps", n_steps)
+        n_warmup_i = _require_integral_param("n_warmup", n_warmup)
+        checkpoint_every_i = (
+            None
+            if checkpoint_every is None
+            else _require_integral_param("checkpoint_every", checkpoint_every)
+        )
+        checkpoint_segments_i = (
+            None
+            if checkpoint_segments is None
+            else _require_integral_param("checkpoint_segments", checkpoint_segments)
+        )
+        available_memory_gb_f = _require_positive_finite_scalar(
+            "available_memory_gb",
+            available_memory_gb,
+        )
+        target_fraction_f = _require_positive_finite_scalar(
+            "target_fraction",
+            target_fraction,
+        )
+        if target_fraction_f > 1.0:
+            raise ValueError("target_fraction must be in the interval (0, 1]")
+
+        # Reuse the existing AD-memory validation contract for counts,
+        # checkpoint knob exclusivity/divisibility, and design-mask shape/dtype.
+        self.estimate_ad_memory(
+            n_steps_i,
+            available_memory_gb=available_memory_gb_f,
+            checkpoint_every=checkpoint_every_i,
+            checkpoint_segments=checkpoint_segments_i,
+            n_warmup=n_warmup_i,
+            design_mask=design_mask,
+        )
+
+        target_memory_gb = available_memory_gb_f * target_fraction_f
+        analysis = _normalize_compiled_memory_analysis(compiled)
+        memory_analysis_fields = (
+            tuple(analysis.fields)
+            if analysis.status == "complete"
+            else None
+        )
+        scope = _canonicalize_exact_scope(
+            compiled=compiled,
+            n_steps=n_steps_i,
+            n_warmup=n_warmup_i,
+            checkpoint_every=checkpoint_every_i,
+            checkpoint_segments=checkpoint_segments_i,
+            available_memory_gb=available_memory_gb_f,
+            target_fraction=target_fraction_f,
+            target_memory_gb=target_memory_gb,
+            precision=precision,
+            input_signature=input_signature,
+            static_signature=static_signature,
+            compiled_object_id=compiled_object_id,
+            runner_or_objective=runner_or_objective,
+            memory_analysis_fields=memory_analysis_fields,
+            preflight=preflight,
+            scope_context=scope_context,
+        )
+
+        if scope.status != "complete":
+            status = scope.status
+            status_reason = scope.reason
+        elif analysis.status != "complete":
+            status = analysis.status
+            status_reason = analysis.reason
+        else:
+            required_bytes = int(analysis.required_bytes)
+            target_bytes = target_memory_gb * 1e9
+            if required_bytes <= target_bytes:
+                status = "certified_budget_fit"
+                status_reason = (
+                    "compiled memory_analysis() required bytes fit within "
+                    "available_memory_gb * target_fraction"
+                )
+            else:
+                status = "certified_budget_exceeded"
+                status_reason = (
+                    "compiled memory_analysis() required bytes exceed "
+                    "available_memory_gb * target_fraction"
+                )
+
+        def _bytes(field: str) -> int | None:
+            return analysis.fields.get(field) if analysis.status == "complete" else None
+
+        def _gb(value: int | None) -> float | None:
+            return None if value is None else value / 1e9
+
+        temp_bytes = _bytes("temp_size_in_bytes")
+        argument_bytes = _bytes("argument_size_in_bytes")
+        output_bytes = _bytes("output_size_in_bytes")
+        alias_bytes = _bytes("alias_size_in_bytes")
+        required_bytes_out = (
+            int(analysis.required_bytes)
+            if analysis.status == "complete"
+            else None
+        )
+        env = _environment_summary()
+        exact_scope = scope.exact_scope
+        jax_version = (
+            str(exact_scope.get("jax_version"))
+            if exact_scope is not None and "jax_version" in exact_scope
+            else str(env["jax_version"])
+        )
+        recommendations = [
+            "Treat this as a bounded certificate for the exact compiled object and declared scope only.",
+            "Digests are audit identities only; they do not prove source-to-executable correspondence.",
+        ]
+        if status == "certified_budget_fit":
+            recommendations.insert(
+                0,
+                "Compiler memory analysis fits the target budget for this exact scope.",
+            )
+        elif status == "certified_budget_exceeded":
+            recommendations.insert(
+                0,
+                "Compiler memory analysis exceeds the target budget; reduce scope, checkpoint more aggressively, or increase memory.",
+            )
+        elif status == "scope_incomplete":
+            recommendations.insert(
+                0,
+                "Provide complete JSON-safe exact-scope metadata before relying on compiler memory evidence.",
+            )
+        elif status == "scope_mismatch":
+            recommendations.insert(
+                0,
+                "Resolve contradictions between declared scope, preflight metadata, and compiled-object introspection.",
+            )
+        elif status == "analysis_unavailable":
+            recommendations.insert(
+                0,
+                "JAX did not provide memory_analysis() evidence for this compiled object/backend.",
+            )
+        else:
+            recommendations.insert(
+                0,
+                "JAX memory_analysis() output is incomplete or invalid for certificate use.",
+            )
+
+        return ADCompiledMemoryCertificate(
+            status=status,
+            available_memory_gb=available_memory_gb_f,
+            target_fraction=target_fraction_f,
+            target_memory_gb=target_memory_gb,
+            compiler_reported_required_bytes=required_bytes_out,
+            compiler_reported_required_gb=_gb(required_bytes_out),
+            temp_size_in_bytes=temp_bytes,
+            argument_size_in_bytes=argument_bytes,
+            output_size_in_bytes=output_bytes,
+            alias_size_in_bytes=alias_bytes,
+            temp_gb=_gb(temp_bytes),
+            argument_gb=_gb(argument_bytes),
+            output_gb=_gb(output_bytes),
+            alias_gb=_gb(alias_bytes),
+            exact_scope=exact_scope,
+            scope_status=scope.status,
+            scope_status_reason=scope.reason,
+            scope_digest=scope.scope_digest,
+            config_digest=scope.config_digest,
+            environment_digest=scope.environment_digest,
+            memory_analysis_status=analysis.status,
+            memory_analysis_status_reason=(
+                status_reason if analysis.status == status else analysis.reason
+            ),
+            jax_version=jax_version,
+            evidence_boundaries=AD_COMPILED_MEMORY_CERTIFICATE_EVIDENCE_BOUNDARIES,
+            recommendations=tuple(recommendations),
+            source_preflight=scope.source_preflight,
+        )
+
     def mesh_intelligence_report(
         self,
         *,
@@ -2861,7 +3351,10 @@ __all__ = [
     "AD_MemoryEstimate",
     "ADMemoryPlan",
     "ADMemoryComponent",
+    "ADMemoryActionHint",
     "ADMemoryExplainabilityReport",
+    "ADMemoryPreflightReport",
+    "ADCompiledMemoryCertificate",
     "MeshIntelligenceReport",
     "Result",
     "ForwardResult",

--- a/rfx/api/_compiled_memory.py
+++ b/rfx/api/_compiled_memory.py
@@ -1,0 +1,676 @@
+"""Private helpers for scoped JAX compiled-memory certificates.
+
+This module intentionally handles only one evidence class: a bounded certificate
+for one caller-supplied compiled JAX executable via ``Compiled.memory_analysis``.
+It does not compile callables, run FDTD, profile runtime peaks, or prove source to
+executable correspondence from digests.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from numbers import Integral
+from typing import Mapping, NamedTuple
+
+import jax
+import numpy as np
+
+
+_REQUIRED_MEMORY_FIELDS = (
+    "temp_size_in_bytes",
+    "argument_size_in_bytes",
+    "output_size_in_bytes",
+    "alias_size_in_bytes",
+)
+
+
+class CompiledMemoryAnalysis(NamedTuple):
+    status: str
+    reason: str
+    required_bytes: int | None
+    fields: dict[str, int]
+    analysis_type: str | None
+    present_known_attrs: tuple[str, ...]
+
+
+class CanonicalScope(NamedTuple):
+    status: str
+    reason: str
+    exact_scope: dict[str, object] | None
+    source_preflight: object | None
+    scope_digest: str | None
+    config_digest: str | None
+    environment_digest: str | None
+
+
+_MISSING_ATTR = object()
+
+
+def _read_attr(value: object, name: str, *, path: str) -> object:
+    try:
+        return getattr(value, name)
+    except AttributeError:
+        return _MISSING_ATTR
+    except Exception as exc:
+        raise TypeError(
+            f"{path}.{name} attribute read raised {type(exc).__name__}: {exc}"
+        ) from exc
+
+
+def _json_safe(value: object, *, path: str = "value") -> object:
+    """Return JSON-native data or raise for unsupported/non-finite values."""
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{path} contains non-finite JSON value")
+        return value
+    if isinstance(value, np.generic):
+        return _json_safe(value.item(), path=path)
+    if isinstance(value, np.dtype):
+        return str(value)
+    shape = _read_attr(value, "shape", path=path)
+    dtype = _read_attr(value, "dtype", path=path)
+    if shape is not _MISSING_ATTR and dtype is not _MISSING_ATTR:
+        weak_type = _read_attr(value, "weak_type", path=path)
+        try:
+            shape_summary = [int(dim) for dim in tuple(shape)]
+        except Exception as exc:
+            raise TypeError(
+                f"{path}.shape could not be summarized as integer dimensions"
+            ) from exc
+        summary: dict[str, object] = {
+            "shape": shape_summary,
+            "dtype": str(dtype),
+        }
+        if weak_type is not _MISSING_ATTR:
+            summary["weak_type"] = bool(weak_type)
+        return summary
+    to_dict = _read_attr(value, "to_dict", path=path)
+    if to_dict is not _MISSING_ATTR and callable(to_dict):
+        try:
+            return _json_safe(to_dict(), path=path)
+        except (TypeError, ValueError):
+            raise
+        except Exception as exc:
+            raise TypeError(f"{path}.to_dict() raised {type(exc).__name__}: {exc}") from exc
+    to_json = _read_attr(value, "to_json", path=path)
+    if to_json is not _MISSING_ATTR and callable(to_json):
+        try:
+            parsed = json.loads(to_json())
+        except Exception as exc:
+            raise TypeError(f"{path}.to_json() did not return JSON data") from exc
+        return _json_safe(parsed, path=path)
+    tolist = _read_attr(value, "tolist", path=path)
+    if tolist is not _MISSING_ATTR and callable(tolist):
+        try:
+            return _json_safe(tolist(), path=path)
+        except (TypeError, ValueError):
+            raise
+        except Exception as exc:
+            raise TypeError(f"{path}.tolist() raised {type(exc).__name__}: {exc}") from exc
+    if isinstance(value, Mapping):
+        out: dict[str, object] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(f"{path} contains non-string mapping key {key!r}")
+            out[key] = _json_safe(item, path=f"{path}.{key}")
+        return out
+    if isinstance(value, tuple):
+        return [_json_safe(item, path=f"{path}[{idx}]") for idx, item in enumerate(value)]
+    if isinstance(value, list):
+        return [_json_safe(item, path=f"{path}[{idx}]") for idx, item in enumerate(value)]
+    raise TypeError(f"{path} contains unsupported value {type(value).__name__}")
+
+
+def _canonical_json(value: object) -> str:
+    safe = _json_safe(value)
+    return json.dumps(safe, allow_nan=False, separators=(",", ":"), sort_keys=True)
+
+
+def _stable_digest(value: object) -> str:
+    """Return SHA-256 over canonical JSON. This is an audit identity only."""
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _required_metadata_text(name: str, raw: object) -> tuple[str | None, str | None]:
+    if raw is None:
+        return None, f"{name} is missing"
+    text = str(raw).strip()
+    if not text or text.lower() in {"unknown", "none"}:
+        return None, f"{name} is missing or unknown"
+    return text, None
+
+
+def _environment_summary() -> dict[str, object]:
+    """Return fail-closed JSON-safe JAX backend/device metadata."""
+    try:
+        jax_version_raw = getattr(jax, "__version__")
+    except Exception as exc:
+        return {
+            "status": "incomplete",
+            "reason": f"jax.__version__ read failed: {type(exc).__name__}: {exc}",
+            "jax_version": None,
+            "backend_platform": None,
+            "device_platform": None,
+            "device_kind": None,
+            "device_count": None,
+        }
+    jax_version, jax_version_error = _required_metadata_text(
+        "jax.__version__",
+        jax_version_raw,
+    )
+    if jax_version_error is not None:
+        return {
+            "status": "incomplete",
+            "reason": jax_version_error,
+            "jax_version": None,
+            "backend_platform": None,
+            "device_platform": None,
+            "device_kind": None,
+            "device_count": None,
+        }
+
+    try:
+        backend_platform_raw = jax.default_backend()
+    except Exception as exc:
+        return {
+            "status": "incomplete",
+            "reason": f"jax.default_backend() failed: {type(exc).__name__}: {exc}",
+            "jax_version": jax_version,
+            "backend_platform": None,
+            "device_platform": None,
+            "device_kind": None,
+            "device_count": None,
+        }
+    backend_platform, backend_error = _required_metadata_text(
+        "jax.default_backend()",
+        backend_platform_raw,
+    )
+    if backend_error is not None:
+        return {
+            "status": "incomplete",
+            "reason": backend_error,
+            "jax_version": jax_version,
+            "backend_platform": None,
+            "device_platform": None,
+            "device_kind": None,
+            "device_count": None,
+        }
+
+    try:
+        devices = tuple(jax.local_devices())
+    except Exception as exc:
+        return {
+            "status": "incomplete",
+            "reason": f"jax.local_devices() failed: {type(exc).__name__}: {exc}",
+            "jax_version": jax_version,
+            "backend_platform": backend_platform,
+            "device_platform": None,
+            "device_kind": None,
+            "device_count": None,
+        }
+    if not devices:
+        return {
+            "status": "incomplete",
+            "reason": "jax.local_devices() returned no devices",
+            "jax_version": jax_version,
+            "backend_platform": backend_platform,
+            "device_platform": None,
+            "device_kind": None,
+            "device_count": 0,
+        }
+
+    first = devices[0]
+    try:
+        device_platform_raw = getattr(first, "platform")
+        device_kind_raw = getattr(first, "device_kind")
+    except Exception as exc:
+        return {
+            "status": "incomplete",
+            "reason": f"JAX device metadata read failed: {type(exc).__name__}: {exc}",
+            "jax_version": jax_version,
+            "backend_platform": backend_platform,
+            "device_platform": None,
+            "device_kind": None,
+            "device_count": len(devices),
+        }
+    device_platform, platform_error = _required_metadata_text(
+        "JAX device platform",
+        device_platform_raw,
+    )
+    device_kind, kind_error = _required_metadata_text(
+        "JAX device_kind",
+        device_kind_raw,
+    )
+    if platform_error is not None or kind_error is not None:
+        return {
+            "status": "incomplete",
+            "reason": platform_error or kind_error,
+            "jax_version": jax_version,
+            "backend_platform": backend_platform,
+            "device_platform": device_platform,
+            "device_kind": device_kind,
+            "device_count": len(devices),
+        }
+
+    return {
+        "status": "complete",
+        "reason": "JAX backend/device metadata collected",
+        "jax_version": jax_version,
+        "backend_platform": backend_platform,
+        "device_platform": device_platform,
+        "device_kind": device_kind,
+        "device_count": int(len(devices)),
+    }
+
+
+def _normalize_byte_field(value: object, *, field: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise TypeError(f"{field} must be a non-negative integer byte count")
+    out = int(value)
+    if out < 0:
+        raise ValueError(f"{field} must be non-negative")
+    return out
+
+
+def _normalize_compiled_memory_analysis(compiled: object) -> CompiledMemoryAnalysis:
+    """Normalize ``compiled.memory_analysis()`` into required byte fields."""
+    try:
+        memory_analysis = getattr(compiled, "memory_analysis")
+    except AttributeError:
+        memory_analysis = None
+    except Exception as exc:
+        return CompiledMemoryAnalysis(
+            status="analysis_unavailable",
+            reason=f"reading memory_analysis attribute raised {type(exc).__name__}: {exc}",
+            required_bytes=None,
+            fields={},
+            analysis_type=None,
+            present_known_attrs=(),
+        )
+    if memory_analysis is None or not callable(memory_analysis):
+        return CompiledMemoryAnalysis(
+            status="analysis_unavailable",
+            reason="compiled object has no callable memory_analysis()",
+            required_bytes=None,
+            fields={},
+            analysis_type=None,
+            present_known_attrs=(),
+        )
+    try:
+        analysis = memory_analysis()
+    except Exception as exc:
+        return CompiledMemoryAnalysis(
+            status="analysis_unavailable",
+            reason=f"memory_analysis() raised {type(exc).__name__}: {exc}",
+            required_bytes=None,
+            fields={},
+            analysis_type=None,
+            present_known_attrs=(),
+        )
+    if analysis is None:
+        return CompiledMemoryAnalysis(
+            status="analysis_unavailable",
+            reason="memory_analysis() returned None",
+            required_bytes=None,
+            fields={},
+            analysis_type=None,
+            present_known_attrs=(),
+        )
+
+    present: list[str] = []
+    missing: list[str] = []
+    raw_fields: dict[str, object] = {}
+    for field in _REQUIRED_MEMORY_FIELDS:
+        try:
+            raw_fields[field] = getattr(analysis, field)
+        except AttributeError:
+            missing.append(field)
+        except Exception as exc:
+            return CompiledMemoryAnalysis(
+                status="analysis_incomplete",
+                reason=f"reading {field} raised {type(exc).__name__}: {exc}",
+                required_bytes=None,
+                fields={},
+                analysis_type=type(analysis).__name__,
+                present_known_attrs=tuple(present),
+            )
+        else:
+            present.append(field)
+    present_tuple = tuple(present)
+    if missing:
+        return CompiledMemoryAnalysis(
+            status="analysis_incomplete",
+            reason="memory_analysis() missing required byte field(s): " + ", ".join(missing),
+            required_bytes=None,
+            fields={},
+            analysis_type=type(analysis).__name__,
+            present_known_attrs=present_tuple,
+        )
+
+    fields: dict[str, int] = {}
+    try:
+        for field in _REQUIRED_MEMORY_FIELDS:
+            fields[field] = _normalize_byte_field(raw_fields[field], field=field)
+        required_bytes = (
+            fields["temp_size_in_bytes"]
+            + fields["argument_size_in_bytes"]
+            + fields["output_size_in_bytes"]
+            - fields["alias_size_in_bytes"]
+        )
+        if required_bytes < 0:
+            raise ValueError("computed required bytes must be non-negative")
+    except (TypeError, ValueError) as exc:
+        return CompiledMemoryAnalysis(
+            status="analysis_incomplete",
+            reason=str(exc),
+            required_bytes=None,
+            fields={},
+            analysis_type=type(analysis).__name__,
+            present_known_attrs=present_tuple,
+        )
+
+    return CompiledMemoryAnalysis(
+        status="complete",
+        reason="memory_analysis() returned complete required byte fields",
+        required_bytes=required_bytes,
+        fields=fields,
+        analysis_type=type(analysis).__name__,
+        present_known_attrs=present_tuple,
+    )
+
+
+def _checkpoint_mode(
+    *,
+    checkpoint_every: int | None,
+    checkpoint_segments: int | None,
+) -> str:
+    if checkpoint_every is not None:
+        return "checkpoint_every"
+    if checkpoint_segments is not None:
+        return "checkpoint_segments"
+    return "none"
+
+
+def _compiled_introspection_scope(compiled: object) -> tuple[object | None, str | None]:
+    for attr in ("rfx_memory_scope", "_rfx_memory_scope", "scope_metadata"):
+        try:
+            value = getattr(compiled, attr)
+        except AttributeError:
+            continue
+        except Exception as exc:
+            return None, (
+                f"compiled object introspection attribute {attr!r} raised "
+                f"{type(exc).__name__}: {exc}"
+            )
+        if value is not None:
+            return value, None
+    return None, None
+
+
+def _preflight_snapshot(preflight: object | None) -> object | None:
+    if preflight is None:
+        return None
+    return _json_safe(preflight, path="preflight")
+
+
+def _float_mismatch(actual: object, expected: float, *, atol: float = 1e-12) -> bool:
+    if not isinstance(actual, (int, float)) or isinstance(actual, bool):
+        return True
+    return abs(float(actual) - float(expected)) > atol
+
+
+def _preflight_mismatches(
+    preflight_snapshot: object | None,
+    *,
+    n_steps: int,
+    available_memory_gb: float,
+    target_fraction: float,
+    target_memory_gb: float,
+    checkpoint_mode: str,
+    checkpoint_every: int | None,
+    checkpoint_segments: int | None,
+) -> list[str]:
+    if not isinstance(preflight_snapshot, Mapping):
+        return []
+    mismatches: list[str] = []
+    if preflight_snapshot.get("n_steps") != n_steps:
+        mismatches.append("preflight n_steps differs from certificate scope")
+    if _float_mismatch(preflight_snapshot.get("available_memory_gb"), available_memory_gb):
+        mismatches.append("preflight available_memory_gb differs from certificate scope")
+    if _float_mismatch(preflight_snapshot.get("target_fraction"), target_fraction):
+        mismatches.append("preflight target_fraction differs from certificate scope")
+    if _float_mismatch(preflight_snapshot.get("target_memory_gb"), target_memory_gb):
+        mismatches.append("preflight target_memory_gb differs from certificate scope")
+
+    preflight_mode = preflight_snapshot.get("supported_checkpoint_mode")
+    normalized_preflight_mode = "none" if preflight_mode is None else preflight_mode
+    if normalized_preflight_mode != checkpoint_mode:
+        mismatches.append("preflight checkpoint mode differs from certificate scope")
+    if preflight_snapshot.get("checkpoint_every") != checkpoint_every:
+        mismatches.append("preflight checkpoint_every differs from certificate scope")
+    if preflight_snapshot.get("checkpoint_segments") != checkpoint_segments:
+        mismatches.append("preflight checkpoint_segments differs from certificate scope")
+    return mismatches
+
+
+def _introspection_mismatches(exact_scope: Mapping[str, object], introspection: object | None) -> list[str]:
+    if introspection is None:
+        return []
+    try:
+        safe = _json_safe(introspection, path="compiled_introspection_scope")
+    except (TypeError, ValueError) as exc:
+        return [f"compiled object introspection scope is not JSON-safe: {exc}"]
+    if not isinstance(safe, Mapping):
+        return ["compiled object introspection scope is not a mapping"]
+    mismatches: list[str] = []
+    for key, actual in safe.items():
+        key_s = str(key)
+        if key_s in exact_scope and exact_scope[key_s] != actual:
+            mismatches.append(f"compiled object introspection field {key_s!r} differs")
+    return mismatches
+
+
+def _canonicalize_exact_scope(
+    *,
+    compiled: object,
+    n_steps: int,
+    n_warmup: int,
+    checkpoint_every: int | None,
+    checkpoint_segments: int | None,
+    available_memory_gb: float,
+    target_fraction: float,
+    target_memory_gb: float,
+    precision: object,
+    input_signature: object,
+    static_signature: object,
+    compiled_object_id: object,
+    runner_or_objective: object,
+    memory_analysis_fields: tuple[str, ...] | None,
+    preflight: object | None,
+    scope_context: Mapping[str, object] | None,
+) -> CanonicalScope:
+    """Build canonical exact scope and fail closed on incomplete/mismatched data."""
+    missing: list[str] = []
+    if precision is None or (isinstance(precision, str) and not precision.strip()):
+        missing.append("precision")
+    if input_signature is None:
+        missing.append("input_signature")
+    if static_signature is None:
+        missing.append("static_signature")
+    if compiled_object_id is None or (
+        isinstance(compiled_object_id, str) and not compiled_object_id.strip()
+    ):
+        missing.append("compiled_object_id")
+    if runner_or_objective is None or (
+        isinstance(runner_or_objective, str) and not runner_or_objective.strip()
+    ):
+        missing.append("runner_or_objective")
+    if missing:
+        return CanonicalScope(
+            status="scope_incomplete",
+            reason="missing required exact-scope metadata: " + ", ".join(missing),
+            exact_scope=None,
+            source_preflight=None,
+            scope_digest=None,
+            config_digest=None,
+            environment_digest=None,
+        )
+
+    env = _environment_summary()
+    if env["status"] != "complete":
+        return CanonicalScope(
+            status="scope_incomplete",
+            reason=str(env["reason"]),
+            exact_scope=None,
+            source_preflight=None,
+            scope_digest=None,
+            config_digest=None,
+            environment_digest=None,
+        )
+    env_scope = {
+        "jax_version": env["jax_version"],
+        "backend_platform": env["backend_platform"],
+        "device_platform": env["device_platform"],
+        "device_kind": env["device_kind"],
+        "device_count": env["device_count"],
+    }
+    checkpoint_mode = _checkpoint_mode(
+        checkpoint_every=checkpoint_every,
+        checkpoint_segments=checkpoint_segments,
+    )
+    try:
+        input_signature_safe = _json_safe(input_signature, path="input_signature")
+        static_signature_safe = _json_safe(static_signature, path="static_signature")
+        scope_context_safe = (
+            None if scope_context is None else _json_safe(scope_context, path="scope_context")
+        )
+        preflight_safe = _preflight_snapshot(preflight)
+        if preflight is not None and not isinstance(preflight_safe, Mapping):
+            return CanonicalScope(
+                status="scope_incomplete",
+                reason="preflight snapshot must be a JSON object mapping",
+                exact_scope=None,
+                source_preflight=preflight_safe,
+                scope_digest=None,
+                config_digest=None,
+                environment_digest=None,
+            )
+        exact_scope: dict[str, object] = {
+            "schema_version": 1,
+            "jax_version": env_scope["jax_version"],
+            "backend_platform": env_scope["backend_platform"],
+            "device_platform": env_scope["device_platform"],
+            "device_kind": env_scope["device_kind"],
+            "device_count": env_scope["device_count"],
+            "compiled_object_type": f"{type(compiled).__module__}.{type(compiled).__qualname__}",
+            "compiled_object_id": _json_safe(compiled_object_id, path="compiled_object_id"),
+            "n_steps": int(n_steps),
+            "n_warmup": int(n_warmup),
+            "checkpoint_mode": checkpoint_mode,
+            "checkpoint_every": checkpoint_every,
+            "checkpoint_segments": checkpoint_segments,
+            "available_memory_gb": float(available_memory_gb),
+            "target_fraction": float(target_fraction),
+            "target_memory_gb": float(target_memory_gb),
+            "precision": _json_safe(precision, path="precision"),
+            "input_signature": input_signature_safe,
+            "static_signature": static_signature_safe,
+            "runner_or_objective": _json_safe(runner_or_objective, path="runner_or_objective"),
+            "memory_analysis_fields": (
+                None if memory_analysis_fields is None else list(memory_analysis_fields)
+            ),
+        }
+        if preflight_safe is not None:
+            exact_scope["source_preflight_digest"] = _stable_digest(preflight_safe)
+        if scope_context_safe is not None:
+            exact_scope["user_context"] = scope_context_safe
+    except (TypeError, ValueError) as exc:
+        return CanonicalScope(
+            status="scope_incomplete",
+            reason=str(exc),
+            exact_scope=None,
+            source_preflight=None,
+            scope_digest=None,
+            config_digest=None,
+            environment_digest=None,
+        )
+
+    mismatches = _preflight_mismatches(
+        preflight_safe,
+        n_steps=n_steps,
+        available_memory_gb=available_memory_gb,
+        target_fraction=target_fraction,
+        target_memory_gb=target_memory_gb,
+        checkpoint_mode=checkpoint_mode,
+        checkpoint_every=checkpoint_every,
+        checkpoint_segments=checkpoint_segments,
+    )
+    introspection_scope, introspection_error = _compiled_introspection_scope(compiled)
+    if introspection_error is not None:
+        mismatches.append(introspection_error)
+    else:
+        mismatches.extend(_introspection_mismatches(exact_scope, introspection_scope))
+    if mismatches:
+        return CanonicalScope(
+            status="scope_mismatch",
+            reason="; ".join(mismatches),
+            exact_scope=exact_scope,
+            source_preflight=preflight_safe,
+            scope_digest=_stable_digest(exact_scope),
+            config_digest=_stable_digest(
+                {
+                    "n_steps": n_steps,
+                    "n_warmup": n_warmup,
+                    "checkpoint_mode": checkpoint_mode,
+                    "checkpoint_every": checkpoint_every,
+                    "checkpoint_segments": checkpoint_segments,
+                    "available_memory_gb": float(available_memory_gb),
+                    "target_fraction": float(target_fraction),
+                    "target_memory_gb": float(target_memory_gb),
+                    "precision": exact_scope["precision"],
+                    "input_signature": input_signature_safe,
+                    "static_signature": static_signature_safe,
+                    "runner_or_objective": exact_scope["runner_or_objective"],
+                }
+            ),
+            environment_digest=_stable_digest(env_scope),
+        )
+
+    return CanonicalScope(
+        status="complete",
+        reason="exact scope metadata is complete and JSON-safe",
+        exact_scope=exact_scope,
+        source_preflight=preflight_safe,
+        scope_digest=_stable_digest(exact_scope),
+        config_digest=_stable_digest(
+            {
+                "n_steps": n_steps,
+                "n_warmup": n_warmup,
+                "checkpoint_mode": checkpoint_mode,
+                "checkpoint_every": checkpoint_every,
+                "checkpoint_segments": checkpoint_segments,
+                "available_memory_gb": float(available_memory_gb),
+                "target_fraction": float(target_fraction),
+                "target_memory_gb": float(target_memory_gb),
+                "precision": exact_scope["precision"],
+                "input_signature": input_signature_safe,
+                "static_signature": static_signature_safe,
+                "runner_or_objective": exact_scope["runner_or_objective"],
+            }
+        ),
+        environment_digest=_stable_digest(env_scope),
+    )
+
+
+__all__ = [
+    "CanonicalScope",
+    "CompiledMemoryAnalysis",
+    "_canonicalize_exact_scope",
+    "_environment_summary",
+    "_normalize_compiled_memory_analysis",
+    "_stable_digest",
+]

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -134,6 +134,81 @@ class AD_MemoryEstimate(NamedTuple):
         return json.dumps(self.to_dict(), **options)
 
 
+class ADMemoryComponent(NamedTuple):
+    """Named contribution to a reverse-mode AD memory explanation."""
+
+    name: str
+    memory_gb: float
+    share_of_selected: float
+    kind: str
+    unit: str | None = None
+    count: int | None = None
+    bytes_per_unit_gb: float | None = None
+    explanation: str = ""
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable component artifact."""
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "memory_gb": float(self.memory_gb),
+            "share_of_selected": float(self.share_of_selected),
+            "unit": self.unit,
+            "count": self.count,
+            "bytes_per_unit_gb": (
+                None
+                if self.bytes_per_unit_gb is None
+                else float(self.bytes_per_unit_gb)
+            ),
+            "explanation": self.explanation,
+        }
+
+
+class ADMemoryExplainabilityReport(NamedTuple):
+    """Static reverse-mode AD memory explainability artifact.
+
+    The report decomposes the selected AD estimate into named components so
+    users can see whether field tape, segment-boundary carries, CPML/material
+    state, or monitor state dominates the planning artifact. It is still static
+    planning evidence, not profiler evidence or a bounded certificate.
+    """
+
+    n_steps: int
+    strategy: str
+    selected_memory_gb: float
+    selected_memory_field: str
+    estimate: AD_MemoryEstimate
+    components: tuple[ADMemoryComponent, ...]
+    dominant_component: str
+    recommendations: tuple[str, ...]
+
+    @property
+    def evidence_class(self) -> str:
+        """Evidence class label serialized with this static explanation."""
+        return "static_ad_explainability"
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable AD explainability artifact."""
+        return {
+            "evidence_class": self.evidence_class,
+            "n_steps": int(self.n_steps),
+            "strategy": self.strategy,
+            "selected_memory_gb": float(self.selected_memory_gb),
+            "selected_memory_field": self.selected_memory_field,
+            "estimate": self.estimate.to_dict(),
+            "components": [component.to_dict() for component in self.components],
+            "dominant_component": self.dominant_component,
+            "recommendations": list(self.recommendations),
+        }
+
+    def to_json(self, **kwargs: object) -> str:
+        """Serialize the explanation for AD-memory diagnostics."""
+        options = {"indent": 2, "sort_keys": True}
+        options.update(kwargs)
+        options["allow_nan"] = False
+        return json.dumps(self.to_dict(), **options)
+
+
 class ADMemoryPlan(NamedTuple):
     """Checkpoint planning result for reverse-mode AD memory.
 
@@ -924,6 +999,8 @@ __all__ = [
     "MATERIAL_LIBRARY",
     "AD_MemoryEstimate",
     "ADMemoryPlan",
+    "ADMemoryComponent",
+    "ADMemoryExplainabilityReport",
     "MeshIntelligenceReport",
     "Result",
     "ForwardResult",

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -73,8 +73,14 @@ class AD_MemoryEstimate(NamedTuple):
     estimate; for FDTD on the non-uniform path this is *not* a
     realistic memory number because the scan carry itself is not
     rematerialised (see issue #31 VESSL 369367233490). Use
-    ``ad_segmented_gb`` when ``checkpoint_every`` is set — that matches
-    the observed memory on RTX 4090 within ~15%.
+    ``ad_segmented_gb`` for the runner-supported segmented paths:
+    ``checkpoint_every`` on the non-uniform scan-of-scan path and
+    ``checkpoint_segments`` on the uniform segmented-scan path. When present,
+    ``ad_segmented_active_segments`` is the actual number of active segment
+    boundaries/carry snapshots used by the segmented estimate after warmup.
+    ``evidence_class`` labels this artifact as a static estimate so downstream
+    tooling does not confuse it with observed profiler evidence or a bounded
+    compiled-executable certificate.
     """
     forward_gb: float
     ad_checkpointed_gb: float
@@ -84,10 +90,20 @@ class AD_MemoryEstimate(NamedTuple):
     warning: str | None
     ad_segmented_gb: float | None = None
     checkpoint_every: int | None = None
+    checkpoint_segments: int | None = None
+    ad_active_steps: int | None = None
+    ad_active_design_fraction: float | None = None
+    ad_segmented_active_segments: int | None = None
+    @property
+    def evidence_class(self) -> str:
+        """Evidence class label serialized with this static estimate."""
+        return "static_estimate"
+
 
     def to_dict(self) -> dict[str, float | int | None | str]:
         """Return a stable JSON-serializable AD memory artifact."""
         return {
+            "evidence_class": self.evidence_class,
             "forward_gb": float(self.forward_gb),
             "ad_checkpointed_gb": float(self.ad_checkpointed_gb),
             "ad_full_gb": float(self.ad_full_gb),
@@ -100,24 +116,39 @@ class AD_MemoryEstimate(NamedTuple):
                 None if self.ad_segmented_gb is None else float(self.ad_segmented_gb)
             ),
             "checkpoint_every": self.checkpoint_every,
+            "checkpoint_segments": self.checkpoint_segments,
+            "ad_active_steps": self.ad_active_steps,
+            "ad_active_design_fraction": (
+                None
+                if self.ad_active_design_fraction is None
+                else float(self.ad_active_design_fraction)
+            ),
+            "ad_segmented_active_segments": self.ad_segmented_active_segments,
         }
 
     def to_json(self, **kwargs: object) -> str:
         """Serialize the estimate for research-note and CI artifacts."""
         options = {"indent": 2, "sort_keys": True}
         options.update(kwargs)
+        options["allow_nan"] = False
         return json.dumps(self.to_dict(), **options)
 
 
 class ADMemoryPlan(NamedTuple):
     """Checkpoint planning result for reverse-mode AD memory.
 
-    ``checkpoint_every`` is the smallest segmented-scan chunk length estimated
-    to fit under ``target_fraction * available_memory_gb``.  ``None`` means the
-    full reverse-mode estimate already fits and segmented checkpointing is not
-    required for memory.
-    """
+    ``checkpoint_every`` is the non-uniform segmented-scan chunk length.
+    ``checkpoint_segments`` is the uniform segmented-scan segment count.
+    ``checkpoint_mode`` is the knob selector, not a runnable-fit verdict:
+    check ``full_ad_fits`` first, then require ``segmented_fits`` before wiring
+    the selected segmented knob. A non-fitting plan may still carry the
+    least-memory candidate knob for diagnostics.
+    ``fit_safety_factor`` records the conservative multiplier used before an
+    estimate is allowed to set ``full_ad_fits`` or ``segmented_fits``.
+    ``evidence_class`` labels this artifact as a calibrated conservative plan,
+    not a certificate or observed runtime profile.
 
+    """
     n_steps: int
     available_memory_gb: float
     target_fraction: float
@@ -127,15 +158,26 @@ class ADMemoryPlan(NamedTuple):
     full_ad_fits: bool
     segmented_fits: bool
     recommendation: str
+    checkpoint_segments: int | None = None
+    checkpoint_mode: str | None = None
+    fit_safety_factor: float = 1.0
+    @property
+    def evidence_class(self) -> str:
+        """Evidence class label serialized with this conservative plan."""
+        return "calibrated_conservative_plan"
 
     def to_dict(self) -> dict[str, object]:
         """Return a stable JSON-serializable AD memory plan artifact."""
         return {
+            "evidence_class": self.evidence_class,
             "n_steps": int(self.n_steps),
             "available_memory_gb": float(self.available_memory_gb),
             "target_fraction": float(self.target_fraction),
             "target_memory_gb": float(self.target_memory_gb),
+            "fit_safety_factor": float(self.fit_safety_factor),
             "checkpoint_every": self.checkpoint_every,
+            "checkpoint_segments": self.checkpoint_segments,
+            "checkpoint_mode": self.checkpoint_mode,
             "selected_estimate": self.selected_estimate.to_dict(),
             "full_ad_fits": bool(self.full_ad_fits),
             "segmented_fits": bool(self.segmented_fits),
@@ -146,6 +188,7 @@ class ADMemoryPlan(NamedTuple):
         """Serialize the plan for memory-budget and CI artifacts."""
         options = {"indent": 2, "sort_keys": True}
         options.update(kwargs)
+        options["allow_nan"] = False
         return json.dumps(self.to_dict(), **options)
 
 
@@ -191,6 +234,7 @@ class MeshIntelligenceReport(NamedTuple):
         """Serialize the report for memory-reduction evidence artifacts."""
         options = {"indent": 2, "sort_keys": True}
         options.update(kwargs)
+        options["allow_nan"] = False
         return json.dumps(self.to_dict(), **options)
 
 

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 import json
-from typing import NamedTuple
+from typing import Mapping, NamedTuple
 
 import jax.numpy as jnp
 import numpy as np
@@ -57,6 +57,27 @@ MATERIAL_LIBRARY: dict[str, dict] = {
         "debye_poles": [DebyePole(delta_eps=74.1, tau=8.3e-12)],
     },
 }
+
+
+def _artifact_to_dict(value: object) -> object:
+    """Serialize nested report artifacts without importing non-leaf rfx modules."""
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    if hasattr(value, "to_dict") and callable(value.to_dict):
+        return _artifact_to_dict(value.to_dict())
+    if hasattr(value, "to_json") and callable(value.to_json):
+        return _artifact_to_dict(json.loads(value.to_json()))
+    if hasattr(value, "tolist") and callable(value.tolist):
+        return _artifact_to_dict(value.tolist())
+    if isinstance(value, Mapping):
+        return {str(key): _artifact_to_dict(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_artifact_to_dict(item) for item in value]
+    if isinstance(value, list):
+        return [_artifact_to_dict(item) for item in value]
+    raise TypeError(
+        f"preflight nested artifact contains unsupported value {type(value).__name__}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -162,6 +183,45 @@ class ADMemoryComponent(NamedTuple):
             ),
             "explanation": self.explanation,
         }
+
+
+class ADMemoryActionHint(NamedTuple):
+    """Actionable AD-memory preflight hint derived from planning evidence."""
+
+    code: str
+    severity: str
+    message: str
+    action: str
+    checkpoint_mode: str | None = None
+    checkpoint_every: int | None = None
+    checkpoint_segments: int | None = None
+    blocking: bool = False
+
+    @property
+    def evidence_class(self) -> str:
+        """Evidence class label serialized with this static action hint."""
+        return "static_action_hint"
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable action-hint artifact."""
+        return {
+            "evidence_class": self.evidence_class,
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "action": self.action,
+            "checkpoint_mode": self.checkpoint_mode,
+            "checkpoint_every": self.checkpoint_every,
+            "checkpoint_segments": self.checkpoint_segments,
+            "blocking": bool(self.blocking),
+        }
+
+    def to_json(self, **kwargs: object) -> str:
+        """Serialize the action hint with non-finite floats rejected."""
+        options = {"indent": 2, "sort_keys": True}
+        options.update(kwargs)
+        options["allow_nan"] = False
+        return json.dumps(self.to_dict(), **options)
 
 
 class ADMemoryExplainabilityReport(NamedTuple):
@@ -307,6 +367,195 @@ class MeshIntelligenceReport(NamedTuple):
 
     def to_json(self, **kwargs: object) -> str:
         """Serialize the report for memory-reduction evidence artifacts."""
+        options = {"indent": 2, "sort_keys": True}
+        options.update(kwargs)
+        options["allow_nan"] = False
+        return json.dumps(self.to_dict(), **options)
+
+
+class ADMemoryPreflightReport(NamedTuple):
+    """Composite AD-memory preflight artifact.
+
+    This report composes static memory planning, static explainability,
+    optional mesh advisories, and optional trace-time JAX saved-residual
+    diagnostics. It is not runtime profiler evidence, XLA memory analysis,
+    a peak-memory guarantee, a certificate, or RF validation.
+    """
+
+    n_steps: int
+    available_memory_gb: float
+    target_fraction: float
+    target_memory_gb: float
+    fit_safety_factor: float
+    status: str
+    supported_checkpoint_mode: str | None
+    checkpoint_every: int | None
+    checkpoint_segments: int | None
+    full_ad_fits: bool
+    checkpointing_fits: bool
+    memory_plan: ADMemoryPlan
+    explainability: ADMemoryExplainabilityReport
+    mesh_report: MeshIntelligenceReport | None
+    residual_diagnostic: object | None
+    action_hints: tuple[ADMemoryActionHint, ...]
+    evidence_boundaries: tuple[str, ...]
+    recommendation: str
+
+    @property
+    def evidence_class(self) -> str:
+        """Evidence class label serialized with this composite preflight."""
+        return "composite_ad_memory_preflight"
+
+    @property
+    def source_evidence_classes(self) -> tuple[str, ...]:
+        """Evidence classes from nested artifacts, in stable order."""
+        classes: list[str] = [
+            self.memory_plan.evidence_class,
+            self.memory_plan.selected_estimate.evidence_class,
+            self.explainability.evidence_class,
+        ]
+        residual_source = getattr(
+            self.residual_diagnostic,
+            "source_evidence_class",
+            None,
+        )
+        if residual_source is not None:
+            classes.append(str(residual_source))
+        residual_evidence = getattr(self.residual_diagnostic, "evidence_class", None)
+        if residual_evidence is not None:
+            classes.append(str(residual_evidence))
+
+        deduped: list[str] = []
+        for evidence_class in classes:
+            if evidence_class not in deduped:
+                deduped.append(evidence_class)
+        return tuple(deduped)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable AD-memory preflight artifact."""
+        return {
+            "evidence_class": self.evidence_class,
+            "source_evidence_classes": list(self.source_evidence_classes),
+            "n_steps": int(self.n_steps),
+            "available_memory_gb": float(self.available_memory_gb),
+            "target_fraction": float(self.target_fraction),
+            "target_memory_gb": float(self.target_memory_gb),
+            "fit_safety_factor": float(self.fit_safety_factor),
+            "status": self.status,
+            "supported_checkpoint_mode": self.supported_checkpoint_mode,
+            "checkpoint_every": self.checkpoint_every,
+            "checkpoint_segments": self.checkpoint_segments,
+            "full_ad_fits": bool(self.full_ad_fits),
+            "checkpointing_fits": bool(self.checkpointing_fits),
+            "memory_plan": self.memory_plan.to_dict(),
+            "explainability": self.explainability.to_dict(),
+            "mesh_report": _artifact_to_dict(self.mesh_report),
+            "residual_diagnostic": _artifact_to_dict(self.residual_diagnostic),
+            "action_hints": [hint.to_dict() for hint in self.action_hints],
+            "evidence_boundaries": list(self.evidence_boundaries),
+            "recommendation": self.recommendation,
+        }
+
+    def to_json(self, **kwargs: object) -> str:
+        """Serialize the preflight report with non-finite floats rejected."""
+        options = {"indent": 2, "sort_keys": True}
+        options.update(kwargs)
+        options["allow_nan"] = False
+        return json.dumps(self.to_dict(), **options)
+
+
+class ADCompiledMemoryCertificate(NamedTuple):
+    """Bounded compiler-memory certificate for one exact compiled executable.
+
+    The report is derived from a caller-supplied JAX compiled object's
+    ``memory_analysis()`` result plus complete exact-scope metadata. It is not a
+    universal peak-memory predictor, runtime profiler artifact, RF validation
+    result, or proof that source/config digests correspond to an opaque
+    executable.
+    """
+
+    status: str
+    available_memory_gb: float
+    target_fraction: float
+    target_memory_gb: float
+    compiler_reported_required_bytes: int | None
+    compiler_reported_required_gb: float | None
+    temp_size_in_bytes: int | None
+    argument_size_in_bytes: int | None
+    output_size_in_bytes: int | None
+    alias_size_in_bytes: int | None
+    temp_gb: float | None
+    argument_gb: float | None
+    output_gb: float | None
+    alias_gb: float | None
+    exact_scope: Mapping[str, object] | None
+    scope_status: str
+    scope_status_reason: str
+    scope_digest: str | None
+    config_digest: str | None
+    environment_digest: str | None
+    memory_analysis_status: str
+    memory_analysis_status_reason: str
+    jax_version: str
+    evidence_boundaries: tuple[str, ...]
+    recommendations: tuple[str, ...]
+    source_preflight: object | None = None
+
+    @property
+    def evidence_class(self) -> str:
+        """Evidence class label serialized with this bounded certificate."""
+        return "bounded_certificate"
+
+    @property
+    def is_valid_certificate(self) -> bool:
+        """Whether compiler evidence and exact scope are complete."""
+        return self.status in {"certified_budget_fit", "certified_budget_exceeded"}
+
+    @property
+    def is_budget_safe(self) -> bool | None:
+        """Whether the compiler estimate fits the configured target budget."""
+        if self.status == "certified_budget_fit":
+            return True
+        if self.status == "certified_budget_exceeded":
+            return False
+        return None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable bounded-certificate artifact."""
+        return {
+            "evidence_class": self.evidence_class,
+            "status": self.status,
+            "is_valid_certificate": self.is_valid_certificate,
+            "is_budget_safe": self.is_budget_safe,
+            "available_memory_gb": float(self.available_memory_gb),
+            "target_fraction": float(self.target_fraction),
+            "target_memory_gb": float(self.target_memory_gb),
+            "compiler_reported_required_bytes": self.compiler_reported_required_bytes,
+            "compiler_reported_required_gb": self.compiler_reported_required_gb,
+            "temp_size_in_bytes": self.temp_size_in_bytes,
+            "argument_size_in_bytes": self.argument_size_in_bytes,
+            "output_size_in_bytes": self.output_size_in_bytes,
+            "alias_size_in_bytes": self.alias_size_in_bytes,
+            "temp_gb": self.temp_gb,
+            "argument_gb": self.argument_gb,
+            "output_gb": self.output_gb,
+            "alias_gb": self.alias_gb,
+            "exact_scope": _artifact_to_dict(self.exact_scope),
+            "scope_status": self.scope_status,
+            "scope_status_reason": self.scope_status_reason,
+            "scope_digest": self.scope_digest,
+            "config_digest": self.config_digest,
+            "environment_digest": self.environment_digest,
+            "memory_analysis_status": self.memory_analysis_status,
+            "memory_analysis_status_reason": self.memory_analysis_status_reason,
+            "jax_version": self.jax_version,
+            "evidence_boundaries": list(self.evidence_boundaries),
+            "recommendations": list(self.recommendations),
+            "source_preflight": _artifact_to_dict(self.source_preflight),
+        }
+
+    def to_json(self, **kwargs: object) -> str:
+        """Serialize the certificate with non-finite floats rejected."""
         options = {"indent": 2, "sort_keys": True}
         options.update(kwargs)
         options["allow_nan"] = False
@@ -1000,8 +1249,11 @@ __all__ = [
     "AD_MemoryEstimate",
     "ADMemoryPlan",
     "ADMemoryComponent",
+    "ADMemoryActionHint",
     "ADMemoryExplainabilityReport",
+    "ADMemoryPreflightReport",
     "MeshIntelligenceReport",
+    "ADCompiledMemoryCertificate",
     "Result",
     "ForwardResult",
     "MaterialSpec",

--- a/rfx/jax_checks.py
+++ b/rfx/jax_checks.py
@@ -1,0 +1,97 @@
+"""JAX checkify helpers for compiled rfx invariants.
+
+The functions here are small wrappers around ``jax.experimental.checkify``. They
+let callers put RF/design invariants inside JAX-traced code so failures survive
+``jit``, ``grad``, ``vmap``, and ``lax.scan`` transformations as checkify errors.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+import jax.numpy as jnp
+from jax.experimental import checkify
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def checkify_invariants(
+    fun: F,
+    *,
+    float_checks: bool = True,
+    index_checks: bool = False,
+) -> Callable[..., tuple[checkify.Error, Any]]:
+    """Return a checkified wrapper for user and optional automatic checks.
+
+    User checks are always enabled because the helpers below emit
+    ``checkify.check`` predicates. ``float_checks`` additionally catches NaN and
+    divide-by-zero errors inserted by JAX checkify. ``index_checks`` is opt-in
+    because it can be noisier for code that intentionally uses masked indexing.
+    """
+    errors = checkify.user_checks
+    if float_checks:
+        errors = errors | checkify.float_checks
+    if index_checks:
+        errors = errors | checkify.index_checks
+    return checkify.checkify(fun, errors=errors)
+
+
+def check_finite(value: Any, name: str = "value"):
+    """Assert that all entries of ``value`` are finite inside JAX tracing."""
+    arr = jnp.asarray(value)
+    checkify.check(jnp.all(jnp.isfinite(arr)), f"{name} must be finite")
+    return value
+
+
+def check_positive(value: Any, name: str = "value", *, allow_zero: bool = False):
+    """Assert that all entries of ``value`` are positive or non-negative."""
+    arr = jnp.asarray(value)
+    if allow_zero:
+        checkify.check(jnp.all(arr >= 0), f"{name} must be non-negative")
+    else:
+        checkify.check(jnp.all(arr > 0), f"{name} must be positive")
+    return value
+
+
+def check_bounds(
+    value: Any,
+    *,
+    lower: float | None = None,
+    upper: float | None = None,
+    name: str = "value",
+):
+    """Assert lower/upper bounds for an array-like value inside JAX tracing."""
+    if lower is None and upper is None:
+        raise ValueError("at least one of lower or upper must be provided")
+    arr = jnp.asarray(value)
+    if lower is not None:
+        checkify.check(jnp.all(arr >= lower), f"{name} must be >= {lower}")
+    if upper is not None:
+        checkify.check(jnp.all(arr <= upper), f"{name} must be <= {upper}")
+    return value
+
+
+def check_courant_number(
+    courant: Any,
+    *,
+    limit: float = 1.0,
+    name: str = "courant",
+):
+    """Assert a finite positive Courant-like number below ``limit``."""
+    if not limit > 0:
+        raise ValueError("limit must be positive")
+    check_finite(courant, name=name)
+    check_positive(courant, name=name)
+    arr = jnp.asarray(courant)
+    checkify.check(jnp.all(arr <= limit), f"{name} must be <= {limit}")
+    return courant
+
+
+__all__ = [
+    "check_bounds",
+    "check_courant_number",
+    "check_finite",
+    "check_positive",
+    "checkify_invariants",
+]

--- a/rfx/pareto.py
+++ b/rfx/pareto.py
@@ -1,0 +1,318 @@
+"""Pareto-front utilities for multi-objective RF design sweeps.
+
+The helpers in this module are intentionally optimizer-agnostic. They operate on
+objective arrays produced by sweeps, scalarized inverse-design runs, or analytic
+tests, then return JSON-serializable Pareto artifacts.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from typing import NamedTuple
+
+import numpy as np
+
+def _json_safe(value: object) -> object:
+    """Convert common NumPy metadata values into JSON-native objects."""
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, np.ndarray):
+        return _json_safe(value.tolist())
+    if isinstance(value, Mapping):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_json_safe(item) for item in value]
+    return value
+
+class ParetoPoint(NamedTuple):
+    """One candidate in a Pareto front."""
+
+    source_index: int
+    id: str
+    objectives: tuple[float, ...]
+    metadata: Mapping[str, object] | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable Pareto point."""
+        return {
+            "source_index": int(self.source_index),
+            "id": self.id,
+            "objectives": [float(value) for value in self.objectives],
+            "metadata": None if self.metadata is None else _json_safe(self.metadata),
+        }
+
+
+class ParetoFront(NamedTuple):
+    """Pareto frontier artifact for a finite set of objective vectors."""
+
+    points: tuple[ParetoPoint, ...]
+    minimize: tuple[bool, ...]
+    objective_names: tuple[str, ...]
+    source_count: int
+    front_indices: tuple[int, ...]
+    dominated_indices: tuple[int, ...]
+
+    @property
+    def evidence_class(self) -> str:
+        """Evidence class label serialized with this design-sweep artifact."""
+        return "pareto_front"
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a stable JSON-serializable Pareto-front artifact."""
+        return {
+            "evidence_class": self.evidence_class,
+            "points": [point.to_dict() for point in self.points],
+            "minimize": list(self.minimize),
+            "objective_names": list(self.objective_names),
+            "source_count": int(self.source_count),
+            "front_indices": list(self.front_indices),
+            "dominated_indices": list(self.dominated_indices),
+        }
+
+    def to_json(self, **kwargs: object) -> str:
+        """Serialize the Pareto-front artifact with non-finite floats rejected."""
+        options = {"indent": 2, "sort_keys": True}
+        options.update(kwargs)
+        options["allow_nan"] = False
+        return json.dumps(self.to_dict(), **options)
+
+
+def _as_2d_objectives(values: Sequence[Sequence[float]] | np.ndarray) -> np.ndarray:
+    arr = np.asarray(values, dtype=float)
+    if arr.ndim != 2:
+        raise ValueError(f"objectives must be a 2D array, got shape {arr.shape}")
+    if arr.shape[0] == 0:
+        raise ValueError("objectives must contain at least one point")
+    if arr.shape[1] == 0:
+        raise ValueError("objectives must contain at least one objective")
+    if not np.all(np.isfinite(arr)):
+        raise ValueError("objectives must be finite")
+    return arr
+
+
+def _orientation(minimize: bool | Sequence[bool], n_objectives: int) -> tuple[bool, ...]:
+    if isinstance(minimize, (bool, np.bool_)):
+        return (bool(minimize),) * n_objectives
+    oriented = tuple(bool(item) for item in minimize)
+    if len(oriented) != n_objectives:
+        raise ValueError(
+            f"minimize must have {n_objectives} entries, got {len(oriented)}"
+        )
+    return oriented
+
+
+def _oriented_values(values: np.ndarray, minimize: tuple[bool, ...]) -> np.ndarray:
+    signs = np.array([1.0 if flag else -1.0 for flag in minimize], dtype=float)
+    return values * signs
+
+
+def _require_nonnegative_finite(name: str, value: float) -> float:
+    scalar = float(value)
+    if not np.isfinite(scalar) or scalar < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative")
+    return scalar
+
+
+def pareto_mask(
+    objectives: Sequence[Sequence[float]] | np.ndarray,
+    *,
+    minimize: bool | Sequence[bool] = True,
+    atol: float = 0.0,
+) -> np.ndarray:
+    """Return a boolean mask selecting non-dominated objective rows.
+
+    ``minimize`` may be one bool for all objectives or one bool per objective.
+    Objectives marked ``False`` are treated as maximization objectives. ``atol``
+    is a dominance tolerance in the raw objective units after orientation.
+    """
+    values = _as_2d_objectives(objectives)
+    minimize_tuple = _orientation(minimize, values.shape[1])
+    oriented = _oriented_values(values, minimize_tuple)
+    tolerance = _require_nonnegative_finite("atol", atol)
+
+    n_points = oriented.shape[0]
+    mask = np.ones(n_points, dtype=bool)
+    for i in range(n_points):
+        if not mask[i]:
+            continue
+        candidate = oriented[i]
+        no_worse = np.all(oriented <= candidate + tolerance, axis=1)
+        strictly_better = np.any(oriented < candidate - tolerance, axis=1)
+        dominated_by_other = no_worse & strictly_better
+        dominated_by_other[i] = False
+        if np.any(dominated_by_other):
+            mask[i] = False
+    return mask
+
+
+def pareto_front(
+    objectives: Sequence[Sequence[float]] | np.ndarray,
+    *,
+    minimize: bool | Sequence[bool] = True,
+    ids: Sequence[str] | None = None,
+    objective_names: Sequence[str] | None = None,
+    metadata: Sequence[Mapping[str, object] | None] | None = None,
+    atol: float = 0.0,
+) -> ParetoFront:
+    """Build a JSON-serializable Pareto-front artifact."""
+    values = _as_2d_objectives(objectives)
+    n_points, n_objectives = values.shape
+    minimize_tuple = _orientation(minimize, n_objectives)
+    mask = pareto_mask(values, minimize=minimize_tuple, atol=atol)
+
+    if ids is None:
+        ids_tuple = tuple(str(i) for i in range(n_points))
+    else:
+        ids_tuple = tuple(ids)
+        if len(ids_tuple) != n_points:
+            raise ValueError(f"ids must have {n_points} entries, got {len(ids_tuple)}")
+
+    if objective_names is None:
+        names_tuple = tuple(f"objective_{i}" for i in range(n_objectives))
+    else:
+        names_tuple = tuple(objective_names)
+        if len(names_tuple) != n_objectives:
+            raise ValueError(
+                f"objective_names must have {n_objectives} entries, got {len(names_tuple)}"
+            )
+
+    if metadata is None:
+        metadata_tuple: tuple[Mapping[str, object] | None, ...] = (None,) * n_points
+    else:
+        metadata_tuple = tuple(metadata)
+        if len(metadata_tuple) != n_points:
+            raise ValueError(
+                f"metadata must have {n_points} entries, got {len(metadata_tuple)}"
+            )
+
+    front_indices = tuple(int(idx) for idx in np.flatnonzero(mask))
+    dominated_indices = tuple(int(idx) for idx in np.flatnonzero(~mask))
+    points = tuple(
+        ParetoPoint(
+            source_index=idx,
+            id=ids_tuple[idx],
+            objectives=tuple(float(value) for value in values[idx]),
+            metadata=metadata_tuple[idx],
+        )
+        for idx in front_indices
+    )
+    return ParetoFront(
+        points=points,
+        minimize=minimize_tuple,
+        objective_names=names_tuple,
+        source_count=n_points,
+        front_indices=front_indices,
+        dominated_indices=dominated_indices,
+    )
+
+
+def weighted_scalarization(
+    objectives: Sequence[Sequence[float]] | np.ndarray,
+    weights: Sequence[float],
+    *,
+    minimize: bool | Sequence[bool] = True,
+    normalize: bool = False,
+) -> np.ndarray:
+    """Return lower-is-better weighted scalarization scores.
+
+    Maximization objectives are sign-flipped before scoring. When ``normalize``
+    is true, each oriented objective is min-max normalized; constant objectives
+    contribute zero after normalization.
+    """
+    values = _as_2d_objectives(objectives)
+    minimize_tuple = _orientation(minimize, values.shape[1])
+    oriented = _oriented_values(values, minimize_tuple)
+    weights_arr = np.asarray(weights, dtype=float)
+    if weights_arr.shape != (values.shape[1],):
+        raise ValueError(
+            f"weights must have shape ({values.shape[1]},), got {weights_arr.shape}"
+        )
+    if not np.all(np.isfinite(weights_arr)) or np.any(weights_arr < 0.0):
+        raise ValueError("weights must be finite and non-negative")
+    if not np.any(weights_arr > 0.0):
+        raise ValueError("at least one weight must be positive")
+
+    if normalize:
+        mins = np.min(oriented, axis=0)
+        ranges = np.max(oriented, axis=0) - mins
+        oriented = np.divide(
+            oriented - mins,
+            ranges,
+            out=np.zeros_like(oriented),
+            where=ranges > 0.0,
+        )
+    return oriented @ weights_arr
+
+
+def epsilon_constraint_mask(
+    objectives: Sequence[Sequence[float]] | np.ndarray,
+    epsilons: Mapping[int, float],
+    *,
+    minimize: bool | Sequence[bool] = True,
+    atol: float = 0.0,
+) -> np.ndarray:
+    """Return points satisfying raw epsilon constraints per objective.
+
+    For minimization objectives the constraint is ``objective <= epsilon``; for
+    maximization objectives it is ``objective >= epsilon``. Objective indices not
+    present in ``epsilons`` are unconstrained.
+    """
+    values = _as_2d_objectives(objectives)
+    minimize_tuple = _orientation(minimize, values.shape[1])
+    tolerance = _require_nonnegative_finite("atol", atol)
+    mask = np.ones(values.shape[0], dtype=bool)
+    for idx, epsilon in epsilons.items():
+        if idx < 0 or idx >= values.shape[1]:
+            raise IndexError(f"epsilon objective index {idx} out of range")
+        eps = float(epsilon)
+        if not np.isfinite(eps):
+            raise ValueError("epsilon values must be finite")
+        if minimize_tuple[idx]:
+            mask &= values[:, idx] <= eps + tolerance
+        else:
+            mask &= values[:, idx] >= eps - tolerance
+    return mask
+
+
+def select_epsilon_constrained(
+    objectives: Sequence[Sequence[float]] | np.ndarray,
+    *,
+    primary_index: int,
+    epsilons: Mapping[int, float],
+    minimize: bool | Sequence[bool] = True,
+    atol: float = 0.0,
+) -> int | None:
+    """Select the best feasible point by one primary objective.
+
+    Returns ``None`` when no point satisfies the epsilon constraints.
+    """
+    values = _as_2d_objectives(objectives)
+    if primary_index < 0 or primary_index >= values.shape[1]:
+        raise IndexError(f"primary_index {primary_index} out of range")
+    minimize_tuple = _orientation(minimize, values.shape[1])
+    feasible = epsilon_constraint_mask(
+        values,
+        epsilons,
+        minimize=minimize_tuple,
+        atol=atol,
+    )
+    indices = np.flatnonzero(feasible)
+    if len(indices) == 0:
+        return None
+    primary = values[indices, primary_index]
+    local_idx = int(np.argmin(primary) if minimize_tuple[primary_index] else np.argmax(primary))
+    return int(indices[local_idx])
+
+
+__all__ = [
+    "ParetoFront",
+    "ParetoPoint",
+    "epsilon_constraint_mask",
+    "pareto_front",
+    "pareto_mask",
+    "select_epsilon_constrained",
+    "weighted_scalarization",
+]

--- a/rfx/sweep.py
+++ b/rfx/sweep.py
@@ -18,9 +18,12 @@ and may be added as a future fast-path.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
 from typing import Callable, Any
 
 import numpy as np
+
+from rfx.pareto import ParetoFront, pareto_front as build_pareto_front
 
 try:
     import matplotlib.pyplot as plt
@@ -99,6 +102,65 @@ class SweepResult:
             else:
                 vals.append(np.nan)
         return np.asarray(vals)
+
+    def pareto_front(
+        self,
+        metrics: Mapping[str, Sequence[float] | np.ndarray] | Sequence[str],
+        *,
+        minimize: bool | Sequence[bool] = True,
+        ids: Sequence[str] | None = None,
+        metadata: Sequence[Mapping[str, object] | None] | None = None,
+        atol: float = 0.0,
+    ) -> ParetoFront:
+        """Build a Pareto-front artifact from sweep metrics.
+
+        ``metrics`` may be a mapping from objective name to one value per sweep
+        point, or a sequence of ``SweepResult`` metric method names such as
+        ``("s11_min_db", "peak_field")``. Maximization objectives are declared
+        through ``minimize=False`` for that objective position.
+        """
+        if isinstance(metrics, Mapping):
+            objective_names = tuple(str(name) for name in metrics)
+            columns = [
+                np.asarray(metrics[name], dtype=float)
+                for name in metrics
+            ]
+        else:
+            objective_names = tuple(str(name) for name in metrics)
+            columns = []
+            for name in objective_names:
+                attr = getattr(self, name, None)
+                if attr is None or not callable(attr):
+                    raise ValueError(f"unknown sweep metric {name!r}")
+                columns.append(np.asarray(attr(), dtype=float))
+
+        if not columns:
+            raise ValueError("at least one metric is required")
+        n_points = len(self.results)
+        for name, column in zip(objective_names, columns, strict=True):
+            if column.shape != (n_points,):
+                raise ValueError(
+                    f"metric {name!r} must have shape ({n_points},), got {column.shape}"
+                )
+        objectives = np.column_stack(columns)
+        point_ids = (
+            ids
+            if ids is not None
+            else [f"{self.param_name}={value}" for value in self.param_values]
+        )
+        point_metadata = (
+            metadata
+            if metadata is not None
+            else [{self.param_name: value} for value in self.param_values.tolist()]
+        )
+        return build_pareto_front(
+            objectives,
+            minimize=minimize,
+            ids=point_ids,
+            objective_names=objective_names,
+            metadata=point_metadata,
+            atol=atol,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ad_diagnostics.py
+++ b/tests/test_ad_diagnostics.py
@@ -1,0 +1,464 @@
+import json
+from pathlib import Path
+
+
+import jax.ad_checkpoint as ad_checkpoint
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import rfx
+from rfx.ad_diagnostics import (
+    ADParserHealth,
+    ADResidualGroup,
+    ADResidualInspection,
+    ADResidualRecord,
+    ADSavedResidualDiagnosticReport,
+    diagnose_ad_saved_residuals,
+    inspect_ad_saved_residuals,
+    parse_saved_residual_line,
+)
+
+
+def test_parse_saved_residual_line_preserves_named_record():
+    record = parse_saved_residual_line("f32[2,3] named 'sin_x' from demo.py:10 (loss)")
+
+    assert record.aval == "f32[2,3]"
+    assert record.dtype == "f32"
+    assert record.shape == (2, 3)
+    assert record.size == 6
+    assert record.estimated_bytes == 24
+    assert record.source_kind == "named"
+    assert record.name == "sin_x"
+    assert record.to_dict()["shape"] == [2, 3]
+
+def test_parse_saved_residual_line_handles_scalar_and_unknown_dtype():
+    scalar = parse_saved_residual_line("f32[] from the argument x")
+    unknown = parse_saved_residual_line("token[2] output of custom from demo.py:1 (f)")
+
+    assert scalar.shape == ()
+    assert scalar.size == 1
+    assert scalar.estimated_bytes == 4
+    assert unknown.dtype == "token"
+    assert unknown.shape == (2,)
+    assert unknown.size == 2
+    assert unknown.estimated_bytes is None
+
+
+def test_parse_saved_residual_line_handles_unknown_future_format():
+    record = parse_saved_residual_line("future-format without parsed aval")
+
+    assert record.raw_line == "future-format without parsed aval"
+    assert record.dtype is None
+    assert record.shape is None
+    assert record.estimated_bytes is None
+    assert record.source_kind == "unknown"
+
+
+def test_inspect_ad_saved_residuals_returns_structured_static_artifact():
+    def loss(x, scale=1.0):
+        named = ad_checkpoint.checkpoint_name(jnp.sin(x * scale), "sin_x")
+        return jnp.sum(named * jnp.cos(x))
+
+    inspection = inspect_ad_saved_residuals(loss, jnp.ones((2, 3)), scale=2.0)
+    artifact = inspection.to_dict()
+
+    assert inspection.evidence_class == "jax_saved_residuals_inspection"
+    assert artifact["evidence_class"] == "jax_saved_residuals_inspection"
+    assert inspection.records
+    assert any(record.name == "sin_x" for record in inspection.records)
+    assert any(record.source_kind == "argument" for record in inspection.records)
+    assert all(record.raw_line for record in inspection.records)
+    assert inspection.unknown_estimate_count == 0
+    known_bytes = [
+        record.estimated_bytes
+        for record in inspection.records
+        if record.estimated_bytes is not None
+    ]
+    assert inspection.total_estimated_bytes == sum(known_bytes)
+    assert inspection.total_estimated_gb == pytest.approx(
+        inspection.total_estimated_bytes / 1e9
+    )
+    assert json.loads(inspection.to_json()) == artifact
+
+
+def test_inspect_ad_saved_residuals_public_export_identity():
+    assert rfx.ADResidualInspection is ADResidualInspection
+    assert rfx.ADResidualRecord is ADResidualRecord
+    assert rfx.inspect_ad_saved_residuals is inspect_ad_saved_residuals
+    assert rfx.parse_saved_residual_line is parse_saved_residual_line
+    assert rfx.ADParserHealth is ADParserHealth
+    assert rfx.ADResidualGroup is ADResidualGroup
+    assert rfx.ADSavedResidualDiagnosticReport is ADSavedResidualDiagnosticReport
+    assert rfx.diagnose_ad_saved_residuals is diagnose_ad_saved_residuals
+
+
+def test_ad_residual_inspection_rejects_nonfinite_json():
+    bad = ADResidualInspection(
+        records=(),
+        raw_lines=(),
+        total_estimated_bytes=1,
+        total_estimated_gb=float("nan"),
+        unknown_estimate_count=0,
+    )
+
+    with pytest.raises(ValueError, match="Out of range"):
+        bad.to_json()
+    with pytest.raises(ValueError, match="Out of range"):
+        bad.to_json(allow_nan=True)
+
+def test_diagnose_ad_saved_residuals_returns_actionable_report():
+    def loss(x, scale=1.0):
+        named = ad_checkpoint.checkpoint_name(jnp.sin(x * scale), "sin_x")
+        return jnp.sum(named * jnp.cos(x))
+
+    report = diagnose_ad_saved_residuals(
+        loss,
+        jnp.ones((2, 3)),
+        scale=2.0,
+        top_n=2,
+        workflow="toy-loss",
+        context={"n_steps": 12},
+        artifacts={"plan": {"evidence_class": "calibrated_conservative_plan"}},
+    )
+    artifact = report.to_dict()
+
+    assert report.evidence_class == "rfx_ad_saved_residuals_diagnostic"
+    assert report.source_evidence_class == "jax_saved_residuals_inspection"
+    assert report.workflow == "toy-loss"
+    assert report.context == {"n_steps": 12}
+    assert artifact["artifact_snapshots"]["plan"]["evidence_class"] == "calibrated_conservative_plan"
+    assert report.top_residuals
+    assert len(report.top_residuals) <= 2
+    assert report.top_residuals[0].estimated_bytes >= report.top_residuals[-1].estimated_bytes
+    assert report.groups
+    assert report.parser_health.record_count == len(report.inspection.records)
+    assert report.parser_health.unknown_count == report.inspection.unknown_estimate_count
+    assert report.known_estimated_bytes == sum(
+        record.estimated_bytes or 0 for record in report.inspection.records
+    )
+    assert report.known_only_bytes == report.known_estimated_bytes
+    assert artifact["known_only_bytes"] == report.known_estimated_bytes
+    assert report.total_estimated_bytes == report.inspection.total_estimated_bytes
+    assert report.jax_version
+    assert any("trace-time JAX saved-residual" in rec for rec in report.recommendations)
+    assert any("residual bytes do not prove budget fit" in rec for rec in report.recommendations)
+    assert any("separate gradient checks" in rec for rec in report.recommendations)
+    assert json.loads(report.to_json()) == artifact
+
+
+def test_diagnostic_report_handles_unknown_lines_without_fake_totals():
+    inspection = ADResidualInspection(
+        records=(
+            ADResidualRecord(
+                aval="f32[2]",
+                source="from the argument x",
+                dtype="f32",
+                shape=(2,),
+                size=2,
+                estimated_bytes=8,
+                source_kind="argument",
+                raw_line="f32[2] from the argument x",
+                line_index=0,
+            ),
+            ADResidualRecord(
+                aval="token[2]",
+                source="output of custom",
+                dtype="token",
+                shape=(2,),
+                size=2,
+                estimated_bytes=None,
+                source_kind="intermediate",
+                raw_line="token[2] output of custom",
+                line_index=1,
+            ),
+        ),
+        raw_lines=("f32[2] from the argument x", "token[2] output of custom"),
+        total_estimated_bytes=None,
+        total_estimated_gb=None,
+        unknown_estimate_count=1,
+    )
+    health = ADParserHealth(
+        record_count=2,
+        known_count=1,
+        unknown_count=1,
+        unknown_fraction=0.5,
+        warnings=("partial",),
+    )
+    group = ADResidualGroup(
+        key="argument|dtype=f32",
+        source_kind="argument",
+        name=None,
+        dtype="f32",
+        record_count=1,
+        known_count=1,
+        unknown_count=0,
+        known_estimated_bytes=8,
+        line_indices=(0,),
+    )
+    report = ADSavedResidualDiagnosticReport(
+        inspection=inspection,
+        top_residuals=(inspection.records[0],),
+        groups=(group,),
+        parser_health=health,
+        known_estimated_bytes=8,
+        known_estimated_gb=8e-9,
+        total_estimated_bytes=None,
+        total_estimated_gb=None,
+        jax_version="test",
+        workflow=None,
+        context=None,
+        artifact_snapshots={},
+        recommendations=("Inspect raw_lines before comparing byte totals.",),
+    )
+    artifact = report.to_dict()
+
+    assert artifact["known_estimated_bytes"] == 8
+    assert artifact["total_estimated_bytes"] is None
+    assert artifact["parser_health"]["unknown_count"] == 1
+    assert artifact["top_residuals"][0]["line_index"] == 0
+    assert json.loads(report.to_json()) == artifact
+
+
+def test_diagnostic_report_rejects_nonfinite_json():
+    report = ADSavedResidualDiagnosticReport(
+        inspection=ADResidualInspection(
+            records=(),
+            raw_lines=(),
+            total_estimated_bytes=None,
+            total_estimated_gb=None,
+            unknown_estimate_count=0,
+        ),
+        top_residuals=(),
+        groups=(),
+        parser_health=ADParserHealth(
+            record_count=0,
+            known_count=0,
+            unknown_count=0,
+            unknown_fraction=float("nan"),
+            warnings=(),
+        ),
+        known_estimated_bytes=0,
+        known_estimated_gb=0.0,
+        total_estimated_bytes=None,
+        total_estimated_gb=None,
+        jax_version="test",
+        workflow=None,
+        context=None,
+        artifact_snapshots={},
+        recommendations=(),
+    )
+
+    with pytest.raises(ValueError, match="Out of range"):
+        report.to_json()
+    with pytest.raises(ValueError, match="Out of range"):
+        report.to_json(allow_nan=True)
+
+
+def _small_preflight_sim() -> rfx.Simulation:
+    sim = rfx.Simulation(
+        freq_max=10e9,
+        domain=(10e-3, 10e-3, 5e-3),
+        dx=1e-3,
+        boundary="cpml",
+        cpml_layers=2,
+    )
+    sim.add_source((5e-3, 5e-3, 2e-3), "ez")
+    sim.add_probe((5e-3, 5e-3, 3e-3), "ez")
+    return sim
+
+
+def _toy_residual_loss(x, *, scale=1.0):
+    named = ad_checkpoint.checkpoint_name(jnp.sin(x * scale), "preflight_sin_x")
+    return jnp.sum(named * jnp.cos(x))
+
+
+class _ValidDictContext:
+    def to_dict(self):
+        return {"kind": "dict", "values": np.array([1, 2], dtype=np.int32)}
+
+
+class _ValidJsonContext:
+    def to_json(self):
+        return json.dumps({"kind": "json", "values": [3, 4]})
+
+
+class _BadDictContext:
+    def to_dict(self):
+        return {"bad": object()}
+
+
+class _BadJsonContext:
+    def to_json(self):
+        return json.dumps({"bad": float("nan")})
+
+
+def test_ad_memory_preflight_composes_residual_diagnostic():
+    sim = _small_preflight_sim()
+
+    report = sim.ad_memory_preflight(
+        n_steps=120,
+        available_memory_gb=0.002,
+        residual_fun=_toy_residual_loss,
+        residual_args=(jnp.ones((2, 3)),),
+        residual_kwargs={"scale": 2.0},
+        residual_top_n=2,
+        residual_workflow="preflight-toy-loss",
+        residual_context={
+            "case": "toy",
+            "shape": np.array([2, 3], dtype=np.int32),
+            "scale": np.float32(2.0),
+            "jax_array": jnp.array([1.0, 2.0]),
+            "jax_scalar": jnp.array(3.0),
+            "nested": [{"values": (jnp.array(4.0), np.array([5, 6]))}],
+            "dict_obj": _ValidDictContext(),
+            "json_obj": _ValidJsonContext(),
+        },
+    )
+    diagnostic = report.residual_diagnostic
+    artifact = report.to_dict()
+    diagnostic_artifact = artifact["residual_diagnostic"]
+
+    assert diagnostic is not None
+    assert diagnostic.evidence_class == "rfx_ad_saved_residuals_diagnostic"
+    assert diagnostic.source_evidence_class == "jax_saved_residuals_inspection"
+    assert report.source_evidence_classes == (
+        "calibrated_conservative_plan",
+        "static_estimate",
+        "static_ad_explainability",
+        "jax_saved_residuals_inspection",
+        "rfx_ad_saved_residuals_diagnostic",
+    )
+    assert diagnostic.workflow == "preflight-toy-loss"
+    assert diagnostic.context["case"] == "toy"
+    assert diagnostic.context["shape"] == [2, 3]
+    assert diagnostic.context["scale"] == pytest.approx(2.0)
+    assert diagnostic.context["jax_array"] == [1.0, 2.0]
+    assert diagnostic.context["jax_scalar"] == pytest.approx(3.0)
+    assert diagnostic.context["nested"] == [{"values": [4.0, [5, 6]]}]
+    assert diagnostic.context["dict_obj"] == {"kind": "dict", "values": [1, 2]}
+    assert diagnostic.context["json_obj"] == {"kind": "json", "values": [3, 4]}
+    assert diagnostic.context["n_steps"] == report.n_steps
+    assert diagnostic.context["available_memory_gb"] == report.available_memory_gb
+    assert diagnostic.context["target_fraction"] == report.target_fraction
+    assert diagnostic.context["target_memory_gb"] == report.target_memory_gb
+    assert diagnostic.context["fit_safety_factor"] == report.fit_safety_factor
+    assert diagnostic.context["preflight_status"] == report.status
+    assert diagnostic.context["checkpoint_mode"] == report.supported_checkpoint_mode
+    assert diagnostic.context["checkpoint_every"] == report.checkpoint_every
+    assert diagnostic.context["checkpoint_segments"] == report.checkpoint_segments
+    assert diagnostic_artifact["evidence_class"] == "rfx_ad_saved_residuals_diagnostic"
+    assert diagnostic_artifact["source_evidence_class"] == "jax_saved_residuals_inspection"
+    assert diagnostic_artifact["artifact_snapshots"]["memory_plan"]["evidence_class"] == "calibrated_conservative_plan"
+    assert diagnostic_artifact["artifact_snapshots"]["explainability"]["evidence_class"] == "static_ad_explainability"
+    assert diagnostic_artifact["artifact_snapshots"]["mesh_report"]["ad_memory"]["evidence_class"] == "static_estimate"
+    assert any(hint.code == "inspect_saved_residuals" for hint in report.action_hints)
+    assert any(
+        hint.code == "validate_physics_separately" and not hint.blocking
+        for hint in report.action_hints
+    )
+    assert json.loads(report.to_json()) == artifact
+
+
+def test_ad_memory_preflight_propagates_residual_trace_errors():
+    sim = _small_preflight_sim()
+
+    def bad_loss(x):
+        raise RuntimeError("trace exploded")
+
+    with pytest.raises(RuntimeError, match="trace exploded"):
+        sim.ad_memory_preflight(
+            n_steps=120,
+            available_memory_gb=0.002,
+            include_mesh_report=False,
+            residual_fun=bad_loss,
+            residual_args=(jnp.ones((2, 3)),),
+        )
+
+
+def test_ad_memory_preflight_residual_context_rejects_unsupported_values():
+    sim = _small_preflight_sim()
+
+    with pytest.raises(TypeError, match="residual_context"):
+        sim.ad_memory_preflight(
+            n_steps=120,
+            available_memory_gb=0.002,
+            include_mesh_report=False,
+            residual_fun=_toy_residual_loss,
+            residual_args=(jnp.ones((2, 3)),),
+            residual_context={"bad": object()},
+        )
+
+    with pytest.raises(TypeError, match="residual_context"):
+        sim.ad_memory_preflight(
+            n_steps=120,
+            available_memory_gb=0.002,
+            include_mesh_report=False,
+            residual_context={"bad": object()},
+        )
+
+    with pytest.raises(TypeError, match="residual_context"):
+        sim.ad_memory_preflight(
+            n_steps=120,
+            available_memory_gb=0.002,
+            include_mesh_report=False,
+            residual_context={"bad": _BadDictContext()},
+        )
+
+
+def test_ad_memory_preflight_residual_context_rejects_nonfinite_values():
+    sim = _small_preflight_sim()
+
+    with pytest.raises(ValueError, match="residual_context.*non-finite JSON|non-finite JSON.*residual_context"):
+        sim.ad_memory_preflight(
+            n_steps=120,
+            available_memory_gb=0.002,
+            include_mesh_report=False,
+            residual_fun=_toy_residual_loss,
+            residual_args=(jnp.ones((2, 3)),),
+            residual_context={"bad": float("nan")},
+        )
+
+    with pytest.raises(ValueError, match="residual_context.*non-finite JSON|non-finite JSON.*residual_context"):
+        sim.ad_memory_preflight(
+            n_steps=120,
+            available_memory_gb=0.002,
+            include_mesh_report=False,
+            residual_context={"bad": float("nan")},
+        )
+
+    with pytest.raises(ValueError, match="residual_context.*non-finite JSON|non-finite JSON.*residual_context"):
+        sim.ad_memory_preflight(
+            n_steps=120,
+            available_memory_gb=0.002,
+            include_mesh_report=False,
+            residual_context={"bad": np.array([np.nan])},
+        )
+
+    with pytest.raises(ValueError, match="residual_context.*non-finite JSON|non-finite JSON.*residual_context"):
+        sim.ad_memory_preflight(
+            n_steps=120,
+            available_memory_gb=0.002,
+            include_mesh_report=False,
+            residual_context={"bad": jnp.array([jnp.inf])},
+        )
+
+    with pytest.raises(ValueError, match="residual_context.*non-finite JSON|non-finite JSON.*residual_context"):
+        sim.ad_memory_preflight(
+            n_steps=120,
+            available_memory_gb=0.002,
+            include_mesh_report=False,
+            residual_context={"bad": _BadJsonContext()},
+        )
+
+def test_memory_reduction_docs_include_residual_inspection_boundary():
+    doc = Path("docs/public/guide/memory-reduction.mdx").read_text()
+
+    assert "`jax_saved_residuals_inspection`" in doc
+    assert "`rfx_ad_saved_residuals_diagnostic`" in doc
+    assert "diagnose_ad_saved_residuals(...)" in doc
+    assert "inspect_ad_saved_residuals(...)" in doc
+    assert "not profiling" in doc
+    assert "not an XLA memory report" in doc or "not XLA memory analysis" in doc
+    assert "not a certificate" in doc
+    assert "not RF validation" in doc

--- a/tests/test_estimate_ad_memory.py
+++ b/tests/test_estimate_ad_memory.py
@@ -21,11 +21,39 @@ during reverse-mode).
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import numpy as np
 import pytest
 
-from rfx import ADMemoryPlan, Simulation
+from rfx import ADMemoryPlan, AD_MemoryEstimate, MeshIntelligenceReport, Simulation
+from rfx.api import AD_MEMORY_FIT_SAFETY_FACTOR
+
+_FORBIDDEN_CURRENT_EVIDENCE_FIELDS = {
+    "compiler_memory_gb",
+    "compiler_reported_required_gb",
+    "observed_peak_gb",
+    "profile_peak_gb",
+    "certificate_status",
+    "scope_digest",
+    "config_digest",
+    "environment_digest",
+    "is_valid_certificate",
+    "is_budget_safe",
+    "peak_bound_gb",
+}
+
+_FORBIDDEN_RECOMMENDATION_TERMS = (
+    "guarantee",
+    "guaranteed",
+    "certified",
+    "certificate",
+    "peak_bound",
+)
+
+
+def _assert_no_forbidden_current_fields(artifact: dict[str, object]) -> None:
+    assert _FORBIDDEN_CURRENT_EVIDENCE_FIELDS.isdisjoint(artifact)
 
 
 def _patch_like_sim():
@@ -40,6 +68,161 @@ def _patch_like_sim():
     sim.add_source((ext / 2, ext / 2, 1e-3), "ez")
     sim.add_probe((ext / 2, ext / 2, 2e-3), "ez")
     return sim
+
+
+def _uniform_sim():
+    sim = Simulation(
+        freq_max=10e9,
+        domain=(10e-3, 10e-3, 5e-3),
+        dx=1e-3,
+        boundary="cpml",
+        cpml_layers=2,
+    )
+    sim.add_source((5e-3, 5e-3, 2e-3), "ez")
+    sim.add_probe((5e-3, 5e-3, 3e-3), "ez")
+    return sim
+
+
+def _grid_shape(sim: Simulation) -> tuple[int, int, int]:
+    dx = sim._dx or (299_792_458.0 / sim._freq_max / 20.0)
+
+    def _axis_cells(extent: float, profile) -> int:
+        if profile is not None:
+            return len(profile) + 1 + 2 * sim._cpml_layers
+        return int(np.ceil(extent / dx)) + 1 + 2 * sim._cpml_layers
+
+    return (
+        _axis_cells(sim._domain[0], sim._dx_profile),
+        _axis_cells(sim._domain[1], sim._dy_profile),
+        _axis_cells(sim._domain[2], sim._dz_profile),
+    )
+
+
+def _design_mask(sim: Simulation, *, fraction: float = 0.25) -> np.ndarray:
+    mask = np.zeros(_grid_shape(sim), dtype=bool)
+    selected = max(1, int(mask.size * fraction))
+    mask.reshape(-1)[:selected] = True
+    return mask
+
+
+def test_public_imports_and_json_roundtrip():
+    from rfx import ADMemoryPlan as TopPlan
+    from rfx import AD_MemoryEstimate as TopEstimate
+    from rfx import Simulation as TopSimulation
+    from rfx.api import ADMemoryPlan as ApiPlan
+    from rfx.api import AD_MemoryEstimate as ApiEstimate
+    from rfx.api import Simulation as ApiSimulation
+
+    assert TopEstimate is ApiEstimate is AD_MemoryEstimate
+    assert TopPlan is ApiPlan is ADMemoryPlan
+    assert TopSimulation is ApiSimulation is Simulation
+
+    sim = _uniform_sim()
+    estimate = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
+    plan = sim.plan_ad_memory(n_steps=120, available_memory_gb=100.0)
+
+    assert json.loads(estimate.to_json()) == estimate.to_dict()
+    assert json.loads(plan.to_json()) == plan.to_dict()
+    assert estimate.to_dict()["checkpoint_segments"] == 10
+    estimate_keys = {
+        "evidence_class",
+        "forward_gb",
+        "ad_checkpointed_gb",
+        "ad_full_gb",
+        "ntff_dft_gb",
+        "available_gb",
+        "warning",
+        "ad_segmented_gb",
+        "checkpoint_every",
+        "checkpoint_segments",
+        "ad_active_steps",
+        "ad_active_design_fraction",
+        "ad_segmented_active_segments",
+    }
+    assert estimate.to_dict()["evidence_class"] == "static_estimate"
+    plan_keys = {
+        "evidence_class",
+        "n_steps",
+        "available_memory_gb",
+        "target_fraction",
+        "target_memory_gb",
+        "fit_safety_factor",
+        "checkpoint_every",
+        "checkpoint_segments",
+        "checkpoint_mode",
+        "selected_estimate",
+        "full_ad_fits",
+        "segmented_fits",
+        "recommendation",
+    }
+    assert plan.to_dict()["evidence_class"] == "calibrated_conservative_plan"
+    assert set(estimate.to_dict()) == estimate_keys
+    assert set(plan.to_dict()) == plan_keys
+    assert set(plan.to_dict()["selected_estimate"]) == estimate_keys
+    assert plan.to_dict()["selected_estimate"]["evidence_class"] == "static_estimate"
+    _assert_no_forbidden_current_fields(estimate.to_dict())
+    _assert_no_forbidden_current_fields(plan.to_dict())
+    _assert_no_forbidden_current_fields(plan.to_dict()["selected_estimate"])
+    assert "evidence_class" not in AD_MemoryEstimate._fields
+    assert "evidence_class" not in ADMemoryPlan._fields
+    with pytest.raises(ValueError):
+        estimate._replace(evidence_class="observed_profile")
+    with pytest.raises(ValueError):
+        plan._replace(evidence_class="bounded_certificate")
+
+
+def test_current_memory_artifacts_keep_evidence_classes_separate():
+    sim = _patch_like_sim()
+    estimate = sim.estimate_ad_memory(n_steps=10_000, checkpoint_every=500)
+    plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=1.0)
+    report = sim.mesh_intelligence_report(
+        n_steps=10_000,
+        checkpoint_every=plan.checkpoint_every,
+        available_memory_gb=1.0,
+    )
+
+    estimate_artifact = estimate.to_dict()
+    plan_artifact = plan.to_dict()
+    report_artifact = report.to_dict()
+
+    assert estimate_artifact["evidence_class"] == "static_estimate"
+    assert plan_artifact["evidence_class"] == "calibrated_conservative_plan"
+    assert plan_artifact["selected_estimate"]["evidence_class"] == "static_estimate"
+    assert report_artifact["ad_memory"]["evidence_class"] == "static_estimate"
+
+    _assert_no_forbidden_current_fields(estimate_artifact)
+    _assert_no_forbidden_current_fields(plan_artifact)
+    _assert_no_forbidden_current_fields(plan_artifact["selected_estimate"])
+    _assert_no_forbidden_current_fields(report_artifact["ad_memory"])
+
+
+def test_current_memory_recommendations_do_not_claim_guarantees():
+    sim = _patch_like_sim()
+    plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=1.0)
+    report = sim.mesh_intelligence_report(
+        n_steps=10_000,
+        checkpoint_every=plan.checkpoint_every,
+        available_memory_gb=1.0,
+    )
+
+    texts = [
+        plan.recommendation,
+        report.recommendation,
+        sim.estimate_ad_memory(n_steps=10_000, available_memory_gb=1e-6).warning,
+    ]
+    for text in texts:
+        assert text is not None
+        lowered = text.lower()
+        assert not any(term in lowered for term in _FORBIDDEN_RECOMMENDATION_TERMS)
+
+
+def test_memory_reduction_docs_separate_planning_from_certificate_evidence():
+    doc = Path("docs/public/guide/memory-reduction.mdx").read_text()
+    assert "`static_estimate`" in doc
+    assert "`calibrated_conservative_plan`" in doc
+    assert "`bounded_certificate`" in doc
+    assert "Current `estimate_ad_memory(...)` and `plan_ad_memory(...)` artifacts are not certificates" in doc
+    assert "not a universal guaranteed peak predictor" in doc
 
 
 @pytest.mark.parametrize("chunk,observed_gb", [
@@ -59,6 +242,7 @@ def test_segmented_estimate_within_tolerance(chunk, observed_gb):
     assert 0.5 * observed_gb <= pred <= 2.0 * observed_gb, (
         f"chunk={chunk}: predicted {pred:.3f} GB vs observed {observed_gb} GB"
     )
+    assert pred * AD_MEMORY_FIT_SAFETY_FACTOR >= observed_gb
 
 
 def test_checkpoint_every_none_leaves_segmented_null():
@@ -85,10 +269,13 @@ def test_plan_ad_memory_returns_none_when_full_ad_fits():
 
     assert isinstance(plan, ADMemoryPlan)
     assert plan.full_ad_fits is True
-    assert plan.segmented_fits is True
+    assert plan.segmented_fits is False
     assert plan.checkpoint_every is None
     assert plan.selected_estimate.checkpoint_every is None
-    assert plan.selected_estimate.ad_full_gb <= plan.target_memory_gb
+    assert plan.checkpoint_segments is None
+    assert plan.checkpoint_mode is None
+    assert plan.selected_estimate.ad_full_gb * plan.fit_safety_factor <= plan.target_memory_gb
+    assert plan.selected_estimate.ad_segmented_gb is None
 
 
 def test_plan_ad_memory_recommends_checkpoint_every_for_budget():
@@ -100,14 +287,38 @@ def test_plan_ad_memory_recommends_checkpoint_every_for_budget():
     assert plan.segmented_fits is True
     assert plan.checkpoint_every is not None
     assert plan.selected_estimate.checkpoint_every == plan.checkpoint_every
-    assert plan.selected_estimate.ad_segmented_gb <= plan.target_memory_gb
+    assert plan.checkpoint_segments is None
+    assert plan.checkpoint_mode == "checkpoint_every"
+    assert plan.selected_estimate.ad_segmented_gb * plan.fit_safety_factor <= plan.target_memory_gb
     if plan.checkpoint_every > 1:
         previous = sim.estimate_ad_memory(
             n_steps=10_000,
             available_memory_gb=1.0,
             checkpoint_every=plan.checkpoint_every - 1,
         )
-        assert previous.ad_segmented_gb > plan.target_memory_gb
+        assert previous.ad_segmented_gb * plan.fit_safety_factor > plan.target_memory_gb
+
+
+def test_plan_ad_memory_checkpoint_every_handles_unaligned_warmup():
+    sim = _patch_like_sim()
+
+    plan = sim.plan_ad_memory(
+        n_steps=120,
+        available_memory_gb=0.35,
+        n_warmup=49,
+    )
+
+    assert plan.segmented_fits is True
+    assert plan.checkpoint_mode == "checkpoint_every"
+    assert plan.checkpoint_every == 12
+    previous = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=0.35,
+        checkpoint_every=11,
+        n_warmup=49,
+    )
+    assert previous.ad_segmented_gb * plan.fit_safety_factor > plan.target_memory_gb
+    assert plan.selected_estimate.ad_segmented_gb * plan.fit_safety_factor <= plan.target_memory_gb
 
 
 def test_plan_ad_memory_reports_unfit_budget():
@@ -119,7 +330,53 @@ def test_plan_ad_memory_reports_unfit_budget():
     assert plan.segmented_fits is False
     assert plan.checkpoint_every == 10_000
     assert plan.selected_estimate.ad_segmented_gb > plan.target_memory_gb
+    assert plan.checkpoint_segments is None
+    assert plan.checkpoint_mode == "checkpoint_every"
     assert "reduce mesh size" in plan.recommendation
+
+    report = sim.mesh_intelligence_report(
+        n_steps=10_000,
+        checkpoint_every=plan.checkpoint_every,
+        available_memory_gb=0.001,
+    )
+    assert "exceeds 85%" in report.recommendation
+    assert "use segmented AD estimate" not in report.recommendation
+
+
+def test_plan_ad_memory_reports_uniform_unfit_budget():
+    sim = _uniform_sim()
+
+    plan = sim.plan_ad_memory(n_steps=120, available_memory_gb=1e-6)
+
+    assert plan.full_ad_fits is False
+    assert plan.segmented_fits is False
+    assert plan.checkpoint_every is None
+    assert plan.checkpoint_segments == 1
+    assert plan.checkpoint_mode == "checkpoint_segments"
+    assert plan.selected_estimate.ad_segmented_gb > plan.target_memory_gb
+    assert "checkpoint_segments=1" in plan.recommendation
+    assert "reduce mesh size" in plan.recommendation
+
+
+def test_plan_ad_memory_uses_valid_custom_target_fraction():
+    sim = _patch_like_sim()
+
+    plan = sim.plan_ad_memory(
+        n_steps=10_000,
+        available_memory_gb=1.0,
+        target_fraction=0.5,
+    )
+
+    assert plan.target_fraction == 0.5
+    assert plan.target_memory_gb == 0.5
+    assert plan.selected_estimate.ad_segmented_gb * plan.fit_safety_factor <= plan.target_memory_gb
+    if plan.checkpoint_every > 1:
+        previous = sim.estimate_ad_memory(
+            n_steps=10_000,
+            available_memory_gb=1.0,
+            checkpoint_every=plan.checkpoint_every - 1,
+        )
+        assert previous.ad_segmented_gb * plan.fit_safety_factor > plan.target_memory_gb
 
 
 def test_plan_ad_memory_serializes_artifact():
@@ -132,4 +389,534 @@ def test_plan_ad_memory_serializes_artifact():
     assert artifact["checkpoint_every"] == plan.checkpoint_every
     assert artifact["selected_estimate"]["checkpoint_every"] == plan.checkpoint_every
     assert artifact["segmented_fits"] is True
+    assert artifact["checkpoint_segments"] == plan.checkpoint_segments
+    assert artifact["checkpoint_mode"] == plan.checkpoint_mode
+    assert artifact["fit_safety_factor"] == plan.fit_safety_factor
+    assert artifact["selected_estimate"]["ad_segmented_active_segments"] is not None
     assert parsed == artifact
+
+
+def test_checkpoint_segments_accounting_matches_uniform_segment_count():
+    sim = _uniform_sim()
+
+    by_segments = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
+    by_chunk = sim.estimate_ad_memory(n_steps=120, checkpoint_every=12)
+
+    assert by_segments.checkpoint_segments == 10
+    assert by_segments.checkpoint_every is None
+    assert by_segments.ad_segmented_gb == by_chunk.ad_segmented_gb
+    assert by_segments.ad_segmented_active_segments == 10
+    assert by_chunk.ad_segmented_active_segments == 10
+    assert by_segments.to_dict()["checkpoint_segments"] == 10
+
+
+def test_checkpoint_segments_active_count_honors_warmup():
+    sim = _uniform_sim()
+
+    full = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
+    warm = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_segments=10,
+        n_warmup=60,
+    )
+
+    assert warm.forward_gb == full.forward_gb
+    assert warm.ad_active_steps == 60
+    assert warm.ad_segmented_gb < full.ad_segmented_gb
+    assert warm.ad_segmented_active_segments == 5
+    same_active_segments = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_every=12,
+        n_warmup=60,
+    )
+    assert warm.ad_segmented_gb == same_active_segments.ad_segmented_gb
+
+    partial_warm = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_segments=10,
+        n_warmup=61,
+    )
+    partial_same_active_segments = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_every=12,
+        n_warmup=61,
+    )
+    assert partial_warm.ad_active_steps == 59
+    assert partial_warm.ad_segmented_gb == partial_same_active_segments.ad_segmented_gb
+    assert partial_warm.ad_segmented_gb == warm.ad_segmented_gb
+    assert partial_warm.ad_segmented_active_segments == 5
+    assert partial_same_active_segments.ad_segmented_active_segments == 5
+
+
+def test_checkpoint_every_active_count_honors_unaligned_warmup():
+    sim = _uniform_sim()
+
+    unaligned = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_every=50,
+        n_warmup=49,
+    )
+    three_active_segments = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_segments=3,
+    )
+    boundary = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_every=50,
+        n_warmup=50,
+    )
+    two_active_segments = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_segments=2,
+    )
+
+    assert unaligned.ad_active_steps == 71
+    assert unaligned.ad_segmented_gb == three_active_segments.ad_segmented_gb
+    assert unaligned.ad_segmented_active_segments == 3
+    assert boundary.ad_active_steps == 70
+    assert boundary.ad_segmented_gb == two_active_segments.ad_segmented_gb
+    assert boundary.ad_segmented_active_segments == 2
+
+
+def test_plan_ad_memory_recommends_checkpoint_segments_for_uniform_budget():
+    sim = _uniform_sim()
+
+    plan = sim.plan_ad_memory(n_steps=120, available_memory_gb=0.002)
+
+    assert plan.full_ad_fits is False
+    assert plan.segmented_fits is True
+    assert plan.checkpoint_every is None
+    assert plan.checkpoint_segments == 10
+    assert plan.checkpoint_mode == "checkpoint_segments"
+    assert plan.selected_estimate.checkpoint_segments == plan.checkpoint_segments
+    assert plan.selected_estimate.ad_segmented_gb * plan.fit_safety_factor <= plan.target_memory_gb
+    assert "0.00 GB" not in plan.recommendation
+    assert "MB" in plan.recommendation
+
+
+def test_estimate_rejects_ambiguous_checkpoint_modes():
+    sim = _uniform_sim()
+
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        sim.estimate_ad_memory(
+            n_steps=120,
+            checkpoint_every=12,
+            checkpoint_segments=10,
+        )
+
+
+def test_estimate_rejects_invalid_checkpoint_segments():
+    sim = _uniform_sim()
+
+    with pytest.raises(ValueError, match="does not divide n_steps"):
+        sim.estimate_ad_memory(n_steps=120, checkpoint_segments=11)
+    with pytest.raises(ValueError, match="checkpoint_segments must be"):
+        sim.estimate_ad_memory(n_steps=120, checkpoint_segments=0)
+    with pytest.raises(ValueError, match="checkpoint_segments must be"):
+        sim.estimate_ad_memory(n_steps=120, checkpoint_segments=-1)
+
+
+def test_estimate_rejects_invalid_active_tape_inputs():
+    sim = _uniform_sim()
+
+    with pytest.raises(ValueError, match="n_steps must be positive"):
+        sim.estimate_ad_memory(n_steps=0)
+    with pytest.raises(ValueError, match="n_warmup must be >= 0"):
+        sim.estimate_ad_memory(n_steps=120, n_warmup=-1)
+    with pytest.raises(ValueError, match="must be < n_steps"):
+        sim.estimate_ad_memory(n_steps=120, n_warmup=120)
+    with pytest.raises(ValueError, match="checkpoint_every must be positive"):
+        sim.estimate_ad_memory(n_steps=120, checkpoint_every=0)
+    with pytest.raises(ValueError, match="checkpoint_every must be positive"):
+        sim.estimate_ad_memory(n_steps=120, checkpoint_every=-1)
+    with pytest.raises(ValueError, match="design_mask must be non-empty"):
+        sim.estimate_ad_memory(n_steps=120, design_mask=np.array([], dtype=bool))
+    with pytest.raises(ValueError, match="boolean array matching grid shape"):
+        sim.estimate_ad_memory(n_steps=120, design_mask=np.array(True))
+    with pytest.raises(TypeError, match="boolean dtype"):
+        sim.estimate_ad_memory(
+            n_steps=120,
+            design_mask=np.ones(_grid_shape(sim), dtype=np.int8),
+        )
+    with pytest.raises(ValueError, match="select at least one cell"):
+        sim.estimate_ad_memory(
+            n_steps=120,
+            design_mask=np.zeros(_grid_shape(sim), dtype=bool),
+        )
+    with pytest.raises(ValueError, match="must match simulation grid shape"):
+        sim.estimate_ad_memory(
+            n_steps=120,
+            design_mask=np.ones((2, 2, 2), dtype=bool),
+        )
+    with pytest.raises(TypeError, match="n_steps must be an integer"):
+        sim.estimate_ad_memory(n_steps=1.5)
+    with pytest.raises(TypeError, match="n_steps must be an integer"):
+        sim.estimate_ad_memory(n_steps=True)
+    with pytest.raises(TypeError, match="n_warmup must be an integer"):
+        sim.estimate_ad_memory(n_steps=120, n_warmup=1.5)
+    with pytest.raises(TypeError, match="checkpoint_every must be an integer"):
+        sim.estimate_ad_memory(n_steps=120, checkpoint_every=12.5)
+    with pytest.raises(TypeError, match="checkpoint_segments must be an integer"):
+        sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10.5)
+    with pytest.raises(ValueError, match="available_memory_gb must be positive"):
+        sim.estimate_ad_memory(n_steps=120, available_memory_gb=0.0)
+    with pytest.raises(ValueError, match="available_memory_gb must be positive"):
+        sim.estimate_ad_memory(n_steps=120, available_memory_gb=-1.0)
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.estimate_ad_memory(n_steps=120, available_memory_gb=True)
+    with pytest.raises(ValueError, match="available_memory_gb must be finite"):
+        sim.estimate_ad_memory(n_steps=120, available_memory_gb=float("nan"))
+    with pytest.raises(ValueError, match="available_memory_gb must be finite"):
+        sim.estimate_ad_memory(n_steps=120, available_memory_gb=float("inf"))
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.estimate_ad_memory(n_steps=120, available_memory_gb=[1.0])
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.estimate_ad_memory(n_steps=120, available_memory_gb=1 + 0j)
+
+
+def test_plan_ad_memory_rejects_invalid_scalar_inputs():
+    sim = _uniform_sim()
+
+    with pytest.raises(ValueError, match="n_steps must be positive"):
+        sim.plan_ad_memory(n_steps=0, available_memory_gb=1.0)
+    with pytest.raises(ValueError, match="n_warmup must be >= 0"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, n_warmup=-1)
+    with pytest.raises(ValueError, match="must be < n_steps"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, n_warmup=120)
+    with pytest.raises(ValueError, match="available_memory_gb must be positive"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=0.0)
+    with pytest.raises(ValueError, match="available_memory_gb must be positive"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=-1.0)
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=True)
+    with pytest.raises(ValueError, match="available_memory_gb must be finite"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=float("nan"))
+    with pytest.raises(ValueError, match="available_memory_gb must be finite"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=float("inf"))
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=[1.0])
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1 + 0j)
+    with pytest.raises(ValueError, match="target_fraction must be positive"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, target_fraction=0.0)
+    with pytest.raises(ValueError, match="target_fraction must be positive"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, target_fraction=-0.1)
+    with pytest.raises(ValueError, match="interval"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, target_fraction=1.5)
+    with pytest.raises(ValueError, match="target_fraction must be finite"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            target_fraction=float("inf"),
+        )
+    with pytest.raises(ValueError, match="target_fraction must be finite"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            target_fraction=float("nan"),
+        )
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            target_fraction=True,
+        )
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            target_fraction=[0.85],
+        )
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            target_fraction=1 + 0j,
+        )
+    with pytest.raises(ValueError, match="safety_factor must be positive"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, safety_factor=0.0)
+    with pytest.raises(ValueError, match="safety_factor must be >= 1"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, safety_factor=0.5)
+    with pytest.raises(ValueError, match="safety_factor must be finite"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            safety_factor=float("nan"),
+        )
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, safety_factor=True)
+
+
+def test_plan_ad_memory_rejects_invalid_design_masks():
+    sim = _uniform_sim()
+
+    with pytest.raises(ValueError, match="design_mask must be non-empty"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            design_mask=np.array([], dtype=bool),
+        )
+    with pytest.raises(ValueError, match="boolean array matching grid shape"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            design_mask=np.array(True),
+        )
+    with pytest.raises(TypeError, match="boolean dtype"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            design_mask=np.ones(_grid_shape(sim), dtype=np.int8),
+        )
+    with pytest.raises(ValueError, match="select at least one cell"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            design_mask=np.zeros(_grid_shape(sim), dtype=bool),
+        )
+    with pytest.raises(ValueError, match="must match simulation grid shape"):
+        sim.plan_ad_memory(
+            n_steps=120,
+            available_memory_gb=1.0,
+            design_mask=np.ones((2, 2, 2), dtype=bool),
+        )
+
+
+def test_warning_uses_realistic_selected_estimate():
+    sim = _uniform_sim()
+
+    full = sim.estimate_ad_memory(n_steps=120, available_memory_gb=1e-6)
+    assert full.warning is not None
+    assert "non-checkpointed" in full.warning
+    assert "Use plan_ad_memory()" in full.warning
+
+    segmented = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=1e-6,
+        checkpoint_segments=10,
+    )
+    assert segmented.warning is not None
+    assert "segmented" in segmented.warning
+    assert "Reduce checkpoint_segments" in segmented.warning
+
+    chunked = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=1e-6,
+        checkpoint_every=12,
+    )
+    assert chunked.warning is not None
+    assert "segmented" in chunked.warning
+    assert "Increase checkpoint_every" in chunked.warning
+
+    minimum_segmented = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=1e-6,
+        checkpoint_segments=1,
+    )
+    assert minimum_segmented.warning is not None
+    assert "Reduce checkpoint_segments" not in minimum_segmented.warning
+    assert "more aggressive memory-reduction lane" in minimum_segmented.warning
+
+    minimum_chunked = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=1e-6,
+        checkpoint_every=120,
+    )
+    assert minimum_chunked.warning is not None
+    assert "Increase checkpoint_every" not in minimum_chunked.warning
+    assert "more aggressive memory-reduction lane" in minimum_chunked.warning
+
+
+def test_warning_has_no_false_positive_at_boundary():
+    sim = _uniform_sim()
+
+    baseline = sim.estimate_ad_memory(n_steps=120)
+    exact_available = baseline.ad_full_gb / 0.85
+    exact = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=exact_available,
+    )
+    below = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=exact_available * 0.99,
+    )
+
+    assert exact.warning is None
+    assert below.warning is not None
+
+    segmented_baseline = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
+    segmented_available = segmented_baseline.ad_segmented_gb / 0.85
+    segmented_exact = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_segments=10,
+        available_memory_gb=segmented_available,
+    )
+    assert segmented_exact.warning is None
+
+    chunked_baseline = sim.estimate_ad_memory(n_steps=120, checkpoint_every=12)
+    chunked_available = chunked_baseline.ad_segmented_gb / 0.85
+    chunked_exact = sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_every=12,
+        available_memory_gb=chunked_available,
+    )
+    assert chunked_exact.warning is None
+
+
+def test_ntff_dft_bytes_contribute_to_ad_estimates():
+    baseline = _uniform_sim().estimate_ad_memory(n_steps=120, checkpoint_segments=10)
+    chunk_baseline = _uniform_sim().estimate_ad_memory(n_steps=120, checkpoint_every=12)
+    sim = _uniform_sim()
+    sim.add_ntff_box(
+        (1e-3, 1e-3, 1e-3),
+        (9e-3, 9e-3, 4e-3),
+        n_freqs=3,
+    )
+
+    with_ntff = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
+    chunk_with_ntff = sim.estimate_ad_memory(n_steps=120, checkpoint_every=12)
+    report = sim.mesh_intelligence_report(n_steps=120, checkpoint_every=12)
+
+    assert with_ntff.ntff_dft_gb > 0.0
+    assert with_ntff.ad_full_gb > baseline.ad_full_gb
+    assert with_ntff.ad_segmented_gb > baseline.ad_segmented_gb
+    assert chunk_with_ntff.ad_segmented_gb > chunk_baseline.ad_segmented_gb
+    assert report.ad_memory is not None
+    assert report.ad_memory.ntff_dft_gb > 0.0
+
+    nu_baseline_sim = _patch_like_sim()
+    nu_baseline = nu_baseline_sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_every=12,
+    )
+    nu_with_ntff_sim = _patch_like_sim()
+    nu_with_ntff_sim.add_ntff_box(
+        (1e-3, 1e-3, 1e-3),
+        (39e-3, 39e-3, 20e-3),
+        n_freqs=3,
+    )
+    nu_with_ntff = nu_with_ntff_sim.estimate_ad_memory(
+        n_steps=120,
+        checkpoint_every=12,
+    )
+    nu_report = nu_with_ntff_sim.mesh_intelligence_report(
+        n_steps=120,
+        checkpoint_every=12,
+    )
+
+    assert nu_with_ntff.ntff_dft_gb > 0.0
+    assert nu_with_ntff.ad_segmented_gb > nu_baseline.ad_segmented_gb
+    assert nu_report.ad_memory is not None
+    assert nu_report.ad_memory.ntff_dft_gb > 0.0
+
+
+def test_nonfinite_artifacts_refuse_json_serialization():
+    bad_estimate = AD_MemoryEstimate(
+        forward_gb=float("nan"),
+        ad_checkpointed_gb=1.0,
+        ad_full_gb=1.0,
+        ntff_dft_gb=0.0,
+        available_gb=None,
+        warning=None,
+    )
+    with pytest.raises(ValueError, match="Out of range"):
+        bad_estimate.to_json()
+    with pytest.raises(ValueError, match="Out of range"):
+        bad_estimate.to_json(allow_nan=True)
+
+    good_estimate = _uniform_sim().estimate_ad_memory(n_steps=120)
+    bad_plan = ADMemoryPlan(
+        n_steps=120,
+        available_memory_gb=float("inf"),
+        target_fraction=0.85,
+        target_memory_gb=1.0,
+        checkpoint_every=None,
+        selected_estimate=good_estimate,
+        full_ad_fits=True,
+        segmented_fits=True,
+        recommendation="bad nonfinite artifact",
+    )
+    with pytest.raises(ValueError, match="Out of range"):
+        bad_plan.to_json()
+    with pytest.raises(ValueError, match="Out of range"):
+        bad_plan.to_json(allow_nan=True)
+
+    bad_report = MeshIntelligenceReport(
+        grid_shape=(1, 1, 1),
+        cells=1,
+        uniform_fine_shape=(1, 1, 1),
+        uniform_fine_cells=1,
+        cell_savings_factor=float("nan"),
+        min_cell_size=1.0,
+        nominal_dx=1.0,
+        uses_nonuniform=False,
+        preflight_issues=(),
+        ad_memory=None,
+        recommendation="bad nonfinite report",
+    )
+    with pytest.raises(ValueError, match="Out of range"):
+        bad_report.to_json()
+    with pytest.raises(ValueError, match="Out of range"):
+        bad_report.to_json(allow_nan=True)
+
+
+def test_n_warmup_reduces_reverse_tape_only():
+    sim = _patch_like_sim()
+
+    full = sim.estimate_ad_memory(n_steps=1_000)
+    warm = sim.estimate_ad_memory(n_steps=1_000, n_warmup=600)
+
+    assert warm.forward_gb == full.forward_gb
+    assert warm.ad_active_steps == 400
+    assert warm.ad_full_gb < full.ad_full_gb
+
+
+def test_design_mask_records_fraction_without_reducing_primary_memory():
+    sim = _patch_like_sim()
+    design_mask = _design_mask(sim)
+    expected_fraction = float(np.count_nonzero(design_mask)) / float(design_mask.size)
+
+    full = sim.estimate_ad_memory(n_steps=1_000)
+    masked = sim.estimate_ad_memory(n_steps=1_000, design_mask=design_mask)
+
+    assert masked.forward_gb == full.forward_gb
+    assert masked.ad_active_design_fraction == pytest.approx(expected_fraction)
+    assert masked.ad_full_gb == full.ad_full_gb
+
+
+def test_plan_ad_memory_rejects_non_integral_counts():
+    sim = _uniform_sim()
+
+    with pytest.raises(TypeError, match="n_steps must be an integer"):
+        sim.plan_ad_memory(n_steps=120.5, available_memory_gb=1.0)
+    with pytest.raises(TypeError, match="n_steps must be an integer"):
+        sim.plan_ad_memory(n_steps=True, available_memory_gb=1.0)
+    with pytest.raises(TypeError, match="n_warmup must be an integer"):
+        sim.plan_ad_memory(n_steps=120, available_memory_gb=1.0, n_warmup=1.5)
+
+
+def test_plan_ad_memory_records_warmup_and_mask_metadata():
+    sim = _patch_like_sim()
+    budget_gb = 0.2
+    design_mask = _design_mask(sim)
+    expected_fraction = float(np.count_nonzero(design_mask)) / float(design_mask.size)
+    warm_only = sim.plan_ad_memory(
+        n_steps=10_000,
+        available_memory_gb=budget_gb,
+        n_warmup=9_000,
+    )
+
+    baseline = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=budget_gb)
+    masked = sim.plan_ad_memory(
+        n_steps=10_000,
+        available_memory_gb=budget_gb,
+        n_warmup=9_000,
+        design_mask=design_mask,
+    )
+
+    assert baseline.full_ad_fits is False
+    assert masked.selected_estimate.ad_active_steps == 1_000
+    assert masked.selected_estimate.ad_active_design_fraction == pytest.approx(expected_fraction)
+    assert masked.selected_estimate.ad_full_gb == warm_only.selected_estimate.ad_full_gb
+    assert masked.checkpoint_every == warm_only.checkpoint_every
+    assert masked.checkpoint_every is None or masked.checkpoint_every < baseline.checkpoint_every

--- a/tests/test_estimate_ad_memory.py
+++ b/tests/test_estimate_ad_memory.py
@@ -27,8 +27,11 @@ import numpy as np
 import pytest
 
 from rfx import (
+    ADMemoryActionHint,
     ADMemoryComponent,
     ADMemoryExplainabilityReport,
+    ADMemoryPreflightReport,
+    ADCompiledMemoryCertificate,
     ADMemoryPlan,
     AD_MemoryEstimate,
     MeshIntelligenceReport,
@@ -56,11 +59,50 @@ _FORBIDDEN_RECOMMENDATION_TERMS = (
     "certified",
     "certificate",
     "peak_bound",
+    "runtime peak",
+    "profiler",
+    "profile",
+    "xla",
+    "compiler memory",
+    "rf validation",
+)
+
+AD_MEMORY_PREFLIGHT_BOUNDARIES = (
+    "static memory planning only",
+    "trace-time JAX saved-residual explainability only when residual_diagnostic is present",
+    "not a runtime peak-memory guarantee",
+    "not XLA memory analysis",
+    "not profiler evidence",
+    "not a certificate",
+    "not RF validation",
 )
 
 
 def _assert_no_forbidden_current_fields(artifact: dict[str, object]) -> None:
     assert _FORBIDDEN_CURRENT_EVIDENCE_FIELDS.isdisjoint(artifact)
+
+
+def _assert_no_forbidden_fields_recursive(value: object) -> None:
+    if isinstance(value, dict):
+        assert _FORBIDDEN_CURRENT_EVIDENCE_FIELDS.isdisjoint(value)
+        for item in value.values():
+            _assert_no_forbidden_fields_recursive(item)
+    elif isinstance(value, list):
+        for item in value:
+            _assert_no_forbidden_fields_recursive(item)
+
+
+def _assert_validate_physics_hint(report: ADMemoryPreflightReport) -> None:
+    hint = next(
+        hint
+        for hint in report.action_hints
+        if hint.code == "validate_physics_separately"
+    )
+    assert hint.severity == "info"
+    assert hint.blocking is False
+    assert hint.checkpoint_mode is None
+    assert "electromagnetic correctness" in hint.message.lower()
+    assert "physics claims" in hint.action.lower()
 
 
 def _patch_like_sim():
@@ -112,32 +154,187 @@ def _design_mask(sim: Simulation, *, fraction: float = 0.25) -> np.ndarray:
     return mask
 
 
+class _Missing:
+    pass
+
+
+_MISSING = _Missing()
+
+
+class _FakeMemoryAnalysis:
+    def __init__(
+        self,
+        *,
+        temp_size_in_bytes=100,
+        argument_size_in_bytes=200,
+        output_size_in_bytes=300,
+        alias_size_in_bytes=50,
+    ):
+        if temp_size_in_bytes is not _MISSING:
+            self.temp_size_in_bytes = temp_size_in_bytes
+        if argument_size_in_bytes is not _MISSING:
+            self.argument_size_in_bytes = argument_size_in_bytes
+        if output_size_in_bytes is not _MISSING:
+            self.output_size_in_bytes = output_size_in_bytes
+        if alias_size_in_bytes is not _MISSING:
+            self.alias_size_in_bytes = alias_size_in_bytes
+
+    def __repr__(self):
+        return "<raw-analysis-repr-must-not-be-serialized>"
+
+
+class _FakeCompiled:
+    def __init__(
+        self,
+        analysis=_MISSING,
+        *,
+        raises: Exception | None = None,
+        scope=None,
+    ):
+        self._analysis = _FakeMemoryAnalysis() if analysis is _MISSING else analysis
+        self._raises = raises
+        if scope is not None:
+            self.rfx_memory_scope = scope
+
+    def memory_analysis(self):
+        if self._raises is not None:
+            raise self._raises
+        return self._analysis
+
+
+class _NoMemoryAnalysis:
+    pass
+
+
+class _RaisingMemoryAnalysisAttribute:
+    @property
+    def memory_analysis(self):
+        raise RuntimeError("attribute boom")
+
+
+class _RaisingAnalysisField:
+    @property
+    def temp_size_in_bytes(self):
+        raise RuntimeError("field boom")
+
+    argument_size_in_bytes = 1
+    output_size_in_bytes = 1
+    alias_size_in_bytes = 0
+
+
+class _RaisingIntrospectionCompiled(_FakeCompiled):
+    @property
+    def rfx_memory_scope(self):
+        raise RuntimeError("scope boom")
+
+
+class _RaisingToDictAttribute:
+    @property
+    def to_dict(self):
+        raise RuntimeError("to_dict descriptor boom")
+
+
+class _RaisingShapeAttribute:
+    @property
+    def shape(self):
+        raise RuntimeError("shape descriptor boom")
+
+
+class _ListPreflight:
+    def to_dict(self):
+        return ["not", "a", "mapping"]
+
+
+class _FakeJaxDevice:
+    def __init__(
+        self,
+        *,
+        platform="cpu",
+        device_kind="Fake CPU",
+        raise_platform=False,
+        raise_kind=False,
+    ):
+        self._platform = platform
+        self._device_kind = device_kind
+        self._raise_platform = raise_platform
+        self._raise_kind = raise_kind
+
+    @property
+    def platform(self):
+        if self._raise_platform:
+            raise RuntimeError("platform boom")
+        return self._platform
+
+    @property
+    def device_kind(self):
+        if self._raise_kind:
+            raise RuntimeError("kind boom")
+        return self._device_kind
+
+
+def _certificate_kwargs(**overrides):
+    kwargs = {
+        "n_steps": 120,
+        "available_memory_gb": 1.0,
+        "precision": "float32",
+        "input_signature": {
+            "eps_r": {
+                "shape": [4, 4],
+                "dtype": "float32",
+                "weak_type": False,
+                "role": "design",
+            }
+        },
+        "static_signature": {"dx": 0.01, "boundary": "pml"},
+        "compiled_object_id": "toy-loss-compiled",
+        "runner_or_objective": "toy_loss",
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
 def test_public_imports_and_json_roundtrip():
     from rfx import ADMemoryPlan as TopPlan
     from rfx import AD_MemoryEstimate as TopEstimate
     from rfx import ADMemoryComponent as TopComponent
+    from rfx import ADMemoryActionHint as TopHint
     from rfx import ADMemoryExplainabilityReport as TopExplanation
+    from rfx import ADMemoryPreflightReport as TopPreflight
+    from rfx import ADCompiledMemoryCertificate as TopCertificate
     from rfx import Simulation as TopSimulation
     from rfx.api import ADMemoryPlan as ApiPlan
     from rfx.api import AD_MemoryEstimate as ApiEstimate
     from rfx.api import ADMemoryComponent as ApiComponent
+    from rfx.api import ADMemoryActionHint as ApiHint
     from rfx.api import ADMemoryExplainabilityReport as ApiExplanation
+    from rfx.api import ADMemoryPreflightReport as ApiPreflight
+    from rfx.api import ADCompiledMemoryCertificate as ApiCertificate
     from rfx.api import Simulation as ApiSimulation
 
     assert TopEstimate is ApiEstimate is AD_MemoryEstimate
     assert TopPlan is ApiPlan is ADMemoryPlan
     assert TopComponent is ApiComponent is ADMemoryComponent
+    assert TopHint is ApiHint is ADMemoryActionHint
     assert TopExplanation is ApiExplanation is ADMemoryExplainabilityReport
+    assert TopPreflight is ApiPreflight is ADMemoryPreflightReport
+    assert TopCertificate is ApiCertificate is ADCompiledMemoryCertificate
     assert TopSimulation is ApiSimulation is Simulation
 
     sim = _uniform_sim()
     estimate = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
     plan = sim.plan_ad_memory(n_steps=120, available_memory_gb=100.0)
     explanation = sim.explain_ad_memory(n_steps=120, checkpoint_segments=10)
+    preflight = sim.ad_memory_preflight(n_steps=120, available_memory_gb=100.0)
+    certificate = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(),
+    )
 
     assert json.loads(estimate.to_json()) == estimate.to_dict()
     assert json.loads(plan.to_json()) == plan.to_dict()
     assert json.loads(explanation.to_json()) == explanation.to_dict()
+    assert json.loads(preflight.to_json()) == preflight.to_dict()
+    assert json.loads(certificate.to_json()) == certificate.to_dict()
     assert estimate.to_dict()["checkpoint_segments"] == 10
     estimate_keys = {
         "evidence_class",
@@ -181,25 +378,508 @@ def test_public_imports_and_json_roundtrip():
         "dominant_component",
         "recommendations",
     }
+    preflight_keys = {
+        "evidence_class",
+        "source_evidence_classes",
+        "n_steps",
+        "available_memory_gb",
+        "target_fraction",
+        "target_memory_gb",
+        "fit_safety_factor",
+        "status",
+        "supported_checkpoint_mode",
+        "checkpoint_every",
+        "checkpoint_segments",
+        "full_ad_fits",
+        "checkpointing_fits",
+        "memory_plan",
+        "explainability",
+        "mesh_report",
+        "residual_diagnostic",
+        "action_hints",
+        "evidence_boundaries",
+        "recommendation",
+    }
+    certificate_keys = {
+        "evidence_class",
+        "status",
+        "is_valid_certificate",
+        "is_budget_safe",
+        "available_memory_gb",
+        "target_fraction",
+        "target_memory_gb",
+        "compiler_reported_required_bytes",
+        "compiler_reported_required_gb",
+        "temp_size_in_bytes",
+        "argument_size_in_bytes",
+        "output_size_in_bytes",
+        "alias_size_in_bytes",
+        "temp_gb",
+        "argument_gb",
+        "output_gb",
+        "alias_gb",
+        "exact_scope",
+        "scope_status",
+        "scope_status_reason",
+        "scope_digest",
+        "config_digest",
+        "environment_digest",
+        "memory_analysis_status",
+        "memory_analysis_status_reason",
+        "jax_version",
+        "evidence_boundaries",
+        "recommendations",
+        "source_preflight",
+    }
+    hint_keys = {
+        "evidence_class",
+        "code",
+        "severity",
+        "message",
+        "action",
+        "checkpoint_mode",
+        "checkpoint_every",
+        "checkpoint_segments",
+        "blocking",
+    }
     assert plan.to_dict()["evidence_class"] == "calibrated_conservative_plan"
     assert set(estimate.to_dict()) == estimate_keys
     assert set(plan.to_dict()) == plan_keys
     assert set(explanation.to_dict()) == explanation_keys
+    assert set(preflight.to_dict()) == preflight_keys
+    assert set(certificate.to_dict()) == certificate_keys
+    assert all(set(hint) == hint_keys for hint in preflight.to_dict()["action_hints"])
+    assert all(
+        hint["evidence_class"] == "static_action_hint"
+        for hint in preflight.to_dict()["action_hints"]
+    )
     assert explanation.to_dict()["estimate"]["evidence_class"] == "static_estimate"
     assert explanation.to_dict()["evidence_class"] == "static_ad_explainability"
+    assert preflight.to_dict()["evidence_class"] == "composite_ad_memory_preflight"
+    assert certificate.to_dict()["evidence_class"] == "bounded_certificate"
     assert set(plan.to_dict()["selected_estimate"]) == estimate_keys
     assert plan.to_dict()["selected_estimate"]["evidence_class"] == "static_estimate"
     _assert_no_forbidden_current_fields(estimate.to_dict())
     _assert_no_forbidden_current_fields(plan.to_dict())
     _assert_no_forbidden_current_fields(plan.to_dict()["selected_estimate"])
+    _assert_no_forbidden_current_fields(preflight.to_dict())
+    _assert_no_forbidden_fields_recursive(preflight.to_dict())
     assert "evidence_class" not in AD_MemoryEstimate._fields
     assert "evidence_class" not in ADMemoryPlan._fields
     assert "evidence_class" not in ADMemoryComponent._fields
     assert "evidence_class" not in ADMemoryExplainabilityReport._fields
+    assert "evidence_class" not in ADMemoryActionHint._fields
+    assert "evidence_class" not in ADMemoryPreflightReport._fields
+    assert "evidence_class" not in ADCompiledMemoryCertificate._fields
     with pytest.raises(ValueError):
         estimate._replace(evidence_class="observed_profile")
     with pytest.raises(ValueError):
         plan._replace(evidence_class="bounded_certificate")
+
+
+def test_ad_memory_compiled_certificate_fit_and_budget_exceeded():
+    sim = _uniform_sim()
+    fit = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(
+            _FakeMemoryAnalysis(
+                temp_size_in_bytes=1_000,
+                argument_size_in_bytes=2_000,
+                output_size_in_bytes=3_000,
+                alias_size_in_bytes=500,
+            )
+        ),
+        **_certificate_kwargs(),
+    )
+    artifact = fit.to_dict()
+
+    assert fit.evidence_class == "bounded_certificate"
+    assert fit.status == "certified_budget_fit"
+    assert fit.is_valid_certificate is True
+    assert fit.is_budget_safe is True
+    assert artifact["compiler_reported_required_bytes"] == 5_500
+    assert artifact["compiler_reported_required_gb"] == pytest.approx(5_500 / 1e9)
+    assert artifact["temp_size_in_bytes"] == 1_000
+    assert artifact["argument_size_in_bytes"] == 2_000
+    assert artifact["output_size_in_bytes"] == 3_000
+    assert artifact["alias_size_in_bytes"] == 500
+    assert artifact["scope_status"] == "complete"
+    assert artifact["memory_analysis_status"] == "complete"
+    assert artifact["exact_scope"]["memory_analysis_fields"] == [
+        "temp_size_in_bytes",
+        "argument_size_in_bytes",
+        "output_size_in_bytes",
+        "alias_size_in_bytes",
+    ]
+    assert "Digests are audit identities only" in " ".join(fit.recommendations)
+    assert "raw-analysis-repr-must-not-be-serialized" not in fit.to_json()
+
+    exceeded = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(
+            _FakeMemoryAnalysis(
+                temp_size_in_bytes=2_000_000_000,
+                argument_size_in_bytes=0,
+                output_size_in_bytes=0,
+                alias_size_in_bytes=0,
+            )
+        ),
+        **_certificate_kwargs(),
+    )
+    assert exceeded.status == "certified_budget_exceeded"
+    assert exceeded.is_valid_certificate is True
+    assert exceeded.is_budget_safe is False
+
+
+def test_ad_memory_compiled_certificate_summarizes_array_signature_inputs():
+    sim = _uniform_sim()
+    report = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(
+            input_signature={
+                "eps_r": np.ones((2, 3), dtype=np.float32),
+                "scalar": np.array(1.0, dtype=np.float64),
+            },
+            static_signature={
+                "bias": np.arange(4, dtype=np.int32),
+                "mode": "toy",
+            },
+        ),
+    )
+    scope = report.exact_scope
+
+    assert report.status == "certified_budget_fit"
+    assert scope["input_signature"]["eps_r"] == {
+        "shape": [2, 3],
+        "dtype": "float32",
+    }
+    assert scope["input_signature"]["scalar"] == {
+        "shape": [],
+        "dtype": "float64",
+    }
+    assert scope["static_signature"]["bias"] == {
+        "shape": [4],
+        "dtype": "int32",
+    }
+    assert scope["static_signature"]["mode"] == "toy"
+    assert scope["input_signature"]["eps_r"] != np.ones((2, 3), dtype=np.float32).tolist()
+
+
+def test_ad_memory_compiled_certificate_scope_failures_are_non_certifying():
+    sim = _uniform_sim()
+
+    missing = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(input_signature=None),
+    )
+    assert missing.status == "scope_incomplete"
+    assert missing.is_valid_certificate is False
+    assert missing.is_budget_safe is None
+    assert missing.memory_analysis_status == "complete"
+    assert "input_signature" in missing.scope_status_reason
+
+    non_json = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(scope_context={"bad": object()}),
+    )
+    assert non_json.status == "scope_incomplete"
+    assert "unsupported value object" in non_json.scope_status_reason
+
+    mismatch = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(scope={"n_steps": 999}),
+        **_certificate_kwargs(),
+    )
+    assert mismatch.status == "scope_mismatch"
+    assert mismatch.scope_status == "scope_mismatch"
+    assert "n_steps" in mismatch.scope_status_reason
+
+    non_string_key = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(input_signature={1: "not-exact-json"}),
+    )
+    assert non_string_key.status == "scope_incomplete"
+    assert "non-string mapping key" in non_string_key.scope_status_reason
+
+    colliding_key = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(input_signature={1: "a", "1": "b"}),
+    )
+    assert colliding_key.status == "scope_incomplete"
+    assert "non-string mapping key" in colliding_key.scope_status_reason
+
+    introspection_error = sim.ad_memory_compiled_certificate(
+        _RaisingIntrospectionCompiled(),
+        **_certificate_kwargs(),
+    )
+    assert introspection_error.status == "scope_mismatch"
+    assert "introspection attribute" in introspection_error.scope_status_reason
+
+    raising_to_dict = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(input_signature={"bad": _RaisingToDictAttribute()}),
+    )
+    assert raising_to_dict.status == "scope_incomplete"
+    assert "to_dict attribute read raised RuntimeError" in raising_to_dict.scope_status_reason
+
+    raising_shape = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(input_signature={"bad": _RaisingShapeAttribute()}),
+    )
+    assert raising_shape.status == "scope_incomplete"
+    assert "shape attribute read raised RuntimeError" in raising_shape.scope_status_reason
+
+
+def test_ad_memory_compiled_certificate_fails_closed_without_environment(monkeypatch):
+    import rfx.api._compiled_memory as compiled_memory
+
+    def fail_default_backend():
+        raise RuntimeError("no backend")
+
+    monkeypatch.setattr(compiled_memory.jax, "default_backend", fail_default_backend)
+    report = _uniform_sim().ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(),
+    )
+
+    assert report.status == "scope_incomplete"
+    assert report.scope_status == "scope_incomplete"
+    assert "default_backend" in report.scope_status_reason
+    assert report.scope_digest is None
+    assert report.environment_digest is None
+
+
+def test_ad_memory_compiled_certificate_fails_closed_without_devices(monkeypatch):
+    import rfx.api._compiled_memory as compiled_memory
+
+    def fail_local_devices():
+        raise RuntimeError("no devices")
+
+    monkeypatch.setattr(compiled_memory.jax, "local_devices", fail_local_devices)
+    report = _uniform_sim().ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(),
+    )
+
+    assert report.status == "scope_incomplete"
+    assert "local_devices" in report.scope_status_reason
+    assert report.exact_scope is None
+
+@pytest.mark.parametrize("version", ["unknown", None, "  "])
+def test_ad_memory_compiled_certificate_fails_closed_on_invalid_jax_version(
+    monkeypatch,
+    version,
+):
+    import rfx.api._compiled_memory as compiled_memory
+
+    monkeypatch.setattr(compiled_memory.jax, "__version__", version)
+    report = _uniform_sim().ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(),
+    )
+
+    assert report.status == "scope_incomplete"
+    assert "__version__" in report.scope_status_reason
+    assert report.exact_scope is None
+
+
+@pytest.mark.parametrize("backend", [None, "unknown", "  "])
+def test_ad_memory_compiled_certificate_fails_closed_on_invalid_backend(
+    monkeypatch,
+    backend,
+):
+    import rfx.api._compiled_memory as compiled_memory
+
+    monkeypatch.setattr(compiled_memory.jax, "default_backend", lambda: backend)
+    report = _uniform_sim().ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(),
+    )
+
+    assert report.status == "scope_incomplete"
+    assert "default_backend" in report.scope_status_reason
+    assert report.exact_scope is None
+
+
+@pytest.mark.parametrize(
+    "device, reason",
+    [
+        (_FakeJaxDevice(platform=None), "JAX device platform"),
+        (_FakeJaxDevice(platform="unknown"), "JAX device platform"),
+        (_FakeJaxDevice(platform="  "), "JAX device platform"),
+        (_FakeJaxDevice(device_kind=None), "JAX device_kind"),
+        (_FakeJaxDevice(device_kind="unknown"), "JAX device_kind"),
+        (_FakeJaxDevice(device_kind="  "), "JAX device_kind"),
+        (_FakeJaxDevice(raise_platform=True), "metadata read failed"),
+        (_FakeJaxDevice(raise_kind=True), "metadata read failed"),
+    ],
+)
+def test_ad_memory_compiled_certificate_fails_closed_on_invalid_device_metadata(
+    monkeypatch,
+    device,
+    reason,
+):
+    import rfx.api._compiled_memory as compiled_memory
+
+    monkeypatch.setattr(compiled_memory.jax, "local_devices", lambda: (device,))
+    report = _uniform_sim().ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(),
+    )
+
+    assert report.status == "scope_incomplete"
+    assert report.scope_status == "scope_incomplete"
+    assert reason in report.scope_status_reason
+    assert report.exact_scope is None
+
+
+@pytest.mark.parametrize(
+    "compiled, reason",
+    [
+        (_NoMemoryAnalysis(), "no callable memory_analysis"),
+        (_FakeCompiled(analysis=None), "returned None"),
+        (_FakeCompiled(raises=RuntimeError("boom")), "raised RuntimeError"),
+        (_RaisingMemoryAnalysisAttribute(), "attribute boom"),
+    ],
+)
+def test_ad_memory_compiled_certificate_analysis_unavailable(compiled, reason):
+    report = _uniform_sim().ad_memory_compiled_certificate(
+        compiled,
+        **_certificate_kwargs(),
+    )
+
+    assert report.status == "analysis_unavailable"
+    assert report.scope_status == "complete"
+    assert report.memory_analysis_status == "analysis_unavailable"
+    assert reason in report.memory_analysis_status_reason
+    assert report.is_valid_certificate is False
+    assert report.compiler_reported_required_bytes is None
+    assert report.exact_scope["memory_analysis_fields"] is None
+
+
+@pytest.mark.parametrize(
+    "analysis, reason",
+    [
+        (
+            _FakeMemoryAnalysis(temp_size_in_bytes=_MISSING),
+            "missing required byte field",
+        ),
+        (
+            _FakeMemoryAnalysis(temp_size_in_bytes=-1),
+            "must be non-negative",
+        ),
+        (
+            _FakeMemoryAnalysis(temp_size_in_bytes=1.5),
+            "non-negative integer byte count",
+        ),
+        (
+            _FakeMemoryAnalysis(temp_size_in_bytes=float("nan")),
+            "non-negative integer byte count",
+        ),
+        (
+            _FakeMemoryAnalysis(temp_size_in_bytes="1"),
+            "non-negative integer byte count",
+        ),
+        (
+            _FakeMemoryAnalysis(
+                temp_size_in_bytes=0,
+                argument_size_in_bytes=0,
+                output_size_in_bytes=0,
+                alias_size_in_bytes=1,
+            ),
+            "computed required bytes must be non-negative",
+        ),
+        (
+            _RaisingAnalysisField(),
+            "reading temp_size_in_bytes raised RuntimeError",
+        ),
+    ],
+)
+def test_ad_memory_compiled_certificate_analysis_incomplete(analysis, reason):
+    report = _uniform_sim().ad_memory_compiled_certificate(
+        _FakeCompiled(analysis),
+        **_certificate_kwargs(),
+    )
+
+    assert report.status == "analysis_incomplete"
+    assert report.scope_status == "complete"
+    assert report.memory_analysis_status == "analysis_incomplete"
+    assert reason in report.memory_analysis_status_reason
+    assert report.is_budget_safe is None
+
+
+def test_ad_memory_compiled_certificate_digests_are_stable_and_scope_sensitive():
+    sim = _uniform_sim()
+
+    first = sim.ad_memory_compiled_certificate(_FakeCompiled(), **_certificate_kwargs())
+    second = sim.ad_memory_compiled_certificate(_FakeCompiled(), **_certificate_kwargs())
+    changed = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(runner_or_objective="different_loss"),
+    )
+
+    assert first.scope_digest == second.scope_digest
+    assert first.config_digest == second.config_digest
+    assert first.environment_digest == second.environment_digest
+    assert first.scope_digest != changed.scope_digest
+    assert first.config_digest != changed.config_digest
+
+
+def test_ad_memory_compiled_certificate_rejects_invalid_budget_scalars():
+    sim = _uniform_sim()
+
+    with pytest.raises(ValueError, match="available_memory_gb must be positive"):
+        sim.ad_memory_compiled_certificate(
+            _FakeCompiled(),
+            **_certificate_kwargs(available_memory_gb=0.0),
+        )
+    with pytest.raises(ValueError, match="target_fraction must be positive"):
+        sim.ad_memory_compiled_certificate(
+            _FakeCompiled(),
+            **_certificate_kwargs(target_fraction=0.0),
+        )
+    with pytest.raises(ValueError, match="interval"):
+        sim.ad_memory_compiled_certificate(
+            _FakeCompiled(),
+            **_certificate_kwargs(target_fraction=1.1),
+        )
+    with pytest.raises(TypeError, match="finite real scalar"):
+        sim.ad_memory_compiled_certificate(
+            _FakeCompiled(),
+            **_certificate_kwargs(available_memory_gb=[1.0]),
+        )
+
+
+def test_ad_memory_compiled_certificate_preflight_snapshot_and_mismatch():
+    sim = _uniform_sim()
+    preflight = sim.ad_memory_preflight(n_steps=120, available_memory_gb=1.0)
+    report = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(preflight=preflight),
+    )
+
+    assert report.status == "certified_budget_fit"
+    assert report.source_preflight["evidence_class"] == "composite_ad_memory_preflight"
+    assert report.source_preflight["status"] == preflight.status
+    _assert_no_forbidden_fields_recursive(preflight.to_dict())
+
+    mismatched = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(preflight=preflight, available_memory_gb=2.0),
+    )
+    assert mismatched.status == "scope_mismatch"
+    assert "available_memory_gb" in mismatched.scope_status_reason
+
+    checkpoint_mismatched = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(preflight=preflight, checkpoint_segments=10),
+    )
+    assert checkpoint_mismatched.status == "scope_mismatch"
+    assert "checkpoint mode" in checkpoint_mismatched.scope_status_reason
+
+    malformed_preflight = sim.ad_memory_compiled_certificate(
+        _FakeCompiled(),
+        **_certificate_kwargs(preflight=_ListPreflight()),
+    )
+    assert malformed_preflight.status == "scope_incomplete"
+    assert "preflight snapshot must be a JSON object mapping" in malformed_preflight.scope_status_reason
 
 
 def test_current_memory_artifacts_keep_evidence_classes_separate():
@@ -356,15 +1036,191 @@ def test_current_memory_recommendations_do_not_claim_guarantees():
         assert not any(term in lowered for term in _FORBIDDEN_RECOMMENDATION_TERMS)
 
 
+def test_ad_memory_preflight_full_fit_branch():
+    sim = _patch_like_sim()
+
+    report = sim.ad_memory_preflight(
+        n_steps=100,
+        available_memory_gb=100.0,
+        include_mesh_report=False,
+    )
+    artifact = report.to_dict()
+    hint_codes = {hint.code for hint in report.action_hints}
+
+    assert isinstance(report, ADMemoryPreflightReport)
+    assert report.status == "full_ad_fits"
+    assert report.supported_checkpoint_mode is None
+    assert report.checkpoint_every is None
+    assert report.checkpoint_segments is None
+    assert report.full_ad_fits is True
+    assert report.checkpointing_fits is False
+    assert report.memory_plan.full_ad_fits is True
+    assert report.explainability.selected_memory_field == "ad_full_gb"
+    assert report.explainability.strategy == "full_reverse_ad_static_tape"
+    assert "full_ad_fits" in hint_codes
+    assert "use_checkpoint_every" not in hint_codes
+    assert "use_checkpoint_segments" not in hint_codes
+    _assert_validate_physics_hint(report)
+    assert report.source_evidence_classes == (
+        "calibrated_conservative_plan",
+        "static_estimate",
+        "static_ad_explainability",
+    )
+    assert artifact["mesh_report"] is None
+    assert json.loads(report.to_json()) == artifact
+
+
+def test_ad_memory_preflight_nonuniform_checkpoint_branch():
+    sim = _patch_like_sim()
+
+    report = sim.ad_memory_preflight(n_steps=10_000, available_memory_gb=1.0)
+    hint = next(
+        hint for hint in report.action_hints if hint.code == "use_checkpoint_every"
+    )
+
+    assert report.status == "checkpointing_fits"
+    assert report.full_ad_fits is False
+    assert report.checkpointing_fits is True
+    assert report.supported_checkpoint_mode == "checkpoint_every"
+    assert report.checkpoint_every == report.memory_plan.checkpoint_every
+    assert report.checkpoint_segments is None
+    assert report.explainability.selected_memory_field == "ad_segmented_gb"
+    assert report.explainability.strategy == "segmented_checkpoint_every"
+    assert hint.checkpoint_mode == "checkpoint_every"
+    assert hint.checkpoint_every == report.checkpoint_every
+    assert hint.checkpoint_segments is None
+    assert hint.blocking is False
+    assert report.mesh_report is not None
+    assert report.mesh_report.ad_memory.checkpoint_every == report.checkpoint_every
+    _assert_validate_physics_hint(report)
+
+
+def test_ad_memory_preflight_uniform_checkpoint_branch():
+    sim = _uniform_sim()
+
+    report = sim.ad_memory_preflight(
+        n_steps=120,
+        available_memory_gb=0.002,
+        include_mesh_report=False,
+    )
+    hint = next(
+        hint for hint in report.action_hints if hint.code == "use_checkpoint_segments"
+    )
+
+    assert report.status == "checkpointing_fits"
+    assert report.checkpointing_fits is True
+    assert report.supported_checkpoint_mode == "checkpoint_segments"
+    assert report.checkpoint_every is None
+    assert report.checkpoint_segments == report.memory_plan.checkpoint_segments == 10
+    assert report.explainability.selected_memory_field == "ad_segmented_gb"
+    assert report.explainability.strategy == "segmented_checkpoint_segments"
+    assert hint.checkpoint_mode == "checkpoint_segments"
+    assert hint.checkpoint_every is None
+    assert hint.checkpoint_segments == 10
+    _assert_validate_physics_hint(report)
+
+
+def test_ad_memory_preflight_unfit_branch_is_diagnostic_only():
+    sim = _patch_like_sim()
+
+    report = sim.ad_memory_preflight(
+        n_steps=10_000,
+        available_memory_gb=0.001,
+        include_mesh_report=False,
+    )
+    blocker = next(
+        hint for hint in report.action_hints if hint.code == "memory_budget_unfit"
+    )
+
+    assert report.status == "does_not_fit"
+    assert report.full_ad_fits is False
+    assert report.checkpointing_fits is False
+    assert report.supported_checkpoint_mode == "checkpoint_every"
+    assert report.checkpoint_every == 10_000
+    assert report.checkpoint_segments is None
+    assert report.explainability.selected_memory_field == "ad_segmented_gb"
+    assert blocker.blocking is True
+    assert blocker.severity == "blocker"
+    assert "diagnostic-only" in report.recommendation
+    assert "do not launch" in report.recommendation.lower()
+    assert "as a fit" in blocker.action
+    assert not any(
+        hint.code in {"full_ad_fits", "use_checkpoint_every", "use_checkpoint_segments"}
+        for hint in report.action_hints
+    )
+    _assert_validate_physics_hint(report)
+
+
+def test_ad_memory_preflight_boundaries_and_action_text_are_safe():
+    patch = _patch_like_sim()
+    uniform = _uniform_sim()
+    reports = [
+        patch.ad_memory_preflight(
+            n_steps=100,
+            available_memory_gb=100.0,
+            include_mesh_report=False,
+        ),
+        patch.ad_memory_preflight(
+            n_steps=10_000,
+            available_memory_gb=1.0,
+            include_mesh_report=False,
+        ),
+        uniform.ad_memory_preflight(
+            n_steps=120,
+            available_memory_gb=0.002,
+            include_mesh_report=False,
+        ),
+        patch.ad_memory_preflight(
+            n_steps=10_000,
+            available_memory_gb=0.001,
+            include_mesh_report=False,
+        ),
+    ]
+
+    for report in reports:
+        artifact = report.to_dict()
+        assert report.evidence_boundaries == AD_MEMORY_PREFLIGHT_BOUNDARIES
+        assert artifact["evidence_boundaries"] == list(AD_MEMORY_PREFLIGHT_BOUNDARIES)
+        _assert_no_forbidden_fields_recursive(artifact)
+
+        action_texts = [
+            report.recommendation,
+            *(
+                f"{hint.message} {hint.action}"
+                for hint in report.action_hints
+            ),
+        ]
+        for text in action_texts:
+            lowered = text.lower()
+            assert not any(
+                term in lowered for term in _FORBIDDEN_RECOMMENDATION_TERMS
+            )
+
 def test_memory_reduction_docs_separate_planning_from_certificate_evidence():
     doc = Path("docs/public/guide/memory-reduction.mdx").read_text()
     assert "`static_estimate`" in doc
     assert "`calibrated_conservative_plan`" in doc
     assert "`static_ad_explainability`" in doc
+    assert "`composite_ad_memory_preflight`" in doc
+    assert "`static_action_hint`" in doc
     assert "explain_ad_memory(...)" in doc
+    assert "ad_memory_preflight(...)" in doc
+    assert "residual_context" in doc
+    assert "checkpoint_every" in doc
+    assert "checkpoint_segments" in doc
+    assert "**checkpoint_kwargs" in doc
     assert "`bounded_certificate`" in doc
     assert "Current `estimate_ad_memory(...)`, `plan_ad_memory(...)`, and `explain_ad_memory(...)` artifacts are not certificates" in doc
     assert "not a universal guaranteed peak predictor" in doc
+    assert "ad_memory_compiled_certificate(...)" in doc
+    assert "`bounded_certificate` | yes" in doc
+    assert "Compiled.memory_analysis()" in doc
+    assert "temp + argument + output - alias" in doc
+    assert "audit identities" in doc
+    assert "version/backend dependent and may be unavailable" in doc
+    assert "not full array values" in doc
+    for boundary in AD_MEMORY_PREFLIGHT_BOUNDARIES:
+        assert boundary in doc
 
 
 @pytest.mark.parametrize("chunk,observed_gb", [

--- a/tests/test_estimate_ad_memory.py
+++ b/tests/test_estimate_ad_memory.py
@@ -26,7 +26,14 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from rfx import ADMemoryPlan, AD_MemoryEstimate, MeshIntelligenceReport, Simulation
+from rfx import (
+    ADMemoryComponent,
+    ADMemoryExplainabilityReport,
+    ADMemoryPlan,
+    AD_MemoryEstimate,
+    MeshIntelligenceReport,
+    Simulation,
+)
 from rfx.api import AD_MEMORY_FIT_SAFETY_FACTOR
 
 _FORBIDDEN_CURRENT_EVIDENCE_FIELDS = {
@@ -108,21 +115,29 @@ def _design_mask(sim: Simulation, *, fraction: float = 0.25) -> np.ndarray:
 def test_public_imports_and_json_roundtrip():
     from rfx import ADMemoryPlan as TopPlan
     from rfx import AD_MemoryEstimate as TopEstimate
+    from rfx import ADMemoryComponent as TopComponent
+    from rfx import ADMemoryExplainabilityReport as TopExplanation
     from rfx import Simulation as TopSimulation
     from rfx.api import ADMemoryPlan as ApiPlan
     from rfx.api import AD_MemoryEstimate as ApiEstimate
+    from rfx.api import ADMemoryComponent as ApiComponent
+    from rfx.api import ADMemoryExplainabilityReport as ApiExplanation
     from rfx.api import Simulation as ApiSimulation
 
     assert TopEstimate is ApiEstimate is AD_MemoryEstimate
     assert TopPlan is ApiPlan is ADMemoryPlan
+    assert TopComponent is ApiComponent is ADMemoryComponent
+    assert TopExplanation is ApiExplanation is ADMemoryExplainabilityReport
     assert TopSimulation is ApiSimulation is Simulation
 
     sim = _uniform_sim()
     estimate = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
     plan = sim.plan_ad_memory(n_steps=120, available_memory_gb=100.0)
+    explanation = sim.explain_ad_memory(n_steps=120, checkpoint_segments=10)
 
     assert json.loads(estimate.to_json()) == estimate.to_dict()
     assert json.loads(plan.to_json()) == plan.to_dict()
+    assert json.loads(explanation.to_json()) == explanation.to_dict()
     assert estimate.to_dict()["checkpoint_segments"] == 10
     estimate_keys = {
         "evidence_class",
@@ -155,9 +170,23 @@ def test_public_imports_and_json_roundtrip():
         "segmented_fits",
         "recommendation",
     }
+    explanation_keys = {
+        "evidence_class",
+        "n_steps",
+        "strategy",
+        "selected_memory_gb",
+        "selected_memory_field",
+        "estimate",
+        "components",
+        "dominant_component",
+        "recommendations",
+    }
     assert plan.to_dict()["evidence_class"] == "calibrated_conservative_plan"
     assert set(estimate.to_dict()) == estimate_keys
     assert set(plan.to_dict()) == plan_keys
+    assert set(explanation.to_dict()) == explanation_keys
+    assert explanation.to_dict()["estimate"]["evidence_class"] == "static_estimate"
+    assert explanation.to_dict()["evidence_class"] == "static_ad_explainability"
     assert set(plan.to_dict()["selected_estimate"]) == estimate_keys
     assert plan.to_dict()["selected_estimate"]["evidence_class"] == "static_estimate"
     _assert_no_forbidden_current_fields(estimate.to_dict())
@@ -165,6 +194,8 @@ def test_public_imports_and_json_roundtrip():
     _assert_no_forbidden_current_fields(plan.to_dict()["selected_estimate"])
     assert "evidence_class" not in AD_MemoryEstimate._fields
     assert "evidence_class" not in ADMemoryPlan._fields
+    assert "evidence_class" not in ADMemoryComponent._fields
+    assert "evidence_class" not in ADMemoryExplainabilityReport._fields
     with pytest.raises(ValueError):
         estimate._replace(evidence_class="observed_profile")
     with pytest.raises(ValueError):
@@ -175,6 +206,11 @@ def test_current_memory_artifacts_keep_evidence_classes_separate():
     sim = _patch_like_sim()
     estimate = sim.estimate_ad_memory(n_steps=10_000, checkpoint_every=500)
     plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=1.0)
+    explanation = sim.explain_ad_memory(
+        n_steps=10_000,
+        checkpoint_every=500,
+        available_memory_gb=1.0,
+    )
     report = sim.mesh_intelligence_report(
         n_steps=10_000,
         checkpoint_every=plan.checkpoint_every,
@@ -184,21 +220,124 @@ def test_current_memory_artifacts_keep_evidence_classes_separate():
     estimate_artifact = estimate.to_dict()
     plan_artifact = plan.to_dict()
     report_artifact = report.to_dict()
+    explanation_artifact = explanation.to_dict()
 
     assert estimate_artifact["evidence_class"] == "static_estimate"
     assert plan_artifact["evidence_class"] == "calibrated_conservative_plan"
     assert plan_artifact["selected_estimate"]["evidence_class"] == "static_estimate"
     assert report_artifact["ad_memory"]["evidence_class"] == "static_estimate"
+    assert explanation_artifact["evidence_class"] == "static_ad_explainability"
+    assert explanation_artifact["estimate"]["evidence_class"] == "static_estimate"
 
     _assert_no_forbidden_current_fields(estimate_artifact)
     _assert_no_forbidden_current_fields(plan_artifact)
     _assert_no_forbidden_current_fields(plan_artifact["selected_estimate"])
     _assert_no_forbidden_current_fields(report_artifact["ad_memory"])
+    _assert_no_forbidden_current_fields(explanation_artifact["estimate"])
+
+
+def test_explain_ad_memory_decomposes_selected_estimate():
+    sim = _patch_like_sim()
+
+    explanation = sim.explain_ad_memory(n_steps=10_000, checkpoint_every=500)
+    artifact = explanation.to_dict()
+    components = {component["name"]: component for component in artifact["components"]}
+
+    assert explanation.strategy == "segmented_checkpoint_every"
+    assert explanation.selected_memory_field == "ad_segmented_gb"
+    assert explanation.selected_memory_gb == explanation.estimate.ad_segmented_gb
+    assert explanation.dominant_component == "segmented_boundary_field_tape"
+    assert {
+        "field_state",
+        "material_auxiliary_state",
+        "cpml_auxiliary_state",
+        "segmented_boundary_field_tape",
+        "ntff_dft_state",
+    } == set(components)
+    assert components["segmented_boundary_field_tape"]["kind"] == "reverse_ad_saved_state"
+    assert components["segmented_boundary_field_tape"]["count"] == (
+        2 * explanation.estimate.ad_segmented_active_segments
+    )
+    assert components["segmented_boundary_field_tape"]["memory_gb"] > components["field_state"]["memory_gb"]
+    assert sum(
+        component["memory_gb"] for component in artifact["components"]
+    ) == pytest.approx(explanation.selected_memory_gb)
+    assert json.loads(explanation.to_json()) == artifact
+
+def test_explain_ad_memory_covers_ntff_and_segmented_warmup_paths():
+    baseline = _uniform_sim().explain_ad_memory(n_steps=120, checkpoint_segments=10)
+    sim = _uniform_sim()
+    sim.add_ntff_box(
+        (1e-3, 1e-3, 1e-3),
+        (9e-3, 9e-3, 4e-3),
+        n_freqs=3,
+    )
+
+    segmented = sim.explain_ad_memory(
+        n_steps=120,
+        checkpoint_segments=10,
+        n_warmup=61,
+    )
+    chunked = sim.explain_ad_memory(
+        n_steps=120,
+        checkpoint_every=12,
+        n_warmup=61,
+    )
+
+    for explanation, strategy in (
+        (segmented, "segmented_checkpoint_segments"),
+        (chunked, "segmented_checkpoint_every"),
+    ):
+        artifact = explanation.to_dict()
+        components = {component["name"]: component for component in artifact["components"]}
+
+        assert explanation.strategy == strategy
+        assert explanation.selected_memory_field == "ad_segmented_gb"
+        assert explanation.estimate.ntff_dft_gb > baseline.estimate.ntff_dft_gb
+        assert explanation.estimate.ad_segmented_active_segments == 5
+        assert components["ntff_dft_state"]["memory_gb"] == pytest.approx(
+            explanation.estimate.ntff_dft_gb
+        )
+        assert components["segmented_boundary_field_tape"]["count"] == (
+            2 * explanation.estimate.ad_segmented_active_segments
+        )
+        assert sum(
+            component["memory_gb"] for component in artifact["components"]
+        ) == pytest.approx(explanation.selected_memory_gb)
+
+
+def test_explain_ad_memory_records_warmup_mask_and_full_tape():
+    sim = _uniform_sim()
+    design_mask = _design_mask(sim, fraction=0.5)
+
+    explanation = sim.explain_ad_memory(
+        n_steps=120,
+        n_warmup=20,
+        design_mask=design_mask,
+    )
+    artifact = explanation.to_dict()
+    components = {component["name"]: component for component in artifact["components"]}
+
+    assert explanation.strategy == "full_reverse_ad_static_tape"
+    assert explanation.selected_memory_field == "ad_full_gb"
+    assert components["full_reverse_field_tape"]["count"] == 100
+    assert explanation.estimate.ad_active_design_fraction == pytest.approx(
+        np.count_nonzero(design_mask) / design_mask.size
+    )
+    assert any("design_mask" in rec for rec in explanation.recommendations)
+    assert sum(
+        component["memory_gb"] for component in artifact["components"]
+    ) == pytest.approx(explanation.selected_memory_gb)
 
 
 def test_current_memory_recommendations_do_not_claim_guarantees():
     sim = _patch_like_sim()
     plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=1.0)
+    explanation = sim.explain_ad_memory(
+        n_steps=10_000,
+        checkpoint_every=plan.checkpoint_every,
+        available_memory_gb=1.0,
+    )
     report = sim.mesh_intelligence_report(
         n_steps=10_000,
         checkpoint_every=plan.checkpoint_every,
@@ -209,6 +348,7 @@ def test_current_memory_recommendations_do_not_claim_guarantees():
         plan.recommendation,
         report.recommendation,
         sim.estimate_ad_memory(n_steps=10_000, available_memory_gb=1e-6).warning,
+        *explanation.recommendations,
     ]
     for text in texts:
         assert text is not None
@@ -220,8 +360,10 @@ def test_memory_reduction_docs_separate_planning_from_certificate_evidence():
     doc = Path("docs/public/guide/memory-reduction.mdx").read_text()
     assert "`static_estimate`" in doc
     assert "`calibrated_conservative_plan`" in doc
+    assert "`static_ad_explainability`" in doc
+    assert "explain_ad_memory(...)" in doc
     assert "`bounded_certificate`" in doc
-    assert "Current `estimate_ad_memory(...)` and `plan_ad_memory(...)` artifacts are not certificates" in doc
+    assert "Current `estimate_ad_memory(...)`, `plan_ad_memory(...)`, and `explain_ad_memory(...)` artifacts are not certificates" in doc
     assert "not a universal guaranteed peak predictor" in doc
 
 

--- a/tests/test_jax_checks.py
+++ b/tests/test_jax_checks.py
@@ -1,0 +1,118 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+import rfx
+from rfx.jax_checks import (
+    check_bounds,
+    check_courant_number,
+    check_finite,
+    check_positive,
+    checkify_invariants,
+)
+
+
+def test_checkify_invariants_catches_user_checks_under_jit():
+    def loss(eps_r):
+        check_finite(eps_r, name="eps_r")
+        check_bounds(eps_r, lower=1.0, upper=12.0, name="eps_r")
+        return jnp.sum(eps_r)
+
+    checked = jax.jit(checkify_invariants(loss))
+
+    err, value = checked(jnp.array([1.0, 2.0, 12.0]))
+    assert err.get() is None
+    assert value == pytest.approx(15.0)
+
+    err, _ = checked(jnp.array([1.0, 13.0]))
+    assert "eps_r must be <= 12.0" in str(err.get())
+
+    err, _ = checked(jnp.array([1.0, jnp.nan]))
+    assert "eps_r must be finite" in str(err.get())
+
+
+def test_checkify_invariants_can_enable_automatic_float_checks():
+    def reciprocal(x):
+        return 1.0 / x
+
+    checked = jax.jit(checkify_invariants(reciprocal, float_checks=True))
+    err, value = checked(jnp.array([1.0, 0.0]))
+
+    assert jnp.isinf(value[1])
+    assert "division by zero" in str(err.get()).lower()
+
+def test_checkify_invariants_can_disable_float_checks_and_enable_index_checks():
+    def reciprocal(x):
+        return 1.0 / x
+
+    no_float_checks = jax.jit(
+        checkify_invariants(reciprocal, float_checks=False)
+    )
+    err, value = no_float_checks(jnp.array([1.0, 0.0]))
+    assert err.get() is None
+    assert jnp.isinf(value[1])
+
+    def out_of_bounds(x):
+        return x[jnp.array([2])][0]
+
+    checked_index = jax.jit(
+        checkify_invariants(out_of_bounds, float_checks=False, index_checks=True)
+    )
+    err, _ = checked_index(jnp.array([1.0, 2.0]))
+    assert "out-of-bounds" in str(err.get())
+
+
+
+def test_check_helpers_work_with_vmap():
+    def validate_courant(courant):
+        check_courant_number(courant, limit=0.99, name="cfl")
+        return courant
+
+    checked = checkify_invariants(jax.vmap(validate_courant))
+
+    err, value = checked(jnp.array([0.1, 0.5, 0.99]))
+    assert err.get() is None
+    assert value.tolist() == pytest.approx([0.1, 0.5, 0.99])
+
+    err, _ = checked(jnp.array([0.1, 1.01]))
+    assert "cfl must be <= 0.99" in str(err.get())
+
+def test_check_helpers_work_through_lax_scan():
+    def body(carry, x):
+        check_positive(x, name="scan_weight")
+        return carry + x, x
+
+    def run_scan(xs):
+        total, _ = jax.lax.scan(body, 0.0, xs)
+        return total
+
+    checked = checkify_invariants(run_scan)
+    err, value = checked(jnp.array([1.0, 2.0, 3.0]))
+    assert err.get() is None
+    assert value == pytest.approx(6.0)
+
+    err, _ = checked(jnp.array([1.0, -1.0, 3.0]))
+    assert "scan_weight must be positive" in str(err.get())
+
+
+def test_positive_and_bounds_validate_python_side_configuration():
+    with pytest.raises(ValueError, match="at least one"):
+        check_bounds(jnp.ones((2,)))
+    with pytest.raises(ValueError, match="limit"):
+        check_courant_number(jnp.array(0.5), limit=0.0)
+
+    def nonnegative(x):
+        check_positive(x, name="loss_weight", allow_zero=True)
+        return jnp.sum(x)
+
+    checked = checkify_invariants(nonnegative)
+    err, _ = checked(jnp.array([0.0, -1.0]))
+    assert "loss_weight must be non-negative" in str(err.get())
+
+
+def test_jax_checks_public_exports():
+    assert rfx.checkify_invariants is checkify_invariants
+    assert rfx.check_finite is check_finite
+    assert rfx.check_positive is check_positive
+    assert rfx.check_bounds is check_bounds
+    assert rfx.check_courant_number is check_courant_number

--- a/tests/test_mesh_intelligence_report.py
+++ b/tests/test_mesh_intelligence_report.py
@@ -57,6 +57,47 @@ def test_mesh_intelligence_report_uses_segmented_ad_estimate():
     assert "legacy step-checkpoint" in report.recommendation
 
 
+def test_mesh_intelligence_report_forwards_ad_tape_metadata():
+    sim = _patch_like_nonuniform_sim()
+    baseline = sim.mesh_intelligence_report(n_steps=1_000, checkpoint_every=100)
+    assert baseline.ad_memory is not None
+
+    mask = np.zeros(baseline.grid_shape, dtype=bool)
+    mask.reshape(-1)[: max(1, mask.size // 4)] = True
+    report = sim.mesh_intelligence_report(
+        n_steps=1_000,
+        checkpoint_every=100,
+        n_warmup=600,
+        design_mask=mask,
+    )
+
+    assert report.ad_memory is not None
+    assert report.ad_memory.forward_gb == baseline.ad_memory.forward_gb
+    assert report.ad_memory.ad_active_steps == 400
+    assert report.ad_memory.ad_active_design_fraction == np.count_nonzero(mask) / mask.size
+    assert report.ad_memory.ad_full_gb < baseline.ad_memory.ad_full_gb
+
+
+def test_mesh_intelligence_report_uses_uniform_checkpoint_segments():
+    sim = Simulation(
+        freq_max=10e9,
+        domain=(10e-3, 10e-3, 5e-3),
+        dx=1e-3,
+        boundary="cpml",
+        cpml_layers=2,
+    )
+    sim.add_source((5e-3, 5e-3, 2e-3), "ez")
+    sim.add_probe((5e-3, 5e-3, 3e-3), "ez")
+
+    report = sim.mesh_intelligence_report(n_steps=120, checkpoint_segments=10)
+
+    assert report.ad_memory is not None
+    assert report.ad_memory.checkpoint_segments == 10
+    assert report.ad_memory.checkpoint_every is None
+    assert report.ad_memory.ad_segmented_gb is not None
+    assert "segmented AD estimate" in report.recommendation
+
+
 def test_mesh_intelligence_report_serializes_artifact():
     sim = _patch_like_nonuniform_sim()
 
@@ -71,6 +112,21 @@ def test_mesh_intelligence_report_serializes_artifact():
     assert artifact["ad_memory"] is not None
     assert artifact["ad_memory"]["checkpoint_every"] == 1000
     assert artifact["ad_memory"]["ad_segmented_gb"] == report.ad_memory.ad_segmented_gb
+    assert artifact["ad_memory"]["evidence_class"] == "static_estimate"
+    forbidden_fields = {
+        "compiler_memory_gb",
+        "compiler_reported_required_gb",
+        "observed_peak_gb",
+        "profile_peak_gb",
+        "certificate_status",
+        "scope_digest",
+        "config_digest",
+        "environment_digest",
+        "is_valid_certificate",
+        "is_budget_safe",
+        "peak_bound_gb",
+    }
+    assert forbidden_fields.isdisjoint(artifact["ad_memory"])
     assert parsed == artifact
 
 

--- a/tests/test_pareto.py
+++ b/tests/test_pareto.py
@@ -1,0 +1,255 @@
+import json
+
+import numpy as np
+import pytest
+
+import rfx
+from rfx.pareto import (
+    ParetoFront,
+    ParetoPoint,
+    epsilon_constraint_mask,
+    pareto_front,
+    pareto_mask,
+    select_epsilon_constrained,
+    weighted_scalarization,
+)
+from rfx.sweep import SweepResult
+
+
+def test_pareto_mask_handles_mixed_minimize_maximize_objectives():
+    # Columns: |S11| to minimize, bandwidth to maximize, footprint to minimize.
+    objectives = np.array([
+        [0.20, 1.0, 10.0],  # dominated by B
+        [0.10, 1.5, 9.0],   # B: non-dominated
+        [0.08, 1.0, 12.0],  # C: trades better S11 for worse area/bandwidth
+        [0.12, 2.0, 11.0],  # D: trades bandwidth for worse S11/area
+        [0.10, 1.5, 9.0],   # duplicate non-dominated point
+    ])
+
+    mask = pareto_mask(objectives, minimize=(True, False, True))
+
+    assert mask.tolist() == [False, True, True, True, True]
+
+def test_pareto_mask_handles_all_maximize_and_tolerance_boundaries():
+    maximize_objectives = np.array([
+        [1.0, 1.0],
+        [2.0, 1.0],
+        [1.0, 2.0],
+    ])
+    close_minimize = np.array([
+        [1.00],
+        [1.05],
+    ])
+
+    assert pareto_mask(maximize_objectives, minimize=False).tolist() == [
+        False,
+        True,
+        True,
+    ]
+    assert pareto_mask(close_minimize, atol=0.0).tolist() == [True, False]
+    assert pareto_mask(close_minimize, atol=0.10).tolist() == [True, True]
+
+
+
+def test_pareto_front_serializes_ids_metadata_and_indices():
+    objectives = np.array([
+        [0.20, 1.0],
+        [0.10, 1.5],
+        [0.08, 1.0],
+    ])
+
+    front = pareto_front(
+        objectives,
+        minimize=(True, False),
+        ids=["wide", "balanced", "narrow"],
+        objective_names=["s11", "bandwidth"],
+        metadata=[{"width_um": 80}, {"width_um": 120}, {"width_um": 60}],
+    )
+    artifact = front.to_dict()
+
+    assert isinstance(front, ParetoFront)
+    assert front.evidence_class == "pareto_front"
+    assert front.front_indices == (1, 2)
+    assert front.dominated_indices == (0,)
+    assert [point.id for point in front.points] == ["balanced", "narrow"]
+    assert front.points[0].source_index == 1
+    assert front.points[0].metadata == {"width_um": 120}
+    assert artifact["points"][0]["source_index"] == 1
+    assert json.loads(front.to_json()) == artifact
+
+def test_pareto_front_normalizes_numpy_metadata_for_json():
+    front = pareto_front(
+        [[1.0, 2.0]],
+        metadata=[
+            {
+                "np_int": np.int64(7),
+                "array": np.array([1.0, 2.0]),
+                "nested": {"flag": np.bool_(True)},
+            }
+        ],
+    )
+    metadata = front.to_dict()["points"][0]["metadata"]
+
+    assert metadata == {
+        "np_int": 7,
+        "array": [1.0, 2.0],
+        "nested": {"flag": True},
+    }
+    assert json.loads(front.to_json())["points"][0]["metadata"] == metadata
+
+
+
+def test_weighted_scalarization_is_lower_better_and_can_normalize():
+    objectives = np.array([
+        [0.20, 1.0, 10.0],
+        [0.10, 1.5, 9.0],
+        [0.12, 2.0, 11.0],
+    ])
+
+    raw_scores = weighted_scalarization(
+        objectives,
+        weights=[1.0, 1.0, 0.0],
+        minimize=(True, False, True),
+    )
+    normalized_scores = weighted_scalarization(
+        objectives,
+        weights=[1.0, 1.0, 0.0],
+        minimize=(True, False, True),
+        normalize=True,
+    )
+
+    assert raw_scores.tolist() == pytest.approx([-0.8, -1.4, -1.88])
+    assert int(np.argmin(raw_scores)) == 2
+    assert int(np.argmin(normalized_scores)) == 2
+
+def test_scalarization_and_epsilon_edge_cases():
+    constant = np.array([
+        [1.0, 3.0],
+        [1.0, 2.0],
+    ])
+
+    scores = weighted_scalarization(
+        constant,
+        weights=[1.0, 1.0],
+        normalize=True,
+    )
+
+    assert scores.tolist() == pytest.approx([1.0, 0.0])
+    assert epsilon_constraint_mask(constant, {}).tolist() == [True, True]
+    assert select_epsilon_constrained(
+        constant,
+        primary_index=1,
+        epsilons={},
+    ) == 1
+
+
+def test_epsilon_constraint_selects_best_feasible_primary_objective():
+    objectives = np.array([
+        [0.20, 1.0, 10.0],
+        [0.10, 1.5, 9.0],
+        [0.08, 1.0, 12.0],
+        [0.12, 2.0, 11.0],
+    ])
+
+    feasible = epsilon_constraint_mask(
+        objectives,
+        {1: 1.4, 2: 11.0},
+        minimize=(True, False, True),
+    )
+    selected = select_epsilon_constrained(
+        objectives,
+        primary_index=0,
+        epsilons={1: 1.4, 2: 11.0},
+        minimize=(True, False, True),
+    )
+
+    assert feasible.tolist() == [False, True, False, True]
+    assert selected == 1
+    assert select_epsilon_constrained(
+        objectives,
+        primary_index=0,
+        epsilons={1: 3.0},
+        minimize=(True, False, True),
+    ) is None
+
+def test_sweep_result_builds_pareto_front_from_metric_mapping():
+    sweep = SweepResult(
+        results=[object(), object(), object()],
+        param_name="width_um",
+        param_values=np.array([80, 120, 160]),
+    )
+
+    front = sweep.pareto_front(
+        {
+            "s11": np.array([0.20, 0.10, 0.08]),
+            "bandwidth": np.array([1.0, 1.5, 1.0]),
+        },
+        minimize=(True, False),
+    )
+
+    assert front.objective_names == ("s11", "bandwidth")
+    assert front.front_indices == (1, 2)
+    assert [point.id for point in front.points] == [
+        "width_um=120",
+        "width_um=160",
+    ]
+    assert front.points[0].metadata == {"width_um": 120}
+
+
+def test_sweep_result_builds_pareto_front_from_builtin_metric_names():
+    class Result:
+        def __init__(self, s11_mag):
+            self.s_params = np.array([[[s11_mag]]], dtype=complex)
+
+    sweep = SweepResult(
+        results=[Result(0.5), Result(0.1), Result(0.2)],
+        param_name="gap_um",
+        param_values=np.array([1, 2, 3]),
+    )
+
+    front = sweep.pareto_front(("s11_min_db",))
+
+    assert front.front_indices == (1,)
+    assert front.points[0].id == "gap_um=2"
+    with pytest.raises(ValueError, match="unknown sweep metric"):
+        sweep.pareto_front(("missing_metric",))
+    with pytest.raises(ValueError, match="shape"):
+        sweep.pareto_front({"bad": np.array([1.0, 2.0])})
+
+
+def test_pareto_helpers_validate_shapes_and_finite_inputs():
+    with pytest.raises(ValueError, match="2D"):
+        pareto_mask([1.0, 2.0])
+    with pytest.raises(ValueError, match="finite"):
+        pareto_mask([[1.0, np.nan]])
+    with pytest.raises(ValueError, match="minimize"):
+        pareto_mask([[1.0, 2.0]], minimize=(True, False, True))
+    with pytest.raises(ValueError, match="weight"):
+        weighted_scalarization([[1.0, 2.0]], weights=[0.0, 0.0])
+    with pytest.raises(IndexError, match="out of range"):
+        epsilon_constraint_mask([[1.0, 2.0]], {2: 1.0})
+    with pytest.raises(ValueError, match="ids"):
+        pareto_front([[1.0, 2.0]], ids=[])
+
+
+def test_pareto_public_export_identity_and_strict_json():
+    assert rfx.ParetoFront is ParetoFront
+    assert rfx.ParetoPoint is ParetoPoint
+    assert rfx.pareto_front is pareto_front
+    assert rfx.pareto_mask is pareto_mask
+    assert rfx.weighted_scalarization is weighted_scalarization
+    assert rfx.epsilon_constraint_mask is epsilon_constraint_mask
+    assert rfx.select_epsilon_constrained is select_epsilon_constrained
+
+    bad = ParetoFront(
+        points=(ParetoPoint(source_index=0, id="bad", objectives=(float("nan"),)),),
+        minimize=(True,),
+        objective_names=("bad",),
+        source_count=1,
+        front_indices=(0,),
+        dominated_indices=(),
+    )
+    with pytest.raises(ValueError, match="Out of range"):
+        bad.to_json()
+    with pytest.raises(ValueError, match="Out of range"):
+        bad.to_json(allow_nan=True)


### PR DESCRIPTION
## Summary
- Add AD saved-residual inspection/diagnostic reports and public exports.
- Add JAX checkify invariant helpers and Pareto-front utilities for RF sweeps.
- Add AD memory preflight UX plus bounded compiled-memory certificate API with exact-scope digests and fail-closed JAX memory analysis normalization.
- Document residual diagnostics, preflight usage, and compiled certificate behavior, including array/ShapeDtypeStruct signature metadata.

## Base
Stacked on #231 (`feat/ad-memory-planner`) so this PR reviews only the follow-up feature commit.

## Verification
- `pytest tests/test_estimate_ad_memory.py tests/test_ad_diagnostics.py tests/test_jax_checks.py tests/test_pareto.py -q` — 108 passed, 25 warnings
- `ruff check rfx/ad_diagnostics.py rfx/api/_compiled_memory.py rfx/api/_spec.py rfx/api/__init__.py rfx/__init__.py rfx/jax_checks.py rfx/pareto.py rfx/sweep.py tests/test_estimate_ad_memory.py tests/test_ad_diagnostics.py tests/test_jax_checks.py tests/test_pareto.py` — OK
