### PR TITLE
chore(sweep): hygiene fixes from the 2026-07-05 multiport capability sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
-### Added — coaxial S-parameters: AD-traceable + end-to-end differentiable + `broad_e5_passed` (PRs #260, #261)
+### Added — coaxial S-parameters: AD-traceable + end-to-end differentiable + `broad_e5_passed` (PRs #260, #261, #262)
 
 - `compute_coaxial_line_reflection(...)` is now **end-to-end differentiable** via a new
   `eps_scale` design channel: `grad(|S11|**2)` w.r.t. the dielectric flows through

--- a/docs/guides/support_matrix.json
+++ b/docs/guides/support_matrix.json
@@ -47,7 +47,7 @@
         "waveguide_port": "shadow_te10_single_mode: normalize=True/'flux' validated at settled num_periods; broad-E5-ANALYTIC envelope committed+gated (graded-dy 1-3x, eps_r 2/4, vs analytic Airy, 16/16<=0.0157); NOT claims-bearing (broad-E4 external cross-solver + AD-traceability pending); other combinations hard_fail",
         "lumped_rlc": "hard_fail",
         "lumped_port_sparameters": "hard_fail",
-        "msl_s_matrix": "hard_fail",
+        "msl_s_matrix": "laplace lane RUNS since PR #239 (mode='laplace' quasi-TEM accepted on the graded mesh; internally gated by tests/test_msl_nu_sparam_gate.py, gpu+slow — externally UNVALIDATED, not claims-bearing); mode='eigenmode' hard_fail (falsified dead-end, raises NotImplementedError)",
         "coaxial_port": "hard_fail"
       },
       "resolved_combinations": {

--- a/tests/test_coax_broad_e5_envelope_gates.py
+++ b/tests/test_coax_broad_e5_envelope_gates.py
@@ -27,10 +27,14 @@ which runs the production extractor against short/open/matched/resistive
 analytic gates at CI time.
 
 Scope honesty: this fixture is the rfx-vs-analytic E5 ENVELOPE class only.
-The independent full-wave broad-E4 comparison (Meep) and the AD-traceable
-extractor requirement (``ad_fd_test`` is null BY DESIGN in the manifest)
-remain OWED before any ``broad_e5_passed`` promotion — committing this
-fixture does not flip the family status.
+At commit time (PR #256) the independent broad-E4 Meep comparison and the
+AD-traceable extractor were still owed and this fixture alone did not flip
+the family status. Both have SINCE been delivered — the Meep broad-E4
+fixture (``tests/fixtures/coax_broad_e4/``, PR #259), the AD-traceable
+extractor + end-to-end ``eps_scale`` channel (PRs #260/#261, gated by
+``tests/test_coax_end_to_end_ad.py``) — and the family was promoted to
+``broad_e5_passed`` (PR #262). This test remains the envelope-class gate
+WITHIN that promotion; weakening it would undermine the promoted claim.
 """
 from __future__ import annotations
 

--- a/tests/test_sparam_driver_matches_eager.py
+++ b/tests/test_sparam_driver_matches_eager.py
@@ -16,6 +16,7 @@ a failure, not a fix (R2-STOP).
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from rfx.api import Simulation
 from rfx.grid import Grid
@@ -156,3 +157,40 @@ def test_driver_matches_eager_wire_1port_cpml():
         f"wire 1-port CPML |S| diverged: max||S_drv|-|S_eager|| = {d:.3e} "
         f">= {_GATE_ATOL}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Mixed lumped + wire set — locked NotImplementedError (#258 behaviour change)
+# ---------------------------------------------------------------------------
+
+def _mixed_lumped_wire_sim():
+    """One lumped + one wire port (heterogeneous sparam-eligible set)."""
+    wf = _waveform()
+    sim = _driver_sim()
+    sim.add_port(position=(0.008, 0.006, 0.006), component="ez",
+                 impedance=50.0, waveform=wf)
+    sim.add_port(position=(0.016, 0.006, 0.005), component="ez",
+                 impedance=50.0, waveform=wf, extent=0.003)
+    return sim
+
+
+def test_mixed_lumped_wire_driver_raises():
+    """The driver rejects heterogeneous lumped+wire sets loudly — their
+    off-diagonal wave-decomposition conventions differ
+    (rfx/probes/sparam_driver.py mixed-set guard, PR #258). Before #258,
+    run(compute_s_params=True) on a mixed set silently returned a wire-only
+    diagonal matrix that DROPPED the lumped ports. This locks the guard
+    (it shipped without a test — declared-only surfaces rot)."""
+    sim = _mixed_lumped_wire_sim()
+    with pytest.raises(NotImplementedError, match=r"mixed lumped \+ wire"):
+        compute_lumped_wire_s_matrix_via_scan(sim, _FREQS, n_steps=200)
+
+
+def test_mixed_lumped_wire_run_compute_s_params_raises():
+    """The PUBLIC run(compute_s_params=True) path raises on a mixed set too:
+    the single-wire fast-path requires ``not lumped_ports``
+    (rfx/runners/uniform.py dispatch), so a mixed set routes to the driver
+    and hits the same guard — the #258 behaviour change users actually see."""
+    sim = _mixed_lumped_wire_sim()
+    with pytest.raises(NotImplementedError, match=r"mixed lumped \+ wire"):
+        sim.run(n_steps=200, compute_s_params=True)


### PR DESCRIPTION
## What

Four small honesty/staleness fixes surfaced by the 6-agent multiport capability sweep. **Docs-truth + declared-only-surface class — no gate weakened, no `rfx/` source touched, no behaviour change.**

| # | Fix | Class |
|---|---|---|
| 1 | `docs/guides/support_matrix.json`: NU lane still declared `msl_s_matrix: "hard_fail"`, contradicting shipped code — the NU **laplace** lane RUNS since PR #239 (only `mode='eigenmode'` raises). Updated to the descriptive style the `waveguide_port` entry already uses (runs / internally gated gpu+slow / externally UNVALIDATED, not claims-bearing). | docs-truth |
| 2 | `tests/test_coax_broad_e5_envelope_gates.py` docstring: still said Meep-E4 + AD extractor "remain OWED" and the fixture "does not flip the family status" — both delivered (#259, #260/#261) and the family promoted (#262). Rewritten to record history AND current state; explicitly notes the gate must not be weakened. | stale prose |
| 3 | `tests/test_sparam_driver_matches_eager.py`: the **#258 mixed lumped+wire `NotImplementedError` shipped with NO locking test**. Added two locks: the driver guard directly, and the PUBLIC `run(compute_s_params=True)` path (the single-wire fast-path requires `not lumped_ports`, so a mixed set genuinely reaches the driver guard). | declared-only surface |
| 4 | CHANGELOG coax heading: now lists #262 alongside #260/#261 (the entry already covered the promotion). | one token |

## Verification

- New locks **2 passed** (2.5s); full driver file **5 passed** (3:51); coax envelope gates **6 passed**; `support_matrix.json` parses; ruff clean.
- **Independent code-review: APPROVE, 0 findings** — verified the NU-laplace claim against `compute_msl_s_matrix` (raises only for eigenmode-on-NU), confirmed the plain `support_matrix.json` has **no test/script consumer** (the auditors read `sparameter_support_matrix.json`), confirmed the coax promotion state against the manifest, and confirmed the new locks cannot false-pass (the `match` phrase exists only at the intended guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)