### PR TITLE
fix(flux): detect float32 subnormal-flushed zero flux and warn (closes #304)

### DIFF
--- a/rfx/probes/probes.py
+++ b/rfx/probes/probes.py
@@ -609,11 +609,75 @@ def flux_spectrum(mon: FluxMonitor) -> jnp.ndarray:
     flux : (n_freqs,) float
         ∫ Re(E × H*) · n̂ dA at each frequency.
         Positive = power flowing in +axis direction.
+
+    Notes
+    -----
+    With x64 disabled the accumulators are complex64, and per-cell E×H*
+    products below the float32 minimum normal (~1.18e-38) are flushed to
+    zero by XLA — a physically tiny-but-nonzero flux then returns EXACTLY
+    0.0 at every frequency with healthy field accumulators (issue #304;
+    single-cell fixed-amplitude sources radiate P ~ dx^6, so fine grids hit
+    this readily). Eager calls detect that state with a float64 NumPy
+    recompute of the identical sum and emit a UserWarning; under
+    jit/grad the check is skipped entirely (tracer-safe, off the AD tape).
     """
     # Poynting: S_n = E1*H2* - E2*H1* (cyclic cross product).
     # mon.dA is the axis-aware area weight (scalar or (n1,n2)).
     integrand = mon.e1_dft * jnp.conj(mon.h2_dft) - mon.e2_dft * jnp.conj(mon.h1_dft)
-    return jnp.real(jnp.sum(integrand * mon.dA, axis=(-2, -1)))
+    flux = jnp.real(jnp.sum(integrand * mon.dA, axis=(-2, -1)))
+    _warn_if_flux_subnormal_flush(mon, flux)
+    return flux
+
+
+def _warn_if_flux_subnormal_flush(mon: FluxMonitor, flux) -> None:
+    """Issue #304: eager-only detector for float32 subnormal-flushed flux.
+
+    Warns when ``flux`` is exactly 0.0 at every frequency, the field
+    accumulators are nonzero, AND a float64 recompute of the identical sum
+    is nonzero — the decisive witness that the zeros are an underflow
+    artefact, not physics. Never fires under tracing (imitates the
+    ``warn_if_nonpassive_lumped_s11`` tracer-safety pattern) and never
+    changes the returned value.
+    """
+    import jax as _jax
+    try:
+        if isinstance(flux, _jax.core.Tracer):
+            return
+    except Exception:
+        return
+    if flux.dtype != jnp.float32:
+        return  # complex128 accumulators (scoped x64) don't flush this way
+    import numpy as np
+    f32 = np.asarray(flux)
+    if f32.size == 0 or np.any(f32 != 0.0):
+        return
+    e1 = np.asarray(mon.e1_dft)
+    e2 = np.asarray(mon.e2_dft)
+    if not (np.any(e1 != 0) or np.any(e2 != 0)):
+        return  # genuinely empty monitor — zero flux is the right answer
+    h1 = np.asarray(mon.h1_dft, dtype=np.complex128)
+    h2 = np.asarray(mon.h2_dft, dtype=np.complex128)
+    dA = np.asarray(mon.dA, dtype=np.float64)
+    f64 = np.real(np.sum(
+        (e1.astype(np.complex128) * np.conj(h2)
+         - e2.astype(np.complex128) * np.conj(h1)) * dA,
+        axis=(-2, -1),
+    ))
+    if not np.any(f64 != 0.0):
+        return  # float64 agrees the flux is zero — no artefact
+    import warnings
+    peak = float(np.max(np.abs(f64)))
+    warnings.warn(
+        f"flux_spectrum returned exactly 0.0 at all {f32.size} frequencies, "
+        f"but the DFT accumulators are healthy and a float64 recompute of "
+        f"the same sum gives nonzero flux (peak |flux| = {peak:.3e}). The "
+        f"per-cell E x H* products underflowed the float32 minimum normal "
+        f"(~1.18e-38) and were flushed to zero (issue #304). Remedies: "
+        f"enable x64 in a scoped context for the flux computation, increase "
+        f"the source amplitude, or recompute from the (healthy) "
+        f"accumulators in float64 as done for this check.",
+        UserWarning, stacklevel=3,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_flux_silent_zero_guard.py
+++ b/tests/test_flux_silent_zero_guard.py
@@ -1,0 +1,84 @@
+"""Issue #304: flux_spectrum must not return exactly 0.0 SILENTLY when the
+per-cell E x H* products underflow float32 (XLA flushes subnormals).
+
+The guard is eager-only and value-preserving: it warns (never raises, never
+changes the returned flux) when flux == 0.0 everywhere, the accumulators are
+nonzero, and a float64 recompute of the identical sum is nonzero — the
+decisive artefact-vs-physics witness. Under jit/grad the check is skipped
+entirely (tracer-safe; flux_spectrum is on the AD tape via normalize='flux',
+PR #172), so no optimization path is perturbed.
+
+Magnitudes below reproduce the empirically confirmed flush: complex64
+1e-20 * conj(1e-22) == exactly 0j (product 1e-42 < min normal 1.1755e-38)
+while 1e-15 * 1e-22 = 1e-37 survives.
+"""
+
+import warnings
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from rfx.probes.probes import FluxMonitor, flux_spectrum
+
+
+def _monitor(e_scale: float, h_scale: float, n_freqs: int = 3) -> FluxMonitor:
+    shape = (n_freqs, 4, 4)
+    c64 = jnp.complex64
+    return FluxMonitor(
+        e1_dft=jnp.full(shape, e_scale + 0j, dtype=c64),
+        e2_dft=jnp.zeros(shape, dtype=c64),
+        h1_dft=jnp.zeros(shape, dtype=c64),
+        h2_dft=jnp.full(shape, h_scale + 0j, dtype=c64),
+        freqs=jnp.linspace(1e9, 3e9, n_freqs),
+        axis=0, index=5,
+        dA=jnp.asarray(1.0, dtype=jnp.float32),
+        total_steps=100, window="rect", window_alpha=0.25,
+    )
+
+
+def test_flushed_flux_warns_and_value_unchanged():
+    """Subnormal-flushed monitor: warn, but still return the flushed zeros."""
+    mon = _monitor(1e-20, 1e-22)  # product 1e-42 -> flushed to exactly 0
+    with pytest.warns(UserWarning, match="issue #304"):
+        flux = flux_spectrum(mon)
+    assert np.all(np.asarray(flux) == 0.0), (
+        "guard must WARN only — the returned value stays the flushed zeros")
+
+
+def test_healthy_flux_does_not_warn():
+    mon = _monitor(1e-3, 1e-3)  # products far above min normal
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning -> test failure
+        flux = flux_spectrum(mon)
+    assert float(np.max(np.abs(np.asarray(flux)))) > 0
+
+
+def test_empty_monitor_does_not_warn():
+    """All-zero accumulators = genuinely zero flux, not an artefact."""
+    mon = _monitor(0.0, 0.0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        flux = flux_spectrum(mon)
+    assert np.all(np.asarray(flux) == 0.0)
+
+
+def test_traced_call_skips_guard_and_matches_eager():
+    """Under jit the guard must not fire and must not perturb the value.
+
+    Traces the ARRAY leaves only (static str/int fields stay Python values,
+    matching production usage where flux_spectrum runs inside jitted
+    extraction with traced accumulators, PR #172).
+    """
+    mon = _monitor(1e-20, 1e-22)
+
+    def _f(e1_dft, h2_dft):
+        return flux_spectrum(mon._replace(e1_dft=e1_dft, h2_dft=h2_dft))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # a traced warn would fail here
+        jitted = jax.jit(_f)(mon.e1_dft, mon.h2_dft)
+    with pytest.warns(UserWarning, match="issue #304"):
+        eager = flux_spectrum(mon)
+    np.testing.assert_array_equal(np.asarray(jitted), np.asarray(eager))


### PR DESCRIPTION
Closes #304.

`flux_spectrum` returned **exactly 0.0** at every frequency — silently — when per-cell E×H* products underflowed the float32 minimum normal (~1.18e-38; XLA flushes subnormals with x64 off) while the field accumulators remained healthy. Found by the NTFF directivity lane (PR #302), which hit it at fine dx where a fixed-amplitude single-cell source's radiated power (~dx⁶) drops into the flush regime.

**Guard design** (eager-only, value-preserving): warn only when flux == 0.0 everywhere AND accumulators are nonzero AND a float64 recompute of the identical sum is nonzero — the decisive artefact-vs-physics witness (empty monitors and genuinely-zero flux never trip it). Tracer-safe via the existing `warn_if_nonpassive_lumped_s11` pattern: skipped entirely under jit/grad, so the `normalize='flux'` AD tape (#172) is untouched.

Tests: 4 new (flushed→warns + value unchanged; healthy→silent; empty→silent; traced→skips and matches eager bit-for-bit). Flux blast radius green (finite-size, waveguide-flux-AD, decay-flux-convergence); verified the guard fires on zero existing tests.

R3: memory=consistent | R2-attempts=0 | falsifier=the flushed-warns test is red on main, green here

🤖 Generated with [Claude Code](https://claude.com/claude-code)