### PR TITLE
feat(sparams): soft passivity advisory for the (2.25, hard-limit] |S| window + lock the pec-open-radiator gate decision (audit #5/#3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Added — waveguide S-matrix soft over-unity advisory (LLM-naive-usage audit item #5)
+
+- `compute_waveguide_s_matrix(normalize=False)` now emits a SEPARATE, humble
+  ADVISORY (warning, never raise) when a passive extraction's max column power
+  lands in `(2.25, hard_limit]` — above the documented single-run overshoot
+  envelope but below the `passivity_tol` extractor-broken hard limit. On the
+  loose `normalize=False` tol (2.0 → column-power limit 3.0) the window
+  `(~2.0, 3.0]` was previously unguarded: a validated PEC short sits at column
+  power ~2.0 there (a documented Yee/near-cutoff artifact, `|S21|≈1` not
+  cancelled by the single-run decomposition), so the existing self-check
+  (`_warn_if_nonpassive_smatrix` in `rfx/api/_sparams.py`) stayed silent for a
+  passive result materially above that envelope. A real coarse-mesh (`dx=2 mm`)
+  WR-90 PEC short landing at column power ~2.51 reproduced the silent gap.
+- The floor is column power 2.25 (`|S| ~ 1.5` for a 1-port): above the ~2.0
+  documented envelope AND the committed `normalize=False` PEC short (column
+  power ~2.00, `test_pec_short_s11_magnitude` /
+  `test_normalize_aware_tol_tolerates_documented_overshoot`) with margin. The
+  window is EMPTY on the tight-tol path (`normalize='flux'`/`True` → tol 0.10 →
+  hard limit 1.10 < 2.25), so the advisory only fires for `normalize=False`. No
+  physics changed; the `tol=2.0` hard threshold and every committed gate are
+  untouched. Message wording is distinct from the hard `UNRELIABLE` error.
+  Witness + false-positive gates in `tests/test_sparam_passivity_guard.py`.
+
+### Changed — pec-open-radiator advisory kept NTFF-gated (LLM-naive-usage audit item #3, R2-STOP)
+
+- The audit asked whether `_validate_cfg_pec_boundary_open_structure`
+  (`rfx/api/_preflight.py`) should be ungated from its `self._ntff is not None`
+  condition so an open radiator read via a near-field probe / S11 alone also
+  warns. R2-STOPPED after investigation: NTFF is the SOLE radiation-intent
+  signal on the `Simulation` config, so a source (and/or a finite PEC object)
+  inside a `boundary="pec"` domain is config-IDENTICAL between an open radiator
+  that mistakenly used PEC and a legitimate closed cavity / internal-PEC
+  numerics test (e.g. `test_adi.py::test_simulation_adi_internal_pec_geometry_masks_ez`,
+  `test_conformal.py::test_api_conformal_flag`,
+  `test_extract_s_matrix_pec_mask.py`). Any broadening that caught the footgun
+  would false-alarm that legion of valid closed-structure sims, and a
+  false-alarming preflight erodes trust worse than the silent gap. The advisory
+  is unchanged; the decision is locked by regression tests in
+  `tests/test_preflight_false_positives.py` (NTFF radiator still warns; valid
+  closed structures stay silent).
+
 ### Added — lumped R/L/C component values as a differentiable design variable (WP 4-E)
 
 - `Simulation.forward()` now processes `add_lumped_rlc(...)` elements on the

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -146,6 +146,44 @@ def _warn_if_nonpassive_smatrix(
         if i.code in ("passivity_violation", "nonfinite_sparams")
     ]
     if not bad:
+        # SOFT ADVISORY (LLM-naive-usage audit item #5): the hard check above
+        # uses the caller's ``passivity_tol``. On the ``normalize=False``
+        # waveguide path that tol is loose (2.0 -> column-power limit 3.0,
+        # i.e. |S| <= 1.732 for a 1-port) to tolerate the DOCUMENTED single-run
+        # Yee/near-cutoff over-unity: a validated strong reflector (PEC short)
+        # sits at column power ~2.0 there (|S11| entry ~1.03 plus the
+        # convention |S21| ~ 1 that the single-run decomposition does not
+        # cancel — see test_waveguide_broad_e5_live_anchor / the tol=2.0 lock
+        # in test_sparam_passivity_guard::
+        # test_normalize_aware_tol_tolerates_documented_overshoot). That leaves
+        # the window (~2.0, 3.0] UNGUARDED: a passive result whose column power
+        # is materially above the documented envelope but below the
+        # extractor-broken hard limit returns silently. Surface it as a
+        # SEPARATE, humble advisory (never raise) so a naive caller does not
+        # trust an over-unity |S| from a reference-plane / normalize choice or
+        # an under-resolved mesh. The floor 2.25 (|S| ~ 1.5 for a 1-port)
+        # clears the ~2.0 documented envelope AND the committed normalize=False
+        # PEC-short column power (~2.00) with margin; the window is EMPTY on
+        # the tight-tol path (tol=0.10 -> hard limit 1.10 < 2.25), so this
+        # advisory only fires for the loose normalize=False tol.
+        _SOFT_COLPOWER_FLOOR = 2.25
+        hard_limit = 1.0 + float(passivity_tol)
+        max_cp = report.metrics.get("max_column_power")
+        if max_cp is not None and _SOFT_COLPOWER_FLOOR < float(max_cp) <= hard_limit:
+            import warnings as _w
+            _w.warn(
+                f"{extractor}: max column power {float(max_cp):.4g} exceeds 1 "
+                f"(non-physical for a passive structure) but stays below the "
+                f"tol={float(passivity_tol):g} extractor-broken hard limit "
+                f"({hard_limit:.4g}). This is an ADVISORY, not an error: on the "
+                f"normalize=False single-run path a modest over-unity is a "
+                f"documented Yee / near-cutoff artifact (validated envelope "
+                f"~2.0), but a column power materially above it can also signal "
+                f"a reference-plane or normalize choice or an under-resolved "
+                f"mesh. Treat these S-parameters with caution and cross-check "
+                f"(normalize='flux', finer dx) before trusting them.",
+                stacklevel=3,
+            )
         return
     detail = "; ".join(f"{i.code}: {i.message}" for i in bad)
     msg = (

--- a/tests/test_preflight_false_positives.py
+++ b/tests/test_preflight_false_positives.py
@@ -36,6 +36,10 @@ def _has(issues, substring):
     return any(substring in i for i in issues)
 
 
+def _codes(sim):
+    return {getattr(i, "code", None) for i in sim.preflight()}
+
+
 # ---------------------------------------------------------------------------
 # FP1 — thin-sheet PEC strip should not trigger PEC-volume warning
 # ---------------------------------------------------------------------------
@@ -183,4 +187,67 @@ def test_hy_probe_inside_thick_pec_volume_still_warns():
     assert _has(issues, "is inside PEC geometry"), (
         f"Hy probe in thick PEC volume must still warn; "
         f"issues: {issues!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Item #3 (LLM-naive-usage audit) — pec_boundary_open advisory: R2-STOP lock.
+#
+# The audit asked whether the ``pec_boundary_open`` advisory
+# (``_validate_cfg_pec_boundary_open_structure``) should be UNGATED from its
+# ``self._ntff is not None`` condition so an open radiator read via a near-field
+# probe / S11 alone (no NTFF box) also warns. Investigation (2026-07-09)
+# R2-STOPPED that ungating: NTFF is the SOLE radiation-intent signal on the
+# Simulation config (there is no directivity / far-field / "radiate" flag), so
+# a source (and/or a finite PEC object) inside a ``boundary="pec"`` domain is
+# config-IDENTICAL between an open radiator that mistakenly used PEC and a
+# legitimate closed cavity / internal-PEC numerics test. The committed suite is
+# full of the latter — e.g. ``test_adi.py::
+# test_simulation_adi_internal_pec_geometry_masks_ez`` (PEC Box in a pec box +
+# source), ``test_extract_s_matrix_pec_mask.py``, ``test_conformal.py::
+# test_api_conformal_flag`` (PEC cylinder in a pec box + port). Any broadening
+# that catches the footgun would false-alarm all of them, and a false-alarming
+# preflight erodes trust worse than the silent gap. These tests LOCK that
+# decision: the NTFF-declared open radiator still warns; the valid closed
+# structures must stay silent so a future well-meaning ungating cannot regress
+# them unnoticed.
+# ---------------------------------------------------------------------------
+def test_pec_boundary_open_still_warns_when_ntff_declared():
+    """Radiation intent (an NTFF box) + boundary='pec' must still warn —
+    the existing, principled gate is preserved by the R2-STOP."""
+    sim = Simulation(freq_max=10e9, domain=(0.06, 0.06, 0.06), dx=2e-3,
+                     boundary="pec")
+    sim.add_source((0.03, 0.03, 0.03), "ez")
+    sim.add(Box((0.028, 0.028, 0.020), (0.032, 0.032, 0.024)), material="pec")
+    sim.add_ntff_box((0.01, 0.01, 0.01), (0.05, 0.05, 0.05))
+    assert "pec_boundary_open" in _codes(sim), (
+        "NTFF-declared open radiator on a PEC boundary must still warn"
+    )
+
+
+def test_pec_cavity_with_internal_pec_object_stays_silent():
+    """FALSE-POSITIVE lock: a source + finite PEC object inside a pec box
+    (the ``test_adi`` internal-PEC-masks-Ez / ``test_conformal`` patterns) is a
+    VALID closed structure and must NOT emit pec_boundary_open. This is the
+    population that any ntff-ungating would false-alarm — the reason #3 was
+    R2-STOPPED."""
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3,
+                     boundary="pec")
+    sim.add(Box((0.008, 0.008, 0.0), (0.012, 0.012, 0.01)), material="pec")
+    sim.add_source((0.01, 0.01, 0.0), "ez")
+    sim.add_probe((0.01, 0.01, 0.0), "ez")
+    assert "pec_boundary_open" not in _codes(sim), (
+        "internal-PEC-object closed cavity must not warn (R2-STOP rationale)"
+    )
+
+
+def test_pec_empty_cavity_with_source_stays_silent():
+    """FALSE-POSITIVE lock: a bare source in a pec box (empty resonant cavity)
+    is config-identical to an open radiator and must NOT warn — there is no
+    discriminator, hence the R2-STOP."""
+    sim = Simulation(freq_max=12e9, domain=(0.03, 0.03, 0.03), dx=1.5e-3,
+                     boundary="pec")
+    sim.add_source((0.015, 0.015, 0.015), "ez")
+    assert "pec_boundary_open" not in _codes(sim), (
+        "empty PEC cavity with a source must not warn (R2-STOP rationale)"
     )

--- a/tests/test_sparam_passivity_guard.py
+++ b/tests/test_sparam_passivity_guard.py
@@ -132,3 +132,139 @@ def test_normalize_aware_tol_tolerates_documented_overshoot():
         _warn_if_nonpassive_smatrix(
             _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=2.0
         )
+
+
+# =============================================================================
+# Item #5 (LLM-naive-usage audit) — SOFT over-unity advisory in the
+# (documented-overshoot, extractor-broken] column-power gap.
+#
+# On the ``normalize=False`` waveguide path the passivity tol is loose (2.0 ->
+# column-power hard limit 3.0, |S| <= 1.732 for a 1-port) to tolerate the
+# DOCUMENTED single-run Yee/near-cutoff over-unity: a validated PEC short sits
+# at column power ~2.0 there (see test_normalize_aware_tol_..._overshoot above
+# and the battery test_pec_short_s11_magnitude). That left the window
+# (~2.0, 3.0] UNGUARDED — a passive result materially above the documented
+# envelope but below the hard limit returned silently. A SEPARATE, humble
+# ADVISORY (never raise) now fires there. Floor is column power 2.25 (|S| ~ 1.5
+# for a 1-port): above the ~2.0 documented envelope + the committed PEC-short
+# with margin, below the tol=2.0 hard limit (3.0). The window is EMPTY on the
+# tight-tol path (tol=0.10 -> hard limit 1.10 < 2.25), so the advisory only
+# fires for normalize=False.  Message says "ADVISORY", NOT "UNRELIABLE".
+# =============================================================================
+def _soft_fired(rec):
+    return any("ADVISORY" in str(w.message) for w in rec)
+
+
+def _hard_fired(rec):
+    return any("UNRELIABLE" in str(w.message) for w in rec)
+
+
+def test_soft_advisory_fires_in_the_over_unity_gap():
+    """A passive 1-port with column power in (2.25, 3.0] on the loose tol=2.0
+    path must emit the SOFT advisory (warning, not the hard UNRELIABLE error)."""
+    s = np.full((1, 1, 3), 1.58 + 0.0j)  # column power ~2.496, in (2.25, 3.0]
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        _warn_if_nonpassive_smatrix(
+            _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=2.0
+        )
+    assert _soft_fired(rec), "expected the soft over-unity advisory in the gap"
+    assert not _hard_fired(rec), "must NOT raise/flag the hard UNRELIABLE error"
+
+
+def test_soft_advisory_silent_at_documented_envelope():
+    """Column power == 2.0 (|S|=1.414, the documented normalize=False PEC-short
+    envelope, locked silent by test_normalize_aware_tol_...) must NOT fire the
+    soft advisory — the floor (2.25) sits above it with margin."""
+    s = np.full((1, 1, 3), np.sqrt(2.0) + 0.0j)  # column power exactly 2.0
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning => failure
+        _warn_if_nonpassive_smatrix(
+            _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=2.0
+        )
+
+
+def test_soft_advisory_silent_just_below_floor():
+    """Column power 2.10 (< 2.25 floor) stays silent — margin for cross-machine
+    float drift on the validated PEC-short (~2.00-2.005)."""
+    s = np.full((1, 1, 3), np.sqrt(2.10) + 0.0j)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_if_nonpassive_smatrix(
+            _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=2.0
+        )
+
+
+def test_soft_advisory_never_fires_on_tight_tol_path():
+    """On the tight tol=0.10 path (normalize='flux'/True) the window is empty
+    (hard limit 1.10 < 2.25): a column power that would be in the gap is a HARD
+    violation here, never the soft advisory."""
+    s = np.full((1, 1, 3), 1.58 + 0.0j)  # column power ~2.496
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        _warn_if_nonpassive_smatrix(
+            _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=0.10
+        )
+    assert not _soft_fired(rec), "soft advisory must not fire on the tight-tol path"
+    assert _hard_fired(rec), "tight tol must flag this as the hard passivity error"
+
+
+def test_gross_violation_still_hard_not_soft():
+    """|S| >> 1 (column power > 3.0) stays the HARD UNRELIABLE error even under
+    tol=2.0 — the soft advisory does not swallow gross extractor bugs."""
+    s = np.full((1, 1, 3), 8.94 + 0.0j)  # column power ~79.9
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        _warn_if_nonpassive_smatrix(
+            _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=2.0
+        )
+    assert _hard_fired(rec)
+    assert not _soft_fired(rec)
+
+
+@pytest.mark.slow
+def test_soft_advisory_real_coarse_pec_short_witness():
+    """REAL-geometry witness: a coarse (dx=2mm) WR-90 PEC-short on the
+    normalize=False path lands at column power ~2.51 — above the ~2.0
+    documented envelope, below the 3.0 hard limit — and used to return
+    silently. It must now emit the soft advisory. The finer validated
+    PEC-short (column power ~2.00) must stay silent (false-positive check)."""
+    import jax.numpy as jnp
+    from rfx import Box, Simulation
+
+    DOMAIN = (0.12, 0.04, 0.02)
+
+    def build(freqs, dx, cpml):
+        freqs = np.asarray(freqs, float)
+        f0 = float(freqs.mean())
+        bw = max(0.2, min(0.8, (freqs[-1] - freqs[0]) / f0))
+        sim = Simulation(freq_max=float(freqs[-1]), domain=DOMAIN,
+                         boundary="cpml", cpml_layers=cpml, dx=dx)
+        sim.add(Box((0.085, 0, 0), (0.087, DOMAIN[1], DOMAIN[2])), material="pec")
+        pf = jnp.asarray(freqs)
+        sim.add_waveguide_port(0.01, direction="+x", mode=(1, 0), mode_type="TE",
+                               freqs=pf, f0=f0, bandwidth=bw,
+                               waveform="modulated_gaussian", name="left")
+        sim.add_waveguide_port(0.09, direction="-x", mode=(1, 0), mode_type="TE",
+                               freqs=pf, f0=f0, bandwidth=bw,
+                               waveform="modulated_gaussian", name="right")
+        return sim
+
+    # Witness: coarse mesh -> column power in the gap -> soft advisory fires.
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        res = build(np.linspace(4e9, 6e9, 6), dx=2e-3, cpml=8).\
+            compute_waveguide_s_matrix(normalize=False, num_periods=30)
+    cp = float(np.sum(np.abs(np.asarray(res.s_params)) ** 2, axis=0).max())
+    assert 2.25 < cp <= 3.0, f"expected witness column power in the gap, got {cp:.4f}"
+    assert _soft_fired(rec), f"coarse PEC-short (colpow {cp:.4f}) must emit the advisory"
+    assert not _hard_fired(rec)
+
+    # False-positive: the finer validated PEC-short (~2.00) stays silent.
+    with warnings.catch_warnings(record=True) as rec2:
+        warnings.simplefilter("always")
+        res2 = build(np.linspace(5e9, 7e9, 6), dx=1e-3, cpml=10).\
+            compute_waveguide_s_matrix(normalize=False, num_periods=40)
+    cp2 = float(np.sum(np.abs(np.asarray(res2.s_params)) ** 2, axis=0).max())
+    assert cp2 <= 2.25, f"validated PEC-short column power drifted into the gap: {cp2:.4f}"
+    assert not _soft_fired(rec2), "validated PEC-short must NOT emit the advisory"


### PR DESCRIPTION
## What

Preflight-hardening from the LLM-naive-usage audit: one confirmed silent-wrong footgun fixed with a correctly-scoped advisory, one confirmed-but-uncleanly-fixable footgun R2-STOPped with a test-locked decision. Additive only — never raises, never changes physics.

## Audit #5 — soft passivity advisory (SHIPPED)

On the `normalize=False` waveguide S-param path, a max column power in **(2.25, hard-limit 3.0]** was returned silently — above the ~2.0 documented/tolerated overshoot, below the `tol=2.0` "extractor-broken" hard error. `_warn_if_nonpassive_smatrix` now emits a humble **advisory** (warning, never raise) in exactly that window, naming the likely cause (reference-plane / normalize choice / under-resolved mesh) and recommending a cross-check.

**The audit's `(1.0, 1.732]` framing was partially refuted and narrowed:** the real metric is column power, not the `|S11|` entry; column power ≤ 2.0 is deliberately-tolerated `normalize=False` overshoot (the single-run decomposition's uncancelled `|S21|≈1` term). Only the (~2.0, 3.0] sub-window is a genuine gap. Floor **2.25** clears the validated PEC-short (~2.0) with margin; the window is structurally EMPTY on tight-tol paths (`normalize='flux'/True` → limit 1.10 < 2.25), so the advisory is `normalize=False`-only and the flux lanes are byte-unchanged.

## Audit #3 — pec-open-radiator advisory (R2-STOP, test-locked)

NTFF is the **only** radiation-intent signal on the `Simulation` config. An open radiator that mistakenly used `boundary="pec"` (read via near-field probe/S11, no NTFF) is config-IDENTICAL to a legitimate closed cavity / internal-PEC numerics test — so ungating the advisory from its `_ntff is not None` gate would false-alarm `test_adi` internal-PEC / `test_conformal` / `test_extract_s_matrix_pec_mask`. Per "a false-alarming preflight erodes trust worse than the silent gap," kept it NTFF-gated and **locked the decision with regression tests** (NTFF radiator still warns; internal-PEC + empty cavities stay silent). Revisit if a radiation-intent flag beyond NTFF is ever added.

## Verification
Independent review: **APPROVE, no must-fixes** — reviewer ran the actual geometries: validated PEC-short (~2.0) stays silent, a coarse dx=2mm PEC-short (~2.51) now warns (hard error does not), nothing wrongly clipped in (2.0,2.25); **false-positive sweep PASS — no committed validated `normalize=False` geometry newly warns** (validation battery / broad-E5 anchor / physics-thresholds / auto-preflight, all 0 new advisories); tight-tol flux/True structurally cannot enter the window (byte-unchanged); the #3 R2-STOP is sound and test-locked. The `tol=2.0` constant + hard-check are byte-unchanged (purely additive). 54 + 29 + 24 tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)