### PR TITLE
docs(harminv): pin lossless-cavity infinite-Q artefact — audit #4 doc-pin R2-STOP (preflight advisory reverted, false-alarmed validated cavities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Changed — lossless-cavity infinite-Q pinned in the harminv docstrings (LLM-naive-usage audit item #4, doc-pin R2-STOP)
+
+- Measuring a resonator Q via `harminv` / `harminv_from_probe` on a **lossless
+  closed (PEC) cavity** gives a window-length artefact (infinite physical Q),
+  not physics — the frequency is fine, the Q is not. Documented with a
+  `.. warning::` in both docstrings (add a realistic `sigma`/`tan_delta` loss
+  or use an open CPML boundary before trusting a Q).
+- R2-STOP on a preflight advisory: a "closed + lossless + soft source" trigger
+  has NO clean call-time discriminator — legitimate lossless-cavity resonance
+  sims (e.g. the NU stage-1 cavity physics gate, memory-planning cavities) use
+  the same config and would be false-alarmed. Per "a false-alarming preflight
+  erodes trust worse than the silent gap," the guidance lives in the API docs,
+  not in `preflight()`. No physics or preflight behaviour changed.
+
+
 ### Changed — RCS bistatic-pattern validation scope pinned in docs (LLM-naive-usage audit item #2, doc-pin R2-STOP)
 
 - `compute_rcs` returns a full bistatic `rcs_dbsm` / `rcs_linear` pattern, but

--- a/rfx/harminv.py
+++ b/rfx/harminv.py
@@ -45,6 +45,18 @@ def harminv(
 ) -> list[HarminvMode]:
     """Extract resonant modes via the Matrix Pencil Method.
 
+    .. warning::
+
+       **Lossless closed cavities have infinite physical Q — do not read a Q
+       off a finite window.** In a PEC-bounded domain with no material loss
+       (an empty or lossless-filled cavity), a resonance never decays, so the
+       Q returned here is a pure *windowing artefact*: it swings by orders of
+       magnitude with the run length rather than tracking any physics. The
+       resonant *frequency* is still meaningful; the *Q* is not. To measure a
+       meaningful Q, add a realistic loss (a finite ``sigma`` / ``tan_delta``
+       on the fill, or a lossy load) so the cavity has a finite physical Q, or
+       use an open (CPML) boundary so radiation sets the Q.
+
     Parameters
     ----------
     signal : 1D real or complex array
@@ -183,6 +195,13 @@ def harminv_from_probe(
 
     Automatically windows the signal to use only the ring-down
     portion (after source has decayed).
+
+    .. warning::
+
+       A **lossless closed (PEC) cavity** has infinite physical Q, so the Q
+       returned here is a window-length artefact, not physics — add a
+       realistic loss or use an open (CPML) boundary before trusting a Q.
+       See :func:`harminv` for the full note. (The frequency is fine.)
 
     Parameters
     ----------


### PR DESCRIPTION
## What

LLM-naive-usage audit item #4: measuring a resonator Q via `harminv` on a **lossless closed (PEC) cavity** gives a window-length artefact (the cavity has infinite physical Q; the frequency is fine, the Q is not). Resolved as a **doc-pin R2-STOP**, not a preflight advisory.

## Why R2-STOP (the honest pivot)

An earlier revision of this branch SHIPPED a preflight advisory ("closed + lossless + soft source → infinite-Q warning"). CI proved it false-alarms **validated** sims: it broke `test_stage1_nu_cavity_physics_gate_passes` (shard 4) and the memory-reduction planning gate `no_preflight_issues` (shard 2) — both are legitimate closed lossless PEC cavities driven by a soft source, the exact trigger. Root cause: **"measuring Q" is a post-processing `harminv` call, not knowable at `preflight()` time**, so "closed + lossless + soft source" has NO clean call-time discriminator — the same structural wall as audit #2/#3. Per "a false-alarming preflight erodes trust worse than the silent gap," the advisory was reverted (`rfx/api/_preflight.py`, `hello_world.py`, the FP tests → **byte-identical to main**) and the guidance moved to the API docs.

## Contents (docs-only — no physics, no preflight behaviour change)
- `rfx/harminv.py` — `.. warning::` in `harminv` + `harminv_from_probe` docstrings: a lossless closed cavity has infinite Q → the returned Q is a window artefact; add a realistic `sigma`/`tan_delta` loss or use an open CPML boundary; the frequency is fine.
- `CHANGELOG.md` — `[Unreleased]` entry recording the doc-pin + the R2-STOP rationale.

## Verification
The two previously-failing tests pass with the advisory gone (`test_stage1_nu_cavity_physics_gate_passes` + memory-planning artifact + harminv estimator → 9 passed). `git diff main` = only `harminv.py` + `CHANGELOG.md`; `_preflight.py` / `hello_world.py` / the FP tests are byte-identical to main. ruff clean.

## Meta
Confirms the audit's own caveat that #4 was lower-confidence; and reinforces the session's recurring lesson — **confirmed-silent-wrong ≠ cleanly-fixable**: a footgun whose only discriminator (intent to measure Q) is absent at preflight time is a doc note, not a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)