### PR TITLE
docs(floquet): scope RCWA feasibility + drive-isolation R2-STOP

### DIFF
--- a/rfx/floquet.py
+++ b/rfx/floquet.py
@@ -535,6 +535,22 @@ def compute_floquet_s_params(
         so ``|S11|`` from such a drive can exceed 1. Do not build accuracy
         claims on it. Tracking: https://github.com/bk-squared/rfx/issues/141
 
+        **Drive-isolation scoping (2026-07-05, R2-STOP):** the obvious fix — a
+        two-run empty-vs-device reference subtraction (``E_scat = E_dev −
+        E_empty`` at a +z-side plane, the pattern that works for waveguide/coax
+        ports) — does NOT resolve this for a periodic Floquet cell. On an εr=4
+        slab vs the exact analytic Airy S11, the two-run extraction is
+        non-physical: |S11|≈1.5 at band-center 6 GHz where Airy=0.09 (the ~1.5
+        extraction-error floor swamps the small true reflection) and larger
+        blow-ups at band edges (small-incident normalization noise). TFSF
+        one-way plane-wave sources — the clean isolation route — are explicitly
+        barred with Floquet ports (see ``add_floquet_port``). A real fix needs
+        dedicated numerics (clean incident normalization + higher-order-mode
+        filtering, or a Floquet-compatible one-way source), NOT a parameter
+        flip; and drive-isolation is the PREREQUISITE to any external (RCWA /
+        Meep-Bloch) accuracy validation — the external reference is moot until
+        FDTD yields a physical |S11|≤1 on a real periodic structure.
+
     Uses incident, reflected, and (optionally) transmitted plane
     DFT data to compute S11 (reflection) and S21 (transmission).
 


### PR DESCRIPTION
## What

Scopes the backlog "floquet RCWA" item and documents the honest R2-STOP outcome of a drive-isolation attempt. **Doc-only**, no behavior change.

## The headline: RCWA is not the bottleneck — drive-isolation is

Getting a *physical* |S11|≤1 out of a real periodic structure via FDTD is unsolved. An RCWA (or Meep-Bloch) reference is **moot** until that's fixed.

### Evidence gathered
- **Extraction math is sound** (recovers planted Γ/τ, passive, AD grad==FD) — but only on **synthetic pre-isolated** input. The only real-FDTD validation is the empty-space broadside null (S11≈0), the weakest analytic check.
- **TFSF one-way sources are barred with Floquet ports** (`api:1842`) — the clean isolation route is closed.
- **Prior external VESSL gates (m58/m60) were DOA** on `ModuleNotFoundError: openEMS` — a dependency failure (same pre-#179 state cv05 was in), never actually ran.
- **Two-run reference subtraction attempted + FAILED** (one crude + one careful, with an analytic-Airy falsifier): on an εr=4 slab, `E_dev − E_empty` gives non-physical |S11| — **≈1.5 at band-center 6 GHz where Airy=0.09** (the ~1.5 extraction-error floor swamps the small true reflection), worse at band edges. The waveguide/coax two-run pattern **does not transfer** to periodic Floquet cells. **R2-STOP** — two attempts, not chased.

### Tiered path (if revisited)
- **Tier-0 (real work):** solve drive-isolation — clean incident normalization + higher-order-mode filter, or a Floquet-compatible one-way source (rfx bars TFSF here). R2-tight dedicated session.
- **Tier-A (CPU-local, exact):** once isolated, broad scan-angle × pol × freq envelope vs analytic stratified-slab Airy/Fresnel.
- **Tier-B:** RCWA build or Meep-Bloch external (VESSL, needs the #179 conda-python fix) for **patterned** FSS.

## Change
Adds a drive-isolation scoping note to the `compute_floquet_s_params` docstring so a future implementer doesn't repeat the two-run dead-end. `ruff` clean; contract tests 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)