### PR TITLE
test(rcs): independent BEM (Bempp) cross-check of PEC-sphere RCS — validation campaign lane 1

### DIFF
--- a/tests/fixtures/rcs_sphere_three_way/README.md
+++ b/tests/fixtures/rcs_sphere_three_way/README.md
@@ -1,0 +1,58 @@
+# PEC-sphere three-way RCS — exact-Mie / rfx-FDTD / Bempp-BEM (campaign Lane 1)
+
+The **first independent integral-equation cross-check** in rfx's RCS pipeline.
+
+## What / why
+
+rfx's RCS is cross-checked against the exact **Mie** series (analytic) and, at
+coarse test-scale, that is the only reference. Every other candidate lane
+(Meep / openEMS) is **also FDTD** — it shares rfx's staircase-and-time-domain
+error class, so FDTD-vs-FDTD agreement cannot rule out a shared-method artefact.
+
+**Bempp-cl** solves the Maxwell EFIE on a **triangulated true curved surface**
+(surface integral equation, RWG basis) — a fundamentally different discretization
+with **no staircase**. BEM-vs-Mie agreement therefore confirms the Mie reference
+with an independent method, and isolates rfx's coarse-ladder error as rfx-side
+resolution (staircasing + the near-field NTFF box; the sibling fixture also
+records a large domain-size swing), not a comparator/extraction artefact.
+
+## Result (measured, this fixture)
+
+Backscatter `sigma/(pi a^2)`, PEC sphere, `a = 0.015 m`, incidence `+x`, `E‖z`:
+
+| ka  | Bempp (BEM) | exact Mie | Bempp − Mie |
+|-----|-------------|-----------|-------------|
+| 0.8 | 2.563 | 2.596 | −0.056 dB |
+| 1.0 | 3.614 | 3.638 | −0.028 dB |
+| 1.5 | 1.098 | 1.076 | +0.091 dB |
+| 2.0 | 0.974 | 1.008 | −0.151 dB |
+
+Bempp reproduces exact Mie to **≤ 0.15 dB** across the ladder. `h`-refinement at
+ka=1 converges monotonically (`a/3 → a/5 → a/8`: −0.109 → −0.046 → −0.018 dB).
+
+**Three-way at ka≈1** — three independent methods within 0.07 dB:
+
+| method | sigma/(pi a^2) | vs Mie |
+|--------|----------------|--------|
+| exact Mie (scipy) | 3.638 | — |
+| rfx FDTD, fine (λ/40, 6.4 cells/radius) | 3.585 | −0.063 dB |
+| Bempp BEM (h=a/6, N=1884) | 3.614 | −0.028 dB |
+
+The rfx **coarse** E4 ladder (λ/10–15, 1–5 cells/radius; `rcs_mie_e4`, 13.9 dB
+envelope) carries 4.7–9.3 dB error; Bempp confirming Mie to ≤0.15 dB at the same
+ka is a non-FDTD witness that this is rfx **resolution** (staircasing + near-field
+NTFF box), consistent with the two-regime finding (fine = 0.06 dB). Stated as an
+rfx-centric distance; no solver is framed as wrong.
+
+## Files
+
+- `fixture.json` — committed Bempp column + re-derived Mie + rfx (sourced from
+  `rcs_sphere_mie/`) + convergence witness + provenance. Clean-checkout durable
+  (never `.omx`).
+- `generate_bempp.py` — offline producer for the Bempp column. Bempp is **not** a
+  CI/runtime dependency of rfx; run manually to regenerate. **Env:** `pip install
+  bempp-cl gmsh` (import name `bempp_cl` in 0.4.x, not `bempp`); set
+  `OPENBLAS_NUM_THREADS<=64` on many-core boxes.
+- Gated by `tests/test_rcs_sphere_three_way_gates.py`, which **re-derives Mie
+  from `scipy.special`** (does not import the producer) so the reference cannot
+  self-certify. Additive — it relaxes no existing RCS gate.

--- a/tests/fixtures/rcs_sphere_three_way/fixture.json
+++ b/tests/fixtures/rcs_sphere_three_way/fixture.json
@@ -1,0 +1,94 @@
+{
+  "schema": "rfx.rcs_sphere_three_way",
+  "schema_version": 1,
+  "issue": "validation-campaign lane-1",
+  "claim_scope": "Independent surface-integral-equation (Bempp-cl EFIE, RWG/SNC) cross-check of monostatic PEC-sphere BACKSCATTER RCS vs the exact Mie series, across the E4 ka ladder {0.8,1.0,1.5,2.0}, plus a three-way point (exact-Mie / rfx-FDTD-fine / Bempp-BEM) at ka~1. Bempp meshes the TRUE CURVED surface with triangles (no FDTD staircase), so it is an independent-METHOD confirmation of the Mie reference and a non-FDTD witness that rfx's coarse-ladder error is rfx-side resolution, not a comparator/extraction artifact. This is NOT a bistatic validation and does not re-open or weaken any existing RCS gate.",
+  "radius_m": 0.015,
+  "convention": {
+    "incidence": "+x",
+    "pol": "E||z",
+    "backscatter": "-x",
+    "rcs": "sigma=4pi|E_inf|^2/|E_inc|^2, reported /(pi a^2)",
+    "far_field_op": "operators.far_field.maxwell.electric_field",
+    "note": "RCS is a magnitude -> convention-insensitive; harness correctness rests on the 4-ka zero-straddle + monotone h-convergence witnesses, not on any sign/conjugation check."
+  },
+  "bempp": {
+    "solver": "bempp-cl EFIE (RWG domain/range, SNC dual), Numba CPU backend",
+    "version": "0.4.2",
+    "ladder": [
+      {
+        "ka": 0.8,
+        "h_m": 0.0025,
+        "N_dofs": 1884,
+        "sigma_bempp_over_pi_a2": 2.5626107631788746,
+        "sigma_mie_over_pi_a2": 2.596026660396595,
+        "dB_bempp_vs_mie": -0.05626502334862686
+      },
+      {
+        "ka": 1.0,
+        "h_m": 0.0025,
+        "N_dofs": 1884,
+        "sigma_bempp_over_pi_a2": 3.614136875190321,
+        "sigma_mie_over_pi_a2": 3.6375665428517023,
+        "dB_bempp_vs_mie": -0.028063505077823042
+      },
+      {
+        "ka": 1.5,
+        "h_m": 0.0025,
+        "N_dofs": 1884,
+        "sigma_bempp_over_pi_a2": 1.0983559155690314,
+        "sigma_mie_over_pi_a2": 1.075609287453262,
+        "dB_bempp_vs_mie": 0.09088549886260966
+      },
+      {
+        "ka": 2.0,
+        "h_m": 0.0025,
+        "N_dofs": 1884,
+        "sigma_bempp_over_pi_a2": 0.9736888399604245,
+        "sigma_mie_over_pi_a2": 1.008143083247345,
+        "dB_bempp_vs_mie": -0.15101982500840289
+      }
+    ],
+    "convergence_ka1": [
+      {
+        "h_m": 0.005,
+        "N_dofs": 543,
+        "sigma_bempp_over_pi_a2": 3.547687958142716,
+        "dB_vs_mie": -0.10865532855891086
+      },
+      {
+        "h_m": 0.003,
+        "N_dofs": 1269,
+        "sigma_bempp_over_pi_a2": 3.5990334023458934,
+        "dB_vs_mie": -0.04625069392166718
+      },
+      {
+        "h_m": 0.001875,
+        "N_dofs": 3183,
+        "sigma_bempp_over_pi_a2": 3.6225490232248303,
+        "dB_vs_mie": -0.017966753141507377
+      }
+    ],
+    "floor_measured_db": 0.15101982500840289,
+    "wall_time_s": 79.13875532150269
+  },
+  "three_way_ka1": {
+    "ka": 1.0,
+    "sigma_mie_over_pi_a2": 3.6375665428517023,
+    "rfx_fine_over_pi_a2": 3.584995414250318,
+    "rfx_fine_source": "tests/fixtures/rcs_sphere_mie/fixture.json monostatic (ka=0.9997, dx=lambda/40, 6.36 cells/radius; the 0.0004 dB ka=0.9997-vs-1.0 mismatch is below any rounded figure)",
+    "bempp_over_pi_a2": 3.614136875190321,
+    "spread_db": {
+      "rfx_vs_mie": -0.06322342240656617,
+      "bempp_vs_mie": -0.028063505077823042,
+      "rfx_vs_bempp": -0.03515991732874326
+    }
+  },
+  "rfx_coarse_ladder_note": "rfx's E4 COARSE ladder (dx=lambda/10-15, only 1-5 cells/radius; tests/fixtures/rcs_mie_e4/, gate 13.914 dB under a 15 dB GO floor) carries 4.7-9.3 dB error. Bempp reproduces exact Mie to <=0.15 dB at the SAME ka with a staircase-free curved mesh, so that coarse-ladder gap is rfx-side resolution (staircasing + near-field NTFF box; the sibling fixture also records a large domain-size swing), independently confirmed by a non-FDTD method -- consistent with the two-regime finding (rcs_sphere_mie fine ~0.06 dB). Stated as an rfx-centric distance; no solver is framed as wrong.",
+  "provenance": {
+    "rfx_commit": "36a675f5a04f2c929aea45b42927fe4f5bd0a782",
+    "bempp_version": "0.4.2",
+    "producer": "tests/fixtures/rcs_sphere_three_way/generate_bempp.py",
+    "env": "OPENBLAS_NUM_THREADS<=64 required (192-core box core-dumps otherwise); import name is bempp_cl (not bempp) in 0.4.x"
+  }
+}

--- a/tests/fixtures/rcs_sphere_three_way/generate_bempp.py
+++ b/tests/fixtures/rcs_sphere_three_way/generate_bempp.py
@@ -1,0 +1,175 @@
+"""Producer for the PEC-sphere three-way RCS fixture (campaign Lane 1).
+
+Emits the COMPLETE ``fixture.json`` mechanically (Bempp BEM column + exact-Mie
+column re-derived from scipy + rfx-fine value sourced from the sibling
+``rcs_sphere_mie/fixture.json`` + provenance), so regeneration needs no hand
+editing. Independent surface-integral-equation (BEM) cross-check of monostatic
+PEC-sphere backscatter RCS: Bempp meshes the TRUE curved surface with triangles
+(no FDTD staircase), so it confirms exact Mie with a *different error class* than
+any FDTD code (Meep/openEMS).
+
+Bempp is NOT a CI/runtime dependency of rfx; the emitted numbers are frozen into
+fixture.json and gated by ``tests/test_rcs_sphere_three_way_gates.py`` (which
+re-derives Mie from scipy.special, so this producer cannot self-certify).
+
+Environment (measured, not assumed):
+  * ``pip install bempp-cl gmsh`` — the import name is ``bempp_cl`` in 0.4.x
+    (NOT ``bempp``); pyopencl absent + numba present -> Numba CPU backend.
+  * On a many-core box set ``OPENBLAS_NUM_THREADS<=64`` (OpenBLAS core-dumps
+    above its thread cap): ``OPENBLAS_NUM_THREADS=32 python generate_bempp.py``.
+
+Convention (aligned with rfx/rcs.py + the Mie oracle): incidence +x, E||z,
+|E_inc|=1; monostatic bin = -x backscatter; sigma = 4*pi*|E_inf|^2/|E_inc|^2,
+reported as sigma/(pi a^2). (RCS is a magnitude, so it is convention-insensitive;
+harness correctness is established by the two discriminating witnesses the gate
+checks: the 4-ka zero-straddle and the monotone h-refinement convergence.)
+"""
+import json
+import subprocess
+import time
+from pathlib import Path
+
+import numpy as np
+from scipy.special import spherical_jn, spherical_yn
+
+import bempp_cl.api as bem
+from bempp_cl.api.linalg import gmres
+
+A = 0.015                          # sphere radius (m); sigma/(pi a^2) depends only on ka
+D = np.array([1.0, 0.0, 0.0])      # incidence +x
+POL = np.array([0.0, 0.0, 1.0])    # E || z, |E_inc| = 1
+KA_LADDER = (0.8, 1.0, 1.5, 2.0)   # E4 ladder (matches rcs_mie_e4)
+
+_HERE = Path(__file__).resolve().parent
+_RFX_FINE = _HERE.parent / "rcs_sphere_mie" / "fixture.json"
+
+
+def mie_ratio(ka: float) -> float:
+    """Exact PEC-sphere backscatter sigma/(pi a^2) (Ruck 1970) via scipy."""
+    x = float(ka)
+    n_max = int(np.ceil(x + 4.05 * x ** (1.0 / 3.0) + 2)) + 15
+    n = np.arange(1, n_max + 1)
+    jn, yn = spherical_jn(n, x), spherical_yn(n, x)
+    jnp_, ynp_ = spherical_jn(n, x, derivative=True), spherical_yn(n, x, derivative=True)
+    hn, hnp_ = jn + 1j * yn, jnp_ + 1j * ynp_
+    a_n = jn / hn
+    b_n = (jn + x * jnp_) / (hn + x * hnp_)
+    return float(np.abs(np.sum(((-1.0) ** n) * (2 * n + 1) * (a_n - b_n))) ** 2 / x ** 2)
+
+
+def bempp_sigma_over_pi_a2(ka: float, h: float):
+    """Backscatter sigma/(pi a^2) via EFIE at mesh element size h."""
+    k = ka / A
+    grid = bem.shapes.sphere(r=A, h=h)
+    rwg = bem.function_space(grid, "RWG", 0)
+    snc = bem.function_space(grid, "SNC", 0)
+    efie = bem.operators.boundary.maxwell.electric_field(rwg, rwg, snc, k)
+
+    @bem.complex_callable
+    def tangential_trace(x, n, domain_index, result):
+        E = POL * np.exp(1j * k * np.dot(D, x))
+        result[:] = np.cross(E, n)
+
+    trace = bem.GridFunction(rwg, fun=tangential_trace, dual_space=snc)
+    sol, _ = gmres(efie, trace, tol=1e-6)
+    ff = bem.operators.far_field.maxwell.electric_field(
+        space=rwg, points=(-D).reshape(3, 1), wavenumber=k)
+    e_inf = ff.evaluate(sol)
+    sigma = 4.0 * np.pi * np.sum(np.abs(e_inf) ** 2)   # |E_inc| = 1
+    return float(sigma / (np.pi * A ** 2)), int(rwg.global_dof_count)
+
+
+def main():
+    t0 = time.time()
+    ladder = []
+    for ka in KA_LADDER:
+        lam = 2 * np.pi * A / ka
+        h = min(A / 6.0, lam / 10.0)                 # small ka -> geometry-limited
+        s, n = bempp_sigma_over_pi_a2(ka, h)
+        mie = mie_ratio(ka)
+        ladder.append({"ka": ka, "h_m": h, "N_dofs": n,
+                       "sigma_bempp_over_pi_a2": s, "sigma_mie_over_pi_a2": mie,
+                       "dB_bempp_vs_mie": 10.0 * np.log10(s / mie)})
+        print(f"ka={ka}: N={n} bempp={s:.4f} mie={mie:.4f} dB={10*np.log10(s/mie):+.3f}")
+
+    convergence = []
+    for frac in (3, 5, 8):                            # h -> h/2 witness at ka=1
+        s, n = bempp_sigma_over_pi_a2(1.0, A / frac)
+        convergence.append({"h_m": A / frac, "N_dofs": n,
+                            "sigma_bempp_over_pi_a2": s,
+                            "dB_vs_mie": 10.0 * np.log10(s / mie_ratio(1.0))})
+        print(f"conv ka=1 h=a/{frac}: N={n} bempp={s:.4f}")
+
+    rfx_fine = json.loads(_RFX_FINE.read_text())
+    rfx_val = rfx_fine["monostatic"]["rfx_sigma_over_pi_a2"]
+    mie1 = mie_ratio(1.0)
+    bempp1 = next(r["sigma_bempp_over_pi_a2"] for r in ladder if r["ka"] == 1.0)
+    sha = subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True,
+                         text=True).stdout.strip()
+
+    fixture = {
+        "schema": "rfx.rcs_sphere_three_way", "schema_version": 1,
+        "issue": "validation-campaign lane-1",
+        "claim_scope": (
+            "Independent surface-integral-equation (Bempp-cl EFIE, RWG/SNC) cross-check "
+            "of monostatic PEC-sphere BACKSCATTER RCS vs the exact Mie series, across the "
+            "E4 ka ladder {0.8,1.0,1.5,2.0}, plus a three-way point (exact-Mie / "
+            "rfx-FDTD-fine / Bempp-BEM) at ka~1. Bempp meshes the TRUE CURVED surface with "
+            "triangles (no FDTD staircase), so it is an independent-METHOD confirmation of "
+            "the Mie reference and a non-FDTD witness that rfx's coarse-ladder error is "
+            "rfx-side resolution, not a comparator/extraction artifact. This is NOT a "
+            "bistatic validation and does not re-open or weaken any existing RCS gate."),
+        "radius_m": A,
+        "convention": {"incidence": "+x", "pol": "E||z", "backscatter": "-x",
+                       "rcs": "sigma=4pi|E_inf|^2/|E_inc|^2, reported /(pi a^2)",
+                       "far_field_op": "operators.far_field.maxwell.electric_field",
+                       "note": "RCS is a magnitude -> convention-insensitive; harness "
+                               "correctness rests on the 4-ka zero-straddle + monotone "
+                               "h-convergence witnesses, not on any sign/conjugation check."},
+        "bempp": {
+            "solver": "bempp-cl EFIE (RWG domain/range, SNC dual), Numba CPU backend",
+            "version": bem.__version__,
+            "ladder": ladder,
+            "convergence_ka1": convergence,
+            "floor_measured_db": max(abs(r["dB_bempp_vs_mie"]) for r in ladder),
+            "wall_time_s": time.time() - t0,
+        },
+        "three_way_ka1": {
+            "ka": 1.0,
+            "sigma_mie_over_pi_a2": mie1,
+            "rfx_fine_over_pi_a2": rfx_val,
+            "rfx_fine_source": (
+                "tests/fixtures/rcs_sphere_mie/fixture.json monostatic "
+                f"(ka={rfx_fine['geometry']['ka']:.4f}, "
+                f"dx=lambda/{rfx_fine['geometry']['resolution_cells_per_lambda']}, "
+                f"{rfx_fine['geometry']['cells_per_radius']:.2f} cells/radius; the "
+                "0.0004 dB ka=0.9997-vs-1.0 mismatch is below any rounded figure)"),
+            "bempp_over_pi_a2": bempp1,
+            "spread_db": {
+                "rfx_vs_mie": 10 * np.log10(rfx_val / mie1),
+                "bempp_vs_mie": 10 * np.log10(bempp1 / mie1),
+                "rfx_vs_bempp": 10 * np.log10(rfx_val / bempp1),
+            },
+        },
+        "rfx_coarse_ladder_note": (
+            "rfx's E4 COARSE ladder (dx=lambda/10-15, only 1-5 cells/radius; "
+            "tests/fixtures/rcs_mie_e4/, gate 13.914 dB under a 15 dB GO floor) carries "
+            "4.7-9.3 dB error. Bempp reproduces exact Mie to <=0.15 dB at the SAME ka with a "
+            "staircase-free curved mesh, so that coarse-ladder gap is rfx-side resolution "
+            "(staircasing + near-field NTFF box; the sibling fixture also records a large "
+            "domain-size swing), independently confirmed by a non-FDTD method -- consistent "
+            "with the two-regime finding (rcs_sphere_mie fine ~0.06 dB). Stated as an "
+            "rfx-centric distance; no solver is framed as wrong."),
+        "provenance": {
+            "rfx_commit": sha, "bempp_version": bem.__version__,
+            "producer": "tests/fixtures/rcs_sphere_three_way/generate_bempp.py",
+            "env": "OPENBLAS_NUM_THREADS<=64 required (192-core box core-dumps otherwise); "
+                   "import name is bempp_cl (not bempp) in 0.4.x",
+        },
+    }
+    (_HERE / "fixture.json").write_text(json.dumps(fixture, indent=2) + "\n")
+    print(f"wrote fixture.json in {fixture['bempp']['wall_time_s']:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_rcs_sphere_three_way_gates.py
+++ b/tests/test_rcs_sphere_three_way_gates.py
@@ -1,0 +1,114 @@
+"""PEC-sphere three-way RCS gates: exact-Mie / rfx-FDTD / Bempp-BEM (campaign Lane 1).
+
+Adds the FIRST independent integral-equation (surface-BEM) cross-check to rfx's
+RCS pipeline, committed under ``tests/fixtures/rcs_sphere_three_way/``. Bempp-cl
+meshes the true curved PEC surface (no FDTD staircase), so BEM-vs-Mie agreement
+rules out a class of shared-method artefacts that FDTD-vs-FDTD (Meep/openEMS)
+cannot, and independently confirms the Mie reference at each ka.
+
+Posture (honest, additive):
+  * The exact Mie column is RE-DERIVED here from ``scipy.special`` (does NOT
+    import the producer), so a producer-side error cannot self-certify.
+  * Bempp values are frozen offline evidence (Bempp is not a CI/runtime dep);
+    the gate reads them from the fixture and checks them against re-derived Mie.
+  * This lane changes/relaxes NO existing gate. The coarse-ladder envelope stays
+    in ``test_rcs_mie_reference_gates.py``; the fine point in
+    ``test_rcs_mie_fixture.py``. All cross-solver distances are stated as
+    rfx-centric / method-distance facts, never a verdict that a solver is wrong.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+from scipy.special import spherical_jn, spherical_yn
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_FIXTURE = _REPO_ROOT / "tests/fixtures/rcs_sphere_three_way/fixture.json"
+_RFX_FINE = _REPO_ROOT / "tests/fixtures/rcs_sphere_mie/fixture.json"
+
+# Measured Bempp-vs-Mie floor is 0.151 dB across the ladder; gate at 0.5 dB
+# leaves margin without being loose enough to hide a harness regression.
+_BEMPP_SELF_ANCHOR_DB = 0.5
+# All three independent methods land within this at ka~1 (measured max 0.063 dB).
+_THREE_WAY_CLOSE_DB = 0.30
+
+
+def _mie_ratio(ka: float) -> float:
+    """sigma/(pi a^2) for a PEC sphere, backscatter (Ruck 1970) — independent."""
+    x = float(ka)
+    n_max = int(np.ceil(x + 4.05 * x ** (1.0 / 3.0) + 2)) + 15
+    n = np.arange(1, n_max + 1)
+    jn, yn = spherical_jn(n, x), spherical_yn(n, x)
+    jnp_, ynp_ = spherical_jn(n, x, derivative=True), spherical_yn(n, x, derivative=True)
+    hn, hnp_ = jn + 1j * yn, jnp_ + 1j * ynp_
+    a_n = jn / hn
+    b_n = (jn + x * jnp_) / (hn + x * hnp_)
+    series = np.sum(((-1.0) ** n) * (2 * n + 1) * (a_n - b_n))
+    return float(np.abs(series) ** 2 / x ** 2)
+
+
+@pytest.fixture(scope="module")
+def fx():
+    return json.loads(_FIXTURE.read_text())
+
+
+def test_committed_mie_column_is_exact_series(fx):
+    """LOAD-BEARING: every committed sigma_mie equals the independently re-derived
+    exact series (rtol 1e-9). Tampering with the reference fails here."""
+    for row in fx["bempp"]["ladder"]:
+        want = _mie_ratio(row["ka"])
+        assert np.isclose(row["sigma_mie_over_pi_a2"], want, rtol=1e-9), row["ka"]
+    assert np.isclose(fx["three_way_ka1"]["sigma_mie_over_pi_a2"], _mie_ratio(1.0), rtol=1e-9)
+
+
+def test_bempp_self_anchor_reproduces_mie(fx):
+    """The independent BEM reference must pass its own limit first: committed
+    Bempp backscatter sigma is within the measured floor of re-derived Mie, and
+    the stored dB is self-consistent with the stored sigmas."""
+    for row in fx["bempp"]["ladder"]:
+        mie = _mie_ratio(row["ka"])
+        dB = 10.0 * np.log10(row["sigma_bempp_over_pi_a2"] / mie)
+        assert np.isclose(dB, row["dB_bempp_vs_mie"], atol=1e-6), row["ka"]
+        assert abs(dB) <= _BEMPP_SELF_ANCHOR_DB, (row["ka"], dB)
+    assert fx["bempp"]["floor_measured_db"] <= _BEMPP_SELF_ANCHOR_DB
+
+
+def test_bempp_h_refinement_converges_to_mie(fx):
+    """Discriminating physical witness: as h -> h/2 (N grows) the Bempp residual
+    vs INDEPENDENTLY re-derived Mie shrinks monotonically toward 0 (mesh
+    convergence), and the finest rung is <= 0.1 dB. dB is recomputed here from the
+    committed sigma against re-derived Mie -- the producer cannot self-certify.
+    (A fixed normalization error would converge to a nonzero constant, not 0, so
+    this + the 4-ka zero-straddle jointly pin the harness normalization.)"""
+    mie1 = _mie_ratio(1.0)
+    conv = sorted(fx["bempp"]["convergence_ka1"], key=lambda c: c["N_dofs"])
+    resid = [abs(10.0 * np.log10(c["sigma_bempp_over_pi_a2"] / mie1)) for c in conv]
+    assert resid == sorted(resid, reverse=True), resid  # strictly improving
+    assert resid[-1] <= 0.1, resid[-1]
+
+
+def test_rfx_fine_value_is_sourced_not_fabricated(fx):
+    """The rfx column of the three-way is the committed fine-resolution monostatic
+    value from the sibling fixture, not a number invented here."""
+    rfx_fine = json.loads(_RFX_FINE.read_text())["monostatic"]["rfx_sigma_over_pi_a2"]
+    assert np.isclose(fx["three_way_ka1"]["rfx_fine_over_pi_a2"], rfx_fine, rtol=1e-12)
+
+
+def test_three_way_spread_self_consistent_and_close(fx):
+    """At ka~1 the three INDEPENDENT methods (exact analytic / FDTD-fine / BEM)
+    mutually agree within _THREE_WAY_CLOSE_DB. Spreads are recomputed from the
+    sigmas and checked against the stored values (humble: rfx-centric distances,
+    not a pass/fail verdict on any solver)."""
+    t = fx["three_way_ka1"]
+    mie, rfx, bem = (t["sigma_mie_over_pi_a2"], t["rfx_fine_over_pi_a2"], t["bempp_over_pi_a2"])
+    want = {
+        "rfx_vs_mie": 10 * np.log10(rfx / mie),
+        "bempp_vs_mie": 10 * np.log10(bem / mie),
+        "rfx_vs_bempp": 10 * np.log10(rfx / bem),
+    }
+    for key, val in want.items():
+        assert np.isclose(t["spread_db"][key], val, atol=1e-6), key
+        assert abs(val) <= _THREE_WAY_CLOSE_DB, (key, val)


### PR DESCRIPTION
## Why — the first independent integral-equation cross-check in rfx

The external-reviewer plan flagged rfx has **"ZERO integral-equation cross-check"**: its RCS is checked against exact Mie (analytic) + FDTD siblings (Meep/openEMS), but every FDTD sibling **shares rfx's staircase/time-domain error class**, so FDTD-vs-FDTD agreement can't rule out a shared-method artefact.

**Bempp-cl** solves the Maxwell EFIE on a **triangulated true curved surface** (surface IE, RWG basis, no staircase) — a fundamentally different discretization. This lane adds it as a third, non-FDTD method.

## Result (measured, CPU, Numba backend)

PEC sphere `a=0.015m`, incidence `+x`, `E‖z`, backscatter `-x`, `σ=4π|E_∞|²`:

| ka | Bempp BEM | exact Mie | Δ |
|---|---|---|---|
| 0.8 | 2.563 | 2.596 | −0.056 dB |
| 1.0 | 3.614 | 3.638 | −0.028 dB |
| 1.5 | 1.098 | 1.076 | +0.091 dB |
| 2.0 | 0.974 | 1.008 | −0.151 dB |

Bempp reproduces exact Mie to **≤0.15 dB**. `h`-refinement at ka=1 (`a/3→a/5→a/8`): −0.109 → −0.046 → −0.018 dB (**monotone → 0**).

**Three-way at ka≈1 — three independent methods within 0.07 dB:** exact-Mie 3.638 / rfx-FDTD-fine (λ/40) 3.585 / Bempp-BEM 3.614. The 4-ka **zero-straddle** + monotone convergence jointly pin the harness normalization (a fixed 4π/½/ik error would converge to a nonzero constant, not to 0).

Bempp confirming Mie to ≤0.15 dB at the same ka is a **non-FDTD witness** that rfx's coarse-ladder error (4.7–9.3 dB, `rcs_mie_e4`) is rfx-side resolution (staircasing + near-field NTFF box), not a comparator artefact — reinforcing the two-regime finding with a third method.

## Discipline

- **Additive only** — touches no existing RCS gate (the 15 dB GO floor, the coarse envelope, the fine 1.0 dB point all unchanged).
- **Anti-self-certification** — `test_rcs_sphere_three_way_gates.py` re-derives Mie from `scipy.special` (never imports the producer); rfx-fine value is sourced from the sibling `rcs_sphere_mie` fixture at rtol 1e-12.
- **No bempp in CI** — offline producer; `generate_bempp.py` emits the full `fixture.json` mechanically. (import name `bempp_cl` in 0.4.x; `OPENBLAS_NUM_THREADS≤64` on many-core boxes.)
- **humble-crossval** — no solver framed as wrong; scope = monostatic PEC-sphere backscatter only, not bistatic.
- **Independent reviewer APPROVE**; fixes applied — removed a **vacuous** conjugation "witness" (RCS magnitude is conjugation-invariant by construction), recompute convergence dB against re-derived Mie, mechanical producer, broadened the coarse-error attribution.

First lane of the sequential independent-solver validation campaign (next: patch-antenna resonance anchor, arbitrary-PEC RCS, MSL-notch scuff-em referee).

🤖 Generated with [Claude Code](https://claude.com/claude-code)