### PR TITLE
Wave 3 physics validation oracles: dispersive Fresnel, lossy material, dipole directivity (W3.1-W3.3)

### DIFF
--- a/tests/test_dispersive_fresnel_validation.py
+++ b/tests/test_dispersive_fresnel_validation.py
@@ -1,0 +1,195 @@
+"""Dispersive-Fresnel validation oracle (roadmap W3.1).
+
+Validates FDTD normal-incidence broadband reflection ``R(f)`` of a **dispersive**
+dielectric slab against a rigorous analytic oracle, for a single-Debye-pole and a
+single-Lorentz-pole material. This is the tracked dispersive R/T oracle called
+for by ``docs/agent-memory/task_recipes/rt_measurement.md`` (the old
+``crossval/08_material_dispersion.py`` numbers became unreproducible once that
+script was removed).
+
+Design note — a finite SLAB, not the "half-space" the roadmap phrasing suggests:
+a slab keeps the CPML in vacuum. A dispersive medium filling the CPML risks
+absorber-reflection artifacts (the CPML stretch is tuned for vacuum). The slab
+exercises the identical ε(ω) ADE physics against a rigorous transfer-matrix
+analytic and is *stricter* than a half-space (two interfaces + internal
+reflections).
+
+Method (matches the canonical two-run reference-subtraction recipe):
+  - High-level ``Simulation`` API only; NO FFT-of-probe-timeseries (window bias).
+  - 2D TMz, ``boundary='cpml'``, TFSF +x plane wave, two ``add_flux_monitor``
+    planes (refl before slab, trans after).
+  - Reflection via FIELD-LEVEL DFT subtraction, then
+    ``R = -flux_spectrum(scattered) / ref_trans_flux``.
+  - ``run(until_decay=1e-4)`` — on cpml this is the #169 total-interior-energy
+    stop (converged vs 1e-5 to ~3e-3; see the research note).
+
+Analytic oracle — rigorous single-slab reflection via the 2x2 characteristic
+(transfer) matrix. ``n(ω)=sqrt(ε(ω))`` complex principal branch; rfx uses
+e^{+jωt} (Im(ε)<0 for loss) so ``np.sqrt`` yields Im(n)<0, the Orfanidis/Macleod
+branch the +j matrix expects. ε(ω) fed to the oracle is the IDENTICAL
+``eval_debye`` / ``eval_lorentz`` used to build the FDTD material.
+
+Gate: ``mean |R_fdtd - R_analytic| < 5%`` over the pulse band (measured 3.46% /
+2.74% on CPU 2026-07-02; recorded in
+``docs/research_notes/20260702_w31_dispersive_fresnel.md``). Gated on the MEAN
+per the roadmap spec, not the per-frequency max.
+"""
+
+import numpy as np
+import pytest
+
+from rfx import Box, Simulation
+from rfx.materials.debye import DebyePole
+from rfx.materials.lorentz import lorentz_pole
+from rfx.material_fit import eval_debye, eval_lorentz
+from rfx.probes.probes import flux_spectrum
+
+C0 = 299_792_458.0
+
+# ---- shared grid / band ----
+DX = 0.5e-3
+FREQ_MAX = 18e9
+F0 = 10e9
+BW = 0.7  # modulated_gaussian fwidth = F0*BW = 7 GHz, covers the 6-14 GHz band
+DOM_X = 120e-3
+DOM_Y = 5e-3
+CENTER_X = DOM_X / 2.0
+REFL_X = CENTER_X - 30e-3
+TRANS_X = CENTER_X + 30e-3
+Y_CENTER = DOM_Y / 2.0
+D_SLAB = 8e-3
+FREQS_RT = np.linspace(6e9, 14e9, 17)
+
+# ---- dispersion parameters (in-band, modest Re(n)) ----
+DEBYE_EPS_INF = 2.0
+DEBYE_DELTA_EPS = 3.0
+DEBYE_TAU = 1.0 / (2.0 * np.pi * 10e9)  # relaxation frequency at 10 GHz
+
+LOR_EPS_INF = 2.0
+LOR_DELTA_EPS = 1.0
+LOR_W0 = 2.0 * np.pi * 10e9  # resonance at 10 GHz (in-band)
+LOR_DELTA = 0.1 * LOR_W0  # damping; Q = w0/(2*delta) = 5
+
+GATE = 0.05  # mean |R_fdtd - R_analytic| over the band
+
+
+def _tmm_slab_R(freqs, eps_complex, d):
+    """Rigorous single-slab |r|^2 via the 2x2 characteristic matrix.
+
+    M = [[cos δ, j sin δ / y], [j y sin δ, cos δ]], δ = n k0 d, y = n,
+    r = (y0 M11 + y0 y_s M12 - M21 - y_s M22) / (y0 M11 + y0 y_s M12
+        + M21 + y_s M22), vacuum both sides (y0 = y_s = 1).
+    """
+    n = np.sqrt(np.asarray(eps_complex))  # complex principal branch
+    R = np.zeros(len(freqs))
+    y0 = ys = 1.0
+    for i, f in enumerate(freqs):
+        k0 = 2.0 * np.pi * f / C0
+        y = n[i]
+        delta = y * k0 * d
+        cd, sd = np.cos(delta), np.sin(delta)
+        m11, m12, m21, m22 = cd, 1j * sd / y, 1j * y * sd, cd
+        num = y0 * m11 + y0 * ys * m12 - m21 - ys * m22
+        den = y0 * m11 + y0 * ys * m12 + m21 + ys * m22
+        R[i] = abs(num / den) ** 2
+    return R
+
+
+def _build_sim(kind, with_slab):
+    sim = Simulation(
+        freq_max=FREQ_MAX, domain=(DOM_X, DOM_Y, DX), dx=DX,
+        boundary="cpml", cpml_layers=20, mode="2d_tmz",
+    )
+    if with_slab:
+        if kind == "debye":
+            sim.add_material("slab", eps_r=DEBYE_EPS_INF,
+                             debye_poles=[DebyePole(DEBYE_DELTA_EPS, DEBYE_TAU)])
+        else:
+            sim.add_material("slab", eps_r=LOR_EPS_INF,
+                             lorentz_poles=[lorentz_pole(LOR_DELTA_EPS, LOR_W0, LOR_DELTA)])
+        # Cell-aligned thickness (inclusive Box bounds -> nudge upper corner
+        # by -dx/2). Oversize the transverse corners: TFSF forces y/z periodic,
+        # so the material must span the full transverse extent incl. CPML.
+        x_lo = CENTER_X - D_SLAB / 2.0
+        x_hi = CENTER_X + D_SLAB / 2.0 - DX / 2.0
+        sim.add(Box((x_lo, -1.0, -1.0), (x_hi, 1.0, 1.0)), material="slab")
+    sim.add_tfsf_source(f0=F0, bandwidth=BW, polarization="ez", direction="+x",
+                        waveform="modulated_gaussian")
+    sim.add_flux_monitor(axis="x", coordinate=REFL_X, freqs=FREQS_RT, name="refl")
+    sim.add_flux_monitor(axis="x", coordinate=TRANS_X, freqs=FREQS_RT, name="trans")
+    return sim
+
+
+def _measure_R(kind):
+    """Two-run reference-subtraction reflectance R(f) for the slab material."""
+    res_ref = _build_sim(kind, with_slab=False).run(
+        until_decay=1e-4, decay_monitor_component="ez",
+        decay_monitor_position=(TRANS_X, Y_CENTER, 0.0))
+    res_slab = _build_sim(kind, with_slab=True).run(
+        until_decay=1e-4, decay_monitor_component="ez",
+        decay_monitor_position=(TRANS_X, Y_CENTER, 0.0))
+
+    ref_refl = res_ref.flux_monitors["refl"]
+    ref_trans_flux = np.asarray(flux_spectrum(res_ref.flux_monitors["trans"]))
+    slab_refl = res_slab.flux_monitors["refl"]
+
+    # Field-level DFT subtraction (Poynting flux is bilinear in E,H; subtracting
+    # already-computed fluxes would leave cross terms). Recover the scattered
+    # (reflected) field, then compute its flux.
+    scat_refl = slab_refl._replace(
+        e1_dft=slab_refl.e1_dft - ref_refl.e1_dft,
+        e2_dft=slab_refl.e2_dft - ref_refl.e2_dft,
+        h1_dft=slab_refl.h1_dft - ref_refl.h1_dft,
+        h2_dft=slab_refl.h2_dft - ref_refl.h2_dft,
+    )
+    scat_refl_flux = np.asarray(flux_spectrum(scat_refl))
+    return -scat_refl_flux / ref_trans_flux  # reflection travels -x
+
+
+def test_eval_lorentz_matches_closed_form():
+    """Witness the oracle: eval_lorentz == documented ε_∞ + κ/(ω₀²-ω²+2jδω).
+
+    Guards eval_lorentz's internal (delta_eps, gamma) param recovery so the
+    analytic oracle it feeds is itself trustworthy.
+    """
+    pole = lorentz_pole(LOR_DELTA_EPS, LOR_W0, LOR_DELTA)
+    w = 2.0 * np.pi * FREQS_RT
+    kappa = LOR_DELTA_EPS * LOR_W0 ** 2
+    closed_form = LOR_EPS_INF + kappa / (LOR_W0 ** 2 - w ** 2 + 2j * LOR_DELTA * w)
+    got = eval_lorentz(FREQS_RT, LOR_EPS_INF, [pole])
+    assert np.max(np.abs(got - closed_form)) < 1e-6
+
+
+@pytest.mark.slow_physics
+def test_dispersive_fresnel_debye():
+    """FDTD R(f) of a single-Debye-pole slab vs the transfer-matrix oracle."""
+    eps_c = eval_debye(FREQS_RT, DEBYE_EPS_INF,
+                       [DebyePole(DEBYE_DELTA_EPS, DEBYE_TAU)])
+    R_analytic = _tmm_slab_R(FREQS_RT, eps_c, D_SLAB)
+    R_fdtd = _measure_R("debye")
+
+    # Oracle sanity (passive slab): analytic reflectance must be physical.
+    assert np.all(np.isfinite(R_fdtd)), "R_fdtd has non-finite entries"
+    assert np.all(R_analytic <= 1.0 + 1e-9), "oracle R>1 — wrong sqrt branch"
+
+    mean_err = float(np.mean(np.abs(R_fdtd - R_analytic)))
+    assert mean_err < GATE, (
+        f"Debye slab mean|R_fdtd - R_analytic| = {mean_err:.4f} exceeds {GATE}"
+    )
+
+
+@pytest.mark.slow_physics
+def test_dispersive_fresnel_lorentz():
+    """FDTD R(f) of a single-Lorentz-pole slab (resonance in-band) vs oracle."""
+    pole = lorentz_pole(LOR_DELTA_EPS, LOR_W0, LOR_DELTA)
+    eps_c = eval_lorentz(FREQS_RT, LOR_EPS_INF, [pole])
+    R_analytic = _tmm_slab_R(FREQS_RT, eps_c, D_SLAB)
+    R_fdtd = _measure_R("lorentz")
+
+    assert np.all(np.isfinite(R_fdtd)), "R_fdtd has non-finite entries"
+    assert np.all(R_analytic <= 1.0 + 1e-9), "oracle R>1 — wrong sqrt branch"
+
+    mean_err = float(np.mean(np.abs(R_fdtd - R_analytic)))
+    assert mean_err < GATE, (
+        f"Lorentz slab mean|R_fdtd - R_analytic| = {mean_err:.4f} exceeds {GATE}"
+    )

--- a/tests/test_farfield.py
+++ b/tests/test_farfield.py
@@ -9,6 +9,7 @@ Validates that:
 
 import numpy as np
 import jax.numpy as jnp
+import pytest
 
 from rfx.grid import Grid
 from rfx.core.yee import init_materials
@@ -149,16 +150,29 @@ def test_dipole_e_phi_small():
 
 
 def test_dipole_directivity():
-    """Short dipole directivity should be near 1.76 dBi (theoretical 1.5 linear)."""
-    ff, _ = _run_dipole_ntff()
-    D = directivity(ff)  # (n_freqs,) dBi
+    """Short (Hertzian) dipole directivity should be near 1.76 dBi (1.5 linear).
 
-    # Theoretical short dipole: 1.76 dBi
-    # FDTD with coarse grid: allow 1-5 dBi range
-    D_val = float(D[0])
-    print(f"\nDipole directivity: {D_val:.2f} dBi (theoretical: 1.76 dBi)")
-    assert 0 < D_val < 8, \
-        f"Directivity {D_val:.2f} dBi outside expected range [0, 8]"
+    R5 measure-before-gate note: the shared ``_run_dipole_ntff`` fixture samples
+    ``phi = [0, pi/2]`` (two points over a quarter circle), which is fine for the
+    pattern-*shape* tests but UNDER-samples the ``directivity()`` P_rad solid-angle
+    integral and inflates D by ~+3 dB (measured 4.78 dBi — a pure integration-grid
+    artefact, not physics: E_theta is phi-flat to ~1% and peaks exactly at 90).
+    We therefore re-integrate the *same* NTFF data on a proper full-2*pi sphere,
+    which recovers the physical directivity (measured ~1.84 dBi, theory 1.76).
+    """
+    _, result = _run_dipole_ntff()
+
+    # Full-sphere sampling so the P_rad integral is unbiased.
+    theta = np.linspace(0.01, np.pi - 0.01, 37)
+    phi = np.linspace(0.0, 2 * np.pi, 24, endpoint=False)
+    ff = compute_far_field(result.ntff_data, result.ntff_box, result.grid,
+                           theta, phi)
+    D_val = float(directivity(ff)[0])
+
+    print(f"\nShort-dipole directivity: {D_val:.3f} dBi (theory 1.76 dBi)")
+    # Theory 1.76 dBi; +/-0.75 absorbs the coarse 3 mm / f0=3 GHz grid bias.
+    assert abs(D_val - 1.76) < 0.75, \
+        f"Short-dipole directivity {D_val:.3f} dBi outside 1.76 +/- 0.75 dBi"
 
 
 def test_ntff_without_ntff_returns_none():
@@ -167,3 +181,73 @@ def test_ntff_without_ntff_returns_none():
     materials = init_materials(grid.shape)
     result = run(grid, materials, 10)
     assert result.ntff_data is None
+
+
+def _run_halfwave_ntff(f0=3e9, freq_max=5e9, n_arm=7, n_steps=800,
+                       domain=(0.08, 0.08, 0.14)):
+    """Run a genuine center-fed ~lambda/2 PEC-wire dipole and return far-field.
+
+    The radiator is a single-cell-wide PEC column along z with a one-cell feed
+    gap at the center, driven by an ez soft source at the gap. Unlike a uniform
+    imposed current line (which radiates 2.43 dBi, not 2.15), a real center-fed
+    conductor self-develops the sinusoidal current of a half-wave dipole.
+    """
+    grid = Grid(freq_max=freq_max, domain=domain, cpml_layers=8)
+    dx = grid.dx
+    materials = init_materials(grid.shape)
+
+    center = (domain[0] / 2, domain[1] / 2, domain[2] / 2)
+    ic, jc, kc = grid.position_to_index(center)
+
+    # PEC wire: arms of n_arm cells above/below a one-cell feed gap at kc.
+    pec_mask = np.zeros(grid.shape, dtype=bool)
+    pec_mask[ic, jc, kc - n_arm:kc + n_arm + 1] = True
+    pec_mask[ic, jc, kc] = False  # feed gap (source cell must radiate)
+    pec_mask = jnp.asarray(pec_mask)
+
+    pulse = GaussianPulse(f0=f0, bandwidth=0.6)
+    src = make_source(grid, center, "ez", pulse, n_steps)
+
+    # NTFF box: enclose the wire while staying a few cells inside the 8-cell CPML.
+    cpml_m = 8 * dx
+    xy_m = cpml_m + 2 * dx
+    z_m = cpml_m + 3 * dx
+    ntff = make_ntff_box(
+        grid,
+        corner_lo=(xy_m, xy_m, z_m),
+        corner_hi=(domain[0] - xy_m, domain[1] - xy_m, domain[2] - z_m),
+        freqs=jnp.array([f0]),
+    )
+
+    result = run(grid, materials, n_steps, boundary="cpml",
+                 sources=[src], ntff=ntff, pec_mask=pec_mask)
+
+    theta = np.linspace(0.01, np.pi - 0.01, 73)
+    phi = np.linspace(0.0, 2 * np.pi, 24, endpoint=False)
+    ff = compute_far_field(result.ntff_data, ntff, grid, theta, phi)
+    return ff, result
+
+
+@pytest.mark.slow_physics
+def test_halfwave_dipole_directivity():
+    """Half-wave dipole directivity should be near 2.15 dBi (1.64 linear).
+
+    Uses a genuine center-fed ~lambda/2 PEC wire (n_arm=7 -> L=0.450 lambda,
+    the classic resonant length). Measured D = 2.380 dBi (full-2*pi sphere,
+    n_steps-converged to 3 decimals). The coarse 3 mm / f0=3 GHz grid biases D
+    slightly high (all lengths sit above theory; the offset shrinks with dx),
+    which the +/-0.5 tolerance absorbs. A uniform imposed current line would
+    give 2.43 dBi and be the wrong geometry, hence the real PEC conductor.
+    """
+    ff, _ = _run_halfwave_ntff()
+    D_val = float(directivity(ff)[0])
+
+    # Pattern-shape witness (R5): a half-wave dipole peaks broadside (theta=90).
+    E_th = np.abs(ff.E_theta[0]).mean(axis=1)  # phi-averaged
+    peak_theta = ff.theta[int(np.argmax(E_th))]
+    assert abs(peak_theta - np.pi / 2) < np.radians(10), \
+        f"Half-wave pattern peak at {np.degrees(peak_theta):.0f} (expected ~90)"
+
+    print(f"\nHalf-wave dipole directivity: {D_val:.3f} dBi (theory 2.15 dBi)")
+    assert abs(D_val - 2.15) < 0.5, \
+        f"Half-wave dipole directivity {D_val:.3f} dBi outside 2.15 +/- 0.5 dBi"

--- a/tests/test_lossy_material_validation.py
+++ b/tests/test_lossy_material_validation.py
@@ -1,0 +1,154 @@
+"""W3.2 — Lossy-material validation oracle (E1->E2).
+
+Validates rfx's conductive-loss FDTD against exact analytics:
+
+  (1) PRIMARY — plane-wave attenuation alpha(f) of a homogeneous conductive
+      medium vs the exact analytic
+          alpha(w) = (w/c) * |Im( sqrt( eps_r - j*sigma/(w*eps0) ) )|
+      (e^{+jwt} convention: loss => Im(eps)<0 => Im(n)<0).  Measured by
+      sampling the per-frequency field magnitude at several interior depths of
+      a thick lossy region and log-linear-fitting the spatial decay of the
+      forward wave.  No probe-FFT (time-window artifact, forbidden); the
+      per-frequency |E(x,f)| comes from add_dft_plane_probe DFT accumulators.
+
+  (2) SECONDARY — a PEC cavity fully filled with a low-loss dielectric has a
+      dielectric-limited quality factor Q ~= 1/tan(delta).  Q is measured by
+      Harminv ring-down and compared to 1/tan(delta) at the measured resonance.
+
+R5 (curves recorded before the gates were set):
+docs/research_notes/20260702_w32_lossy_material.md.  Measured margins are far
+inside the gates (alpha mean rel-err 0.5-0.9%; Q rel-err <0.2%); the gates are
+set at 5% (alpha, mirroring the dispersive-Fresnel oracle) and 5% (Q, generous
+vs the 0.12% measured — Harminv Q is noisier than a decay-rate fit).
+
+Marked slow_physics (opt-in release-tag physics gate).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rfx import Box, GaussianPulse, Simulation
+from rfx.harminv import harminv
+
+C0 = 299_792_458.0
+EPS0 = 8.8541878128e-12
+EPS_R = 4.0
+
+# --- attenuation-case geometry (thick lossy region, planes deep inside) ---
+_DX = 0.5e-3
+_DOM_X = 340e-3
+_DOM_Y = 5e-3
+_FREQ_MAX = 18e9
+_F0 = 10e9
+_BW = 0.7
+_X_ENTRY = 30e-3
+_X_EXIT = 320e-3
+_PLANES = np.array([45e-3, 55e-3, 65e-3, 75e-3, 85e-3, 95e-3])
+_FREQS_A = np.linspace(6e9, 14e9, 9)
+
+ALPHA_GATE = 0.05          # mean |alpha_fdtd/alpha_analytic - 1| over the band
+ALPHA_FIT_RESID_GATE = 0.05   # log-linear fit RMS residual: forward-wave purity
+Q_GATE = 0.05             # |Q_meas / (1/tan(delta)) - 1| at the measured resonance
+
+
+def _eps_c(freqs, sigma):
+    w = 2.0 * np.pi * np.asarray(freqs)
+    return EPS_R - 1j * sigma / (w * EPS0)      # e^{+jwt}: loss -> Im<0
+
+
+def _alpha_analytic(freqs, sigma):
+    w = 2.0 * np.pi * np.asarray(freqs)
+    n = np.sqrt(_eps_c(freqs, sigma))           # principal sqrt -> Im(n)<0
+    return (w / C0) * np.abs(np.imag(n))
+
+
+def _measure_alpha(sigma):
+    """Return (alpha_fit(f), fit_resid(f), alpha_analytic(f)) for the band."""
+    sim = Simulation(freq_max=_FREQ_MAX, domain=(_DOM_X, _DOM_Y, _DX), dx=_DX,
+                     boundary="cpml", cpml_layers=20, mode="2d_tmz")
+    sim.add_material("lossy", eps_r=EPS_R, sigma=sigma)
+    x_hi = _X_EXIT - _DX / 2.0
+    sim.add(Box((_X_ENTRY, -1.0, -1.0), (x_hi, 1.0, 1.0)), material="lossy")
+    sim.add_tfsf_source(f0=_F0, bandwidth=_BW, polarization="ez", direction="+x",
+                        waveform="modulated_gaussian")
+    for i, xc in enumerate(_PLANES):
+        sim.add_dft_plane_probe(axis="x", coordinate=float(xc), component="ez",
+                                freqs=_FREQS_A, name=f"p{i}")
+    res = sim.run(until_decay=1e-4, decay_monitor_component="ez",
+                  decay_monitor_position=(70e-3, _DOM_Y / 2.0, 0.0))
+    # |E(x,f)| = mean over y of |DFT accumulator|
+    mag = np.zeros((len(_PLANES), len(_FREQS_A)))
+    for i in range(len(_PLANES)):
+        acc = np.asarray(res.dft_planes[f"p{i}"].accumulator)  # (nf, ny, nz)
+        mag[i] = np.mean(np.abs(acc[:, :, 0]), axis=1)
+    logmag = np.log(mag)
+    A = np.vstack([_PLANES, np.ones_like(_PLANES)]).T
+    a_fit = np.zeros(len(_FREQS_A))
+    resid = np.zeros(len(_FREQS_A))
+    for fi in range(len(_FREQS_A)):
+        sol, *_ = np.linalg.lstsq(A, logmag[:, fi], rcond=None)
+        a_fit[fi] = -sol[0]
+        resid[fi] = np.sqrt(np.mean((logmag[:, fi] - A @ sol) ** 2))
+    return a_fit, resid, _alpha_analytic(_FREQS_A, sigma)
+
+
+@pytest.mark.slow_physics
+@pytest.mark.parametrize("tand", [0.1, 0.3])   # low + moderate loss
+def test_lossy_slab_attenuation(tand):
+    sigma = tand * (2.0 * np.pi * _F0) * EPS0 * EPS_R   # tan(delta) at F0
+    a_fit, resid, a_an = _measure_alpha(sigma)
+
+    assert np.all(np.isfinite(a_fit)), "alpha_fdtd has non-finite entries"
+    assert np.all(a_fit > 0), "attenuation must be positive for a lossy medium"
+    # forward-wave purity: the interior field is a single decaying exponential
+    # (a standing wave from a leaking far boundary would inflate the fit RMS).
+    assert np.max(resid) < ALPHA_FIT_RESID_GATE, (
+        f"log-linear fit residual {np.max(resid):.4f} too large — "
+        "interior wave is not a clean single exponential (reflection leak?)"
+    )
+    mean_rel = float(np.mean(np.abs(a_fit / a_an - 1.0)))
+    assert mean_rel < ALPHA_GATE, (
+        f"tan(delta)={tand}: mean |alpha_fdtd/alpha_analytic - 1| = "
+        f"{mean_rel:.4f} exceeds {ALPHA_GATE}"
+    )
+
+
+@pytest.mark.slow_physics
+def test_lossy_cavity_Q_vs_tandelta():
+    """PEC cavity filled with a low-loss dielectric: Q ~= 1/tan(delta)."""
+    tand = 0.1                       # Q ~ 10 -> short ring-down, cheap
+    Lx = Ly = 20e-3
+    dx = 0.5e-3
+    f11 = (C0 / (2.0 * np.sqrt(EPS_R))) * np.sqrt((1.0 / Lx) ** 2 + (1.0 / Ly) ** 2)
+    sigma = tand * (2.0 * np.pi * f11) * EPS0 * EPS_R
+    fmax = 3.0 * f11                 # keeps >=15 cells/lambda_eff (clears advisory)
+
+    sim = Simulation(freq_max=fmax, domain=(Lx, Ly, dx), dx=dx,
+                     boundary="pec", mode="2d_tmz")
+    sim.add_material("diel", eps_r=EPS_R, sigma=sigma)
+    sim.add(Box((-1.0, -1.0, -1.0), (Lx + 1.0, Ly + 1.0, 1.0)), material="diel")
+    # off-centre source + probe couple to the TM11 mode
+    sim.add_source((0.3 * Lx, 0.35 * Ly, 0.0), component="ez",
+                   waveform=GaussianPulse(f0=f11, bandwidth=0.6))
+    sim.add_probe((0.62 * Lx, 0.57 * Ly, 0.0), component="ez")
+    res = sim.run(n_steps=9000)
+
+    dt = float(res.grid.dt)
+    ez = np.asarray(res.time_series[:, 0])
+    modes = harminv(ez, dt, 0.5 * f11, 2.5 * f11, min_Q=2.0)
+    assert modes, "Harminv found no cavity mode"
+
+    m0 = max(modes, key=lambda m: m.amplitude)     # dominant TM11
+    assert abs(m0.freq / f11 - 1.0) < 0.05, (
+        f"dominant mode {m0.freq/1e9:.3f} GHz not near TM11 {f11/1e9:.3f} GHz"
+    )
+    # 1/tan(delta) at the MEASURED resonance (sigma fixed => tan(delta) is
+    # frequency-dependent; evaluate the theory where the mode actually sits).
+    tand_at_f = sigma / (2.0 * np.pi * m0.freq * EPS0 * EPS_R)
+    q_theory = 1.0 / tand_at_f
+    rel = abs(m0.Q / q_theory - 1.0)
+    assert rel < Q_GATE, (
+        f"Q_meas={m0.Q:.2f} vs 1/tan(delta)={q_theory:.2f} at "
+        f"{m0.freq/1e9:.3f} GHz — rel-err {rel:.4f} exceeds {Q_GATE}"
+    )


### PR DESCRIPTION
Three roadmap Wave-3 physics-ledger upgrades, each R5 measure-first (curves recorded before gates; research notes local). All new physics tests are `@pytest.mark.slow_physics` (opt-in; deselected in the fast suite).

**W3.1 — dispersive Fresnel oracle (E0→E2)** `test_dispersive_fresnel_validation.py`
Debye + Lorentz slab R(f) via the canonical flux two-run recipe (no probe-FFT) vs a rigorous 2×2 TMM oracle with `n=√ε(ω)` from the identical `eval_debye`/`eval_lorentz`. Measured mean|ΔR| 3.46% (Debye) / 2.74% (Lorentz), gate 5%. Lorentz resonance fully captured (at-resonance |ΔR|=0.005); `eval_lorentz` witnessed against the closed form (exact). Closes the "no tracked dispersive R/T oracle" gap the rt_measurement recipe flagged.

**W3.2 — lossy-material oracle (E1→E2)** `test_lossy_material_validation.py`
Conductive-medium attenuation α(f) via log-linear fit over interior DFT-plane probes vs analytic `(ω/c)|Im√(ε_r−jσ/ωε₀)|` (tan δ=0.1, 0.3) — mean rel-err 0.5–0.9%, gate 5%, with a forward-wave-purity witness (clean single exponential). Plus a lossy-cavity Q vs 1/tan δ Harminv check (Q=10, rel-err 0.12%).

**W3.3 — tighten dipole directivity gates (E1→E2)** `test_farfield.py`
Short-dipole gate `0<D<8` → `1.76±0.75 dBi` (re-integrating the NTFF data on a full-2π sphere — the shared fixture's φ=[0,π/2] cut inflated D by +3 dB; R5 catch). New half-wave case (genuine center-fed PEC wire) gated `2.15±0.5 dBi`. Roadmap item (3) gain/efficiency was already implemented+validated in `rfx/antenna.py` (energy-conservation witness) — not duplicated.

Verification: each test suite passes fresh (`-m slow_physics`); ruff clean. Required fast-suite checks unaffected (slow_physics deselected; the non-slow re-integrated short-dipole test passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)