### PR TITLE
feat(coax): make the coaxial reflection extractor AD-traceable (dual-path)

### DIFF
--- a/docs/guides/sparameter_support_matrix.json
+++ b/docs/guides/sparameter_support_matrix.json
@@ -305,7 +305,7 @@
         "The openEMS coax-line path is superseded because the available openEMS v0.0.35 lacks AddCoaxialPort; MEEP is the retained broad-E4 external comparison"
       ],
       "ad_traceable": "no",
-      "ad_evidence": "empirically verified TracerArrayConversionError through coaxial_line_reflection_from_plane_voltages (numpy matrix-pencil): tests/test_ad_surface_contract.py::test_coaxial_reflection_extraction_breaks_tape"
+      "ad_evidence": "Method-level not-traceable: compute_coaxial_line_reflection concretizes the DFT fields in coaxial_line_plane_voltage and exposes no traced design DoF. The reflection EXTRACTOR (coaxial_line_reflection_from_plane_voltages) is now jax.numpy-traceable (tests/test_ad_surface_contract.py::test_coaxial_reflection_extraction_is_traceable + tests/test_coaxial_line_extraction.py AD-vs-FD/closed-form gates); end-to-end differentiable coax design is a separate feature."
     },
     {
       "primitive": "add_floquet_port(...)",

--- a/rfx/sources/coaxial_port.py
+++ b/rfx/sources/coaxial_port.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -1508,6 +1509,62 @@ def coaxial_line_plane_voltage(
     return np.asarray(res.vi.voltage, dtype=np.complex128)
 
 
+def _coaxial_line_reflection_jnp(
+    z, plane_voltages, *, reference_plane_m, D, z0, load_below
+) -> CoaxialLineReflection:
+    """``jax.numpy`` core of :func:`coaxial_line_reflection_from_plane_voltages`.
+
+    Reached ONLY for *traced* voltages (``jax.grad`` / ``jax.jit``); the concrete
+    path stays in NumPy (float64) so the validated-precision residual gates are
+    byte-identical. ``z`` / ``D`` / ``z0`` / ``load_below`` are static geometry
+    (plain Python / NumPy) — only ``plane_voltages`` carries the tape. Singular
+    points (all-zero field, zero incident wave) use double-``where`` so the
+    gradient stays finite at a perfect match / null.
+    """
+    V = jnp.asarray(plane_voltages)
+    Vm, Vc, Vp = V[:-2], V[1:-1], V[2:]
+    den = jnp.sum(jnp.abs(Vc) ** 2)
+    safe_den = jnp.where(den > 0.0, den, 1.0)          # AD-safe divide (all-zero field)
+    p = jnp.sum((Vm + Vp) * jnp.conj(Vc)) / safe_den
+    gamma = jnp.arccosh(p / 2.0 + 0j) / D
+    gamma = jnp.where(jnp.imag(gamma) < 0.0, jnp.conj(gamma), gamma)  # enforce beta > 0
+    rec_arg = jnp.sum(jnp.abs((Vm + Vp) - p * Vc) ** 2) / (jnp.abs(p) ** 2 * den + 1e-300)
+    rec_ok = rec_arg > 0.0
+    rec_resid = jnp.where(rec_ok, jnp.sqrt(jnp.where(rec_ok, rec_arg, 1.0)), 0.0)
+
+    zc = jnp.asarray(z) - z0
+    Phi = jnp.stack([jnp.exp(+gamma * zc), jnp.exp(-gamma * zc)], axis=1)
+    AB, *_ = jnp.linalg.lstsq(Phi, V, rcond=None)
+    A, B = AB[0], AB[1]
+    resid = Phi @ AB - V
+    # AD-safe norm (double-where): a perfect fit makes the residual exactly 0,
+    # where d(sqrt)/dx = inf; symmetric with rec_resid above.
+    fit_sq = jnp.sum(jnp.abs(resid) ** 2)
+    fit_ok = fit_sq > 0.0
+    fit_num = jnp.where(fit_ok, jnp.sqrt(jnp.where(fit_ok, fit_sq, 1.0)), 0.0)
+    fit_resid = fit_num / (jnp.sqrt(jnp.sum(jnp.abs(V) ** 2)) + 1e-300)
+
+    zr = reference_plane_m - z0
+    a_wave = A * jnp.exp(+gamma * zr)    # travels -z
+    b_wave = B * jnp.exp(-gamma * zr)    # travels +z
+    if load_below:
+        v_inc, v_ref = a_wave, b_wave
+    else:
+        v_inc, v_ref = b_wave, a_wave
+    inc_ok = jnp.abs(v_inc) > 0.0
+    reflection = jnp.where(
+        inc_ok, v_ref / jnp.where(inc_ok, v_inc, 1.0), jnp.asarray(jnp.nan + 1j * jnp.nan)
+    )
+    return CoaxialLineReflection(
+        gamma=gamma,
+        reflection=reflection,
+        recurrence_residual=rec_resid,
+        fit_residual=fit_resid,
+        forward_amp=v_inc,
+        backward_amp=v_ref,
+    )
+
+
 def coaxial_line_reflection_from_plane_voltages(
     plane_positions_m,
     plane_voltages,
@@ -1532,20 +1589,50 @@ def coaxial_line_reflection_from_plane_voltages(
     plane_voltages : (N,) complex modal voltages at those planes (one frequency).
     reference_plane_m : axial position at which Γ is reported (the load plane);
         may lie outside the probe span (the two-wave model is extrapolated).
+
+    AD note
+    -------
+    ``Γ`` is differentiable w.r.t. the modal ``plane_voltages``: *traced* inputs
+    (``jax.grad`` / ``jax.jit``) run a ``jax.numpy`` core
+    (:func:`_coaxial_line_reflection_jnp`), while *concrete* inputs keep the
+    NumPy (float64) path so the validated-precision residual gates stay
+    byte-identical. Plane *positions* are static geometry. This is an
+    ``extractor``-level AD property; the enclosing
+    ``Simulation.compute_coaxial_line_reflection`` method is NOT yet end-to-end
+    differentiable (it concretizes the DFT fields in ``coaxial_line_plane_voltage``
+    and exposes no traced design DoF). Verified by
+    ``tests/test_ad_surface_contract.py::test_coaxial_reflection_extraction_is_traceable``
+    and ``tests/test_coaxial_line_extraction.py``.
     """
 
     z = np.asarray(plane_positions_m, dtype=np.float64)
-    V = np.asarray(plane_voltages, dtype=np.complex128)
     if z.ndim != 1 or z.size < 3:
         raise ValueError("plane_positions_m must be 1-D with at least 3 planes")
-    if V.shape != z.shape:
-        raise ValueError(f"plane_voltages shape {V.shape} must match positions {z.shape}")
+    if np.shape(plane_voltages) != z.shape:
+        raise ValueError(
+            f"plane_voltages shape {np.shape(plane_voltages)} must match positions {z.shape}"
+        )
     d = np.diff(z)
     if np.any(d <= 0.0):
         raise ValueError("plane_positions_m must be strictly increasing")
     D = float(d.mean())
     if np.any(np.abs(d - D) > spacing_rtol * D):
         raise ValueError("plane_positions_m must be equally spaced for the matrix pencil")
+    z0 = float(z.mean())
+    # Reference (load) plane side vs the probe centroid; ``<=`` keeps the tie
+    # case (load exactly at the probe mean — not a valid one-port geometry) on
+    # the load-below branch deterministically. Static (positions only).
+    load_below = bool(reference_plane_m <= z0)
+
+    # Traced voltages -> jax.numpy core (differentiable); concrete -> NumPy.
+    if isinstance(plane_voltages, jax.core.Tracer):
+        return _coaxial_line_reflection_jnp(
+            z, plane_voltages, reference_plane_m=float(reference_plane_m),
+            D=D, z0=z0, load_below=load_below,
+        )
+
+    # --- concrete path: NumPy (float64), byte-identical to the pre-AD code ---
+    V = np.asarray(plane_voltages, dtype=np.complex128)
 
     # Matrix-pencil estimate of p = 2 cosh(γΔ) (LS over interior planes).
     Vm, Vc, Vp = V[:-2], V[1:-1], V[2:]
@@ -1566,22 +1653,15 @@ def coaxial_line_reflection_from_plane_voltages(
     )
 
     # Two-wave least squares for A, B (centred for conditioning).
-    z0 = float(z.mean())
     Phi = np.stack([np.exp(+gamma * (z - z0)), np.exp(-gamma * (z - z0))], axis=1)
     AB, *_ = np.linalg.lstsq(Phi, V, rcond=None)
     A, B = complex(AB[0]), complex(AB[1])
     fit_resid = float(np.linalg.norm(Phi @ AB - V) / (np.linalg.norm(V) + 1e-300))
 
-    # The reference (load) plane lies OUTSIDE the probe span for a one-port
-    # measurement (the probes sit between the source and the load). The incident
-    # wave travels from the probe region toward the load, selected by which side
-    # of the probe centroid the load is on. ``<=`` keeps the centroid-tie case
-    # (load exactly at the probe mean — not a valid one-port geometry) on the
-    # load-below branch deterministically rather than silently inverting it.
     zr = float(reference_plane_m) - z0
     a_wave = A * np.exp(+gamma * zr)    # travels -z
     b_wave = B * np.exp(-gamma * zr)    # travels +z
-    if reference_plane_m <= z0:         # load below the probes: incident is -z (a_wave)
+    if load_below:                      # load below the probes: incident is -z (a_wave)
         v_inc, v_ref = a_wave, b_wave
     else:                               # load above the probes: incident is +z (b_wave)
         v_inc, v_ref = b_wave, a_wave

--- a/scripts/diagnostics/port_external_reference_requirements.json
+++ b/scripts/diagnostics/port_external_reference_requirements.json
@@ -166,9 +166,9 @@
         "tests/fixtures/coax_broad_e5/coaxial_line_broad_e5_envelope.json"
       ],
       "ad_fd_test": null,
-      "ad_fd_test_note": "extractor is numpy / not-traceable (test_ad_surface_contract::test_coaxial_reflection_extraction_breaks_tape proves it breaks the tape); no AD-vs-FD test BY DESIGN -> the differentiable moat is unavailable and MUST be resolved (e.g. a differentiable reflection path) before broad_e5_passed.",
+      "ad_fd_test_note": "The reflection EXTRACTOR (coaxial_line_reflection_from_plane_voltages) is now jax.numpy-traceable (test_ad_surface_contract::test_coaxial_reflection_extraction_is_traceable + tests/test_coaxial_line_extraction.py AD-vs-FD/closed-form gates). BUT the compute_coaxial_line_reflection METHOD is not end-to-end differentiable (numpy DFT-field line integral in coaxial_line_plane_voltage + no traced design DoF), so a method-level AD-vs-FD test is not yet expressible and ad_fd_test stays null; the differentiable moat is still unavailable and MUST be resolved (differentiable field->voltage chain + a traced design DoF) before broad_e5_passed.",
       "target_ceiling": "broad-E5-needs-differentiable-api",
-      "usage_rule": "Coaxial transmission-line reflection (forward). broad-E5 PHYSICS demonstrated but blocked: evidence uncommitted (.omx) AND the numpy matrix-pencil extractor is not-traceable so it cannot satisfy the AD moat. Needs committed artifacts + a differentiable reflection API. Do NOT use in an optimization/AD loop."
+      "usage_rule": "Coaxial transmission-line reflection (forward). broad-E5 PHYSICS demonstrated + broad-E4/E5 evidence artifacts committed (tests/fixtures/coax_broad_e4, coax_broad_e5), but blocked: the compute_coaxial_line_reflection METHOD is not end-to-end differentiable (numpy field->voltage chain + no traced design DoF) so it cannot satisfy the AD moat. The reflection extractor itself is now AD-traceable. Needs an end-to-end differentiable reflection path before broad_e5_passed. Do NOT use in an optimization/AD loop."
     },
     {
       "family": "floquet_port",

--- a/tests/test_ad_surface_contract.py
+++ b/tests/test_ad_surface_contract.py
@@ -66,8 +66,12 @@ AD_CLASSIFICATION = {
     ),
     "Simulation.compute_coaxial_line_reflection": (
         NOT_TRACEABLE,
-        "numpy matrix-pencil extraction; verified empirically by "
-        "test_coaxial_reflection_extraction_breaks_tape in this file",
+        "method-level: concretizes the DFT fields in coaxial_line_plane_voltage "
+        "(np.asarray) and exposes no traced design DoF, so grad(S) w.r.t. a design "
+        "variable is not wired. The reflection EXTRACTOR "
+        "(coaxial_line_reflection_from_plane_voltages) is now jax.numpy-traceable "
+        "— verified empirically by test_coaxial_reflection_extraction_is_traceable "
+        "in this file; end-to-end differentiable coax design is a separate feature",
     ),
     # --- top-level exports --------------------------------------------------
     "compute_error_indicator": (
@@ -178,17 +182,25 @@ def test_grad_safe_evidence_pointers_exist():
             )
 
 
-def test_coaxial_reflection_extraction_breaks_tape():
-    """Empirical basis for the coaxial ``not-traceable`` classification.
+def test_coaxial_reflection_extraction_is_traceable():
+    """The coaxial reflection *extractor* is jax.numpy-traceable.
 
-    The roadmap critic flagged the earlier "coax breaks the tape" claim as
-    digest prose; this test IS the evidence. A synthetic two-wave voltage
-    profile with planted A=theta, B=0.3 must (a) give the planted |B/A| on the
-    concrete path (witness that we exercise the real extractor) and (b) raise
-    TracerArrayConversionError under jax.grad, because
-    ``coaxial_line_reflection_from_plane_voltages`` is numpy (np.asarray /
-    np.linalg.lstsq / complex()). If (b) starts succeeding, the extraction
-    became traceable — upgrade the classification instead of deleting this.
+    Was ``test_coaxial_reflection_extraction_breaks_tape``: the numpy
+    (``np.asarray`` / ``np.linalg.lstsq`` / ``complex()``) extractor concretized
+    traced arrays, so ``coaxial_line_reflection_from_plane_voltages`` raised
+    ``TracerArrayConversionError`` under ``jax.grad``. It now dispatches *traced*
+    voltages to a ``jax.numpy`` core (concrete inputs keep the byte-identical
+    NumPy path). A synthetic two-wave profile with planted ``A=theta``, ``B=0.3``
+    gives ``Γ = B/A = 0.3/theta``, so the closed-form gradient is
+    ``d|Γ|/dtheta = -0.3/theta**2`` — a stronger check than "did not raise".
+
+    Gates: (a) the concrete witness ``|Γ|=0.3/0.7`` is unchanged, (b) ``jax.grad``
+    flows and is finite, (c) the AD gradient matches the closed form.
+
+    SCOPE: this is EXTRACTOR-level. The enclosing
+    ``Simulation.compute_coaxial_line_reflection`` method is still not end-to-end
+    differentiable (numpy DFT-field line integral in ``coaxial_line_plane_voltage``,
+    no traced design DoF), so its ``AD_CLASSIFICATION`` stays ``not-traceable``.
     """
     from rfx.sources.coaxial_port import coaxial_line_reflection_from_plane_voltages
 
@@ -203,12 +215,19 @@ def test_coaxial_reflection_extraction_breaks_tape():
         )
         return jnp.abs(jnp.asarray(res.reflection))
 
+    # (a) concrete witness preserved: |Γ| = |B/A| = 0.3/0.7
     concrete = float(objective(jnp.asarray(0.7)))
     assert abs(concrete - 0.3 / 0.7) < 1e-3, (
         f"concrete witness drifted: |Gamma|={concrete:.6f}, expected ~{0.3/0.7:.6f}"
     )
-    with pytest.raises(jax.errors.TracerArrayConversionError):
-        jax.grad(objective)(jnp.asarray(0.7))
+    # (b) grad flows and is finite (was: TracerArrayConversionError)
+    g = float(jax.grad(objective)(jnp.asarray(0.7)))
+    assert np.isfinite(g), f"gradient is not finite: {g}"
+    # (c) AD gradient matches the closed form d|Γ|/dθ = -0.3/θ²
+    closed_form = -0.3 / 0.7 ** 2
+    assert abs(g - closed_form) < 1e-4, (
+        f"AD grad {g:.8f} != closed form {closed_form:.8f}"
+    )
 
 
 def _collect_nodeids(paths, marker_filter=None):

--- a/tests/test_coaxial_line_extraction.py
+++ b/tests/test_coaxial_line_extraction.py
@@ -6,6 +6,8 @@ calibration (short/open/matched on a real line) lives in the slow_physics
 suite.
 """
 import numpy as np
+import jax
+import jax.numpy as jnp
 import pytest
 
 from rfx.sources.coaxial_port import (
@@ -88,6 +90,51 @@ def test_input_validation():
     # unequal spacing
     with pytest.raises(ValueError):
         extract(np.array([1.0, 2.0, 4.0]) * 1e-3, V, reference_plane_m=0.0)
-    # all-zero voltages
+    # all-zero voltages (concrete path keeps the informative raise)
     with pytest.raises(ValueError):
         extract(z, np.zeros(3, complex), reference_plane_m=0.0)
+
+
+# --- AD-traceability (coax AD-traceable extractor) --------------------------
+# Traced voltages dispatch to a jax.numpy core; concrete voltages keep the
+# byte-identical NumPy path. These gate the differentiable path.
+
+def test_reflection_extractor_grad_matches_closed_form_and_fd():
+    """On a planted two-wave profile V = θ·e^{+jβz} + 0.3·e^{-jβz} the load
+    reflection is Γ = 0.3/θ, so d|Γ|/dθ = -0.3/θ². Gate the AD gradient against
+    BOTH the closed form and a central finite difference."""
+    z = np.linspace(0.002, 0.013, 12)
+
+    def obj(theta):
+        V = theta * jnp.exp(1j * 300.0 * jnp.asarray(z)) + 0.3 * jnp.exp(
+            -1j * 300.0 * jnp.asarray(z)
+        )
+        return jnp.abs(extract(z, V, reference_plane_m=0.0).reflection)
+
+    g = float(jax.grad(obj)(jnp.asarray(0.7)))
+    assert np.isfinite(g), f"gradient not finite: {g}"
+    closed_form = -0.3 / 0.7 ** 2
+    assert abs(g - closed_form) < 1e-4, f"AD {g:.8f} vs closed form {closed_form:.8f}"
+
+    h = 1e-4
+    fd = (float(obj(0.7 + h)) - float(obj(0.7 - h))) / (2 * h)
+    assert abs(g - fd) / max(abs(fd), 1e-12) < 1e-3, f"AD {g:.8f} vs FD {fd:.8f}"
+
+
+def test_reflection_grad_finite_at_reactive_null():
+    """Double-``where`` robustness: a purely reactive |Γ|=1 load — the match/null
+    regime that would leak 0·inf=nan through a naive sqrt/divide — keeps a finite
+    gradient."""
+    z = np.linspace(0.002, 0.013, 12)
+
+    def obj(theta):
+        # B on the unit circle, A=θ  ->  |Γ| = 1/θ  (=1 at θ=1)
+        V = theta * jnp.exp(1j * 150.0 * jnp.asarray(z)) + np.exp(
+            1j * np.radians(120.0)
+        ) * jnp.exp(-1j * 150.0 * jnp.asarray(z))
+        return jnp.abs(extract(z, V, reference_plane_m=0.0).reflection)
+
+    val = float(obj(jnp.asarray(1.0)))
+    g = float(jax.grad(obj)(jnp.asarray(1.0)))
+    assert abs(val - 1.0) < 1e-3, f"|Gamma| not unity: {val}"
+    assert np.isfinite(g), f"gradient not finite at reactive null: {g}"


### PR DESCRIPTION
## What

`coaxial_line_reflection_from_plane_voltages` is now differentiable w.r.t. the modal plane voltages, via a **dual-path** design:

- **Traced** inputs (`jax.grad`/`jax.jit`, detected with `isinstance(v, jax.core.Tracer)`) → new `jax.numpy` core `_coaxial_line_reflection_jnp` with double-`where` at the singular points (all-zero field, zero incident wave, perfect-fit norm).
- **Concrete** inputs → the **unchanged** NumPy (float64) body, so the validated-precision residual gates (`rec_resid < 1e-9`) stay **byte-identical**. Necessary because the test env runs complex64 (no global x64) and loosening those gates for a rewrite is disallowed.

Mirrors the waveguide flux precedent (#148/#172). This closes the coax family's **AD-traceable *extractor*** rung (the P3 follow-on ladder item).

## Scope honesty — coax is **NOT** flipped to `broad_e5_passed`

The established `ad_fd_test` bar (waveguide) differentiates the **full method** w.r.t. a design DoF. But `Simulation.compute_coaxial_line_reflection` still concretizes the DFT fields in `coaxial_line_plane_voltage` (`np.asarray`) **and** exposes no traced design DoF — so end-to-end AD is not expressible without adding a differentiable-design hook + a full jnp field→voltage→assembly chain (a separate, unrequested feature). Therefore:

- `AD_CLASSIFICATION["Simulation.compute_coaxial_line_reflection"]` stays **`not-traceable`** (reason corrected: extractor traceable, method end-to-end AD owed).
- The auditor keeps coax **`blocked`** (`ad_fd_test` stays `null`) — verified below.
- Claiming `broad_e5_passed` here would be the "coax clean-checkout overclaim" the validation-framework audit already flagged; explicitly avoided.

## Changes
- `rfx/sources/coaxial_port.py` — dual-path extractor + jnp core.
- `tests/test_ad_surface_contract.py` — flip `test_coaxial_reflection_extraction_breaks_tape` → `_is_traceable` (asserts `grad == -0.3/θ²` closed form + FD); corrected classification reason.
- `tests/test_coaxial_line_extraction.py` — AD-vs-FD/closed-form gate + reactive-|Γ|=1 double-`where` gate.
- `scripts/diagnostics/port_external_reference_requirements.json`, `docs/guides/sparameter_support_matrix.json` — corrected the now-false "breaks the tape" notes (extractor traceable; method end-to-end AD owed; broad-E4/E5 evidence committed per #256/#259).

## Evidence
- **Concrete parity**: 0.00e+00 byte-identical (reviewer independently confirmed over 2000 random cases).
- **Gradient**: AD vs closed-form −0.3/θ² to 3e-7 (complex64), AD vs FD consistent, reactive-|Γ|=1 null finite.
- **Gates**: 45 + 16 + 56 coax/AD/auditor tests pass; `ruff` clean; auditor `status=blocked incomplete_count=6` (coax unchanged, **no `broad_e5_passed` flip**).
- **Independent code-review: APPROVE** (1 LOW nit — unguarded `fit_residual` sqrt — applied in this branch).

## Follow-on (not in this PR)
End-to-end differentiable `compute_coaxial_line_reflection` (traced design DoF + jnp field→voltage→assembly) is what actually closes `broad_e5_passed` for coax — a separate feature, pending explicit go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)