### PR TITLE
Deslop public RF/EM documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 **Differentiable 3D FDTD electromagnetic simulator for RF and microwave engineering — powered by JAX.**
 
-**v1.6.5 package** — JAX-based RF/FDTD workflows, GPU-oriented execution, practical examples, structured setup guards, and port-family validation envelopes.
+**v1.6.6** — JAX-based RF/FDTD workflows, GPU-oriented execution, practical examples, structured setup guards, and port-family validation envelopes.
 
-> **Project status (June 2026):** `rfx` is an actively validated RF/FDTD simulator. Use the uniform Cartesian Yee RF lane first; additional workflows should be used only inside their documented evidence envelopes.
+> **Project status:** `rfx` is an actively validated RF/FDTD simulator. Use the uniform Cartesian Yee RF lane first; additional workflows should be used only inside their documented evidence envelopes.
 
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Tests](https://github.com/bk-squared/rfx/actions/workflows/pr-tests.yml/badge.svg)](https://github.com/bk-squared/rfx/actions)
@@ -27,22 +27,22 @@ The recommended starting point is the **uniform Cartesian Yee RF/FDTD lane**. Pu
 | | |
 |---|---|
 | **GPU-accelerated** | 7,309 Mcells/s on RTX 4090, 5,249 on A6000 via `jax.lax.scan` JIT |
-| **Differentiable** | `jax.grad` through time-domain workflows for inverse design |
+| **Differentiable workflows** | `jax.grad` through selected JAX-traced time-domain objectives; final RF claims still require the relevant validation envelope |
 | **RF workflow tools** | materials, sources, probes, ports, S-parameter helpers, Harminv, far-field utilities |
 | **Waveguide modal ports** | analytical TE/TM eigenmodes for documented rectangular-guide S-matrix envelopes |
 | **Port-family S-parameter routing** | lumped/wire, microstrip-line, rectangular waveguide, and coaxial-line workflows use different calculators and evidence envelopes |
-| **Published benchmark evidence** | 5-case benchmark against Balanis/Pozar (patch 1.97%, cavity 0.016%) |
+| **Documented benchmark evidence** | public validation cases mapped to analytic or external references with stated envelopes |
 | **Regression checks** | CI and local checks support development without replacing feature-specific validation |
 | **Documentation scope** | public guides cover maintained workflows and explicitly bounded support envelopes |
 
-## Current main highlights
+## Current Highlights
 
-- **Public workflow scope (June 2026)**: user guides lead with uniform Yee RF workflows, documented waveguide/MSL/lumped/wire port envelopes, bounded coaxial line reflection, and conservative differentiable design loops.
-- **Structured preflight and runtime guards (current `main`)**: `preflight()` and `preflight_sparameters()` return coded `PreflightReport` issues while remaining list/string compatible; `run()`, `forward()`, S-matrix calculators, sweeps, and optimizers surface NaN/passivity/setup problems earlier.
-- **Waveguide S-matrix evidence (current `main`)**: rectangular waveguide S-matrices have the strongest current port-family evidence envelope; use the support matrix for exact limits rather than broadening the claim.
-- **Coaxial line reflection (current `main`)**: `compute_coaxial_line_reflection(...)` is the bounded one-port coaxial transmission-line reflection path. It is not a general coaxial network solver.
-- **Curated star-import surface (current `main`)**: `rfx.__all__` exposes the supported public API; per-step kernels and bookkeeping helpers remain available for compatibility but are outside the curated API surface.
-- **Maintained validation lanes (current `main`)**: a full-suite PR gate, API-reference drift checks, a maintained GPU suite harness, weekly external-crossval CI, and on-demand source-built-OpenEMS validation use the honest exit-code convention (reference-missing is a visible SKIP, never a silent pass).
+- **Public workflow scope**: user guides lead with uniform Yee RF workflows, documented waveguide/MSL/lumped/wire port envelopes, bounded coaxial line reflection, and conservative differentiable design loops.
+- **Structured preflight and runtime guards**: `preflight()` and `preflight_sparameters()` return coded `PreflightReport` issues while remaining list/string compatible; `run()`, `forward()`, S-matrix calculators, sweeps, and optimizers surface NaN/passivity/setup problems earlier.
+- **Waveguide S-matrix evidence**: rectangular waveguide S-matrices have the most mature documented port-family evidence envelope; use the support matrix for exact limits rather than broadening the claim.
+- **Coaxial line reflection**: `compute_coaxial_line_reflection(...)` is the bounded one-port coaxial transmission-line reflection path. It is not a general coaxial network solver.
+- **Curated star-import surface**: `rfx.__all__` exposes the supported public API; per-step kernels and bookkeeping helpers remain available for compatibility but are outside the curated API surface.
+- **Maintained validation lanes**: a full-suite PR gate, API-reference drift checks, a maintained GPU suite harness, weekly external-crossval CI, and on-demand source-built-OpenEMS validation use the honest exit-code convention (reference-missing is a visible SKIP, never a silent pass).
 
 ## Installation
 
@@ -61,29 +61,6 @@ For development:
 ```bash
 git clone https://github.com/bk-squared/rfx.git
 cd rfx && pip install -e ".[all]"
-```
-
-### Interactive dashboard (GUI)
-
-rfx ships an experimental Streamlit dashboard — a browser GUI for assembling a
-simulation (geometry, materials, sources/ports, probes), running it, and
-inspecting the results (S-parameter magnitude (dB) plots, Smith chart, field
-slices, probe time series, and Touchstone export) without writing Python. It is
-a convenience front end for quick exploration, not a replacement for the
-scripted API used in the validation lanes.
-
-Install the optional dependency and launch the bundled console command:
-
-```bash
-pip install "rfx-fdtd[dashboard]"
-rfx-dashboard
-```
-
-`rfx-dashboard` forwards any extra arguments straight to `streamlit run`, so you
-can override Streamlit options as usual:
-
-```bash
-rfx-dashboard --server.port 8502
 ```
 
 ## Quick Start
@@ -105,46 +82,32 @@ modes = result.find_resonances(freq_range=(1.5e9, 3.5e9))
 print(f"Resonance: {modes[0].freq/1e9:.4f} GHz  Q={modes[0].Q:.0f}")
 ```
 
-> This compact snippet favours brevity over a production-clean mesh, so `run()`
-> prints a few non-fatal preflight advisories (thin PEC sheets; substrate/feed
-> near the CPML absorber) and the reported resonance is only approximate (this
-> coarse mesh lands ~10–15% high). For a
-> properly resolved patch — PEC ground, non-uniform z-mesh, lossy FR4, and a
-> cross-checked resonance — follow the
-> [First Patch tutorial](docs/public/guide/first-patch.mdx).
+> This compact snippet is for API orientation, not a resolved reference case.
+> It uses a coarse mesh and may print non-fatal preflight advisories. For a
+> resolved rectangular patch workflow with geometry, mesh, material, and
+> validation notes, follow the [First Patch tutorial](docs/public/guide/first-patch.mdx).
 
-## Differentiable S-Parameters
+## Differentiable Design Workflows
 
-`jax.grad` flows end-to-end through the **public S-parameter API** — the
-gradient of a measured S-parameter with respect to material design variables
-in one call, no adjoint plumbing:
+rfx supports selected JAX-traced objectives for inverse design. Treat these as
+**sensitivity calculations through the implemented discrete solver**, not as
+standalone RF validation. For S-parameter-driven work, use the calculator that
+matches the port family and keep the final claim inside that family's evidence
+envelope.
 
-```python
-import jax
+The runnable gradient examples include:
 
-def objective(eps_plug):
-    eps = base_eps.at[plug_region].set(eps_plug)   # design variable
-    res = sim.compute_waveguide_s_matrix(normalize=False, eps_override=eps)
-    s11 = res.s_params[0, 0, target_freq_idx]
-    return jnp.abs(s11) ** 2
+- [`examples/inverse_design/differentiable_s11_design.py`](examples/inverse_design/differentiable_s11_design.py) — differentiable S11 objective with a finite-difference cross-check.
+- [`examples/inverse_design/multilayer_ar_coating.py`](examples/inverse_design/multilayer_ar_coating.py) — conservative differentiable material-profile demo.
 
-grad_fn = jax.grad(objective)        # that's the whole adjoint setup
-g = grad_fn(2.0)
-```
-
-The runnable version with a finite-difference cross-check is
-[`examples/inverse_design/differentiable_s11_design.py`](examples/inverse_design/differentiable_s11_design.py)
-(measured: FD↔AD relative error 4.5e-4, ~15 s on CPU). The CI-gated
-correctness lock is `tests/test_sparam_ad_end_to_end.py`. Memory-bounded
-reverse mode for long runs is available via `checkpoint_segments`.
+For the conceptual background, see the public [Autodiff and Adjoint Background](docs/public/guide/autodiff-adjoint.mdx) guide.
 
 ## Support Contracts
 
-Machine-readable and maintainer-facing support contracts keep public claims aligned with evidence:
+Support contracts keep public claims aligned with evidence:
 
 - [`docs/guides/support_matrix.md`](docs/guides/support_matrix.md) and [`docs/guides/support_matrix.json`](docs/guides/support_matrix.json) — feature support status and public-scope rules.
 - [`docs/guides/sparameter_support_matrix.md`](docs/guides/sparameter_support_matrix.md) and [`docs/guides/sparameter_support_matrix.json`](docs/guides/sparameter_support_matrix.json) — port-family calculators, result schemas, and evidence envelopes.
-- [`docs/guides/public_surface_scope_inventory_20260617.md`](docs/guides/public_surface_scope_inventory_20260617.md) — maintainer-only list of public-repo code surfaces that stay outside user docs until support evidence and public workflow docs exist.
 
 The public API surface is pinned by a symbol/signature inventory gate and the curated public docs.
 
@@ -167,7 +130,7 @@ Gradient (reverse-mode AD): ~3-4x forward pass with `jax.checkpoint`.
 
 ## Accuracy Validation
 
-Benchmarked against Balanis "Antenna Theory" and Pozar "Microwave Engineering":
+Representative public validation cases are tied to named analytic or textbook references:
 
 | Structure | Reference | Error |
 |-----------|-----------|-------|
@@ -199,15 +162,12 @@ For practical public examples, start with `examples/crossval/05_patch_antenna.py
 ### Materials
 - Debye/Lorentz/Drude dispersive, Kerr nonlinear (chi3)
 - Subpixel smoothing, thin conductor correction
-- Material fitting: CSV import, Debye/Lorentz pole fitting
-- Differentiable material fitting (jax.grad through FDTD)
 - Library: pec, fr4, rogers4003c, copper, alumina, water_20c, ...
 
 ### Analysis & Optimization
 - S-parameter tooling with per-family calculators: lumped/wire, MSL, waveguide, and coaxial-line workflows use different APIs and evidence envelopes
 - Harminv resonance extraction (MPM)
-- Far-field, RCS, radiation patterns, polarization
-- Antenna metrics: gain, efficiency, HPBW, F/B ratio, bandwidth
+- Documented far-field, RCS, radiation-pattern, and polarization workflows
 - Differentiable proxy-objective optimization for selected workflows
 - Parametric sweep + jax.vmap batch evaluation
 - Smith chart, de-embedding, Touchstone I/O (.s2p/.s4p/.snp)
@@ -264,13 +224,6 @@ Gitops-side snapshot/build CI lives in the deploy repo:
 - [Validation hub](docs/public/validation/index.mdx) — support overview and lane labels
 - [Examples hub](docs/public/examples/index.mdx) — current runnable entry points
 
-### For AI coding agents
-Working from a fresh clone with an LLM agent? Start with the purpose-built agent docs:
-- [Agent overview & operating rules](docs/agent/overview.mdx) — start here; includes a safe prompt skeleton
-- [Repo map & feature discovery](docs/agent/repo-map.mdx) — how the code is organized + the grep map for finding existing primitives before writing new code
-- [Port selection](docs/agent/port-selection.mdx) — pick the right port family / S-parameter calculator
-- Task recipes: [waveguide S-params](docs/agent/recipe-waveguide-sparams.mdx) · [R(f)/T(f) measurement](docs/agent/recipe-rt-measurement.mdx) · [resonance extraction](docs/agent/recipe-resonance-extraction.mdx) · [differentiable design loop](docs/agent/recipe-design-loop.mdx) · [parameter sweeps](docs/agent/recipe-parameter-sweeps.mdx) · [failed-gate triage](docs/agent/recipe-failed-gate-triage.mdx)
-
 ### Tutorials
 - [Patch Antenna Design](docs/public/guide/tutorial-patch-antenna.mdx) — practical patch workflow from local resonance run to external cross-check
 - [Convergence Study](docs/public/guide/tutorial-convergence.mdx) — mesh independence methodology
@@ -288,7 +241,7 @@ Working from a fresh clone with an LLM agent? Start with the purpose-built agent
   title        = {rfx: JAX-based differentiable 3D FDTD simulator for RF engineering},
   institution  = {REMI Lab, Chungnam National University},
   year         = {2026},
-  version      = {1.6.5},
+  version      = {1.6.6},
   url          = {https://github.com/bk-squared/rfx}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 **Differentiable 3D FDTD electromagnetic simulator for RF and microwave engineering — powered by JAX.**
 
-**v1.6.6** — JAX-based RF/FDTD workflows, GPU-oriented execution, practical examples, structured setup guards, and port-family validation envelopes.
+**v1.6.6** — GPU-scaled `lax.scan` time-stepping, per-port-family S-parameter extractors, and structured preflight guards that surface setup errors before a run.
 
-> **Project status:** `rfx` is an actively validated RF/FDTD simulator. Use the uniform Cartesian Yee RF lane first; additional workflows should be used only inside their documented evidence envelopes.
+> **Project status:** active RF/FDTD simulator. Start with the uniform Cartesian Yee lane; other workflows are supported only within the evidence envelopes documented in the [support matrix](docs/guides/support_matrix.md).
 
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Tests](https://github.com/bk-squared/rfx/actions/workflows/pr-tests.yml/badge.svg)](https://github.com/bk-squared/rfx/actions)
@@ -22,27 +22,25 @@
 
 ## At a Glance
 
-The recommended starting point is the **uniform Cartesian Yee RF/FDTD lane**. Public claims are scoped to documented workflows and bounded evidence envelopes rather than every importable symbol.
+Start with the **uniform Cartesian Yee RF/FDTD lane**; the table below scopes each capability to its supported claim.
 
 | | |
 |---|---|
 | **GPU-accelerated** | 7,309 Mcells/s on RTX 4090, 5,249 on A6000 via `jax.lax.scan` JIT |
-| **Differentiable workflows** | `jax.grad` through selected JAX-traced time-domain objectives; final RF claims still require the relevant validation envelope |
-| **RF workflow tools** | materials, sources, probes, ports, S-parameter helpers, Harminv, far-field utilities |
-| **Waveguide modal ports** | analytical TE/TM eigenmodes for documented rectangular-guide S-matrix envelopes |
-| **Port-family S-parameter routing** | lumped/wire, microstrip-line, rectangular waveguide, and coaxial-line workflows use different calculators and evidence envelopes |
-| **Documented benchmark evidence** | public validation cases mapped to analytic or external references with stated envelopes |
-| **Regression checks** | CI and local checks support development without replacing feature-specific validation |
-| **Documentation scope** | public guides cover maintained workflows and explicitly bounded support envelopes |
+| **Differentiable** | `jax.grad` through the JAX-traced time-domain solver for sensitivity and inverse design |
+| **RF workflow tools** | materials, sources, probes, ports, S-parameter helpers, Harminv, far-field / RCS |
+| **Waveguide modal ports** | analytic TE/TM eigenmodes for rectangular-guide S-matrices |
+| **Per-family S-parameters** | lumped/wire, microstrip-line, rectangular waveguide, and coaxial-line paths use distinct calculators |
+| **Cross-validated** | public cases mapped to Meep / OpenEMS / Palace / analytic references, each with a reproduce command |
 
 ## Current Highlights
 
-- **Public workflow scope**: user guides lead with uniform Yee RF workflows, documented waveguide/MSL/lumped/wire port envelopes, bounded coaxial line reflection, and conservative differentiable design loops.
-- **Structured preflight and runtime guards**: `preflight()` and `preflight_sparameters()` return coded `PreflightReport` issues while remaining list/string compatible; `run()`, `forward()`, S-matrix calculators, sweeps, and optimizers surface NaN/passivity/setup problems earlier.
-- **Waveguide S-matrix evidence**: rectangular waveguide S-matrices have the most mature documented port-family evidence envelope; use the support matrix for exact limits rather than broadening the claim.
-- **Coaxial line reflection**: `compute_coaxial_line_reflection(...)` is the bounded one-port coaxial transmission-line reflection path. It is not a general coaxial network solver.
-- **Curated star-import surface**: `rfx.__all__` exposes the supported public API; per-step kernels and bookkeeping helpers remain available for compatibility but are outside the curated API surface.
-- **Maintained validation lanes**: a full-suite PR gate, API-reference drift checks, a maintained GPU suite harness, weekly external-crossval CI, and on-demand source-built-OpenEMS validation use the honest exit-code convention (reference-missing is a visible SKIP, never a silent pass).
+- **Documented workflows**: uniform Yee RF simulation; rectangular-waveguide, MSL, lumped, and wire ports; one-port coaxial-line reflection; and conservative differentiable design loops.
+- **Structured preflight and runtime guards**: `preflight()` and `preflight_sparameters()` return a coded `PreflightReport` (a `list` subclass, so existing list/string checks still work); `run()`, `forward()`, the S-matrix calculators, sweeps, and optimizers surface NaN / passivity / setup problems early.
+- **Waveguide S-matrices** are the most mature port family; consult the [S-parameter support matrix](docs/guides/sparameter_support_matrix.md) for exact limits rather than broadening the claim.
+- **Coaxial-line reflection**: `compute_coaxial_line_reflection(...)` is the one-port coaxial transmission-line reflection path — not a general coaxial network solver.
+- **Curated star-import surface**: `rfx.__all__` is the supported public API; per-step kernels and bookkeeping helpers stay importable for back-compatibility but sit outside it.
+- **Maintained validation lanes**: a full-suite PR gate, API-reference drift checks, a GPU-suite harness, weekly external-crossval CI, and on-demand source-built-OpenEMS validation, all under the honest exit-code convention (a missing reference is a visible SKIP, never a silent pass).
 
 ## Installation
 
@@ -61,6 +59,18 @@ For development:
 ```bash
 git clone https://github.com/bk-squared/rfx.git
 cd rfx && pip install -e ".[all]"
+```
+
+### Interactive dashboard (GUI)
+
+rfx ships an experimental Streamlit dashboard — a browser GUI for assembling a
+simulation, running it, and inspecting results (S-parameter plots, Smith chart,
+field slices, Touchstone export) without writing Python. Install the optional
+dependency and launch:
+
+```bash
+pip install "rfx-fdtd[dashboard]"
+rfx-dashboard
 ```
 
 ## Quick Start
@@ -82,10 +92,10 @@ modes = result.find_resonances(freq_range=(1.5e9, 3.5e9))
 print(f"Resonance: {modes[0].freq/1e9:.4f} GHz  Q={modes[0].Q:.0f}")
 ```
 
-> This compact snippet is for API orientation, not a resolved reference case.
-> It uses a coarse mesh and may print non-fatal preflight advisories. For a
-> resolved rectangular patch workflow with geometry, mesh, material, and
-> validation notes, follow the [First Patch tutorial](docs/public/guide/first-patch.mdx).
+> This compact snippet favours brevity over a production-clean mesh, so `run()`
+> may print non-fatal preflight advisories and the reported resonance is only
+> approximate (coarse mesh lands ~10–15% high). For a properly resolved patch
+> workflow, follow the [First Patch tutorial](docs/public/guide/first-patch.mdx).
 
 ## Differentiable Design Workflows
 
@@ -97,7 +107,7 @@ envelope.
 
 The runnable gradient examples include:
 
-- [`examples/inverse_design/differentiable_s11_design.py`](examples/inverse_design/differentiable_s11_design.py) — differentiable S11 objective with a finite-difference cross-check.
+- [`examples/inverse_design/differentiable_s11_design.py`](examples/inverse_design/differentiable_s11_design.py) — differentiable S11 objective with a finite-difference cross-check (measured: FD↔AD relative error 4.5e-4, ~15 s on CPU); CI-gated by `tests/test_sparam_ad_end_to_end.py`.
 - [`examples/inverse_design/multilayer_ar_coating.py`](examples/inverse_design/multilayer_ar_coating.py) — conservative differentiable material-profile demo.
 
 For the conceptual background, see the public [Autodiff and Adjoint Background](docs/public/guide/autodiff-adjoint.mdx) guide.
@@ -130,19 +140,22 @@ Gradient (reverse-mode AD): ~3-4x forward pass with `jax.checkpoint`.
 
 ## Accuracy Validation
 
-Representative public validation cases are tied to named analytic or textbook references:
+Each A/B cross-validation case is mapped to a named analytic or external reference. The values below are the **accept envelopes** enforced by each script's own gate code — not single-point marketing errors. Several cases (e.g. `11_waveguide_port_wr90`) are diagnostic reporters whose authoritative gates live in `tests/`.
 
-| Structure | Reference | Error |
-|-----------|-----------|-------|
-| Patch antenna resonance | Balanis Ch 14 | 1.97% |
-| WR-90 TE10 cutoff | Analytical | 0.60% |
-| Dielectric cavity TM110 | Analytical | 0.016% |
-| Microstrip Z0 | Hammerstad-Jensen | 0.47% |
-| Coupled-line filter | Pozar Ch 8 | 22.5% (formula limitation) |
+| Case (`examples/crossval/`) | Upstream reference | Accept envelope (from the script's gate) |
+|---|---|---|
+| `05_patch_antenna` | OpenEMS patch tutorial + Balanis TL analytic | rfx vs OpenEMS Harminv < 20%; vs Balanis TL < 10%; self-consistency < 5%; \|S11\| ≤ 1 |
+| `04_multilayer_fresnel` | Analytic transfer-matrix / Fresnel (Taflove Ch 5) | `T`, `R` mean error and `R+T` energy deviation each < 0.05 |
+| `02_ring_resonator` | Meep "Basics" tutorial + Harminv | mean mode-frequency error < 5%; ≥ 2 modes matched |
+| `09_half_symmetric_waveguide` | Analytic rectangular cavity TE₁₀₁ (Pozar Ch 6) | `f` within 10% of analytic; PMC-half vs full PEC < 5% |
+| `11_waveguide_port_wr90` | Analytic Airy + Meep/Palace JSON when present | empty-guide max\|S11\| < 0.02, min\|S21\| > 0.97; PEC-short mean \|S11\| ∈ [0.97, 1.03] |
+| `06b_msl_notch_filter_uniform` | Analytic quarter-wave stub notch | notch-frequency error < 15%; depth < −10 dB; Z₀ median ∈ (40, 65) Ω |
 
-The full cross-validation suite (Meep / OpenEMS / Palace / analytic references, one reproduce command per case) is summarized in the public validation docs. The CPU-feasible subset runs locally via `python scripts/run_crossval_cpu.py` using the repo-wide exit-code convention (0 = full pass with external reference, 1 = self-check failure, 2 = reference unavailable — visibly skipped, never silently green).
+For the per-case metric, reproduce command, and last-touched commit, see the [benchmark table](docs/public/guide/benchmarks.mdx); for lane guidance and support boundaries, read [Cross-Validation and Accuracy](docs/public/guide/validation.mdx) first.
 
-For practical public examples, start with `examples/crossval/05_patch_antenna.py` for the patch workflow and `examples/crossval/11_waveguide_port_wr90.py` for rectangular waveguide ports. Use scripts outside the recommended example set only as local diagnostics unless a public guide and support matrix entry state otherwise.
+The CPU-feasible subset runs locally via `PYTHONPATH=. python scripts/run_crossval_cpu.py`, using the repo-wide exit-code convention: `0` = full pass including the external cross-check, `1` = a self-check / numeric gate failed, `2` = the external reference (e.g. Meep / OpenEMS) was unavailable, so the case is visibly skipped — never silently green.
+
+For a first read, start with `examples/crossval/05_patch_antenna.py` (patch workflow) and `examples/crossval/11_waveguide_port_wr90.py` (rectangular waveguide ports). Treat scripts outside this validated set as local diagnostics unless a public guide and support-matrix entry list them.
 
 ## Key Features
 
@@ -162,12 +175,14 @@ For practical public examples, start with `examples/crossval/05_patch_antenna.py
 ### Materials
 - Debye/Lorentz/Drude dispersive, Kerr nonlinear (chi3)
 - Subpixel smoothing, thin conductor correction
+- Material fitting: `fit_debye` / `fit_lorentz` (Debye/Lorentz pole fitting from data); `differentiable_material_fit` (jax.grad-traced fitting through FDTD)
 - Library: pec, fr4, rogers4003c, copper, alumina, water_20c, ...
 
 ### Analysis & Optimization
-- S-parameter tooling with per-family calculators: lumped/wire, MSL, waveguide, and coaxial-line workflows use different APIs and evidence envelopes
+- Per-family S-parameter extraction (lumped/wire, MSL, waveguide, coaxial-line — see Sources & Ports above)
 - Harminv resonance extraction (MPM)
 - Documented far-field, RCS, radiation-pattern, and polarization workflows
+- Antenna metrics: `antenna_gain`, `antenna_efficiency`, `half_power_beamwidth`, `front_to_back_ratio`, `antenna_bandwidth` (rfx/antenna.py)
 - Differentiable proxy-objective optimization for selected workflows
 - Parametric sweep + jax.vmap batch evaluation
 - Smith chart, de-embedding, Touchstone I/O (.s2p/.s4p/.snp)
@@ -223,6 +238,13 @@ Gitops-side snapshot/build CI lives in the deploy repo:
 - [Public landing page](docs/public/index.mdx)
 - [Validation hub](docs/public/validation/index.mdx) — support overview and lane labels
 - [Examples hub](docs/public/examples/index.mdx) — current runnable entry points
+
+### For AI coding agents
+Working from a fresh clone with an LLM agent? Start with the purpose-built agent docs:
+- [Agent overview & operating rules](docs/agent/overview.mdx) — start here; includes a safe prompt skeleton
+- [Repo map & feature discovery](docs/agent/repo-map.mdx) — how the code is organized + the grep map for finding existing primitives before writing new code
+- [Port selection](docs/agent/port-selection.mdx) — pick the right port family / S-parameter calculator
+- Task recipes: [waveguide S-params](docs/agent/recipe-waveguide-sparams.mdx) · [R(f)/T(f) measurement](docs/agent/recipe-rt-measurement.mdx) · [resonance extraction](docs/agent/recipe-resonance-extraction.mdx) · [differentiable design loop](docs/agent/recipe-design-loop.mdx) · [parameter sweeps](docs/agent/recipe-parameter-sweeps.mdx) · [failed-gate triage](docs/agent/recipe-failed-gate-triage.mdx)
 
 ### Tutorials
 - [Patch Antenna Design](docs/public/guide/tutorial-patch-antenna.mdx) — practical patch workflow from local resonance run to external cross-check

--- a/docs/guides/support_matrix.md
+++ b/docs/guides/support_matrix.md
@@ -88,9 +88,9 @@ Current policy:
 | Combination | Status | Expected behavior |
 |---|---|---|
 | Periodic-port workflows + nonuniform | unsupported | hard-fail |
-| NTFF + nonuniform | unsupported | hard-fail |
-| DFT planes + nonuniform | unsupported | hard-fail |
-| TFSF + nonuniform | unsupported | hard-fail |
+| NTFF + nonuniform | shadow | runs on graded-z path; validate observable before any public claim |
+| DFT planes + nonuniform | shadow | runs on graded-z path; validate observable before any public claim |
+| TFSF + nonuniform | shadow / restricted | normal ±x incidence (`direction='+x'`/`'-x'`, `angle_deg=0`) runs on graded-z path (shadow); oblique or ±z incidence raises |
 | Waveguide ports + nonuniform | shadow / restricted | `compute_waveguide_s_matrix(normalize=True/'flux')` single-mode TE10 validated at settled `num_periods`; **broad-E5-analytic envelope committed + gated** (graded-`dy` 1-3x, eps_r 2/4, vs analytic Airy, `tests/test_waveguide_nu_broad_e5_envelope_gates.py`); still **shadow / not claims-bearing** pending broad-E4 external cross-solver + AD-traceability; otherwise hard-fail |
 | Lumped-port S-parameters + nonuniform | unsupported | hard-fail |
 | `compute_msl_s_matrix()` + nonuniform | unsupported | hard-fail |

--- a/docs/public/api/automation.mdx
+++ b/docs/public/api/automation.mdx
@@ -15,7 +15,7 @@ without hand-deriving every simulation parameter.
 | `plan_mesh` | `plan_mesh(geometry, freq_range, materials=None, accuracy="standard", boundary="cpml", ...)` | returns a serializable `MeshPlan` with mesh, CFL, absorber, memory, support-check, and artifact declarations |
 | `auto_configure` | `auto_configure(geometry, freq_range, materials=None, accuracy="standard", boundary="cpml", dx_override=None, margin_override=None, n_steps_override=None, max_memory_mb=None)` | derives mesh, margin, and run budget from geometry + frequency range |
 | `Simulation.auto` | `Simulation.auto(freq_range, accuracy="standard", **kwargs)` | convenience constructor for a full simulation |
-| `smooth_grading` | mesh-profile smoothing helper | used by current crossval workflows for graded z-profiles |
+| `smooth_grading` | mesh-profile smoothing helper | used by documented thin-substrate workflows for graded z-profiles |
 | `apply_thirds_rule` | feature-aware mesh helper | used when derived meshes need conservative refinement |
 
 ```python
@@ -41,9 +41,8 @@ and carry the requested `accuracy`; they have not run `Simulation.preflight()`.
 - Use the result in public reporting only after it matches the support matrix and validation
   evidence for the intended lane.
 
-## Current workflow note
+## Workflow note
 
-The newest thin-substrate crossval scripts use `smooth_grading()` to build
-non-uniform z-profiles around the substrate. That is useful workflow evidence,
-but it does not by itself make the graded-z workflow a validated reference path.
-
+Thin-substrate workflows can use `smooth_grading()` to build non-uniform
+z-profiles around the substrate. That is useful setup evidence, but it does not
+by itself make the graded-z workflow a validated reference path.

--- a/docs/public/api/automation.mdx
+++ b/docs/public/api/automation.mdx
@@ -5,44 +5,73 @@ sidebar:
   order: 25
 ---
 
-Automation helpers are useful when you want a fast, reproducible starting point
-without hand-deriving every simulation parameter.
+Automation helpers derive a first-pass mesh, domain, absorber, and run budget from
+geometry plus a frequency range, so you don't hand-derive every simulation
+parameter.
 
 ## Core helpers
 
 | Helper | Signature | What it does |
 |---|---|---|
-| `plan_mesh` | `plan_mesh(geometry, freq_range, materials=None, accuracy="standard", boundary="cpml", ...)` | returns a serializable `MeshPlan` with mesh, CFL, absorber, memory, support-check, and artifact declarations |
-| `auto_configure` | `auto_configure(geometry, freq_range, materials=None, accuracy="standard", boundary="cpml", dx_override=None, margin_override=None, n_steps_override=None, max_memory_mb=None)` | derives mesh, margin, and run budget from geometry + frequency range |
-| `Simulation.auto` | `Simulation.auto(freq_range, accuracy="standard", **kwargs)` | convenience constructor for a full simulation |
-| `smooth_grading` | mesh-profile smoothing helper | used by documented thin-substrate workflows for graded z-profiles |
-| `apply_thirds_rule` | feature-aware mesh helper | used when derived meshes need conservative refinement |
+| `auto_configure` | `auto_configure(geometry, freq_range, materials=None, accuracy="standard", *, boundary="cpml", dx_override=None, margin_override=None, n_steps_override=None, max_memory_mb=None)` | derives `dx`, `domain`, CPML layers, timestep, `n_steps`, and (for thin z-features) a `dz_profile`; returns a `SimConfig` |
+| `plan_mesh` | `plan_mesh(geometry, freq_range, materials=None, accuracy="standard", *, boundary="cpml", dx_override=None, margin_override=None, n_steps_override=None, max_memory_mb=None, artifact_root=None)` | wraps `auto_configure` and returns a serializable `MeshPlan` with the derived mesh, CFL basis, absorber, memory estimate, resolution/support rows, and declaration-only artifact paths |
+| `Simulation.auto` | `Simulation.auto(freq_range, *, accuracy="standard", **kwargs)` | classmethod that builds a `Simulation` with mesh/domain/CPML derived from `freq_range` alone (empty geometry). Add geometry afterward; it warns by design to remind you |
+| `smooth_grading` | `smooth_grading(cells, max_ratio=1.3, *, preserve_regions=None)` | inserts geometric transition cells into a cell-size array so no two adjacent cells differ by more than `max_ratio` (default 1.3), reducing reflections at abrupt mesh steps |
+| `apply_thirds_rule` | `apply_thirds_rule(cells, boundary_indices)` | at each material-interface index, splits the neighbouring cells into 1/3 + 2/3 pairs so no E-field node lands exactly on the interface |
+
+`accuracy` selects a preset — `"draft"` (10 cells/λ), `"standard"` (20 cells/λ), or
+`"high"` (40 cells/λ); any other value raises. `smooth_grading` and
+`apply_thirds_rule` are the same primitives `auto_configure` calls internally when
+it builds a non-uniform `dz_profile`; reach for them directly only when
+hand-building a mesh.
 
 ```python
-from rfx import Simulation, plan_mesh
+from rfx import Box, Simulation, plan_mesh
+
+# geometry is a list of (Shape, material_name) tuples; "fr4" is in the
+# built-in material library, so no separate materials dict is needed here.
+geometry = [(Box((0.0, 0.0, 0.0), (0.02, 0.01, 0.002)), "fr4")]
 
 plan = plan_mesh(geometry, freq_range=(1.5e9, 3.5e9), accuracy="standard")
+print(plan.to_markdown())   # inspect the derived mesh before committing to a run
+
+# to_sim_kwargs() carries only mesh/domain/boundary/dx (+ dz_profile when the
+# plan is non-uniform); geometry is NOT included, so re-add it afterward.
 sim = Simulation(**plan.to_sim_kwargs())
+sim.add(Box((0.0, 0.0, 0.0), (0.02, 0.01, 0.002)), material="fr4")
 ```
 
-`plan_mesh(...)` is the inspectable planning layer. It reuses `auto_configure(...)`
-rather than forking mesh math. Its artifact declarations are read-only intended
-paths; passing `artifact_root` does not create directories or write files.
+`plan_mesh(...)` is the inspectable planning layer. It is a facade around
+`auto_configure(...)` and does not duplicate the mesh preset math. `artifact_root`
+only declares intended output paths; it never creates directories or writes files.
 
-`MeshPlan` v1 includes `plan_source`, nullable unknowns, and a stable
-`cell_sizes` block (`nominal_dx`, per-axis min/max values, and
-`profiles_present`). Geometry-derived plans use `plan_source="auto_configure"`
-and carry the requested `accuracy`; they have not run `Simulation.preflight()`.
+The serialized `MeshPlan` (`schema_version="mesh-plan/v1"`) reports `plan_source`,
+the `freq_range`/`accuracy`/`boundary` inputs, and a stable `cell_sizes` block
+(`nominal_dx`, per-axis min/max, and `profiles_present`). Fields whose value is
+unknown are `None` rather than omitted — for example the lower frequency bound,
+`margin`, or the memory estimate. Serialize with `plan.to_dict()`,
+`plan.to_json()`, or `plan.to_markdown()`, and recover constructor kwargs with
+`plan.to_sim_kwargs()`. Geometry-derived plans use `plan_source="auto_configure"`
+and carry the requested `accuracy`, but they have not run `Simulation.preflight()`
+— a `MeshPlan` is a planning artifact, not physics validation.
+
+For an already-configured `Simulation`, use `sim.plan_mesh(...)` instead (it
+accepts a memory budget, checkpoint spacing, and optional S-parameter checks, and
+runs `preflight()`). See the [non-uniform mesh guide](/rfx/guide/nonuniform-mesh/)
+for when to choose each and [Simulation](./simulation/) for `Simulation.auto` and
+`sim.plan_mesh`.
 
 ## When to use automation
 
 - Use it for first-pass setup, not as a replacement for design review.
 - Keep the derived mesh and domain visible in public examples.
-- Use the result in public reporting only after it matches the support matrix and validation
-  evidence for the intended lane.
+- Use the result in public reporting only after it matches the support matrix and
+  validation evidence for the intended lane.
 
-## Workflow note
+## Non-uniform z profiles
 
-Thin-substrate workflows can use `smooth_grading()` to build non-uniform
-z-profiles around the substrate. That is useful setup evidence, but it does not
-by itself make the graded-z workflow a validated reference path.
+For a thin substrate, `auto_configure` may return a graded `dz_profile`
+automatically (surfaced in `MeshPlan.cell_sizes` via `profiles_present`). To
+hand-build one, use `smooth_grading()` to bound the adjacent-cell ratio on an
+existing cell array. That is useful setup evidence, but it does not by itself make
+a graded-z workflow a validated reference path.

--- a/docs/public/api/simulation.mdx
+++ b/docs/public/api/simulation.mdx
@@ -29,7 +29,7 @@ Key constructor arguments:
 | Argument | Meaning | Notes |
 |---|---|---|
 | `freq_max` | highest frequency of interest | drives mesh and timestep selection |
-| `domain` | `(x, y, z)` domain size in metres | required unless derived by automation |
+| `domain` | `(x, y, z)` domain size in meters | required unless derived by automation |
 | `boundary` | boundary type | the public docs currently center on `cpml` |
 | `cpml_layers` | absorber thickness | high-level `Simulation` default is 16 |
 | `pec_faces` | face-based PEC truncation | use for boundaries, not for a finite antenna ground plane |
@@ -63,9 +63,9 @@ result = sim.run(n_steps=8000, compute_s_params=True)
 ```
 
 `run()` returns a tuple-like `Result` object with fields such as
-`time_series`, `s_params`, `freqs`, `ntff_data`, and `grid`. Current `main` also
-warns on non-finite run/forward outputs instead of letting silent NaNs pass
-through ordinary workflows. For S-parameter claims, use the port-family
+`time_series`, `s_params`, `freqs`, `ntff_data`, and `grid`. Non-finite
+run/forward outputs should be treated as setup or numerical failures, not as
+successful S-parameter evidence. For S-parameter claims, use the port-family
 evidence levels in the support matrix rather than the presence of `s_params`
 alone.
 

--- a/docs/public/api/simulation.mdx
+++ b/docs/public/api/simulation.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Simulation"
-description: "Constructor, run loop, and orchestration entry points for the current curated rfx API."
+description: "Constructor, run loop, and orchestration entry points for the curated rfx API."
 sidebar:
   order: 21
 ---
@@ -30,16 +30,16 @@ Key constructor arguments:
 |---|---|---|
 | `freq_max` | highest frequency of interest | drives mesh and timestep selection |
 | `domain` | `(x, y, z)` domain size in meters | required unless derived by automation |
-| `boundary` | boundary type | the public docs currently center on `cpml` |
-| `cpml_layers` | absorber thickness | high-level `Simulation` default is 16 |
-| `pec_faces` | face-based PEC truncation | use for boundaries, not for a finite antenna ground plane |
+| `boundary` | boundary type | `"cpml"`, `"pec"`, `"upml"`, or a per-face `BoundarySpec`; the public examples center on `cpml` |
+| `cpml_layers` | absorber thickness | `Simulation` default is 16 |
+| `pec_faces` | face-based PEC truncation | deprecated (removed in rfx v2.0); encode PEC faces in a `BoundarySpec` instead. Not a substitute for finite antenna ground-plane metal |
 | `dx` | base lateral cell size | may be inferred by automation |
 | `dz_profile` / `dx_profile` / `dy_profile` | non-uniform cell profiles | workflow helper for thin-substrate or graded meshes |
 | `solver` | solver family | the public reference lane is currently Yee |
 
 > **Ground-plane rule:** if the structure needs a finite ground plane, model it
-> as geometry. Do not use `pec_faces={"z_lo"}` as a substitute for antenna
-> ground-plane metal.
+> as geometry. Do not use PEC face truncation (`pec_faces`, or a `pec` face in a
+> `BoundarySpec`) as a substitute for antenna ground-plane metal.
 
 ## Core methods
 
@@ -56,30 +56,44 @@ Key constructor arguments:
 | `plan_mesh(...)` | return a serializable `MeshPlan` for this configured simulation | wraps `mesh_intelligence_report()`, `preflight()`, and optional S-parameter preflight checks |
 | `run(...)` | advance the simulation | returns a `Result` object |
 
+Source, port, and probe builders are documented in detail in
+[Sources & Ports](./sources-ports/); the fields they populate are described in
+[Results & Observables](./results-observables/).
+
 ## Run loop
 
 ```python
 result = sim.run(n_steps=8000, compute_s_params=True)
 ```
 
-`run()` returns a tuple-like `Result` object with fields such as
-`time_series`, `s_params`, `freqs`, `ntff_data`, and `grid`. Non-finite
-run/forward outputs should be treated as setup or numerical failures, not as
-successful S-parameter evidence. For S-parameter claims, use the port-family
-evidence levels in the support matrix rather than the presence of `s_params`
-alone.
+`run()` returns a tuple-like `Result` (a `NamedTuple`) with fields such as
+`time_series`, `s_params`, `freqs`, `ntff_data`, and `grid` — see
+[Results & Observables](./results-observables/) for the full field list.
+Non-finite `run()` / `forward()` outputs are setup or numerical failures (rfx
+warns on them), not successful S-parameter evidence.
+
+`compute_s_params=True` populates `Result.s_params` only for lumped/wire
+`add_port(...)`; it is not a universal port dispatcher. Microstrip-line,
+waveguide, and coaxial-line ports use dedicated calculators
+(`compute_msl_s_matrix()`, `compute_waveguide_s_matrix()`,
+`compute_coaxial_line_reflection()`). See [Sources & Ports](./sources-ports/)
+for the calculator that matches each port family.
 
 ## Automation entry points
 
-`Simulation` also exposes a convenience constructor:
+`Simulation` also exposes a convenience constructor that derives `dx`, `domain`,
+CPML thickness, and step count from the analysis frequency range:
 
 ```python
 sim = Simulation.auto(freq_range=(1.5e9, 3.5e9), accuracy="standard")
 ```
 
-Use `Simulation.auto()` when you want a quick starting point.
-Use the lower-level constructor when you need to inspect or override the
-derived setup.
+`accuracy` is one of `"draft"`, `"standard"`, or `"high"`. Because the domain is
+sized from the frequency range rather than from your structure, `auto()` emits a
+warning reminding you to add geometry after construction (or to pass `domain` /
+`dx` overrides). Use the plain constructor when you need to inspect or override
+the derived setup. See [Automation](./automation/) for the underlying
+`auto_configure()` helper.
 
 Configured simulations can also produce the same planning artifact:
 
@@ -101,4 +115,4 @@ accuracy preset or lower-band edge is implied by an existing `Simulation`.
 ## Current public boundary
 
 This page covers the supported builder surface only.
-Lower-level solver internals, lower-level symbol inventories, and internal extensions are outside this curated public API until a guide and support entry document them.
+Lower-level solver internals, private symbol inventories, and internal extensions are outside this curated public API until documented. For what is recommended, bounded, or unsupported, see [Support Boundaries](./support-boundaries/).

--- a/docs/public/api/sources-ports.mdx
+++ b/docs/public/api/sources-ports.mdx
@@ -16,7 +16,7 @@ rfx separates **sources** from **ports**:
 |---|---|---|
 | `GaussianPulse` | `GaussianPulse(f0, bandwidth=0.5, amplitude=1.0)` | default wideband excitation |
 | `ModulatedGaussian` | `ModulatedGaussian(f0, bandwidth=0.5, amplitude=1.0, cutoff=5.0)` | resonance work with reduced DC content |
-| `CWSource` | `CWSource(f0, amplitude=1.0, ramp_steps=50)` | steady-state field visualisation |
+| `CWSource` | `CWSource(f0, amplitude=1.0, ramp_steps=50)` | steady-state field visualization |
 | `CustomWaveform` | `CustomWaveform(func)` | JAX-compatible custom excitation |
 
 ## Sources

--- a/docs/public/api/sources-ports.mdx
+++ b/docs/public/api/sources-ports.mdx
@@ -8,7 +8,9 @@ sidebar:
 rfx separates **sources** from **ports**:
 
 - sources inject fields without impedance loading
-- ports add an impedance model for S-parameter style workflows
+- ports add an impedance model for S-parameter workflows
+
+Most sources and ports accept a `waveform=` object that sets the time-domain excitation, so those shared types are listed first. (Waveguide ports instead select a built-in pulse by name plus `f0`/`bandwidth`.) This page is the API reference; the [Sources & Ports guide](/rfx/guide/sources-ports/) carries the worked end-to-end examples.
 
 ## Waveforms
 
@@ -28,6 +30,8 @@ sim.add_polarized_source((0.025, 0.025, 0.010), polarization="rhcp")
 
 Use `add_source()` for ringdown and Harminv work when you do **not** want a load on the excited cell.
 
+`add_polarized_source()` accepts the string shortcuts `"ex"`, `"ey"`, `"ez"`, `"slant45"`, `"rhcp"`/`"circular"`, `"lhcp"`, or an arbitrary `(Ex, Ey)` Jones tuple (normalized internally).
+
 ## Ports
 
 | Method | Public role |
@@ -44,6 +48,8 @@ sim.add_port((0.01, 0.02, 0.0), "ez", impedance=50.0, extent=0.0016)
 sim.add_coaxial_port((0.02, 0.02, 0.0016), face="top", impedance=50.0)
 sim.add_waveguide_port(x_position=0.01, y_range=(0.0, 0.023), z_range=(0.0, 0.010))
 ```
+
+`extent` promotes the single-cell lumped port to a multi-cell wire port spanning `extent` metres from `position` along the `component` axis (here `+z`); omit it for a lumped port.
 
 ## S-parameter calculators
 
@@ -68,7 +74,11 @@ sim.preflight_sparameters(calculator="waveguide")
 sim.preflight_sparameters(calculator="forward")
 ```
 
+An empty report means the selected calculator is valid for the registered port families; otherwise it lists coded issues to fix first. Pass `strict=True` to raise instead of returning them.
+
 ## Public boundary rules
+
+See [Support Boundaries](./support-boundaries/) for the authoritative support scope. In short:
 
 - Use sources for clean transient or resonance extraction.
 - Use ports when you need impedance-normalized outputs.

--- a/docs/public/guide/api-reference.mdx
+++ b/docs/public/guide/api-reference.mdx
@@ -30,7 +30,7 @@ Use these pages first:
 - The current validated reference lane is the **uniform Cartesian Yee RF workflow**.
 - S-parameter APIs are port-family-specific: lumped/wire ports use `run(compute_s_params=True)`, MSL ports use `compute_msl_s_matrix()`, waveguide ports use `compute_waveguide_s_matrix()`, and coaxial line reflection uses `compute_coaxial_line_reflection(...)`.
 - Importable lower-level symbols are not public API promises unless documented in the curated API and support matrix.
-- Prefer the newest current recommended workflow pages when choosing a public example or reference path.
+- Prefer the recommended workflow pages when choosing a public example or reference path.
 
 ## Boundary rule
 

--- a/docs/public/guide/api-reference.mdx
+++ b/docs/public/guide/api-reference.mdx
@@ -1,19 +1,13 @@
 ---
 title: "Simulation API"
-description: "Bridge page into the curated public API surface for rfx."
+description: "Guide-side entrypoint to rfx's curated public API pages."
 sidebar:
   order: 8
 ---
 
-This page is the **guide-side API entrypoint** for the current public surface. Use it to decide which API surface you need, then jump into the dedicated `/rfx/api/` pages.
-
-## How to use the API docs
-
-`rfx` documents the supported public API through curated pages that users should start from.
+This is the guide-side entrypoint to the rfx public API. The public API is intentionally narrow: the supported surface is exactly what the curated `/rfx/api/` pages document. Use the table below to route to the page you need.
 
 ## Start with the curated API
-
-Use these pages first:
 
 | Need | Page |
 |---|---|
@@ -23,15 +17,17 @@ Use these pages first:
 | Shapes, materials, and dispersive models | [/rfx/api/geometry-materials/](/rfx/api/geometry-materials/) |
 | Sources, lumped ports, microstrip-line ports, waveguide ports, and coaxial line reflection | [/rfx/api/sources-ports/](/rfx/api/sources-ports/) |
 | `auto_configure()` and higher-level setup helpers | [/rfx/api/automation/](/rfx/api/automation/) |
-| Supported, bounded, and outside the documented public support scope boundaries | [/rfx/api/support-boundaries/](/rfx/api/support-boundaries/) |
+| What is supported, bounded, or outside the documented public scope | [/rfx/api/support-boundaries/](/rfx/api/support-boundaries/) |
 
-## Current API contract rules
+## API contract rules
 
-- The current validated reference lane is the **uniform Cartesian Yee RF workflow**.
-- S-parameter APIs are port-family-specific: lumped/wire ports use `run(compute_s_params=True)`, MSL ports use `compute_msl_s_matrix()`, waveguide ports use `compute_waveguide_s_matrix()`, and coaxial line reflection uses `compute_coaxial_line_reflection(...)`.
-- Importable lower-level symbols are not public API promises unless documented in the curated API and support matrix.
-- Prefer the recommended workflow pages when choosing a public example or reference path.
+- The validated reference lane is the **uniform Cartesian Yee RF workflow**.
+- S-parameter extraction is port-family-specific:
+  - lumped/wire ports use `run(compute_s_params=True)`;
+  - waveguide ports use the `Simulation.compute_waveguide_s_matrix()` method;
+  - microstrip-line (MSL) ports use `Simulation.compute_msl_s_matrix()`;
+  - coaxial line reflection uses `Simulation.compute_coaxial_line_reflection(...)`.
 
-## Boundary rule
-
-The public API is intentionally narrow. Supported public workflows are the ones described in the curated API pages and support matrices.
+  MSL and coaxial ports are **not** included in `run(compute_s_params=True)`; call their dedicated method instead.
+- An importable lower-level symbol is not a public API promise unless it is documented in the curated API pages and the [support matrix](/rfx/api/support-boundaries/).
+- When choosing an example or reference path, prefer the curated pages over lower-level imports.

--- a/docs/public/guide/autodiff-adjoint.mdx
+++ b/docs/public/guide/autodiff-adjoint.mdx
@@ -46,7 +46,7 @@ a dielectric tuning region.
 | Adjoint method | Solve a forward problem and an adjoint sensitivity problem | roughly independent of design-variable count for one scalar objective family | large design regions and topology-style optimization |
 | Reverse-mode automatic differentiation | Apply the chain rule to the implemented discrete program | one differentiated program, with memory/recompute tradeoffs | JAX-native differentiable workflows in rfx |
 
-Meep's current adjoint-solver documentation describes a dedicated adjoint module
+Meep's adjoint-solver documentation describes a dedicated adjoint module
 for gradients of functions of mode coefficients, S-parameters, DFT fields, LDOS,
 and far fields with respect to a `MaterialGrid`. In that formulation, Meep runs a
 forward calculation to obtain the objective and design-region fields, then an
@@ -175,7 +175,7 @@ adjust based on the scale of the loss and the design variable.
 
 - Use [Inverse Design](/rfx/guide/inverse-design/) for the rfx optimization API
   and objective families.
-- Use [Gradient Behavior](/rfx/guide/gradient-behavior/) for known stable,
-  noisy, and non-differentiable paths.
+- Use [Gradient Behavior](/rfx/guide/gradient-behavior/) for usually
+  well-behaved, noisy, and non-differentiable paths.
 - Use [Memory Reduction](/rfx/guide/memory-reduction/) when reverse-mode memory,
   checkpointing, or run size is the limiting factor.

--- a/docs/public/guide/autodiff-adjoint.mdx
+++ b/docs/public/guide/autodiff-adjoint.mdx
@@ -95,8 +95,11 @@ In rfx, the public gradient story is:
   workflows.
 - The result is a gradient of the implemented discrete simulation, not a
   guarantee that the chosen observable is the right RF metric.
-- `checkpoint=True` or segmented checkpointing can reduce reverse-mode memory by
-  recomputing parts of the forward pass during the backward pass.
+- `forward(...)` recomputes each step during the backward pass by default
+  (`checkpoint=True`) to bound reverse-mode memory. Long runs can trade extra
+  compute for an approximately `sqrt(n_steps)` memory reduction via segmented
+  checkpointing: `checkpoint_segments` on uniform meshes, `checkpoint_every` on
+  non-uniform. See [Memory Reduction](/rfx/guide/memory-reduction/).
 - New problem setups should start with finite-difference checks on a few cells or
   parameters before trusting the gradient for optimization.
 - Final RF claims should be verified by the relevant public workflow: port-family
@@ -123,7 +126,12 @@ and support entry.
 
 ## Minimal gradient-check pattern
 
-Use this kind of check before a new optimization setup:
+Here `params` is a JAX array of design variables (for example an `eps_override`
+field passed to `sim.forward(...)`), and `loss_fn(params)` returns a scalar loss
+from that forward run. See [Inverse Design](/rfx/guide/inverse-design/) for how
+to build `loss_fn` from a `Simulation` and an objective. Run this single-cell
+finite-difference check before trusting the gradient for a new optimization
+setup:
 
 ```python
 import jax

--- a/docs/public/guide/changelog.mdx
+++ b/docs/public/guide/changelog.mdx
@@ -11,18 +11,24 @@ This page summarizes user-visible changes.
 
 The recommended starting point remains the **uniform Cartesian Yee RF/FDTD lane**. Public guides emphasize maintained workflows and bounded port-family envelopes.
 
+## v1.6.6 — July 2026
+
+- AD memory-planning docs now separate static estimates, conservative budget-fitting plans, explainability artifacts, and measured-profile artifacts so memory reports are not mistaken for runtime certificates or RF validation evidence.
+- Differentiable workflow wording was tightened around selected JAX-traced objectives, finite-difference checks, and final port/resonance/far-field validation.
+- Public non-uniform mesh guidance now presents graded-z meshes as a bounded workflow for thin layered structures, with unsupported combinations and validation responsibilities stated up front.
+
 ## v1.6.5 — June 2026
 
 - Validation reporting is stricter: promoted port-family results now require magnitude evidence, phase-consistency evidence, differentiability checks where gradients are part of the claim, and reproducible artifact checks.
 - Port-family support wording is clearer: users should match each source or port family to its documented calculator and evidence envelope instead of treating any S-parameter helper as universal.
 - `compute_msl_s_matrix` now reports a positive characteristic impedance on both ports. This fixes reported metadata while leaving the S-parameter calculation invariant.
 - Non-uniform mesh accuracy coverage now includes an analytic gated cavity case whose resonance frequency depends on the graded axis.
-- Public guides and support pages were tightened around maintained workflows, validation boundaries, and device-count-adaptive test behaviour.
+- Public guides and support pages were tightened around maintained workflows, validation boundaries, and device-count-adaptive test behavior.
 
 ## v1.6.4 — June 2026
 
 - Rectangular waveguide-port evidence now covers WR-band empty-guide, PEC-short, and dielectric-slab cases with analytic and external-reference comparisons.
-- `preflight()` and `preflight_sparameters()` now expose coded report objects for automation while preserving older list/string behaviour.
+- `preflight()` and `preflight_sparameters()` now expose coded report objects for automation while preserving older list/string behavior.
 - Run/forward results, S-matrix calculators, sweeps, and optimizers now surface finite-data, passivity, setup, and NaN-gradient issues earlier.
 - `compute_coaxial_line_reflection(...)` is the current coaxial line-reflection path inside its documented transmission-line envelope.
 - `compute_waveguide_s_matrix(checkpoint_segments=...)` adds segmented checkpointing for uniform waveguide AD-heavy runs.

--- a/docs/public/guide/changelog.mdx
+++ b/docs/public/guide/changelog.mdx
@@ -9,17 +9,17 @@ This page summarizes user-visible changes.
 
 ## Current public status
 
-The recommended starting point remains the **uniform Cartesian Yee RF/FDTD lane**. Public guides emphasize maintained workflows and bounded port-family envelopes.
+The recommended starting point remains the **uniform Cartesian Yee RF/FDTD lane**. Non-default lanes such as non-uniform mesh are documented through their [support and evidence envelopes](/rfx/guide/validation/), not presented as the default path.
 
-## v1.6.6 — July 2026
+## Unreleased
 
-- AD memory-planning docs now separate static estimates, conservative budget-fitting plans, explainability artifacts, and measured-profile artifacts so memory reports are not mistaken for runtime certificates or RF validation evidence.
-- Differentiable workflow wording was tightened around selected JAX-traced objectives, finite-difference checks, and final port/resonance/far-field validation.
-- Public non-uniform mesh guidance now presents graded-z meshes as a bounded workflow for thin layered structures, with unsupported combinations and validation responsibilities stated up front.
+- [AD memory-planning docs](/rfx/guide/memory-reduction/) now tag each artifact with an evidence class — static estimate, conservative budget-fit plan, or explainability breakdown — so a planning estimate is never read as a runtime profiler measurement, a peak-memory guarantee, or RF validation evidence. The compiled-executable check reports the JAX compiler's memory *estimate*, not a runtime peak.
+- [Differentiable-design guidance](/rfx/guide/autodiff-adjoint/) was tightened: it separates JAX-traced objectives and finite-difference gradient checks from the final port/resonance/far-field physics validation.
+- [Non-uniform mesh guidance](/rfx/guide/nonuniform-mesh/) now frames graded-z meshes as a bounded workflow for thin layered structures, stating the unsupported combinations and the caller's validation responsibilities up front.
 
 ## v1.6.5 — June 2026
 
-- Validation reporting is stricter: promoted port-family results now require magnitude evidence, phase-consistency evidence, differentiability checks where gradients are part of the claim, and reproducible artifact checks.
+- [Validation reporting](/rfx/guide/validation/) is stricter: a promoted port-family result now requires magnitude evidence, a phase-consistency witness, an AD-vs-finite-difference check where gradients are part of the claim, and committed (reproducible) artifacts.
 - Port-family support wording is clearer: users should match each source or port family to its documented calculator and evidence envelope instead of treating any S-parameter helper as universal.
 - `compute_msl_s_matrix` now reports a positive characteristic impedance on both ports. This fixes reported metadata while leaving the S-parameter calculation invariant.
 - Non-uniform mesh accuracy coverage now includes an analytic gated cavity case whose resonance frequency depends on the graded axis.
@@ -37,20 +37,19 @@ The recommended starting point remains the **uniform Cartesian Yee RF/FDTD lane*
 
 ## Documentation direction
 
-- Public docs lead with the recommended default lane and bounded port-family evidence envelopes.
-- Current examples are routed through maintained paths such as `examples/crossval/05_patch_antenna.py`, `examples/crossval/11_waveguide_port_wr90.py`, `examples/nonuniform_patch_demo.py`, and `examples/inverse_design/multilayer_ar_coating.py`.
-- S-parameter documentation emphasizes matching the calculator to the port family: lumped/wire, MSL, waveguide, or bounded coaxial line reflection.
+- Current examples are routed through maintained paths: `examples/crossval/05_patch_antenna.py`, `examples/crossval/11_waveguide_port_wr90.py`, `examples/nonuniform_patch_demo.py`, and `examples/inverse_design/multilayer_ar_coating.py`.
+- [S-parameter documentation](/rfx/guide/probes-sparams/) matches the calculator to the port family: lumped/wire, MSL, waveguide, or bounded coaxial line reflection.
 
 ## v1.6 line
 
-- Continued work on differentiable design loops and validation-boundary reporting.
-- Added clearer feature-boundary wording so repository code outside the documented support scope is not presented as the default public path.
-- Improved port and observable APIs for selected RF workflows.
+- Advanced the differentiable design loops and validation-boundary reporting.
+- Added feature-boundary wording so repository code outside the documented support scope is not presented as the default public path.
+- Improved port and observable APIs for RF workflows.
 
 ## v1.5 line
 
-- Expanded public guide structure for examples, API surfaces, and validation/support boundaries.
-- Added practical RF examples and clearer routing for patch, waveguide, and microstrip-style workflows.
+- Expanded the public guide structure for examples, API surfaces, and validation/support boundaries.
+- Added RF examples and clearer routing for patch, waveguide, and microstrip workflows.
 
 ## Earlier releases
 

--- a/docs/public/guide/farfield-rcs.md
+++ b/docs/public/guide/farfield-rcs.md
@@ -4,20 +4,27 @@ sidebar:
   order: 11
 ---
 
-rfx computes far-field radiation patterns via near-to-far-field transform (NTFF) and radar cross section (RCS) via TFSF + NTFF integration.
+rfx computes far-field radiation patterns from a near-to-far-field transform
+(NTFF), and radar cross section (RCS) by combining TFSF plane-wave illumination
+with the same NTFF integration.
 
 ## Radiation Pattern (NTFF)
 
-The NTFF approach records tangential E/H fields on a closed Huygens box during simulation, then computes far-field integrals.
+An NTFF box records the tangential E and H fields on a closed Huygens surface
+during the time stepping. After the run, those surface fields are converted to
+equivalent currents and integrated to the far field — so the pattern comes from
+the recorded surface, not from probes sitting in the radiating near field.
 
 ```python
 from rfx import Simulation, compute_far_field, radiation_pattern
 import numpy as np
 
 sim = Simulation(freq_max=5e9, domain=(0.1, 0.1, 0.1), boundary="cpml")
-# ... add antenna geometry and source ...
+# ... add the radiator geometry and its source (see the Materials & Geometry
+#     and Sources & Ports guides) ...
 
-# Define an NTFF box enclosing the radiator but clear of the CPML.
+# NTFF box: encloses the radiator but stays inside the simulation region,
+# clear of the CPML absorber.
 sim.add_ntff_box(
     corner_lo=(0.02, 0.02, 0.02),
     corner_hi=(0.08, 0.08, 0.08),
@@ -26,14 +33,19 @@ sim.add_ntff_box(
 
 result = sim.run(n_steps=1000)
 
-# Compute far-field
+# Far field over a (theta, phi) grid. run() stores the raw NTFF data,
+# the box spec, and the grid on the result.
 theta = np.linspace(0, np.pi, 181)
-phi = np.linspace(0, 2*np.pi, 360)
+phi = np.linspace(0, 2 * np.pi, 360)
 ff = compute_far_field(result.ntff_data, result.ntff_box, result.grid, theta, phi)
 
-# Radiation pattern in dB
-pattern_dB = radiation_pattern(ff)  # (n_freqs, n_theta, n_phi)
+# Normalized pattern in dB (peak = 0 dB), shape (n_freqs, n_theta, n_phi).
+pattern_dB = radiation_pattern(ff)
 ```
+
+`compute_far_field` returns a `FarFieldResult` (fields `E_theta`, `E_phi`,
+`theta`, `phi`, `freqs`) that both `radiation_pattern` and `directivity`
+consume.
 
 ## Directivity
 
@@ -44,53 +56,92 @@ D = directivity(ff)  # (n_freqs,) in dBi
 print(f"Directivity: {D[0]:.1f} dBi")
 ```
 
+`directivity` integrates radiated power over the whole sphere (D = 4π·U_max /
+P_rad), so `ff` must be sampled over the full range — `theta` in [0, π] and
+`phi` in [0, 2π], as in the block above. A single cut plane yields the wrong
+P_rad.
+
 For inverse-design objectives that change total radiated power, use
-`maximize_directivity(..., log_ratio=True)` so the gradient follows the full
-directivity ratio instead of a stopped-power proxy.
+`maximize_directivity(theta_target, phi_target, log_ratio=True)` so the gradient
+follows the full directivity ratio instead of a stopped-power proxy. See the
+[Inverse Design](/rfx/guide/inverse-design/) guide.
 
 ## Radar Cross Section (RCS)
 
-RCS measures the electromagnetic scattering from a target illuminated by a plane wave.
+`compute_rcs` illuminates a target with a TFSF plane wave, captures the
+scattered field (the field outside the TFSF box) on an NTFF box, and reports
+RCS(θ, φ) = 4π r² |E_scat|² / |E_inc|². It is a functional API: you pass a
+`Grid` and a `MaterialArrays` holding the scatterer, not a `Simulation`.
 
 ```python
-from rfx import compute_rcs
 import numpy as np
+import jax.numpy as jnp
+from rfx import Grid, Box, compute_rcs
+from rfx.geometry.csg import rasterize
+from rfx.core.yee import MaterialArrays
 
-# Define scatterer (PEC plate, sphere, etc.)
-grid = Grid(freq_max=6e9, domain=(0.10, 0.10, 0.10), dx=0.002, cpml_layers=10)
-materials = init_materials(grid.shape)
-# ... add PEC object to materials ...
+f0 = 3e9              # illumination centre frequency (lambda = 0.1 m)
+dx = 0.01            # ~lambda/10 at 3 GHz; leaves room for scatterer + TFSF + NTFF + CPML
+grid = Grid(
+    freq_max=f0 * 1.5,
+    domain=(0.12, 0.12, 0.12),
+    dx=dx,
+    cpml_layers=8,
+)
+
+# PEC plate: 4 cm square, one cell thick, centred and normal to x.
+c = 0.06
+plate = Box(
+    corner_lo=(c - dx / 2, c - 0.02, c - 0.02),
+    corner_hi=(c + dx / 2, c + 0.02, c + 0.02),
+)
+# rasterize takes (shape, eps_r, sigma) tuples; sigma = 1e7 S/m approximates PEC.
+eps_r, sigma = rasterize(grid, [(plate, 1.0, 1e7)])
+materials = MaterialArrays(
+    eps_r=eps_r, sigma=sigma, mu_r=jnp.ones(grid.shape, dtype=jnp.float32),
+)
 
 result = compute_rcs(
     grid, materials,
-    n_steps=1000,
-    f0=3e9,
-    bandwidth=0.5,
+    n_steps=400,
+    f0=f0,
+    bandwidth=0.5,            # fractional bandwidth of the Gaussian excitation
     polarization="ez",
-    theta_obs=np.linspace(0, np.pi, 91),
-    phi_obs=np.array([0.0, np.pi/2]),
-    freqs=np.array([3e9]),
+    theta_obs=np.linspace(0.01, np.pi - 0.01, 91),
+    phi_obs=np.array([0.0, np.pi / 2]),
+    freqs=np.array([f0]),
 )
 
+# monostatic_rcs is the observation angle nearest backscatter (theta ~ pi,
+# phi ~ 0 for the default +x incidence); populated whenever obs angles are given.
 print(f"Monostatic RCS: {result.monostatic_rcs[0]:.1f} dBsm")
-print(f"RCS range: {result.rcs_dbsm.min():.1f} to {result.rcs_dbsm.max():.1f} dBsm")
+print(f"Bistatic RCS range: {result.rcs_dbsm.min():.1f} to {result.rcs_dbsm.max():.1f} dBsm")
 ```
+
+`RCSResult` carries `rcs_dbsm` and `rcs_linear` (shape `(n_freqs, n_theta,
+n_phi)`), `monostatic_rcs` (`(n_freqs,)` dBsm, or `None` when no observation
+angles are given), and the `freqs` / `theta` / `phi` axes.
 
 ## Plotting RCS
 
 ```python
 from rfx import plot_rcs
 
-plot_rcs(result, freq_idx=0, mode="polar")    # Polar plot
-plot_rcs(result, freq_idx=0, mode="rectangular")  # dBsm vs angle
+plot_rcs(result, freq_idx=0, polar=True)    # polar cut
+plot_rcs(result, freq_idx=0, polar=False)   # dBsm vs angle
 ```
+
+`plot_rcs` selects one frequency (`freq_idx`) and one φ cut (`phi_idx`, default
+0). For the other plotting helpers see
+[Visualization & Result Analysis](/rfx/guide/visualization-and-analysis/).
 
 ## Notes
 
-- NTFF box surfaces should sit in the ordinary simulation region, outside all
-  sources/scatterers/radiators and with margin from the CPML absorber.
-- For RCS, the TFSF and NTFF boxes are derived from the configured scatterer and
-  margin settings.
-- The scattered field (outside TFSF) is what the NTFF box captures
-- Public RCS examples should state the incident direction, polarization,
-  observation angles, and support envelope used for the claim.
+- Keep NTFF box surfaces in the ordinary simulation region — outside every
+  source, scatterer, and radiator, with margin from the CPML absorber.
+  `sim.preflight()` warns when a box extends into the absorber.
+- `compute_rcs` places the TFSF and NTFF boxes automatically from `cpml_layers`,
+  `tfsf_margin`, and `ntff_offset` (the NTFF box sits `ntff_offset` cells outside
+  the TFSF boundary); you supply only the grid and the scatterer materials.
+- Report the incident direction, polarization, observation angles, and frequency
+  band alongside any published RCS number.

--- a/docs/public/guide/farfield-rcs.md
+++ b/docs/public/guide/farfield-rcs.md
@@ -11,23 +11,25 @@ rfx computes far-field radiation patterns via near-to-far-field transform (NTFF)
 The NTFF approach records tangential E/H fields on a closed Huygens box during simulation, then computes far-field integrals.
 
 ```python
-from rfx import Simulation, make_ntff_box, compute_far_field, radiation_pattern
+from rfx import Simulation, compute_far_field, radiation_pattern
 import numpy as np
 
 sim = Simulation(freq_max=5e9, domain=(0.1, 0.1, 0.1), boundary="cpml")
 # ... add antenna geometry and source ...
 
-# Define NTFF box enclosing the antenna
-ntff_box = make_ntff_box(grid, corner_lo=(0.02, 0.02, 0.02),
-                         corner_hi=(0.08, 0.08, 0.08),
-                         freqs=np.array([3e9]))
+# Define an NTFF box enclosing the radiator but clear of the CPML.
+sim.add_ntff_box(
+    corner_lo=(0.02, 0.02, 0.02),
+    corner_hi=(0.08, 0.08, 0.08),
+    freqs=np.array([3e9]),
+)
 
-result = sim.run(n_steps=1000, ntff=ntff_box)
+result = sim.run(n_steps=1000)
 
 # Compute far-field
 theta = np.linspace(0, np.pi, 181)
 phi = np.linspace(0, 2*np.pi, 360)
-ff = compute_far_field(result.ntff_data, ntff_box, grid, theta, phi)
+ff = compute_far_field(result.ntff_data, result.ntff_box, result.grid, theta, phi)
 
 # Radiation pattern in dB
 pattern_dB = radiation_pattern(ff)  # (n_freqs, n_theta, n_phi)
@@ -85,7 +87,10 @@ plot_rcs(result, freq_idx=0, mode="rectangular")  # dBsm vs angle
 
 ## Notes
 
-- NTFF box must be **inside** the CPML region and **outside** all sources/scatterers
-- For RCS, the TFSF box is placed automatically around the scatterer
+- NTFF box surfaces should sit in the ordinary simulation region, outside all
+  sources/scatterers/radiators and with margin from the CPML absorber.
+- For RCS, the TFSF and NTFF boxes are derived from the configured scatterer and
+  margin settings.
 - The scattered field (outside TFSF) is what the NTFF box captures
-- Currently supports normal-incidence TFSF only (oblique in development)
+- Public RCS examples should state the incident direction, polarization,
+  observation angles, and support envelope used for the claim.

--- a/docs/public/guide/first-patch.mdx
+++ b/docs/public/guide/first-patch.mdx
@@ -142,7 +142,7 @@ sim.add_source(
 sim.add_probe((feed_x, feed_y, feed_z), "ez")
 ```
 
-`add_source` injects a soft (no impedance loading) current source — ideal for resonance characterisation. Use `add_port` if you want S-parameter extraction against a 50 Ω reference.
+`add_source` injects a soft (no impedance loading) current source — ideal for resonance characterization. Use `add_port` if you want S-parameter extraction against a 50 Ω reference.
 
 ---
 
@@ -180,61 +180,14 @@ if modes:
 
 ---
 
-## 7. Optional: exploratory lumped-port run
+## 7. S-parameter follow-up
 
-If you want a quick diagnostic S-parameter run, you can re-run with a lumped
-port instead of a soft source:
-
-!!! warning
-    This single-cell lumped-port `compute_s_params=True` snippet is illustrative.
-    It raises `NotImplementedError` on the non-uniform `dz_profile` mesh built in
-    §2 — single-cell lumped-port S-parameters are not wired for the non-uniform
-    path. For calibrated S-parameters use a multi-cell `add_port(..., extent=...)`
-    WirePort, or a dedicated port workflow (see the waveguide/MSL S-parameter
-    recipes).
-
-```python
-sim2 = Simulation(
-    freq_max=4e9,
-    domain=(dom_x, dom_y, dom_z),
-    boundary="cpml",
-    cpml_layers=12,
-    dx=5e-4,
-    dz_profile=dz_profile,
-)
-sim2.add_material("fr4_24ghz", eps_r=4.4, sigma=sigma_fr4)
-sim2.add(Box((0, 0, 0), (dom_x, dom_y, dz_sub)), material="pec")
-sim2.add(Box((0, 0, 0), (dom_x, dom_y, h)), material="fr4_24ghz")
-sim2.add(Box((px0, py0, h), (px0+L, py0+W, h+dz_sub)), material="pec")
-sim2.add_port(
-    (feed_x, feed_y, feed_z), "ez",
-    impedance=50,
-    waveform=GaussianPulse(f0=f0, bandwidth=0.8),
-)
-
-result2 = sim2.run(n_steps=n_steps, compute_s_params=True)
-
-import matplotlib.pyplot as plt
-freqs  = result2.freqs
-s11_db = 20 * np.log10(np.abs(result2.s_params[0, 0, :]) + 1e-12)
-
-plt.figure()
-plt.plot(freqs / 1e9, s11_db)
-plt.xlabel("Frequency (GHz)")
-plt.ylabel("|S11| (dB)")
-plt.title("Patch antenna S11 — FR4 2.4 GHz")
-plt.ylim(-30, 2)
-plt.grid(True)
-plt.tight_layout()
-plt.savefig("patch_s11.png", dpi=150)
-plt.show()
-```
-
-!!! warning
-    For patch and microstrip feeds, treat this lumped-port S11 result as a
-    **diagnostic workflow**, not yet as the canonical public validation path.
-    The current recommended path for this tutorial is the
-    current-source + Harminv resonance workflow above.
+This tutorial intentionally uses a soft current source and Harminv resonance
+extraction. Do not reuse the non-uniform `dz_profile` setup above with the
+single-cell lumped-port S-parameter path; that combination is outside the
+documented support envelope. For impedance-referenced patch or feed studies,
+start from the documented wire-port, microstrip-line, or external cross-check
+workflow and keep the result inside its S-parameter support entry.
 
 ---
 
@@ -246,19 +199,18 @@ plt.show()
 | Analytical prediction | 2.40 GHz |
 | Discrepancy | ~1–3 % (formula limitation) |
 | Q factor | 20–60 (lossy FR4) |
-| Diagnostic lumped-port S11 | depends strongly on feed position / port model |
 
 ---
 
 ## Full script
 
-For the current public patch cross-check, prefer
+For the public patch cross-check, prefer
 `examples/crossval/05_patch_antenna.py`.
 
-That crossval is the newest committed public patch workflow in this repo and is
-the script we currently use for the OpenEMS-backed external sanity check
-described in [Tutorial: Patch Antenna Design](./tutorial-patch-antenna/).
+That script is the public patch workflow paired with the OpenEMS-backed external
+sanity check described in
+[Tutorial: Patch Antenna Design](./tutorial-patch-antenna/).
 
 Older patch example scripts can still be useful as local experiments, but they
 should not be treated as the primary public reference path unless they are
-checked against the current public workflow.
+checked against the documented public workflow.

--- a/docs/public/guide/first-patch.mdx
+++ b/docs/public/guide/first-patch.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Your First Patch Antenna"
-description: "This tutorial designs a 2.4 GHz rectangular microstrip patch on FR4 and walks through the current-source resonance workflow."
+description: "This tutorial designs a 2.4 GHz rectangular microstrip patch on FR4 and walks through the soft-source resonance workflow."
 sidebar:
   order: 2
 ---
@@ -10,8 +10,7 @@ This tutorial designs a 2.4 GHz rectangular microstrip patch on FR4, runs the
 FDTD simulation, and extracts the resonant frequency with Harminv. Estimated
 time: 20 minutes.
 
-If you want an **external-solver** check of the same class of structure after
-this resonance workflow is stable, continue to
+For an **external-solver** cross-check of this structure, continue to
 [Tutorial: Patch Antenna Design](./tutorial-patch-antenna/).
 
 ---
@@ -89,14 +88,27 @@ sim = Simulation(
 )
 ```
 
+!!! note
+    The substrate→air step in `dz_profile` (0.27 mm → 1.5 mm) is an abrupt grading
+    jump. `Simulation` warns when adjacent cells differ by more than 1.3×, since
+    large ratios seed spurious reflections. Smooth it with
+    `rfx.smooth_grading(dz_profile)` before passing it in — see
+    [Non-uniform mesh](./nonuniform-mesh/).
+
 !!! tip
-    `auto_configure()` can derive `dz_profile` automatically. Use it when you prefer
-    a one-shot configuration:
+    `auto_configure()` can derive `dz_profile` automatically. Pass the material
+    properties so it sizes cells for the dielectric (a bare name resolves to
+    vacuum, `εᵣ=1`, when you call `auto_configure` directly):
 
     ```python
     from rfx import auto_configure
     geom = [(Box((0,0,0),(dom_x,dom_y,h)), "fr4")]
-    cfg  = auto_configure(geom, freq_range=(1e9, 4e9), accuracy="standard")
+    cfg  = auto_configure(
+        geom,
+        freq_range=(1e9, 4e9),
+        materials={"fr4": {"eps_r": eps_r, "sigma": sigma_fr4}},
+        accuracy="standard",
+    )
     sim  = Simulation(**cfg.to_sim_kwargs())
     ```
 
@@ -142,7 +154,7 @@ sim.add_source(
 sim.add_probe((feed_x, feed_y, feed_z), "ez")
 ```
 
-`add_source` injects a soft (no impedance loading) current source — ideal for resonance characterization. Use `add_port` if you want S-parameter extraction against a 50 Ω reference.
+`add_source` injects a soft point source (no impedance loading) — ideal for resonance characterization, where a port's resistive load would damp the cavity. Use `add_port` (default 50 Ω) when you need S-parameter extraction against a reference impedance.
 
 ---
 
@@ -174,20 +186,22 @@ if modes:
 ```
 
 !!! note
-    The ~3 % difference between FDTD and the analytical formula is expected and is a
-    known limitation of the Hammerstad-Jensen fringe-correction formula, not an rfx
-    accuracy problem. See [Cross-Validation](./validation/).
+    The ~3 % difference between FDTD and the analytical formula is expected: it is a
+    known limitation of the closed-form fringe correction (§1), not an rfx accuracy
+    problem. For an external-solver check of rfx itself, see
+    [Cross-Validation](./validation/).
 
 ---
 
 ## 7. S-parameter follow-up
 
-This tutorial intentionally uses a soft current source and Harminv resonance
-extraction. Do not reuse the non-uniform `dz_profile` setup above with the
-single-cell lumped-port S-parameter path; that combination is outside the
-documented support envelope. For impedance-referenced patch or feed studies,
-start from the documented wire-port, microstrip-line, or external cross-check
-workflow and keep the result inside its S-parameter support entry.
+This tutorial deliberately uses a soft source plus Harminv, not an
+impedance-referenced port. Do not pair the non-uniform `dz_profile` above with
+the single-cell lumped-port S-parameter path (`add_port` +
+`run(compute_s_params=True)`): that combination is outside the validated
+S-parameter envelope. For impedance-referenced patch or feed studies, use the
+documented wire-port or microstrip-line workflow — see
+[Probes & S-parameters](./probes-sparams/).
 
 ---
 
@@ -204,13 +218,7 @@ workflow and keep the result inside its S-parameter support entry.
 
 ## Full script
 
-For the public patch cross-check, prefer
-`examples/crossval/05_patch_antenna.py`.
-
-That script is the public patch workflow paired with the OpenEMS-backed external
-sanity check described in
-[Tutorial: Patch Antenna Design](./tutorial-patch-antenna/).
-
-Older patch example scripts can still be useful as local experiments, but they
-should not be treated as the primary public reference path unless they are
-checked against the documented public workflow.
+The canonical patch script is `examples/crossval/05_patch_antenna.py` — the full
+workflow paired with the OpenEMS external cross-check described in
+[Tutorial: Patch Antenna Design](./tutorial-patch-antenna/). Treat it, not
+ad-hoc local scripts, as the reference path.

--- a/docs/public/guide/gradient-behavior.md
+++ b/docs/public/guide/gradient-behavior.md
@@ -13,14 +13,22 @@ background, see [Autodiff and Adjoint Background](/rfx/guide/autodiff-adjoint/).
 ## How it works
 
 JAX traces the supported FDTD time-stepping and objective path as a computation
-graph. `jax.checkpoint` or the documented segmented checkpoint knobs can reduce
-reverse-mode memory by recomputing forward states during backpropagation.
+graph. Per-step `jax.checkpoint` (the `checkpoint=True` default) or the
+segmented checkpoint knobs — `checkpoint_segments` on uniform grids,
+`checkpoint_every` on non-uniform grids — reduce reverse-mode memory by
+recomputing forward states during backpropagation. See the
+[Memory-Reduction Path](/rfx/guide/memory-reduction/) for how to size and pick
+these knobs.
 
 ```python
 import jax
 import jax.numpy as jnp
 
 # sim is an already configured Simulation with sources/probes/ports.
+# Discover the permittivity-array shape from a quick run, then build the
+# starting array (result.grid is populated after every run() call):
+eps0 = jnp.ones(sim.run(n_steps=1).grid.shape, dtype=jnp.float32)
+
 def objective(eps_r):
     result = sim.forward(eps_override=eps_r, n_steps=400, checkpoint=True)
     return jnp.sum(result.time_series ** 2)
@@ -58,10 +66,13 @@ makes the optimization objective less dominated by one sample.
 
 ### Documented differentiable port paths
 
-Selected `forward(port_s11_freqs=...)`, waveguide, MSL, and proxy-objective
-paths are differentiable where their public support entry says so. Treat the AD
-path as a contract for sensitivity calculation; the physical claim still follows
-the port-family evidence envelope.
+Some port paths carry a differentiable |S| channel: the lumped/wire path via
+`forward(port_s11_freqs=...)`, and the `compute_waveguide_s_matrix` /
+`compute_msl_s_matrix` calculators via their `eps_override` argument. Each is
+differentiable only where its own support entry says so. Treat the AD path as a
+contract for the sensitivity calculation; the physical claim still follows the
+port-family evidence envelope. See [Inverse Design](/rfx/guide/inverse-design/)
+for end-to-end optimization loops built on these paths.
 
 ## Where gradients are noisy or problematic
 
@@ -99,9 +110,10 @@ final design with a convergence or cross-reference check.
 
 ### Float32 finite-difference checks
 
-JAX commonly runs these workflows in float32. If the finite-difference step is
-too small, cancellation can make the finite-difference witness look worse than
-the AD path.
+rfx runs these workflows in float32 by default (complex64 field and DFT
+buffers), unless you enable JAX 64-bit precision. If the finite-difference step
+is too small, cancellation can make the finite-difference witness look worse
+than the AD path.
 
 **Mitigation:** start finite-difference checks with a step that is meaningful for
 the variable scale, often around `h = 1e-2` for permittivity-like variables, then
@@ -120,6 +132,14 @@ CPML cells from design regions.
 Grid dimensions, CPML layer count, timestep count, and shape insertion/removal
 are discrete choices. Use them as fixed setup parameters, or run an outer design
 search that launches separate differentiable problems with fixed topology.
+
+### Subpixel smoothing
+
+Subpixel averaging of material properties at geometry boundaries is precomputed
+once at setup and is not part of the JAX computation graph. Gradients do not
+flow through the subpixel weights — the material boundary is treated as fixed
+during reverse-mode differentiation. Exclude geometry boundary positions from
+design variables when subpixel smoothing is active.
 
 ### Unsupported physics combinations
 
@@ -159,8 +179,9 @@ and support envelope before changing optimizer settings.
    parameters.
 5. **Prefer broadband or averaged losses** when a single frequency point is
    noisy or near a resonance null.
-6. **Use documented checkpoint knobs** when reverse-mode memory is the limiting
-   factor.
+6. **Use the segmented checkpoint knobs** (`checkpoint_segments` on uniform
+   grids, `checkpoint_every` on non-uniform grids) when reverse-mode memory is
+   the limiting factor.
 7. **Validate the final RF observable** through the relevant port, resonance,
    far-field, or convergence workflow.
 
@@ -170,7 +191,7 @@ and support envelope before changing optimizer settings.
 |---|---|---|
 | Yee E/H update | differentiable inside supported runners | validate the observable, not just the tape |
 | CPML absorber | may be on the AD tape | exclude from physical design variables |
-| Lumped/wire `forward(port_s11_freqs=...)` | differentiable S11-vector path where preflight allows it | inherits the lumped/wire support envelope |
+| Lumped/wire `forward(port_s11_freqs=...)` | differentiable S11-vector path on the uniform single-device runner | inherits the lumped/wire support envelope |
 | MSL or waveguide S-matrix AD paths | differentiable only where the calculator documents `eps_override` support | use the matching calculator and support entry |
 | DFT probes / time series | useful proxy-objective signals | not an impedance-defined port by themselves |
 | Dispersive or lossy materials | case-dependent AD path | verify with finite differences and physics evidence |

--- a/docs/public/guide/gradient-behavior.md
+++ b/docs/public/guide/gradient-behavior.md
@@ -6,112 +6,136 @@ sidebar:
 
 rfx gradient workflows use JAX reverse-mode automatic differentiation through
 the implemented discrete FDTD calculation. This guide documents where gradients
-are reliable, where they are noisy, and best practices for using them. For the
-conceptual background, see [Autodiff and Adjoint Background](/rfx/guide/autodiff-adjoint/).
+are usually well behaved, where they are numerically stiff or noisy, and how to
+check them before using them for RF design decisions. For the conceptual
+background, see [Autodiff and Adjoint Background](/rfx/guide/autodiff-adjoint/).
 
-## How It Works
+## How it works
 
 JAX traces the supported FDTD time-stepping and objective path as a computation
-graph. `jax.checkpoint` (rematerialization) reduces reverse-mode memory by
-recomputing forward states during backpropagation.
+graph. `jax.checkpoint` or the documented segmented checkpoint knobs can reduce
+reverse-mode memory by recomputing forward states during backpropagation.
 
 ```python
 import jax
-from rfx.simulation import run
+import jax.numpy as jnp
 
+# sim is an already configured Simulation with sources/probes/ports.
 def objective(eps_r):
-    result = run(grid, materials(eps_r), n_steps,
-                 sources=[src], probes=[probe],
-                 checkpoint=True)
+    result = sim.forward(eps_override=eps_r, n_steps=400, checkpoint=True)
     return jnp.sum(result.time_series ** 2)
 
-grad = jax.grad(objective)(eps_r)  # discrete reverse-mode AD gradient
+grad = jax.grad(objective)(eps0)  # discrete reverse-mode AD gradient
 ```
 
-## Where Gradients Work Well
+The gradient is a sensitivity of this discrete objective. It is not, by itself,
+a calibrated S-parameter, far-field, or resonance validation result.
 
-### Smooth dielectric variations
-Continuous changes in eps_r produce smooth objective landscapes. Gradient
-descent converges reliably in 10-30 iterations.
+## Where gradients are usually well behaved
+
+### Smooth dielectric variables
+
+Continuous changes in `eps_r` inside a fixed design region are the safest first
+case. Use bounded parameterizations, such as a sigmoid or projection from latent
+variables, so the optimizer cannot leave the material range you intend to test.
 
 ```python
-# Optimizing eps_r in a design region: well-behaved
-eps_r = eps_r.at[design_region].set(sigmoid(latent) * 5 + 1)
+# Example bounded dielectric parameterization.
+eps_design = eps_min + (eps_max - eps_min) * jax.nn.sigmoid(latent)
 ```
 
-### Lumped-port S-parameter objectives
-|S11|², |S21|², impedance matching — all produce smooth, differentiable
-objectives when computed from DFT probes.
+### Broadband or averaged objectives
 
-### Broadband objectives
-Objectives averaged over multiple frequencies smooth out individual
-frequency-point noise:
+Objectives averaged over a band are often less sensitive to a single noisy
+frequency point:
+
 ```python
-loss = jnp.mean(jnp.abs(s11) ** 2)  # smoother than single-frequency
+loss = jnp.mean(jnp.abs(s11) ** 2)
 ```
 
-### CW steady-state
-CWSource with adequate ramp_steps produces stable gradients for
-frequency-domain objectives.
+This does not remove the need for a final port-family validation run. It only
+makes the optimization objective less dominated by one sample.
 
-## Where Gradients Are Noisy or Problematic
+### Documented differentiable port paths
 
-### Sharp PEC boundaries
-Stairstepping creates discontinuities in the objective landscape when
-geometry parameters move a PEC edge across a cell boundary. The gradient
-at these transitions is technically correct but can be very large or change
-sign abruptly.
+Selected `forward(port_s11_freqs=...)`, waveguide, MSL, and proxy-objective
+paths are differentiable where their public support entry says so. Treat the AD
+path as a contract for sensitivity calculation; the physical claim still follows
+the port-family evidence envelope.
 
-**Mitigation**: Use subpixel smoothing for dielectric boundaries. For PEC,
-accept that topology changes are non-smooth — use larger learning rates or
-stochastic methods.
+## Where gradients are noisy or problematic
 
-### Very long simulations (> 5000 steps)
-Gradient magnitude can decay through many timesteps (vanishing gradient) or
-accumulate numerical errors. The `jax.checkpoint` mechanism is exact in
-theory but float32 rounding compounds over many recomputation segments.
+### Moving PEC and topology boundaries
 
-**Mitigation**: Use the minimum n_steps needed. `run_until_decay(decay_by=1e-3)`
-automatically determines sufficient length.
+Stairstepping creates discontinuities when a geometry parameter moves a PEC edge
+across a Yee cell boundary. The gradient can be large, change sign abruptly, or
+represent the rasterized discretization more than the intended CAD motion.
 
-### Near-cutoff waveguide modes
-At frequencies near cutoff, the propagation constant beta approaches zero,
-causing large sensitivity to small parameter changes. Gradients are correct
-but numerically stiff.
+**Mitigation:** keep topology fixed during a gradient run, use smooth dielectric
+or relaxed occupancy variables where the workflow documents them, apply filters
+or minimum-feature constraints, and re-run a final discrete geometry validation.
+Do not rely on a larger learning rate to repair a discontinuous objective.
 
-**Mitigation**: Avoid including near-cutoff frequencies in the objective.
-Use a frequency band starting at 1.3 * f_cutoff.
+### Long time windows
 
-### Float32 precision limits
-JAX defaults to float32. For very small perturbations, finite-difference
-validation may show large disagreement with AD due to cancellation.
+Long simulations can have weak gradient signal, large dynamic range, or more
+roundoff sensitivity. Checkpointing preserves the mathematical reverse-mode
+program for the chosen computation, but recomputation still occurs in finite
+precision.
 
-**Mitigation**: When validating with FD, use h >= 1e-2 (not 1e-4).
-A too-small FD step can be imprecise even when the AD path is stable.
+**Mitigation:** use the minimum run length that captures the observable, record
+the time-window choice, and compare gradients against finite differences on a
+small set of cells or scalar parameters.
 
-## What Is NOT Differentiable
+### Near-cutoff and high-Q cases
 
-### CPML absorber region
-Gradients w.r.t. eps_r inside the CPML layers are not physically meaningful.
-The CPML is an artificial absorber, not a physical material. Exclude CPML
-cells from your design region.
+Near waveguide cutoff, beta changes rapidly with frequency and geometry. High-Q
+resonances can also make a single frequency sample highly sensitive to small
+mesh, material, or run-length changes.
 
-### Integer parameters
-Grid dimensions, CPML layer count, timestep count — these are discrete and
-not differentiable. Use them as fixed hyperparameters.
+**Mitigation:** keep optimization bands away from cutoffs unless that is the
+actual design target; use broadband or mode-tracking objectives; and verify the
+final design with a convergence or cross-reference check.
 
-### Geometry topology
-Adding or removing a shape (e.g., "should there be a hole here?") is a
-discrete decision. rfx gradients optimize continuous parameters within a
-fixed topology. For topology changes, use genetic algorithms or RL.
+### Float32 finite-difference checks
 
-## Validating Gradients
+JAX commonly runs these workflows in float32. If the finite-difference step is
+too small, cancellation can make the finite-difference witness look worse than
+the AD path.
 
-Always validate AD gradients against finite differences for new problem setups:
+**Mitigation:** start finite-difference checks with a step that is meaningful for
+the variable scale, often around `h = 1e-2` for permittivity-like variables, then
+adjust based on the loss magnitude and local sensitivity.
+
+## What is not differentiable
+
+### CPML absorber cells
+
+Gradients with respect to physical material variables inside CPML are not useful
+for RF design. CPML is an artificial absorber, not a device material. Exclude
+CPML cells from design regions.
+
+### Integer and topology choices
+
+Grid dimensions, CPML layer count, timestep count, and shape insertion/removal
+are discrete choices. Use them as fixed setup parameters, or run an outer design
+search that launches separate differentiable problems with fixed topology.
+
+### Unsupported physics combinations
+
+If a source, port, mesh, or monitor combination is outside the documented support
+scope, finite AD output is not validation evidence. The correct outcome for an
+unsupported combination is an explicit support error or a clearly scoped local
+engineering check, not a public claim.
+
+## Validating gradients
+
+Always check a new objective against finite differences at a few representative
+cells or scalar design parameters before trusting a full optimization run:
 
 ```python
 def fd_check(objective, eps_r, cell=(10, 5, 5), h=1e-2):
-    """Finite-difference gradient validation."""
+    """Finite-difference gradient witness for one cell."""
     eps_p = eps_r.at[cell].add(h)
     eps_m = eps_r.at[cell].add(-h)
     fd = (objective(eps_p) - objective(eps_m)) / (2 * h)
@@ -119,37 +143,35 @@ def fd_check(objective, eps_r, cell=(10, 5, 5), h=1e-2):
     rel_err = abs(ad - fd) / max(abs(fd), 1e-30)
     print(f"AD={ad:.6e}, FD={fd:.6e}, err={rel_err:.2%}")
     return rel_err
-
-# Rules of thumb:
-# - h=1e-2: reliable for float32 (< 5% error expected)
-# - h=1e-3: may work, check case by case
-# - h=1e-4: often unreliable in float32 (cancellation)
 ```
 
-## Best Practices
+Use the result as a witness, not as a universal tolerance. If the witness fails,
+inspect the objective scale, perturbation size, run length, monitor placement,
+and support envelope before changing optimizer settings.
 
-1. **Always use `checkpoint=True`** — 10-100x memory savings, no accuracy loss
-2. **Start with small grids** — iterate fast, scale up for final design
-3. **Learning rate 0.01-0.1** — for eps_r optimization with Adam
-4. **Validate with FD first** — before trusting gradient on a new problem type
-5. **Average over frequencies** — broadband objectives are smoother
-6. **Exclude CPML from design region** — gradients there are artifacts
-7. **Use `until_decay`** — don't run longer than needed
-8. **GPU for speed** — same differentiated program, faster execution when JAX has CUDA devices
+## Best practices
 
-## Supported Gradient Paths
+1. **Start with a small, supported setup** before scaling the grid or objective.
+2. **Use bounded continuous variables** for dielectric or occupancy design.
+3. **Exclude CPML and fixed metal from the design region** unless the guide for
+   that workflow explicitly documents a relaxed variable.
+4. **Check AD against finite differences** on a small set of cells or scalar
+   parameters.
+5. **Prefer broadband or averaged losses** when a single frequency point is
+   noisy or near a resonance null.
+6. **Use documented checkpoint knobs** when reverse-mode memory is the limiting
+   factor.
+7. **Validate the final RF observable** through the relevant port, resonance,
+   far-field, or convergence workflow.
 
-| Physics path | Gradient flows? | Evidence framing |
-|-------------|----------------|------------|
-| Yee E/H update | Yes | FD < 2% |
-| CPML absorber | Yes (but not useful) | — |
-| Lumped port excitation | Yes | FD < 2% |
-| TFSF plane wave | Yes | FD < 2% |
-| Waveguide port | Yes | FD < 2% |
-| DFT probe accumulation | Yes | FD < 50% (tiny values) |
-| Debye dispersion | Yes | Needs validation |
-| Lorentz/Drude dispersion | Yes | Needs validation |
-| Lossy conductors (sigma) | Yes | Needs validation |
-| Magnetic materials (mu_r) | Yes | Needs validation |
-| S-parameter extraction | Yes | AD contract only unless paired with the port-family E-level envelope in the S-parameter support matrix |
-| Subpixel smoothing | No (precomputed, not in AD graph) | N/A |
+## Gradient-path framing
+
+| Path | Gradient-path framing | RF evidence reminder |
+|---|---|---|
+| Yee E/H update | differentiable inside supported runners | validate the observable, not just the tape |
+| CPML absorber | may be on the AD tape | exclude from physical design variables |
+| Lumped/wire `forward(port_s11_freqs=...)` | differentiable S11-vector path where preflight allows it | inherits the lumped/wire support envelope |
+| MSL or waveguide S-matrix AD paths | differentiable only where the calculator documents `eps_override` support | use the matching calculator and support entry |
+| DFT probes / time series | useful proxy-objective signals | not an impedance-defined port by themselves |
+| Dispersive or lossy materials | case-dependent AD path | verify with finite differences and physics evidence |
+| S-parameter post-processing helpers | reporting/objective utilities | do not promote an undocumented port workflow |

--- a/docs/public/guide/inverse-design.md
+++ b/docs/public/guide/inverse-design.md
@@ -4,34 +4,40 @@ sidebar:
   order: 16
 ---
 
-rfx exposes JAX-differentiable FDTD workflows: `jax.grad` computes reverse-mode
-gradients of a scalar loss through the implemented discrete time-domain
-calculation. If you are coming from Meep's adjoint terminology, start with
+rfx runs a JAX-differentiable FDTD: `jax.grad` returns reverse-mode gradients of
+a scalar loss through the FDTD time-stepping, so the same solver that computes
+the fields also computes design sensitivities. If you are coming from Meep's
+adjoint terminology, start with
 [Autodiff and Adjoint Background](/rfx/guide/autodiff-adjoint/).
 
 ## How it works
 
-JAX traces the supported solver and objective path as a computation graph.
-`jax.checkpoint` reduces reverse-mode memory by recomputing forward states
-during backpropagation.
+JAX traces the solver and objective path as a computation graph. Gradient
+checkpointing recomputes forward states during backpropagation to bound
+reverse-mode memory (see [Memory Reduction](/rfx/guide/memory-reduction/)).
 
 ```text
-Forward:  eps_r → FDTD steps → probes / NTFF / loss
-Backward: jax.grad(loss)(eps_r) → gradient of eps_r
+Forward:  eps_r → FDTD steps → probes / NTFF → scalar loss
+Backward: jax.grad(loss)(eps_r) → ∂loss/∂eps_r
 ```
 
 ## Manual gradient loop
 
-For custom objectives, keep the loop on the high-level differentiable API. Build
-the `Simulation` once, create an `eps_override` array with the configured grid
-shape, and differentiate a scalar loss from `Simulation.forward(...)`:
+Most designs should use the higher-level [`optimize()` driver](#design-region-api),
+which builds this loop for you. Drop to a manual `jax.grad` loop only for custom
+objectives or training loops. Stay on the differentiable `Simulation.forward()`
+API instead of hand-writing FDTD updates: build the `Simulation` once, pass an
+`eps_override` array shaped like the grid permittivity, and differentiate a
+scalar loss:
 
 ```python
 import jax
 import jax.numpy as jnp
 
 # sim is an already configured Simulation with sources/probes/ports.
-# eps0 has the same shape as the simulation grid's permittivity array.
+# Discover the grid shape from a quick run (result.grid is always populated):
+eps0 = jnp.ones(sim.run(n_steps=1).grid.shape, dtype=jnp.float32)
+
 def objective(eps_r):
     result = sim.forward(eps_override=eps_r, n_steps=150, checkpoint=True)
     return -jnp.sum(result.time_series ** 2)  # example proxy loss
@@ -39,17 +45,21 @@ def objective(eps_r):
 grad = jax.grad(objective)(eps0)
 ```
 
-This computes the gradient of the implemented discrete proxy objective. It does
-not by itself validate the final RF observable; run the relevant port, resonance,
-far-field, or convergence check after optimization.
+This differentiates the proxy objective only. It does not by itself validate the
+final RF observable; re-run the relevant port, resonance, far-field, or
+convergence check on the optimized design (see [Validation](/rfx/guide/validation/)).
 
 ## Built-in objectives: choose the right family
 
 ### 1) Post-processed S-parameter objectives
 
-These are convenient when you already have a completed simulation result with
-S-parameters. They do not upgrade the physics claim of that result; use the
-port-family evidence envelope before treating the objective as validated.
+Each factory returns `objective(result) -> scalar` that reads `result.s_params`,
+so it applies to a completed `run(compute_s_params=True)` result. These raise
+`ValueError` inside the default `optimize()`/`forward()` loop, which does not
+build the post-processed S-parameter matrix (see family 2). An objective value
+is only as trustworthy as the S-parameter extraction behind it — confirm that
+port's S-parameter path is validated (see [Validation](/rfx/guide/validation/))
+before treating the optimized number as a physical result.
 
 ```python
 from rfx import minimize_s11, maximize_s21, target_impedance, maximize_bandwidth
@@ -62,10 +72,10 @@ obj_bw = maximize_bandwidth(f_center=5e9, f_bw=2e9, s11_threshold=-10)
 
 ### 2) Differentiable loop objectives for `optimize()`
 
-Inside the traced forward pass, rfx does **not** build a full post-processed
-S-parameter matrix for every port family. For gradient-based optimization loops,
-prefer the proxy losses below unless the selected calculator explicitly documents
-its differentiable S-parameter path:
+The `optimize()`/`forward()` pass emits `result.time_series` but not the
+post-processed `result.s_params` matrix, so the family-1 objectives cannot run
+inside a gradient loop. Use these time-domain proxies instead — they read only
+`result.time_series` and compose with both `optimize()` and `topology_optimize()`:
 
 ```python
 from rfx import minimize_reflected_energy, maximize_transmitted_energy
@@ -74,21 +84,33 @@ obj_reflect = minimize_reflected_energy(port_probe_idx=0)
 obj_transmit = maximize_transmitted_energy(output_probe_idx=-1)
 ```
 
-These are the recommended defaults for reflection-minimization and
-throughput-maximization tasks.
+`minimize_reflected_energy` is a late-time-reflection S11 proxy;
+`maximize_transmitted_energy` is an output-power S21 proxy. Both index
+`result.time_series` columns: `port_probe_idx` selects the probe co-located with
+the excitation port, `output_probe_idx` the downstream probe.
 
-For NTFF/directivity optimization, prefer
+For NTFF/directivity optimization, pass
 `maximize_directivity(..., log_ratio=True)` when the design variable can change
-total radiated power; this keeps the directivity-gradient sign consistent with
-the full ratio objective.
+total radiated power (conductors/PEC, lossy, or magnitude-changing dielectric
+DoFs). The default `log_ratio=False` mode drops a quotient-rule term and yields
+wrong-sign gradients for those DoFs; it is correct only for shape-preserving,
+constant-radiated-power DoFs.
 
 ## Design-region API
 
+`optimize()` is the high-level driver: give it a configured `Simulation`, a
+`DesignRegion` box (physical `corner_lo`/`corner_hi` in metres plus an
+`eps_range` the design is clamped to), and a proxy objective from family 2. It
+runs an Adam gradient loop over the region's permittivity and returns an
+`OptimizeResult` with `eps_design` (optimized permittivity in the box),
+`loss_history`, and the final `latent` parameters. For port/probe setup on the
+base simulation, see [Sources & Ports](/rfx/guide/sources-ports/).
+
 ```python
-from rfx import Simulation, DesignRegion, optimize
+from rfx import Simulation, DesignRegion, optimize, minimize_reflected_energy
 
 sim = Simulation(freq_max=10e9, domain=(0.1, 0.04, 0.02), boundary="cpml")
-sim.add_port(...)
+sim.add_port(...)  # see Sources & Ports for the concrete call
 
 region = DesignRegion(
     corner_lo=(0.03, 0.0, 0.0),
@@ -103,33 +125,43 @@ result = optimize(
     n_iters=50,
     lr=0.01,
 )
+# result.eps_design, result.loss_history, result.latent
 ```
+
+The region is clamped to the grid interior; `optimize()` raises `ValueError` if
+it lies entirely inside the CPML absorber, so keep `corner_lo`/`corner_hi` within
+the physical domain rather than the padding.
 
 ## Far-field objectives with NTFF data
 
-`optimize()` can pass NTFF data to objectives that explicitly accept
-`ntff_box=...`. Use this only when the NTFF setup and final far-field validation
-path are documented for the workflow.
+`maximize_directivity` optimizes the directivity ratio toward a target direction.
+It reads `result.ntff_data`, `result.ntff_box`, and `result.grid`, so the base
+simulation must register a near-to-far-field box first via
+`sim.add_ntff_box(corner_lo, corner_hi)`; without it the objective raises
+`ValueError`. `theta_target`/`phi_target` are in radians.
 
 ```python
 from rfx import maximize_directivity
 
 objective = maximize_directivity(
-    theta_target=0.0,
+    theta_target=0.0,  # radians
     phi_target=0.0,
     log_ratio=True,
 )
 ```
 
-This supports target-direction directivity and other radiation-aware objectives
-when the simulation has a documented NTFF setup and the final design is re-run
-through the far-field validation path.
+Pass this to `optimize()` like any family-2 proxy. (`optimize()` also forwards
+`result.ntff_box` as a keyword to any custom objective whose signature includes
+an `ntff_box` parameter; the built-in objective does not need that — it reads the
+box from the result.) NTFF passes cost more than probe-only losses, so iterate on
+a coarse grid, then re-run the final design through the far-field validation path
+(see [Far-field & RCS](/rfx/guide/farfield-rcs/)).
 
 ## Tips
 
-- **Use `checkpoint=True` or the documented segmented checkpoint knob** in custom loops when reverse-mode memory is the limiting factor.
+- **Memory**: `checkpoint=True` is the default; for large `n_steps`, use `checkpoint_segments` (uniform) or `checkpoint_every` (non-uniform) to trade ~2x compute for ~√n_steps memory. See [Memory Reduction](/rfx/guide/memory-reduction/).
 - **Start with small grids** for design iteration, then scale up for the final verification run.
-- **Learning rate**: `0.01–0.1` is a good first range for permittivity optimization.
-- **Proxy objectives first**: when in doubt, start with `minimize_reflected_energy()` or `maximize_transmitted_energy()`.
-- **Use NTFF objectives selectively** — they are powerful, but more expensive than probe-only losses.
+- **Learning rate**: `0.01–0.1` is a reasonable first range for permittivity optimization; see [Gradient Behavior](/rfx/guide/gradient-behavior/).
+- **Proxy objectives first**: start with `minimize_reflected_energy()` or `maximize_transmitted_energy()`.
+- **NTFF objectives cost more** than probe-only losses; reserve them for radiation targets.
 - **GPU acceleration** depends on the installed JAX/CUDA environment; verify device placement for performance-sensitive runs.

--- a/docs/public/guide/inverse-design.md
+++ b/docs/public/guide/inverse-design.md
@@ -22,30 +22,26 @@ Backward: jax.grad(loss)(eps_r) → gradient of eps_r
 
 ## Manual gradient loop
 
-The most flexible approach is still a custom objective written directly against
-`run()`:
+For custom objectives, keep the loop on the high-level differentiable API. Build
+the `Simulation` once, create an `eps_override` array with the configured grid
+shape, and differentiate a scalar loss from `Simulation.forward(...)`:
 
 ```python
 import jax
 import jax.numpy as jnp
-from rfx.grid import Grid
-from rfx.core.yee import MaterialArrays
-from rfx.simulation import run, make_source, make_probe, ProbeSpec
-from rfx.sources.sources import GaussianPulse
 
-grid = Grid(freq_max=8e9, domain=(0.04, 0.01, 0.01), dx=0.001, cpml_layers=6)
-src = make_source(grid, (0.008, 0.005, 0.005), "ez", GaussianPulse(f0=4e9), n_steps=150)
-probe = ProbeSpec(i=30, j=5, k=5, component="ez")
-
-sigma = jnp.zeros(grid.shape, dtype=jnp.float32)
-mu_r = jnp.ones(grid.shape, dtype=jnp.float32)
-
+# sim is an already configured Simulation with sources/probes/ports.
+# eps0 has the same shape as the simulation grid's permittivity array.
 def objective(eps_r):
-    mats = MaterialArrays(eps_r=eps_r, sigma=sigma, mu_r=mu_r)
-    result = run(grid, mats, 150, sources=[src], probes=[probe],
-                 boundary="pec", checkpoint=True)
-    return -jnp.sum(result.time_series ** 2)  # maximize transmission
+    result = sim.forward(eps_override=eps_r, n_steps=150, checkpoint=True)
+    return -jnp.sum(result.time_series ** 2)  # example proxy loss
+
+grad = jax.grad(objective)(eps0)
 ```
+
+This computes the gradient of the implemented discrete proxy objective. It does
+not by itself validate the final RF observable; run the relevant port, resonance,
+far-field, or convergence check after optimization.
 
 ## Built-in objectives: choose the right family
 
@@ -64,11 +60,12 @@ obj_z = target_impedance(freq=5e9, z_target=50.0)
 obj_bw = maximize_bandwidth(f_center=5e9, f_bw=2e9, s11_threshold=-10)
 ```
 
-### 2) Differentiable loop objectives for `optimize()` / `topology_optimize()`
+### 2) Differentiable loop objectives for `optimize()`
 
 Inside the traced forward pass, rfx does **not** build a full post-processed
-S-parameter matrix. For gradient-based optimisation loops, prefer the proxy
-losses below:
+S-parameter matrix for every port family. For gradient-based optimization loops,
+prefer the proxy losses below unless the selected calculator explicitly documents
+its differentiable S-parameter path:
 
 ```python
 from rfx import minimize_reflected_energy, maximize_transmitted_energy
@@ -77,10 +74,10 @@ obj_reflect = minimize_reflected_energy(port_probe_idx=0)
 obj_transmit = maximize_transmitted_energy(output_probe_idx=-1)
 ```
 
-These are the recommended defaults for reflection-minimisation and
-throughput-maximisation tasks.
+These are the recommended defaults for reflection-minimization and
+throughput-maximization tasks.
 
-For NTFF/directivity optimisation, prefer
+For NTFF/directivity optimization, prefer
 `maximize_directivity(..., log_ratio=True)` when the design variable can change
 total radiated power; this keeps the directivity-gradient sign consistent with
 the full ratio objective.
@@ -110,31 +107,29 @@ result = optimize(
 
 ## Far-field objectives with NTFF data
 
-A recent improvement makes `optimize()` NTFF-aware. If your objective accepts
-`ntff_box=...`, the optimiser will build the far-field box and pass it in.
+`optimize()` can pass NTFF data to objectives that explicitly accept
+`ntff_box=...`. Use this only when the NTFF setup and final far-field validation
+path are documented for the workflow.
 
 ```python
-import jax.numpy as jnp
-from rfx import compute_far_field_jax
+from rfx import maximize_directivity
 
-grid = sim._build_grid()  # advanced usage: capture once outside the objective
-theta = jnp.linspace(0.0, jnp.pi, 181)
-phi = jnp.array([0.0])
-
-def objective(result, ntff_box=None):
-    ff = compute_far_field_jax(result.ntff_data, ntff_box, grid, theta, phi)
-    broadside = jnp.abs(ff.E_theta[0, 90, 0]) ** 2 + jnp.abs(ff.E_phi[0, 90, 0]) ** 2
-    return -broadside
+objective = maximize_directivity(
+    theta_target=0.0,
+    phi_target=0.0,
+    log_ratio=True,
+)
 ```
 
-This enables beam shaping, broadside maximisation, and other radiation-aware
-advanced objectives.
+This supports target-direction directivity and other radiation-aware objectives
+when the simulation has a documented NTFF setup and the final design is re-run
+through the far-field validation path.
 
 ## Tips
 
-- **Always use `checkpoint=True`** in custom loops — it saves large amounts of memory.
+- **Use `checkpoint=True` or the documented segmented checkpoint knob** in custom loops when reverse-mode memory is the limiting factor.
 - **Start with small grids** for design iteration, then scale up for the final verification run.
-- **Learning rate**: `0.01–0.1` is a good first range for permittivity optimisation.
+- **Learning rate**: `0.01–0.1` is a good first range for permittivity optimization.
 - **Proxy objectives first**: when in doubt, start with `minimize_reflected_energy()` or `maximize_transmitted_energy()`.
 - **Use NTFF objectives selectively** — they are powerful, but more expensive than probe-only losses.
-- **GPU acceleration** is automatic when JAX sees CUDA devices.
+- **GPU acceleration** depends on the installed JAX/CUDA environment; verify device placement for performance-sensitive runs.

--- a/docs/public/guide/materials-geometry.mdx
+++ b/docs/public/guide/materials-geometry.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Materials and Geometry"
-description: "Library materials are available directly by name; no `add_material()` call is needed:"
+description: "Library and custom materials, dispersive poles, CSG shapes, PEC handling, and thin conductors in rfx."
 sidebar:
   order: 3
 ---
 
 
-rfx uses a two-step workflow: register a material by name, then attach it to a geometric shape.
+Building a structure in rfx is two steps: pick a material — a built-in library name or one you register with `add_material()` — and attach it to a CSG shape with `sim.add()`.
 
 ---
 
@@ -17,23 +17,27 @@ rfx uses a two-step workflow: register a material by name, then attach it to a g
 ```python
 from rfx import MATERIAL_LIBRARY
 print(list(MATERIAL_LIBRARY.keys()))
-# ['vacuum', 'air', 'fr4', 'rogers4003c', 'alumina', 'silicon',
-#  'ptfe', 'copper', 'aluminum', 'pec', 'water_20c']
+# ['vacuum', 'air', 'fr4', 'rogers4003c', 'rogers4350b', 'rt_duroid_5880',
+#  'alumina', 'silicon', 'ptfe', 'copper', 'aluminum', 'pec', 'water_20c']
 ```
 
 | Name | εᵣ | σ (S/m) | Notes |
 |---|---|---|---|
 | `vacuum` | 1.0 | 0 | Lossless free space |
 | `air` | 1.0006 | 0 | Standard atmosphere |
-| `fr4` | 4.4 | 0.025 | PCB laminate, tan_δ ≈ 0.02 at 1 GHz |
-| `rogers4003c` | 3.55 | ~0.0027·ω·ε₀·εᵣ | Low-loss microwave substrate |
+| `fr4` | 4.4 | 0.025 | Lossy PCB laminate (constant-σ loss model) |
+| `rogers4003c` | 3.55 | 2.67×10⁻³ | Low-loss substrate; σ from tan δ 0.0027 @ 5 GHz (process Dk 3.55) |
+| `rogers4350b` | 3.48 | 7.16×10⁻³ | Low-loss substrate; σ from tan δ 0.0037 @ 10 GHz (design Dk 3.48) |
+| `rt_duroid_5880` | 2.20 | 1.10×10⁻³ | Very-low-loss PTFE composite; σ from tan δ 0.0009 @ 10 GHz |
 | `alumina` | 9.8 | 0 | Ceramic substrate |
 | `silicon` | 11.9 | 0.01 | Lightly doped semiconductor |
 | `ptfe` | 2.1 | 0 | PTFE / Teflon |
-| `copper` | 1.0 | 5.8×10⁷ | Good conductor |
-| `aluminum` | 1.0 | 3.5×10⁷ | Good conductor |
+| `copper` | 1.0 | 5.8×10⁷ | Good conductor — mask-enforced as PEC (see below) |
+| `aluminum` | 1.0 | 3.5×10⁷ | Good conductor — mask-enforced as PEC (see below) |
 | `pec` | 1.0 | 1×10¹⁰ | Perfect electric conductor (mask-enforced) |
 | `water_20c` | 4.9 + Debye | 0 | Water at 20 °C with one Debye pole |
+
+The tabulated σ for the substrate laminates is a fixed effective conductivity derived from the datasheet loss tangent at the stated frequency, not a frequency-dependent model.
 
 Library materials are available directly by name; no `add_material()` call is needed:
 
@@ -104,32 +108,46 @@ sim.add_material(
 
 ### Lorentz poles
 
-Lorentz poles model phonon resonances and plasma-like media:
+Lorentz poles model phonon resonances and plasma-like media. Build them from
+physical parameters with the `lorentz_pole()` and `drude_pole()` helpers, which
+return a `LorentzPole` and pass straight into `lorentz_poles=[...]`:
 
 ```python
-from rfx import LorentzPole, drude_pole, lorentz_pole
+import numpy as np
+from rfx import lorentz_pole, drude_pole
 
-# Manual Lorentz pole
+# Lorentz oscillator from (Δε, resonance, damping)
 sim.add_material(
     "resonant_material",
     eps_r=1.0,
     lorentz_poles=[
-        LorentzPole(delta_eps=2.0, omega_0=2*3.14159*10e9, delta=1e8),
+        lorentz_pole(delta_eps=2.0, omega_0=2 * np.pi * 10e9, delta=1e8),
     ],
 )
 
-# Helper: Drude (free-electron) model for metals
-drude = drude_pole(omega_p=1.37e16, gamma=4.05e13)   # gold
-sim.add_material("gold", eps_r=1.0, lorentz_poles=[drude])
+# Drude (free-electron) model for metals — gold, illustrative constants
+gold = drude_pole(omega_p=1.37e16, gamma=4.05e13)
+sim.add_material("gold", eps_r=1.0, lorentz_poles=[gold])
 ```
 
-`LorentzPole` fields:
+`lorentz_pole()` parameters:
 
-| Field | Description |
+| Parameter | Description |
 |---|---|
-| `delta_eps` | Oscillator strength |
+| `delta_eps` | Oscillator strength Δε (dimensionless) |
 | `omega_0` | Resonance angular frequency (rad/s) |
-| `delta` | Damping rate (rad/s) |
+| `delta` | Damping coefficient (rad/s) |
+
+`drude_pole()` parameters:
+
+| Parameter | Description |
+|---|---|
+| `omega_p` | Plasma frequency (rad/s) |
+| `gamma` | Collision rate (rad/s) |
+
+Both helpers return the low-level `LorentzPole(omega_0, delta, kappa)` tuple used
+internally, where `kappa = delta_eps · omega_0²` (Lorentz) or `omega_p²` (Drude).
+Prefer the helpers over constructing `LorentzPole` directly.
 
 ---
 
@@ -171,45 +189,55 @@ rod  = Cylinder((0.010, 0.025, 0.000), radius=0.001,  height=0.050, axis="x")
 sim.add(via, material="copper")
 ```
 
-### Boolean operations
+`Box`, `Sphere`, and `Cylinder` cover most structures. rfx also ships
+`PolylineWire`, `Via`, and `CurvedPatch`; see the
+[Geometry and Materials API reference](/rfx/api/geometry-materials/) for their
+signatures.
 
-Combine shapes with set operations:
+### Composing shapes with draw order
+
+rfx has no Shape-level Boolean CSG that you can pass to `sim.add()`. Instead,
+shapes are rasterised in the order they are added, and on overlapping cells a
+later shape overwrites the (εᵣ, σ, μᵣ) fill of an earlier one. Carve or layer a
+structure by adding shapes back-to-front:
 
 ```python
-from rfx.geometry.csg import union, difference, intersection
-
-# Hollow cylinder (tube)
-outer = Cylinder((0.025, 0.025, 0.0), radius=0.010, height=0.020, axis="z")
-inner = Cylinder((0.025, 0.025, 0.0), radius=0.007, height=0.020, axis="z")
-tube  = difference(outer, inner)
-sim.add(tube, material="copper")
-
-# Lens-shaped dielectric
-sphere1 = Sphere((0.025, 0.025, 0.005), radius=0.008)
-sphere2 = Sphere((0.025, 0.025, 0.015), radius=0.008)
-lens    = intersection(sphere1, sphere2)
-sim.add(lens, material="alumina")
+# Dielectric block with a lower-εr insert carved into it
+sim.add(Box((0.010, 0.010, 0.0), (0.040, 0.040, 0.004)), material="alumina")
+sim.add(Box((0.020, 0.020, 0.0), (0.030, 0.030, 0.004)), material="air")  # wins here
 ```
+
+!!! warning
+    Draw-order overwrite applies only to dielectric / conductivity fills. PEC
+    cells (σ ≥ 10⁶ S/m, including `copper`, `aluminum`, and `pec`) accumulate in
+    a Boolean mask that is never cleared, so a later shape **cannot** carve a hole
+    in PEC. Model hollow or patterned metal by placing conductor only where metal
+    should exist.
 
 ---
 
 ## PEC mask enforcement
 
-Materials with σ ≥ 10⁶ S/m (including library `pec`) are enforced via a
-Boolean PEC mask rather than through the conductivity update. Within the
-discrete PEC-mask model, the E-field is set to zero on every PEC cell at each
-time step; this avoids the numerical instability that arises from very large σ
-in the standard update equations.
+Any material with σ ≥ 10⁶ S/m is enforced via a Boolean PEC mask rather than
+through the conductivity update: the E-field is set to zero on every PEC cell at
+each time step, which avoids the numerical instability that very large σ would
+cause in the standard update equations. This threshold captures library `pec`
+(σ = 10¹⁰) **and** the good-metal entries `copper` (5.8×10⁷) and `aluminum`
+(3.5×10⁷) — all three are modelled as perfect conductors, so finite-conductivity
+loss is not represented on this path.
 
 !!! warning
-    Do not set σ > 10⁸ S/m for non-PEC conductors such as copper. Use the library value
-    `sigma=5.8e7` for copper or define `"pec"` explicitly when a perfect conductor is intended.
+    To model a genuinely lossy conductor, keep σ below 10⁶ S/m; any material at or
+    above that threshold is silently promoted to PEC. The library `copper` and
+    `aluminum` entries are already above it, so they behave as perfect conductors,
+    not lossy metals.
 
 ---
 
 ## Thin conductor correction
 
-For printed traces and patches thinner than one cell, use the subcell thin-conductor model:
+For printed traces and patches thinner than one cell, use the subcell
+thin-conductor model instead of refining the mesh to resolve the sheet:
 
 ```python
 from rfx import Box
@@ -218,8 +246,15 @@ trace = Box((0.010, 0.014, 0.0016), (0.040, 0.016, 0.0016))
 sim.add_thin_conductor(
     trace,
     sigma_bulk=5.8e7,     # copper
-    thickness=35e-6,       # 1 oz copper = 35 µm
+    thickness=35e-6,      # 1 oz copper = 35 µm
 )
 ```
 
-This applies an effective surface conductivity correction to the Yee cells intersected by the thin sheet, rather than fully filling them.
+`add_thin_conductor` picks one of two regimes from `sigma_bulk`:
+
+- **σ_bulk ≥ 10⁶ S/m** (copper, as above): the sheet is enforced as a thin PEC
+  sheet — its cells are added to the PEC mask, no volumetric meshing needed. rfx
+  emits a warning noting this routing. This is the common case for printed copper.
+- **σ_bulk < 10⁶ S/m** (resistive films, inks): rfx sets an effective conductivity
+  `σ_eff = σ_bulk · (thickness / Δx)` on the intersected Yee cells rather than
+  fully filling them, preserving the sheet resistance `R_s = 1 / (σ_bulk · thickness)`.

--- a/docs/public/guide/materials-geometry.mdx
+++ b/docs/public/guide/materials-geometry.mdx
@@ -147,14 +147,14 @@ slab  = Box((0.0,  0.0,  0.0),  (0.05, 0.05, 0.002))
 patch = Box((0.01, 0.01, 0.002),(0.04, 0.04, 0.002))
 ```
 
-Coordinates are in metres. `corner_lo` and `corner_hi` are `(x, y, z)` tuples.
+Coordinates are in meters. `corner_lo` and `corner_hi` are `(x, y, z)` tuples.
 
 ### Sphere
 
 ```python
 from rfx import Sphere
 
-# Sphere(centre, radius)
+# Sphere(center, radius)
 ball = Sphere((0.025, 0.025, 0.010), radius=0.005)
 sim.add(ball, material="alumina")
 ```
@@ -164,7 +164,7 @@ sim.add(ball, material="alumina")
 ```python
 from rfx import Cylinder
 
-# Cylinder(centre, radius, height, axis)
+# Cylinder(center, radius, height, axis)
 # axis: "x", "y", or "z"
 via  = Cylinder((0.025, 0.015, 0.000), radius=0.0005, height=0.002, axis="z")
 rod  = Cylinder((0.010, 0.025, 0.000), radius=0.001,  height=0.050, axis="x")
@@ -195,7 +195,11 @@ sim.add(lens, material="alumina")
 
 ## PEC mask enforcement
 
-Materials with σ ≥ 10⁶ S/m (including library `pec`) are automatically enforced via a Boolean PEC mask rather than through the conductivity update. This is exact (E-field set to zero on every PEC cell at each time step) and avoids the numerical instability that arises from very large σ in the standard update equations.
+Materials with σ ≥ 10⁶ S/m (including library `pec`) are enforced via a
+Boolean PEC mask rather than through the conductivity update. Within the
+discrete PEC-mask model, the E-field is set to zero on every PEC cell at each
+time step; this avoids the numerical instability that arises from very large σ
+in the standard update equations.
 
 !!! warning
     Do not set σ > 10⁸ S/m for non-PEC conductors such as copper. Use the library value

--- a/docs/public/guide/migration.md
+++ b/docs/public/guide/migration.md
@@ -60,7 +60,7 @@ sim = Simulation(freq_max=5e9, domain=(0.1, 0.1, 0.05), boundary="pec")
 sim.add_source(position=(0.03, 0.03, 0.02), component="ez")
 sim.add_probe(position=(0.06, 0.06, 0.02), component="ez")
 result = sim.run(until_decay=1e-3)
-freqs = result.find_resonances()
+modes = result.find_resonances()   # list of HarminvMode (fields: freq, decay, Q, ...)
 ```
 
 ### OpenEMS: Waveguide S-Parameters
@@ -78,15 +78,22 @@ s11 = port{1}.uf.ref ./ port{1}.uf.inc;
 ```
 
 ```python
-# rfx equivalent (waveguide port family)
-from rfx import Simulation, Box
+# rfx equivalent (waveguide modal-port family)
+import jax.numpy as jnp
+from rfx import Simulation
 
-sim = Simulation(freq_max=15e9, domain=(0.04, 0.02, 0.01), boundary="cpml")
-sim.add(Box((0, 0, 0), (0.04, 0.02, 0.01)), material="pec")
-sim.add_waveguide_port(0.005, direction="+x", f0=10e9, name="in")
-sim.add_waveguide_port(0.035, direction="-x", f0=10e9, name="out")
-result = sim.compute_waveguide_s_matrix(num_periods=30, normalize=True)
-s11 = result.s_params[0, 0, :]
+# WR-90 rectangular guide. The guide walls are implied by the modal port
+# and the transverse (y, z) domain extents -- no explicit PEC fill is needed.
+freqs = jnp.linspace(8e9, 11.5e9, 8)   # above the ~6.56 GHz TE10 cutoff
+sim = Simulation(freq_max=12e9, domain=(0.10, 0.02286, 0.01016),
+                 dx=2e-3, boundary="cpml", cpml_layers=8)
+sim.add_waveguide_port(0.024, direction="+x", freqs=freqs, f0=9.75e9, name="in")
+sim.add_waveguide_port(0.076, direction="-x", freqs=freqs, f0=9.75e9, name="out")
+
+# Modal V/I decomposition (the default, normalize=False). For dispersion-
+# corrected transmission magnitude, pass normalize="flux".
+result = sim.compute_waveguide_s_matrix(num_periods=30, normalize=False)
+s11 = result.s_params[0, 0, :]   # s_params shape: (n_ports, n_ports, n_freqs)
 ```
 
 The waveguide path is recommended only within the documented
@@ -104,17 +111,32 @@ f, g = opt()  # forward + adjoint
 ```
 
 ```python
-# rfx (native JAX autodiff)
-import jax
+# rfx: gradient-based inverse design (optimize() runs jax.grad through the
+# differentiable sim.forward() internally -- no adjoint code to hand-write)
+import jax.numpy as jnp
+from rfx import Simulation, Box, DesignRegion, GaussianPulse
+from rfx.optimize import optimize
+from rfx.optimize_objectives import minimize_s11_at_freq_wave_decomp
 
-def loss(eps_r):
-    sim = Simulation(freq_max=8e9, domain=(0.04, 0.01, 0.01), boundary="cpml")
-    sim.add_port(position=(0.008, 0.005, 0.005), component="ez")
-    result = sim.run(n_steps=150, compute_s_params=True, eps_r_override=eps_r)
-    return -jnp.abs(result.s_params[0, 0, 50])
+sim = Simulation(freq_max=5e9, domain=(0.05, 0.05, 0.025), dx=2.5e-3, boundary="pec")
+sim.add_material("slab_init", eps_r=4.0)
+sim.add(Box((0.015, 0.015, 0.005), (0.035, 0.035, 0.020)), material="slab_init")
+sim.add_port((0.025, 0.025, 0.0125), "ez",
+             waveform=GaussianPulse(f0=3e9, bandwidth=0.8))
 
-grad_fn = jax.grad(loss)
-gradient = grad_fn(initial_eps_r)
+region = DesignRegion(
+    corner_lo=(0.015, 0.015, 0.005),
+    corner_hi=(0.035, 0.035, 0.020),
+    eps_range=(1.0, 12.0),
+)
+objective = minimize_s11_at_freq_wave_decomp(target_freq=3e9, port_idx=0)
+
+# port_s11_freqs is required by this objective (it accumulates per-port V/I
+# DFTs at those frequencies inside the JIT scan body).
+result = optimize(sim, region, objective,
+                  n_iters=50, lr=0.01,
+                  port_s11_freqs=jnp.asarray([3e9]))
+# result.eps_design (optimized permittivity), result.loss_history (per-iter)
 ```
 
 ---
@@ -125,8 +147,8 @@ gradient = grad_fn(initial_eps_r)
 
 rfx runs on GPU out of the box via JAX. No separate engine binary, no
 file-based I/O between the Python front-end and a C++ solver. The full
-time-stepping loop is JIT-compiled and executes on GPU (~3,000 Mcells/s on
-RTX 4090).
+time-stepping loop is a single JIT-compiled `jax.lax.scan` that executes on
+GPU (the project README reports ~7,300 Mcells/s on an RTX 4090).
 
 ### JAX-Native Differentiation
 
@@ -138,28 +160,35 @@ loss functions, while final RF claims still need the relevant validation path.
 ### Declarative Builder API
 
 rfx uses a single `Simulation` object that accumulates geometry, materials,
-sources, and probes. Call `run()` once -- S-parameters, resonances, and
-field snapshots are computed automatically based on what was requested.
+sources, and probes. `run()` computes S-parameters when ports exist
+(`compute_s_params` defaults to True in that case) and field snapshots when a
+`SnapshotSpec` is passed; resonances are extracted on demand from the returned
+`Result` via `result.find_resonances()`.
 
 ### Built-in Material Library
 
-Eleven common RF materials (`fr4`, `rogers4003c`, `alumina`, `silicon`,
-`copper`, `pec`, etc.) are available by name. No need to look up
-permittivity tables for standard substrates and conductors.
+A built-in material library covers common RF substrates and conductors
+(`fr4`, `rogers4003c`, `rogers4350b`, `rt_duroid_5880`, `alumina`, `ptfe`,
+`silicon`, `copper`, `aluminum`, `pec`, `air`, `vacuum`, `water_20c`) by name,
+so you do not have to look up permittivity tables for standard materials.
 
 ### Auto-Configuration
 
-`Simulation(freq_max=N)` automatically sets cell size, time step, CPML
-thickness, and source waveform. For most antenna and waveguide problems you
-only need to specify `freq_max` and `domain`.
+When you do not pass `dx`, rfx derives the cell size from `freq_max` (and the
+time step from the CFL limit) at run time, and point sources default to a
+`GaussianPulse` centered at `freq_max/2`. CPML uses a 16-layer pad by
+default (`cpml_layers=16`). For most antenna and waveguide problems you only
+need `freq_max` and `domain`; `Simulation.auto(freq_range=(f_min, f_max))`
+additionally proposes a domain and mesh from a target band.
 
 ### Bounded Non-Uniform Z for Thin Substrates
 
-For PCB and patch-style problems, graded z meshing via `dz_profile` /
-`auto_configure()` can reduce cell count when the thin feature is primarily
-along z. Treat it as a bounded workflow: use the documented support checks and
-validate the final observable through the relevant uniform or external reference
-lane.
+For PCB and patch-style problems, graded z meshing via the `dz_profile=`
+constructor argument or `auto_configure()` can reduce cell count when the thin
+feature is primarily along z. Treat it as a bounded workflow: use the
+documented support checks and validate the final observable through the
+relevant uniform or external reference lane. See
+[Non-Uniform Mesh](/rfx/guide/nonuniform-mesh/) for the support envelope.
 
 ---
 
@@ -171,7 +200,7 @@ lane.
 | `freq_max` is in Hz, not normalized frequency | Use `freq_max=5e9` for 5 GHz |
 | PML is outside the domain you specify | `domain=` is the physical region; CPML pads are added automatically |
 | `run()` returns a `Result` object | Access fields via `result.s_params`, `result.time_series`, `result.find_resonances()` |
-| No mesh file export | rfx solves in-process; use `sim.grid` to inspect the mesh |
+| No mesh file export | rfx solves in-process; the solved `Grid` is on `result.grid`, and `rfx.plan_simulation_mesh(sim)` audits the mesh before a run |
 
 ---
 

--- a/docs/public/guide/migration.md
+++ b/docs/public/guide/migration.md
@@ -15,7 +15,7 @@ concepts are familiar -- the API surface is different.
 | Concept | Meep | OpenEMS | rfx |
 |---------|------|---------|-----|
 | Grid setup | `Simulation(resolution=N)` | `InitCSX()` + `InitFDTD()` | `Simulation(freq_max=...)` or `Simulation.auto(...)` |
-| Cell size | `resolution` (cells/unit) | `SetDeltaUnit(1e-3)` | `dx=` in metres (auto-calculated from `freq_max`) |
+| Cell size | `resolution` (cells/unit) | `SetDeltaUnit(1e-3)` | `dx=` in meters (auto-calculated from `freq_max`) |
 | Source | `EigenModeSource`, `Source` | `AddExcitation` | `add_port()`, `add_source()` |
 | S-parameters | `add_flux()` + post-processing | `CalcPort` | port-family-specific: lumped/wire `run(compute_s_params=True)`, MSL `compute_msl_s_matrix()`, waveguide `compute_waveguide_s_matrix()` |
 | Resonance finding | `harminv(...)` | Manual FFT | `result.find_resonances()` |
@@ -26,7 +26,7 @@ concepts are familiar -- the API surface is different.
 | Dispersive media | `LorentzianSusceptibility` | `AddLorentzMaterial` | `DebyePole`, `LorentzPole`, `drude_pole()` |
 | Differentiable | adjoint-solver workflows for selected design-region objectives | not native | `jax.grad(loss_fn)(params)` on supported JAX-traced workflows |
 | Inverse design | `meep.adjoint` / `OptimizationProblem` | not native | `rfx.optimize(sim, design_region, objective)` |
-| Non-uniform mesh | Not native | `SmoothMeshLines` | `dz_profile` or `auto_configure()` |
+| Non-uniform mesh | Not native | `SmoothMeshLines` | bounded `dz_profile` / `auto_configure()` workflows |
 
 ---
 
@@ -153,11 +153,13 @@ permittivity tables for standard substrates and conductors.
 thickness, and source waveform. For most antenna and waveguide problems you
 only need to specify `freq_max` and `domain`.
 
-### Non-Uniform Z for Thin Substrates
+### Bounded Non-Uniform Z for Thin Substrates
 
-For PCB and patch-style problems, the most practical recent `rfx` workflow is
-graded z meshing via `dz_profile` / `auto_configure()`, rather than assuming
-one globally fine uniform mesh.
+For PCB and patch-style problems, graded z meshing via `dz_profile` /
+`auto_configure()` can reduce cell count when the thin feature is primarily
+along z. Treat it as a bounded workflow: use the documented support checks and
+validate the final observable through the relevant uniform or external reference
+lane.
 
 ---
 
@@ -165,7 +167,7 @@ one globally fine uniform mesh.
 
 | Issue | Solution |
 |-------|----------|
-| Coordinates are in metres, not mm or cell units | All positions use SI metres |
+| Coordinates are in meters, not mm or cell units | All positions use SI meters |
 | `freq_max` is in Hz, not normalized frequency | Use `freq_max=5e9` for 5 GHz |
 | PML is outside the domain you specify | `domain=` is the physical region; CPML pads are added automatically |
 | `run()` returns a `Result` object | Access fields via `result.s_params`, `result.time_series`, `result.find_resonances()` |

--- a/docs/public/guide/nonuniform-mesh.mdx
+++ b/docs/public/guide/nonuniform-mesh.mdx
@@ -6,29 +6,39 @@ sidebar:
 ---
 
 
-rfx provides a **graded z-profile** (non-uniform Yee grid) with uniform `dx`
-and `dy`. This is a bounded workflow for thin layered structures, not the
-recommended default reference lane. Use the uniform Cartesian Yee lane first
-unless the thin feature would force an impractically small uniform cell.
+rfx supports a **non-uniform (graded) Yee grid**. This guide covers the common
+case — a graded z-profile (`dz_profile`) with uniform `dx` and `dy` — for thin
+layered structures. (`dx_profile` and `dy_profile` grade the transverse axes and
+follow the same rules.) This is a bounded workflow, not the recommended default
+reference lane: use the uniform Cartesian Yee lane first unless the thin feature
+would force an impractically small uniform cell.
 
 ### Current support status
 
 - suitable for thin-substrate or layered-z RF setup studies when the observable
   remains inside a documented support envelope;
 - memory and mesh reports are planning artifacts, not physics validation;
-- unsupported combinations raise explicit errors instead of silently dropping
-  features.
+- most unsupported combinations raise explicit errors rather than silently
+  dropping features; a few (NTFF, DFT-plane probes, full-plane flux monitors)
+  instead run on the graded-z path but stay outside the validated reference
+  lane — see the table below.
 
 Current unsupported or restricted combinations:
 
 | Combination | Public status |
 |---|---|
-| periodic-port workflows + non-uniform z mesh | unsupported |
-| NTFF, DFT planes, or TFSF + non-uniform z mesh | unsupported |
-| single-cell lumped-port S-parameters + non-uniform z mesh | unsupported |
-| `compute_msl_s_matrix()` + non-uniform z mesh | unsupported unless a specific guide and support entry says otherwise |
-| coaxial ports or lumped RLC + non-uniform z mesh | unsupported |
-| waveguide ports + non-uniform z mesh | restricted to the documented single-mode waveguide support entry; use the support matrix before making public claims |
+| periodic (Floquet) ports + non-uniform z mesh | unsupported (raises) |
+| single-cell lumped-port S-parameters + non-uniform z mesh | unsupported (raises); use `add_port(..., extent=...)` WirePort extraction or the uniform lane |
+| coaxial-port S-parameters + non-uniform z mesh | unsupported (raises) |
+| lumped-RLC + non-uniform z mesh | runs as a field ADE element (time-domain fields only); no S-parameter output — not a S-param workflow and does not raise |
+| `compute_msl_s_matrix()` + non-uniform mesh | `mode='laplace'`/`'uniform'` only (the `add_msl_port` default); `mode='eigenmode'` raises |
+| `compute_waveguide_s_matrix()` + non-uniform *transverse* mesh (`dx_profile`/`dy_profile`) | restricted to `normalize=True` and single-mode ports; consult the waveguide support entry before public claims |
+| TFSF plane-wave source + non-uniform z mesh | normal incidence along x only (`direction='+x'`/`'-x'`, `angle_deg=0`); `±z` or oblique incidence raises |
+| finite-region flux monitor (`add_flux_monitor(size=...)`) + non-uniform z mesh | unsupported (raises); use a full-plane monitor (omit `size=`) |
+
+NTFF boxes, DFT-plane probes, and full-plane flux monitors run on the graded-z
+path, but — like the rest of this lane — their observables must be validated
+against the uniform or external reference before any public claim.
 
 ---
 
@@ -41,7 +51,7 @@ Current unsupported or restricted combinations:
 | Bulk 3-D structure with no thin z-features | Uniform grid |
 | RCS / far-field only | Uniform grid is usually sufficient |
 
-Without a non-uniform z-profile, resolving a 1.6 mm substrate with a 0.5 mm cell gives only 3 cells — too coarse. Shrinking the uniform cell to 0.2 mm resolves the substrate but inflates cell count by 15x in all three dimensions.
+Without a non-uniform z-profile, resolving a 1.6 mm substrate with a 0.5 mm cell gives only 3 cells — too coarse. Shrinking the uniform cell to 0.2 mm resolves the substrate but refines all three axes at once (2.5x per axis), inflating the total cell count by roughly 15x.
 
 A non-uniform profile uses **fine cells inside the substrate** (e.g., 0.27 mm) and **coarse cells in the air region** (e.g., 1.5 mm). The resulting cell-count reduction is setup-dependent; record the mesh report and verify the RF observable, rather than treating the mesh saving itself as validation evidence.
 
@@ -71,24 +81,39 @@ dz_profile = np.concatenate([
 ```
 
 !!! tip
-    Choose `n_sub` so that `dz_sub ≤ dx / 2`. At least 4 substrate cells are
-    a practical starting point for thin-substrate studies. Use 6–8 cells when
-    the substrate field variation matters, then verify the resonance or
-    S-parameter observable for the specific geometry.
+    Resolve the substrate with at least 4 cells as a practical starting point;
+    use 6–8 when the in-substrate field variation matters. Then verify the
+    resonance or S-parameter observable for the specific geometry.
 
 ### Graded transition
 
-Avoid abrupt fine-to-coarse jumps unless a convergence check says they are
-acceptable. Adjacent-cell ratios above roughly `1.5x` can introduce transition
-reflections or dispersion. Keep grading conservative, document the generated
-profile, and verify the observable against the relevant reference lane.
+Avoid abrupt fine-to-coarse jumps; adjacent-cell ratios above 1.3x can introduce
+numerical reflections or dispersion. To generate a graded profile from scratch,
+use `make_z_profile` from `rfx.nonuniform`:
+
+```python
+from rfx.nonuniform import make_z_profile
+
+dz_profile = make_z_profile(
+    features=[0.0, h],      # z-positions that must align to cell boundaries
+    domain_z=h + margin,
+    dx_fine=dz_sub,
+    dx_coarse=dz_air,
+    grading=1.4,            # max ratio between adjacent cells
+)
+```
+
+To repair an existing profile that trips the `Simulation` grading warning, use
+`rfx.smooth_grading(dz_profile)` (default `max_ratio=1.3`). Keep grading
+conservative, document the generated profile, and verify the observable against
+the relevant reference lane.
 
 ---
 
 ## Passing `dz_profile` to `Simulation`
 
 ```python
-from rfx import Simulation, Box, GaussianPulse
+from rfx import Simulation
 import numpy as np
 
 h      = 1.6e-3
@@ -135,7 +160,8 @@ cfg = auto_configure(
 
 print(cfg.summary())
 # SimConfig (accuracy='standard'):
-#   dx = 0.500 mm (20 cells/lambda_min)
+#   dx = 0.500 mm (20 cells/λ_min)
+#   ...                              # domain / cpml / n_steps / freq / source lines
 #   dz = 0.267 – 1.500 mm (26 cells, non-uniform)
 
 if cfg.uses_nonuniform:
@@ -159,10 +185,10 @@ dt = 0.99 / (c * sqrt(1/dx^2 + 1/dy^2 + 1/dz_min^2))
 A fine substrate cell `dz_sub = 0.267 mm` with `dx = dy = 0.5 mm` gives:
 
 ```
-dt ~= 0.99 / (c * sqrt(4 + 4 + 14)) ~= 0.64 ps
+dt ~= 0.99 / (c * sqrt(4 + 4 + 14)) ~= 0.70 ps
 ```
 
-compared to `dt ~= 0.96 ps` for a uniform 0.5 mm grid. The non-uniform grid pays more timesteps because the smallest cell controls CFL; whether it is faster overall depends on the configured domain, material, monitors, and validation run.
+(the 4, 4, 14 are `1/dx^2`, `1/dy^2`, `1/dz_min^2` in mm^-2), compared to `dt ~= 0.95 ps` for a uniform 0.5 mm grid. The non-uniform grid pays more timesteps because the smallest cell controls CFL; whether it is faster overall depends on the configured domain, material, monitors, and validation run.
 
 ---
 
@@ -190,19 +216,16 @@ plan_json = plan.to_json()
 report_json = report.to_json()
 ```
 
-Use `plan_mesh(...)` when deriving a mesh from geometry, or
-`Simulation.plan_mesh(...)` before running an already configured
-memory-constrained non-uniform case. The returned `MeshPlan` carries the
-non-uniform profile audit (`nominal_dx`, `dx_min`/`dx_max`,
-`dy_min`/`dy_max`, `dz_min`/`dz_max`, and `profiles_present`), the configured
-memory summary, optional S-parameter support checks, and declaration-only
-artifact paths. Supplying `artifact_root` names intended mesh-plan/report
-outputs but does not create directories or write files; scene and replay remain
-unclaimed until dedicated exporters exist.
-
-`MeshPlan` is still a planning artifact rather than physics validation. Resolve
-any support checks, then verify the observable against the appropriate uniform
-or external reference lane.
+Use the module-level `rfx.plan_mesh(geometry, freq_range, ...)` when deriving a
+mesh from geometry, or `Simulation.plan_mesh(...)` before running an already
+configured memory-constrained non-uniform case. The returned `MeshPlan` carries
+the non-uniform profile audit in its `cell_sizes` block (`nominal_dx`,
+`dx_min`/`dx_max`, `dy_min`/`dy_max`, `dz_min`/`dz_max`, and `profiles_present`),
+the configured memory summary, optional S-parameter support checks, and
+declaration-only artifact paths. Supplying `artifact_root` names intended
+mesh-plan/report outputs but does not create directories or write files; the
+`scene` and `replay` declarations stay `not_claimed` until dedicated exporters
+exist.
 
 The same planning artifact can be generated from the command line with:
 
@@ -210,8 +233,18 @@ The same planning artifact can be generated from the command line with:
 python scripts/memory_reduction_planning_artifact.py --available-memory-gb 24.0
 ```
 
-For validated work, treat the report as a planning artifact rather than a
-physics validation by itself: resolve any `preflight_issues`, then verify the
-observable against the appropriate uniform or external reference lane.
+Both `MeshPlan` and the mesh-intelligence report are planning artifacts, not
+physics validation. Resolve any `preflight_issues` / support checks, then verify
+the observable against the appropriate uniform or external reference lane.
+
+---
+
+## Low-level API
+
+For advanced use, `run_nonuniform` and `make_current_source` (both in `rfx.__all__`)
+expose the non-uniform field-update loop and cell-volume-normalized source
+injection directly, bypassing `Simulation`. See `rfx/nonuniform.py` for their
+signatures and the `!!! note` in the graded-transition section above for when
+`make_current_source` is needed.
 
 ---

--- a/docs/public/guide/nonuniform-mesh.mdx
+++ b/docs/public/guide/nonuniform-mesh.mdx
@@ -1,32 +1,34 @@
 ---
 title: "Non-Uniform Mesh"
-description: "Without a non-uniform z-profile, resolving a 1.6 mm substrate with a 0.5 mm cell gives only 3 cells — too coarse. Shri"
+description: "Bounded graded-z mesh workflow for thin layered RF structures."
 sidebar:
   order: 6
 ---
 
 
-rfx provides a **graded z-profile** (non-uniform Yee grid) with uniform dx and
-dy. In the current support contract, this is a **limited-support path**:
-retained for thin-substrate workflows, but not the default validated
-reference lane.
+rfx provides a **graded z-profile** (non-uniform Yee grid) with uniform `dx`
+and `dy`. This is a bounded workflow for thin layered structures, not the
+recommended default reference lane. Use the uniform Cartesian Yee lane first
+unless the thin feature would force an impractically small uniform cell.
 
 ### Current support status
 
-- retained for thin-substrate / layered RF qualification work
-- no silent fallback / no silent feature dropping
-- unsupported combinations now fail clearly
+- suitable for thin-substrate or layered-z RF setup studies when the observable
+  remains inside a documented support envelope;
+- memory and mesh reports are planning artifacts, not physics validation;
+- unsupported combinations raise explicit errors instead of silently dropping
+  features.
 
-Current unsupported combinations:
-- periodic-port workflows + non-uniform z mesh
-- NTFF + non-uniform z mesh
-- DFT planes + non-uniform z mesh
-- TFSF + non-uniform z mesh
-- waveguide ports + non-uniform z mesh except the documented restricted `compute_waveguide_s_matrix(normalize=True)` single-mode limited-support path
-- single-cell lumped-port S-parameters + non-uniform z mesh
-- `compute_msl_s_matrix()` + non-uniform z mesh
-- coaxial ports + non-uniform z mesh
-- lumped RLC + non-uniform z mesh
+Current unsupported or restricted combinations:
+
+| Combination | Public status |
+|---|---|
+| periodic-port workflows + non-uniform z mesh | unsupported |
+| NTFF, DFT planes, or TFSF + non-uniform z mesh | unsupported |
+| single-cell lumped-port S-parameters + non-uniform z mesh | unsupported |
+| `compute_msl_s_matrix()` + non-uniform z mesh | unsupported unless a specific guide and support entry says otherwise |
+| coaxial ports or lumped RLC + non-uniform z mesh | unsupported |
+| waveguide ports + non-uniform z mesh | restricted to the documented single-mode waveguide support entry; use the support matrix before making public claims |
 
 ---
 
@@ -34,20 +36,20 @@ Current unsupported combinations:
 
 | Situation | Recommendation |
 |---|---|
-| Substrate much thinner than wavelength (e.g., 1.6 mm FR4 at 2.4 GHz, lambda = 125 mm) | Non-uniform z is the limited-support tool to evaluate |
-| Layer stack with multiple thin dielectric sheets | Non-uniform z for each layer, with limited-support caveats |
+| Substrate much thinner than wavelength (e.g., 1.6 mm FR4 at 2.4 GHz, lambda = 125 mm) | Evaluate a non-uniform z mesh, then validate the final observable |
+| Layer stack with multiple thin dielectric sheets | Non-uniform z can reduce cell count; keep support checks visible |
 | Bulk 3-D structure with no thin z-features | Uniform grid |
 | RCS / far-field only | Uniform grid is usually sufficient |
 
 Without a non-uniform z-profile, resolving a 1.6 mm substrate with a 0.5 mm cell gives only 3 cells — too coarse. Shrinking the uniform cell to 0.2 mm resolves the substrate but inflates cell count by 15x in all three dimensions.
 
-A non-uniform profile uses **fine cells inside the substrate** (e.g., 0.27 mm) and **coarse cells in the air region** (e.g., 1.5 mm), saving roughly 5–10x in total cell count.
+A non-uniform profile uses **fine cells inside the substrate** (e.g., 0.27 mm) and **coarse cells in the air region** (e.g., 1.5 mm). The resulting cell-count reduction is setup-dependent; record the mesh report and verify the RF observable, rather than treating the mesh saving itself as validation evidence.
 
 ---
 
 ## Constructing `dz_profile`
 
-`dz_profile` is a 1-D NumPy array of physical z-cell sizes in metres, from z = 0 upward through the physical domain (excluding CPML padding, which rfx adds automatically).
+`dz_profile` is a 1-D NumPy array of physical z-cell sizes in meters, from z = 0 upward through the physical domain (excluding CPML padding, which rfx adds automatically).
 
 ### Manual construction
 
@@ -70,25 +72,16 @@ dz_profile = np.concatenate([
 
 !!! tip
     Choose `n_sub` so that `dz_sub ≤ dx / 2`. At least 4 substrate cells are
-    recommended for accurate dispersion. 6–8 cells typically give under 0.5 % resonance error.
+    a practical starting point for thin-substrate studies. Use 6–8 cells when
+    the substrate field variation matters, then verify the resonance or
+    S-parameter observable for the specific geometry.
 
-### Graded transition (optional)
+### Graded transition
 
-For structures where abrupt fine-to-coarse transitions cause numerical reflections, use `make_z_profile()` to insert a smooth grading:
-
-```python
-from rfx.nonuniform import make_z_profile
-
-dz_profile = make_z_profile(
-    features=[0.0, h],         # z-positions that must align to cell boundaries
-    domain_z=h + margin,
-    dx_fine=dz_sub,
-    dx_coarse=dz_air,
-    grading=1.4,               # max ratio between adjacent cells
-)
-```
-
-Adjacent cells differing by more than ~1.5x introduce grid dispersion at the transition; keep `grading ≤ 1.4`.
+Avoid abrupt fine-to-coarse jumps unless a convergence check says they are
+acceptable. Adjacent-cell ratios above roughly `1.5x` can introduce transition
+reflections or dispersion. Keep grading conservative, document the generated
+profile, and verify the observable against the relevant reference lane.
 
 ---
 
@@ -169,7 +162,7 @@ A fine substrate cell `dz_sub = 0.267 mm` with `dx = dy = 0.5 mm` gives:
 dt ~= 0.99 / (c * sqrt(4 + 4 + 14)) ~= 0.64 ps
 ```
 
-compared to `dt ~= 0.96 ps` for a uniform 0.5 mm grid. The non-uniform grid pays ~1.5x more timesteps, but saves ~10x in cells — a net win of ~7x for typical patch antenna problems.
+compared to `dt ~= 0.96 ps` for a uniform 0.5 mm grid. The non-uniform grid pays more timesteps because the smallest cell controls CFL; whether it is faster overall depends on the configured domain, material, monitors, and validation run.
 
 ---
 
@@ -192,7 +185,7 @@ print(plan.recommendation)
 print(report.cell_savings_factor)
 print(report.recommendation)
 
-# Store this alongside validation or experiment artifacts.
+# Store this alongside validation or local-run artifacts.
 plan_json = plan.to_json()
 report_json = report.to_json()
 ```
@@ -222,55 +215,3 @@ physics validation by itself: resolve any `preflight_issues`, then verify the
 observable against the appropriate uniform or external reference lane.
 
 ---
-
-## `make_current_source` normalisation
-
-When building sources for the non-uniform grid at the low level, use `make_current_source` to correctly normalise the current injection to the local cell volume:
-
-```python
-from rfx.nonuniform import make_current_source, make_nonuniform_grid
-import numpy as np
-
-grid = make_nonuniform_grid(
-    domain_xy=(0.10, 0.08),
-    dz_profile=dz_profile,
-    dx=5e-4,
-    cpml_layers=12,
-)
-
-# Convert physical position to grid index
-from rfx.nonuniform import z_position_to_index
-iz = z_position_to_index(grid, z_phys=h / 2)
-
-src = make_current_source(
-    grid,
-    ix=grid.nx // 2,
-    iy=grid.ny // 2,
-    iz=iz,
-    component="ez",
-)
-```
-
-!!! note
-    The high-level `Simulation.add_source()` handles this normalisation automatically.
-    `make_current_source` is only needed when using the low-level `run_nonuniform()` API
-    directly.
-
----
-
-## `NonUniformGrid` internals
-
-`make_nonuniform_grid()` returns a `NonUniformGrid` NamedTuple:
-
-| Field | Shape | Description |
-|---|---|---|
-| `nx, ny, nz` | int | Grid dimensions including CPML |
-| `dx, dy` | float | Uniform x/y cell size (m) |
-| `dz` | (nz,) | Per-cell z sizes including CPML padding |
-| `dt` | float | Timestep from min-cell CFL (s) |
-| `cpml_layers` | int | CPML cells per face |
-| `inv_dx` | (nx,) | 1/dx, pre-computed for E-curl update |
-| `inv_dz` | (nz,) | 1/dz[k], pre-computed |
-| `inv_dz_h` | (nz,) | 2/(dz[k]+dz[k+1]), for H-curl update |
-
-All inverse-spacing arrays are stored as `jnp.float32` for GPU efficiency.

--- a/docs/public/guide/probes-sparams.mdx
+++ b/docs/public/guide/probes-sparams.mdx
@@ -16,7 +16,7 @@ Records a single field component at one Yee cell over time. The time series is s
 
 ```python
 sim.add_probe(
-    position=(0.025, 0.025, 0.010),  # (x, y, z) in metres
+    position=(0.025, 0.025, 0.010),  # (x, y, z) in meters
     component="ez",                   # ex / ey / ez / hx / hy / hz
 )
 ```
@@ -83,7 +83,7 @@ Use the calculator that matches the port family:
 |---|---|---|---|
 | `add_port(..., extent=None)` | `run(compute_s_params=True)` | `Result.s_params`, `Result.freqs` | limited / bounded by the documented examples |
 | `add_port(..., extent=...)` | `run(compute_s_params=True)` | `Result.s_params`, `Result.freqs` | partial / bounded by the documented examples, calibration caveated |
-| lumped/wire `add_port(...)` in AD objectives | `forward(port_s11_freqs=...)` | S11 vectors in `ForwardResult.s_params` | differentiable workflow; check current limitations |
+| lumped/wire `add_port(...)` in AD objectives | `forward(port_s11_freqs=...)` | S11 vectors in `ForwardResult.s_params` | differentiable workflow inside documented limits |
 | `add_msl_port(...)` | `compute_msl_s_matrix()` | `MSLSMatrixResult.S`, `.freqs`, `.Z0`, `.beta` | specialized uniform-Yee workflow; broader support bounded by the documented examples |
 | `add_waveguide_port(...)` | `compute_waveguide_s_matrix()` | `WaveguideSMatrixResult.s_params`, `.freqs`, metadata | recommended rectangular-guide workflow within documented limits |
 | `add_coaxial_port(...)` | `compute_coaxial_line_reflection(...)` | `CoaxialLineReflectionResult.s11`, `.freqs`, diagnostics | bounded one-port coaxial line-reflection envelope |
@@ -123,7 +123,7 @@ s11_db = 20 * np.log10(np.abs(s_matrix[0, 0, :]))
 s21_db = 20 * np.log10(np.abs(s_matrix[1, 0, :]))
 ```
 
-The S-matrix is normalised to each port's `impedance`.
+The S-matrix is normalized to each port's `impedance`.
 
 ### Wire port S-matrix (JIT-DFT)
 

--- a/docs/public/guide/probes-sparams.mdx
+++ b/docs/public/guide/probes-sparams.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Probes and S-Parameters"
-description: "Records a single field component at one Yee cell over time. The time series is stored in `result.time_series`."
+description: "Extract field data with point, vector, and DFT-plane probes; compute S-parameters per port family; and pull resonances via harmonic inversion."
 sidebar:
   order: 5
 ---
@@ -66,7 +66,8 @@ Access the result:
 ```python
 result = sim.run(n_steps=4000)
 plane = result.dft_planes["ez_cross_section"]
-# plane.data : shape (n_freqs, nx, ny) complex
+# plane.accumulator : shape (n_freqs, nx, ny) complex  (in-plane dims depend on axis)
+# plane.freqs       : shape (n_freqs,)
 ```
 
 !!! tip
@@ -79,18 +80,18 @@ plane = result.dft_planes["ez_cross_section"]
 
 Use the calculator that matches the port family:
 
-| Primitive | Calculator | Result | Evidence framing |
+| Primitive | Calculator | Result | Port model / scope |
 |---|---|---|---|
-| `add_port(..., extent=None)` | `run(compute_s_params=True)` | `Result.s_params`, `Result.freqs` | limited / bounded by the documented examples |
-| `add_port(..., extent=...)` | `run(compute_s_params=True)` | `Result.s_params`, `Result.freqs` | partial / bounded by the documented examples, calibration caveated |
-| lumped/wire `add_port(...)` in AD objectives | `forward(port_s11_freqs=...)` | S11 vectors in `ForwardResult.s_params` | differentiable workflow inside documented limits |
-| `add_msl_port(...)` | `compute_msl_s_matrix()` | `MSLSMatrixResult.S`, `.freqs`, `.Z0`, `.beta` | specialized uniform-Yee workflow; broader support bounded by the documented examples |
-| `add_waveguide_port(...)` | `compute_waveguide_s_matrix()` | `WaveguideSMatrixResult.s_params`, `.freqs`, metadata | recommended rectangular-guide workflow within documented limits |
-| `add_coaxial_port(...)` | `compute_coaxial_line_reflection(...)` | `CoaxialLineReflectionResult.s11`, `.freqs`, diagnostics | bounded one-port coaxial line-reflection envelope |
+| `add_port(..., extent=None)` | `run(compute_s_params=True)` | `Result.s_params`, `Result.freqs` | Single-cell lumped port; S normalized to each port impedance |
+| `add_port(..., extent=...)` | `run(compute_s_params=True)` | `Result.s_params`, `Result.freqs` | Multi-cell wire port; V/I DFT integrals |
+| lumped/wire `add_port(...)` in AD objectives | `forward(port_s11_freqs=...)` | per-port S11 in `ForwardResult.s_params` | Differentiable S11 through `forward()` |
+| `add_msl_port(...)` | `compute_msl_s_matrix()` | `MSLSMatrixResult.S`, `.freqs`, `.Z0`, `.beta` | Microstrip line; uniform-Yee mesh, N-probe de-embedding |
+| `add_waveguide_port(...)` | `compute_waveguide_s_matrix()` | `WaveguideSMatrixResult.s_params`, `.freqs`, metadata | Rectangular metal waveguide; modal V/I or power-flux |
+| `add_coaxial_port(...)` | `compute_coaxial_line_reflection(...)` | `CoaxialLineReflectionResult.s11`, `.freqs`, diagnostics | One-port coaxial line reflection (short/open/matched/load) |
 
 Sources, TFSF, probes, DFT plane probes, and flux monitors are non-port
-observables. They do not define a port impedance or S-matrix reference.
-Use the S-parameter support matrix for the artifact, metric, and envelope attached to each result.
+observables: they record fields but do not define a port impedance or
+S-matrix reference. Pick the calculator by the port family you registered.
 
 For host-side report checks on any S-matrix cube, use
 `network_quality_metrics()`:
@@ -102,9 +103,10 @@ quality = network_quality_metrics(s_matrix)
 print(quality["passivity_excess"], quality["reciprocity_error"])
 ```
 
-This helper reports finite-data, passivity, reciprocity, max magnitude, and
-column-power checks. It is an interop/reporting gate, not a substitute for
-the port-family physics evidence listed in the support matrix.
+This helper reports finite-data, passivity, reciprocity, max-magnitude, and
+column-power checks. These are host-side report diagnostics; they do not
+alter any solver path and are not a substitute for physically validating the
+S-parameters themselves.
 
 ### Lumped port S-matrix
 
@@ -146,13 +148,14 @@ s11 = result.s_params[0, 0, :]  # complex, shape (n_freqs,)
 MSL ports use their own calculator and result object:
 
 ```python
-msl = sim.compute_msl_s_matrix(n_freqs=101, num_periods=20)
+msl = sim.compute_msl_s_matrix(n_freqs=101, num_periods=40)
 S = msl.S          # (n_ports, n_ports, n_freqs)
 freqs = msl.freqs  # (n_freqs,) Hz
 Z0 = msl.Z0        # extracted characteristic impedance
 ```
 
-Do not expect `run(compute_s_params=True)` to include MSL ports in
+`num_periods=40` is the docstring default; values below that may under-settle
+the fields. Do not expect `run(compute_s_params=True)` to include MSL ports in
 `Result.s_params`.
 
 ### Waveguide S-parameters
@@ -166,9 +169,17 @@ S = wg.s_params      # (n_ports, n_ports, n_freqs)
 freqs = wg.freqs
 ```
 
-For memory-heavy uniform waveguide AD runs, pass
-`checkpoint_segments=K` to segment the reverse-mode tape. `K` must divide the
-timestep count; non-uniform waveguide extraction rejects the knob explicitly.
+`normalize=True` is suitable for transmission measurements. For strong-reflector
+S11 (e.g. a PEC short), use `normalize=False` or `normalize='flux'` to avoid
+the reference-run subtraction artifact — see [Migration](./migration.md) and the
+[S-parameter support matrix](../../guides/sparameter_support_matrix.md).
+
+For memory-heavy waveguide AD runs, pass `checkpoint_segments=K` to segment
+the reverse-mode tape (peak backward memory drops from O(n_steps) toward
+O(√n_steps) near K≈√n_steps). `K` must divide the timestep count exactly. On
+a non-uniform mesh (`dx_profile` / `dy_profile`) the knob is also supported:
+`K` is translated to the NU runner's per-chunk size and applied to the
+device run.
 
 `run(...)` can also expose per-port waveguide diagnostics:
 
@@ -189,7 +200,7 @@ print(f"Probe plane:     {sp.probe_plane*1e3:.1f} mm")
 | `freqs` | ndarray | Frequency array (Hz) |
 | `s11` | complex ndarray | Reflection coefficient at port |
 | `s21` | complex ndarray | Transmission to measurement plane |
-| `calibration_preset` | str | `"measured"` or `"source_to_probe"` |
+| `calibration_preset` | str | `"measured"`, `"source_to_probe"`, or `"explicit"` |
 | `source_plane` | float | Actual source injection plane (m) |
 | `reference_plane` | float | Reported S11 reference plane (m) |
 | `probe_plane` | float | Reported S21 measurement plane (m) |
@@ -198,7 +209,7 @@ print(f"Probe plane:     {sp.probe_plane*1e3:.1f} mm")
 
 ## Resonance extraction — Harminv
 
-`result.find_resonances()` applies the Harminv MUSIC-like algorithm to extract complex resonant frequencies from the probe ring-down signal. It returns a list of `HarminvMode` objects sorted by amplitude.
+`result.find_resonances()` runs harmonic inversion (the Matrix Pencil Method, Sarkar & Pereira 1995) on the probe ring-down signal to extract complex resonant frequencies. It returns a list of `HarminvMode` objects sorted by amplitude (strongest first).
 
 ```python
 modes = result.find_resonances(
@@ -217,8 +228,9 @@ for m in modes:
 | `freq` | Resonant frequency (Hz) |
 | `decay` | Exponential decay rate (1/s) |
 | `Q` | Quality factor = pi*f/decay |
-| `amplitude` | Complex mode amplitude |
+| `amplitude` | Mode amplitude (magnitude) |
 | `phase` | Phase (radians) |
+| `error` | Relative fit-error estimate for the mode |
 
 ### Parameters
 
@@ -253,12 +265,20 @@ modes = harminv(signal, dt, f_min=1e9, f_max=5e9)
 
 ## Plotting helpers
 
+Each helper takes arrays (or the final `state` + `grid`) rather than the
+`Result` object, and returns a matplotlib `Figure`:
+
 ```python
 from rfx import plot_s_params, plot_time_series, plot_field_slice
 
-plot_s_params(result)           # S11/S21 magnitude and phase
-plot_time_series(result)        # all probe time series on one axes
-plot_field_slice(result, "ez", axis="z", index=30)  # 2-D Ez cross-section
+# Magnitude (dB) of every S_ij vs frequency
+plot_s_params(result.s_params, result.freqs)
+
+# All probe time series on one axes
+plot_time_series(result.time_series, result.dt)
+
+# 2-D Ez slice through the final field state
+plot_field_slice(result.state, result.grid, component="ez", axis="z", index=30)
 ```
 
 ---

--- a/docs/public/guide/sources-ports.mdx
+++ b/docs/public/guide/sources-ports.mdx
@@ -22,7 +22,7 @@ A Gaussian-modulated sinusoid (default excitation for ports):
 from rfx import GaussianPulse
 
 pulse = GaussianPulse(
-    f0=2.4e9,       # centre frequency (Hz)
+    f0=2.4e9,       # center frequency (Hz)
     bandwidth=0.8,  # fractional bandwidth (default 0.8 -> wideband)
     amplitude=1.0,  # peak amplitude
 )
@@ -47,7 +47,7 @@ Pass `ModulatedGaussian(...)` explicitly when you want zero-DC excitation.
 
 ### CWSource
 
-Continuous-wave sinusoid, useful for steady-state field visualisation:
+Continuous-wave sinusoid, useful for steady-state field visualization:
 
 ```python
 from rfx import CWSource
@@ -82,19 +82,19 @@ A soft current source injected at a single Yee cell. No resistive load — cavit
 
 ```python
 sim.add_source(
-    position=(0.025, 0.025, 0.010),  # (x, y, z) in metres
+    position=(0.025, 0.025, 0.010),  # (x, y, z) in meters
     component="ez",                   # "ex", "ey", or "ez"
     waveform=GaussianPulse(f0=3e9),
 )
 ```
 
-Use `add_source` for resonance characterisation (Harminv) where port loading would suppress the ring-down signal.
+Use `add_source` for resonance characterization (Harminv) where port loading would suppress the ring-down signal.
 
 ---
 
-## Polarised source (`add_polarized_source`)
+## Polarized source (`add_polarized_source`)
 
-Injects a source with a specified Jones-vector polarisation:
+Injects a source with a specified Jones-vector polarization:
 
 ```python
 # Linear
@@ -113,7 +113,7 @@ sim.add_polarized_source(
 # Arbitrary Jones vector (complex)
 sim.add_polarized_source(
     (0.025, 0.025, 0.01),
-    polarization=(1.0, 1j),   # (Ex, Ey) — normalised internally
+    polarization=(1.0, 1j),   # (Ex, Ey) — normalized internally
     waveform=GaussianPulse(f0=3e9),
 )
 ```
@@ -159,7 +159,7 @@ sim.add_port(
     position=(0.029, 0.030, 0.0),    # start of wire
     component="ez",
     impedance=50.0,
-    extent=0.0016,                    # wire length in metres
+    extent=0.0016,                    # wire length in meters
     waveform=GaussianPulse(f0=2.4e9),
 )
 ```
@@ -274,7 +274,7 @@ sim.add_tfsf_source(
 
 | Method | Use case | S-params / evidence framing |
 |---|---|---|
-| `add_source()` | Resonance, visualisation | No: not a port |
+| `add_source()` | Resonance, visualization | No: not a port |
 | `add_polarized_source()` | Antenna radiation, polarimetry | No: not a port |
 | `add_port(extent=None)` | Lumped-port S-params | `run(compute_s_params=True)`; limited / bounded by the documented examples |
 | `add_port(extent=...)` | Wire / probe-feed S-params | `run(compute_s_params=True)`; partial / bounded by the documented examples, calibration caveated |

--- a/docs/public/guide/sources-ports.mdx
+++ b/docs/public/guide/sources-ports.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Sources and Ports"
-description: "All sources accept a waveform object that defines the time-domain excitation envelope."
+description: "rfx source and port primitives: waveforms, point and polarized sources, lumped/wire/microstrip/waveguide ports, TFSF plane waves, and how each feeds S-parameter extraction."
 sidebar:
   order: 4
 ---
@@ -16,25 +16,32 @@ All sources accept a waveform object that defines the time-domain excitation env
 
 ### GaussianPulse
 
-A Gaussian-modulated sinusoid (default excitation for ports):
+A differentiated Gaussian pulse (no explicit carrier) — the default excitation
+when `add_source`/`add_port` build a waveform for you:
 
 ```python
 from rfx import GaussianPulse
 
 pulse = GaussianPulse(
     f0=2.4e9,       # center frequency (Hz)
-    bandwidth=0.8,  # fractional bandwidth (default 0.8 -> wideband)
+    bandwidth=0.5,  # fractional bandwidth (class default 0.5)
     amplitude=1.0,  # peak amplitude
 )
 ```
 
-The pulse energy is concentrated in `[f0*(1-bw/2), f0*(1+bw/2)]`. Set `bandwidth` below `0.5` for narrowband excitation near `f0`.
+`f0` sets the center frequency and `bandwidth` the fractional spectral width;
+a larger `bandwidth` gives broader (more wideband) excitation, a smaller one a
+narrower band. The class default is `bandwidth=0.5`, but when rfx auto-builds
+the pulse for a source or port it uses `0.8`. The differentiated Gaussian
+carries a small DC residual (~1e-4); use `ModulatedGaussian` below when exact
+zero-DC excitation matters.
 
 ### ModulatedGaussian
 
-Like `GaussianPulse` but with zero DC content. This is often the better choice
-for resonance-focused `add_source()` runs because it prevents static charge
-accumulation on PEC surfaces:
+A Gaussian-envelope modulated carrier (Meep-style): its integral is exactly
+zero, so it adds no DC and avoids static charge buildup on PEC surfaces. Its
+spectrum is centered at `f0` with fractional width `bandwidth`, which makes it
+the preferred choice for resonance-focused `add_source()` runs:
 
 ```python
 from rfx import ModulatedGaussian
@@ -42,8 +49,9 @@ from rfx import ModulatedGaussian
 waveform = ModulatedGaussian(f0=3e9, bandwidth=0.6)
 ```
 
-If `waveform` is omitted, the current high-level API uses `GaussianPulse`.
-Pass `ModulatedGaussian(...)` explicitly when you want zero-DC excitation.
+When `waveform` is omitted, `add_source`/`add_port` default to `GaussianPulse`
+(not `ModulatedGaussian`); pass `ModulatedGaussian(...)` explicitly to get
+zero-DC excitation.
 
 ### CWSource
 
@@ -54,7 +62,7 @@ from rfx import CWSource
 
 cw = CWSource(
     f0=5.8e9,       # frequency (Hz)
-    ramp_steps=200, # linear ramp-up steps to avoid impulse at t=0
+    ramp_steps=200, # cosine-taper onset over 200 source cycles (default 50; 0 = instant on)
 )
 ```
 
@@ -124,8 +132,7 @@ Supported string shortcuts: `"ex"`, `"ey"`, `"ez"`, `"circular"` / `"rhcp"`, `"l
 
 ## Lumped port (`add_port`)
 
-A single-cell port with a resistive load equal to `impedance`. Enables S-parameter extraction referenced to that impedance.
-Its current public support is bounded by the documented examples. Use it for the documented uniform-Yee lumped-port workflows and keep any broader result scoped to its validation evidence.
+A single-cell port with a resistive load equal to `impedance`. Enables S-parameter extraction referenced to that impedance. It is validated on the uniform-Yee lumped-port examples; scope any broader result to that evidence.
 
 ```python
 sim.add_port(
@@ -136,25 +143,31 @@ sim.add_port(
 )
 ```
 
-Run with `compute_s_params=True` to extract the S-matrix:
+Run with `compute_s_params=True` to extract the S-matrix. When no frequency
+grid is supplied, rfx uses 50 points from `freq_max/10` to `freq_max`:
 
 ```python
 result = sim.run(n_steps=2000, compute_s_params=True)
-s11 = result.s_params[0, 0, :]   # (n_freqs,) complex
+s11 = result.s_params[0, 0, :]   # s_params shape (n_ports, n_ports, n_freqs), complex
 ```
 
+See [Probes and S-parameters](./probes-sparams/#s-parameter-extraction) for the
+full extraction, plotting, and Touchstone-export path.
+
 !!! tip
-    Multiple `add_port()` calls create a multi-port structure. rfx drives one port at a
-    time and assembles the full N×N S-matrix automatically.
+    Multiple `add_port()` calls create a multi-port structure. rfx drives one
+    port at a time and assembles the full N×N S-matrix automatically — you do
+    not need to set `excite=False` yourself. The set must be homogeneous
+    (all lumped or all wire); a mixed lumped+wire set is not supported.
 
 ---
 
 ## Wire port (`add_port` with `extent`)
 
-A wire port spans multiple Yee cells along the port axis, connecting conductor to conductor across a gap. This is the standard model for coaxial probe feeds and SMA connectors:
+A wire port spans multiple Yee cells along the port axis, connecting conductor to conductor across a gap. It is a common model for probe- and coaxial-style feeds:
 
 ```python
-# Port spans 1.5 mm in z, from substrate bottom to patch surface
+# Port spans 1.6 mm in z, from substrate bottom to patch surface
 sim.add_port(
     position=(0.029, 0.030, 0.0),    # start of wire
     component="ez",
@@ -164,7 +177,7 @@ sim.add_port(
 )
 ```
 
-The `extent` parameter turns the lumped port into a `WirePort`. S-parameters are extracted using voltage/current integrals over the wire span. Public examples use this primarily for probe-fed resonance workflows; broader absolute calibration should be checked against the documented examples.
+The `extent` parameter turns the lumped port into a `WirePort`. S-parameters are extracted from voltage/current integrals over the wire span. The public examples exercise this for probe-fed resonance workflows; treat absolute calibration outside that regime as unvalidated.
 
 !!! warning
     `extent` must be aligned with the `component` direction. For `component="ez"`, `extent`
@@ -195,19 +208,24 @@ sim.add_msl_port(
     name="out",
 )
 
-msl = sim.compute_msl_s_matrix(n_freqs=101, num_periods=20)
-S = msl.S          # (n_ports, n_ports, n_freqs)
-Z0 = msl.Z0        # (n_ports, n_freqs)
+msl = sim.compute_msl_s_matrix(n_freqs=101, num_periods=40)
+S = msl.S          # (n_ports, n_ports, n_freqs) complex
+Z0 = msl.Z0        # (n_ports, n_freqs) complex
 ```
 
-This path uses 3-probe numerical de-embedding. It is a uniform-lane specialized calculator; unsupported mesh/source/port combinations are rejected instead of silently returning `None`. The thru-line and notch examples define the public uniform-Yee envelope.
+The calculator drives each port in turn and de-embeds β and Z0 downstream of the
+feed plane with an N-probe (default `n_probes=5`) least-squares
+wave-decomposition extractor. It is a uniform-mesh path; unsupported
+mesh/source/port combinations are rejected rather than silently returning
+`None`. `num_periods` defaults to 40 because MSL transients drain slowly. The
+thru-line and notch examples define the public uniform-Yee envelope.
 
 ---
 
 ## Waveguide port (`add_waveguide_port`)
 
 Modal waveguide excitation for rectangular waveguide S-matrix extraction.
-Injects a specific TE/TM mode and decomposes the reflected/transmitted fields into the same modal basis. Current public examples use documented rectangular-guide gates; branch and T-junction geometries need their own reference checks before public reporting.
+Injects a specific TE/TM mode and decomposes the reflected/transmitted fields into the same modal basis. Requires `boundary="cpml"` (with `cpml_layers > 0`) and `mode="3d"`; it cannot be combined with lumped ports or a TFSF source. The public examples cover rectangular guides — validate branch or T-junction geometries against a reference before reporting.
 
 ```python
 sim.add_waveguide_port(
@@ -237,11 +255,18 @@ sim.add_waveguide_port(
 )
 
 wg = sim.compute_waveguide_s_matrix(num_periods=30, normalize=True)
-S = wg.s_params    # (n_ports, n_ports, n_freqs)
+S = wg.s_params    # (n_ports, n_ports, n_freqs) complex
 ```
 
-For a single waveguide port, `run(...)` can expose per-port diagnostic
-calibrated quantities:
+`normalize=True` cancels one-way Yee dispersion in the transmission
+(off-diagonal) terms and is the right choice for S21. It does **not** correct
+the round-trip dispersion in reflection, so for the S11 of a strong reflector
+use `normalize=False` (default) or `normalize="flux"`.
+
+A plain `run(...)` also populates `result.waveguide_sparams` — per-port,
+plane-calibrated `s11`/`s21` from that single excitation. This is a diagnostic
+of one driven configuration, not the full driven-in-turn matrix that
+`compute_waveguide_s_matrix` assembles:
 
 ```python
 result = sim.run(n_steps=3000)
@@ -249,19 +274,25 @@ sp = result.waveguide_sparams["port1"]
 # sp.freqs, sp.s11, sp.s21
 ```
 
+See [Waveguide ports](./waveguide-ports/) for mode selection, calibration
+planes, and validated gates.
+
 ---
 
 ## TFSF plane-wave source (`add_tfsf_source`)
 
-Total-field/scattered-field plane wave for scattering and RCS simulations:
+Total-field/scattered-field plane wave for scattering and RCS simulations.
+Requires `boundary="cpml"` (with `cpml_layers > 0`) and a 3D or 2D-TE/TM mode.
+Scope is deliberately narrow: propagation along x only (`direction` `"+x"`/`"-x"`)
+and `polarization` `"ez"` or `"ey"`.
 
 ```python
 sim.add_tfsf_source(
     f0=5e9,
     bandwidth=0.4,
     polarization="ez",
-    direction="+x",    # propagation direction
-    angle_deg=0.0,     # oblique incidence angle (degrees from normal)
+    direction="+x",    # propagation direction (+x or -x)
+    angle_deg=0.0,     # oblique incidence angle (|angle_deg| < 90, degrees from normal)
 )
 ```
 
@@ -272,13 +303,13 @@ sim.add_tfsf_source(
 
 ## Summary table
 
-| Method | Use case | S-params / evidence framing |
+| Method | Use case | S-parameter extraction |
 |---|---|---|
-| `add_source()` | Resonance, visualization | No: not a port |
-| `add_polarized_source()` | Antenna radiation, polarimetry | No: not a port |
-| `add_port(extent=None)` | Lumped-port S-params | `run(compute_s_params=True)`; limited / bounded by the documented examples |
-| `add_port(extent=...)` | Wire / probe-feed S-params | `run(compute_s_params=True)`; partial / bounded by the documented examples, calibration caveated |
-| `add_msl_port()` | Full-strip microstrip-line S-matrix | `compute_msl_s_matrix()`; specialized uniform-Yee workflow; broader support bounded by the documented examples |
-| `add_waveguide_port()` | Modal waveguide S-matrix | `compute_waveguide_s_matrix()`; recommended rectangular-guide workflow within documented limits |
-| `add_coaxial_port()` | Coaxial transmission-line reflection | `compute_coaxial_line_reflection()` inside the documented one-port line envelope |
-| `add_tfsf_source()` | RCS, scattering, plane-wave | No: not a port |
+| `add_source()` | Resonance, field visualization | none (soft source, no port) |
+| `add_polarized_source()` | Antenna / polarimetry excitation | none (soft source, no port) |
+| `add_port(extent=None)` | Lumped-port S-params | `run(compute_s_params=True)`; validated on uniform-Yee examples |
+| `add_port(extent=...)` | Wire / probe-feed S-params | `run(compute_s_params=True)`; probe-feed examples, calibration caveated |
+| `add_msl_port()` | Full-strip microstrip S-matrix | `compute_msl_s_matrix()`; uniform mesh only |
+| `add_waveguide_port()` | Modal waveguide S-matrix | `compute_waveguide_s_matrix()`; rectangular guide, cpml + 3D |
+| `add_coaxial_port()` | One-port coaxial line reflection | `compute_coaxial_line_reflection()`; one-port line envelope |
+| `add_tfsf_source()` | RCS / scattering plane wave | none (not a port) |

--- a/docs/public/guide/tutorial-patch-antenna.mdx
+++ b/docs/public/guide/tutorial-patch-antenna.mdx
@@ -10,7 +10,7 @@ import { Aside } from '@astrojs/starlight/components';
 This page connects the quick resonance workflow in [Your First Patch Antenna](/rfx/guide/first-patch/) with the current public patch cross-check in `examples/crossval/05_patch_antenna.py`.
 
 <Aside type="note" title="Public scope">
-  Treat this as a recommended practical patch workflow. It is not a blanket claim that every antenna, feed, substrate, or mesh setting is already fully qualified.
+  This is a recommended patch workflow, not a guarantee that every antenna, feed, substrate, or mesh setting is qualified.
 </Aside>
 
 ## Recommended workflow
@@ -21,26 +21,28 @@ This page connects the quick resonance workflow in [Your First Patch Antenna](/r
 | 2. Cross-check | Compare the same class of structure against the documented reference script | `examples/crossval/05_patch_antenna.py` |
 | 3. Radiation / reporting | Move to far-field reporting after the resonance setup is stable | [Far-Field & RCS](/rfx/guide/farfield-rcs/) |
 
-## Current baseline geometry
+## Baseline geometry
 
-The current patch workflow uses a rectangular 2.4 GHz FR4 patch with a finite ground plane. The important setup rule is simple: model the antenna ground plane as geometry, and use an absorber setup appropriate for an open radiation problem.
+The workflow models a rectangular 2.4 GHz patch on a 1.5 mm FR4 substrate over a finite ground plane. One setup choice is load-bearing: place the ground plane as an explicit finite PEC box inside the domain, not as a full-domain PEC boundary wall. A finite ground plane radiates into the absorber beneath it, which is the physical open-radiation problem; turning the bottom of the domain into a PEC wall instead makes the structure a closed cavity and shifts the resonance high. Pair the geometry with absorbing (CPML) boundaries on all faces.
 
-## How to run the practical cross-check
+## How to run the cross-check
 
 ```bash
 python examples/crossval/05_patch_antenna.py
 ```
 
-Expected output is a console summary and generated output files from the script.
-If the external solver dependency is not available, treat the script as an
-rfx-only run rather than a full cross-solver check.
+With the OpenEMS/CSXCAD Python bindings installed, the script prints a console
+summary comparing the rfx and OpenEMS resonances and writes a plot plus a JSON
+result file. Those bindings are not an rfx dependency: if they are missing, the
+script still runs and prints the rfx Harminv resonance pass, then exits with
+status 2 behind a SKIPPED banner — it flags the run as inconclusive rather than
+reporting a pass, so it is not a cross-solver check.
 
 ## Interpretation rules
 
-- Use Harminv resonance as the primary frequency estimate.
-- Use impedance-referenced S-parameter results only through a documented port workflow.
+- Read Harminv resonance as the primary frequency estimate. The script's primary gate is a resonance-frequency agreement — rfx Harminv vs OpenEMS Harminv within 20 %, and rfx internal self-consistency (Harminv vs the lumped-port S11 local dip) within 5 % — not an |S11| magnitude match.
+- Use impedance-referenced S-parameter results only through a documented port workflow — see [Sources & Ports](/rfx/guide/sources-ports/) for `add_port`. The lumped-port S11 dip in this script is a secondary check with a known single-cell parasitic reactance, so read it as a local dip near the Harminv frequency, not a deep matched null.
 - Treat non-uniform mesh variants as limited support unless the page you are following says otherwise.
-- For top-level claims, keep the wording narrow: this is a recommended patch workflow, not a universal antenna guarantee.
 
 ## Where to go next
 

--- a/docs/public/guide/tutorial-patch-antenna.mdx
+++ b/docs/public/guide/tutorial-patch-antenna.mdx
@@ -18,7 +18,7 @@ This page connects the quick resonance workflow in [Your First Patch Antenna](/r
 | Stage | Goal | Primary page / script |
 |---|---|---|
 | 1. Quick resonance check | Size the patch, run the simulation, and extract the dominant mode | [Your First Patch Antenna](/rfx/guide/first-patch/) |
-| 2. Cross-check | Compare the same class of structure against the current repo reference | `examples/crossval/05_patch_antenna.py` |
+| 2. Cross-check | Compare the same class of structure against the documented reference script | `examples/crossval/05_patch_antenna.py` |
 | 3. Radiation / reporting | Move to far-field reporting after the resonance setup is stable | [Far-Field & RCS](/rfx/guide/farfield-rcs/) |
 
 ## Current baseline geometry
@@ -31,12 +31,14 @@ The current patch workflow uses a rectangular 2.4 GHz FR4 patch with a finite gr
 python examples/crossval/05_patch_antenna.py
 ```
 
-Expected output is a console summary and generated local artifacts from the script. If the external solver dependency is not available, treat the script as a local rfx run rather than a full cross-solver check.
+Expected output is a console summary and generated output files from the script.
+If the external solver dependency is not available, treat the script as an
+rfx-only run rather than a full cross-solver check.
 
 ## Interpretation rules
 
 - Use Harminv resonance as the primary frequency estimate.
-- Treat lumped-port S11 dips as secondary diagnostics.
+- Use impedance-referenced S-parameter results only through a documented port workflow.
 - Treat non-uniform mesh variants as limited support unless the page you are following says otherwise.
 - For top-level claims, keep the wording narrow: this is a recommended patch workflow, not a universal antenna guarantee.
 

--- a/docs/public/guide/visualization-and-analysis.md
+++ b/docs/public/guide/visualization-and-analysis.md
@@ -124,7 +124,9 @@ vswr = (1 + np.abs(s11)) / (1 - np.abs(s11))
 
 ```python
 import jax.numpy as jnp
-from rfx.core.yee import EPS_0, MU_0
+
+EPS_0 = 8.8541878128e-12
+MU_0 = 1.25663706212e-6
 
 grid = result.grid
 state = result.state
@@ -175,9 +177,9 @@ if result.snapshots is not None:
 
 ## External Analysis Workflows
 
-You can hand summaries to notebooks, scripts, or LLMs, but keep the raw arrays
-and plots as the source of truth. A good summary includes the frequency grid,
-S-parameters, resonant peaks, bandwidth, return loss, and the pass/fail rule you
+You can hand summaries to notebooks or scripts, but keep the raw arrays and
+plots as the source of truth. A good summary includes the frequency grid,
+S-parameters, resonant peaks, bandwidth, return loss, and the pass/fail rule
 used to judge the result.
 
 When you write public notes or reports, describe the exact metric you used

--- a/docs/public/guide/visualization-and-analysis.md
+++ b/docs/public/guide/visualization-and-analysis.md
@@ -4,9 +4,13 @@ sidebar:
   order: 15
 ---
 
-rfx ships matplotlib-based helpers for the most common RF post-processing tasks.
-The helpers expect the same objects that the simulation and analysis APIs return,
-so prefer passing raw arrays or result fields directly.
+rfx ships matplotlib-based helpers for common RF post-processing: S-parameters,
+field slices, radiation patterns, RCS, and probe time series. Each helper takes
+plain arrays (`result.s_params`, `result.freqs`, `result.time_series`) or the
+result objects the analysis APIs return (`FarFieldResult`, `RCSResult`). For the
+most common plots, `Result` also exposes convenience methods —
+`result.plot_s_params()`, `result.plot_smith()`, and `result.plot_time_series()` —
+that forward to the functions below.
 
 ## Built-in Visualization
 
@@ -65,7 +69,8 @@ from rfx import plot_rcs
 fig = plot_rcs(rcs_result, freq_idx=0, polar=True)
 ```
 
-If you want the full computation flow, see `docs/public/guide/farfield-rcs.md`.
+For how to produce `rcs_result` from a scattering run, see
+[Far-Field & RCS](/rfx/guide/farfield-rcs/).
 
 ### Time-Domain Signal
 
@@ -135,12 +140,15 @@ state = result.state
 u_e = 0.5 * EPS_0 * (state.ex**2 + state.ey**2 + state.ez**2)
 # Magnetic energy density
 u_h = 0.5 * MU_0 * (state.hx**2 + state.hy**2 + state.hz**2)
-# Total stored energy for a uniform cubic grid
+# Approximate total stored energy on a uniform cubic grid
 stored_energy = float(jnp.sum(u_e + u_h) * grid.dx**3)
 ```
 
-The final line assumes a **uniform cubic grid**. For non-uniform spacing,
-integrate with the actual cell-volume weights instead of `grid.dx**3`.
+This is an estimate: it uses the vacuum permittivity `EPS_0` everywhere (no
+per-cell `eps_r` weighting, so it under-counts energy inside dielectrics) and
+treats the staggered Yee field components as if they were co-located. The final
+line also assumes a **uniform cubic grid** — for non-uniform spacing, integrate
+with the actual cell-volume weights instead of `grid.dx**3`.
 
 ### Export for External Tools
 
@@ -177,15 +185,11 @@ if result.snapshots is not None:
 
 ## External Analysis Workflows
 
-You can hand summaries to notebooks or scripts, but keep the raw arrays and
-plots as the source of truth. A good summary includes the frequency grid,
-S-parameters, resonant peaks, bandwidth, return loss, and the pass/fail rule
-used to judge the result.
+Hand summaries to notebooks or reports, but keep the raw arrays and plots as the
+source of truth. A useful summary records the frequency grid, S-parameters,
+resonant peaks, bandwidth, return loss, and the exact pass/fail rule used to
+judge the result — state the metric rather than only that a design "looks good".
 
-When you write public notes or reports, describe the exact metric you used
-instead of saying only that a design "looks good".
-
-
-For reports, keep a small machine-readable manifest next to exported plots or
-Touchstone files. Include the command, git SHA, support status, and metric used
-to make the figure so the artifact can be reproduced.
+Alongside exported plots or Touchstone files, keep a small machine-readable
+manifest with the command, git SHA, support status, and metric used to produce
+the figure, so the artifact can be reproduced.

--- a/docs/public/index.mdx
+++ b/docs/public/index.mdx
@@ -5,23 +5,21 @@ sidebar:
   order: 1
 ---
 
-**Differentiable FDTD for RF/Microwave — powered by JAX**
-
 rfx is a 3-D finite-difference time-domain (FDTD) electromagnetic simulator built in JAX. These docs focus on maintained user workflows with explicit support boundaries.
 
 ## Current public status
 
-Use the **uniform Cartesian Yee RF/FDTD lane** first. The public docs highlight maintained workflows and explicitly bounded claim envelopes:
+Start with the **uniform Cartesian Yee FDTD lane**. Each surface below states an explicit support scope:
 
 | Surface | Public role |
 |---|---|
-| **Uniform Yee RF workflows** | recommended default for tutorials, examples, probes, Harminv, selected S-parameter workflows, and benchmarked far-field workflows |
+| **Uniform Yee RF workflows** | recommended default for tutorials, examples, probes, Harminv, selected S-parameter workflows, and far-field workflows |
 | **Rectangular waveguide S-matrices** | validated inside the documented rectangular-guide envelope |
 | **Lumped, wire, and microstrip-line port workflows** | available through their matching calculators; validation scope follows the support matrix |
 | **Coaxial line reflection** | bounded one-port transmission-line workflow only; not a general coaxial S-matrix promise |
 | **Differentiable design loops** | use proxy objectives, gradient checks, and documented validation before treating a design result as evidence |
 
-If a capability is not listed here or in the support-boundary page, treat it as outside the documented public support scope until the support matrix lists it.
+If a capability is not listed here or on the [Support Boundaries](/rfx/api/support-boundaries/) page, treat it as outside the documented public support scope until that page lists it.
 
 ---
 

--- a/docs/public/index.mdx
+++ b/docs/public/index.mdx
@@ -30,7 +30,7 @@ If a capability is not listed here or in the support-boundary page, treat it as 
 | Feature | Detail |
 |---|---|
 | **GPU acceleration** | JAX/JIT execution for large 3-D grids |
-| **Differentiable simulation** | `jax.grad` through time-domain workflows for inverse design |
+| **Differentiable workflows** | `jax.grad` through selected JAX-traced objectives; validate final RF observables through their support envelope |
 | **RF workflow tools** | materials, sources, probes, ports, S-parameter helpers, Harminv, far-field utilities |
 | **Recommended examples** | current runnable scripts under `examples/crossval/` and selected inverse-design examples |
 | **Support-boundary discipline** | public claims are tied to explicit guide/support-matrix envelopes, not to every importable symbol |
@@ -100,7 +100,7 @@ print(f"Resonance: {modes[0].freq/1e9:.4f} GHz")
 
 - [Autodiff and Adjoint Background](guide/autodiff-adjoint/) — Meep-informed gradient concepts for microwave engineers
 - [Inverse Design](guide/inverse-design/) — autodiff-driven optimization with documented proxy objectives
-- [Gradient Behavior](guide/gradient-behavior/) — where gradients are reliable vs noisy
+- [Gradient Behavior](guide/gradient-behavior/) — where gradients are usually well behaved vs noisy
 - [Parametric Sweeps](guide/parametric-sweeps/) — sequential sweep and `jax.vmap` design-space exploration
 - [Patch Antenna Design](guide/tutorial-patch-antenna/) — rectangular patch workflow
 


### PR DESCRIPTION
## Summary
- deslop README and public docs by removing AI-agent/dashboard exposure, stale meta phrasing, and overbroad differentiable/S-parameter claims
- tighten autodiff/gradient/non-uniform mesh wording around discrete sensitivities, support envelopes, and final RF validation
- fix RF/EM-professional issues in public examples: remove unsupported non-uniform lumped-port S-parameter snippet, remove private `_build_grid` usage, update NTFF usage to `add_ntff_box(...)`, and correct NTFF placement guidance
- standardize public-doc wording to English-only/American spelling where touched

## Validation
- `python3 scripts/check_public_docs_manifest.py`
- `python3 scripts/export_public_docs_to_gitops.py --check --repo-root "$(pwd)" --gitops-root /root/workspace/byungkwan-workspace/infra/remilab-sites-gitops`
- `python3 scripts/check_api_reference.py`
- `python3 -m py_compile scripts/check_public_docs_manifest.py scripts/check_public_docs_sync.py scripts/export_public_docs_to_gitops.py scripts/check_api_reference.py`
- public CJK scan over `README.md` and `docs/public`
- public text-quality scan for retired/meta/AI-slop terms
- `git diff --check`

## Notes
- Docs source branch only; gitops snapshot/live deploy intentionally not changed in this PR.
