### PR TITLE
fix(rcs): monostatic extraction at true backscatter + exact-Mie sphere fixture (#276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — `compute_rcs` monostatic extraction pointed at −z broadside, not backscatter (issue #276)
+
+- `RCSResult.monostatic_rcs` was argmin-extracted at (θ=π, φ=0), which under
+  the far-field convention (`r_hat = [sinθcosφ, sinθsinφ, cosθ]`) is the −z
+  BROADSIDE direction — not the −x backscatter of the +x TFSF incidence
+  (θ=π/2, φ=π). Measured on a validated exact-Mie PEC-sphere falsifier
+  (ka≈1.0, dx=λ/40): the shipped number was 10.06 dB off Mie; the same run
+  re-extracted at the true backscatter direction is 0.06 dB off.
+- The backscatter direction is now derived from the incident propagation
+  unit vector (b_hat = −k_hat) and the far field is evaluated EXACTLY at
+  that direction on the already-accumulated NTFF data — no observation-grid
+  snapping (the default φ grid `[0, π/2]` does not even contain φ=π).
+  `monostatic_rcs` is therefore independent of `theta_obs`/`phi_obs` and is
+  now always computed (previously `None` for empty observation grids).
+- New committed evidence + gate: `tests/fixtures/rcs_sphere_mie/`
+  (exact-Mie oracle self-validated by four rfx-independent witnesses —
+  Rayleigh 9(ka)^4, GO→1, term-doubling convergence, bistatic-bridge — plus
+  fixture JSON with the full H-plane trace) and
+  `tests/test_rcs_mie_fixture.py` (live recompute at the committed
+  resolution, gate |Δ| ≤ 1.0 dB vs Mie; measured 0.06 dB). Claim scope is
+  MONOSTATIC magnitude at the committed resolution only — the same run
+  shows a NON-GATED spurious forward-oblique lobe (25–55°, ~10 dB high vs
+  Mie; TFSF/NTFF forward-face contamination suspected) and a ~1.6 dB
+  forward-scatter delta, documented per-angle in the fixture rather than
+  hidden.
+
 ### Added — waveguide multi-port junction references (`port_reference_sims`)
 
 - `compute_waveguide_s_matrix(..., port_reference_sims=[...])` exposes public

--- a/docs/public/guide/farfield-rcs.md
+++ b/docs/public/guide/farfield-rcs.md
@@ -112,15 +112,17 @@ result = compute_rcs(
     freqs=np.array([f0]),
 )
 
-# monostatic_rcs is the observation angle nearest backscatter (theta ~ pi,
-# phi ~ 0 for the default +x incidence); populated whenever obs angles are given.
+# monostatic_rcs is evaluated exactly at the backscatter direction
+# (theta=pi/2, phi=pi for the +x incidence), independent of theta_obs/phi_obs.
 print(f"Monostatic RCS: {result.monostatic_rcs[0]:.1f} dBsm")
 print(f"Bistatic RCS range: {result.rcs_dbsm.min():.1f} to {result.rcs_dbsm.max():.1f} dBsm")
 ```
 
 `RCSResult` carries `rcs_dbsm` and `rcs_linear` (shape `(n_freqs, n_theta,
-n_phi)`), `monostatic_rcs` (`(n_freqs,)` dBsm, or `None` when no observation
-angles are given), and the `freqs` / `theta` / `phi` axes.
+n_phi)`), `monostatic_rcs` (`(n_freqs,)` dBsm, always populated — evaluated
+exactly at the backscatter direction opposite the incident propagation
+vector, so it does not depend on the observation grid), and the
+`freqs` / `theta` / `phi` axes.
 
 ## Plotting RCS
 

--- a/rfx/rcs.py
+++ b/rfx/rcs.py
@@ -47,7 +47,7 @@ class RCSResult(NamedTuple):
     phi: np.ndarray
     rcs_dbsm: np.ndarray
     rcs_linear: np.ndarray
-    monostatic_rcs: np.ndarray | None
+    monostatic_rcs: np.ndarray
 
 
 def _incident_spectrum_amplitude(

--- a/rfx/rcs.py
+++ b/rfx/rcs.py
@@ -36,7 +36,11 @@ class RCSResult(NamedTuple):
     phi : (n_phi,) radians
     rcs_dbsm : (n_freqs, n_theta, n_phi) in dBsm
     rcs_linear : (n_freqs, n_theta, n_phi) in m^2
-    monostatic_rcs : (n_freqs,) backscatter RCS in dBsm, or None
+    monostatic_rcs : (n_freqs,) backscatter RCS in dBsm, evaluated
+        exactly at the backscatter direction (opposite the incident
+        propagation vector), independent of the theta/phi observation
+        grid. For normal-incidence +x propagation this is
+        (theta=pi/2, phi=pi), i.e. -x.
     """
     freqs: np.ndarray
     theta: np.ndarray
@@ -138,7 +142,10 @@ def compute_rcs(
     -------
     RCSResult
         freqs, theta, phi, rcs_dbsm (dBsm), rcs_linear (m^2),
-        monostatic_rcs (dBsm at backscatter direction).
+        monostatic_rcs (dBsm, evaluated exactly at the true backscatter
+        direction — for +x incidence that is (theta=pi/2, phi=pi) under
+        the farfield r_hat convention; it does not depend on
+        theta_obs/phi_obs).
     """
     # Defaults
     if theta_obs is None:
@@ -261,16 +268,52 @@ def compute_rcs(
     rcs_dbsm = 10.0 * np.log10(np.maximum(rcs_linear, 1e-30))
 
     # --- 7. Extract monostatic (backscatter) RCS ---
-    # For +x incidence, backscatter direction is theta=pi, phi=0
-    # (i.e., -x direction in spherical coordinates).
-    # Find the closest observation angle to (theta=pi, phi=0).
-    monostatic_rcs = None
-    if len(theta_obs) > 0 and len(phi_obs) > 0:
-        # Backscatter: theta = pi (or close to it), phi = 0 (or close)
-        theta_back_idx = np.argmin(np.abs(theta_obs - np.pi))
-        phi_back_idx = np.argmin(np.abs(phi_obs - 0.0))
-        mono_linear = rcs_linear[:, theta_back_idx, phi_back_idx]
-        monostatic_rcs = 10.0 * np.log10(np.maximum(mono_linear, 1e-30))
+    # Backscatter is the direction OPPOSITE the incident propagation
+    # vector.  The TFSF source above propagates along +x
+    # (``direction="+x"`` in the init_tfsf call); a non-zero theta_inc
+    # tilts the propagation in the x-y plane for "ez" polarization and
+    # in the x-z plane for "ey" (see the t_delay lines in
+    # rfx/sources/tfsf_2d.py).  So:
+    #     k_hat = (cos(theta_inc), sin(theta_inc), 0)   for "ez"
+    #     k_hat = (cos(theta_inc), 0, sin(theta_inc))   for "ey"
+    #     b_hat = -k_hat                                (backscatter)
+    # Under the far-field convention (rfx/farfield.py:
+    # r_hat = [sin(th)cos(ph), sin(th)sin(ph), cos(th)], theta = polar
+    # angle from +z), the spherical angles of b_hat are
+    #     theta_back = arccos(b_hat_z)
+    #     phi_back   = atan2(b_hat_y, b_hat_x)
+    # For the supported normal-incidence case (theta_inc = 0) this gives
+    # (theta_back, phi_back) = (pi/2, pi), i.e. the -x direction.
+    # NOTE (issue #276): the pre-fix code hardcoded (theta=pi, phi=0),
+    # which under this convention is the -z BROADSIDE direction, not
+    # backscatter.
+    #
+    # The far field is evaluated EXACTLY at the backscatter direction
+    # (one extra direction on the already-accumulated NTFF data) instead
+    # of argmin-snapping to the observation grid: the default phi grid
+    # ([0, pi/2]) does not contain phi=pi, so grid snapping would
+    # silently return a different cut.
+    theta_inc_rad = float(np.radians(theta_inc))
+    if polarization == "ey":
+        k_hat = np.array([np.cos(theta_inc_rad), 0.0, np.sin(theta_inc_rad)])
+    else:  # "ez"
+        k_hat = np.array([np.cos(theta_inc_rad), np.sin(theta_inc_rad), 0.0])
+    b_hat = -k_hat
+    theta_back = float(np.arccos(np.clip(b_hat[2], -1.0, 1.0)))
+    phi_back = float(np.mod(np.arctan2(b_hat[1], b_hat[0]), 2.0 * np.pi))
+
+    ff_back = compute_far_field(
+        result.ntff_data,
+        ntff_box,
+        grid,
+        np.array([theta_back]),
+        np.array([phi_back]),
+    )
+    Eb_theta = np.asarray(ff_back.E_theta, dtype=np.complex128)[:, 0, 0]
+    Eb_phi = np.asarray(ff_back.E_phi, dtype=np.complex128)[:, 0, 0]
+    power_back = np.abs(Eb_theta) ** 2 + np.abs(Eb_phi) ** 2  # (nf,)
+    mono_linear = 4.0 * np.pi * power_back / safe_power_inc
+    monostatic_rcs = 10.0 * np.log10(np.maximum(mono_linear, 1e-30))
 
     return RCSResult(
         freqs=freqs_arr,

--- a/tests/fixtures/rcs_sphere_mie/README.md
+++ b/tests/fixtures/rcs_sphere_mie/README.md
@@ -1,0 +1,47 @@
+# PEC-sphere exact-Mie monostatic RCS fixture (issue #276)
+
+Committed evidence for the `compute_rcs` monostatic-extraction fix and its
+gate test `tests/test_rcs_mie_fixture.py`.
+
+## Files
+
+- `mie_oracle.py` — exact Mie series for a PEC sphere (backscatter +
+  bistatic, Bohren & Huffman convention). Self-validated by
+  `validate_oracle()` with four rfx-independent witnesses: Rayleigh limit
+  `9(ka)^4`, geometric-optics limit → 1, term-doubling convergence at
+  ka~1, and the bistatic-formula bridge at the backscatter angle.
+- `generate_fixture.py` — runs the committed-resolution rfx simulation
+  (CPU, ~7 s) and writes `fixture.json`. Regenerate after any change to
+  the RCS / NTFF / TFSF path.
+- `fixture.json` — geometry + mesh metadata, the rfx monostatic value,
+  the Mie value, the measured delta, and the full H-plane bistatic trace.
+
+## Claim scope (read before citing numbers)
+
+**Validated claim: MONOSTATIC (backscatter) RCS magnitude only**, for a
+staircased PEC sphere at ka≈1.0, at the committed resolution
+(dx=λ/40, ≈6.4 cells per sphere radius, 58³ grid), against the exact Mie
+series. The gate is |Δ| ≤ 1.0 dB on this single configuration.
+
+**This is NOT a bistatic validation.** The same run that produced this
+fixture (2026-07-06 falsifier, reproduced by `generate_fixture.py`) shows:
+
+- a **spurious forward-oblique lobe** at scattering angles 25–55°,
+  ~10 dB high vs the Mie H-plane pattern — TFSF/NTFF forward-face
+  contamination is the suspicion, not yet root-caused;
+- a **forward-scatter (0°) delta of ~1.6 dB**.
+
+Both are recorded per-angle in `fixture.json` under
+`bistatic_trace_non_gated` for R5 inspection and are deliberately NOT
+gated. Do not cite this fixture as evidence that rfx bistatic RCS
+patterns are Mie-accurate, and do not add gates on the bistatic trace
+without first root-causing the forward-oblique lobe.
+
+## Context
+
+Before the #276 fix, `compute_rcs` reported "monostatic" RCS at
+(θ=π, φ=0), which under the `rfx/farfield.py` `r_hat` convention is the
+−z broadside direction, not the −x backscatter of the +x TFSF incidence.
+The shipped number was 10.06 dB off Mie; re-extracting the same run at
+the true backscatter direction (θ=π/2, φ=π) gives the ~0.06 dB recorded
+here.

--- a/tests/fixtures/rcs_sphere_mie/fixture.json
+++ b/tests/fixtures/rcs_sphere_mie/fixture.json
@@ -1,0 +1,277 @@
+{
+  "schema": "rfx.rcs_sphere_mie_monostatic_fixture",
+  "schema_version": 1,
+  "issue": 276,
+  "claim_scope": "MONOSTATIC (backscatter) RCS MAGNITUDE of a staircased PEC sphere at ka~1, at the committed resolution (dx=lambda/40, ~6.4 cells per radius), vs the exact Mie series. This is NOT a bistatic validation: the same run shows a spurious forward-oblique lobe at scattering angles 25-55 deg (~10 dB high vs Mie; TFSF/NTFF forward-face contamination suspected) and a forward-scatter delta of 1.64 dB. Those are recorded in bistatic_trace_non_gated for inspection and are deliberately NOT gated.",
+  "geometry": {
+    "f0_hz": 3000000000.0,
+    "radius_m": 0.0159,
+    "ka": 0.9997180754709523,
+    "dx_m": 0.0024982704833333333,
+    "resolution_cells_per_lambda": 40,
+    "cells_per_radius": 6.364402936380741,
+    "grid_shape": [
+      58,
+      58,
+      58
+    ],
+    "domain_m": [
+      0.1,
+      0.1,
+      0.1
+    ],
+    "cpml_layers": 8,
+    "n_steps": 700,
+    "bandwidth": 0.5,
+    "polarization": "ez",
+    "pec_sigma_s_per_m": 10000000.0
+  },
+  "monostatic": {
+    "rfx_sigma_over_pi_a2": 3.584995414250318,
+    "rfx_dbsm": -25.455672741889146,
+    "mie_sigma_over_pi_a2": 3.637213989031767,
+    "mie_dbsm": -25.392870259132977,
+    "abs_delta_db": 0.0628,
+    "extraction": "RCSResult.monostatic_rcs \u2014 far field evaluated exactly at the backscatter direction (theta=pi/2, phi=pi for +x incidence), post issue-#276 fix."
+  },
+  "mie_oracle_witnesses": {
+    "rayleigh_rel_err": 0.0018482253863655238,
+    "go_window_mean": 1.0042708339090898,
+    "convergence_abs_change": {
+      "0.9997": 0.0,
+      "1.0": 0.0
+    },
+    "bistatic_bridge_value": 3.6371912636831043
+  },
+  "bistatic_trace_non_gated": {
+    "note": "H-plane cut (theta=pi/2, scattering angle == phi). For R5 inspection only \u2014 NOT gated. Known deviations: spurious forward-oblique lobe 25-55 deg (~10 dB high vs Mie), forward-scatter delta ~1.6 dB.",
+    "trace": [
+      {
+        "scattering_angle_deg": 0.0,
+        "rfx_sigma_over_pi_a2": 2.4623529409634424,
+        "mie_sigma_over_pi_a2": 1.6863616486068083,
+        "abs_delta_db": 1.644
+      },
+      {
+        "scattering_angle_deg": 5.0,
+        "rfx_sigma_over_pi_a2": 2.1439462190468994,
+        "mie_sigma_over_pi_a2": 1.690367662588042,
+        "abs_delta_db": 1.032
+      },
+      {
+        "scattering_angle_deg": 10.0,
+        "rfx_sigma_over_pi_a2": 1.8774455141640969,
+        "mie_sigma_over_pi_a2": 1.7024210501738155,
+        "abs_delta_db": 0.425
+      },
+      {
+        "scattering_angle_deg": 15.0,
+        "rfx_sigma_over_pi_a2": 3.0025867850185843,
+        "mie_sigma_over_pi_a2": 1.7226193070385603,
+        "abs_delta_db": 2.413
+      },
+      {
+        "scattering_angle_deg": 20.0,
+        "rfx_sigma_over_pi_a2": 6.453193943729794,
+        "mie_sigma_over_pi_a2": 1.751097479696038,
+        "abs_delta_db": 5.665
+      },
+      {
+        "scattering_angle_deg": 25.0,
+        "rfx_sigma_over_pi_a2": 11.856310682814865,
+        "mie_sigma_over_pi_a2": 1.787990452716075,
+        "abs_delta_db": 8.216
+      },
+      {
+        "scattering_angle_deg": 30.0,
+        "rfx_sigma_over_pi_a2": 17.484525563701407,
+        "mie_sigma_over_pi_a2": 1.8333866170347328,
+        "abs_delta_db": 9.794
+      },
+      {
+        "scattering_angle_deg": 35.0,
+        "rfx_sigma_over_pi_a2": 21.135953508379334,
+        "mie_sigma_over_pi_a2": 1.8872784073942899,
+        "abs_delta_db": 10.492
+      },
+      {
+        "scattering_angle_deg": 40.0,
+        "rfx_sigma_over_pi_a2": 21.361379768304534,
+        "mie_sigma_over_pi_a2": 1.9495155238429638,
+        "abs_delta_db": 10.397
+      },
+      {
+        "scattering_angle_deg": 45.0,
+        "rfx_sigma_over_pi_a2": 18.22650464022756,
+        "mie_sigma_over_pi_a2": 2.0197662941441012,
+        "abs_delta_db": 9.554
+      },
+      {
+        "scattering_angle_deg": 50.0,
+        "rfx_sigma_over_pi_a2": 13.154927249080707,
+        "mie_sigma_over_pi_a2": 2.097491662092714,
+        "abs_delta_db": 7.974
+      },
+      {
+        "scattering_angle_deg": 55.0,
+        "rfx_sigma_over_pi_a2": 8.048969919295251,
+        "mie_sigma_over_pi_a2": 2.1819348474911426,
+        "abs_delta_db": 5.669
+      },
+      {
+        "scattering_angle_deg": 60.0,
+        "rfx_sigma_over_pi_a2": 4.323748501538195,
+        "mie_sigma_over_pi_a2": 2.272128013703097,
+        "abs_delta_db": 2.794
+      },
+      {
+        "scattering_angle_deg": 65.0,
+        "rfx_sigma_over_pi_a2": 2.4252074029772364,
+        "mie_sigma_over_pi_a2": 2.366915515188657,
+        "abs_delta_db": 0.106
+      },
+      {
+        "scattering_angle_deg": 70.0,
+        "rfx_sigma_over_pi_a2": 1.9721759005781516,
+        "mie_sigma_over_pi_a2": 2.4649916864759525,
+        "abs_delta_db": 0.969
+      },
+      {
+        "scattering_angle_deg": 75.0,
+        "rfx_sigma_over_pi_a2": 2.249686028921327,
+        "mie_sigma_over_pi_a2": 2.56494984489109,
+        "abs_delta_db": 0.57
+      },
+      {
+        "scattering_angle_deg": 80.0,
+        "rfx_sigma_over_pi_a2": 2.6637502218621196,
+        "mie_sigma_over_pi_a2": 2.665338325872505,
+        "abs_delta_db": 0.003
+      },
+      {
+        "scattering_angle_deg": 85.0,
+        "rfx_sigma_over_pi_a2": 2.9339864728377663,
+        "mie_sigma_over_pi_a2": 2.764719001687031,
+        "abs_delta_db": 0.258
+      },
+      {
+        "scattering_angle_deg": 90.0,
+        "rfx_sigma_over_pi_a2": 3.043110147460255,
+        "mie_sigma_over_pi_a2": 2.861723839054995,
+        "abs_delta_db": 0.267
+      },
+      {
+        "scattering_angle_deg": 95.0,
+        "rfx_sigma_over_pi_a2": 3.0944959360453113,
+        "mie_sigma_over_pi_a2": 2.9551055628912843,
+        "abs_delta_db": 0.2
+      },
+      {
+        "scattering_angle_deg": 100.0,
+        "rfx_sigma_over_pi_a2": 3.2078463300793474,
+        "mie_sigma_over_pi_a2": 3.0437793089821037,
+        "abs_delta_db": 0.228
+      },
+      {
+        "scattering_angle_deg": 105.0,
+        "rfx_sigma_over_pi_a2": 3.484938853268688,
+        "mie_sigma_over_pi_a2": 3.1268531455893442,
+        "abs_delta_db": 0.471
+      },
+      {
+        "scattering_angle_deg": 110.0,
+        "rfx_sigma_over_pi_a2": 4.002367811251383,
+        "mie_sigma_over_pi_a2": 3.203646398876545,
+        "abs_delta_db": 0.967
+      },
+      {
+        "scattering_angle_deg": 115.0,
+        "rfx_sigma_over_pi_a2": 4.784814440408893,
+        "mie_sigma_over_pi_a2": 3.273695719366723,
+        "abs_delta_db": 1.648
+      },
+      {
+        "scattering_angle_deg": 120.0,
+        "rfx_sigma_over_pi_a2": 5.761019769294626,
+        "mie_sigma_over_pi_a2": 3.33674969018783,
+        "abs_delta_db": 2.372
+      },
+      {
+        "scattering_angle_deg": 125.0,
+        "rfx_sigma_over_pi_a2": 6.747809493665321,
+        "mie_sigma_over_pi_a2": 3.3927534462060955,
+        "abs_delta_db": 2.986
+      },
+      {
+        "scattering_angle_deg": 130.0,
+        "rfx_sigma_over_pi_a2": 7.500525862170858,
+        "mie_sigma_over_pi_a2": 3.4418252204721407,
+        "abs_delta_db": 3.383
+      },
+      {
+        "scattering_angle_deg": 135.0,
+        "rfx_sigma_over_pi_a2": 7.8160750258769385,
+        "mie_sigma_over_pi_a2": 3.4842269624533886,
+        "abs_delta_db": 3.509
+      },
+      {
+        "scattering_angle_deg": 140.0,
+        "rfx_sigma_over_pi_a2": 7.626467512515712,
+        "mie_sigma_over_pi_a2": 3.520331204877265,
+        "abs_delta_db": 3.357
+      },
+      {
+        "scattering_angle_deg": 145.0,
+        "rfx_sigma_over_pi_a2": 7.022468283048381,
+        "mie_sigma_over_pi_a2": 3.550586230985185,
+        "abs_delta_db": 2.962
+      },
+      {
+        "scattering_angle_deg": 150.0,
+        "rfx_sigma_over_pi_a2": 6.197517787987066,
+        "mie_sigma_over_pi_a2": 3.575481357405156,
+        "abs_delta_db": 2.389
+      },
+      {
+        "scattering_angle_deg": 155.0,
+        "rfx_sigma_over_pi_a2": 5.355656228283122,
+        "mie_sigma_over_pi_a2": 3.5955138464782603,
+        "abs_delta_db": 1.731
+      },
+      {
+        "scattering_angle_deg": 160.0,
+        "rfx_sigma_over_pi_a2": 4.640553137906639,
+        "mie_sigma_over_pi_a2": 3.6111586383265544,
+        "abs_delta_db": 1.089
+      },
+      {
+        "scattering_angle_deg": 165.0,
+        "rfx_sigma_over_pi_a2": 4.1144497132070645,
+        "mie_sigma_over_pi_a2": 3.6228417820886145,
+        "abs_delta_db": 0.553
+      },
+      {
+        "scattering_angle_deg": 170.0,
+        "rfx_sigma_over_pi_a2": 3.7784677955526225,
+        "mie_sigma_over_pi_a2": 3.6309181727215956,
+        "abs_delta_db": 0.173
+      },
+      {
+        "scattering_angle_deg": 175.0,
+        "rfx_sigma_over_pi_a2": 3.6083665668762834,
+        "mie_sigma_over_pi_a2": 3.635653979417406,
+        "abs_delta_db": 0.033
+      },
+      {
+        "scattering_angle_deg": 180.0,
+        "rfx_sigma_over_pi_a2": 3.5849954142503186,
+        "mie_sigma_over_pi_a2": 3.637213989031767,
+        "abs_delta_db": 0.063
+      }
+    ]
+  },
+  "provenance": {
+    "generator": "tests/fixtures/rcs_sphere_mie/generate_fixture.py",
+    "wall_seconds_cpu": 5.2
+  }
+}

--- a/tests/fixtures/rcs_sphere_mie/generate_fixture.py
+++ b/tests/fixtures/rcs_sphere_mie/generate_fixture.py
@@ -1,0 +1,219 @@
+"""Generate fixture.json for the PEC-sphere exact-Mie monostatic RCS gate.
+
+Runs the committed-resolution rfx RCS pipeline (PEC sphere, ka~1,
+dx=lambda/40) once on CPU and records:
+
+  * geometry + mesh metadata,
+  * the rfx monostatic (backscatter) RCS from ``RCSResult.monostatic_rcs``
+    (the shipped extraction fixed in issue #276),
+  * the exact-Mie oracle value and the measured delta in dB,
+  * the full H-plane bistatic trace (rfx vs Mie) for R5 inspection —
+    clearly labeled NON-GATED,
+  * a claim_scope string bounding what this fixture validates.
+
+Usage (from the repo root, CPU is sufficient — wall ~7 s):
+
+    JAX_PLATFORMS=cpu python tests/fixtures/rcs_sphere_mie/generate_fixture.py
+
+The gate test ``tests/test_rcs_mie_fixture.py`` recomputes the rfx value
+live and asserts both |rfx - Mie| <= 1.0 dB and |rfx - fixture| small
+(anti-drift), so regenerate this file whenever the RCS/NTFF path changes.
+"""
+
+import json
+import os
+import sys
+import time
+
+import numpy as np
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+# Pin THIS repo tree ahead of any installed rfx: running the script directly
+# puts only the script dir on sys.path, so a stale editable/site-packages rfx
+# would silently win otherwise (caught during #276 fixture generation: the
+# first run produced the FORWARD-scatter value because the installed rfx
+# still had the pre-fix argmin extraction).
+_REPO_ROOT = os.path.abspath(os.path.join(_SCRIPT_DIR, "..", "..", ".."))
+sys.path.insert(0, _REPO_ROOT)
+sys.path.insert(0, _SCRIPT_DIR)
+
+from mie_oracle import (  # noqa: E402
+    backscatter_rcs_over_pi_a2,
+    bistatic_over_pi_a2,
+    validate_oracle,
+)
+
+# --- Committed configuration (matches the 2026-07-06 falsifier run) -------
+F0 = 3e9                 # Hz
+RADIUS = 0.0159          # m  -> ka ~ 0.9997
+RESOLUTION = 40          # dx = lambda / RESOLUTION
+DOMAIN_SIZE = 0.10       # m, cubic
+CPML_LAYERS = 8
+N_STEPS = 700
+BANDWIDTH = 0.5
+POLARIZATION = "ez"
+PEC_SIGMA = 1e7          # S/m, PEC approximation
+N_PHI = 37               # H-plane trace: phi in [0, pi], includes 0 and pi
+
+
+def run_rfx():
+    """Run the committed-resolution rfx RCS simulation. Returns raw pieces."""
+    import rfx
+    _rfx_root = os.path.dirname(os.path.dirname(os.path.abspath(rfx.__file__)))
+    if _rfx_root != _REPO_ROOT:
+        raise RuntimeError(
+            f"import rfx resolved outside this repo tree ({rfx.__file__}); "
+            "refusing to generate a fixture against a different rfx build."
+        )
+    import jax.numpy as jnp
+    from rfx.grid import Grid, C0
+    from rfx.geometry.csg import Sphere, rasterize
+    from rfx.core.yee import MaterialArrays
+    from rfx.rcs import compute_rcs
+
+    lam = C0 / F0
+    dx = lam / RESOLUTION
+    ka = 2 * np.pi * RADIUS / lam
+
+    grid = Grid(
+        freq_max=F0 * 1.5,
+        domain=(DOMAIN_SIZE,) * 3,
+        dx=dx,
+        cpml_layers=CPML_LAYERS,
+    )
+    center = (DOMAIN_SIZE / 2,) * 3
+    sphere = Sphere(center=center, radius=RADIUS)
+    eps_r, sigma = rasterize(grid, [(sphere, 1.0, PEC_SIGMA)])
+    mu_r = jnp.ones(grid.shape, dtype=jnp.float32)
+    materials = MaterialArrays(eps_r=eps_r, sigma=sigma, mu_r=mu_r)
+
+    # H-plane cut in the x-y plane: theta=pi/2, phi in [0, pi].
+    # Scattering angle == phi (phi=0 forward +x, phi=pi backscatter -x).
+    theta_obs = np.array([np.pi / 2])
+    phi_obs = np.linspace(0.0, np.pi, N_PHI)
+
+    t0 = time.time()
+    result = compute_rcs(
+        grid, materials, N_STEPS,
+        f0=F0, bandwidth=BANDWIDTH, theta_inc=0.0,
+        polarization=POLARIZATION,
+        theta_obs=theta_obs, phi_obs=phi_obs, freqs=np.array([F0]),
+        boundary="cpml", cpml_layers=CPML_LAYERS,
+    )
+    wall = time.time() - t0
+    return grid, ka, dx, phi_obs, result, wall
+
+
+def main():
+    # Oracle self-check FIRST — refuse to write a fixture off a broken oracle.
+    witnesses = validate_oracle()
+    print("Mie oracle witnesses PASS:", witnesses)
+
+    grid, ka, dx, phi_obs, result, wall = run_rfx()
+    pi_a2 = np.pi * RADIUS ** 2
+
+    # Shipped monostatic extraction (the quantity gated by the fixture test)
+    mono_dbsm = float(result.monostatic_rcs[0])
+    rfx_back_over = float(10.0 ** (mono_dbsm / 10.0) / pi_a2)
+
+    mie_back_over = float(backscatter_rcs_over_pi_a2(ka, n_max=20))
+    mie_back_dbsm = float(10.0 * np.log10(mie_back_over * pi_a2))
+    delta_db = abs(mono_dbsm - mie_back_dbsm)
+
+    # H-plane bistatic trace (R5 inspection only — NOT gated)
+    rcs_over = np.asarray(result.rcs_linear[0, 0, :]) / pi_a2  # (n_phi,)
+    trace = []
+    for ph, ro in zip(phi_obs, rcs_over):
+        mv = float(bistatic_over_pi_a2(ka, float(ph), "H"))
+        d = abs(10 * np.log10(max(float(ro), 1e-30))
+                - 10 * np.log10(max(mv, 1e-30)))
+        trace.append({
+            "scattering_angle_deg": round(float(np.degrees(ph)), 2),
+            "rfx_sigma_over_pi_a2": float(ro),
+            "mie_sigma_over_pi_a2": mv,
+            "abs_delta_db": round(d, 3),
+        })
+
+    fwd_delta_db = trace[0]["abs_delta_db"]
+
+    fixture = {
+        "schema": "rfx.rcs_sphere_mie_monostatic_fixture",
+        "schema_version": 1,
+        "issue": 276,
+        "claim_scope": (
+            "MONOSTATIC (backscatter) RCS MAGNITUDE of a staircased PEC "
+            "sphere at ka~1, at the committed resolution "
+            f"(dx=lambda/{RESOLUTION}, ~{RADIUS / (299792458.0 / F0 / RESOLUTION):.1f} "
+            "cells per radius), vs the exact Mie series. This is NOT a "
+            "bistatic validation: the same run shows a spurious "
+            "forward-oblique lobe at scattering angles 25-55 deg (~10 dB "
+            "high vs Mie; TFSF/NTFF forward-face contamination suspected) "
+            f"and a forward-scatter delta of {fwd_delta_db:.2f} dB. Those "
+            "are recorded in bistatic_trace_non_gated for inspection and "
+            "are deliberately NOT gated."
+        ),
+        "geometry": {
+            "f0_hz": F0,
+            "radius_m": RADIUS,
+            "ka": float(ka),
+            "dx_m": float(dx),
+            "resolution_cells_per_lambda": RESOLUTION,
+            "cells_per_radius": float(RADIUS / dx),
+            "grid_shape": list(grid.shape),
+            "domain_m": [DOMAIN_SIZE] * 3,
+            "cpml_layers": CPML_LAYERS,
+            "n_steps": N_STEPS,
+            "bandwidth": BANDWIDTH,
+            "polarization": POLARIZATION,
+            "pec_sigma_s_per_m": PEC_SIGMA,
+        },
+        "monostatic": {
+            "rfx_sigma_over_pi_a2": rfx_back_over,
+            "rfx_dbsm": mono_dbsm,
+            "mie_sigma_over_pi_a2": mie_back_over,
+            "mie_dbsm": mie_back_dbsm,
+            "abs_delta_db": round(delta_db, 4),
+            "extraction": (
+                "RCSResult.monostatic_rcs — far field evaluated exactly at "
+                "the backscatter direction (theta=pi/2, phi=pi for +x "
+                "incidence), post issue-#276 fix."
+            ),
+        },
+        "mie_oracle_witnesses": {
+            "rayleigh_rel_err": witnesses["rayleigh_rel_err"],
+            "go_window_mean": witnesses["go_window_mean"],
+            "convergence_abs_change": {
+                str(k): v for k, v in witnesses["convergence_abs_change"].items()
+            },
+            "bistatic_bridge_value": witnesses["bistatic_bridge_value"],
+        },
+        "bistatic_trace_non_gated": {
+            "note": (
+                "H-plane cut (theta=pi/2, scattering angle == phi). For R5 "
+                "inspection only — NOT gated. Known deviations: spurious "
+                "forward-oblique lobe 25-55 deg (~10 dB high vs Mie), "
+                "forward-scatter delta ~1.6 dB."
+            ),
+            "trace": trace,
+        },
+        "provenance": {
+            "generator": "tests/fixtures/rcs_sphere_mie/generate_fixture.py",
+            "wall_seconds_cpu": round(wall, 1),
+        },
+    }
+
+    out = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                       "fixture.json")
+    with open(out, "w") as f:
+        json.dump(fixture, f, indent=2)
+        f.write("\n")
+
+    print(f"\nwall={wall:.1f}s  grid={tuple(grid.shape)}  ka={ka:.4f}")
+    print(f"rfx  monostatic: sigma/pi_a2={rfx_back_over:.4f}  ({mono_dbsm:+.2f} dBsm)")
+    print(f"Mie  monostatic: sigma/pi_a2={mie_back_over:.4f}  ({mie_back_dbsm:+.2f} dBsm)")
+    print(f"|delta| = {delta_db:.3f} dB")
+    print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/rcs_sphere_mie/mie_oracle.py
+++ b/tests/fixtures/rcs_sphere_mie/mie_oracle.py
@@ -1,0 +1,175 @@
+"""Exact Mie series oracle: RCS of a perfectly conducting (PEC) sphere.
+
+Provides the monostatic (backscatter) RCS and the bistatic pattern used by
+the committed sphere fixture (``fixture.json``) and its gate test
+(``tests/test_rcs_mie_fixture.py``).
+
+Convention (Bohren & Huffman, e^{-i w t}):
+  Riccati-Bessel:  psi_n(x)  = x j_n(x),      psi_n'(x)  = j_n(x) + x j_n'(x)
+                   xi_n(x)   = x h_n^(1)(x),  h_n^(1) = j_n + i y_n
+  PEC (m -> inf) Mie coefficients:
+                   a_n = psi_n'(x) / xi_n'(x)
+                   b_n = psi_n(x)  / xi_n(x)
+  Backscatter efficiency (B&H eq. 4.61/4.77):
+                   sigma_b/(pi a^2) = (1/x^2) | sum_{n>=1} (2n+1)(-1)^n (a_n - b_n) |^2
+  Bistatic amplitude functions (B&H eq. 4.74), scattering angle t
+  (0 = forward, pi = backscatter):
+      S1(t) = sum (2n+1)/(n(n+1)) [a_n pi_n(cos t) + b_n tau_n(cos t)]  ("H-plane")
+      S2(t) = sum (2n+1)/(n(n+1)) [a_n tau_n(cos t) + b_n pi_n(cos t)]  ("E-plane")
+      sigma(t)/(pi a^2) = (4/x^2) |S(t)|^2
+
+The oracle is validated INDEPENDENTLY of rfx by ``validate_oracle()`` (four
+witnesses, all pure assertions):
+  (a) Rayleigh limit:      sigma/(pi a^2) -> 9 (ka)^4      as ka -> 0
+  (b) geometric optics:    sigma/(pi a^2) -> 1              as ka -> inf
+  (c) series convergence:  term-doubling changes the ka~1 value by < 1e-6
+  (d) bistatic bridge:     (4/x^2)|S1(pi)|^2 == backscatter formula
+"""
+
+import numpy as np
+from scipy.special import spherical_jn, spherical_yn
+
+
+def _riccati(n_max, x):
+    """Return psi, psi', xi, xi' arrays for n = 1..n_max at scalar x."""
+    n = np.arange(0, n_max + 1)
+    jn = spherical_jn(n, x)                     # j_n(x)
+    jnp_ = spherical_jn(n, x, derivative=True)  # j_n'(x)
+    yn = spherical_yn(n, x)                     # y_n(x)
+    ynp_ = spherical_yn(n, x, derivative=True)  # y_n'(x)
+
+    hn = jn + 1j * yn        # h_n^(1)(x)
+    hnp_ = jnp_ + 1j * ynp_  # h_n^(1)'(x)
+
+    psi = x * jn             # psi_n = x j_n
+    psip = jn + x * jnp_     # psi_n' = j_n + x j_n'
+    xi = x * hn              # xi_n = x h_n^(1)
+    xip = hn + x * hnp_      # xi_n' = h_n^(1) + x h_n^(1)'
+
+    # drop n=0 (Mie sum starts at n=1)
+    return psi[1:], psip[1:], xi[1:], xip[1:]
+
+
+def mie_pec_coeffs(x, n_max):
+    """PEC Mie coefficients a_n, b_n for n=1..n_max at size parameter x=ka."""
+    psi, psip, xi, xip = _riccati(n_max, x)
+    a_n = psip / xip
+    b_n = psi / xi
+    return a_n, b_n
+
+
+def backscatter_rcs_over_pi_a2(x, n_max=None):
+    """Normalized monostatic RCS sigma_b/(pi a^2) for a PEC sphere at x=ka.
+
+    Wiscombe rule-of-thumb term count if n_max is None:
+    n = x + 4.05 x^(1/3) + 2.
+    """
+    if n_max is None:
+        n_max = int(np.ceil(x + 4.05 * x ** (1.0 / 3.0) + 2)) + 1
+        n_max = max(n_max, 1)
+    a_n, b_n = mie_pec_coeffs(x, n_max)
+    n = np.arange(1, n_max + 1)
+    terms = (2 * n + 1) * ((-1) ** n) * (a_n - b_n)
+    S = np.sum(terms)
+    return (1.0 / x ** 2) * np.abs(S) ** 2
+
+
+def pi_tau(n_max, cos_t):
+    """Angular functions pi_n, tau_n for n=1..n_max at scalar cos_t."""
+    pin = np.zeros(n_max + 1)
+    taun = np.zeros(n_max + 1)
+    pin[0] = 0.0
+    pin[1] = 1.0
+    taun[1] = cos_t * pin[1]  # tau_1 = 1*cos*pi_1 - 2*pi_0 = cos
+    for n in range(2, n_max + 1):
+        pin[n] = ((2 * n - 1) / (n - 1)) * cos_t * pin[n - 1] \
+            - (n / (n - 1)) * pin[n - 2]
+        taun[n] = n * cos_t * pin[n] - (n + 1) * pin[n - 1]
+    return pin[1:], taun[1:]
+
+
+def mie_S1_S2(x, theta, n_max=20):
+    """Far-field amplitude functions S1, S2 at scattering angle theta."""
+    a_n, b_n = mie_pec_coeffs(x, n_max)
+    n = np.arange(1, n_max + 1)
+    fac = (2 * n + 1) / (n * (n + 1))
+    pin, taun = pi_tau(n_max, np.cos(theta))
+    S1 = np.sum(fac * (a_n * pin + b_n * taun))
+    S2 = np.sum(fac * (a_n * taun + b_n * pin))
+    return S1, S2
+
+
+def bistatic_over_pi_a2(x, theta, plane, n_max=20):
+    """Bistatic sigma(theta)/(pi a^2).
+
+    plane='H' -> S1 (E perp scattering plane); plane='E' -> S2 (E in
+    scattering plane). theta is the SCATTERING angle: 0 = forward,
+    pi = backscatter.
+    """
+    S1, S2 = mie_S1_S2(x, theta, n_max)
+    S = S1 if plane == "H" else S2
+    return (4.0 / x ** 2) * np.abs(S) ** 2
+
+
+def validate_oracle():
+    """Self-check the oracle against four independent witnesses (asserts).
+
+    Raises AssertionError on any failure; returns a dict of the measured
+    witness values on success.
+    """
+    # (a) Rayleigh limit: sigma/(pi a^2) -> 9 (ka)^4 as ka -> 0
+    ka = 0.1
+    val = backscatter_rcs_over_pi_a2(ka, n_max=8)
+    rayleigh = 9.0 * ka ** 4
+    rel_a = abs(val - rayleigh) / rayleigh
+    assert rel_a < 0.02, (
+        f"Rayleigh witness failed at ka={ka}: computed {val:.6e} vs "
+        f"9(ka)^4={rayleigh:.6e}, rel err {rel_a:.3e} >= 0.02"
+    )
+
+    # (b) geometric-optics limit: window-mean over ka in [18, 22] -> 1
+    n_terms = int(np.ceil(22.0 + 4.05 * 22.0 ** (1 / 3) + 2)) + 5
+    kas = np.linspace(18, 22, 41)
+    go_mean = float(np.mean(
+        [backscatter_rcs_over_pi_a2(k, n_max=n_terms) for k in kas]
+    ))
+    assert abs(go_mean - 1.0) < 0.1, (
+        f"GO witness failed: window-mean sigma/(pi a^2) over ka in [18,22] "
+        f"= {go_mean:.4f}, expected 1.0 +/- 0.1"
+    )
+
+    # (c) series convergence at ka ~ 1: doubling n_max changes < 1e-6
+    conv = {}
+    for ka_c in (0.9997, 1.0):
+        v1 = backscatter_rcs_over_pi_a2(ka_c, n_max=10)
+        v2 = backscatter_rcs_over_pi_a2(ka_c, n_max=20)
+        dd = abs(v2 - v1)
+        assert dd < 1e-6, (
+            f"Convergence witness failed at ka={ka_c}: "
+            f"|n_max 10 -> 20 change| = {dd:.3e} >= 1e-6"
+        )
+        conv[ka_c] = dd
+
+    # (d) bistatic-formula bridge: (4/x^2)|S(pi)|^2 == backscatter formula
+    x = 0.9997
+    back_formula = backscatter_rcs_over_pi_a2(x, n_max=20)
+    back_bi_H = bistatic_over_pi_a2(x, np.pi, "H")
+    back_bi_E = bistatic_over_pi_a2(x, np.pi, "E")
+    assert np.allclose([back_bi_H, back_bi_E], back_formula, rtol=1e-9), (
+        f"Bistatic bridge witness failed at ka={x}: backscatter formula "
+        f"{back_formula:.9f} vs S1(pi) {back_bi_H:.9f} / S2(pi) {back_bi_E:.9f}"
+    )
+
+    return {
+        "rayleigh_rel_err": rel_a,
+        "go_window_mean": go_mean,
+        "convergence_abs_change": conv,
+        "bistatic_bridge_value": back_formula,
+    }
+
+
+if __name__ == "__main__":
+    witnesses = validate_oracle()
+    print("Mie PEC-sphere oracle — all witnesses PASS")
+    for k, v in witnesses.items():
+        print(f"  {k}: {v}")

--- a/tests/test_rcs_mie_fixture.py
+++ b/tests/test_rcs_mie_fixture.py
@@ -1,0 +1,181 @@
+"""Gate test: PEC-sphere monostatic RCS vs exact Mie series (issue #276).
+
+Recomputes the committed-resolution sphere run live and gates the SHIPPED
+monostatic extraction (``RCSResult.monostatic_rcs``) against the exact Mie
+oracle committed in ``tests/fixtures/rcs_sphere_mie/mie_oracle.py``.
+
+Claim scope (see the fixture README): MONOSTATIC (backscatter) magnitude
+only, at the committed resolution. The bistatic trace in the fixture is
+NON-GATED — the same run shows a spurious forward-oblique lobe (25-55 deg,
+~10 dB high vs Mie) and a ~1.6 dB forward-scatter delta; do not add
+bistatic gates here without root-causing those first.
+
+Runtime: one 58^3 x 700-step CPU run, ~7 s.
+"""
+
+import importlib.util
+import json
+import os
+
+import numpy as np
+import jax.numpy as jnp
+
+from rfx.grid import Grid, C0
+from rfx.geometry.csg import Sphere, rasterize
+from rfx.core.yee import MaterialArrays
+from rfx.rcs import compute_rcs
+
+FIXTURE_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "fixtures", "rcs_sphere_mie",
+)
+
+
+def _load_mie_oracle():
+    spec = importlib.util.spec_from_file_location(
+        "rcs_sphere_mie_oracle", os.path.join(FIXTURE_DIR, "mie_oracle.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_fixture():
+    with open(os.path.join(FIXTURE_DIR, "fixture.json")) as f:
+        return json.load(f)
+
+
+def test_mie_oracle_witnesses():
+    """The oracle must pass its four rfx-independent validation witnesses."""
+    oracle = _load_mie_oracle()
+    witnesses = oracle.validate_oracle()  # raises AssertionError on failure
+    # Rayleigh witness measured at 1.8e-3 rel err; keep the committed bound.
+    assert witnesses["rayleigh_rel_err"] < 0.02
+    assert abs(witnesses["go_window_mean"] - 1.0) < 0.1
+
+
+def test_monostatic_backscatter_matches_exact_mie():
+    """Live recompute at the committed resolution: |rfx - Mie| <= 1.0 dB.
+
+    Also asserts (a) the exact-direction monostatic value agrees with the
+    observation-grid sample at (theta=pi/2, phi=pi) — internal consistency
+    witness for the #276 extraction — and (b) the live value matches the
+    committed fixture.json within a cross-machine float tolerance
+    (anti-drift).
+    """
+    oracle = _load_mie_oracle()
+    fixture = _load_fixture()
+    geo = fixture["geometry"]
+
+    f0 = geo["f0_hz"]
+    radius = geo["radius_m"]
+    lam = C0 / f0
+    dx = lam / geo["resolution_cells_per_lambda"]
+    ka = 2 * np.pi * radius / lam
+    domain = tuple(geo["domain_m"])
+    cpml = geo["cpml_layers"]
+
+    grid = Grid(
+        freq_max=f0 * 1.5, domain=domain, dx=dx, cpml_layers=cpml,
+    )
+    assert tuple(grid.shape) == tuple(geo["grid_shape"]), (
+        "Committed grid metadata drifted from the live Grid construction; "
+        "regenerate the fixture."
+    )
+
+    center = tuple(d / 2 for d in domain)
+    sphere = Sphere(center=center, radius=radius)
+    eps_r, sigma = rasterize(
+        grid, [(sphere, 1.0, geo["pec_sigma_s_per_m"])],
+    )
+    mu_r = jnp.ones(grid.shape, dtype=jnp.float32)
+    materials = MaterialArrays(eps_r=eps_r, sigma=sigma, mu_r=mu_r)
+
+    # H-plane observation cut; phi grid contains the exact backscatter
+    # angle (phi=pi) so the grid sample can witness the exact-direction
+    # extraction.
+    theta_obs = np.array([np.pi / 2])
+    phi_obs = np.linspace(0.0, np.pi, 37)
+
+    result = compute_rcs(
+        grid, materials, geo["n_steps"],
+        f0=f0, bandwidth=geo["bandwidth"], theta_inc=0.0,
+        polarization=geo["polarization"],
+        theta_obs=theta_obs, phi_obs=phi_obs, freqs=np.array([f0]),
+        boundary="cpml", cpml_layers=cpml,
+    )
+
+    mono_dbsm = float(result.monostatic_rcs[0])
+
+    # (a) Internal witness: exact-direction evaluation == grid sample at
+    # (theta=pi/2, phi=pi). Same NTFF data, same float64 post-processing.
+    grid_back_dbsm = float(result.rcs_dbsm[0, 0, -1])
+    assert abs(mono_dbsm - grid_back_dbsm) < 1e-6, (
+        f"monostatic_rcs ({mono_dbsm:.6f} dBsm) != observation-grid sample "
+        f"at (pi/2, pi) ({grid_back_dbsm:.6f} dBsm) — the exact-direction "
+        "extraction disagrees with the grid path."
+    )
+
+    # (b) THE gate: shipped monostatic vs exact Mie series.
+    pi_a2 = np.pi * radius ** 2
+    mie_over = float(oracle.backscatter_rcs_over_pi_a2(ka, n_max=20))
+    mie_dbsm = 10.0 * np.log10(mie_over * pi_a2)
+    delta_db = abs(mono_dbsm - mie_dbsm)
+    assert delta_db <= 1.0, (
+        f"Monostatic RCS {mono_dbsm:.2f} dBsm is {delta_db:.2f} dB from the "
+        f"exact Mie value {mie_dbsm:.2f} dBsm (gate 1.0 dB; measured 0.06 dB "
+        "on the 2026-07-06 falsifier run and at fixture generation). "
+        "A regression here means the monostatic extraction or the "
+        "TFSF/NTFF/RCS chain drifted — see tests/fixtures/rcs_sphere_mie/."
+    )
+
+    # (c) Anti-drift: live recompute must match the committed fixture value.
+    # Tolerance covers cross-machine float32 FDTD accumulation differences
+    # only — a real physics/extraction change exceeds it.
+    fix_dbsm = fixture["monostatic"]["rfx_dbsm"]
+    assert abs(mono_dbsm - fix_dbsm) < 0.25, (
+        f"Live monostatic {mono_dbsm:.4f} dBsm drifted from committed "
+        f"fixture value {fix_dbsm:.4f} dBsm by "
+        f"{abs(mono_dbsm - fix_dbsm):.4f} dB (>= 0.25). If an intentional "
+        "physics change caused this, regenerate the fixture with "
+        "tests/fixtures/rcs_sphere_mie/generate_fixture.py and re-review "
+        "the delta vs Mie."
+    )
+
+    # R5 breadcrumb for -s runs.
+    print(
+        f"\nMie fixture gate: rfx {mono_dbsm:+.3f} dBsm | Mie "
+        f"{mie_dbsm:+.3f} dBsm | |delta| {delta_db:.3f} dB | "
+        f"fixture {fix_dbsm:+.3f} dBsm"
+    )
+
+
+def test_fixture_claim_scope_is_monostatic_only():
+    """The committed fixture must keep its honesty markers.
+
+    The claim scope is monostatic-only; the known bistatic deviations
+    (forward-oblique lobe, forward delta) must stay documented and the
+    bistatic trace must stay labeled non-gated.
+    """
+    fixture = _load_fixture()
+    scope = fixture["claim_scope"]
+    assert "MONOSTATIC" in scope
+    assert "NOT a bistatic validation" in scope
+    assert "bistatic_trace_non_gated" in fixture
+    trace = fixture["bistatic_trace_non_gated"]["trace"]
+    # Trace spans forward (0 deg) to backscatter (180 deg) for inspection.
+    assert trace[0]["scattering_angle_deg"] == 0.0
+    assert trace[-1]["scattering_angle_deg"] == 180.0
+    # The recorded backscatter delta (the gated quantity) is small ...
+    assert trace[-1]["abs_delta_db"] <= 1.0
+    # ... while the documented forward-oblique deviation is real and large;
+    # this assertion guards against silently "cleaning up" the evidence.
+    oblique = [
+        p["abs_delta_db"] for p in trace
+        if 25.0 <= p["scattering_angle_deg"] <= 55.0
+    ]
+    assert max(oblique) > 5.0, (
+        "The committed bistatic trace no longer shows the documented "
+        "forward-oblique deviation (25-55 deg). If the lobe was actually "
+        "fixed, update the fixture README + claim_scope alongside the "
+        "regenerated trace instead of leaving stale honesty text."
+    )


### PR DESCRIPTION
Fixes #276.

## Bug

`compute_rcs` argmin-extracted "monostatic" RCS at (θ=π, φ=0), which under the far-field convention (`rfx/farfield.py` `r_hat = [sinθcosφ, sinθsinφ, cosθ]`) is the **−z broadside** direction — not the −x backscatter of the +x TFSF incidence. True backscatter is (θ=π/2, φ=π). Measured on the validated exact-Mie falsifier (PEC sphere, ka=0.9997, dx=λ/40): shipped value was **10.06 dB** off Mie; the same run re-extracted at the true angle is **0.06 dB** off.

## Fix

- Derive the backscatter direction explicitly from the incident propagation unit vector (`b_hat = −k_hat` → `θ=arccos(b_z)`, `φ=atan2(b_y, b_x)`; +x normal incidence → (π/2, π)), with the tilt-plane convention for `theta_inc≠0` cited from `rfx/sources/tfsf_2d.py`.
- **Deviation from the issue's "fix the argmin" sketch (deliberate):** the far field is evaluated **exactly** at the backscatter direction on the already-accumulated NTFF data instead of argmin-snapping to the observation grid — the default `phi_obs=[0, π/2]` does not contain φ=π (and `tests/test_rcs.py` passes `phi_obs=[0.0]`), so a corrected argmin target would still silently snap to a wrong cut. `monostatic_rcs` is now grid-independent and always populated (previously `None` for empty obs grids).
- Public-doc truth surface updated: `docs/public/guide/farfield-rcs.md` no longer documents the wrong angle / `None` case.

## Committed evidence + gate (regenerated with the FIXED code, not pasted)

`tests/fixtures/rcs_sphere_mie/` + `tests/test_rcs_mie_fixture.py`:

| quantity | value |
|---|---|
| ka / dx / grid | 0.9997 / λ40 (6.36 cells per radius) / 58³, 700 steps, wall ~5.2 s CPU |
| rfx monostatic σ/πa² | **3.5850** (−25.456 dBsm) |
| exact Mie σ/πa² | **3.6372** (−25.393 dBsm) |
| measured delta | **0.063 dB** (gate ≤ 1.0 dB — honest headroom) |

- Mie oracle self-validated by four rfx-independent witnesses kept as assertions: Rayleigh `9(ka)^4` (rel err 1.8e-3), GO→1 (window-mean 1.004), term-doubling convergence (|Δ|=0 at ka~1), bistatic-bridge identity at θ=π.
- Gate test also asserts: exact-direction extraction == observation-grid sample at (π/2, π) (internal witness), live recompute matches committed `fixture.json` within 0.25 dB (anti-drift), and an honesty guard that the claim scope stays monostatic-only while the documented bistatic deviations stay in the committed trace.

## Claim scope (honesty)

**MONOSTATIC (backscatter) magnitude at the committed resolution vs exact Mie — NOT a bistatic validation.** The same run shows a spurious forward-oblique lobe at 25–55° (~10 dB high vs Mie; TFSF/NTFF forward-face contamination suspected) and a forward-scatter Δ≈1.6 dB. Both are recorded per-angle in `fixture.json` (`bistatic_trace_non_gated`) and in the fixture README — documented, not gated, not hidden.

## Gates (all green)

- `pytest tests/test_rcs.py tests/test_rcs_mie_fixture.py -q` → **6 passed in 10.49s**. Plate-PO test (±10 dB) byte-identical, passes at 1.0 dB from PO (now at the true backscatter angle); sphere-GO test (±15 dB) byte-identical, passes at 11.5 dB (staircase-dominated at its λ/10, 1.5-cells-per-radius resolution).
- `ruff check rfx/ tests/ --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402` → All checks passed.
- `pytest tests/test_forward_docstring_contract.py tests/test_api_private_surface_guard.py -q` → 9 passed (public docstrings touched).

## R3 self-audit

1. **Contradicted by memory?** None found after grep of `docs/agent-memory/` + MEMORY.md. Consistent with `project_wr90_architectural_candidates.md` (comparator/extractor pattern — this is another instance: the 10 dB "gap" was extraction convention, not FDTD physics), `feedback_metric_first_skepticism.md` / R5 (the wrong angle only surfaced via the full per-angle dump), and `feedback_root_cause_before_gate_change.md` (no gates weakened; a tighter external-oracle gate added).
2. **R2 count:** 0 non-closing physics fix attempts. One tooling iteration during fixture generation: the first generator run reproduced the FORWARD value — R5 inspection traced it to `sys.path` resolving the stale pre-fix editable rfx install (script-dir-only path), not a physics residual; the generator now pins the repo tree and refuses foreign rfx builds. Regenerated once → 0.063 dB.
3. **Falsifier:** the fixture gate itself — a live recompute that fails on >1.0 dB vs exact Mie, on exact-direction/grid-sample disagreement, or on drift from the committed fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
