### PR TITLE
docs(ntff): confirm + lock NU support, fix stale complex128/Kahan docstrings

### DIFF
--- a/docs/guides/support_matrix.md
+++ b/docs/guides/support_matrix.md
@@ -88,7 +88,7 @@ Current policy:
 | Combination | Status | Expected behavior |
 |---|---|---|
 | Periodic-port workflows + nonuniform | unsupported | hard-fail |
-| NTFF + nonuniform | shadow | runs on graded-z path; validate observable before any public claim |
+| NTFF + nonuniform | benchmarked (dipole) | graded-z far-field runs and a short-dipole directivity benchmarks within ~0.05 dB of the 1.76 dBi theory (`tests/test_farfield_nonuniform.py`); other observables/geometries remain shadow — validate before any public claim |
 | DFT planes + nonuniform | shadow | runs on graded-z path; validate observable before any public claim |
 | TFSF + nonuniform | shadow / restricted | normal ±x incidence (`direction='+x'`/`'-x'`, `angle_deg=0`) runs on graded-z path (shadow); oblique or ±z incidence raises |
 | Waveguide ports + nonuniform | shadow / restricted | `compute_waveguide_s_matrix(normalize=True/'flux')` single-mode TE10 validated at settled `num_periods`; **broad-E5-analytic envelope committed + gated** (graded-`dy` 1-3x, eps_r 2/4, vs analytic Airy, `tests/test_waveguide_nu_broad_e5_envelope_gates.py`); still **shadow / not claims-bearing** pending broad-E4 external cross-solver + AD-traceability; otherwise hard-fail |

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2011,7 +2011,11 @@ class _PreflightMixin:
                     )
                     break
 
-        # P1.5: (merged into P2.1 — non-uniform + NTFF is unsupported)
+        # P1.5: non-uniform + NTFF is SUPPORTED (stale "unsupported" note removed
+        # 2026-07-02). The NU runner accumulates the NTFF box and
+        # compute_far_field handles graded-z per-cell dS + z-edges; a graded-z
+        # dipole directivity benchmarks within ~0.05 dB of theory
+        # (tests/test_farfield_nonuniform.py). No guard needed.
 
     def _validate_cfg_ntff_min_steps(self, dx: float) -> None:
         """P1.7: NTFF with too few steps."""

--- a/rfx/farfield.py
+++ b/rfx/farfield.py
@@ -84,9 +84,10 @@ class NTFFData(NamedTuple):
     x faces store [ey, ez, hy, hz], y faces [ex, ez, hx, hz],
     z faces [ex, ey, hx, hy].  Shape: (n_freqs, face_n1, face_n2, 4).
 
-    Kahan compensation arrays (c_*) maintain near-float64 precision
-    in float32 accumulation over thousands of timesteps. The true
-    accumulated value is ``x_lo + c_x_lo`` (compensation is small).
+    Kahan compensation arrays (c_*) maintain near-float64 precision in
+    complex64 accumulation over thousands of timesteps. The value read by the
+    far-field transform is ``x_lo`` (the compensated running sum); ``c_x_lo``
+    is the running Kahan residual carried to the next add, not added at read.
     """
     x_lo: jnp.ndarray
     x_hi: jnp.ndarray
@@ -143,12 +144,11 @@ def make_ntff_box(
 def init_ntff_data(box: NTFFBox) -> NTFFData:
     """Initialize zeroed NTFF DFT accumulators.
 
-    Uses complex128 (float64 real/imag) to avoid catastrophic cancellation
-    during long DFT accumulations over thousands of timesteps.  At coarse
-    dx (e.g., 2 mm at 5 GHz), the phase rotation in each step is small
-    (dt ~ 4 ps), and float32 accumulation can lose the signal entirely.
-
-    Automatically enables JAX float64 support if not already enabled.
+    Uses complex64 accumulators with Kahan compensated summation (the ``c_*``
+    arrays), which keeps near-float64 precision over thousands of timesteps
+    WITHOUT enabling JAX x64 mode (x64 caused an MLIR scan-carry mismatch,
+    issue #14). Plain float32 accumulation would lose the signal at coarse dx,
+    where the per-step phase rotation is small; Kahan avoids that.
     """
     # Always use complex64 — Kahan compensated summation provides near-float64
     # precision without requiring JAX x64 mode (which causes MLIR issues #14).

--- a/tests/test_farfield_nonuniform.py
+++ b/tests/test_farfield_nonuniform.py
@@ -1,0 +1,43 @@
+"""NU + NTFF regression: non-uniform (graded-z) far-field is a real, accurate
+capability — not the "unsupported" the stale preflight note (P1.5) claimed.
+
+The non-uniform runner accumulates the NTFF box in its scan and
+``compute_far_field`` handles the graded-z per-cell dS + z-edge geometry. A
+z-oriented short (Hertzian) dipole on a graded-z mesh must give the same
+~1.76 dBi directivity as the uniform lane. Measured (R5, clean box interior to
+CPML, no skip_preflight): uniform-z-via-NU 1.721 dBi, graded-z 1.716 dBi — both
+within ~0.04 dB of theory. Gate 1.76 +/- 0.3 dBi.
+"""
+import numpy as np
+import pytest
+
+from rfx import Simulation
+from rfx.farfield import compute_far_field, directivity
+
+
+def _nu_dipole_directivity(dz_profile):
+    # cpml_layers=6 -> 9 mm CPML per x/y face; interior is 9-21 mm, so the
+    # 10-20 mm NTFF box sits fully inside (no absorber overlap; preflight clean).
+    sim = Simulation(freq_max=5e9, domain=(0.03, 0.03, 0.03), dx=1.5e-3,
+                     dz_profile=dz_profile, boundary="cpml", cpml_layers=6)
+    sim.add_source((0.015, 0.015, 0.015), "ez")
+    sim.add_probe((0.015, 0.015, 0.015), "ez")
+    sim.add_ntff_box(corner_lo=(0.010, 0.010, 0.010),
+                     corner_hi=(0.020, 0.020, 0.020), freqs=[3e9])
+    res = sim.run(n_steps=200)                 # preflight runs (must NOT block)
+    assert res.ntff_data is not None, "NU runner did not accumulate NTFF data"
+    theta = np.linspace(0.01, np.pi - 0.01, 73)   # full sphere, avoid poles
+    phi = np.linspace(0.0, 2.0 * np.pi, 72)
+    ff = compute_far_field(res.ntff_data, res.ntff_box, res.grid, theta, phi)
+    return float(directivity(ff)[0])              # full-sphere directivity, dBi
+
+
+@pytest.mark.slow_physics
+@pytest.mark.parametrize("dz_profile,label", [
+    (np.full(18, 1.5e-3), "uniform-z-via-NU-path"),
+    (np.concatenate([np.full(8, 1.0e-3), np.full(14, 1.5e-3)]), "graded-z"),
+])
+def test_nu_ntff_dipole_directivity(dz_profile, label):
+    D = _nu_dipole_directivity(dz_profile)
+    assert 1.76 - 0.3 < D < 1.76 + 0.3, \
+        f"NU+NTFF {label} dipole D={D:.3f} dBi outside 1.76 +/- 0.3 dBi"


### PR DESCRIPTION
Evidence-based NTFF re-review — **no numerics change**. Full memo: `docs/research_notes/20260702_ntff_differentiability_directions.md`.

**NU + NTFF is a working, accurate capability — not "unsupported".** The non-uniform runner accumulates the NTFF box and `compute_far_field` handles graded-z per-cell dS + z-edges. Measured (clean box interior to CPML, `run()` with preflight on): a graded-z short-dipole directivity = **1.716–1.721 dBi**, within ~0.04 dB of the 1.76 dBi theory. So:
- New `tests/test_farfield_nonuniform.py` (`slow_physics`) locks it (gate 1.76 ± 0.3 dBi).
- `support_matrix.md` NTFF+nonuniform: `shadow` → `benchmarked (dipole)`.
- Stale `_preflight.py` P1.5 comment ("non-uniform + NTFF is unsupported") corrected — there was never an active guard, just the note.

**Docstring corrections (code contradicted the docs):**
- `init_ntff_data` claimed complex128 + "Automatically enables JAX float64", but the code forces **complex64 + Kahan** (x64 caused an MLIR scan-carry mismatch, #14).
- `NTFFData` claimed the "true accumulated value is `x_lo + c_x_lo`", but the far-field transform reads only `x_lo`; `c_*` is the running Kahan residual, not added back.

**Refuted (measured, kept OUT):** Yee half-cell co-location gave no directivity benefit (1.775→1.784 dBi, slightly worse — the ½-cell phase error cancels in the ratio); numpy vs jnp far-field paths already agree to 4e-7 (float32 floor, not an algorithmic drift). The only genuine fixes from this review were A/B (objective correctness, PR #248).

Verification: new NU test 2 passed; existing `test_farfield.py` 6 passed (docstring-only change); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)