### PR TITLE
test(rcs): exact Mie-series cross-method reference for the PEC-sphere RCS lane (WP 1-A)

### DIFF
--- a/scripts/diagnostics/build_rcs_mie_reference.py
+++ b/scripts/diagnostics/build_rcs_mie_reference.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+"""Build the exact-Mie-series cross-method REFERENCE for rfx's RCS pipeline.
+
+THE REFERENCE QUESTION
+----------------------
+rfx ships an FDTD RCS pipeline (``rfx/rcs.py``, TFSF illumination + NTFF
+transform, Taflove & Hagness Ch. 8-9). Its committed tests
+(``tests/test_rcs.py``) gate the PEC sphere only against the geometrical-optics
+(GO) large-sphere limit ``sigma = pi a^2`` with a generous +/-15 dB tolerance,
+and the PEC plate against a physical-optics (PO) estimate. Neither is an exact
+solution: at ``ka ~ 1`` the true monostatic RCS oscillates well away from the GO
+limit (the first Mie maximum sits ~5.6 dB above ``pi a^2``). There is no exact
+analytic cross-method check in the RCS lane.
+
+The exact conducting-sphere Mie series IS that check. It is a closed-form
+analytic solution (no FDTD, no FEM, no mesh), so it is the strongest possible
+arbiter for the sphere. This script:
+
+  (a) ``mie_pec_backscatter_*`` -- the exact series (pure scipy/numpy), the
+      oracle. Validated against two closed-form anchors: the Rayleigh limit
+      ``sigma/(pi a^2) -> 9 (ka)^4`` as ``ka -> 0`` and the optical limit
+      ``sigma/(pi a^2) -> 1`` as ``ka -> inf``.
+  (b) runner mode -- computes rfx monostatic RCS for a small ``ka`` ladder at
+      TWO grid resolutions (lambda/10 and lambda/15) for a convergence witness,
+      matching the committed ``test_rcs.py`` sphere geometry (radius 15 mm,
+      0.10 m cubic domain, 8 CPML, ez pol, 37 observation angles).
+  (c) fixture-builder mode -- writes
+      ``tests/fixtures/rcs_mie_e4/rcs_pec_sphere_mie.json`` with the raw per-ka
+      rfx values + exact Mie values + errors + meta, so the gate test survives a
+      clean checkout WITHOUT re-running FDTD (the committed reference column is
+      re-derivable from the series by ``tests/test_rcs_mie_reference_gates.py``).
+
+HONEST-ENVELOPE POSTURE
+-----------------------
+A staircased curved-PEC sphere on a Cartesian grid carries an O(dx) surface
+error that refinement narrows but does NOT close (conformal PEC is not wired on
+this path). The deliverable is therefore the MEASURED agreement envelope across
+the ka ladder, not a pre-chosen dB target. We do not enter a refinement loop
+chasing a number; we report the distance rfx sits from the exact series.
+
+Mie backscatter convention (Ruck, Radar Cross Section Handbook, 1970):
+
+    sigma / (pi a^2) = (1/(ka)^2) | sum_{n=1}^inf (-1)^n (2n+1) (a_n - b_n) |^2
+
+with x = ka and PEC Mie coefficients
+
+    a_n = j_n(x) / h_n(x)
+    b_n = [x j_n(x)]' / [x h_n(x)]'        (Riccati-Bessel derivative)
+
+h_n = j_n + i y_n (spherical Hankel, 1st kind); |a_n - b_n| is invariant to the
+Hankel-kind choice, so the RCS magnitude is convention-independent.
+
+Usage::
+
+    python scripts/diagnostics/build_rcs_mie_reference.py            # verdict from fixture
+    python scripts/diagnostics/build_rcs_mie_reference.py --run      # rerun FDTD ladder + rebuild fixture
+    python scripts/diagnostics/build_rcs_mie_reference.py --anchors  # self-validate the Mie oracle
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from scipy.special import spherical_jn, spherical_yn
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FIXTURES = _REPO_ROOT / "tests/fixtures/rcs_mie_e4"
+_FIXTURE = "rcs_pec_sphere_mie.json"
+
+# Committed-test sphere geometry (tests/test_rcs.py::TestRCSPECSphere).
+_RADIUS_M = 0.015
+_DOMAIN_M = 0.10
+_CPML = 8
+_N_THETA = 37
+_POL = "ez"
+
+# ka ladder + the two convergence-witness resolutions (cells per wavelength).
+_KA_LADDER = (0.8, 1.0, 1.5, 2.0)
+_RESOLUTIONS = {"coarse": 10, "fine": 15}
+
+# Domain-robustness witness (R5): at test-scale domains the NTFF box sits only
+# 1-2 wavelengths from the sphere, so the extracted monostatic magnitude is not
+# a converged quantity. We sweep the domain at two ka to record the swing as
+# committed evidence -- a single dBsm number is NOT sufficient (CLAUDE.md R5).
+_DOMAIN_WITNESS_KA = (1.0, 1.5)
+_DOMAIN_WITNESS_M = (0.10, 0.15, 0.20)
+
+
+# --------------------------------------------------------------------------- #
+# (a) The exact Mie oracle (pure scipy/numpy -- no FDTD).
+# --------------------------------------------------------------------------- #
+def mie_pec_backscatter_ratio(ka: float, n_max: int | None = None) -> float:
+    """Exact monostatic RCS of a PEC sphere, normalised: sigma / (pi a^2)."""
+    x = float(ka)
+    if n_max is None:
+        n_max = int(np.ceil(x + 4.05 * x ** (1.0 / 3.0) + 2)) + 15
+    n = np.arange(1, n_max + 1)
+
+    jn = spherical_jn(n, x)
+    jnp_ = spherical_jn(n, x, derivative=True)
+    yn = spherical_yn(n, x)
+    ynp_ = spherical_yn(n, x, derivative=True)
+
+    hn = jn + 1j * yn
+    hnp_ = jnp_ + 1j * ynp_
+
+    a_n = jn / hn                      # electric (TM) coefficient
+    b_n = (jn + x * jnp_) / (hn + x * hnp_)  # magnetic (TE), Riccati-Bessel'
+
+    series = np.sum(((-1.0) ** n) * (2 * n + 1) * (a_n - b_n))
+    return float(np.abs(series) ** 2 / x ** 2)
+
+
+def mie_pec_backscatter_sigma_m2(ka: float, a_radius: float) -> float:
+    """Exact monostatic RCS in m^2."""
+    return mie_pec_backscatter_ratio(ka) * np.pi * a_radius ** 2
+
+
+def mie_pec_backscatter_dbsm(ka: float, a_radius: float) -> float:
+    """Exact monostatic RCS in dBsm."""
+    return float(10.0 * np.log10(mie_pec_backscatter_sigma_m2(ka, a_radius)))
+
+
+def _self_anchor_report() -> None:
+    """Validate the oracle against its two closed-form limits (CHECK-MWE-FIRST)."""
+    print("Rayleigh limit  sigma/(pi a^2) -> 9 (ka)^4 :")
+    for ka in (0.01, 0.02, 0.05):
+        got, want = mie_pec_backscatter_ratio(ka), 9.0 * ka ** 4
+        print(f"  ka={ka:.3f}: got {got:.6e}  target {want:.6e}  ratio {got/want:.5f}")
+    print("Optical limit   sigma/(pi a^2) -> 1 :")
+    for ka in (20.0, 50.0, 100.0):
+        print(f"  ka={ka:6.1f}: {mie_pec_backscatter_ratio(ka):.5f}")
+    print("Canonical curve (first Mie max near ka~1) :")
+    for ka in _KA_LADDER:
+        r = mie_pec_backscatter_ratio(ka)
+        print(f"  ka={ka:.3f}: sigma/(pi a^2)={r:.4f}  ({10*np.log10(r):+.3f} dB rel pi a^2)")
+
+
+# --------------------------------------------------------------------------- #
+# (b) rfx runner -- monostatic RCS at a given ka and resolution.
+# --------------------------------------------------------------------------- #
+def run_rfx_mono(
+    ka: float, cells_per_lambda: int, domain_m: float = _DOMAIN_M
+) -> dict[str, Any]:
+    """Run rfx's RCS pipeline on a PEC sphere at this ka / resolution / domain.
+
+    Fixed physical geometry (radius, CPML, angles) matches the committed
+    ``test_rcs.py`` sphere; ka is swept by frequency, f0 = ka c / (2 pi a). The
+    grid step is lambda/cells_per_lambda; n_steps scales to hold the physical
+    sim duration roughly constant across ka, resolution, and domain size.
+    """
+    import jax.numpy as jnp
+    from rfx.grid import Grid, C0
+    from rfx.geometry.csg import Sphere, rasterize
+    from rfx.core.yee import MaterialArrays
+    from rfx.rcs import compute_rcs
+
+    f0 = ka * C0 / (2.0 * np.pi * _RADIUS_M)
+    lam = C0 / f0
+    dx = lam / cells_per_lambda
+
+    grid = Grid(
+        freq_max=f0 * 1.5,
+        domain=(domain_m, domain_m, domain_m),
+        dx=dx,
+        cpml_layers=_CPML,
+    )
+    center = (domain_m / 2, domain_m / 2, domain_m / 2)
+    sphere = Sphere(center=center, radius=_RADIUS_M)
+    eps_r, sigma = rasterize(grid, [(sphere, 1.0, 1e7)])  # PEC_SIGMA
+    materials = MaterialArrays(
+        eps_r=eps_r, sigma=sigma, mu_r=jnp.ones(grid.shape, dtype=jnp.float32)
+    )
+
+    # Hold physical duration ~ constant: the committed test uses 400 steps at
+    # f0=3 GHz, lambda/10, 0.10 m. dt ~ dx, so steps scale with f0, resolution,
+    # and (to keep the same number of domain crossings) the domain size.
+    n_steps = int(round(
+        400 * (f0 / 3.0e9) * (cells_per_lambda / 10.0) * (domain_m / _DOMAIN_M)
+    ))
+
+    theta_obs = np.linspace(0.01, np.pi - 0.01, _N_THETA)
+    phi_obs = np.array([0.0])
+
+    t0 = time.time()
+    result = compute_rcs(
+        grid, materials, n_steps,
+        f0=f0, bandwidth=0.5, theta_inc=0.0, polarization=_POL,
+        theta_obs=theta_obs, phi_obs=phi_obs, freqs=np.array([f0]),
+        boundary="cpml", cpml_layers=_CPML,
+    )
+    wall = time.time() - t0
+
+    mie_dbsm = mie_pec_backscatter_dbsm(ka, _RADIUS_M)
+    rfx_dbsm = float(result.monostatic_rcs[0])
+    return {
+        "ka": float(ka),
+        "f0_hz": float(f0),
+        "lambda_m": float(lam),
+        "dx_m": float(dx),
+        "cells_per_lambda": int(cells_per_lambda),
+        "domain_m": float(domain_m),
+        "radius_cells": float(_RADIUS_M / dx),
+        "grid_shape": [int(s) for s in grid.shape],
+        "n_steps": int(n_steps),
+        "rfx_mono_dbsm": rfx_dbsm,
+        "mie_dbsm": mie_dbsm,
+        "err_db": float(rfx_dbsm - mie_dbsm),
+        "wall_s": round(wall, 1),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# (c) Fixture builder / verdict.
+# --------------------------------------------------------------------------- #
+def _meta(commit: str) -> dict[str, Any]:
+    import rfx
+    return {
+        "reference": "exact-mie-series-pec-sphere",
+        "method": "analytic conducting-sphere Mie backscatter series "
+        "(Ruck 1970), pure scipy.special -- no FDTD/FEM/mesh",
+        "solver_under_test": "rfx.rcs.compute_rcs (TFSF + NTFF, Taflove Ch.8-9)",
+        "mie_convention": "sigma/(pi a^2) = (1/(ka)^2)|sum (-1)^n (2n+1)(a_n-b_n)|^2; "
+        "a_n=j_n/h_n, b_n=[x j_n]'/[x h_n]'",
+        "radius_m": _RADIUS_M,
+        "domain_m": _DOMAIN_M,
+        "cpml_layers": _CPML,
+        "polarization": _POL,
+        "n_theta_obs": _N_THETA,
+        "resolutions_cells_per_lambda": _RESOLUTIONS,
+        "ka_ladder": list(_KA_LADDER),
+        "rfx_version": rfx.__version__,
+        "commit": commit,
+        "date": "2026-07-07",
+        "committed_test_point": {
+            "test": "tests/test_rcs.py::TestRCSPECSphere::test_rcs_pec_sphere_mie",
+            "ka": 0.9431,
+            "f0_hz": 3.0e9,
+            "note": "falsifier at the committed test point measured "
+            "|rfx - Mie| = 4.89 dB (coarse lambda/10), PASS (<5 dB R2 gate)",
+        },
+        "note": "raw arrays hold rfx monostatic dBsm + exact Mie dBsm + errors; "
+        "the Mie column is re-derivable from the series (scipy) by the gate test.",
+        "finding": "The exact Mie series CONFIRMS the committed test's +/-15 dB GO "
+        "tolerance rather than tightening it. rfx's monostatic RCS magnitude does "
+        "not converge with mesh refinement (convergence_delta mostly positive) or "
+        "with domain size (domain_robustness swings several dB) at these test-scale "
+        "1-2 wavelength domains, where the NTFF box sits close to the sphere. The "
+        "ka~1 error (~4.9 dB) is within 5 dB but is not a converged agreement. A "
+        "dedicated RCS diagnostic session (larger domains, NTFF-box placement, "
+        "source-spectrum SNR at f0) is the recommended follow-up; this fixture does "
+        "not chase the residual.",
+    }
+
+
+def build_fixture(run: bool, commit: str) -> dict[str, Any]:
+    """Build (or reload) the ka-ladder fixture dict.
+
+    If ``run`` is False and the fixture exists, the committed rfx values are
+    reused (no FDTD); only the meta/commit is refreshed if asked.
+    """
+    fixtures = _FIXTURES
+    fixtures.mkdir(parents=True, exist_ok=True)
+    out = fixtures / _FIXTURE
+
+    if run:
+        rungs: list[dict[str, Any]] = []
+        for ka in _KA_LADDER:
+            row: dict[str, Any] = {"ka": float(ka)}
+            for name, cpl in _RESOLUTIONS.items():
+                res = run_rfx_mono(ka, cpl)
+                print(
+                    f"  ka={ka:.2f} {name:6s} (lam/{cpl}): grid={res['grid_shape']} "
+                    f"steps={res['n_steps']} rfx={res['rfx_mono_dbsm']:+.2f} "
+                    f"mie={res['mie_dbsm']:+.2f} err={res['err_db']:+.2f}dB "
+                    f"[{res['wall_s']}s]"
+                )
+                row[name] = {k: v for k, v in res.items() if k != "wall_s"}
+            row["mie_dbsm"] = mie_pec_backscatter_dbsm(ka, _RADIUS_M)
+            rungs.append(row)
+
+        witness: list[dict[str, Any]] = []
+        print("  domain-robustness witness (lam/10):")
+        for ka in _DOMAIN_WITNESS_KA:
+            sweep = []
+            for dom in _DOMAIN_WITNESS_M:
+                res = run_rfx_mono(ka, 10, domain_m=dom)
+                print(
+                    f"    ka={ka:.2f} domain={dom*100:.0f}cm: grid={res['grid_shape']} "
+                    f"rfx={res['rfx_mono_dbsm']:+.2f} err={res['err_db']:+.2f}dB"
+                )
+                sweep.append({k: v for k, v in res.items() if k != "wall_s"})
+            witness.append({
+                "ka": float(ka),
+                "mie_dbsm": mie_pec_backscatter_dbsm(ka, _RADIUS_M),
+                "sweep": sweep,
+            })
+
+        fixture = {"meta": _meta(commit), "ka_ladder": rungs, "domain_robustness": witness}
+        fixture["envelope"] = _envelope(rungs, witness)
+        out.write_text(json.dumps(fixture, indent=2) + "\n")
+        return fixture
+
+    fixture = json.loads(out.read_text())
+    return fixture
+
+
+def _envelope(
+    rungs: list[dict[str, Any]], witness: list[dict[str, Any]] | None = None
+) -> dict[str, Any]:
+    """Measured agreement envelope across the ladder (per resolution)."""
+    env: dict[str, Any] = {}
+    for name in _RESOLUTIONS:
+        errs = [abs(r[name]["err_db"]) for r in rungs]
+        env[name] = {
+            "max_abs_err_db": round(max(errs), 4),
+            "mean_abs_err_db": round(float(np.mean(errs)), 4),
+        }
+    # Convergence witness: fine minus coarse |err| per rung (negative = improved).
+    # A positive value means refinement did NOT close the gap.
+    env["convergence_delta_db"] = [
+        round(abs(r["fine"]["err_db"]) - abs(r["coarse"]["err_db"]), 4) for r in rungs
+    ]
+    # Domain-robustness swing: max-min monostatic dBsm across the domain sweep at
+    # each witness ka. A large swing means the single-frequency magnitude is not
+    # a converged quantity at test-scale domains.
+    if witness:
+        env["domain_swing_db"] = [
+            round(max(s["rfx_mono_dbsm"] for s in w["sweep"])
+                  - min(s["rfx_mono_dbsm"] for s in w["sweep"]), 4)
+            for w in witness
+        ]
+    # Gate the committed rfx column at measured max * 1.5, CLAMPED to be never
+    # looser than the existing GO test's +/-15 dB tolerance. Reported, not
+    # chased: this is the honest wide envelope, not a tightening of the bound.
+    measured_max = max(env["coarse"]["max_abs_err_db"], env["fine"]["max_abs_err_db"])
+    env["measured_max_abs_err_db"] = round(measured_max, 4)
+    env["gate_db"] = round(min(15.0, measured_max * 1.5), 4)
+    env["gate_floor_db"] = 15.0
+    return env
+
+
+def _print_verdict(fixture: dict[str, Any]) -> None:
+    env = fixture["envelope"]
+    print("\nEXACT-MIE RCS REFERENCE (PEC sphere, monostatic)")
+    print(f"  {'ka':>5} {'mie dBsm':>9} {'rfx coarse':>11} {'err':>7} "
+          f"{'rfx fine':>10} {'err':>7} {'conv d':>7}")
+    for r, cd in zip(fixture["ka_ladder"], env["convergence_delta_db"]):
+        print(f"  {r['ka']:5.2f} {r['mie_dbsm']:9.2f} "
+              f"{r['coarse']['rfx_mono_dbsm']:11.2f} {r['coarse']['err_db']:+7.2f} "
+              f"{r['fine']['rfx_mono_dbsm']:10.2f} {r['fine']['err_db']:+7.2f} {cd:+7.2f}")
+    print(f"  measured max|err|: coarse={env['coarse']['max_abs_err_db']} dB "
+          f"fine={env['fine']['max_abs_err_db']} dB  -> gate={env['gate_db']} dB "
+          f"(floor {env['gate_floor_db']} dB, NOT a tightening)")
+    if "domain_robustness" in fixture:
+        print("  domain-robustness witness (mono dBsm vs domain, lam/10):")
+        for w, swing in zip(fixture["domain_robustness"], env.get("domain_swing_db", [])):
+            vals = " ".join(f"{s['domain_m']*100:.0f}cm={s['rfx_mono_dbsm']:+.1f}"
+                            for s in w["sweep"])
+            print(f"    ka={w['ka']:.2f} mie={w['mie_dbsm']:+.1f}: {vals}  swing={swing:.1f}dB")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--anchors", action="store_true",
+                   help="self-validate the Mie oracle against Rayleigh/optical limits")
+    p.add_argument("--run", action="store_true",
+                   help="rerun the rfx FDTD ladder and rebuild the committed fixture")
+    p.add_argument("--commit", default="uncommitted",
+                   help="commit SHA to stamp into the rebuilt fixture meta")
+    args = p.parse_args(argv)
+
+    if args.anchors:
+        _self_anchor_report()
+        return 0
+
+    fixture = build_fixture(run=args.run, commit=args.commit)
+    _print_verdict(fixture)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diagnostics/build_rcs_mie_reference.py
+++ b/scripts/diagnostics/build_rcs_mie_reference.py
@@ -52,9 +52,12 @@ Hankel-kind choice, so the RCS magnitude is convention-independent.
 
 Usage::
 
-    python scripts/diagnostics/build_rcs_mie_reference.py            # verdict from fixture
-    python scripts/diagnostics/build_rcs_mie_reference.py --run      # rerun FDTD ladder + rebuild fixture
-    python scripts/diagnostics/build_rcs_mie_reference.py --anchors  # self-validate the Mie oracle
+    python scripts/diagnostics/build_rcs_mie_reference.py                    # verdict from fixture
+    python scripts/diagnostics/build_rcs_mie_reference.py --run --commit SHA # rerun FDTD ladder + rebuild fixture
+    python scripts/diagnostics/build_rcs_mie_reference.py --anchors          # self-validate the Mie oracle
+
+Pair ``--run`` with ``--commit <sha>``: the default stamp is "uncommitted",
+which the fixture meta-integrity gate rejects on purpose (forces a real SHA).
 """
 
 from __future__ import annotations
@@ -241,8 +244,11 @@ def _meta(commit: str) -> dict[str, Any]:
             "test": "tests/test_rcs.py::TestRCSPECSphere::test_rcs_pec_sphere_mie",
             "ka": 0.9431,
             "f0_hz": 3.0e9,
-            "note": "falsifier at the committed test point measured "
-            "|rfx - Mie| = 4.89 dB (coarse lambda/10), PASS (<5 dB R2 gate)",
+            "note": "one-off R2 go/no-go falsifier at the committed test point "
+            "(f0=3 GHz, lambda/10, ka=0.9431 -- NOT on the ladder) measured "
+            "|rfx - Mie| ~ 4.9 dB. This was the falsifier check, NOT a committed "
+            "gate: the committed sphere gate is +/-15 dB vs the GO limit, and the "
+            "exact-Mie envelope here is +/-10-15 dB (see meta.finding).",
         },
         "note": "raw arrays hold rfx monostatic dBsm + exact Mie dBsm + errors; "
         "the Mie column is re-derivable from the series (scipy) by the gate test.",

--- a/tests/fixtures/rcs_mie_e4/rcs_pec_sphere_mie.json
+++ b/tests/fixtures/rcs_mie_e4/rcs_pec_sphere_mie.json
@@ -1,0 +1,341 @@
+{
+  "meta": {
+    "reference": "exact-mie-series-pec-sphere",
+    "method": "analytic conducting-sphere Mie backscatter series (Ruck 1970), pure scipy.special -- no FDTD/FEM/mesh",
+    "solver_under_test": "rfx.rcs.compute_rcs (TFSF + NTFF, Taflove Ch.8-9)",
+    "mie_convention": "sigma/(pi a^2) = (1/(ka)^2)|sum (-1)^n (2n+1)(a_n-b_n)|^2; a_n=j_n/h_n, b_n=[x j_n]'/[x h_n]'",
+    "radius_m": 0.015,
+    "domain_m": 0.1,
+    "cpml_layers": 8,
+    "polarization": "ez",
+    "n_theta_obs": 37,
+    "resolutions_cells_per_lambda": {
+      "coarse": 10,
+      "fine": 15
+    },
+    "ka_ladder": [
+      0.8,
+      1.0,
+      1.5,
+      2.0
+    ],
+    "rfx_version": "1.6.6",
+    "commit": "82f3126",
+    "date": "2026-07-07",
+    "committed_test_point": {
+      "test": "tests/test_rcs.py::TestRCSPECSphere::test_rcs_pec_sphere_mie",
+      "ka": 0.9431,
+      "f0_hz": 3000000000.0,
+      "note": "falsifier at the committed test point measured |rfx - Mie| = 4.89 dB (coarse lambda/10), PASS (<5 dB R2 gate)"
+    },
+    "note": "raw arrays hold rfx monostatic dBsm + exact Mie dBsm + errors; the Mie column is re-derivable from the series (scipy) by the gate test.",
+    "finding": "The exact Mie series CONFIRMS the committed test's +/-15 dB GO tolerance rather than tightening it. rfx's monostatic RCS magnitude does not converge with mesh refinement (convergence_delta mostly positive) or with domain size (domain_robustness swings several dB) at these test-scale 1-2 wavelength domains, where the NTFF box sits close to the sphere. The ka~1 error (~4.9 dB) is within 5 dB but is not a converged agreement. A dedicated RCS diagnostic session (larger domains, NTFF-box placement, source-spectrum SNR at f0) is the recommended follow-up; this fixture does not chase the residual."
+  },
+  "ka_ladder": [
+    {
+      "ka": 0.8,
+      "coarse": {
+        "ka": 0.8,
+        "f0_hz": 2544717418.2597027,
+        "lambda_m": 0.11780972450961724,
+        "dx_m": 0.011780972450961723,
+        "cells_per_lambda": 10,
+        "domain_m": 0.1,
+        "radius_cells": 1.2732395447351628,
+        "grid_shape": [
+          26,
+          26,
+          26
+        ],
+        "n_steps": 339,
+        "rfx_mono_dbsm": -21.32532036523639,
+        "mie_dbsm": -27.363584609723077,
+        "err_db": 6.038264244486687
+      },
+      "fine": {
+        "ka": 0.8,
+        "f0_hz": 2544717418.2597027,
+        "lambda_m": 0.11780972450961724,
+        "dx_m": 0.007853981633974483,
+        "cells_per_lambda": 15,
+        "domain_m": 0.1,
+        "radius_cells": 1.9098593171027438,
+        "grid_shape": [
+          30,
+          30,
+          30
+        ],
+        "n_steps": 509,
+        "rfx_mono_dbsm": -23.847444831740386,
+        "mie_dbsm": -27.363584609723077,
+        "err_db": 3.5161397779826906
+      },
+      "mie_dbsm": -27.363584609723077
+    },
+    {
+      "ka": 1.0,
+      "coarse": {
+        "ka": 1.0,
+        "f0_hz": 3180896772.8246284,
+        "lambda_m": 0.09424777960769379,
+        "dx_m": 0.00942477796076938,
+        "cells_per_lambda": 10,
+        "domain_m": 0.1,
+        "radius_cells": 1.5915494309189533,
+        "grid_shape": [
+          28,
+          28,
+          28
+        ],
+        "n_steps": 424,
+        "rfx_mono_dbsm": -23.12395083309338,
+        "mie_dbsm": -25.89856662477798,
+        "err_db": 2.7746157916845995
+      },
+      "fine": {
+        "ka": 1.0,
+        "f0_hz": 3180896772.8246284,
+        "lambda_m": 0.09424777960769379,
+        "dx_m": 0.006283185307179586,
+        "cells_per_lambda": 15,
+        "domain_m": 0.1,
+        "radius_cells": 2.3873241463784303,
+        "grid_shape": [
+          33,
+          33,
+          33
+        ],
+        "n_steps": 636,
+        "rfx_mono_dbsm": -29.55129882212939,
+        "mie_dbsm": -25.89856662477798,
+        "err_db": -3.6527321973514084
+      },
+      "mie_dbsm": -25.89856662477798
+    },
+    {
+      "ka": 1.5,
+      "coarse": {
+        "ka": 1.5,
+        "f0_hz": 4771345159.236942,
+        "lambda_m": 0.06283185307179587,
+        "dx_m": 0.006283185307179587,
+        "cells_per_lambda": 10,
+        "domain_m": 0.1,
+        "radius_cells": 2.38732414637843,
+        "grid_shape": [
+          33,
+          33,
+          33
+        ],
+        "n_steps": 636,
+        "rfx_mono_dbsm": -21.00581800426381,
+        "mie_dbsm": -31.190130656690034,
+        "err_db": 10.184312652426225
+      },
+      "fine": {
+        "ka": 1.5,
+        "f0_hz": 4771345159.236942,
+        "lambda_m": 0.06283185307179587,
+        "dx_m": 0.004188790204786391,
+        "cells_per_lambda": 15,
+        "domain_m": 0.1,
+        "radius_cells": 3.5809862195676447,
+        "grid_shape": [
+          41,
+          41,
+          41
+        ],
+        "n_steps": 954,
+        "rfx_mono_dbsm": -18.020981314131713,
+        "mie_dbsm": -31.190130656690034,
+        "err_db": 13.16914934255832
+      },
+      "mie_dbsm": -31.190130656690034
+    },
+    {
+      "ka": 2.0,
+      "coarse": {
+        "ka": 2.0,
+        "f0_hz": 6361793545.649257,
+        "lambda_m": 0.047123889803846894,
+        "dx_m": 0.00471238898038469,
+        "cells_per_lambda": 10,
+        "domain_m": 0.1,
+        "radius_cells": 3.1830988618379066,
+        "grid_shape": [
+          39,
+          39,
+          39
+        ],
+        "n_steps": 848,
+        "rfx_mono_dbsm": -30.889587326735214,
+        "mie_dbsm": -31.47145434371843,
+        "err_db": 0.5818670169832174
+      },
+      "fine": {
+        "ka": 2.0,
+        "f0_hz": 6361793545.649257,
+        "lambda_m": 0.047123889803846894,
+        "dx_m": 0.003141592653589793,
+        "cells_per_lambda": 15,
+        "domain_m": 0.1,
+        "radius_cells": 4.7746482927568605,
+        "grid_shape": [
+          49,
+          49,
+          49
+        ],
+        "n_steps": 1272,
+        "rfx_mono_dbsm": -25.13266164834132,
+        "mie_dbsm": -31.47145434371843,
+        "err_db": 6.338792695377112
+      },
+      "mie_dbsm": -31.47145434371843
+    }
+  ],
+  "domain_robustness": [
+    {
+      "ka": 1.0,
+      "mie_dbsm": -25.89856662477798,
+      "sweep": [
+        {
+          "ka": 1.0,
+          "f0_hz": 3180896772.8246284,
+          "lambda_m": 0.09424777960769379,
+          "dx_m": 0.00942477796076938,
+          "cells_per_lambda": 10,
+          "domain_m": 0.1,
+          "radius_cells": 1.5915494309189533,
+          "grid_shape": [
+            28,
+            28,
+            28
+          ],
+          "n_steps": 424,
+          "rfx_mono_dbsm": -23.12395083309338,
+          "mie_dbsm": -25.89856662477798,
+          "err_db": 2.7746157916845995
+        },
+        {
+          "ka": 1.0,
+          "f0_hz": 3180896772.8246284,
+          "lambda_m": 0.09424777960769379,
+          "dx_m": 0.00942477796076938,
+          "cells_per_lambda": 10,
+          "domain_m": 0.15,
+          "radius_cells": 1.5915494309189533,
+          "grid_shape": [
+            33,
+            33,
+            33
+          ],
+          "n_steps": 636,
+          "rfx_mono_dbsm": -18.600802669706486,
+          "mie_dbsm": -25.89856662477798,
+          "err_db": 7.2977639550714954
+        },
+        {
+          "ka": 1.0,
+          "f0_hz": 3180896772.8246284,
+          "lambda_m": 0.09424777960769379,
+          "dx_m": 0.00942477796076938,
+          "cells_per_lambda": 10,
+          "domain_m": 0.2,
+          "radius_cells": 1.5915494309189533,
+          "grid_shape": [
+            39,
+            39,
+            39
+          ],
+          "n_steps": 848,
+          "rfx_mono_dbsm": -27.842734611869332,
+          "mie_dbsm": -25.89856662477798,
+          "err_db": -1.944167987091351
+        }
+      ]
+    },
+    {
+      "ka": 1.5,
+      "mie_dbsm": -31.190130656690034,
+      "sweep": [
+        {
+          "ka": 1.5,
+          "f0_hz": 4771345159.236942,
+          "lambda_m": 0.06283185307179587,
+          "dx_m": 0.006283185307179587,
+          "cells_per_lambda": 10,
+          "domain_m": 0.1,
+          "radius_cells": 2.38732414637843,
+          "grid_shape": [
+            33,
+            33,
+            33
+          ],
+          "n_steps": 636,
+          "rfx_mono_dbsm": -21.00581800426381,
+          "mie_dbsm": -31.190130656690034,
+          "err_db": 10.184312652426225
+        },
+        {
+          "ka": 1.5,
+          "f0_hz": 4771345159.236942,
+          "lambda_m": 0.06283185307179587,
+          "dx_m": 0.006283185307179587,
+          "cells_per_lambda": 10,
+          "domain_m": 0.15,
+          "radius_cells": 2.38732414637843,
+          "grid_shape": [
+            41,
+            41,
+            41
+          ],
+          "n_steps": 954,
+          "rfx_mono_dbsm": -23.735161595273553,
+          "mie_dbsm": -31.190130656690034,
+          "err_db": 7.454969061416481
+        },
+        {
+          "ka": 1.5,
+          "f0_hz": 4771345159.236942,
+          "lambda_m": 0.06283185307179587,
+          "dx_m": 0.006283185307179587,
+          "cells_per_lambda": 10,
+          "domain_m": 0.2,
+          "radius_cells": 2.38732414637843,
+          "grid_shape": [
+            49,
+            49,
+            49
+          ],
+          "n_steps": 1272,
+          "rfx_mono_dbsm": -23.596787815479843,
+          "mie_dbsm": -31.190130656690034,
+          "err_db": 7.593342841210191
+        }
+      ]
+    }
+  ],
+  "envelope": {
+    "coarse": {
+      "max_abs_err_db": 10.1843,
+      "mean_abs_err_db": 4.8948
+    },
+    "fine": {
+      "max_abs_err_db": 13.1691,
+      "mean_abs_err_db": 6.6692
+    },
+    "convergence_delta_db": [
+      -2.5221,
+      0.8781,
+      2.9848,
+      5.7569
+    ],
+    "domain_swing_db": [
+      9.2419,
+      2.7293
+    ],
+    "measured_max_abs_err_db": 13.1691,
+    "gate_db": 15.0,
+    "gate_floor_db": 15.0
+  }
+}

--- a/tests/fixtures/rcs_mie_e4/rcs_pec_sphere_mie.json
+++ b/tests/fixtures/rcs_mie_e4/rcs_pec_sphere_mie.json
@@ -20,13 +20,13 @@
       2.0
     ],
     "rfx_version": "1.6.6",
-    "commit": "82f3126",
+    "commit": "a82264a",
     "date": "2026-07-07",
     "committed_test_point": {
       "test": "tests/test_rcs.py::TestRCSPECSphere::test_rcs_pec_sphere_mie",
       "ka": 0.9431,
       "f0_hz": 3000000000.0,
-      "note": "falsifier at the committed test point measured |rfx - Mie| = 4.89 dB (coarse lambda/10), PASS (<5 dB R2 gate)"
+      "note": "one-off R2 go/no-go falsifier at the committed test point (f0=3 GHz, lambda/10, ka=0.9431 -- NOT on the ladder) measured |rfx - Mie| ~ 4.9 dB. This was the falsifier check, NOT a committed gate: the committed sphere gate is +/-15 dB vs the GO limit, and the exact-Mie envelope here is +/-10-15 dB (see meta.finding)."
     },
     "note": "raw arrays hold rfx monostatic dBsm + exact Mie dBsm + errors; the Mie column is re-derivable from the series (scipy) by the gate test.",
     "finding": "The exact Mie series CONFIRMS the committed test's +/-15 dB GO tolerance rather than tightening it. rfx's monostatic RCS magnitude does not converge with mesh refinement (convergence_delta mostly positive) or with domain size (domain_robustness swings several dB) at these test-scale 1-2 wavelength domains, where the NTFF box sits close to the sphere. The ka~1 error (~4.9 dB) is within 5 dB but is not a converged agreement. A dedicated RCS diagnostic session (larger domains, NTFF-box placement, source-spectrum SNR at f0) is the recommended follow-up; this fixture does not chase the residual."

--- a/tests/test_rcs.py
+++ b/tests/test_rcs.py
@@ -143,6 +143,13 @@ class TestRCSPECSphere:
     For electrically small spheres (ka < 1), Rayleigh scattering applies.
     We target ka ~ 1 where both approximations are rough, so we use
     a generous tolerance.
+
+    An exact conducting-sphere Mie-series cross-method reference for this
+    geometry (ka ladder + convergence + domain-robustness witness) lives in
+    ``tests/fixtures/rcs_mie_e4/`` and is gated by
+    ``tests/test_rcs_mie_reference_gates.py``; it confirms this +/-15 dB
+    tolerance rather than tightening it (the monostatic magnitude does not
+    converge with mesh/domain refinement at these test-scale domains).
     """
 
     def test_rcs_pec_sphere_mie(self):

--- a/tests/test_rcs_mie_reference_gates.py
+++ b/tests/test_rcs_mie_reference_gates.py
@@ -1,0 +1,195 @@
+"""RCS PEC-sphere — exact-Mie cross-method REFERENCE gates (WP 1-A).
+
+Locks the first analytic (non-FDTD / non-FEM) cross-method reference for rfx's
+RCS pipeline, committed under
+``tests/fixtures/rcs_mie_e4/rcs_pec_sphere_mie.json``. The load-bearing gate is
+the exact conducting-sphere Mie backscatter series (Ruck, Radar Cross Section
+Handbook 1970), RE-DERIVED INDEPENDENTLY here from ``scipy.special`` — it does
+not import the producer's Mie function, so a producer-side error cannot
+self-certify. No FDTD runs here; the committed rfx monostatic values are frozen
+evidence.
+
+MEASURED-ENVELOPE POSTURE (honest, not tightened)
+-------------------------------------------------
+At the committed test-scale geometry (0.10 m cubic domain = 1-2 wavelengths) the
+exact Mie series CONFIRMS the committed ``test_rcs.py`` +/-15 dB GO tolerance
+rather than tightening it. Across the ka ladder {0.8, 1.0, 1.5, 2.0}:
+
+  * measured max |rfx - Mie| = 13.17 dB (ka=1.5, lambda/15);
+  * refinement (lambda/10 -> lambda/15) worsens 3 of 4 rungs (convergence_delta
+    mostly positive, max +5.76 dB) -- the staircased curved-PEC surface + close
+    NTFF box do not converge to the exact value here;
+  * the monostatic magnitude swings up to 9.24 dB (ka=1.0) across domain size.
+
+So ``gate_db`` clamps to the 15 dB GO floor (measured_max * 1.5 would be looser).
+The value of this fixture is the exact oracle + the committed evidence that rfx
+RCS is a ~+/-10-15 dB tool at these domains; a dedicated RCS diagnostic session
+is the recommended follow-up. These gates lock that honest record; they must not
+be re-tuned to look tighter than the physics.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from scipy.special import spherical_jn, spherical_yn
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_FIXTURE = _REPO_ROOT / "tests/fixtures/rcs_mie_e4/rcs_pec_sphere_mie.json"
+
+
+# --------------------------------------------------------------------------- #
+# Independent exact-Mie re-derivation (does NOT import the producer).
+# --------------------------------------------------------------------------- #
+def _mie_ratio(ka: float) -> float:
+    """sigma/(pi a^2) for a PEC sphere, backscatter (Ruck 1970)."""
+    x = float(ka)
+    n_max = int(np.ceil(x + 4.05 * x ** (1.0 / 3.0) + 2)) + 15
+    n = np.arange(1, n_max + 1)
+    jn, yn = spherical_jn(n, x), spherical_yn(n, x)
+    jnp_, ynp_ = spherical_jn(n, x, derivative=True), spherical_yn(n, x, derivative=True)
+    hn, hnp_ = jn + 1j * yn, jnp_ + 1j * ynp_
+    a_n = jn / hn
+    b_n = (jn + x * jnp_) / (hn + x * hnp_)
+    series = np.sum(((-1.0) ** n) * (2 * n + 1) * (a_n - b_n))
+    return float(np.abs(series) ** 2 / x ** 2)
+
+
+def _mie_dbsm(ka: float, radius_m: float) -> float:
+    return float(10.0 * np.log10(_mie_ratio(ka) * np.pi * radius_m ** 2))
+
+
+@pytest.fixture(scope="module")
+def fixture():
+    return json.loads(_FIXTURE.read_text())
+
+
+# --------------------------------------------------------------------------- #
+# Oracle self-anchors (the reference must pass its own closed-form limits).
+# --------------------------------------------------------------------------- #
+def test_mie_oracle_rayleigh_limit():
+    """sigma/(pi a^2) -> 9 (ka)^4 as ka -> 0 (electrically small sphere)."""
+    for ka in (0.01, 0.02, 0.05):
+        assert np.isclose(_mie_ratio(ka), 9.0 * ka ** 4, rtol=2e-3), ka
+
+
+def test_mie_oracle_optical_limit():
+    """sigma/(pi a^2) -> 1 as ka -> inf (geometrical-optics / GO limit)."""
+    assert _mie_ratio(50.0) == pytest.approx(1.0, abs=0.01)
+    assert _mie_ratio(100.0) == pytest.approx(1.0, abs=0.005)
+
+
+# --------------------------------------------------------------------------- #
+# Fixture integrity: the committed Mie column is the exact series.
+# --------------------------------------------------------------------------- #
+def test_committed_mie_column_is_exact_series(fixture):
+    """LOAD-BEARING: every committed mie_dbsm equals the independently re-derived
+    exact series (rel 1e-9). Tampering with the reference fails here."""
+    radius = fixture["meta"]["radius_m"]
+    for rung in fixture["ka_ladder"]:
+        want = _mie_dbsm(rung["ka"], radius)
+        assert np.isclose(rung["mie_dbsm"], want, rtol=1e-9), (rung["ka"], want)
+        for res in (rung["coarse"], rung["fine"]):
+            assert np.isclose(res["mie_dbsm"], want, rtol=1e-9), (rung["ka"], "res")
+    for w in fixture["domain_robustness"]:
+        want = _mie_dbsm(w["ka"], radius)
+        assert np.isclose(w["mie_dbsm"], want, rtol=1e-9), (w["ka"], want)
+
+
+def test_errors_self_consistent(fixture):
+    """err_db == rfx_mono_dbsm - mie_dbsm for every stored rfx value."""
+    for rung in fixture["ka_ladder"]:
+        for res in (rung["coarse"], rung["fine"]):
+            assert np.isclose(
+                res["err_db"], res["rfx_mono_dbsm"] - res["mie_dbsm"], atol=1e-9
+            ), (rung["ka"], res["cells_per_lambda"])
+    for w in fixture["domain_robustness"]:
+        for s in w["sweep"]:
+            assert np.isclose(s["err_db"], s["rfx_mono_dbsm"] - s["mie_dbsm"], atol=1e-9)
+
+
+# --------------------------------------------------------------------------- #
+# Measured-envelope gates (honest, no tightening).
+# --------------------------------------------------------------------------- #
+def test_ladder_within_measured_envelope(fixture):
+    """Every committed rfx-vs-Mie error is within the measured envelope gate.
+    Measured max |err| = 13.17 dB; gate_db = 15 dB (clamped to the GO floor)."""
+    gate = fixture["envelope"]["gate_db"]
+    for rung in fixture["ka_ladder"]:
+        for res in (rung["coarse"], rung["fine"]):
+            assert abs(res["err_db"]) <= gate + 1e-9, (rung["ka"], res["err_db"], gate)
+
+
+def test_envelope_no_regression(fixture):
+    """gate_db is never LOOSER than the existing GO tolerance (15 dB), and equals
+    min(15, measured_max * 1.5). This adds a cross-method gate without relaxing
+    any existing bound."""
+    env = fixture["envelope"]
+    assert env["gate_floor_db"] == 15.0
+    assert env["gate_db"] <= env["gate_floor_db"] + 1e-9
+    measured_max = max(
+        abs(res["err_db"])
+        for rung in fixture["ka_ladder"]
+        for res in (rung["coarse"], rung["fine"])
+    )
+    # Stored envelope numbers are rounded to 4 decimals by the producer.
+    assert np.isclose(env["measured_max_abs_err_db"], measured_max, atol=1e-3)
+    assert np.isclose(env["gate_db"], min(15.0, measured_max * 1.5), atol=1e-3)
+
+
+def test_convergence_witness(fixture):
+    """Convergence witness: refinement (lambda/10 -> lambda/15) does not blow the
+    error up beyond a measured margin. Recorded convergence_delta == |fine err| -
+    |coarse err|; measured max is +5.76 dB (refinement does NOT close the gap --
+    an honest curved-PEC staircase floor), gated <= 6.5 dB so a future regression
+    that made refinement diverge would trip."""
+    deltas = fixture["envelope"]["convergence_delta_db"]
+    assert len(deltas) == len(fixture["ka_ladder"])
+    for rung, d in zip(fixture["ka_ladder"], deltas):
+        recomputed = abs(rung["fine"]["err_db"]) - abs(rung["coarse"]["err_db"])
+        assert np.isclose(d, recomputed, atol=1e-3), (rung["ka"], d, recomputed)
+        assert d <= 6.5, (rung["ka"], d)
+
+
+def test_domain_robustness_witness(fixture):
+    """R5 evidence lock: the monostatic magnitude does not converge with domain
+    size at test-scale (swing recorded per witness ka). Swing == max-min of the
+    swept monostatic dBsm; committed swings are ~9.2 dB (ka=1.0) and ~2.7 dB
+    (ka=1.5) -- a single dBsm number is not a converged quantity here."""
+    swings = fixture["envelope"]["domain_swing_db"]
+    assert len(swings) == len(fixture["domain_robustness"])
+    for w, swing in zip(fixture["domain_robustness"], swings):
+        vals = [s["rfx_mono_dbsm"] for s in w["sweep"]]
+        assert len(vals) >= 3, w["ka"]
+        assert np.all(np.isfinite(vals))
+        assert np.isclose(swing, max(vals) - min(vals), atol=1e-3), (w["ka"], swing)
+    # The witness must actually witness non-convergence (largest swing > 2 dB),
+    # else it is not evidence. This locks the finding, not a tuned pass.
+    assert max(swings) > 2.0
+
+
+# --------------------------------------------------------------------------- #
+# Provenance.
+# --------------------------------------------------------------------------- #
+def test_meta_integrity(fixture):
+    """Provenance guard: exact-Mie reference, geometry matches the committed
+    test_rcs.py sphere, the honest 'finding' note + falsifier record are kept."""
+    meta = fixture["meta"]
+    assert meta["reference"] == "exact-mie-series-pec-sphere"
+    assert meta["radius_m"] == 0.015
+    assert meta["domain_m"] == 0.10
+    assert meta["cpml_layers"] == 8
+    assert meta["polarization"] == "ez"
+    assert meta["n_theta_obs"] == 37
+    assert meta["ka_ladder"] == [0.8, 1.0, 1.5, 2.0]
+    assert meta["commit"] and meta["commit"] != "uncommitted"
+    assert "finding" in meta and "does not" in meta["finding"].lower()
+    fp = meta["committed_test_point"]
+    assert 0.9 <= fp["ka"] <= 1.0
+    assert "4.8" in fp["note"] or "4.9" in fp["note"], fp["note"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-q"])


### PR DESCRIPTION
## WP 1-A — exact conducting-sphere Mie series: first analytic cross-method reference for the RCS lane

Adds the first exact analytic (non-FDTD / non-FEM) cross-method reference for
rfx's RCS pipeline (`rfx/rcs.py`, TFSF + NTFF). The committed `test_rcs.py`
gates the PEC sphere only against the geometrical-optics limit (`pi a^2`,
+/-15 dB); this PR adds the exact Ruck (1970) conducting-sphere backscatter Mie
series as an independent oracle, a committed evidence fixture, and fail-closed
gates.

### Falsifier first (R2 rule)
The Mie script self-validates against its two closed-form anchors — Rayleigh
`sigma/(pi a^2) -> 9 (ka)^4` (ratio 0.9998) and optical `-> 1.0`. At the
committed test point (ka = 0.943): **rfx = -21.19 dBsm vs exact Mie = -26.07
dBsm, |err| = 4.89 dB < 5 dB -> PASS** (the GO limit the test currently uses is
-31.51 dBsm, 10.3 dB away). Note: the exact backscatter coefficient is
`(2n+1)`, not `(n+1/2)` — the latter fails the anchors by 4x.

### R5 finding (honest, load-bearing): the agreement does not converge
Inspecting intermediates rather than the headline shows the ka~1 pass is
**coincidental, not converged**. rfx's monostatic RCS does not converge with
mesh or domain refinement at test-scale (1-2 wavelength) domains:

| ka | exact Mie | rfx lambda/10 | err | rfx lambda/15 | err |
|----|-----------|---------------|-----|---------------|-----|
| 0.8 | -27.36 | -21.33 | +6.04 | -23.85 | +3.52 |
| 1.0 | -25.90 | -23.12 | +2.77 | -29.55 | -3.65 |
| 1.5 | -31.19 | -21.01 | +10.18 | -18.02 | +13.17 |
| 2.0 | -31.47 | -30.89 | +0.58 | -25.13 | +6.34 |

Refinement worsens 3 of 4 rungs; a domain sweep at ka=1.0 swings the value
-23.1 -> -18.6 -> -27.8 dBsm across 10/15/20 cm domains (**9.24 dB swing**,
even flipping the sign of the error). So the exact series **confirms the
existing +/-15 dB GO tolerance rather than tightening it**. This is consistent
with the committed test's own stated reasons (coarse grid + sphere staircasing +
close NTFF box); it is a genuine pipeline property, not a runner bug (the runner
imitates `test_rcs.py` exactly and runs are time-converged, ~20 domain
crossings).

### What this PR commits
- `scripts/diagnostics/build_rcs_mie_reference.py` — exact Mie oracle (pure
  scipy) + rfx runner (ka ladder x 2 resolutions + domain-robustness witness) +
  fixture builder. Anchor-validated.
- `tests/fixtures/rcs_mie_e4/rcs_pec_sphere_mie.json` — raw per-ka rfx + exact
  Mie + errors + measured envelope + the domain-swing witness. `gate_db` clamps
  to the 15 dB GO floor (measured max err 13.17 dB; `x1.5` would be *looser*, so
  no relaxation).
- `tests/test_rcs_mie_reference_gates.py` — 9 fail-closed gates, no FDTD. The
  Mie column is re-derived by an **independent inline series** (not importing
  the producer) at rel 1e-9; the rfx errors are gated at the measured envelope;
  convergence + domain-robustness witnesses lock the honest non-convergence.
- One-sentence-scale prose pointer added to `tests/test_rcs.py`'s sphere test.
  **No existing assert or tolerance is changed; no `rfx/` source is touched.**

### Verification
- `tests/test_rcs_mie_reference_gates.py` 9 passed + `tests/test_rcs.py` 3
  passed (12 total, ~5 s).
- `ruff check` clean on all changed files (repo flags).
- CPU only, no VESSL; each FDTD run < 10 s. No preflight suppressed
  (`compute_rcs` uses the low-level functional `run`, same as `test_rcs.py`).

### Follow-up (not in this PR)
The "tighten the GO bound to the Mie envelope" goal is **not achievable** at
test-scale domains. The delivered value is (1) the first exact analytic
cross-method oracle in the RCS lane and (2) committed evidence that rfx RCS is a
+/-10-15 dB tool here. A dedicated RCS diagnostic session (larger domains,
NTFF-box placement, source-spectrum SNR at f0 — the differentiated-Gaussian puts
f0 ~21 dB down the source tail) is the recommended follow-up; the residual is
documented, not chased (R2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
