### PR TITLE
chore(gitignore): ignore .claude/ so clones inherit the governance-file exclusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 docs-site/
 CLAUDE.md
 AGENTS.md
+.claude/
 
 # docs/ publication boundaries live in docs/.gitignore
 


### PR DESCRIPTION
One-line change: add `.claude/` next to the existing `CLAUDE.md` / `AGENTS.md` ignores.

Rationale: the primary checkout excluded `.claude/` only via local `.git/info/exclude`, which clones/worktrees don't inherit. Installing the (intentionally untracked) agent-governance ruleset into secondary clones therefore produced untracked noise at risk of accidental commit. With the exclusion tracked, every clone treats these files identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)