### PR TITLE
fix(directivity): sign-correct default + full-sphere P_rad in maximize_directivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,22 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   `check_positive`, `check_bounds`, `check_courant_number` wrap
   `jax.experimental.checkify` so RF/design invariants survive jit/grad/vmap/scan.
 
+### Changed — `maximize_directivity` objective defaults (behaviour change)
+
+- `maximize_directivity(...)` now defaults to **`log_ratio=True`** — the full,
+  sign-correct quotient gradient `U'/U - P'/P` — instead of the legacy
+  `-U/stop_gradient(P)` mode, which is wrong-sign for any degree of freedom that
+  changes total radiated power (PEC/conductor topology, lossy/σ, magnitude-only
+  dielectric reshape; GitHub #129). Pass `log_ratio=False` for the old behaviour.
+  The loss is now `-(log U - log P)` (positive below ~11 dBi), not the old
+  fixed-negative ratio.
+- The directivity denominator `P_rad` is now integrated over the **full sphere**
+  (matching `farfield.directivity()` / `antenna._total_radiated_power`) rather
+  than the upper hemisphere, so the optimized quantity is the true directivity;
+  the hemisphere-only integral inflated it (~+3 dB) for any radiator with back
+  radiation. The shipped tap-paper beam-steering example is unaffected (it builds
+  its own full-sphere `4π U/P_rad` objective and never called this function).
+
 ## [1.6.6] - 2026-06-24
 
 Maintenance release: a behaviour-preserving internal refactor (extract the

--- a/rfx/optimize_objectives.py
+++ b/rfx/optimize_objectives.py
@@ -287,16 +287,19 @@ def maximize_directivity(
     *,
     n_theta: int = 37,
     n_phi: int = 73,
-    log_ratio: bool = False,
+    log_ratio: bool = True,
     eps: float = 1e-37,
 ) -> Callable:
     """Maximize directivity in a target direction (ratio-based, scale-invariant).
 
     Computes the directivity ratio ``U(θ_target, φ_target) / P_rad`` where
     ``U = |E_θ|² + |E_φ|²`` is the radiation intensity and ``P_rad`` is
-    the total radiated power integrated over the upper hemisphere. The
-    ratio is scale-invariant, so the absolute magnitude of the NTFF
-    spectral integral drops out — gradients reflect pattern shape only.
+    the total radiated power integrated over the FULL sphere (matching
+    ``farfield.directivity()`` and ``antenna._total_radiated_power`` — so the
+    optimized quantity is the true directivity, not an upper-hemisphere proxy
+    that would inflate D for antennas with any back radiation). The ratio is
+    scale-invariant, so the absolute magnitude of the NTFF spectral integral
+    drops out — gradients reflect pattern shape only.
 
     Prior versions used absolute ``|E|²`` at the target direction, which
     is ~1e-27 in rfx's spectral NTFF convention and produces zero
@@ -309,8 +312,8 @@ def maximize_directivity(
     phi_target : float
         Azimuthal angle in radians [0, 2π].
     n_theta : int, optional
-        Number of polar samples in [0, π/2] for the hemisphere
-        integration (default 37 → 2.5° spacing).
+        Number of polar samples in [0, π] for the full-sphere P_rad
+        integration (default 37 → 5° spacing).
     n_phi : int, optional
         Number of azimuthal samples in [0, 2π] (default 73 → 5° spacing).
 
@@ -321,11 +324,12 @@ def maximize_directivity(
     Parameters (continued)
     ----------------------
     log_ratio : bool, optional
-        If True, optimize ``-(log U - log P)`` (full, sign-correct quotient
-        gradient ``U'/U - P'/P``) instead of the legacy ``-U/stop_gradient(P)``.
-        Default False (legacy, back-compat). USE ``log_ratio=True`` (or the
-        ``maximize_directivity_logratio`` factory) for any DoF that changes
-        total radiated power — see the warning below.
+        Default ``True``: optimize ``-(log U - log P)`` — the full, sign-correct
+        quotient gradient ``U'/U - P'/P`` that is right for every degree of
+        freedom (including power-changing ones). ``log_ratio=False`` selects the
+        legacy ``-U/stop_gradient(P)`` mode, kept for back-compat only; it is
+        WRONG-SIGN for any DoF that changes total radiated power — see the
+        warning below. (The default was flipped to ``True`` after GitHub #129.)
     eps : float, optional
         Floor for the ``log_ratio`` log arguments (default 1e-37). It only
         guards ``log(0)``; the log-ratio gradient ``U'/U`` is scale-invariant, so
@@ -337,7 +341,7 @@ def maximize_directivity(
 
     Notes
     -----
-    In the default (``log_ratio=False``) mode, ``stop_gradient`` is applied to
+    In the legacy (``log_ratio=False``) mode, ``stop_gradient`` is applied to
     the P_rad denominator: the ratio is scale-invariant, so a shape-preserving
     scaling leaves the directivity unchanged, and letting the denominator carry
     gradient would add noise + NaN risk when P_rad is near zero.
@@ -356,8 +360,12 @@ def maximize_directivity(
     """
     theta_arr = np.array([theta_target])
     phi_arr = np.array([phi_target])
-    theta_hemi = np.linspace(0.0, np.pi / 2.0, n_theta)
-    phi_hemi = np.linspace(0.0, 2.0 * np.pi, n_phi)
+    # Full sphere [0, pi] x [0, 2pi] so P_rad is the TRUE total radiated power
+    # (poles theta=0,pi carry sin(theta)=0 weight, so no singularity). An
+    # upper-hemisphere-only integral undercounts back radiation and inflates the
+    # normalized directivity for free-space radiators.
+    theta_sphere = np.linspace(0.0, np.pi, n_theta)
+    phi_full = np.linspace(0.0, 2.0 * np.pi, n_phi)
 
     def objective(result) -> jnp.ndarray:
         from rfx.farfield import compute_far_field
@@ -385,14 +393,14 @@ def maximize_directivity(
         u_target = (jnp.abs(ff_tgt.E_theta[:, 0, 0]) ** 2
                     + jnp.abs(ff_tgt.E_phi[:, 0, 0]) ** 2)
 
-        # Hemisphere P_rad: ∬ U(θ,φ) sin(θ) dθ dφ — (n_freqs, n_theta, n_phi)
-        ff_hemi = compute_far_field(ntff_data, ntff_box, grid, theta_hemi, phi_hemi)
-        u_hemi = (jnp.abs(ff_hemi.E_theta) ** 2 + jnp.abs(ff_hemi.E_phi) ** 2)
-        sin_theta = jnp.asarray(np.sin(theta_hemi), dtype=u_hemi.dtype)
+        # Full-sphere P_rad: ∬ U(θ,φ) sin(θ) dθ dφ — (n_freqs, n_theta, n_phi)
+        ff_sphere = compute_far_field(ntff_data, ntff_box, grid, theta_sphere, phi_full)
+        u_sphere = (jnp.abs(ff_sphere.E_theta) ** 2 + jnp.abs(ff_sphere.E_phi) ** 2)
+        sin_theta = jnp.asarray(np.sin(theta_sphere), dtype=u_sphere.dtype)
         # trapz in θ then φ
-        integrand = u_hemi * sin_theta[None, :, None]
-        p_rad_phi = jnp.trapezoid(integrand, theta_hemi, axis=1)
-        p_rad = jnp.trapezoid(p_rad_phi, phi_hemi, axis=1)  # (n_freqs,)
+        integrand = u_sphere * sin_theta[None, :, None]
+        p_rad_phi = jnp.trapezoid(integrand, theta_sphere, axis=1)
+        p_rad = jnp.trapezoid(p_rad_phi, phi_full, axis=1)  # (n_freqs,)
 
         if log_ratio:
             # Full, NaN-safe quotient: grad = U'/U - P'/P (== true dD/dθ up to

--- a/tests/test_directivity_gradient.py
+++ b/tests/test_directivity_gradient.py
@@ -62,7 +62,8 @@ def test_maximize_directivity_gradient_nonzero():
 
     value = float(loss(jnp.array(1.0)))
     assert np.isfinite(value)
-    assert value < 0.0, "objective sign: -directivity should be < 0"
+    # log-ratio loss = -(log U - log P) = log(4pi/D); its sign depends on D
+    # (positive below ~11 dBi), so it is not fixed-negative like the old ratio.
 
     grad = float(jax.grad(loss)(jnp.array(1.0)))
     assert np.isfinite(grad)
@@ -109,11 +110,11 @@ def _forward_lossy(sigma_scale):
 
 
 def _u_target_and_p_rad(result):
-    """Value-only (no AD) U(target) and hemisphere P_rad — for the ground-truth FD."""
+    """Value-only (no AD) U(target) and full-sphere P_rad — for the ground-truth FD."""
     from rfx.farfield import compute_far_field
     th = np.array([np.pi / 2])
     ph = np.array([0.0])
-    th_h = np.linspace(0.0, np.pi / 2, 37)
+    th_h = np.linspace(0.0, np.pi, 37)          # full sphere (matches the objective)
     ph_h = np.linspace(0.0, 2 * np.pi, 73)
     ff = compute_far_field(result.ntff_data, result.ntff_box, result.grid, th, ph)
     u = float(jnp.abs(ff.E_theta[0, 0, 0]) ** 2 + jnp.abs(ff.E_phi[0, 0, 0]) ** 2)
@@ -141,7 +142,7 @@ def test_directivity_logratio_sign_correct_vs_fd_power_changing_dof():
     g_log_fd = (_log_loss(up, pp) - _log_loss(um, pm)) / (2 * _H)
 
     g_leg = float(jax.grad(
-        lambda s: maximize_directivity(np.pi / 2, 0.0)(_forward_lossy(s))
+        lambda s: maximize_directivity(np.pi / 2, 0.0, log_ratio=False)(_forward_lossy(s))
     )(jnp.asarray(_S0)))
     g_log = float(jax.grad(
         lambda s: maximize_directivity(np.pi / 2, 0.0, log_ratio=True)(_forward_lossy(s))
@@ -158,6 +159,41 @@ def test_directivity_logratio_sign_correct_vs_fd_power_changing_dof():
     # (3) BUG repro: legacy stop_gradient opposes the correct direction here.
     assert np.sign(g_leg) != np.sign(g_log), (
         f"#129 not reproduced: legacy {g_leg:+.3e} should oppose log_ratio {g_log:+.3e}")
+
+
+def test_directivity_default_is_logratio_and_prad_full_sphere():
+    """A+B: the default objective is now the sign-correct log-ratio (A), and its
+    P_rad spans the FULL sphere (B) — not the upper hemisphere, which would be
+    ~2x smaller (+3 dB inflation) for a free-space radiator."""
+    from rfx.farfield import compute_far_field
+    r = _forward_lossy(_S0)
+
+    # (A) default == log_ratio=True (value), and differs from the legacy mode.
+    v_def = float(maximize_directivity(np.pi / 2, 0.0)(r))
+    v_log = float(maximize_directivity(np.pi / 2, 0.0, log_ratio=True)(r))
+    v_leg = float(maximize_directivity(np.pi / 2, 0.0, log_ratio=False)(r))
+    assert v_def == v_log, "default objective is no longer the log-ratio"
+    assert v_def != v_leg, "default must differ from the legacy stop-gradient mode"
+
+    # (B) exp(-loss) = U(target)/P_rad matches the FULL-sphere normalization.
+    ff_t = compute_far_field(r.ntff_data, r.ntff_box, r.grid,
+                             np.array([np.pi / 2]), np.array([0.0]))
+    u_t = float(jnp.abs(ff_t.E_theta[0, 0, 0]) ** 2 + jnp.abs(ff_t.E_phi[0, 0, 0]) ** 2)
+
+    def _prad(theta_hi):
+        th = np.linspace(0.0, theta_hi, 37)
+        ph = np.linspace(0.0, 2 * np.pi, 73)
+        ff = compute_far_field(r.ntff_data, r.ntff_box, r.grid, th, ph)
+        u = jnp.abs(ff.E_theta) ** 2 + jnp.abs(ff.E_phi) ** 2
+        st = jnp.asarray(np.sin(th))
+        return float(jnp.trapezoid(
+            jnp.trapezoid(u * st[None, :, None], th, axis=1), ph, axis=1)[0])
+
+    p_full, p_hemi = _prad(np.pi), _prad(np.pi / 2)
+    assert abs(p_full - p_hemi) / p_full > 0.1, "setup: full/hemi P_rad must differ"
+    ratio_obj = np.exp(-v_def)                       # single freq -> U/P_rad
+    assert abs(ratio_obj - u_t / p_full) / (u_t / p_full) < 0.02, \
+        "objective P_rad is not full-sphere (regressed to hemisphere?)"
 
 
 def test_maximize_directivity_logratio_factory_matches_flag():

--- a/tests/test_farfield.py
+++ b/tests/test_farfield.py
@@ -96,7 +96,12 @@ def test_maximize_directivity_works_with_low_level_simresult():
 
     assert loss.shape == ()
     assert jnp.isfinite(loss)
-    assert float(loss) < 0.0
+    # Default is the log-ratio objective: loss = -(log U - log P) = log(4pi/D),
+    # positive for a low-directivity source (D < 4pi) — not the old ratio-mode
+    # negative value. Guard that the default IS the log-ratio path.
+    assert float(loss) == float(
+        maximize_directivity(theta_target=np.pi / 2, phi_target=0.0,
+                             log_ratio=True)(result))
 
 
 def test_dipole_sin_theta_pattern():


### PR DESCRIPTION
Two correctness fixes to the differentiable directivity objective, from the NTFF differentiability review. **The TMTT/TAP paper is unaffected** — its beam-steering example builds its own full-sphere `4π U/P_rad` objective and never calls `maximize_directivity`; the sole callers are tests.

**A — default `log_ratio` flip.** `maximize_directivity(...)` defaulted to `log_ratio=False` (`-U/stop_gradient(P)`), which drops the `-U·P'/P²` quotient term → **wrong-sign gradients for any power-changing DoF** (PEC/conductor topology, lossy/σ, magnitude-only dielectric reshape; #129). The sign-correct log-ratio path already existed but was opt-in and a standing trap. Default is now `log_ratio=True`; `log_ratio=False` still selects the legacy mode. Loss is now `-(log U - log P) = log(4π/D)` (positive below ~11 dBi), not the old fixed-negative ratio.

**B — full-sphere `P_rad`.** The objective normalized by an **upper-hemisphere-only** `P_rad`, inflating the optimized directivity (~+3 dB) for any radiator with back radiation and diverging from `farfield.directivity()` / `antenna._total_radiated_power` (full sphere ×4π). `P_rad` now integrates `[0,π]×[0,2π]` — the true total radiated power, single source of truth with the reporting path.

**Validation:** `#129` legacy-bug repro now selects `log_ratio=False` explicitly; the FD ground-truth integrates the full sphere; a new witness asserts default==log-ratio (A) and `exp(-loss)==U/P_full-sphere` not hemisphere (B). Two `loss<0` asserts (a ratio-convention artifact — the log-ratio loss is positive for D<4π) relaxed. 11 tests pass; ruff + api-reference clean. Behaviour change noted in CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)