### PR TITLE
fix(api): estimate_ad_memory counts the live-segment rematerialization tape (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,33 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   forward-scatter delta, documented per-angle in the fixture rather than
   hidden.
 
+### Fixed — `estimate_ad_memory` counts the live-segment rematerialization tape (#277)
+
+- Both segmented paths (`checkpoint_segments` and `checkpoint_every`) now model
+  peak reverse-mode AD memory as
+  `(2 x active_segments + live_tape_steps) x field_bytes + forward + ntff`.
+  The previous formula (issue #39) counted only the segment-boundary
+  carry + cotangent term; during the backward pass each segment is
+  rematerialized as a unit, so one segment's per-step field tape
+  (`n_steps // checkpoint_segments`, or `checkpoint_every` on the padded
+  non-uniform path, capped at the active step count) is resident on top of it.
+  At segment counts far from `sqrt(n_steps)` the old estimate under-counted
+  peak by up to `~(segment_len / (2 x segments))x` (a hypothetical
+  far-from-sqrt(N) knob: ~272x at `n_steps=6999`, `checkpoint_segments=3`;
+  the committed desk ladder's sqrt(N) path shifts only ~1.5x); the VESSL 369367233509
+  inverse-design gradient peaks (5.84 GB at chunk=100/n_steps=10000 vs the old
+  ~3.1 GB estimate) confirm the missing term.
+- Planning numbers shift accordingly: `ad_segmented_gb` grows, is minimized
+  near `sqrt(2 x n_steps)` steps per segment (no longer monotone in the knob),
+  and `preflight`/`estimate_ad_memory` VRAM warnings fire more often — that is
+  the estimate becoming honest, not a regression. Warnings now point at the
+  dominant term (increase or reduce the knob toward `sqrt(n_steps)`).
+- `explain_ad_memory` decomposes the new term as a
+  `segmented_live_segment_tape` component; `plan_ad_memory`'s does-not-fit
+  diagnostics now report the true least-memory candidate (balanced segment
+  size) instead of `checkpoint_segments=1` / `checkpoint_every=n_steps`, which
+  are ~full-AD-sized under the corrected model.
+
 ### Added — waveguide multi-port junction references (`port_reference_sims`)
 
 - `compute_waveguide_s_matrix(..., port_reference_sims=[...])` exposes public

--- a/docs/public/guide/memory-reduction.mdx
+++ b/docs/public/guide/memory-reduction.mdx
@@ -192,7 +192,8 @@ explain_json = explain.to_json()
 `explain_ad_memory(...)` reports the selected memory field (`ad_full_gb` or
 `ad_segmented_gb`), the active AD strategy, and a component breakdown. Use it to
 decide whether the dominant cost is full field tape, segmented boundary state,
-CPML/material state, or NTFF monitor state.
+the live-segment rematerialization tape, CPML/material state, or NTFF monitor
+state.
 
 For a JAX-level saved-residual diagnostic on a small loss function or reduced
 problem, use `diagnose_ad_saved_residuals(...)`:
@@ -256,6 +257,15 @@ Use the mesh intelligence report to check:
 `checkpoint_every` for the non-uniform scan-of-scan path, where it means chunk
 length in timesteps. Use `checkpoint_segments` for the uniform segmented-scan
 path, where it means the number of equal segments and must divide `n_steps`.
+The segmented estimate counts two tape terms: carry + cotangent state at the
+active segment boundaries (`2 x active_segments` field states), plus the
+live-segment rematerialization tape — the backward pass replays one segment at
+a time, so that segment's per-step field tape (its full length in timesteps) is
+resident on top of the boundary storage. The estimate is minimized where the
+two terms balance, near `sqrt(2 x n_steps)` timesteps per segment; pushing a
+checkpoint knob to either extreme *increases* peak memory, so let
+`plan_ad_memory(...)` pick the knob rather than hand-tuning it to the smallest
+segment count.
 `n_warmup` reduces the reported active reverse-mode timestep count. `design_mask`
 is recorded as active-design metadata only; the primary memory estimates stay
 full-grid until masked-state memory has observed calibration. `n_warmup` must be

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -2131,7 +2131,27 @@ class Simulation(
         ``ad_segmented_gb`` reflects the non-uniform segmented scan-of-scan
         chunk-size path from issue #31. When ``checkpoint_segments`` is
         provided, it reflects the uniform segmented-scan segment-count path
-        from issue #73. ``n_warmup`` must be an integer with
+        from issue #73.
+
+        The segmented model (issue #277) counts BOTH terms of the
+        rematerialized backward pass:
+
+        * segment-boundary storage — carry + cotangent per active segment,
+          ``2 * active_segments * field_bytes``;
+        * the live-segment rematerialization tape — the backward pass
+          replays one segment at a time, so that segment's per-step field
+          tape (``n_steps // checkpoint_segments`` steps on the uniform
+          path, ``checkpoint_every`` steps on the chunked path) is resident
+          on top of the boundary storage. The non-uniform runner pads the
+          trailing chunk with zero source to a full chunk, so the full
+          chunk length is the correct live-tape size; both live terms are
+          capped at the active (post-warmup) step count.
+
+        The segmented estimate is therefore minimized when the two terms
+        balance, near ``sqrt(2 * n_steps)`` steps per segment — NOT by
+        pushing the segment count to either extreme. Use
+        :meth:`plan_ad_memory` to pick a balanced knob for a budget.
+        ``n_warmup`` must be an integer with
         ``0 <= n_warmup < n_steps``. ``design_mask`` must be a boolean array
         matching the simulation grid shape and selecting at least one cell.
         ``n_warmup`` reduces reported reverse-mode tape time. ``design_mask``
@@ -2228,22 +2248,36 @@ class Simulation(
         # Segmented scan paths. ``checkpoint_every`` is the non-uniform
         # scan-of-scan chunk length (issue #31); ``checkpoint_segments`` is
         # the uniform segmented-scan segment count (issue #73). Both store
-        # carry + cotangent at segment boundaries.
+        # carry + cotangent at segment boundaries, AND during the backward
+        # pass the segment currently being differentiated is rematerialized
+        # as a whole, so its per-step field tape is live at the same time
+        # (issue #277; the runners document peak as O((K + s) · |carry|)).
         ad_seg_bytes: int | None = None
         segmented_active_segments: int | None = None
+        segmented_live_tape_steps: int | None = None
         if checkpoint_segments_i is not None:
             segment_len = n_steps_i // checkpoint_segments_i
             first_active_segment = n_warmup_i // segment_len
             segmented_active_segments = checkpoint_segments_i - first_active_segment
+            segmented_live_tape_steps = min(segment_len, active_steps)
             ad_seg_bytes = (
-                2 * segmented_active_segments * active_tape_field_bytes + forward_bytes + ntff_bytes
+                (2 * segmented_active_segments + segmented_live_tape_steps)
+                * active_tape_field_bytes
+                + forward_bytes + ntff_bytes
             )
         elif checkpoint_every_i is not None:
             total_segments = math.ceil(n_steps_i / checkpoint_every_i)
             inactive_segments = n_warmup_i // checkpoint_every_i
             segmented_active_segments = total_segments - inactive_segments
+            # The non-uniform runner pads the trailing chunk with zero
+            # source up to a full ``checkpoint_every`` steps, so the live
+            # rematerialized chunk is a full chunk (capped at the active
+            # reverse-mode step count).
+            segmented_live_tape_steps = min(checkpoint_every_i, active_steps)
             ad_seg_bytes = (
-                2 * segmented_active_segments * active_tape_field_bytes + forward_bytes + ntff_bytes
+                (2 * segmented_active_segments + segmented_live_tape_steps)
+                * active_tape_field_bytes
+                + forward_bytes + ntff_bytes
             )
 
         # VRAM detection (best effort)
@@ -2267,14 +2301,29 @@ class Simulation(
         warning = None
         if avail_gb is not None and primary_bytes * to_gb > avail_gb * 0.85:
             label = "segmented" if ad_seg_bytes is not None else "non-checkpointed"
+            # Direction-aware advice (#277): with the live-segment tape in
+            # the model, the segmented peak is minimized when the boundary
+            # term (2 · active_segments) and the live term (steps per
+            # segment) balance near sqrt(2 · n_steps). Point the user
+            # toward the dominant term.
+            live_dominates = (
+                segmented_live_tape_steps is not None
+                and segmented_active_segments is not None
+                and segmented_live_tape_steps
+                > 2 * segmented_active_segments
+            )
             if checkpoint_segments_i is not None:
                 if segmented_active_segments == 1:
                     action = "Reduce grid size, reduce n_steps, or use a more aggressive memory-reduction lane."
+                elif live_dominates:
+                    action = "Increase checkpoint_segments toward sqrt(n_steps) to shrink the live-segment tape, reduce grid size, or reduce n_steps."
                 else:
                     action = "Reduce checkpoint_segments, reduce grid size, or reduce n_steps."
             elif ad_seg_bytes is not None:
                 if segmented_active_segments == 1:
                     action = "Reduce grid size, reduce n_steps, or use a more aggressive memory-reduction lane."
+                elif live_dominates:
+                    action = "Reduce checkpoint_every toward sqrt(n_steps) to shrink the live-chunk tape, reduce grid size, or reduce n_steps."
                 else:
                     action = "Increase checkpoint_every, reduce grid size, or reduce n_steps."
             else:
@@ -2358,7 +2407,18 @@ class Simulation(
                 "time step."
             )
             tape_unit = "carry-or-cotangent-field-state"
+            # Live-segment rematerialization tape (#277): backward replays
+            # one segment at a time, so that segment's per-step field tape
+            # is resident on top of the boundary storage. Mirrors the
+            # estimate_ad_memory accounting.
+            if estimate.checkpoint_segments is not None:
+                live_tape_steps = min(
+                    n_steps_i // int(estimate.checkpoint_segments), active_steps
+                )
+            else:
+                live_tape_steps = min(int(estimate.checkpoint_every), active_steps)
         else:
+            live_tape_steps = None
             selected_field = "ad_full_gb"
             selected_gb = float(estimate.ad_full_gb)
             strategy = "full_reverse_ad_static_tape"
@@ -2397,6 +2457,24 @@ class Simulation(
                     None if bytes_per_unit is None else bytes_per_unit / 1e9
                 ),
                 explanation=explanation,
+            )
+
+        live_components: tuple[ADMemoryComponent, ...] = ()
+        if live_tape_steps is not None:
+            live_components = (
+                _component(
+                    "segmented_live_segment_tape",
+                    live_tape_steps * field_bytes,
+                    "reverse_ad_saved_state",
+                    unit="live-segment-time-step-field-state",
+                    count=int(live_tape_steps),
+                    bytes_per_unit=field_bytes,
+                    explanation=(
+                        "The backward pass rematerializes one segment at a "
+                        "time, so the live segment's per-step field tape is "
+                        "resident on top of the segment-boundary storage."
+                    ),
+                ),
             )
 
         components = (
@@ -2442,6 +2520,7 @@ class Simulation(
                 bytes_per_unit=field_bytes,
                 explanation=tape_explanation,
             ),
+            *live_components,
             _component(
                 "ntff_dft_state",
                 ntff_bytes,
@@ -2467,7 +2546,10 @@ class Simulation(
             )
         else:
             recommendations.append(
-                f"Selected strategy stores {tape_count} {tape_unit} unit(s) instead of {active_steps} active time-step tape entries."
+                f"Selected strategy stores {tape_count} {tape_unit} unit(s) "
+                f"plus one live rematerialized segment of {live_tape_steps} "
+                f"time-step tape entries, instead of {active_steps} active "
+                "time-step tape entries."
             )
         if estimate.ad_active_design_fraction is not None and estimate.ad_active_design_fraction < 1.0:
             recommendations.append(
@@ -2620,35 +2702,64 @@ class Simulation(
                     ),
                 )
 
-            minimum_segment_estimate = self.estimate_ad_memory(
-                n_steps_i,
-                available_memory_gb=available_memory_gb_f,
-                checkpoint_segments=1,
-                n_warmup=n_warmup_i,
-                design_mask=design_mask,
+            # With the live-segment term (#277) the least-memory candidate
+            # is the divisor balancing the boundary and live tape terms,
+            # NOT checkpoint_segments=1 (which is ~full-AD-sized). Report
+            # the true least-memory divisor as the diagnostic candidate.
+            least_segments: int | None = None
+            least_estimate: AD_MemoryEstimate | None = None
+            for segments in sorted(divisors):
+                estimate = self.estimate_ad_memory(
+                    n_steps_i,
+                    available_memory_gb=available_memory_gb_f,
+                    checkpoint_segments=segments,
+                    n_warmup=n_warmup_i,
+                    design_mask=design_mask,
+                )
+                segmented_gb = estimate.ad_segmented_gb
+                if segmented_gb is None:
+                    continue
+                if least_estimate is None or segmented_gb < least_estimate.ad_segmented_gb:
+                    least_segments = segments
+                    least_estimate = estimate
+            least_fits = (
+                least_estimate is not None
+                and least_estimate.ad_segmented_gb * safety_factor_f
+                <= target_memory_gb
             )
+            if least_fits:
+                recommendation = (
+                    f"use checkpoint_segments={least_segments}: segmented AD estimate "
+                    f"{_format_memory_with_safety(least_estimate.ad_segmented_gb, safety_factor_f)} fits within the "
+                    f"{_format_memory_gb(target_memory_gb)} target"
+                )
+            else:
+                recommendation = (
+                    f"no checkpoint_segments divisor fits; the least-memory candidate "
+                    f"checkpoint_segments={least_segments} is estimated at "
+                    f"{_format_memory_with_safety(least_estimate.ad_segmented_gb, safety_factor_f)}, above the "
+                    f"{_format_memory_gb(target_memory_gb)} target; reduce mesh size, reduce "
+                    "n_steps, or use a more aggressive memory-reduction lane"
+                )
             return ADMemoryPlan(
                 n_steps=n_steps_i,
                 available_memory_gb=available_memory_gb_f,
                 target_fraction=target_fraction_f,
                 target_memory_gb=target_memory_gb,
                 checkpoint_every=None,
-                checkpoint_segments=1,
+                checkpoint_segments=least_segments,
                 checkpoint_mode="checkpoint_segments",
                 fit_safety_factor=safety_factor_f,
-                selected_estimate=minimum_segment_estimate,
+                selected_estimate=least_estimate,
                 full_ad_fits=False,
-                segmented_fits=False,
-                recommendation=(
-                    "even checkpoint_segments=1 is estimated at "
-                    f"{_format_memory_with_safety(minimum_segment_estimate.ad_segmented_gb, safety_factor_f)}, above the "
-                    f"{_format_memory_gb(target_memory_gb)} target; reduce mesh size, reduce "
-                    "n_steps, or use a more aggressive memory-reduction lane"
-                ),
+                segmented_fits=least_fits,
+                recommendation=recommendation,
             )
 
         best_checkpoint: int | None = None
         best_estimate: AD_MemoryEstimate | None = None
+        least_checkpoint: int | None = None
+        least_estimate: AD_MemoryEstimate | None = None
         for checkpoint in range(1, n_steps_i + 1):
             estimate = self.estimate_ad_memory(
                 n_steps_i,
@@ -2658,6 +2769,12 @@ class Simulation(
                 design_mask=design_mask,
             )
             segmented_gb = estimate.ad_segmented_gb
+            if segmented_gb is not None and (
+                least_estimate is None
+                or segmented_gb < least_estimate.ad_segmented_gb
+            ):
+                least_checkpoint = checkpoint
+                least_estimate = estimate
             if segmented_gb is not None and segmented_gb * safety_factor_f <= target_memory_gb:
                 best_checkpoint = checkpoint
                 best_estimate = estimate
@@ -2683,28 +2800,27 @@ class Simulation(
                 ),
             )
 
-        largest_chunk_estimate = self.estimate_ad_memory(
-            n_steps_i,
-            available_memory_gb=available_memory_gb_f,
-            checkpoint_every=n_steps_i,
-            n_warmup=n_warmup_i,
-            design_mask=design_mask,
-        )
+        # The full 1..n_steps sweep found no fitting chunk, so nothing
+        # fits. With the live-chunk term (#277) the least-memory candidate
+        # balances the boundary and live tape terms near
+        # sqrt(2 * n_steps), NOT checkpoint_every=n_steps (which is
+        # ~full-AD-sized) — report the tracked least-memory candidate.
         return ADMemoryPlan(
             n_steps=n_steps_i,
             available_memory_gb=available_memory_gb_f,
             target_fraction=target_fraction_f,
             target_memory_gb=target_memory_gb,
-            checkpoint_every=n_steps_i,
+            checkpoint_every=least_checkpoint,
             checkpoint_segments=None,
             checkpoint_mode="checkpoint_every",
             fit_safety_factor=safety_factor_f,
-            selected_estimate=largest_chunk_estimate,
+            selected_estimate=least_estimate,
             full_ad_fits=False,
             segmented_fits=False,
             recommendation=(
-                f"even checkpoint_every={n_steps_i} is estimated at "
-                f"{_format_memory_with_safety(largest_chunk_estimate.ad_segmented_gb, safety_factor_f)}, above the "
+                f"no checkpoint_every value fits; the least-memory candidate "
+                f"checkpoint_every={least_checkpoint} is estimated at "
+                f"{_format_memory_with_safety(least_estimate.ad_segmented_gb, safety_factor_f)}, above the "
                 f"{_format_memory_gb(target_memory_gb)} target; reduce mesh size, reduce "
                 "n_steps, or use a more aggressive memory-reduction lane"
             ),

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -96,7 +96,12 @@ class AD_MemoryEstimate(NamedTuple):
     rematerialised (see issue #31 VESSL 369367233490). Use
     ``ad_segmented_gb`` for the runner-supported segmented paths:
     ``checkpoint_every`` on the non-uniform scan-of-scan path and
-    ``checkpoint_segments`` on the uniform segmented-scan path. When present,
+    ``checkpoint_segments`` on the uniform segmented-scan path. The
+    segmented model counts segment-boundary storage (carry + cotangent,
+    ``2 × active_segments``) PLUS the live-segment rematerialization tape
+    (one segment's per-step field tape resident during backward replay,
+    issue #277); it is minimized near ``sqrt(2 × n_steps)`` steps per
+    segment. When present,
     ``ad_segmented_active_segments`` is the actual number of active segment
     boundaries/carry snapshots used by the segmented estimate after warmup.
     ``evidence_class`` labels this artifact as a static estimate so downstream

--- a/tests/test_estimate_ad_memory.py
+++ b/tests/test_estimate_ad_memory.py
@@ -1,21 +1,36 @@
-"""Issue #39 pin: estimate_ad_memory predictions must match observed
+"""Issue #39 / #277 pin: estimate_ad_memory predictions must match observed
 memory on the segmented scan-of-scan path within a tolerance.
 
-Reference observations from VESSL job 369367233490 on RTX 4090:
-  geometry: 2.4 GHz FR4 patch, dx=0.5mm NU (~608k cells)
-  n_steps = 10000, emit_time_series=False
+Model (#277): segmented reverse-mode AD peak =
+``(2 × active_segments + live_tape_steps) × field_bytes + forward + ntff``.
+The ``2 × active_segments`` term is boundary carry + cotangent storage
+(issue #39). The ``live_tape_steps`` term is the live-segment
+rematerialization tape: the backward pass replays one segment at a time,
+so that segment's per-step field tape is resident on top of the boundary
+storage (the runners document peak as O((K + s) · |carry|)).
 
-    checkpoint_every | peak GB
-    ---------------- | -------
-    50               | 4.82
-    100              | 2.45
-    200              | 1.26
-    500              | 0.59
-    1000             | 0.33
+Observed evidence (2.4 GHz FR4 patch, dx=0.5mm NU, RTX 4090):
 
-The formula `2 × n_segments × field_bytes + forward_bytes` fits these
-points within ~25% (factor-of-2 accounts for carry + cotangent stacks
-during reverse-mode).
+* VESSL 369367233509 (inverse-design GRADIENT smoke — the regime this
+  estimator serves) is the calibration reference:
+
+      cells  | n_steps | checkpoint_every | peak GB
+      ------ | ------- | ---------------- | -------
+      ~603k  | 10000   | 100              | 5.84
+      ~603k  | 2000    | 64               | 2.56
+
+  The boundary-only #39 formula under-predicts these by 1.9-2.6x; the
+  corrected #277 formula lands within ~1.3x below (conservative planning
+  band, see AD_MEMORY_FIT_SAFETY_FACTOR).
+
+* VESSL 369367233490 (the original #39 "segmented scan validation" sweep:
+  4.82/2.45/1.26/0.59/0.33 GB at chunk 50/100/200/500/1000, n_steps=10000)
+  tracked the boundary term only — its backward pass did not materialize
+  field-sized per-step residuals, so it cannot calibrate the live-segment
+  term. It is retained here as history, NOT as the estimator reference:
+  a planner that matched ...490 would under-predict the ...509
+  gradient-run peaks by up to ~2.6x (and the #277 desk ladder by ~272x at
+  n_steps=6999, checkpoint_segments=3).
 """
 
 from __future__ import annotations
@@ -967,18 +982,23 @@ def test_explain_ad_memory_decomposes_selected_estimate():
     assert explanation.strategy == "segmented_checkpoint_every"
     assert explanation.selected_memory_field == "ad_segmented_gb"
     assert explanation.selected_memory_gb == explanation.estimate.ad_segmented_gb
-    assert explanation.dominant_component == "segmented_boundary_field_tape"
+    # #277: at chunk=500 (well above the balanced ≈141) the live-chunk
+    # rematerialization tape dominates the decomposition.
+    assert explanation.dominant_component == "segmented_live_segment_tape"
     assert {
         "field_state",
         "material_auxiliary_state",
         "cpml_auxiliary_state",
         "segmented_boundary_field_tape",
+        "segmented_live_segment_tape",
         "ntff_dft_state",
     } == set(components)
     assert components["segmented_boundary_field_tape"]["kind"] == "reverse_ad_saved_state"
     assert components["segmented_boundary_field_tape"]["count"] == (
         2 * explanation.estimate.ad_segmented_active_segments
     )
+    assert components["segmented_live_segment_tape"]["kind"] == "reverse_ad_saved_state"
+    assert components["segmented_live_segment_tape"]["count"] == 500
     assert components["segmented_boundary_field_tape"]["memory_gb"] > components["field_state"]["memory_gb"]
     assert sum(
         component["memory_gb"] for component in artifact["components"]
@@ -1022,6 +1042,10 @@ def test_explain_ad_memory_covers_ntff_and_segmented_warmup_paths():
         assert components["segmented_boundary_field_tape"]["count"] == (
             2 * explanation.estimate.ad_segmented_active_segments
         )
+        # #277: both segmented paths carry the same 12-step live tape here
+        # (segment length 120/10 on the uniform path, chunk 12 on the
+        # scan-of-scan path).
+        assert components["segmented_live_segment_tape"]["count"] == 12
         assert sum(
             component["memory_gb"] for component in artifact["components"]
         ) == pytest.approx(explanation.selected_memory_gb)
@@ -1114,7 +1138,9 @@ def test_ad_memory_preflight_full_fit_branch():
 def test_ad_memory_preflight_nonuniform_checkpoint_branch():
     sim = _patch_like_sim()
 
-    report = sim.ad_memory_preflight(n_steps=10_000, available_memory_gb=1.0)
+    # Budget raised 1.0 → 8.0 GB for #277 (see
+    # test_plan_ad_memory_recommends_checkpoint_every_for_budget).
+    report = sim.ad_memory_preflight(n_steps=10_000, available_memory_gb=8.0)
     hint = next(
         hint for hint in report.action_hints if hint.code == "use_checkpoint_every"
     )
@@ -1139,9 +1165,11 @@ def test_ad_memory_preflight_nonuniform_checkpoint_branch():
 def test_ad_memory_preflight_uniform_checkpoint_branch():
     sim = _uniform_sim()
 
+    # Budget raised 0.002 → 0.003 GB for #277 (see
+    # test_plan_ad_memory_recommends_checkpoint_segments_for_uniform_budget).
     report = sim.ad_memory_preflight(
         n_steps=120,
-        available_memory_gb=0.002,
+        available_memory_gb=0.003,
         include_mesh_report=False,
     )
     hint = next(
@@ -1177,7 +1205,9 @@ def test_ad_memory_preflight_unfit_branch_is_diagnostic_only():
     assert report.full_ad_fits is False
     assert report.checkpointing_fits is False
     assert report.supported_checkpoint_mode == "checkpoint_every"
-    assert report.checkpoint_every == 10_000
+    # #277: the diagnostic candidate is the least-memory chunk, not
+    # checkpoint_every=n_steps (see test_plan_ad_memory_reports_unfit_budget).
+    assert report.checkpoint_every == 137
     assert report.checkpoint_segments is None
     assert report.explainability.selected_memory_field == "ad_segmented_gb"
     assert blocker.blocking is True
@@ -1264,20 +1294,21 @@ def test_memory_reduction_docs_separate_planning_from_certificate_evidence():
         assert boundary in doc
 
 
-@pytest.mark.parametrize("chunk,observed_gb", [
-    (50, 4.82),
-    (100, 2.45),
-    (200, 1.26),
-    (500, 0.59),
-    (1000, 0.33),
+# Calibration rows from VESSL 369367233509 (inverse-design gradient smoke,
+# ~603k-cell FR4 patch — see module docstring). The pre-#277 boundary-only
+# formula fails the 0.5x floor at the (64, 2000) row (0.39x observed);
+# these rows are what discriminate the corrected model.
+@pytest.mark.parametrize("chunk,n_steps,observed_gb", [
+    (100, 10_000, 5.84),
+    (64, 2_000, 2.56),
 ])
-def test_segmented_estimate_within_tolerance(chunk, observed_gb):
+def test_segmented_estimate_within_tolerance(chunk, n_steps, observed_gb):
     sim = _patch_like_sim()
-    est = sim.estimate_ad_memory(n_steps=10000, checkpoint_every=chunk)
+    est = sim.estimate_ad_memory(n_steps=n_steps, checkpoint_every=chunk)
     assert est.ad_segmented_gb is not None
     pred = est.ad_segmented_gb
     # Predictions should be within 2x (very loose to tolerate XLA
-    # allocator slack); typical is ~1.2x.
+    # allocator slack); typical is ~1.3x below the observed gradient peak.
     assert 0.5 * observed_gb <= pred <= 2.0 * observed_gb, (
         f"chunk={chunk}: predicted {pred:.3f} GB vs observed {observed_gb} GB"
     )
@@ -1291,14 +1322,74 @@ def test_checkpoint_every_none_leaves_segmented_null():
     assert est.checkpoint_every is None
 
 
-def test_monotone_in_chunk():
-    """Bigger chunk → smaller segmented memory (fewer segment boundaries)."""
+def test_u_shaped_in_chunk_with_minimum_near_balanced_size():
+    """#277: the segmented estimate is U-shaped in the chunk size.
+
+    Boundary storage (2 · n_segments) shrinks with bigger chunks while the
+    live-chunk tape grows with them, so the estimate is minimized where the
+    terms balance, near chunk ≈ sqrt(2 · n_steps) (~141 for n_steps=10000)
+    — it is NOT monotone decreasing in the chunk size (the pre-#277
+    boundary-only model was).
+    """
     sim = _patch_like_sim()
     gbs = [
         sim.estimate_ad_memory(n_steps=10000, checkpoint_every=c).ad_segmented_gb
-        for c in [50, 100, 500, 1000]
+        for c in [50, 100, 141, 500, 1000]
     ]
-    assert gbs == sorted(gbs, reverse=True), gbs
+    # Decreasing toward the balanced chunk...
+    assert gbs[0] > gbs[1] > gbs[2], gbs
+    # ...then increasing beyond it as the live-chunk tape dominates.
+    assert gbs[2] < gbs[3] < gbs[4], gbs
+
+
+def test_live_segment_term_invariance_witness_277():
+    """#277 invariance witness: exact, hand-checkable component accounting.
+
+    n_steps=100 on the uniform sim. Boundary storage is 2·K field states;
+    the live segment adds n_steps//K more. At K far below sqrt(n_steps)
+    the pre-#277 estimate missed almost the entire peak: the omitted live
+    tape is (n_steps//K)/(2·K) times the boundary term it kept — 12.5x at
+    K=2 here, and ~389x in the issue #277 λ/100 desk ladder (n_steps=6999,
+    checkpoint_segments=3 → live/boundary = 2333/6, the ~272x total
+    under-count after the forward-state offset). At K = sqrt(n_steps) the
+    two terms are the same order (0.5x), which is why the omission was
+    invisible in balanced-sqrt(N) usage.
+    """
+    sim = _uniform_sim()
+    accounting = sim._ad_memory_static_accounting()
+    field_bytes = accounting["field_bytes"]
+    overhead = accounting["forward_bytes"] + accounting["ntff_bytes"]
+    to_gb = 1.0 / 1e9
+
+    est_2 = sim.estimate_ad_memory(n_steps=100, checkpoint_segments=2)
+    est_10 = sim.estimate_ad_memory(n_steps=100, checkpoint_segments=10)
+
+    # Exact corrected-formula bytes: (2·K + n_steps//K)·field + overhead.
+    expected_2 = (2 * 2 + 50) * field_bytes + overhead
+    expected_10 = (2 * 10 + 10) * field_bytes + overhead
+    assert est_2.ad_segmented_gb == expected_2 * to_gb
+    assert est_10.ad_segmented_gb == expected_10 * to_gb
+
+    # The delta versus the pre-#277 formula (2·K·field + overhead) is
+    # exactly one segment of per-step field tape.
+    old_2 = 2 * 2 * field_bytes + overhead
+    old_10 = 2 * 10 * field_bytes + overhead
+    assert expected_2 - old_2 == 50 * field_bytes
+    assert expected_10 - old_10 == 10 * field_bytes
+
+    # Ratio demonstration: omitted-live-tape / kept-boundary-term =
+    # (n_steps//K) / (2·K).
+    assert (50 * field_bytes) / (2 * 2 * field_bytes) == 12.5
+    assert (10 * field_bytes) / (2 * 10 * field_bytes) == 0.5
+
+    # Fewer segments no longer implies less memory: K=2 must now exceed
+    # K=10 (under the boundary-only model K=2 looked "cheaper").
+    assert est_2.ad_segmented_gb > est_10.ad_segmented_gb
+
+    # checkpoint_every mirror: a 50-step chunk carries the same live tape
+    # as a 50-step segment, byte-for-byte.
+    est_chunk = sim.estimate_ad_memory(n_steps=100, checkpoint_every=50)
+    assert est_chunk.ad_segmented_gb == est_2.ad_segmented_gb
 
 
 def test_plan_ad_memory_returns_none_when_full_ad_fits():
@@ -1320,7 +1411,11 @@ def test_plan_ad_memory_returns_none_when_full_ad_fits():
 def test_plan_ad_memory_recommends_checkpoint_every_for_budget():
     sim = _patch_like_sim()
 
-    plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=1.0)
+    # Budget raised 1.0 → 8.0 GB for #277: with the live-chunk tape counted,
+    # the least segmented memory for this case is ≈4.3 GB (balanced chunk),
+    # so 1.0 GB is genuinely unfit — the old budget only fit under the
+    # boundary-only under-count.
+    plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=8.0)
 
     assert plan.full_ad_fits is False
     assert plan.segmented_fits is True
@@ -1332,7 +1427,7 @@ def test_plan_ad_memory_recommends_checkpoint_every_for_budget():
     if plan.checkpoint_every > 1:
         previous = sim.estimate_ad_memory(
             n_steps=10_000,
-            available_memory_gb=1.0,
+            available_memory_gb=8.0,
             checkpoint_every=plan.checkpoint_every - 1,
         )
         assert previous.ad_segmented_gb * plan.fit_safety_factor > plan.target_memory_gb
@@ -1341,19 +1436,22 @@ def test_plan_ad_memory_recommends_checkpoint_every_for_budget():
 def test_plan_ad_memory_checkpoint_every_handles_unaligned_warmup():
     sim = _patch_like_sim()
 
+    # Budget 0.35 → 0.7 GB and expected chunk 12 → 8 for #277: the plan now
+    # also carries the live-chunk tape, so the first fitting chunk shrinks
+    # and the old budget no longer fits any chunk.
     plan = sim.plan_ad_memory(
         n_steps=120,
-        available_memory_gb=0.35,
+        available_memory_gb=0.7,
         n_warmup=49,
     )
 
     assert plan.segmented_fits is True
     assert plan.checkpoint_mode == "checkpoint_every"
-    assert plan.checkpoint_every == 12
+    assert plan.checkpoint_every == 8
     previous = sim.estimate_ad_memory(
         n_steps=120,
-        available_memory_gb=0.35,
-        checkpoint_every=11,
+        available_memory_gb=0.7,
+        checkpoint_every=7,
         n_warmup=49,
     )
     assert previous.ad_segmented_gb * plan.fit_safety_factor > plan.target_memory_gb
@@ -1367,10 +1465,15 @@ def test_plan_ad_memory_reports_unfit_budget():
 
     assert plan.full_ad_fits is False
     assert plan.segmented_fits is False
-    assert plan.checkpoint_every == 10_000
+    # #277: the diagnostic candidate is the least-memory chunk (boundary and
+    # live-chunk terms balanced near sqrt(2 · n_steps)), not
+    # checkpoint_every=n_steps, which is ~full-AD-sized under the corrected
+    # model.
+    assert plan.checkpoint_every == 137
     assert plan.selected_estimate.ad_segmented_gb > plan.target_memory_gb
     assert plan.checkpoint_segments is None
     assert plan.checkpoint_mode == "checkpoint_every"
+    assert "least-memory candidate" in plan.recommendation
     assert "reduce mesh size" in plan.recommendation
 
     report = sim.mesh_intelligence_report(
@@ -1390,29 +1493,36 @@ def test_plan_ad_memory_reports_uniform_unfit_budget():
     assert plan.full_ad_fits is False
     assert plan.segmented_fits is False
     assert plan.checkpoint_every is None
-    assert plan.checkpoint_segments == 1
+    # #277: the diagnostic candidate is the least-memory divisor of n_steps
+    # (K=8 balances 2·K boundary states against 120/K live-tape steps), not
+    # checkpoint_segments=1, which is ~full-AD-sized under the corrected
+    # model.
+    assert plan.checkpoint_segments == 8
     assert plan.checkpoint_mode == "checkpoint_segments"
     assert plan.selected_estimate.ad_segmented_gb > plan.target_memory_gb
-    assert "checkpoint_segments=1" in plan.recommendation
+    assert "least-memory candidate" in plan.recommendation
+    assert "checkpoint_segments=8" in plan.recommendation
     assert "reduce mesh size" in plan.recommendation
 
 
 def test_plan_ad_memory_uses_valid_custom_target_fraction():
     sim = _patch_like_sim()
 
+    # Budget raised 1.0 → 16.0 GB for #277 (least segmented memory for this
+    # case is ≈4.3 GB once the live-chunk tape is counted).
     plan = sim.plan_ad_memory(
         n_steps=10_000,
-        available_memory_gb=1.0,
+        available_memory_gb=16.0,
         target_fraction=0.5,
     )
 
     assert plan.target_fraction == 0.5
-    assert plan.target_memory_gb == 0.5
+    assert plan.target_memory_gb == 8.0
     assert plan.selected_estimate.ad_segmented_gb * plan.fit_safety_factor <= plan.target_memory_gb
     if plan.checkpoint_every > 1:
         previous = sim.estimate_ad_memory(
             n_steps=10_000,
-            available_memory_gb=1.0,
+            available_memory_gb=16.0,
             checkpoint_every=plan.checkpoint_every - 1,
         )
         assert previous.ad_segmented_gb * plan.fit_safety_factor > plan.target_memory_gb
@@ -1421,7 +1531,9 @@ def test_plan_ad_memory_uses_valid_custom_target_fraction():
 def test_plan_ad_memory_serializes_artifact():
     sim = _patch_like_sim()
 
-    plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=1.0)
+    # Budget raised 1.0 → 8.0 GB for #277 so the serialized artifact still
+    # exercises the segmented-fit branch.
+    plan = sim.plan_ad_memory(n_steps=10_000, available_memory_gb=8.0)
     artifact = plan.to_dict()
     parsed = json.loads(plan.to_json())
 
@@ -1510,17 +1622,41 @@ def test_checkpoint_every_active_count_honors_unaligned_warmup():
     )
 
     assert unaligned.ad_active_steps == 71
-    assert unaligned.ad_segmented_gb == three_active_segments.ad_segmented_gb
     assert unaligned.ad_segmented_active_segments == 3
+    assert three_active_segments.ad_segmented_active_segments == 3
     assert boundary.ad_active_steps == 70
-    assert boundary.ad_segmented_gb == two_active_segments.ad_segmented_gb
     assert boundary.ad_segmented_active_segments == 2
+    assert two_active_segments.ad_segmented_active_segments == 2
+
+    # #277: totals across the two knobs are no longer equal at matching
+    # active-segment counts, because the live rematerialization tapes
+    # differ — a 50-step chunk replays 50 steps, while a 120/3=40-step
+    # (or 120/2=60-step) segment replays its own length. Assert the exact
+    # (2·active_segments + live_tape_steps)·field + forward + ntff
+    # composition for each instead.
+    accounting = sim._ad_memory_static_accounting()
+    field_bytes = accounting["field_bytes"]
+    overhead = accounting["forward_bytes"] + accounting["ntff_bytes"]
+    assert unaligned.ad_segmented_gb * 1e9 == pytest.approx(
+        (2 * 3 + 50) * field_bytes + overhead
+    )
+    assert three_active_segments.ad_segmented_gb * 1e9 == pytest.approx(
+        (2 * 3 + 40) * field_bytes + overhead
+    )
+    assert boundary.ad_segmented_gb * 1e9 == pytest.approx(
+        (2 * 2 + 50) * field_bytes + overhead
+    )
+    assert two_active_segments.ad_segmented_gb * 1e9 == pytest.approx(
+        (2 * 2 + 60) * field_bytes + overhead
+    )
 
 
 def test_plan_ad_memory_recommends_checkpoint_segments_for_uniform_budget():
     sim = _uniform_sim()
 
-    plan = sim.plan_ad_memory(n_steps=120, available_memory_gb=0.002)
+    # Budget raised 0.002 → 0.003 GB for #277: K=10 now also carries the
+    # 12-step live-segment tape (≈1.87 MB total, ≈2.43 MB with safety).
+    plan = sim.plan_ad_memory(n_steps=120, available_memory_gb=0.003)
 
     assert plan.full_ad_fits is False
     assert plan.segmented_fits is True
@@ -1747,6 +1883,25 @@ def test_warning_uses_realistic_selected_estimate():
     assert "segmented" in chunked.warning
     assert "Increase checkpoint_every" in chunked.warning
 
+    # #277 direction-aware advice: when the live-segment tape dominates
+    # the boundary term, the fix is to move TOWARD sqrt(n_steps), not
+    # away from it.
+    live_dominated_segments = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=1e-6,
+        checkpoint_segments=2,
+    )
+    assert live_dominated_segments.warning is not None
+    assert "Increase checkpoint_segments" in live_dominated_segments.warning
+
+    live_dominated_chunk = sim.estimate_ad_memory(
+        n_steps=120,
+        available_memory_gb=1e-6,
+        checkpoint_every=60,
+    )
+    assert live_dominated_chunk.warning is not None
+    assert "Reduce checkpoint_every" in live_dominated_chunk.warning
+
     minimum_segmented = sim.estimate_ad_memory(
         n_steps=120,
         available_memory_gb=1e-6,
@@ -1783,8 +1938,12 @@ def test_warning_has_no_false_positive_at_boundary():
     assert exact.warning is None
     assert below.warning is not None
 
+    # One-ulp headroom: gb / 0.85 * 0.85 does not round-trip exactly for
+    # every float value, and whether it lands above or below is value
+    # luck. The intent is "no warning at/above the boundary", so nudge the
+    # availability by 1e-12 relative.
     segmented_baseline = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
-    segmented_available = segmented_baseline.ad_segmented_gb / 0.85
+    segmented_available = segmented_baseline.ad_segmented_gb / 0.85 * (1 + 1e-12)
     segmented_exact = sim.estimate_ad_memory(
         n_steps=120,
         checkpoint_segments=10,
@@ -1793,7 +1952,7 @@ def test_warning_has_no_false_positive_at_boundary():
     assert segmented_exact.warning is None
 
     chunked_baseline = sim.estimate_ad_memory(n_steps=120, checkpoint_every=12)
-    chunked_available = chunked_baseline.ad_segmented_gb / 0.85
+    chunked_available = chunked_baseline.ad_segmented_gb / 0.85 * (1 + 1e-12)
     chunked_exact = sim.estimate_ad_memory(
         n_steps=120,
         checkpoint_every=12,

--- a/tests/test_estimate_ad_memory.py
+++ b/tests/test_estimate_ad_memory.py
@@ -1938,10 +1938,11 @@ def test_warning_has_no_false_positive_at_boundary():
     assert exact.warning is None
     assert below.warning is not None
 
-    # One-ulp headroom: gb / 0.85 * 0.85 does not round-trip exactly for
-    # every float value, and whether it lands above or below is value
-    # luck. The intent is "no warning at/above the boundary", so nudge the
-    # availability by 1e-12 relative.
+    # Float round-trip headroom: gb / 0.85 * 0.85 does not round-trip
+    # exactly for every float value (observed gap ~0.5 ulp), and whether it
+    # lands above or below is value luck. The intent is "no warning
+    # at/above the boundary", so nudge the availability by 1e-12 relative —
+    # orders of magnitude above the round-trip gap, physically negligible.
     segmented_baseline = sim.estimate_ad_memory(n_steps=120, checkpoint_segments=10)
     segmented_available = segmented_baseline.ad_segmented_gb / 0.85 * (1 + 1e-12)
     segmented_exact = sim.estimate_ad_memory(


### PR DESCRIPTION
Fixes #277

## What

Both segmented paths in `Simulation.estimate_ad_memory` now count the **live-segment rematerialization tape** on top of the segment-boundary storage:

```
ad_seg_bytes = (2 * active_segments + live_tape_steps) * field_bytes + forward + ntff
```

- `checkpoint_segments` path: `live_tape_steps = n_steps // checkpoint_segments`
- `checkpoint_every` path: `live_tape_steps = checkpoint_every` (the non-uniform runner pads the trailing chunk with zero source to a full chunk, so the full chunk length is exact, not merely conservative)
- both capped at the active (post-warmup) step count

The `2 * active_segments` boundary term from #39 (carry + cotangent at segment boundaries) is kept unchanged.

## Premise verification / evidence

- The runners' own comments document the corrected model: `rfx/simulation.py:1686-1688` — "peak memory drops from O(n_steps · |carry|) to **O((K + s) · |carry|)**". The estimator only counted the `K` part.
- The old test table (VESSL **369367233490**, "segmented scan validation") tracks the boundary-only formula, but its backward pass did not materialize field-sized per-step residuals; it cannot calibrate the live term. The inverse-design **gradient** smoke (VESSL **369367233509**, same FR4-patch geometry, from `docs/research_notes/2026-04-15_issue31_memory_efficient_inverse_design_results.md`) observed **5.84 GB at chunk=100/N=10000** (old formula: 2.9 GB — a 1.9x under-count) and **2.56 GB at chunk=64/N=2000** (old: 0.93 GB — 2.7x under). The corrected formula lands at 4.58 / 1.98 GB, within the 1.30x safety factor below the observed gradient peaks. The recalibrated `test_segmented_estimate_within_tolerance` pins these rows; the pre-#277 formula fails its 0.5x floor at the (64, 2000) row.

## Hand-check (before → after)

| case | old estimate | corrected | witness |
|---|---|---|---|
| patch 630k cells, N=10000, chunk=100 | 3.07 GB | 4.58 GB | observed gradient peak 5.84 GB (VESSL ...509) |
| patch 630k cells, N=10000, chunk=1000 | 0.34 GB | 15.47 GB | live chunk = 1000 x 15.1 MB field state |
| issue #277 λ/100 ladder: 46,033,920 cells, N=6999, segments=3 | ~9.5 GB | ~2.59 TB | live/boundary = 2333/6 ≈ 389x tape ratio, ~272x total |

Segmented estimates are now **U-shaped** in the knob (minimum near sqrt(2·n_steps) steps per segment), no longer monotone.

## Consequential changes (reported, not silent)

1. **`explain_ad_memory`** gains a `segmented_live_segment_tape` component so components still sum to the selected estimate (existing sum-check tests enforce this).
2. **`plan_ad_memory` does-not-fit fallback** now reports the true least-memory candidate (balanced segment size; K=8 for N=120, chunk=137 for N=10000) instead of `checkpoint_segments=1` / `checkpoint_every=n_steps`, which are ~full-AD-sized under the corrected model. This is required by the documented contract (memory-reduction.mdx: "the returned least-memory candidate"). Fit-search semantics are untouched.
3. **VRAM warning actions** are direction-aware: when the live tape dominates, advice points *toward* sqrt(n_steps) (the old "Reduce checkpoint_segments"/"Increase checkpoint_every" advice is kept when the boundary term dominates, and those existing test pins still pass on their original cases).
4. `preflight`/`estimate_ad_memory` warnings fire more often — that is the estimate becoming honest, per the issue. No committed example or test newly trips the 85 percent warning (preflight's `check_ad_memory` uses the full-AD path, which is unchanged; plan-based tests were re-budgeted with root-caused justification comments).
5. One test-mechanics fix: `test_warning_has_no_false_positive_at_boundary` gets 1e-12 relative headroom — `gb / 0.85 * 0.85` does not round-trip exactly for the new value (1-ulp float luck, intent preserved).

## Tests

- NEW `test_live_segment_term_invariance_witness_277`: exact-bytes assertions for N=100, K=2 vs K=10 on the uniform sim ((2K + N/K)·field + overhead, byte-for-byte), the omitted/kept ratio (N/K)/(2K) = 12.5x at K=2 vs 0.5x at K=sqrt(N), and the checkpoint_every mirror equality.
- Updated pins each carry a `#277` comment citing the root-caused formula bug (never a blind gate change): observed-table recalibration to ...509, U-shape property replaces monotone-in-chunk, exact-composition assertions replace cross-knob total equality (live tapes legitimately differ: 50-step chunk vs 40/60-step segment), plan/preflight budgets 1.0→8.0 / 0.002→0.003 / 0.35→0.7 GB and fallback pins 10000→137, 1→8.

## Gates

```
tests/test_estimate_ad_memory.py .... 75 passed
+ test_memory_reduction_planning_artifact.py, test_mesh_intelligence_report.py,
  test_inverse_design_preflight.py, test_forward_docstring_contract.py
  => 92 passed total
ruff check rfx/ tests/ --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402
  => All checks passed!
```

## R3 self-audit

1. **Contradicted by memory?** None found. Consistent with `project_rfx_memory_efficiency_strategy` (tape axis = sqrt(N) checkpointing; this makes the estimator model that trade-off honestly), `feedback_metric_first_skepticism` (the old observed table's causality was verified before recalibrating: ...490 vs ...509 reconciliation above), `feedback_root_cause_before_gate_change` (every pin change cites the formula root cause), and `development_methodology`'s invariance-witness requirement for user-visible numbers (witness test added).
2. **R2 tripped?** No — attempt count 0 (single design pass; the initial 17 test failures were anticipated recalibrations, not non-closing fix attempts).
3. **Falsifier:** the witness test's exact-bytes assertions; empirically, a profiled *gradient* run at chunk=1000/N=10000 on the 608k patch peaking near 0.33 GB instead of ~15 GB would falsify the live term (VESSL ...509 already shows the opposite at chunk=100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
