### PR TITLE
docs(rcs): pin the bistatic-pattern validation scope (audit #2 — doc-pin R2-STOP, no false-alarming advisory)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Changed — RCS bistatic-pattern validation scope pinned in docs (LLM-naive-usage audit item #2, doc-pin R2-STOP)
+
+- `compute_rcs` returns a full bistatic `rcs_dbsm` / `rcs_linear` pattern, but
+  only the `monostatic_rcs` (backscatter) bin is cross-validated against the
+  exact Mie series (~0.06 dB at ka~1). At the auto-placed default NTFF box
+  (`ntff_offset=1`, ~1 cell off the TFSF boundary, deep in the reactive near
+  field) the off-backscatter bins can be several dB to ~20 dB off — the
+  committed ka~1 PEC sphere shows a spurious forward-oblique lobe near 25-55 deg
+  scattering angle measured ~10 dB high vs Mie. This was already recorded
+  non-gated in `tests/fixtures/rcs_sphere_mie/`; the audit asked whether it
+  should surface at call time.
+- R2-STOPPED to a doc-pin (no runtime advisory added). `monostatic_rcs` is
+  computed at the exact backscatter direction INDEPENDENT of the
+  `theta_obs`/`phi_obs` grid, and every validated monostatic test passes a full
+  observation grid, so there is no call-time signal that separates
+  "monostatic-only" from "bistatic" intent to key an advisory on without
+  false-alarming those tests (the same trap as item #3). Wiring the
+  `Simulation` NTFF near-field guard into `compute_rcs` would likewise fire on
+  every validated monostatic RCS test.
+- Pinned the caveat in the `compute_rcs` / `RCSResult` docstrings, the module
+  docstring, and `docs/public/guide/farfield-rcs.md`. Verify-first finding also
+  recorded: enlarging `ntff_offset` alone does NOT close the oblique gap at test
+  scale (offset 1->2 leaves the 25-55 deg error ~10 dB and worsens backscatter;
+  a larger domain did not help), so the docs steer users away from that dead
+  end. No physics changed; no gate touched. Doc-contract witness in
+  `tests/test_rcs_bistatic_caveat_docpin.py`.
+
 ### Added — waveguide S-matrix soft over-unity advisory (LLM-naive-usage audit item #5)
 
 - `compute_waveguide_s_matrix(normalize=False)` now emits a SEPARATE, humble

--- a/docs/public/guide/farfield-rcs.md
+++ b/docs/public/guide/farfield-rcs.md
@@ -124,6 +124,22 @@ exactly at the backscatter direction opposite the incident propagation
 vector, so it does not depend on the observation grid), and the
 `freqs` / `theta` / `phi` axes.
 
+### Validation scope: monostatic yes, bistatic not yet
+
+Only `monostatic_rcs` (the backscatter bin) is cross-validated against the
+exact Mie series — ~0.06 dB at ka ≈ 1 on a PEC sphere. The full
+`rcs_dbsm` / `rcs_linear` **bistatic pattern is not validated** at the
+auto-placed default NTFF box (`ntff_offset=1`, one cell off the TFSF
+boundary, deep in the reactive near field). At off-backscatter angles the
+default setup can be several dB to ~20 dB off — a ka ≈ 1 PEC sphere shows a
+spurious forward-oblique lobe near 25–55° scattering angle measured ~10 dB
+high versus Mie. Enlarging `ntff_offset` alone does **not** close this at
+test scale (it can worsen the backscatter bin), because the oblique error is
+dominated by the staircased curved surface and forward TFSF-face
+contamination, not box distance. Treat off-backscatter cuts as qualitative
+until a converged (finer-resolution) far-field setup is used; only the
+monostatic number carries the cross-method gate.
+
 ## Plotting RCS
 
 ```python

--- a/rfx/rcs.py
+++ b/rfx/rcs.py
@@ -9,6 +9,11 @@ The standard FDTD RCS approach:
 3. NTFF computes far-field pattern
 4. RCS(theta, phi) = 4*pi*r^2 * |E_scat|^2 / |E_inc|^2
 
+Validation scope: the monostatic (backscatter) bin is cross-validated
+against the exact Mie series; the full bistatic pattern at the default
+near-field NTFF box is NOT validated (see ``compute_rcs`` / ``RCSResult``
+"Bistatic pattern caveat", audit item #2).
+
 Reference: Taflove & Hagness, Ch. 8-9.
 """
 
@@ -41,6 +46,18 @@ class RCSResult(NamedTuple):
         propagation vector), independent of the theta/phi observation
         grid. For normal-incidence +x propagation this is
         (theta=pi/2, phi=pi), i.e. -x.
+
+    VALIDATION SCOPE (read before trusting the full pattern)
+    -------------------------------------------------------
+    Only ``monostatic_rcs`` (the backscatter bin) is cross-validated
+    against the exact Mie series (``tests/test_rcs_mie_fixture.py``,
+    ~0.06 dB at ka~1). The full ``rcs_dbsm`` / ``rcs_linear`` bistatic
+    pattern is NOT validated at the auto-placed default box: the
+    off-backscatter bins can be several dB to ~20 dB off (a spurious
+    forward-oblique lobe near 25-55 deg scattering angle, measured
+    ~10 dB high vs Mie). See ``compute_rcs`` ("Bistatic pattern
+    caveat") for the cause and why bumping ``ntff_offset`` does not
+    close it at test scale.
     """
     freqs: np.ndarray
     theta: np.ndarray
@@ -136,7 +153,12 @@ def compute_rcs(
         Cells between CPML edge and TFSF boundary.
     ntff_offset : int
         Cells between TFSF boundary and NTFF box (NTFF must be in the
-        scattered-field region, i.e., outside the TFSF box).
+        scattered-field region, i.e., outside the TFSF box). The default
+        (1) places the Huygens surface deep in the reactive near field.
+        See "Bistatic pattern caveat" below: this default is validated
+        for the backscatter/monostatic bin, but is NOT a validated
+        bistatic setup, and increasing it does not close the oblique gap
+        at test scale.
 
     Returns
     -------
@@ -146,6 +168,37 @@ def compute_rcs(
         direction — for +x incidence that is (theta=pi/2, phi=pi) under
         the farfield r_hat convention; it does not depend on
         theta_obs/phi_obs).
+
+    Bistatic pattern caveat (LLM-naive-usage audit item #2)
+    -------------------------------------------------------
+    VALIDATED: ``RCSResult.monostatic_rcs`` (the backscatter bin) agrees
+    with the exact Mie series to ~0.06 dB at ka~1
+    (``tests/test_rcs_mie_fixture.py``).
+
+    NOT VALIDATED: the full ``rcs_dbsm`` / ``rcs_linear`` bistatic
+    pattern at off-backscatter angles. With the auto-placed default NTFF
+    box (``ntff_offset=1``, ~1 cell off the TFSF boundary, distance
+    << lambda) the oblique/forward bins can be several dB to ~20 dB off.
+    On the committed ka~1 PEC sphere the H-plane cut shows a spurious
+    forward-oblique lobe near 25-55 deg scattering angle measured
+    ~10 dB high vs Mie (recorded, non-gated, in
+    ``tests/fixtures/rcs_sphere_mie/``; residual diagnostic issue #280).
+
+    This caveat is a doc-pin, not a runtime warning, on purpose: the
+    monostatic value is computed at the exact backscatter direction
+    INDEPENDENT of ``theta_obs``/``phi_obs``, and the validated
+    monostatic tests themselves pass full observation grids, so there is
+    no call-time signal that separates "monostatic-only" from "bistatic"
+    intent to key an advisory on without false-alarming those tests.
+
+    Do NOT try to fix the bistatic pattern by only enlarging
+    ``ntff_offset``: measured at test scale it does not close the oblique
+    gap (offset 1->2 on the committed sphere leaves the 25-55 deg error
+    ~10 dB and worsens the backscatter bin; a larger domain did not help
+    either). The oblique lobe is dominated by the staircased curved-PEC
+    surface plus forward TFSF-face contamination, not box distance alone.
+    A converged bistatic setup needs finer resolution (and likely a
+    conformal-PEC / larger radiating-region box), tracked by issue #280.
     """
     # Defaults
     if theta_obs is None:

--- a/tests/test_rcs_bistatic_caveat_docpin.py
+++ b/tests/test_rcs_bistatic_caveat_docpin.py
@@ -1,0 +1,61 @@
+"""Doc-contract witness for the RCS bistatic near-field caveat (audit item #2).
+
+`compute_rcs` returns a full bistatic `rcs_dbsm`/`rcs_linear` pattern, but only
+the monostatic (backscatter) bin is cross-validated against the exact Mie series
+(``tests/test_rcs_mie_fixture.py``). At the auto-placed default NTFF box
+(``ntff_offset=1``, deep in the reactive near field) the off-backscatter bins
+can be several dB to ~20 dB off (a spurious forward-oblique lobe, ~10 dB high vs
+Mie on the committed ka~1 sphere; ``tests/fixtures/rcs_sphere_mie/``).
+
+The audit asked whether that should surface at call time. It was R2-STOPPED to a
+doc-pin: ``monostatic_rcs`` is computed at the exact backscatter direction
+INDEPENDENT of the observation grid, and every validated monostatic test passes
+a FULL observation grid, so there is no call-time signal that separates
+"monostatic-only" from "bistatic" intent to key an advisory on without
+false-alarming those tests.
+
+This test locks the honesty text (docstrings + public guide) so the doc-pin
+cannot be silently stripped. It asserts NO physics and changes NO gate; the
+quantitative gate stays in ``tests/test_rcs_mie_fixture.py`` (monostatic) and
+``tests/test_rcs_mie_reference_gates.py`` (envelope).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rfx.rcs import RCSResult, compute_rcs
+
+
+def _norm(text: str) -> str:
+    # collapse whitespace so line-wrapping in the source can change freely
+    return " ".join(text.split()).lower()
+
+
+def test_compute_rcs_docstring_pins_bistatic_caveat():
+    doc = _norm(compute_rcs.__doc__ or "")
+    assert "bistatic pattern caveat" in doc
+    assert "not validated" in doc
+    # names the validated quantity and the exact-Mie anchor
+    assert "monostatic_rcs" in doc and "mie" in doc
+    # names the near-field cause (default box) ...
+    assert "ntff_offset" in doc and "near field" in doc
+    # ... and steers users off the falsified "just enlarge ntff_offset" fix
+    assert "does not" in doc and "oblique" in doc
+
+
+def test_rcsresult_docstring_pins_validation_scope():
+    doc = _norm(RCSResult.__doc__ or "")
+    assert "validation scope" in doc
+    assert "monostatic_rcs" in doc and "not validated" in doc
+    assert "rcs_dbsm" in doc  # the non-validated field is named
+
+
+def test_public_guide_pins_bistatic_caveat():
+    guide = Path(__file__).resolve().parents[1] / "docs/public/guide/farfield-rcs.md"
+    assert guide.exists(), guide
+    text = _norm(guide.read_text())
+    assert "bistatic pattern is not validated" in text
+    assert "monostatic" in text and "mie" in text
+    # the guide must keep the honest "enlarging ntff_offset does not fix it" note
+    assert "ntff_offset" in text and "does not" in text


### PR DESCRIPTION
## What

LLM-naive-usage audit item #2: `compute_rcs` returns a full bistatic RCS(θ,φ) pattern, but only the `monostatic_rcs` (backscatter) bin is validated — off-backscatter bins are several dB to ~20 dB off at the auto-placed default NTFF box. Resolved as a **doc-pin R2-STOP** (no runtime advisory), because the correct fix has no clean discriminator and the assumed remedy was falsified.

## Verify-first + R5 (the disciplined part)

- **Audit confirmed** (live run vs the committed exact-Mie oracle, ka≈1 PEC sphere): backscatter **0.06 dB** (right, gated); oblique 25–55° **max 10.49 dB / mean 8.87 dB** (wrong). Matches the audit and the already-committed non-gated bistatic trace.
- **No clean call-time discriminator** (Option A rejected): `monostatic_rcs` is computed at the exact backscatter direction independent of the θ/φ grid, and every validated monostatic test passes a FULL observation grid while reading only backscatter — so "user requested off-axis angles" would false-alarm 3 of the 4 validated tests. Wiring the NTFF near-field guard in would fire on **every** validated monostatic RCS test (same box) — the exact item-#3 false-alarm trap.
- **R5 falsified the assumed remedy** (one attempt, then stop): enlarging `ntff_offset` does NOT close the oblique gap — offset 1→2 left oblique ~10.3 dB and *worsened* backscatter (0.06→0.29 dB); a larger domain made oblique *worse* (~15.7 dB). The oblique error is dominated by staircased curved-PEC + forward TFSF-face contamination (issue #280), not box distance. So the docs steer users OFF that dead end rather than recommending it.

## Contents (docs-only — no physics, no logic, no gate touched)
- `rfx/rcs.py` — bistatic-caveat + validation-scope in the `compute_rcs` / `RCSResult` docstrings (docstring-only; zero code-line change).
- `docs/public/guide/farfield-rcs.md` — "Validation scope: monostatic yes, bistatic not yet" section.
- `CHANGELOG.md` — `[Unreleased]` entry citing the audit.
- `tests/test_rcs_bistatic_caveat_docpin.py` — doc-contract witnesses locking the caveat text so it can't be silently stripped.

## Verification
Docs-only confirmed (rcs.py diff is pure docstring). RCS suite + doc-contract test run with `-W error::UserWarning` → **18 passed** — proving the monostatic path emits **zero** new advisories (the doc-pin adds no runtime warning, so it cannot false-alarm the validated tests). Prose passed a separate anti-slop review (terse, evidence-bound, every number traces to a run). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)