### PR TITLE
test(waveguide): honest gates for the 4-port parallel-guides test (warns-lock)

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -408,7 +408,32 @@ def test_waveguide_multiport_same_direction_requires_shared_boundary_plane():
 
 
 def test_waveguide_four_port_parallel_guides_through_api():
-    """Disjoint left/right apertures should support a 4-port parallel-guide S-matrix."""
+    """4-port parallel-guide PLUMBING + relative isolation — |S| is NON-PHYSICAL.
+
+    What this test validates: the >2-port assembly plumbing (S shape, port-name
+    ordering) and the within-column RELATIVE isolation (cross-coupling between
+    the two septum-separated guides < through-transmission). Within one driven
+    column every entry shares the same incident-power normalization, so those
+    relative comparisons are meaningful even when the normalization is wrong.
+
+    What it does NOT validate: absolute |S| magnitudes. The interior-PEC septum
+    (``Box(material='pec')``) is stripped from the vacuum reference run, so the
+    guided incident power P_inc is mis-normalized and the extracted S-matrix is
+    NON-PHYSICAL — measured 2026-07-05: max|S| ~ 6.2, per-drive column power up
+    to ~42 (passive requires <= 1), 18/40 (drive, freq) points exceed unity by
+    >5% (34/40 at a strict >1.0). Same root cause as the SKIPPED T-junction
+    test below (see its
+    skip reason + the extract_waveguide_s_matrix_flux docstring): ANY multi-port
+    built from interior PEC (branches, septa, splitters) hits this; only
+    straight guides whose walls are the domain boundary (pec_axes) have a
+    correct vacuum reference. The ``lo_tx/hi_tx > 0.2`` gates below are loose
+    channel-is-alive checks on that inflated scale, NOT calibrated magnitudes.
+
+    The ``pytest.warns`` wrapper LOCKS the known limitation empirically: the
+    extractor's own passivity self-check must fire on this geometry. If a
+    reference-run fix lands and the S-matrix becomes passive, this test FAILS —
+    upgrade it to real magnitude/passivity gates instead of deleting the wrapper.
+    """
     sim = Simulation(
         freq_max=10e9,
         domain=(0.12, 0.10, 0.02),
@@ -430,7 +455,10 @@ def test_waveguide_four_port_parallel_guides_through_api():
     sim.add_waveguide_port(0.09, y_range=(0.00, 0.04), z_range=(0.00, 0.02), direction="-x", name="right_lo", **common)
     sim.add_waveguide_port(0.09, y_range=(0.06, 0.10), z_range=(0.00, 0.02), direction="-x", name="right_hi", **common)
 
-    result = sim.compute_waveguide_s_matrix(num_periods=30)
+    # Interior-PEC vacuum-reference limitation: the extractor's passivity
+    # self-check MUST fire here (locked — see docstring).
+    with pytest.warns(UserWarning, match="passivity"):
+        result = sim.compute_waveguide_s_matrix(num_periods=30)
     S = result.s_params
     assert S.shape == (4, 4, 10)
     assert result.port_names == ("left_lo", "left_hi", "right_lo", "right_hi")
@@ -440,8 +468,10 @@ def test_waveguide_four_port_parallel_guides_through_api():
     cross_lo_to_hi = np.mean(np.abs(S[3, 0, :]))
     cross_hi_to_lo = np.mean(np.abs(S[2, 1, :]))
 
+    # Channel-is-alive (inflated scale — see docstring; NOT calibrated |S|).
     assert lo_tx > 0.2
     assert hi_tx > 0.2
+    # Relative isolation (normalization-independent within a driven column).
     assert cross_lo_to_hi < lo_tx
     assert cross_hi_to_lo < hi_tx
 


### PR DESCRIPTION
## What

Review follow-up to #264 (found while answering "can rfx do multi-port networks like T-junctions?"): the **passing** 4-port parallel-guides test was **false-green** in the same way the *skipped* T-junction test would be. The interior-PEC septum is stripped from the vacuum reference run, so P_inc is mis-normalized and the extracted S-matrix is **non-physical** — measured: max|S|≈6.2, per-drive column power up to **≈42** (passive limit 1), 18/40 (drive,freq) points exceed unity by >5% (34/40 at strict >1.0); rfx's own passivity self-check fires. The test passed anyway because its gates are magnitude-only.

## Change (single file; no gate weakened — all original assertions kept)

- **Docstring**: states exactly what IS validated (>2-port assembly plumbing + within-column **relative** isolation, which is normalization-independent — every entry in a driven column shares the same P_inc, so `cross < tx` is meaningful even when P_inc is wrong) and what is NOT (absolute |S| — same interior-PEC vacuum-reference root cause as the skipped T-junction, see #264).
- **`pytest.warns(UserWarning, match="passivity")`** LOCKS the known limitation empirically: if a reference-run fix lands and the S-matrix becomes passive, this test FAILS and forces an upgrade to real magnitude/passivity gates (the coax `breaks_tape` "upgrade instead of delete" pattern).

## Evidence

**Independent code-review: APPROVE** — reviewer rebuilt the sim and reproduced every load-bearing number (max|S|=6.197, column power 41.94, warning text matches, no pytest `filterwarnings=error` risk, warning deterministic so no flaky false-fail), and confirmed the relative-isolation signal is genuinely physical (cross≈0.01 vs tx≈1.05, ~100× margin). The one LOW nit (threshold-dependence of "18/40") is fixed in the amended commit.

Gates: test passes with the lock active; 44 tests collect; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)