### PR TITLE
docs: pin the empty-window gradient footgun + add_lumped_rlc-is-not-a-port (blind docs-only audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Changed — empty-window gradient + `add_lumped_rlc`-is-not-a-port pinned in docs (blind docs-only audit, doc-pin R2-STOP)
+
+- A blind, docs-only agent (validated across two model families) trusted a
+  finite-difference-verified gradient whose loss was `~1e-7` — orders of
+  magnitude too small — because the reflection it minimized never landed in
+  `minimize_reflected_energy`'s late-time split window. AD and FD agreed because
+  both differentiate the **same empty window**; the docs prescribed the FD check
+  as the trust ritual but never warned it cannot detect an empty observable.
+- Documented the round-trip **precondition** for `minimize_reflected_energy`'s
+  split window (docstring + [Inverse Design](/rfx/guide/inverse-design/)) and the
+  "a passing finite-difference check is necessary, not sufficient — check the loss
+  **magnitude** against a physical expectation" caveat in
+  [Autodiff & Adjoint](/rfx/guide/autodiff-adjoint/) and
+  [Gradient Behavior](/rfx/guide/gradient-behavior/).
+- Clarified in [Sources & Ports](/rfx/api/sources-ports/) that
+  `add_lumped_rlc(...)` is a circuit element, **not** a reflection-referenced
+  port: a single-cell lumped element reports its own self-interaction, not a
+  `Z0`-referenced `S11`; drive with `add_port(..., impedance=Z0)` to measure a
+  load reflection coefficient.
+- R2-STOP on a preflight advisory: the split-window premise depends on the
+  geometry's round-trip time and the run length, which `preflight()` cannot know,
+  so the guidance lives in the docs, not a call-time gate. Locked by
+  `tests/test_empty_window_gradient_caveat_docpin.py`. No physics or preflight
+  behaviour changed.
+
 ### Changed — lossless-cavity infinite-Q pinned in the harminv docstrings (LLM-naive-usage audit item #4, doc-pin R2-STOP)
 
 - Measuring a resonator Q via `harminv` / `harminv_from_probe` on a **lossless

--- a/docs/public/api/sources-ports.mdx
+++ b/docs/public/api/sources-ports.mdx
@@ -65,6 +65,8 @@ Use the calculator that matches the port family:
 
 `run(compute_s_params=True)` is **not** a universal port dispatcher. MSL, waveguide, and coaxial-line workflows use specialized calculators.
 
+`add_lumped_rlc(...)` is deliberately absent from the S-parameter calculators table above: it embeds an R/L/C circuit element in the FDTD update, but it is **not** a reflection-referenced port and does not by itself yield a transmission-line-referenced load reflection coefficient. A single-cell lumped element read directly reports its own near-field self-interaction, not a `Z0`-referenced `S11`. To measure the reflection a load presents to a reference line, drive the structure with `add_port(..., impedance=Z0)` — which fixes the reference impedance — and read `run(compute_s_params=True)` (or `forward(port_s11_freqs=...)`); place the `add_lumped_rlc` element inside that structure as the load.
+
 Before launching a long run, call the S-parameter preflight for the calculator you intend to use:
 
 ```python

--- a/docs/public/guide/autodiff-adjoint.mdx
+++ b/docs/public/guide/autodiff-adjoint.mdx
@@ -152,6 +152,26 @@ For float32 FDTD workflows, very small finite-difference steps can be dominated
 by cancellation. Start with `h = 1e-2` for permittivity-like variables, then
 adjust based on the scale of the loss and the design variable.
 
+### A passing finite-difference check is necessary, not sufficient
+
+Finite-difference agreement validates the **autodiff machinery** — that the tape
+computes the derivative of the loss you actually wrote. It does **not** validate
+that the loss observes the physics you intended. Both AD and FD differentiate the
+same objective through the same observation window, so if that window is empty —
+for example the reflection you are minimizing never reaches the probe inside the
+run, or the monitor sits in an absorber — the two will still agree, on a gradient
+of numerical noise.
+
+Before trusting a low-magnitude loss, sanity-check its **absolute value** against a
+physical expectation. A time-domain reflected-energy proxy over a design that
+reflects a meaningful fraction of the incident pulse lands around `1e-2`–`1e-1`; a
+loss orders of magnitude smaller (say `~1e-7`) usually means the reflection never
+landed in the observation window, and the gradient — however cleanly it matches
+finite differences — is meaningless. Fix the setup (longer run, correct
+monitor/split placement) before reading the derivative. See
+[Inverse Design](/rfx/guide/inverse-design/) for the round-trip precondition
+behind `minimize_reflected_energy`'s split window.
+
 ## Reading map
 
 - [Meep Adjoint Solver](https://meep.readthedocs.io/en/latest/Python_Tutorials/Adjoint_Solver/)

--- a/docs/public/guide/gradient-behavior.md
+++ b/docs/public/guide/gradient-behavior.md
@@ -169,6 +169,16 @@ Use the result as a witness, not as a universal tolerance. If the witness fails,
 inspect the objective scale, perturbation size, run length, monitor placement,
 and support envelope before changing optimizer settings.
 
+A *passing* witness is also not sufficient on its own. Finite differences and AD
+differentiate the same objective through the same observation window, so both
+agree even when that window is empty — an objective that never sees the physics it
+is supposed to (reflection that never reaches the probe, a monitor inside an
+absorber) produces a self-consistent gradient of numerical noise. Guard against
+this by checking the loss **magnitude** against a physical expectation, not only
+the AD-vs-FD relative error: a reflected-energy proxy on a meaningfully reflecting
+design lands near `1e-2`–`1e-1`, so a value like `~1e-7` signals an empty window,
+not a matched design.
+
 ## Best practices
 
 1. **Start with a small, supported setup** before scaling the grid or objective.

--- a/docs/public/guide/inverse-design.md
+++ b/docs/public/guide/inverse-design.md
@@ -89,6 +89,26 @@ obj_transmit = maximize_transmitted_energy(output_probe_idx=-1)
 `result.time_series` columns: `port_probe_idx` selects the probe co-located with
 the excitation port, `output_probe_idx` the downstream probe.
 
+**Precondition — the split window must contain the reflection.**
+`minimize_reflected_energy` splits the probe time series at `late_fraction`
+(default: the second half) and treats the late half as reflected energy. That
+premise only holds if the round trip from the port to the reflecting feature and
+back arrives *after* the split point and *before* the run ends. On a short
+round-trip geometry (a thin substrate, a feature close to the port), the
+reflection lands in the early "incident" half and the late window is nearly empty,
+so the proxy collapses to `~0` and its gradient becomes numerical noise — with no
+error raised. Sanity-check the loss magnitude (a meaningfully reflecting design
+sits near `1e-2`–`1e-1`, not `~1e-7`), then fix the window by its failure mode:
+enlarge `n_steps` if the reflection arrives after the run ends; **raise**
+`late_fraction` (which moves the split earlier) if it arrives before the split; or,
+if the incident pulse and reflection overlap in time on a very short round trip,
+narrow the source bandwidth to compress the incident pulse — or use an
+impedance-referenced port (`add_port(..., impedance=Z0)` with
+`forward(port_s11_freqs=...)`), which separates incident and reflected waves
+exactly. Note that an AD-vs-finite-difference check will *not* catch an empty
+window: both differentiate the same window and agree (see
+[Autodiff and Adjoint Background](/rfx/guide/autodiff-adjoint/#a-passing-finite-difference-check-is-necessary-not-sufficient)).
+
 For NTFF/directivity optimization, pass
 `maximize_directivity(..., log_ratio=True)` when the design variable can change
 total radiated power (conductors/PEC, lossy, or magnitude-changing dielectric

--- a/rfx/optimize_objectives.py
+++ b/rfx/optimize_objectives.py
@@ -471,6 +471,23 @@ def minimize_reflected_energy(
     This objective works with ``optimize()`` and ``topology_optimize()``
     because it uses only ``result.time_series`` (no S-parameters needed).
 
+    .. warning::
+        The "late half = reflection" split is only valid when the round trip
+        from the port to the reflecting feature and back arrives *after* the
+        split (``1 - late_fraction`` of the series) and *before* the run ends.
+        On a short round-trip geometry (thin substrate, feature near the port)
+        the reflection lands in the early window and the late window is nearly
+        empty, so this ratio collapses toward 0 and its gradient is numerical
+        noise -- with no error raised. Sanity-check the returned magnitude (a
+        meaningfully reflecting design sits near 1e-2--1e-1, not ~1e-7), then fix
+        an empty window by its mode: enlarge ``n_steps`` if the reflection
+        arrives after the run ends; RAISE ``late_fraction`` (which moves the
+        split earlier) if it arrives before the split; if the incident pulse and
+        reflection overlap in time on a very short round trip, no split separates
+        them -- narrow the source bandwidth or use an impedance-referenced port.
+        An AD-vs-finite-difference check does NOT catch this: both differentiate
+        the same empty window and agree.
+
     Parameters
     ----------
     port_probe_idx : int

--- a/tests/test_empty_window_gradient_caveat_docpin.py
+++ b/tests/test_empty_window_gradient_caveat_docpin.py
@@ -1,0 +1,73 @@
+"""Doc-contract witness for the empty-window gradient caveat (blind-docs audit).
+
+A blind, docs-only agent building an inverse-design loop trusted a
+finite-difference-verified gradient whose loss was ~1e-7 — orders of magnitude
+too small — because the reflection it was minimizing never landed in
+``minimize_reflected_energy``'s late-time split window. AD and FD agreed because
+both differentiate the SAME empty window; the docs prescribed the FD check as the
+trust ritual but never warned that a passing check cannot detect an empty
+observable.
+
+This was R2-STOPPED to a doc-pin (there is no clean call-time discriminator: the
+split-window premise depends on the geometry's round-trip time and the run
+length, which preflight cannot know). The pin adds (a) the round-trip precondition
+to ``minimize_reflected_energy`` + the inverse-design guide, (b) the "FD agreement
+validates the machinery, not the physics; check the loss magnitude" caveat to the
+autodiff and gradient-behavior guides, and (c) clarifies that ``add_lumped_rlc``
+is not a reflection-referenced port (the separate near-miss in the same audit).
+
+This test locks that honesty text so it cannot be silently stripped. It asserts
+NO physics and changes NO gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from rfx.optimize_objectives import minimize_reflected_energy
+
+_DOCS = Path(__file__).resolve().parents[1] / "docs/public"
+
+
+def _norm(text: str) -> str:
+    # collapse whitespace so line-wrapping in the source can change freely
+    return " ".join(text.split()).lower()
+
+
+def test_objective_docstring_pins_split_window_precondition():
+    doc = _norm(minimize_reflected_energy.__doc__ or "")
+    assert "round trip" in doc
+    assert "late window" in doc and "empty" in doc
+    assert "numerical noise" in doc
+    # steers off the false-confidence FD ritual
+    assert "finite-difference check does not catch" in doc
+
+
+def test_inverse_design_guide_pins_split_window_precondition():
+    text = _norm((_DOCS / "guide/inverse-design.md").read_text())
+    assert "split window must contain the reflection" in text
+    assert "round trip" in text
+    assert "1e-2" in text and "1e-7" in text
+
+
+def test_autodiff_guide_pins_fd_necessary_not_sufficient():
+    text = _norm((_DOCS / "guide/autodiff-adjoint.mdx").read_text())
+    assert "necessary, not sufficient" in text
+    assert "autodiff machinery" in text
+    assert "numerical noise" in text
+    assert "1e-2" in text
+
+
+def test_gradient_behavior_guide_pins_passing_witness_caveat():
+    text = _norm((_DOCS / "guide/gradient-behavior.md").read_text())
+    assert "witness is also not sufficient" in text
+    assert "window is empty" in text
+    assert "magnitude" in text
+
+
+def test_sources_ports_guide_pins_lumped_rlc_not_a_port():
+    text = _norm((_DOCS / "api/sources-ports.mdx").read_text())
+    assert "reflection-referenced port" in text
+    assert "add_lumped_rlc" in text
+    assert "self-interaction" in text
+    assert "reference impedance" in text


### PR DESCRIPTION
## Why

A **blind, docs-only LLM agent** — given only the public docs + docstrings, no source/tests/memory — building an inverse-design loop trusted a finite-difference-verified gradient whose **loss was ~1e-7** (orders of magnitude too small) because the reflection it was minimizing never landed in `minimize_reflected_energy`'s late-time split window. AD and FD *agreed* because both differentiate the **same empty observation window**. The docs prescribed the FD-vs-AD check as the "trust ritual" but never warned it cannot detect an empty observable.

This was reproduced **across two model families** (Claude + Codex/OpenAI): where a footgun's warning had reached the public docs (lossless-Q, `normalize=False`, bistatic-RCS), *both* families read it and adapted. The gaps that still bite are the **undocumented / counter-documented** ones — this PR closes the largest of them.

## What (doc-pin only — no physics or code behaviour changed)

- **`minimize_reflected_energy` docstring + [Inverse Design] guide** — the split-window **round-trip precondition**, with the correct **per-mode** remedy:
  - reflection arrives *after the run ends* → enlarge `n_steps`;
  - reflection arrives *before the split* → **RAISE** `late_fraction` (moves the split earlier);
  - incident pulse and reflection *overlap* (very short round trip) → no split separates them; narrow source bandwidth or use an impedance-referenced port.
- **[Autodiff & Adjoint] + [Gradient Behavior] guides** — "a passing finite-difference check is **necessary, not sufficient**: it validates the autodiff *machinery*, not that the loss observes the intended *physics*; sanity-check the loss **magnitude** (a meaningfully reflecting design lands ~`1e-2`–`1e-1`, not `~1e-7`)."
- **[Sources & Ports] (API)** — `add_lumped_rlc(...)` is a **circuit element, not a reflection-referenced port**: a single-cell lumped element reports its own self-interaction, not a `Z0`-referenced `S11`; drive with `add_port(..., impedance=Z0)` to measure a load reflection coefficient. (Deliberately did **not** claim "series-RLC diverges" — unverified; series/parallel are both valid.)

## R2-STOP rationale

The split-window premise depends on the geometry's round-trip time and the run length, which `preflight()` cannot know — so there is no clean call-time discriminator. Per "a false-alarming preflight erodes trust worse than the silent gap," the guidance lives in the docs, not a gate (same disposition as the #291 RCS and #292 harminv doc-pins).

## Verification

- Locked by `tests/test_empty_window_gradient_caveat_docpin.py` (5/5) so the honesty text can't be silently stripped.
- Remedy direction **verified numerically** (reflection@0.30n: `late_fraction` 0.5→ratio 0.0, 0.7→4.5e-2, 0.8→9.0e-2).
- **Independent reviewer** (author/reviewer separation) returned REQUEST-CHANGES on a backwards remedy (`lower`→`raise late_fraction`) + a mis-routed changelog link → both fixed, magnitude/mechanism/`add_lumped_rlc`/house-style all verified accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)