### PR TITLE
feat(preflight): warn on solver='adi' with a 3D grid — known-inaccurate LOD scheme (W3.8)

### DIFF
--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -302,7 +302,13 @@ class Simulation(
         for storage.
     solver : str
         ``"yee"`` (default) for the standard explicit scheme or
-        ``"adi"`` for the current 2D TMz ADI-FDTD path.
+        ``"adi"`` for the ADI-FDTD path. ADI is validated ONLY in 2D TMz
+        (``mode="2d_tmz"``, 2% cavity-resonance gate). The 3D ADI (LOD)
+        scheme is KNOWN-INACCURATE for physical results (a 3D PEC-cavity
+        eigenfrequency misses the analytic mode by ~41% even at 2x CFL —
+        artificial diffusion on off-axis E components); preflight emits an
+        ``adi_3d_accuracy`` warning for that combination. Use 3D ADI only
+        for qualitative stability studies.
     adi_cfl_factor : float
         Timestep multiplier relative to the standard 2D CFL limit when
         ``solver="adi"``.

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1589,6 +1589,7 @@ class _PreflightMixin:
         self._validate_cfg_nonuniform_limitations(_w, cpml_thickness)
         self._validate_cfg_subgrid_limitations(_w)
         self._validate_cfg_conformal_fine_dx(dx)
+        self._validate_cfg_adi_3d_accuracy(_w)
         self._validate_cfg_lossless_resonator_in_absorber(_w)
         self._validate_cfg_waveguide_reference_plane(
             _w, cpml_thick_lo, cpml_thick_hi
@@ -1656,6 +1657,45 @@ class _PreflightMixin:
                 ),
                 stacklevel=2,
             )
+
+    def _validate_cfg_adi_3d_accuracy(self, _w) -> None:
+        """Warn when ``solver='adi'`` is combined with a 3D grid (OPT-C1).
+
+        The 3D ADI path (``adi_step_3d``) uses an LOD split that applies the
+        implicit tridiagonal solve to ALL E components along each sweep axis —
+        artificial diffusion on components whose curl has no derivative along
+        that axis. Measured: a lossless 3D PEC cubic cavity misses the analytic
+        eigenfrequency by ~41% even at a modest 2x CFL (2.077 vs 3.533 GHz),
+        and over-dissipates ~42% at 5x CFL. The 2D TMz ADI path is unaffected
+        (holds a 2% cavity-resonance gate). Note ``mode='3d'`` is the
+        constructor DEFAULT, so ``Simulation(solver='adi')`` lands here.
+
+        WARNING severity (NOT error): 3D ADI stays runnable for qualitative
+        stability/divergence studies, and a hard-fail would block the very
+        tests characterising it. MAINTENANCE: the strict-xfail adjudication
+        test ``tests/test_review_tier1_validation_battery.py::
+        test_optc1_adi_3d_cavity_eigenfrequency`` will hard-fail (XPASS) when
+        the scheme is fixed, forcing this warning's removal.
+        """
+        if self._solver != "adi" or self._mode != "3d":
+            return
+        _w.warn(
+            PreflightWarning(
+                "solver='adi' with a 3D grid (mode='3d' is the default): the "
+                "3D ADI (LOD) scheme is KNOWN-INACCURATE for physical "
+                "results — the implicit solve is applied to E components "
+                "whose curl has no derivative along the sweep axis "
+                "(artificial diffusion). Measured: a lossless 3D PEC cubic "
+                "cavity misses the analytic eigenfrequency by ~41% even at "
+                "2x CFL (~42% over-dissipation at 5x CFL). Use the explicit "
+                "Yee solver (solver='yee') for 3D physics; ADI is validated "
+                "only on the 2D TMz path (mode='2d_tmz', 2% resonance gate).",
+                code="adi_3d_accuracy",
+                severity="warning",
+                source="_validate_cfg_adi_3d_accuracy",
+            ),
+            stacklevel=2,
+        )
 
     def _validate_cfg_lossless_resonator_in_absorber(self, _w) -> None:
         """Warn when EVERY dielectric is perfectly lossless in an open (CPML/

--- a/tests/test_adi_preflight.py
+++ b/tests/test_adi_preflight.py
@@ -1,0 +1,80 @@
+"""Preflight must surface the KNOWN-INACCURATE 3D ADI (LOD) path (W3.8).
+
+``adi_step_3d`` applies the implicit tridiagonal solve to E components whose
+curl has no derivative along the sweep axis — artificial diffusion (OPT-C1):
+a lossless 3D PEC cubic cavity misses the analytic eigenfrequency by ~41%
+even at 2x CFL. The strict-xfail adjudication test lives in
+``test_review_tier1_validation_battery.py::test_optc1_adi_3d_cavity_eigenfrequency``
+(it XPASSes when the scheme is fixed, forcing removal of this warning).
+
+This file locks the user-facing preflight warning (code ``adi_3d_accuracy``):
+it must fire on ``solver='adi'`` + a 3D grid (note ``mode='3d'`` is the
+constructor DEFAULT, so ``Simulation(solver='adi')`` lands on the inaccurate
+path), and stay silent on the validated 2D TMz path and on the explicit Yee
+solver.
+"""
+
+from __future__ import annotations
+
+from rfx import Simulation
+
+
+def _codes(issues):
+    return {getattr(i, "code", "") for i in issues}
+
+
+def test_adi_3d_fires_accuracy_warning():
+    sim = Simulation(
+        freq_max=5e9, domain=(0.06, 0.06, 0.06), dx=5e-3,
+        boundary="pec", mode="3d", solver="adi",
+    )
+    sim.add_source((0.03, 0.03, 0.03), "ez")
+    sim.add_probe((0.02, 0.02, 0.02), "ez")
+    issues = sim.preflight()
+    assert "adi_3d_accuracy" in _codes(issues), (
+        f"3D ADI must warn (OPT-C1 known inaccuracy); issues: {issues!r}"
+    )
+    severities = {
+        getattr(i, "code", ""): getattr(i, "severity", "")
+        for i in issues
+    }
+    # WARNING severity, not error — 3D ADI must stay runnable for the
+    # stability/divergence tests that characterise it.
+    assert severities["adi_3d_accuracy"] == "warning"
+
+
+def test_adi_default_mode_fires_accuracy_warning():
+    """mode is omitted → constructor default '3d' → must still warn."""
+    sim = Simulation(
+        freq_max=5e9, domain=(0.06, 0.06, 0.06), dx=5e-3,
+        boundary="pec", solver="adi",
+    )
+    sim.add_source((0.03, 0.03, 0.03), "ez")
+    issues = sim.preflight()
+    assert "adi_3d_accuracy" in _codes(issues)
+
+
+def test_adi_2d_tmz_is_silent():
+    sim = Simulation(
+        freq_max=10e9, domain=(0.02, 0.02, 0.01),
+        boundary="pec", mode="2d_tmz", solver="adi",
+    )
+    sim.add_source((0.01, 0.01, 0.0), "ez")
+    sim.add_probe((0.012, 0.01, 0.0), "ez")
+    issues = sim.preflight()
+    assert "adi_3d_accuracy" not in _codes(issues), (
+        f"validated 2D TMz ADI path must NOT warn; issues: {issues!r}"
+    )
+
+
+def test_yee_3d_is_silent():
+    sim = Simulation(
+        freq_max=5e9, domain=(0.06, 0.06, 0.06), dx=5e-3,
+        boundary="pec", mode="3d", solver="yee",
+    )
+    sim.add_source((0.03, 0.03, 0.03), "ez")
+    sim.add_probe((0.02, 0.02, 0.02), "ez")
+    issues = sim.preflight()
+    assert "adi_3d_accuracy" not in _codes(issues), (
+        f"explicit Yee solver must NOT get the ADI warning; issues: {issues!r}"
+    )


### PR DESCRIPTION
## Summary

Roadmap W3.8: the 3D ADI path (`adi_step_3d`) is known-inaccurate (OPT-C1 — the LOD split applies the implicit solve to E components whose curl has no derivative along the sweep axis → artificial diffusion; measured **~41% eigenfrequency miss on a lossless 3D PEC cubic cavity even at 2x CFL**, ~42% over-dissipation at 5x CFL) but shipped behind a strict xfail with **no user-facing warning**. Worse, `mode='3d'` is the constructor default, so plain `Simulation(solver='adi')` lands directly on the inaccurate path silently.

## Changes

- **New preflight validator `_validate_cfg_adi_3d_accuracy`**: WARNING-severity `PreflightWarning` (code `adi_3d_accuracy`) when `solver='adi'` meets a 3D grid. Silent on the validated 2D TMz path (2% cavity-resonance gate) and on the explicit Yee solver. WARNING not error — 3D ADI stays runnable for stability/divergence studies, and agents gate on the code.
- **`Simulation` docstring**: the `solver` parameter now states the 2D-only validation scope and the 3D accuracy bound.
- **`tests/test_adi_preflight.py`**: fires on explicit 3D + on default-mode; silent on 2D TMz + Yee-3D; severity locked to `"warning"`.
- The strict-xfail adjudication test (`test_review_tier1_validation_battery.py::test_optc1_adi_3d_cavity_eigenfrequency`) is **left untouched** as the fix tripwire — it XPASSes when the scheme is fixed, forcing this warning's removal (maintenance note in the validator docstring).

## Verification

`pytest tests/test_adi_preflight.py tests/test_adi.py tests/test_preflight_structured_and_guards.py tests/test_preflight_physics_thresholds.py tests/test_preflight_false_positives.py tests/test_auto_preflight.py tests/test_forward_docstring_contract.py`: **50 passed** (18 slow deselected). `ruff` clean. `support_matrix.md` already lists ADI as outside public support scope — consistent, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)