### PR TITLE
fix(ci): least-privilege GITHUB_TOKEN + pin third-party action to SHA

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   ruff:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -13,6 +13,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   guards-and-preflight:
     runs-on: ubuntu-latest

--- a/.github/workflows/public-docs-source.yml
+++ b/.github/workflows/public-docs-source.yml
@@ -30,6 +30,9 @@ on:
       - "scripts/check_api_reference.py"
       - "docs/guides/api_symbol_inventory.json"
 
+permissions:
+  contents: read
+
 jobs:
   public-docs-source:
     runs-on: ubuntu-latest

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 6 * * 1'  # Every Monday 06:00 UTC
   workflow_dispatch:  # Manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   slow-tests:
     runs-on: ubuntu-latest
@@ -77,7 +80,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up conda (miniforge + mamba)
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3
         with:
           python-version: "3.11"
           miniforge-version: latest


### PR DESCRIPTION
## Summary

Defense-in-depth CI hardening from the 2026-07-02 security review.
No secrets or `pull_request_target` exist today so not exploitable,
but the mitigations are cheap and correct regardless.

**Workflows touched (all 4 active workflows):**

| Workflow | File | Change |
|----------|------|--------|
| lint | `lint.yml` | Added `permissions: contents: read` |
| pr-tests | `pr-tests.yml` | Added `permissions: contents: read` |
| public-docs-source | `public-docs-source.yml` | Added `permissions: contents: read` |
| scientific-validation | `validation.yml` | Added `permissions: contents: read` + SHA-pinned conda action |

**Third-party action pin:**

`conda-incubator/setup-miniconda@v3` → `@fc2d68f6413eb2d87b895e92f8584b5b94a10167 # v3`

The v3 tag is a lightweight tag pointing directly to this commit (confirmed via `gh api repos/conda-incubator/setup-miniconda/git/ref/tags/v3`). GitHub-owned actions (`actions/checkout`, `setup-python`, `setup-node`, `upload-artifact`) are left on version tags per review scope.

**Verification:**
- All 4 workflows parse cleanly (`yaml.safe_load`)
- `grep -L "^permissions:" .github/workflows/*.yml` → empty (all covered)
- Conda line carries 40-hex SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)