### PR TITLE
chore(gradient-ladder): regenerate desk feasibility table with the corrected #277 estimator

### DIFF
--- a/scripts/diagnostics/gradient_dx_ladder/desk_feasibility.json
+++ b/scripts/diagnostics/gradient_dx_ladder/desk_feasibility.json
@@ -35,7 +35,7 @@
           "segment_len": 27,
           "forward_gb": 0.013942656000000001,
           "full_tape_gb": 3.778459776,
-          "ckpt_sqrtN_gb": 0.292795776,
+          "ckpt_sqrtN_gb": 0.437584896,
           "verdict": "fits-4090"
         },
         {
@@ -52,7 +52,7 @@
           "segment_len": 38,
           "forward_gb": 0.036413644,
           "full_tape_gb": 19.727792332,
-          "ckpt_sqrtN_gb": 1.0728019960000001,
+          "ckpt_sqrtN_gb": 1.60500142,
           "verdict": "fits-4090"
         },
         {
@@ -69,7 +69,7 @@
           "segment_len": 46,
           "forward_gb": 0.07293836100000001,
           "full_tape_gb": 59.433543417,
-          "ckpt_sqrtN_gb": 2.653834233,
+          "ckpt_sqrtN_gb": 3.944282169,
           "verdict": "fits-4090"
         },
         {
@@ -86,7 +86,7 @@
           "segment_len": 53,
           "forward_gb": 0.128009232,
           "full_tape_gb": 138.427214112,
-          "ckpt_sqrtN_gb": 5.3468471520000005,
+          "ckpt_sqrtN_gb": 7.956266112000001,
           "verdict": "fits-4090"
         },
         {
@@ -103,7 +103,7 @@
           "segment_len": 60,
           "forward_gb": 0.199591392,
           "full_tape_gb": 271.950948192,
-          "ckpt_sqrtN_gb": 9.257969952,
+          "ckpt_sqrtN_gb": 13.863925152,
           "verdict": "fits-4090"
         }
       ]
@@ -131,7 +131,7 @@
           "segment_len": 27,
           "forward_gb": 0.002446579,
           "full_tape_gb": 0.6630229630000001,
-          "ckpt_sqrtN_gb": 0.051378163000000004,
+          "ckpt_sqrtN_gb": 0.076784947,
           "verdict": "fits-4090"
         },
         {
@@ -148,7 +148,7 @@
           "segment_len": 38,
           "forward_gb": 0.007069171000000001,
           "full_tape_gb": 3.829859443,
-          "ckpt_sqrtN_gb": 0.20826865900000002,
+          "ckpt_sqrtN_gb": 0.31158731500000003,
           "verdict": "fits-4090"
         },
         {
@@ -165,7 +165,7 @@
           "segment_len": 46,
           "forward_gb": 0.015190156000000002,
           "full_tape_gb": 12.377640844,
-          "ckpt_sqrtN_gb": 0.5526880120000001,
+          "ckpt_sqrtN_gb": 0.82143694,
           "verdict": "fits-4090"
         },
         {
@@ -182,7 +182,7 @@
           "segment_len": 53,
           "forward_gb": 0.027768,
           "full_tape_gb": 30.027888,
-          "ckpt_sqrtN_gb": 1.159848,
+          "ckpt_sqrtN_gb": 1.725888,
           "verdict": "fits-4090"
         },
         {
@@ -199,7 +199,7 @@
           "segment_len": 60,
           "forward_gb": 0.045761164,
           "full_tape_gb": 62.351347084000004,
-          "ckpt_sqrtN_gb": 2.122614028,
+          "ckpt_sqrtN_gb": 3.178640908,
           "verdict": "fits-4090"
         }
       ]

--- a/scripts/diagnostics/gradient_dx_ladder/desk_feasibility.py
+++ b/scripts/diagnostics/gradient_dx_ladder/desk_feasibility.py
@@ -38,28 +38,31 @@ lambda = 29.98 mm, num_periods = 20; JSON beside this file is authoritative)
 --------------------------------------------------------------------------
 (a) WR-90 2-port (120 x 22.86 x 10.16 mm, cpml_layers = 16)
  dx       cells      n_steps  fwd GB  full-tape GB  ckpt sqrtN GB  verdict
- l/20    2.234e+05     702     0.0139     3.78          0.293      fits-4090
- l/40    5.836e+05    1406     0.0364    19.73          1.073      fits-4090
- l/60    1.169e+06    2116     0.0729    59.43          2.654      fits-4090
- l/80    2.051e+06    2809     0.1280   138.43          5.347      fits-4090
- l/100   3.199e+06    3540     0.1996   271.95          9.258      fits-4090
+ l/20    2.234e+05     702     0.0139     3.78          0.438      fits-4090
+ l/40    5.836e+05    1406     0.0364    19.73          1.605      fits-4090
+ l/60    1.169e+06    2116     0.0729    59.43          3.944      fits-4090
+ l/80    2.051e+06    2809     0.1280   138.43          7.956      fits-4090
+ l/100   3.199e+06    3540     0.1996   271.95         13.864      fits-4090
 
 (b) Smooth slab witness (60 x 12 x 12 mm, cpml_layers = 8)
  dx       cells      n_steps  fwd GB  full-tape GB  ckpt sqrtN GB  verdict
- l/20    3.921e+04     702     0.0024     0.66          0.051      fits-4090
- l/40    1.133e+05    1406     0.0071     3.83          0.208      fits-4090
- l/60    2.434e+05    2116     0.0152    12.38          0.553      fits-4090
- l/80    4.450e+05    2809     0.0278    30.03          1.160      fits-4090
- l/100   7.334e+05    3540     0.0458    62.35          2.123      fits-4090
+ l/20    3.921e+04     702     0.0024     0.66          0.077      fits-4090
+ l/40    1.133e+05    1406     0.0071     3.83          0.312      fits-4090
+ l/60    2.434e+05    2116     0.0152    12.38          0.821      fits-4090
+ l/80    4.450e+05    2809     0.0278    30.03          1.726      fits-4090
+ l/100   7.334e+05    3540     0.0458    62.35          3.179      fits-4090
 
 3-0 verdict (falsifier did NOT trigger)
 ---------------------------------------
 The GPU ladder does NOT die at lambda/100 on MEMORY for either canonical
 geometry once the tape is O(sqrt(N))-checkpointed: the smallest sensible
-domain (smooth slab) needs 2.12 GB at lambda/100, and even the WR-90 2-port
-needs only 9.26 GB -- both fit a single 24 GB RTX 4090 (and remain under
-24 GB with the ~segment_len within-segment recompute term the shipped model
-omits: WR-90 l/100 ~ 9.3 + 4.6 = ~14 GB). The reason the falsifier expected a
+domain (smooth slab) needs 3.18 GB at lambda/100, and even the WR-90 2-port
+needs only 13.86 GB -- both fit a single 24 GB RTX 4090. (These numbers are
+from the corrected estimator that counts the live-segment rematerialization
+tape, issue #277 / PR #282; the earlier revision of this table under-counted
+by ~1.5x at sqrt(N) -- 9.26 GB for WR-90 l/100 -- because it omitted that
+term. The verdict column is unchanged: the fix moved the numbers, not the
+conclusion.) The reason the falsifier expected a
 wall but none appears: both canonical geometries are electrically THIN in the
 transverse plane (single-mode WR-90; a small slab box), so the cell count
 grows only ~14x over the 5x dx refinement -- the fixed 2*cpml_layers padding


### PR DESCRIPTION
## What

Required post-merge coordination for #282 (estimate_ad_memory live-segment fix). The #281 desk table was generated with the pre-fix estimator; regenerated here with the corrected model.

## Numbers move ~1.5×; the conclusion does not

| rung | ckpt-√N GB (old) | ckpt-√N GB (corrected) |
|---|---|---|
| WR-90 λ/100 | 9.26 | **13.86** |
| WR-90 λ/80 | 5.35 | 7.96 |
| slab λ/100 | 2.12 | 3.18 |

Every rung, both geometries, stays **fits-4090** (13.86 < 24×0.85 = 20.4 GB). The `estimate_ad_memory` fix (#282) vindicates the desk conclusion — it moves the numbers, not the answer. The `13.86 GB` the corrected estimator now reports directly is exactly the `9.3 + 4.6 = ~14 GB` hand-correction the #281 desk docstring already anticipated; that prose is updated to the estimator's direct output.

## Contents
- `desk_feasibility.json` regenerated (byte-stable across two regenerations); `desk_feasibility.py` docstring table + 3-0 verdict prose updated, with an explicit note that the shift is the #277 fix.

## Verification
`test_gradient_dx_ladder_gates.py` still green (7 passed — it replays the AD-vs-FD fixture, makes no estimator calls); ruff clean; JSON regeneration deterministic. No rfx/ source, no tolerance changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)