### PR TITLE
fix: make forward()/optimize() wrappable in an outer jax.jit (blind-docs finding)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — `forward()` / `optimize()` are now wrappable in an outer `jax.jit` (blind-docs finding)
+
+- `_assemble_materials` decided whether to return the PEC mask via
+  `bool(jnp.any(pec_mask))` — a host-side boolean conversion on a
+  geometry-derived device array. Fine eagerly and under a bare `jax.grad`, but
+  when the whole `forward()` was wrapped in an **outer `jax.jit`** the
+  geometry-derived `pec_mask` became a tracer and the conversion raised
+  `TracerBoolConversionError` deep in material assembly — so a user JITing their
+  optimization step (a natural performance move) crashed with an opaque error.
+- The eager path keeps the exact `jnp.any` test (**bit-identical** results,
+  verified across a PEC-cavity / interior-PEC / dielectric-CPML / thin-PEC /
+  forward-override / degenerate-empty-mask digest gate); only under a trace,
+  where a host bool is impossible, does it fall back to a static Python
+  `has_pec` predicate. Now `jax.jit(loss)` and `jax.jit(jax.grad(loss))` over a
+  `forward(eps_override=...)` objective both run and match the un-jitted values.
+- Locked by `tests/test_forward_outer_jit_traceable.py`.
+
 ### Changed — empty-window gradient + `add_lumped_rlc`-is-not-a-port pinned in docs (blind docs-only audit, doc-pin R2-STOP)
 
 - A blind, docs-only agent (validated across two model families) trusted a

--- a/rfx/api/_compile.py
+++ b/rfx/api/_compile.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import math  # noqa: F401  (used by moved method bodies)
 
+import jax
 import jax.numpy as jnp
 import numpy as np  # noqa: F401  (used by moved method bodies)
 
@@ -132,6 +133,17 @@ class _CompileMixin:
         pec_mask = jnp.zeros(grid.shape, dtype=jnp.bool_)
         pec_shapes = []
         has_kerr = False
+        # Track whether any PEC cells were added as a Python-side (static)
+        # predicate. This replaces a later ``bool(jnp.any(pec_mask))``, which
+        # is a host-side boolean conversion on a device array — fine eagerly,
+        # but it raises TracerBoolConversionError when the whole forward()
+        # is wrapped in an outer ``jax.jit`` (the geometry-derived pec_mask
+        # becomes a tracer). PEC cells enter pec_mask only from a PEC geometry
+        # entry or a PEC thin conductor below, both keyed on static config,
+        # so a Python flag set at those two sites is equivalent (it can only
+        # differ when a PEC shape's mask is empty — e.g. entirely outside the
+        # grid — where returning the all-False mask is a downstream no-op).
+        has_pec_cells = False
 
         # Collect per-pole masks so distinct materials do not inherit
         # each other's dispersion poles.
@@ -146,6 +158,7 @@ class _CompileMixin:
                 # True PEC: mark in mask, keep eps/sigma at vacuum values
                 pec_mask = pec_mask | mask
                 pec_shapes.append(entry.shape)
+                has_pec_cells = True
             else:
                 eps_r = jnp.where(mask, mat.eps_r, eps_r)
                 sigma = jnp.where(mask, mat.sigma, sigma)
@@ -219,6 +232,7 @@ class _CompileMixin:
                 grid, tc, materials, pec_mask=pec_mask)
             if tc.is_pec:
                 pec_shapes.append(tc.shape)
+                has_pec_cells = True
 
         # Stage 1 conformal PEC face-shift (issue: WR-90 mesh-conv xfail).
         # When an axis is declared ``Boundary(conformal=True)`` we promote
@@ -297,7 +311,17 @@ class _CompileMixin:
             lorentz_masks = [lorentz_masks_by_pole[pole] for pole in lorentz_poles]
             lorentz_spec = (lorentz_poles, lorentz_masks)
 
-        has_pec = bool(jnp.any(pec_mask))
+        # Eager path keeps the exact ``jnp.any`` test (a PEC shape whose mask is
+        # empty -- e.g. entirely outside the grid -- still returns None, so the
+        # eager result is bit-identical). Only under an outer ``jax.jit`` trace,
+        # where pec_mask is a tracer and cannot be host-converted to bool, do we
+        # fall back to the static Python predicate (which can over-approximate
+        # only in that empty-mask corner). This makes forward()/optimize()
+        # wrappable in an outer jax.jit without changing any eager behaviour.
+        try:
+            has_pec = bool(jnp.any(pec_mask))
+        except jax.errors.TracerBoolConversionError:
+            has_pec = has_pec_cells
         kerr_chi3 = chi3_arr if has_kerr else None
         return materials, debye_spec, lorentz_spec, pec_mask if has_pec else None, pec_shapes, boundary_pec_shapes, kerr_chi3
 

--- a/tests/test_forward_outer_jit_traceable.py
+++ b/tests/test_forward_outer_jit_traceable.py
@@ -1,0 +1,117 @@
+"""forward()/optimize() must be wrappable in an OUTER jax.jit.
+
+Regression for the blind-docs finding: ``_assemble_materials`` decided whether to
+return the PEC mask via ``bool(jnp.any(pec_mask))`` -- a host-side boolean
+conversion on a geometry-derived device array. That is fine eagerly (and under a
+bare ``jax.grad``, where materials stay concrete), but when the whole
+``forward()`` is wrapped in an *outer* ``jax.jit`` the geometry-derived
+``pec_mask`` becomes a tracer and the ``bool(...)`` raised
+``TracerBoolConversionError`` deep in material assembly -- so a user JITing their
+optimization step crashed with an opaque error.
+
+Fix: the eager path keeps the exact ``jnp.any`` test (bit-identical results,
+including the corner where a PEC shape's mask is empty); only under trace, where a
+host bool is impossible, does it fall back to a static Python ``has_pec``
+predicate. These tests lock the capability (outer-jit works) and the eager
+invariant (a PEC shape entirely outside the grid stays a no-op).
+"""
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from rfx import GaussianPulse, Simulation
+from rfx.geometry import Box
+
+
+def _pec_sim():
+    s = Simulation(freq_max=6e9, domain=(0.04, 0.02, 0.02), boundary="pec")
+    s.add_source((0.02, 0.01, 0.01), "ez",
+                 waveform=GaussianPulse(f0=3e9, bandwidth=3e9))
+    s.add_probe((0.012, 0.008, 0.008), "ez")
+    return s
+
+
+def _reflected_energy_loss(sim):
+    def loss(eps):
+        r = sim.forward(eps_override=eps, n_steps=60, checkpoint=True,
+                        skip_preflight=True)
+        ts = r.time_series[:, 0]
+        n = ts.shape[0]
+        return jnp.sum(ts[n // 2:] ** 2) / (jnp.sum(ts[:n // 2] ** 2) + 1e-30)
+    return loss
+
+
+def test_forward_wrappable_in_outer_jit():
+    """jax.jit(loss) must run (previously TracerBoolConversionError) and match eager."""
+    sim = _pec_sim()
+    shape = sim.run(n_steps=1, skip_preflight=True).grid.shape
+    eps = jnp.ones(shape, dtype=jnp.float32) * 1.5
+    loss = _reflected_energy_loss(sim)
+
+    eager = float(loss(eps))
+    jitted = float(jax.jit(loss)(eps))  # must not raise
+    assert np.isfinite(jitted)
+    assert abs(eager - jitted) <= 1e-6 * (abs(eager) + 1e-12), (eager, jitted)
+
+
+def test_grad_wrappable_in_outer_jit():
+    """jax.jit(jax.grad(loss)) must run and match the un-jitted gradient."""
+    sim = _pec_sim()
+    shape = sim.run(n_steps=1, skip_preflight=True).grid.shape
+    eps = jnp.ones(shape, dtype=jnp.float32) * 1.5
+    loss = _reflected_energy_loss(sim)
+
+    g_plain = jax.grad(loss)(eps)
+    g_jit = jax.jit(jax.grad(loss))(eps)  # must not raise
+    assert np.all(np.isfinite(np.asarray(g_jit)))
+    # float32 gradients through 60 FDTD steps: jit fuses ops differently, so
+    # allow the usual XLA-reordering slack (agreement is to ~6 sig figs).
+    assert np.allclose(np.asarray(g_plain), np.asarray(g_jit),
+                       rtol=3e-4, atol=1e-6)
+
+
+def test_real_interior_pec_under_outer_jit_matches_eager():
+    """The point of the fix on the hot path: a sim with a REAL interior PEC
+    obstacle (so ``has_pec_cells`` is True and the trace fallback returns the
+    actual mask) must still be outer-jit-wrappable and match eager. `_pec_sim`
+    has only a PEC *boundary* (separate grid path), which leaves ``pec_mask``
+    empty — this exercises the non-trivial fallback branch."""
+    s = Simulation(freq_max=6e9, domain=(0.04, 0.02, 0.02), boundary="pec")
+    s.add(Box((0.018, 0.006, 0.006), (0.024, 0.014, 0.014)), material="pec")
+    s.add_source((0.008, 0.01, 0.01), "ez",
+                 waveform=GaussianPulse(f0=3e9, bandwidth=3e9))
+    s.add_probe((0.012, 0.008, 0.008), "ez")
+    shape = s.run(n_steps=1, skip_preflight=True).grid.shape
+    # confirm this sim really populates pec_mask (the branch under test)
+    assert s._assemble_materials(s._build_grid())[3] is not None
+
+    eps = jnp.ones(shape, dtype=jnp.float32) * 1.5
+    loss = _reflected_energy_loss(s)
+    eager = float(loss(eps))
+    jitted = float(jax.jit(loss)(eps))
+    assert abs(eager - jitted) <= 1e-5 * (abs(eager) + 1e-12), (eager, jitted)
+    g_plain = jax.grad(loss)(eps)
+    g_jit = jax.jit(jax.grad(loss))(eps)
+    assert np.allclose(np.asarray(g_plain), np.asarray(g_jit), rtol=3e-4, atol=1e-6)
+
+
+def test_assemble_materials_eager_pec_mask_none_when_empty():
+    """Eager ``has_pec`` decision is byte-identical to the pre-fix ``jnp.any``:
+    a PEC shape whose mask is empty (entirely outside the grid) still returns
+    ``pec_mask=None``, while an interior PEC obstacle returns a real mask. This
+    locks the corner the trace-only static fallback would otherwise
+    over-approximate."""
+    s_empty = Simulation(freq_max=6e9, domain=(0.04, 0.02, 0.02), boundary="pec")
+    s_empty.add(Box((10.0, 10.0, 10.0), (11.0, 11.0, 11.0)), material="pec")
+    grid = s_empty._build_grid()
+    pec_mask = s_empty._assemble_materials(grid)[3]
+    assert pec_mask is None, "empty-mask PEC must stay None on the eager path"
+
+    s_real = Simulation(freq_max=6e9, domain=(0.04, 0.02, 0.02), boundary="pec")
+    s_real.add(Box((0.018, 0.006, 0.006), (0.024, 0.014, 0.014)), material="pec")
+    grid_r = s_real._build_grid()
+    pec_mask_r = s_real._assemble_materials(grid_r)[3]
+    assert pec_mask_r is not None and bool(pec_mask_r.any()), \
+        "interior PEC obstacle must return a non-empty mask"


### PR DESCRIPTION
## Why

The one **code-level** footgun the blind docs-only test exposed (the `grad-optimize` path). `sim.forward(eps_override=...)` could not be wrapped in an outer `jax.jit`:

```python
jax.jit(loss)(eps)            # TracerBoolConversionError
jax.jit(jax.grad(loss))(eps)  # TracerBoolConversionError
jax.grad(loss)(eps)           # OK  (bare grad keeps materials concrete)
```

`_assemble_materials` decided whether to return the PEC mask via `bool(jnp.any(pec_mask))` — a **host-side boolean conversion on a geometry-derived device array**. Fine eagerly and under a bare `jax.grad`, but an outer `jax.jit` makes `pec_mask` a tracer, so the `bool()` raised `TracerBoolConversionError` deep in material assembly. A user JITing their optimization step (a natural performance move) crashed with an opaque error.

## Fix

Keep the **exact** `jnp.any` test on the eager path (bit-identical, including the empty-mask corner that returns `None`); only under a trace — where a host `bool()` is impossible — fall back to a static Python `has_pec` predicate set at the **two, and only two,** sites that add `True` cells to `pec_mask`: a geometry entry with `sigma >= _PEC_SIGMA_THRESHOLD`, and a PEC thin conductor. The flag over-approximates only for an empty PEC mask (a shape entirely outside the grid), where returning an all-False mask is a downstream no-op — so a real PEC is **never** silently dropped under jit.

## Verification

- **Byte-identity digest gate**, 6 cases (PEC cavity / interior-PEC obstacle / dielectric-CPML / thin-PEC / `forward(eps_override)` / degenerate-PEC-outside-grid): all bit-identical before/after.
- `jax.jit(loss)` and `jax.jit(jax.grad(loss))` now run and match the un-jitted values (relerr ~1e-6).
- 414 pec/material/forward/thin-conductor/compile tests pass — no regression.
- Locked by `tests/test_forward_outer_jit_traceable.py` (4 tests, incl. a **real interior PEC under an outer jit** exercising the fallback branch).

## Process

The byte-identity gate **failed once** on a naive static-flag-only approach (the degenerate empty-mask case diverged) → R2-STOP → the `try/except` redesign preserves exact eager semantics and passed the gate cleanly. Independent reviewer **APPROVE** (independently reproduced real-PEC-under-jit matching eager to ~1e-6; flagged the missing real-PEC test, now added).

Companion to #294/#295 (the docs + periodic-test lane the same blind run produced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)