### PR TITLE
fix(sparams): route multi-port wire run() through the scan driver (item-5 Stage 4, audit P5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — multi-port wire `run(compute_s_params=True)` S-matrix (item-5 Stage 4)
+
+- Multi-port wire ports now return the FULL S-matrix from `run(compute_s_params=True)`
+  on a uniform mesh. Previously the uniform fast-path filled only the diagonal
+  `S[j,j]` and silently dropped the off-diagonal (a 2-port wire `S21` came out
+  identically `0`); multi-port wire now routes through the production-scan driver
+  (`compute_lumped_wire_s_matrix_via_scan`), which fills the full matrix. The
+  well-conditioned single-port wire fast-path is unchanged.
+- **Behaviour change**: a MIXED lumped + wire port set with `compute_s_params=True`
+  now raises `NotImplementedError` (their wave-decomposition conventions differ)
+  instead of silently returning a wire-only diagonal matrix that dropped the
+  lumped ports. Use a homogeneous all-lumped or all-wire port set.
+- The eager `extract_s_matrix_wire` is no longer on the `run()` hot path (kept for
+  diagnostics / openEMS-crossval tooling), removing the last hand-maintained
+  second-FDTD-loop drift-class root (siblings of #203/#205/#206).
+
 ### Added — MSL S-parameters on non-uniform meshes (PRs #238, #239)
 
 - `compute_msl_s_matrix()` now runs on non-uniform (`dz_profile`/`dx_profile`/

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -670,8 +670,8 @@ def run_uniform(
             sim, s_param_freqs, n_steps=sp_n_steps,
         )
 
-        # Passivity self-check (tracer-safe) — surface non-physical |S11|>1 from
-        # the single-cell lumped/wire extractor, matching forward() and
+        # Passivity self-check (tracer-safe) — surface non-physical |S|>1 in the
+        # driver-extracted lumped/wire S-matrix, matching forward() and
         # compute_*_s_matrix (which previously had no such check on this path).
         if s_params is not None:
             from rfx.probes.probes import warn_if_nonpassive_lumped_s11

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -10,7 +10,7 @@ from rfx.simulation import (
     run as _run, run_until_decay as _run_until_decay,
 )
 from rfx.sources.sources import LumpedPort, setup_lumped_port, WirePort, setup_wire_port
-from rfx.probes.probes import extract_s_matrix, extract_s_matrix_wire, init_dft_plane_probe, init_flux_monitor
+from rfx.probes.probes import init_dft_plane_probe, init_flux_monitor
 from rfx.sources.waveguide_port import (
     extract_waveguide_sparams,
     waveguide_plane_positions,
@@ -605,35 +605,41 @@ def run_uniform(
     s_params = None
     freqs_out = None
 
-    if compute_s_params and wire_ports and sim_result.wire_port_sparams:
-        # Extract S-params from JIT-accumulated DFTs (100x faster)
-        # NOTE: The JIT scan body accumulates V/I after source injection.
-        # For accurate S-params the Python-loop path
-        # (extract_s_matrix_wire) should be preferred; this fast path
-        # gives a usable but less accurate approximation.
+    _single_wire_fastpath = (
+        compute_s_params
+        and wire_ports
+        and not lumped_ports
+        and len(wire_ports) == 1
+        and bool(sim_result.wire_port_sparams)
+    )
+
+    if _single_wire_fastpath:
+        # SINGLE-port wire fast-path: the JIT main-scan V/I accumulators give
+        # the complete 1-port S-matrix (diagonal IS the full matrix), and this
+        # path is BETTER-CONDITIONED than the per-drive driver on lossless PEC
+        # cavities — it stays passive and byte-close to forward() in-band (the
+        # keystone contract in tests/test_run_forward_s11_contract.py). It is
+        # kept ONLY for the single-port case; MULTI-port wire routes through the
+        # driver below because this diagonal-only fill silently drops the
+        # off-diagonal S[i,j] (a 2-port wire S21 came out identically 0).
         n_wp = len(wire_ports)
         if s_param_freqs is None:
-            s_param_freqs = wire_ports[0].excitation.f0  # placeholder
-            # Use freqs from the first wire port spec
-            for wp_meta, accs in sim_result.wire_port_sparams:
+            for wp_meta, _accs in sim_result.wire_port_sparams:
                 s_param_freqs = np.array(wp_meta.freqs)
                 break
         freqs_out = np.array(s_param_freqs)
         n_freqs = len(freqs_out)
         S = np.zeros((n_wp, n_wp, n_freqs), dtype=np.complex64)
-
         for j, (wp_meta, accs) in enumerate(sim_result.wire_port_sparams):
             v_dft, i_dft, _ = accs
             z0 = wp_meta.impedance
-            # Wave decomposition with FDTD sign convention (V = -E·dx)
+            # Wave decomposition with FDTD sign convention (V = -E·dx).
             a_j = (-v_dft + z0 * i_dft) / (2.0 * np.sqrt(z0))
             safe_a = jnp.where(jnp.abs(a_j) > 0, a_j, jnp.ones_like(a_j))
             b_j = (-v_dft - z0 * i_dft) / (2.0 * np.sqrt(z0))
             S[j, j, :] = np.array(b_j / safe_a)
-
         s_params = S
     elif compute_s_params and (lumped_ports or wire_ports):
-        # Fall back to Python-loop extraction
         if s_param_freqs is None:
             s_param_freqs = jnp.linspace(
                 sim._freq_max / 10, sim._freq_max, 50,
@@ -644,34 +650,28 @@ def run_uniform(
         # extraction runs long enough for high-Q cavities to ring down.
         sp_n_steps = s_param_n_steps if s_param_n_steps is not None else n_steps
 
-        if wire_ports:
-            s_params = extract_s_matrix_wire(
-                grid, base_materials, wire_ports, s_param_freqs,
-                n_steps=sp_n_steps,
-                boundary=sim._boundary,
-                debye_spec=debye_spec,
-                lorentz_spec=lorentz_spec,
-                pec_mask=pec_mask,
-            )
-        else:
-            # item-5 Stage 3 (reroute-only): the LUMPED run() path now goes
-            # through the production-scan driver (= forward()'s graph) instead
-            # of the eager extract_s_matrix loop. The eager extractors are KEPT
-            # (diagnostics / openEMS-crossval tooling) but are no longer on the
-            # run() hot path. Consequence: run()-lumped now inherits forward()'s
-            # band-edge non-physical |S11|>1 on lossless PEC cavities (it was
-            # better-conditioned on the old eager path); the #210 passivity
-            # warning below correctly surfaces those unreliable band-edge bins.
-            # CPML run()-lumped stays byte-close (driver↔eager ~1e-6..1.5e-3).
-            from rfx.probes.sparam_driver import (
-                compute_lumped_wire_s_matrix_via_scan,
-            )
-            s_params, _ = compute_lumped_wire_s_matrix_via_scan(
-                sim, s_param_freqs, n_steps=sp_n_steps,
-            )
+        # item-5 Stage 4 (2026-07-03): lumped AND multi-port wire run() paths go
+        # through the production-scan driver (= forward()'s graph). Stage 3
+        # (#214) rerouted only lumped; this completes it for MULTI-port wire, so
+        # the eager extract_s_matrix / extract_s_matrix_wire loops are OFF the
+        # run() hot path (the #203/#205/#206 config-drift-class root — a
+        # hand-maintained second FDTD loop). They are KEPT for diagnostics /
+        # openEMS-crossval tooling. For multi-port wire this also FIXES the
+        # latent off-diagonal drop of the single-port fast-path above (its
+        # diagonal-only fill returned S21 = 0; the driver's
+        # decompose_wire_s_matrix fills the full N-port matrix, byte-close to
+        # the eager extractor on CPML — tests/test_sparam_driver_matches_eager).
+        # (The well-conditioned single-port wire case stays on the fast-path so
+        # the run()↔forward() PEC contract is preserved.)
+        from rfx.probes.sparam_driver import (
+            compute_lumped_wire_s_matrix_via_scan,
+        )
+        s_params, _ = compute_lumped_wire_s_matrix_via_scan(
+            sim, s_param_freqs, n_steps=sp_n_steps,
+        )
 
         # Passivity self-check (tracer-safe) — surface non-physical |S11|>1 from
-        # the eager single-cell lumped/wire extractor, matching forward() and
+        # the single-cell lumped/wire extractor, matching forward() and
         # compute_*_s_matrix (which previously had no such check on this path).
         if s_params is not None:
             from rfx.probes.probes import warn_if_nonpassive_lumped_s11


### PR DESCRIPTION
## Summary

Audit P5 / item-5 Stage 4 — completes the wire leg of the lumped/wire consolidation (Stage 3 #214 did lumped). Removes the eager `extract_s_matrix_wire` (a hand-maintained second FDTD loop = the #203/#205/#206 config-drift-class root) from the `run(compute_s_params=True)` hot path, and **fixes a latent multi-port bug** on the way.

## Two things this does

1. **Drift-class hygiene**: multi-port wire `run()` now routes through `compute_lumped_wire_s_matrix_via_scan` (the production scan = `forward()`'s graph), byte-close to the eager extractor on CPML (`test_sparam_driver_matches_eager`, atol 2e-3). `extract_s_matrix_wire` is off the hot path (kept for diagnostics/openEMS tooling; unused import dropped).
2. **Latent multi-port fix**: the uniform JIT fast-path filled only the diagonal `S[j,j]` and **silently dropped the off-diagonal** — a 2-port uniform wire `S21` came out identically `0`. `run()` now returns the full matrix (`S21 = 1.57e-4`, byte-identical to the driver). (The nonuniform runner already had the off-diagonal decomposition.)

## Why HYBRID, not a blanket reroute (R5/R2-tight)

Routing **all** wire through the driver broke the keystone `run()`/`forward()` contract (`test_run_forward_s11_contract`): run()-wire PEC went non-passive (`max|S11| 1.0079`) and diverged from `forward()` by `0.064` at 7 GHz.

Per-bin inspection: the divergence is **systematic/monotone** (0.006→0.064 through 1→7 GHz), and the driver's diagonal formula `(Z_in−Z0)/(Z_in+Z0)` (`Z_in=−V/I`) is **algebraically identical** to `forward()`'s `extract_lumped_s11` `(V+Z0·I)/(V−Z0·I)`. So it is **float32 graph-conditioning** on the ill-conditioned lossless-PEC V/I ratio (the driver's per-drive scan rounds differently than the better-conditioned main-scan fast-path), **not a formula bug**. Forcing the test green would launder that gap — the test's own docstring forbids "forcing bit-equality".

**Resolution**: keep the well-conditioned main-scan fast-path for the **single-port** wire case (diagonal *is* the full 1-port matrix → preserves the contract + trustworthy passivity); route **multi-port** wire (where the fast-path is genuinely wrong) through the driver. Not a compromise on either goal.

## Verification

Full wire/lumped/sparam/nonuniform suite: **64 passed** (`test_run_forward_s11_contract` 3/3, `test_twoport_wire_port`, `test_sparam_driver_matches_eager`, cpml-dielectric, passivity-warn, periodic-guard, preflight-parity, nonuniform-grad). `ruff` clean.

## Scope-fenced (honest)

`forward()`-wire still uses `extract_lumped_s11` at `_execute.py:988` — for single-port it is algebraically the same as the driver's diagonal, and the PEC run/forward divergence is float32 conditioning, not a formula bug, so **no forward() change is owed**. Making forward()-wire use `decompose_wire_s_matrix` would be an AD-path change (forward = the differentiable moat) for a separate session. The 3b full-delete of the eager extractors stays DROPPED (public API + openEMS scripts depend on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)