### PR TITLE
fix(preflight): NTFF advisory tier for run() + honest all-clear + probes not culprits (closes #303)

### DIFF
--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -319,7 +319,7 @@ class _ExecuteMixin:
 
     def _auto_preflight(
         self, *, skip: bool = False, context: str = "forward",
-        check_ntff: bool = True,
+        check_ntff: bool | str = True,
     ) -> None:
         """Emit a UserWarning if preflight finds issues (issue #66).
 
@@ -329,11 +329,15 @@ class _ExecuteMixin:
         spending minutes of GPU compute. Pass ``skip_preflight=True`` at
         the call site to opt out (tests, already-validated configs).
 
-        ``check_ntff`` gates the inverse-design NTFF checks (PEC-overlap hard
-        error + λ/4 near-field gap warning). ``run()`` passes ``check_ntff=
-        False`` because those are inverse-design concerns that ``run()``
-        historically never ran — only ``forward(port_s11_freqs=...)`` /
-        ``optimize`` (the inverse-design entry points) should hard-fail on them.
+        ``check_ntff`` gates the NTFF check family. ``run()`` passes
+        ``check_ntff="advisory"`` (issue #303): the λ/4 near-field gap
+        advisories are physics-relevant to any far-field computation and
+        run() is the common NTFF entry point, so they are surfaced as
+        warnings — but only ``forward(port_s11_freqs=...)`` / ``optimize``
+        (the inverse-design entry points) hard-fail on the PEC-overlap
+        error. Previously run() skipped the family entirely and still
+        printed "All checks passed", which contradicted explicit
+        ``sim.preflight()`` output on the same configuration.
         """
         if skip:
             return
@@ -2200,7 +2204,7 @@ class _ExecuteMixin:
         # NTFF PEC-overlap check; keep that surface (it belongs to
         # forward(port_s11_freqs=...)/optimize). Avoids hard-failing run() on
         # an NTFF-box-crosses-PEC config that completed before this change.
-        self._auto_preflight(skip=skip_preflight, context="run", check_ntff=False)
+        self._auto_preflight(skip=skip_preflight, context="run", check_ntff="advisory")
 
         # ---- (2,4) stencil fence: reject order=4 on unsupported lanes ----
         _distributed_run = devices is not None and len(devices) > 1

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1004,7 +1004,7 @@ class _PreflightMixin:
         self,
         *,
         strict: bool = False,
-        check_ntff: bool = True,
+        check_ntff: bool | str = True,
         check_resolution: bool = True,
         check_ad_memory: bool = False,
         n_steps_for_memory: int | None = None,
@@ -1017,9 +1017,14 @@ class _PreflightMixin:
         strict : bool
             If True, raise ValueError on the first issue instead of
             collecting warnings.
-        check_ntff : bool
-            Run inverse-design NTFF checks (PEC overlap hard-error,
-            λ/4 near-field gap warning). Default True.
+        check_ntff : bool or "advisory"
+            ``True`` (default): run the full NTFF check family (PEC-overlap
+            hard error + λ/4 / λ/2 near-field gap advisories).
+            ``"advisory"``: run only the near-field gap advisories — the
+            tier ``run()`` uses, because the λ/4 warning is physics-relevant
+            to any far-field computation while the PEC-overlap hard error
+            remains an inverse-design gate (issue #303).
+            ``False``: skip the family entirely.
         check_resolution : bool
             Run the tightened resolution check (existing _validate_mesh_quality
             uses per-material thresholds already — this flag kept for
@@ -1049,7 +1054,9 @@ class _PreflightMixin:
                     self._validate_mesh_quality()
                 self._validate_simulation_config()
                 if check_ntff:
-                    self._validate_ntff_inverse_design()
+                    self._validate_ntff_inverse_design(
+                        include_pec_overlap_error=(check_ntff != "advisory"),
+                    )
             except ValueError as e:
                 # Collect (do NOT fail-on-first): the aggregated raise at the
                 # end escalates every finding at once under strict.
@@ -1116,8 +1123,14 @@ class _PreflightMixin:
         if issues:
             for iss in issues:
                 print(f"  [PREFLIGHT] {iss}")
-        else:
+        elif check_ntff is True:
             print("  [PREFLIGHT] All checks passed.")
+        elif check_ntff == "advisory":
+            print("  [PREFLIGHT] All checks passed (NTFF advisory tier; the "
+                  "PEC-overlap error check runs on forward()/preflight()).")
+        else:
+            print("  [PREFLIGHT] All checks passed (NTFF checks skipped; "
+                  "run sim.preflight() for the full set).")
 
         return issues
 
@@ -1396,11 +1409,18 @@ class _PreflightMixin:
                 "compute_coaxial_s_matrix() is not supported with solver='adi'."
             )
 
-    def _validate_ntff_inverse_design(self) -> None:
-        """NTFF inverse-design checks: PEC overlap (error) and λ/4 gap (warn).
+    def _validate_ntff_inverse_design(
+        self, *, include_pec_overlap_error: bool = True,
+    ) -> None:
+        """NTFF checks: PEC overlap (error) and λ/4 gap (warn).
 
-        CHECK 2: NTFF face plane strictly intersecting a PEC bbox.
-        CHECK 3: NTFF face closer than λ/4 to any geometry/source/probe.
+        CHECK 2: NTFF face plane strictly intersecting a PEC bbox
+        (hard error; skipped when ``include_pec_overlap_error=False`` —
+        the ``run()`` advisory tier, issue #303).
+        CHECK 3: NTFF face closer than λ/4 to any geometry or port/source.
+        Passive DFT probes are NOT counted: they read field state without
+        perturbing it, so a probe on a box face is a measurement choice,
+        not a radiating/scattering culprit (issue #303).
         """
         import warnings as _w
 
@@ -1418,7 +1438,10 @@ class _PreflightMixin:
             faces.append(("hi", axis, corner_hi[axis], tang))
 
         # CHECK 2: strict PEC intersection
-        pec_entries = [e for e in self._geometry if e.material_name == "pec"]
+        pec_entries = (
+            [e for e in self._geometry if e.material_name == "pec"]
+            if include_pec_overlap_error else []
+        )
         for side, axis, coord, tang in faces:
             for entry in pec_entries:
                 try:
@@ -1446,7 +1469,7 @@ class _PreflightMixin:
                     )
 
         # CHECK 3: λ/2 (Huygens) and λ/4 (reactive-near-field) gaps to any
-        # geometry/source/probe. Issue #77: the λ/2 Huygens-equivalence rule
+        # geometry/source (probes excluded, issue #303). Issue #77: the λ/2 Huygens-equivalence rule
         # was documented but only the λ/4 strong
         # tier was enforced; a face at λ/30 above a ground-plane PEC silently
         # ran and produced corrupted directivity. The two-tier check below
@@ -1473,8 +1496,8 @@ class _PreflightMixin:
         points: list[tuple[str, tuple]] = []
         for pe in self._ports:
             points.append(("port/source", tuple(pe.position)))
-        for pe in self._probes:
-            points.append(("probe", tuple(pe.position)))
+        # Probes intentionally excluded (issue #303): a DFT probe is a
+        # passive observer and does not radiate or scatter.
 
         for side, axis, coord, tang in faces:
             other = [a for a in range(3) if a != axis]

--- a/tests/test_inverse_design_preflight.py
+++ b/tests/test_inverse_design_preflight.py
@@ -163,3 +163,134 @@ def test_waveguide_resolution_warns():
         and ("cells per λ_eff" in s or "phase-accurate" in s)
         for s in issues
     ), "Expected a dielectric resolution warning: " + "\n".join(issues)
+
+
+# ---------------------------------------------------------------------------
+# Issue #303: run() advisory tier + honest summary + probe exclusion
+# ---------------------------------------------------------------------------
+
+def _pec_overlap_sim():
+    """The test_ntff_pec_overlap_rejects config, reused for tier tests."""
+    sim = _sane_sim()
+    sim.add(Box((0.005, 0.005, 0.010), (0.035, 0.035, 0.040)),
+                     material="pec")
+    sim.add_ntff_box(
+        corner_lo=(0.010, 0.010, 0.024),
+        corner_hi=(0.030, 0.030, 0.035),
+        n_freqs=4,
+    )
+    return sim
+
+
+def test_advisory_tier_keeps_gap_warning_drops_pec_error():
+    """check_ntff="advisory" = λ/4 advisories WITHOUT the PEC hard error.
+
+    This is run()'s tier (issue #303): the near-field advisory is
+    physics-relevant to any far-field computation, while the PEC-overlap
+    structural error stays an inverse-design (forward/optimize/explicit
+    preflight) gate.
+    """
+    # PEC-overlap config: full tier errors, advisory tier must not.
+    issues_adv = _pec_overlap_sim().preflight(check_ntff="advisory")
+    assert not any("PEC" in s and "NTFF face" in s for s in issues_adv), (
+        "advisory tier must not run the PEC-overlap error check: "
+        + "\n".join(issues_adv))
+
+    # λ/4-gap config (from test_ntff_near_field_gap_warns): advisory tier
+    # must still surface the near-field advisory.
+    freq_max = 5e9
+    dx = C / freq_max / 20.0
+    sim = Simulation(freq_max=freq_max, domain=(0.04, 0.04, 0.04),
+                     boundary="cpml", cpml_layers=8, dx=dx)
+    src_z = 0.020
+    sim.add_port((0.020, 0.020, src_z), "ez")
+    sim.add_ntff_box(
+        corner_lo=(0.010, 0.010, src_z + 2 * dx),
+        corner_hi=(0.030, 0.030, src_z + 3 * dx),
+        n_freqs=4,
+    )
+    issues = sim.preflight(check_ntff="advisory")
+    assert any("near-field" in s or "λ/4" in s for s in issues), (
+        "advisory tier must keep the λ/4 gap advisory: " + "\n".join(issues))
+
+
+def test_run_auto_preflight_surfaces_ntff_advisories():
+    """run() now WARNS on NTFF near-field configs instead of silence (#303).
+
+    Previously run() skipped the NTFF family (check_ntff=False) and printed
+    "All checks passed", contradicting explicit sim.preflight() on the same
+    configuration. The advisory must be a non-blocking UserWarning: the run
+    completes.
+    """
+    freq_max = 5e9
+    dx = C / freq_max / 20.0
+    sim = Simulation(freq_max=freq_max, domain=(0.04, 0.04, 0.04),
+                     boundary="cpml", cpml_layers=8, dx=dx)
+    src_z = 0.020
+    sim.add_port((0.020, 0.020, src_z), "ez")
+    sim.add_ntff_box(
+        corner_lo=(0.010, 0.010, src_z + 2 * dx),
+        corner_hi=(0.030, 0.030, src_z + 3 * dx),
+        n_freqs=4,
+    )
+    with pytest.warns(UserWarning, match=r"\[run\] preflight found"):
+        result = sim.run(n_steps=3)
+    assert result is not None  # non-blocking: the run completed
+
+
+def test_run_does_not_hard_fail_on_ntff_pec_overlap():
+    """The PEC-overlap ERROR stays off run()'s tier (historical contract)."""
+    sim = _pec_overlap_sim()
+    # Must not raise PreflightConfigError/ValueError from preflight; other
+    # advisories (if any) surface as UserWarning, which we tolerate here.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = sim.run(n_steps=3)
+    assert result is not None
+
+
+def test_probe_on_ntff_face_is_not_a_culprit():
+    """Passive DFT probes are excluded from the near-field culprits (#303).
+
+    A probe ON the box face previously produced a 0.00mm 'radiating/
+    scattering structure' advisory. Config keeps every face >= λ/2 from the
+    SOURCE (x_lo gap 35mm > λ/2 = 30mm; other faces tangentially out of
+    scope), so with probes excluded the report must carry no NTFF finding.
+    """
+    freq_max = 5e9
+    domain = (0.10, 0.10, 0.10)
+    sim = Simulation(freq_max=freq_max, domain=domain, boundary="cpml",
+                     cpml_layers=8, dx=C / freq_max / 20.0)
+    sim.add_port((0.010, 0.060, 0.060), "ez")
+    sim.add_probe((0.045, 0.060, 0.060), "ez")  # exactly on the x_lo face
+    sim.add_ntff_box(
+        corner_lo=(0.045, 0.045, 0.045),
+        corner_hi=(0.075, 0.075, 0.075),
+        n_freqs=4,
+    )
+    issues = sim.preflight()
+    ntff_issues = [s for s in issues if "NTFF face" in s]
+    assert ntff_issues == [], (
+        "probe-on-face must not be an NTFF culprit: " + "\n".join(ntff_issues))
+
+
+def test_zero_issue_summary_line_is_honest(capsys):
+    """The all-clear line states which NTFF tier actually ran (#303)."""
+    def _clean_sim():
+        from rfx.sources.sources import GaussianPulse
+        sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02),
+                         dx=0.02 / 15, boundary="cpml", cpml_layers=6)
+        sim.add_port(position=(0.0093, 0.0093, 0.0093), component="ez",
+                     impedance=50.0,
+                     waveform=GaussianPulse(f0=5e9, bandwidth=0.9),
+                     extent=0.004)
+        return sim
+
+    assert _clean_sim().preflight() == []
+    assert "All checks passed." in capsys.readouterr().out
+
+    assert _clean_sim().preflight(check_ntff="advisory") == []
+    assert "NTFF advisory tier" in capsys.readouterr().out
+
+    assert _clean_sim().preflight(check_ntff=False) == []
+    assert "NTFF checks skipped" in capsys.readouterr().out

--- a/tests/test_ntff_directivity_validation_battery.py
+++ b/tests/test_ntff_directivity_validation_battery.py
@@ -76,17 +76,19 @@ same-session base-rung remeasure, bit-reproducible on this CPU box):
     max|dev| = 0.004575; max|E_phi|/max|E_theta| over sphere = 1.002629;
     D = 1.7999 dBi
 
-Preflight (quoted per feedback_never_ignore_preflight): explicit
-``sim.preflight()`` on this fixture returns six lambda/4 advisories of the
-form "NTFF face x_lo is 9.00mm from port/source at (0.03, 0.03, 0.03) —
-below λ/4 = 24.98mm at f_max=3.00GHz. NTFF will integrate reactive
-near-field; directivity / pattern likely corrupted. Move NTFF box ≥ λ/2
-from any radiating/scattering structure (Huygens-equivalence rule)."
-(one per NTFF face; the x_hi one is triggered by a passive witness probe
-sitting ON that face). The measured 0.006-0.039 dB directivity error shows
-the advisory is conservative for a point dipole 9 mm from the box; the
-fixture keeps the run non-blocking (run()'s auto-preflight passes) and the
-battery does NOT use skip_preflight.
+Preflight (quoted per feedback_never_ignore_preflight): ``sim.preflight()``
+on this fixture returns lambda/4 advisories of the form "NTFF face x_lo is
+9.00mm from port/source at (0.03, 0.03, 0.03) — below λ/4 = 24.98mm at
+f_max=3.00GHz. NTFF will integrate reactive near-field; directivity /
+pattern likely corrupted. Move NTFF box ≥ λ/2 from any radiating/scattering
+structure (Huygens-equivalence rule)." (originally six — one per NTFF face,
+with the x_hi one triggered by a passive witness probe ON that face; since
+issue #303 passive probes are excluded from the culprit list, and run()'s
+auto-preflight surfaces these same advisories as a non-blocking UserWarning
+via its "advisory" tier instead of skipping the family). The measured
+0.006-0.039 dB directivity error shows the advisory is conservative for a
+point dipole 9 mm from the box; the runs stay non-blocking and the battery
+does NOT use skip_preflight.
 
 Known numerics caveats carried by this battery (documented, not patched):
   (1) float32 flush-to-zero in ``flux_spectrum`` at fine dx — at the

--- a/tests/test_preflight_structured_and_guards.py
+++ b/tests/test_preflight_structured_and_guards.py
@@ -88,7 +88,7 @@ def test_error_severity_mapping_end_to_end():
     severity='error' PreflightIssue (not masking other checks)."""
     sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
     sim.add_source((0.01, 0.01, 0.01), component="ez")
-    sim._validate_ntff_inverse_design = lambda: warnings.warn(
+    sim._validate_ntff_inverse_design = lambda **kw: warnings.warn(
         "forced known-bad config", PreflightErrorWarning
     )
     report = sim.preflight()
@@ -299,24 +299,32 @@ def test_validator_crash_propagates_not_swallowed():
 
 
 # ----------------------------------------- run() error-severity + NTFF surface
-def test_run_skips_ntff_inverse_design_check_but_forward_runs_it():
-    """run() must NOT hard-fail on the inverse-design NTFF check (it historically
-    never ran it — run() uses check_ntff=False), while forward()/optimize (the
-    inverse-design entry points) still do. Regression lock for the NTFF/PEC
-    behavior change flagged in cold review."""
+def test_run_uses_ntff_advisory_tier_but_forward_gets_the_error():
+    """run() must NOT hard-fail on the NTFF PEC-overlap error, while
+    forward()/optimize (the inverse-design entry points) still do.
+
+    Issue #303 changed the MECHANISM (run() now uses check_ntff="advisory"
+    — the validator IS invoked, with include_pec_overlap_error=False — so
+    λ/4 advisories reach run() users) but the CONTRACT locked here is
+    unchanged: the error tier stays off run() and on forward(). The mock
+    respects the kwarg the way the real validator does."""
     def _sim():
         s = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
         s.add_source((0.01, 0.01, 0.01), component="ez")
         s.add_probe((0.01, 0.01, 0.012), component="ez")
-        # Stand in for an NTFF-box-crosses-PEC error-severity finding.
-        s._validate_ntff_inverse_design = lambda: (_ for _ in ()).throw(
-            ValueError("NTFF box face crosses PEC")
-        )
+
+        # Stand in for an NTFF-box-crosses-PEC error-severity finding that
+        # honors the error-tier switch like the real validator.
+        def _fake_ntff(*, include_pec_overlap_error: bool = True):
+            if include_pec_overlap_error:
+                raise ValueError("NTFF box face crosses PEC")
+
+        s._validate_ntff_inverse_design = _fake_ntff
         return s
 
-    # run(): check_ntff=False -> the NTFF validator is not invoked -> no hard-fail
+    # run(): advisory tier -> validator invoked WITHOUT the error tier
     _sim().run(n_steps=5)
-    # forward(): check_ntff=True -> invoked -> error-severity -> re-raised
+    # forward(): full tier -> error-severity -> re-raised
     with pytest.raises(ValueError, match="NTFF box face crosses PEC"):
         _sim().forward(n_steps=5)
 


### PR DESCRIPTION
Closes #303. Implements the three findings verified in the issue:

1. **run() gets the NTFF advisory tier** (`check_ntff="advisory"`): λ/4 near-field advisories now reach run() users as a non-blocking UserWarning — run() is the common NTFF entry point and the advisory is physics-relevant to any far-field computation. The PEC-overlap **hard error stays inverse-design-gated** (forward/optimize/explicit preflight): the existing regression lock keeps that contract with the mechanism updated (mock honors `include_pec_overlap_error` like the real validator).
2. **Honest all-clear line**: 'All checks passed.' only when the full family ran; advisory/skipped tiers say so explicitly. (Previously run() printed the unconditional all-clear while explicit `sim.preflight()` reported six advisories on the identical configuration.)
3. **Passive probes excluded from CHECK 3 culprits**: a DFT probe doesn't radiate or scatter; the old advisory told users to move the NTFF box away from their own witness probe at '0.00mm'.

Tests: 5 new + 2 mock updates; suites green: preflight/guards 32, NTFF battery fast + docstring contract + rcs + farfield 21 (the 15 warnings in that run are the newly-surfaced advisories, non-blocking by design). NTFF battery module docstring updated to describe the new behavior.

R3: memory=consistent | R2-attempts=0 | falsifier=test_run_auto_preflight_surfaces_ntff_advisories is red on main, green here

🤖 Generated with [Claude Code](https://claude.com/claude-code)