### PR TITLE
fix(subgrid): material-aware CPML on the subgrid scan bodies — last #205 leg

### DIFF
--- a/rfx/subgridding/jit_runner.py
+++ b/rfx/subgridding/jit_runner.py
@@ -1818,8 +1818,11 @@ def _make_step_fn(ctx):
                          step=step_idx)
         st_c = update_h(st_c, mats_c, dt, dx_c)
         if use_cpml:
+            # materials= keeps the CPML impedance-matched inside dielectrics
+            # (issue #205; free-space coefficients diverge when a dielectric
+            # overlaps the absorber — same mechanism as #203/#204).
             st_c, cpml_new = apply_cpml_h(st_c, cpml_params, carry["cpml"],
-                                           grid_c, cpml_axes)
+                                           grid_c, cpml_axes, materials=mats_c)
         if use_exterior_owned_z_slab and is_full_xy_z_slab:
             hx_c, hy_c, hz_c = _mask_z_slab_coarse_shadow_all(
                 (st_c.hx, st_c.hy, st_c.hz),
@@ -1946,7 +1949,7 @@ def _make_step_fn(ctx):
         st_c = update_e(st_c, mats_c, dt, dx_c)
         if use_cpml:
             st_c, cpml_new = apply_cpml_e(st_c, cpml_params, cpml_new,
-                                           grid_c, cpml_axes)
+                                           grid_c, cpml_axes, materials=mats_c)
         st_c = apply_pec(st_c)
         if use_pec_mask_c:
             st_c = apply_pec_mask(st_c, pec_mask_c)

--- a/rfx/subgridding/runner.py
+++ b/rfx/subgridding/runner.py
@@ -110,7 +110,11 @@ def run_subgridded(
                          hx=hx_c, hy=hy_c, hz=hz_c,
                          step=jnp.array(step, dtype=jnp.int32))
         st_c = update_h(st_c, mats_c, dt, dx_c)
-        st_c, cpml_state = apply_cpml_h(st_c, cpml_params, cpml_state, grid_c, cpml_axes)
+        # materials= keeps the CPML impedance-matched inside dielectrics
+        # (issue #205; without it the free-space coefficients diverge when a
+        # dielectric overlaps the absorber — same mechanism as #203/#204).
+        st_c, cpml_state = apply_cpml_h(st_c, cpml_params, cpml_state, grid_c, cpml_axes,
+                                        materials=mats_c)
 
         # === Fine grid: H update ===
         st_f = FDTDState(ex=ex_f, ey=ey_f, ez=ez_f,
@@ -120,7 +124,8 @@ def run_subgridded(
 
         # === Coarse grid: E update + CPML + PEC ===
         st_c = update_e(st_c, mats_c, dt, dx_c)
-        st_c, cpml_state = apply_cpml_e(st_c, cpml_params, cpml_state, grid_c, cpml_axes)
+        st_c, cpml_state = apply_cpml_e(st_c, cpml_params, cpml_state, grid_c, cpml_axes,
+                                        materials=mats_c)
         st_c = apply_pec(st_c)
         if pec_mask_c is not None:
             st_c = apply_pec_mask(st_c, pec_mask_c)

--- a/tests/test_subgrid_cpml_dielectric.py
+++ b/tests/test_subgrid_cpml_dielectric.py
@@ -1,0 +1,88 @@
+"""Regression: material-aware CPML on the subgrid scan bodies (issue #205, last leg).
+
+The subgrid coarse-grid scan bodies (``rfx/subgridding/jit_runner.py`` — the
+``Simulation.add_refinement`` API lane — and the eager
+``rfx/subgridding/runner.py``) called ``apply_cpml_h/e`` WITHOUT ``materials=``,
+so the absorber used free-space eps_0/mu_0 coefficients regardless of the local
+dielectric. When a dielectric overlaps the CPML region the free-space
+coefficient is eps_r-times too strong and the scan diverges to NaN — the same
+mechanism as the uniform extractor bug (#203/#204), the non-uniform scan body
+(#208), the vmap sweep (#224), and the three distributed runners (#227-#229).
+This was the last remaining CPML scan body without ``materials=``.
+
+WHY ``validation="research"``: the production subgrid envelope structurally
+rejects every CPML-adjacent configuration (measured 2026-07-03:
+``z_slab_requires_guarded_boundary`` for centered slabs,
+``boundary_terminated_requires_pec_no_cpml`` + ``subgrid_overlaps_absorber``
+for boundary-touching slabs — even all-vacuum with x/y-only CPML). The buggy
+code path is therefore reachable only through the research lane, which this
+test exercises deliberately; it is a divergence regression, not a
+physics-accuracy claim for the experimental subgrid lane.
+
+Witness measured on the pre-fix tree (research lane, dielectric filling the
+domain incl. all x/y CPML faces, z=PEC): eps_r=4 and eps_r=10 both diverge to
+all-NaN, while the vacuum control stays finite and absorbing
+(tail/peak ~1e-2). Post-fix all three are finite and absorbing; the vacuum
+control changes only at float32 round-off (the materials-aware coefficient
+path with all-vacuum arrays differs from the materials=None fallback by
+~6e-8 absolute on ~1e-3-scale fields).
+"""
+
+import numpy as np
+
+from rfx import Box, Simulation
+from rfx.boundaries.spec import Boundary, BoundarySpec
+from rfx.sources.sources import GaussianPulse
+
+
+def _subgrid_dielectric_cpml_sim(eps_r):
+    """Subgrid (z-slab refinement) sim with x/y CPML, z PEC, and a dielectric
+    filling the entire domain — every x/y CPML cell is dielectric, forcing
+    absorption through dielectric-filled CPML on the coarse grid."""
+    lz = 0.016
+    sim = Simulation(
+        freq_max=10e9, domain=(0.02, 0.02, lz), dx=1.0e-3,
+        boundary=BoundarySpec(
+            x=Boundary(lo="cpml", hi="cpml"),
+            y=Boundary(lo="cpml", hi="cpml"),
+            z=Boundary(lo="pec", hi="pec"),
+        ),
+        cpml_layers=5,
+    )
+    sim.add_refinement((0.0, 0.006), ratio=2, validation="research")
+    if eps_r is not None:
+        sim.add_material("diel", eps_r=eps_r)
+        sim.add(Box((-1.0, -1.0, -1.0), (1.0, 1.0, 1.0)), material="diel")
+    sim.add_source((0.010, 0.010, 0.003), "ez",
+                   waveform=GaussianPulse(f0=4e9, bandwidth=0.7))
+    sim.add_probe((0.015, 0.010, 0.003), "ez")
+    return sim
+
+
+def test_subgrid_cpml_dielectric_stable_and_absorbing():
+    """Subgrid coarse-grid CPML in a dielectric-filled domain must stay finite
+    and absorb. Pre-fix (free-space CPML coefficients in the dielectric) this
+    diverged to all-NaN at eps_r=4 and eps_r=10 (issue #205)."""
+    for eps_r in (4.0, 10.0):
+        res = _subgrid_dielectric_cpml_sim(eps_r).run(n_steps=1500)
+        ts = np.abs(np.asarray(res.time_series).reshape(-1))
+        assert ts.size > 0
+        assert np.all(np.isfinite(ts)), \
+            f"subgrid CPML diverged (non-finite) in eps_r={eps_r} dielectric (issue #205)"
+        peak = float(ts.max())
+        tail = float(ts[-150:].max())
+        assert tail <= 0.05 * peak, \
+            f"subgrid CPML did not absorb (eps_r={eps_r}): tail/peak={tail / max(peak, 1e-30):.3e}"
+
+
+def test_subgrid_cpml_vacuum_control_still_absorbing():
+    """Vacuum control: the materials-aware coefficient path with all-vacuum
+    arrays must behave like the old materials=None fallback (same finite,
+    absorbing run — only float32 round-off moves)."""
+    res = _subgrid_dielectric_cpml_sim(None).run(n_steps=1500)
+    ts = np.abs(np.asarray(res.time_series).reshape(-1))
+    assert np.all(np.isfinite(ts))
+    peak = float(ts.max())
+    tail = float(ts[-150:].max())
+    assert tail <= 0.05 * peak, \
+        f"subgrid vacuum CPML control regressed: tail/peak={tail / max(peak, 1e-30):.3e}"


### PR DESCRIPTION
## Summary

Closes #205 — the last remaining CPML scan body without `materials=`. The subgrid coarse-grid scan bodies (`rfx/subgridding/jit_runner.py`, the `add_refinement` API lane, plus the eager `rfx/subgridding/runner.py`) applied CPML with free-space ε₀/μ₀ coefficients regardless of the local dielectric — ε_r-times too strong inside a dielectric → exponential divergence. Same mechanism and same one-kwarg fix as the six previously fixed legs (#204 uniform, #208 non-uniform, #224 vmap, #227–#229 distributed).

## Witness (measured, evidence-before-defaults)

Research lane, dielectric filling the domain incl. all x/y CPML faces (z = PEC), 2026-07-03 on main:

| case | pre-fix | post-fix |
|---|---|---|
| vacuum control | finite, tail/peak 1.05e-2 | unchanged to float32 round-off |
| ε_r = 4 | **all-NaN** | finite, tail/peak 5.2e-3 |
| ε_r = 10 | **all-NaN** | finite, tail/peak 2.4e-2 |

Measured coefficient-path delta for the vacuum case (vacuum-`materials` vs `materials=None`): 2.3e-10 (H) / 6.0e-8 (E) on 1e-3-scale fields — round-off only.

## Reachability (measured, not assumed)

The production subgrid validation envelope structurally rejects every CPML-adjacent configuration (`z_slab_requires_guarded_boundary`; `boundary_terminated_requires_pec_no_cpml` + `subgrid_overlaps_absorber` even for all-vacuum x/y-only CPML). The bug was therefore latent behind `validation="research"` — but that lane is a shipped, runnable path, and the wiring now matches every other CPML scan body. The regression test uses the research lane deliberately, with the justification in its docstring; it is a divergence regression, not a physics-accuracy claim for the experimental subgrid lane.

## Verification

- **Revert-proof**: `tests/test_subgrid_cpml_dielectric.py` FAILS on the pre-fix code (divergence at ε_r=4) and passes post-fix (2 tests, ~21 s).
- Existing subgrid family (`test_sbp_sat_jit`, `test_subgrid_jit_*`, `test_subgrid_material_zhi_eps_blend`, `test_subgrid_crossval`): **23 passed** post-fix — no golden moved on the round-off delta.
- `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)