### PR TITLE
feat(optimize): opt-in multi-start / best-iterate / step-clamp in rfx.optimize (default-off, bit-identical)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Added — opt-in multi-start / best-iterate / step-clamp knobs on `optimize()` (WP 4-C)
+
+- `optimize()` gained four keyword-only, DEFAULT-OFF parameters promoted
+  from the MSL open-stub inverse-design example (`_multistart_adam`, issue
+  #171): `n_starts` (best-of random restarts), `best_iterate` (return the
+  lowest-loss visited iterate instead of the last), `step_clamp` (bound the
+  L2 norm of each Adam latent update), and `seed` (reproducible restart
+  inits).
+- Defaults (`n_starts=1`, `best_iterate=False`, `step_clamp=None`) reproduce
+  the previous single-run Adam loop BYTE-for-BYTE — start 0 always uses the
+  caller's `init_latent`, extra restarts draw i.i.d. standard-normal latents
+  from `seed`, and the legacy NaN/Inf gradient guard (warn + return the last
+  finite design) is unchanged. A bit-identity gate against a verbatim copy of
+  the legacy loop is committed in `tests/test_optimize_multistart.py`.
+- The step-clamp is GENERIC (an exact whole-step L2-norm rescale, direction
+  preserved) rather than the example's physical-length bisection, which stays
+  specialized in the example. Multi-start fails closed (raises) only when
+  every restart is non-finite; a single start keeps the fail-soft contract.
+- Scope is optimizer-loop plumbing only — no objective or numerics change.
+  Extra restarts help only on a genuinely multimodal loss surface.
+
 ### Fixed — `compute_rcs` monostatic extraction pointed at −z broadside, not backscatter (issue #276)
 
 - `RCSResult.monostatic_rcs` was argmin-extracted at (θ=π, φ=0), which under

--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -1368,7 +1368,11 @@
         "design_mask",
         "distributed",
         "port_s11_freqs",
-        "checkpoint_segments"
+        "checkpoint_segments",
+        "n_starts",
+        "best_iterate",
+        "step_clamp",
+        "seed"
       ]
     },
     "parametric_sweep": {

--- a/rfx/optimize.py
+++ b/rfx/optimize.py
@@ -19,6 +19,7 @@ Example
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Callable
 
@@ -67,6 +68,177 @@ def _latent_to_eps(latent: jnp.ndarray, eps_min: float, eps_max: float) -> jnp.n
     return eps_min + (eps_max - eps_min) * jax.nn.sigmoid(latent)
 
 
+def _adam_multistart(
+    cost_fn: Callable,
+    latent_inits,
+    *,
+    n_iters: int,
+    lr: float,
+    best_iterate: bool = False,
+    step_clamp: float | None = None,
+    beta1: float = 0.9,
+    beta2: float = 0.999,
+    eps_adam: float = 1e-8,
+    verbose: bool = False,
+    it_count: list | None = None,
+):
+    """Best-of multi-start Adam with optional best-iterate + step-clamp.
+
+    Generic promotion of the MSL open-stub example's ``_multistart_adam``
+    (issue #171).  The three knobs are all OPT-IN and, with a single
+    start (``len(latent_inits) == 1``), ``best_iterate=False`` and
+    ``step_clamp=None``, this runs the hand-rolled Adam loop with the exact
+    same arithmetic as the legacy inline ``optimize()`` loop — the default
+    ``optimize()`` path is therefore byte-identical to before this helper
+    existed (see ``tests/test_optimize_multistart.py`` bit-identity gate).
+
+    Unlike the example, the step-clamp here is GENERIC: it bounds the L2
+    norm of the DoF (latent) update vector, rescaling the whole step by
+    ``step_clamp / ||step||`` when it overshoots (direction preserved).
+    The example clamps a physical LENGTH move through a nonlinear
+    ``latent_to_L`` and so needs a bisection; that specialization stays in
+    the example.  For a latent-space step the rescale is exact — no
+    bisection — and it reduces to ``|Δlatent| <= step_clamp`` in the
+    scalar/identity case the example tests exercise.
+
+    Parameters
+    ----------
+    cost_fn : callable(latent) -> scalar
+        Differentiable scalar objective (``jax.value_and_grad`` is taken
+        internally).  Pure in ``cost_fn`` so this is testable against a
+        synthetic cost with no FDTD forward.
+    latent_inits : sequence of latent arrays
+        One optimization is run from each init; the best is returned.
+        Element 0 is the "primary" start (``optimize()`` uses the caller's
+        ``init_latent`` here so ``n_starts=1`` is the legacy single run).
+    n_iters, lr : int, float
+        Adam iterations per start and learning rate.
+    best_iterate : bool
+        If True, each start returns (and is scored by) its lowest-loss
+        visited iterate rather than its final iterate.  Guards the sharp-
+        null overshoot the #171 GPU run caught.
+    step_clamp : float or None
+        If set (>0), clamp the L2 norm of each latent update to this value.
+    it_count : list([int]) or None
+        Optional mutable one-element counter threaded from ``optimize()``
+        so the ``forward()`` first-call banner fires exactly once.
+
+    Returns
+    -------
+    (best_latent, best_loss_history, all_loss_histories, best_start)
+        ``best_latent`` is the winning start's final iterate (or its best
+        visited iterate when ``best_iterate=True``).  ``best_loss_history``
+        is that start's per-iteration loss list.
+
+    Raises
+    ------
+    RuntimeError
+        Only for MULTI-start (``len(latent_inits) > 1``) when EVERY start
+        produced a non-finite loss at every iterate — fail-closed rather
+        than returning a NaN optimum.  A single start preserves the legacy
+        fail-soft contract (warn + return the last finite design).
+    """
+    if step_clamp is not None and step_clamp <= 0:
+        raise ValueError(f"optimize: step_clamp must be > 0, got {step_clamp}")
+
+    grad_fn = jax.value_and_grad(cost_fn)
+
+    def _run_one(init_lat):
+        m = jnp.zeros_like(init_lat)
+        v = jnp.zeros_like(init_lat)
+        latent = init_lat
+        loss_history: list[float] = []
+        # Only retain visited iterates when best-iterate is requested, so the
+        # default path holds no extra design tensors in memory.
+        latents: list = [] if best_iterate else None
+        last_good = latent  # last design with a confirmed-finite forward+gradient
+        for it in range(n_iters):
+            loss, grad = grad_fn(latent)
+
+            # NaN/Inf gradient guard (unchanged from the legacy loop): a
+            # non-finite gradient silently poisons ``latent`` and every later
+            # iteration, so stop fast and RESTORE the last finite design.
+            if not (bool(jnp.isfinite(loss)) and bool(jnp.all(jnp.isfinite(grad)))):
+                import warnings as _w
+                _w.warn(
+                    f"optimize: non-finite loss/gradient (NaN or Inf) at iteration "
+                    f"{it} — the FDTD forward almost certainly diverged. Common "
+                    f"causes: dt above CFL, conformal=True at fine dx (a known NaN), "
+                    f"PEC inside the CPML region, or a sub-cell PEC feature. Stopping early and "
+                    f"returning the last finite design (from before iteration "
+                    f"{it}).",
+                    stacklevel=2,
+                )
+                latent = last_good
+                break
+
+            last_good = latent  # this design produced a finite forward+gradient
+            if it_count is not None:
+                it_count[0] = it + 1
+            loss_val = float(loss)
+            loss_history.append(loss_val)
+            if latents is not None:
+                latents.append(latent)
+
+            # Adam update
+            m = beta1 * m + (1 - beta1) * grad
+            v = beta2 * v + (1 - beta2) * grad ** 2
+            m_hat = m / (1 - beta1 ** (it + 1))
+            v_hat = v / (1 - beta2 ** (it + 1))
+            if step_clamp is None:
+                latent = latent - lr * m_hat / (jnp.sqrt(v_hat) + eps_adam)
+            else:
+                step = lr * m_hat / (jnp.sqrt(v_hat) + eps_adam)
+                snorm = jnp.linalg.norm(step)
+                step = jnp.where(snorm > step_clamp,
+                                 step * (step_clamp / snorm), step)
+                latent = latent - step
+
+            if verbose and (it % 10 == 0 or it == n_iters - 1):
+                print(f"  iter {it:4d}  loss = {loss_val:.6e}")
+
+        if loss_history:
+            if best_iterate:
+                best_i = int(np.argmin(np.asarray(loss_history)))
+                ret_latent = latents[best_i]
+                score = loss_history[best_i]
+            else:
+                ret_latent = latent
+                score = loss_history[-1]
+        else:
+            # No finite loss was recorded (diverged at iter 0): fail-soft,
+            # return the last-good design (== init_lat) with no score.
+            ret_latent = last_good
+            score = None
+        return loss_history, ret_latent, score
+
+    all_histories: list[list[float]] = []
+    results = []  # (loss_history, ret_latent, score)
+    for init_lat in latent_inits:
+        lh, rl, sc = _run_one(init_lat)
+        all_histories.append(lh)
+        results.append((lh, rl, sc))
+
+    eligible = [
+        (i, r) for i, r in enumerate(results)
+        if r[2] is not None and math.isfinite(r[2])
+    ]
+    if eligible:
+        best_start, (best_lh, best_lat, _score) = min(
+            eligible, key=lambda t: t[1][2]
+        )
+        return best_lat, best_lh, all_histories, best_start
+    if len(latent_inits) == 1:
+        # Single-start fail-soft: preserve the legacy warn-and-return-last-good
+        # contract (tests/test_result_finite_guard.py).
+        lh, rl, _sc = results[0]
+        return rl, lh, all_histories, 0
+    raise RuntimeError(
+        f"optimize multi-start: all {len(latent_inits)} starts produced a "
+        "non-finite loss at every iterate; no usable optimum."
+    )
+
+
 def optimize(
     sim,
     region: DesignRegion,
@@ -86,6 +258,10 @@ def optimize(
     distributed: bool = False,
     port_s11_freqs: object | None = None,
     checkpoint_segments: int | None = None,
+    n_starts: int = 1,
+    best_iterate: bool = False,
+    step_clamp: float | None = None,
+    seed: int = 0,
 ) -> OptimizeResult:
     """Run gradient-based optimization on a design region.
 
@@ -130,11 +306,38 @@ def optimize(
         Non-uniform meshes and ``distributed=True`` will raise
         ``NotImplementedError``; NU support is tracked as a follow-up
         on issue #73.
+    n_starts : int
+        Number of random-initialized restarts (opt-in; default 1 = the
+        legacy single run).  Start 0 always uses ``init_latent`` (so
+        ``n_starts=1`` is byte-identical to before this parameter existed);
+        starts 1..N-1 draw i.i.d. standard-normal latents from ``seed``.
+        The best restart by final loss (or best-visited loss when
+        ``best_iterate=True``) is returned.  Promoted from the MSL
+        open-stub multimodal example (issue #171); the surface must be
+        multimodal for extra starts to help.
+    best_iterate : bool
+        If True, return the lowest-loss iterate visited during the run
+        rather than the final iterate (default False = final iterate =
+        legacy behaviour).  Guards the sharp-null overshoot the #171 GPU
+        run caught.  Selection among ``n_starts`` restarts uses the same
+        best-visited loss when this is True.
+    step_clamp : float or None
+        If set (>0), clamp the L2 norm of each Adam latent update to this
+        value, rescaling the whole step (direction preserved) when it
+        overshoots.  Default None = unclamped = legacy behaviour.  Generic
+        analogue of the example's physical-length clamp.
+    seed : int
+        PRNG seed for the extra ``n_starts`` restart inits (deterministic /
+        reproducible).  Unused when ``n_starts=1``.
 
     Returns
     -------
     OptimizeResult
+        For ``n_starts>1`` this is the winning restart's result
+        (``loss_history`` is that restart's own trajectory).
     """
+    if n_starts < 1:
+        raise ValueError(f"optimize: n_starts must be >= 1, got {n_starts}")
     sim._auto_preflight(skip=skip_preflight, context="optimize")
 
     # #64: dispatch to NU or uniform grid. The differentiable pipeline
@@ -190,13 +393,6 @@ def optimize(
     base_eps_r = base_materials.eps_r
     _n_steps = n_steps if n_steps is not None else _n_steps_auto
 
-    # Adam state
-    m = jnp.zeros_like(init_latent)
-    v = jnp.zeros_like(init_latent)
-    beta1, beta2, eps_adam = 0.9, 0.999, 1e-8
-
-    latent = init_latent
-    loss_history = []
     it_count = [0]  # mutable counter for verbose inside forward()
 
     def forward(lat):
@@ -233,53 +429,32 @@ def optimize(
             return objective(result, ntff_box=result.ntff_box)
         return objective(result)
 
-    grad_fn = jax.value_and_grad(forward)
+    # Restart inits: start 0 is always ``init_latent`` (so n_starts=1 is the
+    # legacy single run, byte-identical); extras are i.i.d. standard-normal
+    # latents drawn from ``seed`` for reproducibility.
+    latent_inits = [init_latent]
+    if n_starts > 1:
+        keys = jax.random.split(jax.random.PRNGKey(seed), n_starts - 1)
+        latent_inits.extend(
+            jax.random.normal(k, design_shape, dtype=jnp.float32) for k in keys
+        )
 
-    last_good = latent  # last design with a confirmed-finite forward+gradient
-    for it in range(n_iters):
-        loss, grad = grad_fn(latent)
+    best_latent, loss_history, _all_histories, _best_start = _adam_multistart(
+        forward,
+        latent_inits,
+        n_iters=n_iters,
+        lr=lr,
+        best_iterate=best_iterate,
+        step_clamp=step_clamp,
+        verbose=verbose,
+        it_count=it_count,
+    )
 
-        # NaN/Inf gradient guard. A non-finite gradient does not crash an
-        # inverse-design loop — the Adam update below would silently poison
-        # ``latent`` (and every later iteration), so the optimizer "succeeds"
-        # while wandering on garbage. Stop fast with a cause hint and RESTORE
-        # the last design whose forward was finite (the CURRENT ``latent`` is
-        # the one that just diverged, so returning it would hand back a
-        # divergence-causing design).
-        if not (bool(jnp.isfinite(loss)) and bool(jnp.all(jnp.isfinite(grad)))):
-            import warnings as _w
-            _w.warn(
-                f"optimize: non-finite loss/gradient (NaN or Inf) at iteration "
-                f"{it} — the FDTD forward almost certainly diverged. Common "
-                f"causes: dt above CFL, conformal=True at fine dx (a known NaN), "
-                f"PEC inside the CPML region, or a sub-cell PEC feature. Stopping early and "
-                f"returning the last finite design (from before iteration "
-                f"{it}).",
-                stacklevel=2,
-            )
-            latent = last_good
-            break
-
-        last_good = latent  # this design produced a finite forward+gradient
-        it_count[0] = it + 1
-        loss_val = float(loss)
-        loss_history.append(loss_val)
-
-        # Adam update
-        m = beta1 * m + (1 - beta1) * grad
-        v = beta2 * v + (1 - beta2) * grad ** 2
-        m_hat = m / (1 - beta1 ** (it + 1))
-        v_hat = v / (1 - beta2 ** (it + 1))
-        latent = latent - lr * m_hat / (jnp.sqrt(v_hat) + eps_adam)
-
-        if verbose and (it % 10 == 0 or it == n_iters - 1):
-            print(f"  iter {it:4d}  loss = {loss_val:.6e}")
-
-    eps_design = _latent_to_eps(latent, eps_min, eps_max)
+    eps_design = _latent_to_eps(best_latent, eps_min, eps_max)
     return OptimizeResult(
         eps_design=eps_design,
         loss_history=loss_history,
-        latent=latent,
+        latent=best_latent,
     )
 
 

--- a/tests/test_optimize_multistart.py
+++ b/tests/test_optimize_multistart.py
@@ -1,0 +1,325 @@
+"""Contract tests for the opt-in multi-start / best-iterate / step-clamp
+knobs promoted into ``rfx.optimize`` (WP 4-C, from the MSL open-stub
+example's ``_multistart_adam``, issue #171).
+
+Two layers:
+
+1. **Bit-identity gate (load-bearing).** With ``n_starts=1``,
+   ``best_iterate=False`` and ``step_clamp=None`` the promoted
+   ``_adam_multistart`` core must reproduce the LEGACY inline Adam loop
+   BYTE-for-BYTE — both on a synthetic cost (portable, FDTD-free) and
+   end-to-end through ``optimize()`` (adding the new defaulted params
+   changes nothing).  This is the non-negotiable falsifier: if it ever
+   fails, the default path drifted.
+
+2. **Six MSL-G2 behaviors** replicated at the library level against
+   synthetic costs (mirrors ``tests/test_msl_multistart.py`` for the
+   example), plus the generic step-clamp semantics and fail-closed guards.
+
+NOTE: do NOT call ``jax.config.update("jax_enable_x64", True)`` at module
+level — it is a PROCESS-GLOBAL flag and contaminates other pytest-split
+shards.  These tests use float32 (the production dtype); tolerances are
+float32-safe.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+import jax
+import jax.numpy as jnp
+
+from rfx.optimize import _adam_multistart, optimize, DesignRegion, OptimizeResult
+
+
+# ---------------------------------------------------------------------------
+# Reference: verbatim copy of the LEGACY (pre-WP-4-C) inline optimize() Adam
+# loop.  The bit-identity gate asserts the promoted core reproduces this.
+# ---------------------------------------------------------------------------
+def _legacy_single_start_adam(cost_fn, init_latent, n_iters, lr):
+    beta1, beta2, eps_adam = 0.9, 0.999, 1e-8
+    m = jnp.zeros_like(init_latent)
+    v = jnp.zeros_like(init_latent)
+    latent = init_latent
+    loss_history = []
+    grad_fn = jax.value_and_grad(cost_fn)
+    last_good = latent
+    for it in range(n_iters):
+        loss, grad = grad_fn(latent)
+        if not (bool(jnp.isfinite(loss)) and bool(jnp.all(jnp.isfinite(grad)))):
+            latent = last_good
+            break
+        last_good = latent
+        loss_val = float(loss)
+        loss_history.append(loss_val)
+        m = beta1 * m + (1 - beta1) * grad
+        v = beta2 * v + (1 - beta2) * grad ** 2
+        m_hat = m / (1 - beta1 ** (it + 1))
+        v_hat = v / (1 - beta2 ** (it + 1))
+        latent = latent - lr * m_hat / (jnp.sqrt(v_hat) + eps_adam)
+    return loss_history, latent
+
+
+def _bowl_cost(z):
+    """Smooth quadratic bowl over a small latent array (real Adam path)."""
+    target = jnp.asarray([1.0, -1.0, 0.5], dtype=jnp.float32)
+    return jnp.sum((z - target) ** 2)
+
+
+# ---------------------------------------------------------------------------
+# 1. BIT-IDENTITY GATE (load-bearing) — synthetic, portable
+# ---------------------------------------------------------------------------
+def test_bit_identity_default_matches_legacy_loop():
+    """`_adam_multistart` at defaults == the legacy inline Adam loop, bit-for-bit.
+
+    This is the committed form of the WP-4-C falsifier: the default path
+    (single start, no best-iterate, no clamp) must be byte-identical to the
+    algorithm that shipped before the knobs existed.
+    """
+    init = jnp.asarray([0.5, -0.3, 1.2], dtype=jnp.float32)
+    n_iters, lr = 8, 0.1
+
+    legacy_lh, legacy_latent = _legacy_single_start_adam(_bowl_cost, init, n_iters, lr)
+    best_latent, lh, all_h, best_start = _adam_multistart(
+        _bowl_cost, [init], n_iters=n_iters, lr=lr,
+    )
+
+    assert best_start == 0
+    assert len(all_h) == 1
+    assert np.array_equal(np.asarray(lh, dtype=np.float64),
+                          np.asarray(legacy_lh, dtype=np.float64)), \
+        "loss history drifted from the legacy loop"
+    assert np.array_equal(np.asarray(best_latent), np.asarray(legacy_latent)), \
+        "final latent drifted from the legacy loop"
+
+
+# ---------------------------------------------------------------------------
+# Synthetic costs (mirrors tests/test_msl_multistart.py)
+# ---------------------------------------------------------------------------
+def _bimodal_cost(x):
+    shallow = 0.30 * jnp.exp(-((x - 2.0) ** 2) / (2.0 * 0.6 ** 2))
+    deep = 0.90 * jnp.exp(-((x - 8.0) ** 2) / (2.0 * 0.6 ** 2))
+    return 1.0 - shallow - deep
+
+
+def _bimodal_cost_nan_below(x):
+    return jnp.where(x < 0.5, jnp.nan, _bimodal_cost(x))
+
+
+def _sharp_well(x):
+    return 1.0 - jnp.exp(-((x - 8.0) ** 2) / (2.0 * 0.3 ** 2))
+
+
+def _scalar(v):
+    return jnp.asarray(v, dtype=jnp.float32)
+
+
+# ---------------------------------------------------------------------------
+# 2. The six MSL-G2 behaviors, at the library level
+# ---------------------------------------------------------------------------
+# Behavior 1: multi-start best-of returns the deeper (global) basin.
+def test_behavior1_multistart_finds_global_min_from_both_basins():
+    best_latent, lh, all_h, best_start = _adam_multistart(
+        _bimodal_cost,
+        [_scalar(1.5), _scalar(5.0), _scalar(8.5)],
+        n_iters=120, lr=0.2, best_iterate=True,
+    )
+    assert abs(float(best_latent) - 8.0) < 0.15, \
+        f"best_latent={float(best_latent)} should be the global min near 8.0"
+    # best_start's own trajectory holds the deep-well floor.
+    assert min(all_h[best_start]) < 0.2
+    assert len(all_h) == 3
+
+
+# Behavior 2: best-of selection is independent of seed order.
+def test_behavior2_selection_independent_of_seed_order():
+    _, _, _, best_start_a = _adam_multistart(
+        _bimodal_cost, [_scalar(2.0), _scalar(8.0)],
+        n_iters=100, lr=0.2, best_iterate=True,
+    )
+    best_latent_b, _, _, best_start_b = _adam_multistart(
+        _bimodal_cost, [_scalar(8.0), _scalar(2.0)],
+        n_iters=100, lr=0.2, best_iterate=True,
+    )
+    assert best_start_a == 1   # deep basin listed second wins
+    assert best_start_b == 0   # deep basin listed first wins
+    assert abs(float(best_latent_b) - 8.0) < 0.15
+
+
+# Behavior 3: step-clamp bounds the per-step DoF (latent) move.
+def test_behavior3_step_clamp_bounds_per_step_move():
+    # Constant-gradient (linear) cost => Adam pushes a large, steady step.
+    w = jnp.asarray([3.0, -4.0], dtype=jnp.float32)  # ||grad|| large
+
+    def lin_cost(z):
+        return jnp.sum(w * z)
+
+    init = jnp.zeros((2,), dtype=jnp.float32)
+    clamp = 0.05
+
+    # n_iters=1 isolates a single clamped step: ||Δlatent|| <= step_clamp.
+    bl1, _, _, _ = _adam_multistart(lin_cost, [init], n_iters=1, lr=5.0,
+                                    step_clamp=clamp)
+    move1 = float(jnp.linalg.norm(bl1 - init))
+    assert move1 <= clamp + 1e-6, f"single clamped step {move1} exceeded {clamp}"
+
+    # Unclamped: the same huge lr moves far more than the clamp would allow.
+    bu1, _, _, _ = _adam_multistart(lin_cost, [init], n_iters=1, lr=5.0)
+    move_unclamped = float(jnp.linalg.norm(bu1 - init))
+    assert move_unclamped > clamp, "control: unclamped step should exceed clamp"
+
+    # Cumulative bound over K clamped steps: ||final-init|| <= K*step_clamp.
+    K = 6
+    blK, _, _, _ = _adam_multistart(lin_cost, [init], n_iters=K, lr=5.0,
+                                    step_clamp=clamp)
+    assert float(jnp.linalg.norm(blK - init)) <= K * clamp + 1e-6
+
+
+# Behavior 4: best-iterate returns the best-visited, not the overshot final.
+def test_behavior4_best_iterate_not_overshot_final():
+    init = [_scalar(7.0)]
+    # High lr builds momentum and overshoots the sharp well at x=8.
+    best_lat, best_lh, _, _ = _adam_multistart(
+        _sharp_well, init, n_iters=40, lr=0.8, best_iterate=True,
+    )
+    final_lat, _, _, _ = _adam_multistart(
+        _sharp_well, init, n_iters=40, lr=0.8, best_iterate=False,
+    )
+    c_best = float(_sharp_well(best_lat))
+    c_final = float(_sharp_well(final_lat))
+    # best-iterate is no worse than, and here strictly better than, final.
+    assert c_best <= c_final + 1e-9
+    assert c_best < c_final, "expected an overshoot (best strictly < final)"
+    assert abs(float(best_lat) - 8.0) < 0.1, "best-iterate should sit at the well floor"
+    # best-iterate's returned latent achieves the trajectory-min recorded loss.
+    assert abs(c_best - min(best_lh)) < 1e-5
+
+
+# Behavior 5: a NaN start listed first must not lock in as best.
+def test_behavior5_nan_start_first_is_rejected():
+    with pytest.warns(UserWarning, match="non-finite"):
+        best_lat, best_lh, all_h, best_start = _adam_multistart(
+            _bimodal_cost_nan_below,
+            [_scalar(-1.0), _scalar(8.0)],   # NaN region first, global basin second
+            n_iters=60, lr=0.2, best_iterate=True,
+        )
+    assert best_start == 1
+    assert all_h[0] == [], "the NaN start recorded no finite loss"
+    assert math.isfinite(min(best_lh)), "best loss leaked a NaN"
+    assert abs(float(best_lat) - 8.0) < 0.15
+
+
+# Behavior 6: all-non-finite multi-start fails loudly (fail-closed).
+def test_behavior6_all_nan_multistart_raises():
+    with pytest.warns(UserWarning, match="non-finite"):
+        with pytest.raises(RuntimeError, match="non-finite loss at every iterate"):
+            _adam_multistart(
+                _bimodal_cost_nan_below,
+                [_scalar(-1.0), _scalar(-2.0)],
+                n_iters=20, lr=0.2,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Fail-soft (single start) + input validation
+# ---------------------------------------------------------------------------
+def test_single_start_nan_is_fail_soft_not_raise():
+    """A SINGLE non-finite start preserves the legacy warn-and-return-last-good
+    contract (does NOT raise — that is a multi-start-only guard)."""
+    init = _scalar(-1.0)
+    with pytest.warns(UserWarning, match="non-finite"):
+        best_lat, best_lh, all_h, best_start = _adam_multistart(
+            _bimodal_cost_nan_below, [init], n_iters=10, lr=0.2,
+        )
+    assert best_lh == []
+    assert best_start == 0
+    assert float(best_lat) == float(init)  # last-good == the (finite) init
+
+
+def test_step_clamp_nonpositive_raises():
+    with pytest.raises(ValueError, match="step_clamp must be > 0"):
+        _adam_multistart(_bowl_cost, [jnp.zeros((3,), jnp.float32)],
+                         n_iters=1, lr=0.1, step_clamp=0.0)
+
+
+def test_helper_is_pure_no_fdtd():
+    """`_adam_multistart` is importable and runs with no rfx forward."""
+    bl, lh, all_h, bs = _adam_multistart(
+        lambda z: jnp.sum((z - 3.0) ** 2),
+        [jnp.asarray(3.0, dtype=jnp.float32)],
+        n_iters=1, lr=0.1,
+    )
+    assert abs(float(bl) - 3.0) < 1e-3   # already at the min
+    assert bs == 0 and len(all_h) == 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through optimize() — FDTD (gpu-marked like the other optimize tests)
+# ---------------------------------------------------------------------------
+def _tiny_sim():
+    from rfx.api import Simulation
+    sim = Simulation(freq_max=5e9, domain=(0.015, 0.015, 0.015), boundary="pec")
+    sim.add_port((0.005, 0.0075, 0.0075), "ez")
+    sim.add_probe((0.011, 0.0075, 0.0075), "ez")
+    return sim
+
+
+def _tiny_region():
+    return DesignRegion(
+        corner_lo=(0.006, 0.006, 0.006),
+        corner_hi=(0.010, 0.010, 0.009),
+        eps_range=(1.0, 4.4),
+    )
+
+
+def _obj(r):
+    return -jnp.sum(r.time_series ** 2)
+
+
+@pytest.mark.gpu
+def test_optimize_default_bit_identity_end_to_end():
+    """optimize() with the new params at their defaults is byte-identical to
+    optimize() with the params omitted (and seed is irrelevant at n_starts=1)."""
+    region = _tiny_region()
+    res_a = optimize(_tiny_sim(), region, _obj, n_iters=5, lr=0.2, verbose=False)
+    res_b = optimize(_tiny_sim(), region, _obj, n_iters=5, lr=0.2, verbose=False,
+                     n_starts=1, best_iterate=False, step_clamp=None, seed=12345)
+    assert np.array_equal(np.asarray(res_a.loss_history, dtype=np.float64),
+                          np.asarray(res_b.loss_history, dtype=np.float64))
+    assert np.array_equal(np.asarray(res_a.latent), np.asarray(res_b.latent))
+    assert np.array_equal(np.asarray(res_a.eps_design), np.asarray(res_b.eps_design))
+
+
+@pytest.mark.gpu
+def test_optimize_multistart_is_deterministic_under_fixed_seed():
+    """Same seed => identical multi-start result (explicit, reproducible RNG)."""
+    region = _tiny_region()
+    r1 = optimize(_tiny_sim(), region, _obj, n_iters=3, lr=0.2, verbose=False,
+                  n_starts=2, seed=7)
+    r2 = optimize(_tiny_sim(), region, _obj, n_iters=3, lr=0.2, verbose=False,
+                  n_starts=2, seed=7)
+    assert np.array_equal(np.asarray(r1.loss_history, dtype=np.float64),
+                          np.asarray(r2.loss_history, dtype=np.float64))
+    assert np.array_equal(np.asarray(r1.latent), np.asarray(r2.latent))
+
+
+@pytest.mark.gpu
+def test_optimize_multistart_and_knobs_plumb_through():
+    """n_starts>1 / best_iterate / step_clamp all run and return a valid result."""
+    region = _tiny_region()
+    res = optimize(_tiny_sim(), region, _obj, n_iters=3, lr=0.2, verbose=False,
+                   n_starts=2, best_iterate=True, step_clamp=1e-2, seed=1)
+    assert isinstance(res, OptimizeResult)
+    assert len(res.loss_history) >= 1
+    assert np.all(np.isfinite(np.asarray(res.eps_design)))
+    assert res.eps_design.shape == res.latent.shape
+
+
+def test_optimize_rejects_bad_n_starts():
+    # Raised before any FDTD work, so this stays in the fast (non-gpu) suite.
+    with pytest.raises(ValueError, match="n_starts must be >= 1"):
+        optimize(_tiny_sim(), _tiny_region(), _obj, n_iters=1, verbose=False,
+                 n_starts=0)


### PR DESCRIPTION
## What

WP 4-C of the external-reviewer plan: promote the multi-start / best-iterate / step-clamp optimizer knobs — validated in the MSL-G2 inverse-design example — **into the `rfx.optimize` library** as opt-in, default-off parameters. This fixes the *documented* optimizer failure modes (multimodal cost surfaces, sharp-null overshoot) for every user, not just the one example.

## The bit-identity guarantee (the falsifier)

Four new keyword-only params default to today's exact behavior:

| param | default | default = legacy? |
|---|---|---|
| `n_starts` | 1 | single run, caller's `init_latent` |
| `best_iterate` | False | returns last iterate |
| `step_clamp` | None | no clamp branch |
| `seed` | 0 | inert at n_starts=1 |

The inline Adam loop was extracted into a pure `_adam_multistart` core; `optimize()` with defaults reproduces the pre-change loss history / latent / eps_design **byte-identically**. This was the non-negotiable gate — if it had broken, the plan mandated R2-STOP; it held throughout.

## Generic, not example-specific

`step_clamp` is a generic L2-norm rescale on the latent update (the example's physical-length-specific bisection clamp stays in `examples/inverse_design/msl_stub_notch_tuning.py`). Multi-start restarts draw deterministic `jax.random.normal` off an explicit `seed` (start 0 always uses the caller's init). Single-start keeps the legacy fail-soft NaN-guard (warn + return last-good); multi-start fails closed (`RuntimeError`) only when *every* restart is non-finite.

## Contents
- `rfx/optimize.py` — the opt-in knobs + `_adam_multistart` core (default path byte-unchanged).
- `tests/test_optimize_multistart.py` — the bit-identity gate + the six MSL-G2 behaviors as library-level contract tests (fail-closed, each a real falsifier).
- CHANGELOG `[Unreleased]`; `api_symbol_inventory.json` pinned (the public-surface gate flagged the new params — regenerated, diff is exactly the 4 names).

## Verification
Independent review: **APPROVE, no must-fixes** — reviewer independently re-ran the bit-identity check against **real git-history `main:rfx/optimize.py`** (not the test's re-implemented helper): max|Δ| = 0.0 on loss history / latent / eps_design at defaults and with all four params explicit; confirmed the test's legacy helper faithfully mirrors the pre-change loop, the fail-soft contract is preserved (single-start warn-and-return vs multi-start raise-only-when-all-fail), `step_clamp=None` is a true no-op branch, seed determinism (no global randomness), and the api-inventory diff is exactly the 4 params. Regression: 75 passed. ruff clean. Scope = 4 files, no other rfx/ source, no validation-gate tolerance touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)