### PR TITLE
test: add the blind docs-only footgun test lane (periodic doc-quality gate)

### DIFF
--- a/scripts/diagnostics/blind_docs_test/README.md
+++ b/scripts/diagnostics/blind_docs_test/README.md
@@ -1,0 +1,86 @@
+# Blind docs-only footgun test — a periodic doc-quality gate
+
+Does a context-free LLM, building an rfx simulation from the **public docs
+alone**, get bitten by rfx's known footguns — or do the docs protect it?
+
+This lane answers that empirically. It is the counterpart to the internal footgun
+audit: the audit (PRIMED agents with full repo + hypotheses) proves a footgun
+*exists*; this lane proves whether the *public docs* actually stop a real,
+context-free user from stepping on it. It also doubles as an acceptance gate for
+agent-facing documentation: if a blind agent still gets bitten, the doc, not the
+agent, is the thing to fix.
+
+## Cadence (on-demand, no CI job)
+
+The test spawns LLM agents, so it cannot run in pytest/CI. Run it:
+
+- **per release tag**, alongside the GPU + external-crossval lanes, and
+- **after any PR that touches public docs** (`docs/public/**`) or a documented
+  footgun surface (a docstring a user is steered to, a preflight advisory, a
+  gate/normalize/objective default).
+
+## Protocol
+
+1. **Spawn a fresh agent with NO context.** It may read only:
+   - the published guide (`docs/public/**`), and
+   - docstrings via `help(...)` / `?` on the public API.
+
+   It may **not** read `rfx/` source, `tests/`, `docs/agent-memory/`,
+   `docs/research_notes/`, git history, or any footgun hint. State this in the
+   prompt explicitly; a leaked hint invalidates the run.
+2. **Give it the task battery** (`tasks.md`), one task per agent, verbatim. Each
+   task is a realistic, footgun-prone request with a known ground-truth answer.
+3. **Score each result** against the rubric below using the ground truth in
+   `tasks.md`. The agent does not self-score.
+4. **Cross-model.** Run at least one non-Anthropic model (e.g. Codex/OpenAI) each
+   cycle. A footgun avoided by one model family may be that model's caution, not
+   the docs; agreement across families is the evidence the *docs* protect.
+5. **Record** the per-task outcomes in the results table below and open a doc-pin
+   PR for anything that scored BITTEN or relied on undocumented behaviour.
+
+## Scoring rubric
+
+| Outcome | Meaning | Doc action |
+|---|---|---|
+| `CORRECT` | Got the right answer, no footgun in the task path | none |
+| `PROTECTED_BY_DOCS` | A doc/docstring warning steered it off the footgun | none — the doc works; keep it |
+| `WARNED_ADAPTED` | Read a validation-scope caveat and down-scoped its claim | none — the caveat works |
+| `ERRORED_LOUD` | Hit a wall and **refused to report a number** | acceptable, but a doc that explains the wall is better than a refusal |
+| `BITTEN` | Reported a wrong number **with confidence**, no warning read | **doc-pin required** — this is the failure this lane exists to catch |
+
+`BITTEN` is the only hard failure. `ERRORED_LOUD` is a near-miss: the user was
+protected by luck (a crash), not by the docs — prefer converting it to
+`PROTECTED_BY_DOCS` with a doc-pin. Cross-model divergence on the *same* task
+(one family refuses, another reports wrong) marks an **undocumented** surface:
+the fix is the doc, because you cannot rely on model caution.
+
+## Baseline — 2026-07-09 (two model families)
+
+Public docs at the time of PR #294. Full write-up in the durable memory entry
+`project_blind_docs_cross_model_test_20260709`.
+
+| task | Claude (Fable 5) | Codex (OpenAI) | footgun bit either? |
+|---|---|---|---|
+| cavity-Q | CORRECT (refused finite Q) | CORRECT (Q=∞) | no — both protected |
+| pec-short-s11 | PROTECTED_BY_DOCS (`normalize=False`) | PROTECTED_BY_DOCS (`normalize=False`) | no — both protected |
+| lumped-load-s11 | ERRORED_LOUD (refused) | BITTEN-ish (`|S11|≈0.997` low-conf = port self-reflection) | **diverged — undocumented surface** |
+| rcs-pattern | WARNED_ADAPTED (bistatic caveat) | — | no |
+| grad-optimize | **BITTEN** (empty-window gradient) | — | **yes — docs were complicit** |
+
+**Findings that drove PR #294:** the well-warned footguns (lossless-Q,
+`normalize`, bistatic-RCS) protected *both* families — the fixes are not an
+Anthropic quirk. The two exposures were (1) `grad-optimize`, where the docs
+prescribed the FD-vs-AD check as a trust ritual but never warned it cannot detect
+an empty observation window, and (2) `lumped-load-s11`, an undocumented path from
+`add_lumped_rlc` to a load `S11`. Both are pinned by PR #294; re-running this lane
+after #294 merges should move `grad-optimize` and `lumped-load-s11` toward
+`PROTECTED_BY_DOCS`.
+
+## Next-run checklist
+
+- [ ] docs snapshot = current `main` (note the commit in the results row)
+- [ ] ≥ 2 model families, one non-Anthropic
+- [ ] no source/test/memory leakage in any agent prompt
+- [ ] every `BITTEN` (or cross-model divergence) → a doc-pin PR + a contract test
+      locking the new text (see `tests/test_empty_window_gradient_caveat_docpin.py`
+      and `tests/test_rcs_bistatic_caveat_docpin.py` for the pattern)

--- a/scripts/diagnostics/blind_docs_test/tasks.md
+++ b/scripts/diagnostics/blind_docs_test/tasks.md
@@ -1,0 +1,76 @@
+# Task battery — blind docs-only footgun test
+
+Each task is a realistic request a docs-only user would make. Give the agent the
+**Prompt** verbatim (plus the standing "public docs + docstrings only, no source"
+constraint from the README). Score its output against **Ground truth** using the
+rubric in the README. The **Footgun** column is for the scorer only — never put it
+in the agent's prompt.
+
+Rotate/extend this battery over time; add a task whenever a new footgun is found
+so future runs regression-test the fix. Keep each task self-contained and
+answerable from the public docs alone.
+
+---
+
+## T1 — cavity-Q
+
+- **Prompt:** "Build a small rfx simulation of a closed rectangular PEC cavity and
+  report its lowest resonant frequency and its quality factor Q."
+- **Footgun:** a lossless closed cavity has *infinite* physical Q; a finite Q read
+  from `harminv` on such a run is a window-length artifact. Frequency is fine.
+- **Ground truth:** the resonant frequency for the chosen box (analytic
+  `f = (c/2)·sqrt((m/a)²+(n/b)²+(p/d)²)`); Q should be reported as
+  infinite/ill-defined for the lossless case (or the agent should add a realistic
+  loss / open boundary before quoting a finite Q). A confidently-quoted finite Q
+  with no caveat = `BITTEN`.
+
+## T2 — pec-short-s11
+
+- **Prompt:** "Terminate a rectangular waveguide (or a lumped port line) in a PEC
+  short and compute |S11| across the band. Report the magnitude."
+- **Footgun:** `normalize=True` is wrong for a strong total reflector; it can push
+  |S11| well below the physical ~1.0. The docs steer to `normalize=False`.
+- **Ground truth:** |S11| ≈ 1.0 across the band (a PEC short reflects all power).
+  Values materially below 1.0 reported as physical = `BITTEN`.
+
+## T3 — lumped-load-s11
+
+- **Prompt:** "Place a lumped RLC load in an rfx simulation and compute the |S11|
+  that a 50 Ω line sees looking into it."
+- **Footgun:** `add_lumped_rlc` is a circuit element, not a reflection-referenced
+  port; a single-cell lumped element read directly reports its own self-reflection
+  (~1.0), not a `Z0`-referenced load Γ. The documented path is
+  `add_port(..., impedance=50)` + `run(compute_s_params=True)` /
+  `forward(port_s11_freqs=...)`. (Pinned by PR #294.)
+- **Ground truth:** for a chosen `R` the analytic Γ = (R−Z0)/(R+Z0) (real load),
+  or the full RLC Γ(f). Reporting the ~1.0 single-cell self-reflection as the load
+  |S11| = `BITTEN`. Refusing / redirecting to `add_port(impedance=)` =
+  `PROTECTED_BY_DOCS` (the target state after #294).
+
+## T4 — rcs-pattern
+
+- **Prompt:** "Compute the radar cross section of a conducting sphere in rfx and
+  report the full bistatic RCS pattern."
+- **Footgun:** only the monostatic (backscatter) bin is cross-validated against
+  the exact Mie series; the off-backscatter bistatic pattern at the default NTFF
+  box is not validated (a spurious near-field lobe). Enlarging `ntff_offset` alone
+  does not fix it.
+- **Ground truth:** monostatic RCS near the Mie value for the chosen `ka`;
+  bistatic cuts labelled qualitative / not-validated. Presenting the full bistatic
+  pattern as validated = `BITTEN`; trusting only monostatic = `WARNED_ADAPTED`.
+
+## T5 — grad-optimize
+
+- **Prompt:** "Use rfx's differentiable FDTD to optimize a dielectric matching
+  block that minimizes reflection at a port. Set up the gradient loop, verify the
+  gradient, and report the optimized reflection objective."
+- **Footgun:** `minimize_reflected_energy` splits the probe series into
+  early/late; if the round trip is short (or the run too short) the reflection
+  never lands in the late window, the proxy collapses to `~1e-7`, and its gradient
+  is numerical noise. An AD-vs-FD check **passes anyway** (both differentiate the
+  same empty window). (Pinned by PR #294.)
+- **Ground truth:** a meaningfully reflecting design gives a proxy of order
+  `1e-2`–`1e-1`; a reported optimized loss of `~1e-7` accepted as a matched design
+  = `BITTEN`. Sanity-checking the loss magnitude and fixing the window
+  (raise `late_fraction` / enlarge `n_steps` / use an impedance-referenced port)
+  = `PROTECTED_BY_DOCS` (the target state after #294).


### PR DESCRIPTION
## Why

Per the standing decision to run the blind docs-only footgun test **periodically**, this commits it as a durable, re-runnable lane instead of a one-off.

It is the counterpart to the internal footgun audit: the audit (primed agents, full repo) proves a footgun *exists*; this lane proves whether the **public docs** actually stop a context-free user from stepping on it. It doubles as an acceptance gate for agent-facing documentation — if a blind agent still gets bitten, the doc is the thing to fix.

## What

`scripts/diagnostics/blind_docs_test/` (on-demand lane, same convention as `palace_notch_referee/` / `wr90_port/` — the test spawns LLM agents, so no CI job):

- **README.md** — protocol (context-free agent, `docs/public/**` + docstrings only, no source/test/memory leakage), the scoring rubric (`CORRECT` / `PROTECTED_BY_DOCS` / `WARNED_ADAPTED` / `ERRORED_LOUD` / `BITTEN`), the **cross-model** requirement (≥1 non-Anthropic family, so "the docs protect" is distinguishable from "this model happens to be cautious"), the 2026-07-09 two-family baseline, and a next-run checklist.
- **tasks.md** — the reusable 5-task battery (cavity-Q, pec-short-s11, lumped-load-s11, rcs-pattern, grad-optimize) with per-task ground truth + the footgun each probes (scorer-only).

## Cadence

On-demand: **per release tag** and **after any PR touching `docs/public/**`** or a documented footgun surface. Every `BITTEN` (or cross-model divergence) → a doc-pin PR + a contract test locking the new text (pattern: `tests/test_empty_window_gradient_caveat_docpin.py`).

Companion to #294 (the doc-pins the first run produced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)