### PR TITLE
fix(preflight): warn when a wire port's midpoint V/I probe cell lands inside PEC (closes #314)

### DIFF
--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2186,6 +2186,49 @@ class _PreflightMixin:
         PEC volume H still decays to zero, so the warning still
         fires there.
         """
+        # Issue #314: for a WIRE port (extent set) the V/I reference plane
+        # is the MIDPOINT probe cell of the production rasterization, not
+        # the start position — a midpoint landing inside PEC silently
+        # corrupts S-parameters (measured on the 2-port thru fixture:
+        # forward |S21| collapses to ~0.005-0.01 while the reverse channel
+        # reads over-unity ~1.06-1.15, because the voltage probe samples a
+        # PEC-shorted environment and the port column punches a hole in
+        # the trace). Check the exact cell production will use.
+        for pe in self._ports:
+            if not getattr(pe, "extent", None):
+                continue
+            mid_center = self._wire_port_midpoint_center(pe)
+            if mid_center is None:
+                continue
+            for entry in self._geometry:
+                if entry.material_name != "pec":
+                    continue
+                if not hasattr(entry.shape, "bounding_box"):
+                    continue
+                try:
+                    c1, c2 = entry.shape.bounding_box()
+                except (NotImplementedError, TypeError):
+                    continue
+                if all(c1[ax] <= mid_center[ax] <= c2[ax] for ax in range(3)):
+                    _w.warn(
+                        PreflightWarning(
+                            f"Wire port at {pe.position} (extent "
+                            f"{pe.extent}): its MIDPOINT V/I probe cell "
+                            f"(center {tuple(round(x, 6) for x in mid_center)}) "
+                            f"lands inside PEC geometry "
+                            f"'{entry.material_name}'. S-parameters from "
+                            f"this port are silently corrupted (measured: "
+                            f"near-null forward transmission + over-unity "
+                            f"reverse). Shorten/lengthen the extent or move "
+                            f"the port so the midpoint cell sits in "
+                            f"dielectric (issue #314).",
+                            code="wire_port_midpoint_in_pec",
+                            source="_validate_cfg_port_inside_pec",
+                        ),
+                        stacklevel=3,
+                    )
+                    break
+
         for pe in list(self._ports) + list(self._probes):
             pos = pe.position
             component = (getattr(pe, "component", "") or "").lower()
@@ -2216,6 +2259,43 @@ class _PreflightMixin:
                             )
                     except (NotImplementedError, TypeError):
                         pass
+
+    def _wire_port_midpoint_center(self, pe):
+        """Physical center of a wire port's midpoint V/I probe cell.
+
+        Mirrors the production rasterization exactly (issue #314):
+        ``_wire_port_cells`` on the same WirePort that
+        ``forward()``/``run()`` build from this entry, midpoint =
+        ``cells[len(cells) // 2]`` (rfx/api/_execute.py). Returns None
+        when the geometry cannot be resolved (defensive: preflight must
+        never crash a run over a diagnostics helper).
+        """
+        try:
+            from rfx.sources.sources import WirePort, _wire_port_cells
+            axis = {"ex": 0, "ey": 1, "ez": 2}[pe.component]
+            end = list(pe.position)
+            end[axis] += pe.extent
+            wp = WirePort(start=tuple(pe.position), end=tuple(end),
+                          component=pe.component, impedance=pe.impedance)
+            grid = self._build_grid()
+            cells = _wire_port_cells(grid, wp)
+            if not cells:
+                return None
+            mid = cells[len(cells) // 2]
+            d = (grid.dx, getattr(grid, "dy", grid.dx),
+                 getattr(grid, "dz", grid.dx))
+            pad = (getattr(grid, "pad_x_lo", 0),
+                   getattr(grid, "pad_y_lo", 0),
+                   getattr(grid, "pad_z_lo", 0))
+            # Inverse of grid.position_to_index (index = round(pos/d) +
+            # pad_lo): node coordinate, plus the Yee half-cell offset of
+            # the E component along its own axis (where the V probe
+            # actually samples).
+            pos = [(mid[ax] - pad[ax]) * d[ax] for ax in range(3)]
+            pos[axis] += 0.5 * d[axis]
+            return tuple(pos)
+        except Exception:
+            return None
 
     def _validate_cfg_floating_single_cell_port(self, _w) -> None:
         """P1.9: Single-cell port in dielectric with no adjacent PEC pin

--- a/tests/test_inverse_design_preflight.py
+++ b/tests/test_inverse_design_preflight.py
@@ -294,3 +294,42 @@ def test_zero_issue_summary_line_is_honest(capsys):
 
     assert _clean_sim().preflight(check_ntff=False) == []
     assert "NTFF checks skipped" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Issue #314: wire-port MIDPOINT V/I probe cell inside PEC
+# ---------------------------------------------------------------------------
+
+def _microstrip_sim(port_extent_m: float) -> Simulation:
+    """Minimal air-microstrip: PEC trace at z in [1.0, 1.5] mm, dx=0.5 mm.
+
+    A vertical ez wire port from z=0 rasterizes (production
+    ``_wire_port_cells``) to cells of 0.5 mm; extent 1.5 mm -> 4 cells,
+    midpoint cell center z = 1.25 mm INSIDE the trace (the measured #314
+    corruption case); extent 1.0 mm -> 3 cells, midpoint center z =
+    0.75 mm in the substrate gap (healthy).
+    """
+    sim = Simulation(freq_max=10e9, domain=(0.016, 0.010, 0.006),
+                     boundary="cpml", cpml_layers=6, dx=0.5e-3)
+    sim.add(Box((0.004, 0.003, 0.001), (0.012, 0.007, 0.0015)),
+            material="pec")
+    sim.add_port(position=(0.008, 0.005, 0.0), component="ez",
+                 impedance=50.0, extent=port_extent_m)
+    return sim
+
+
+def test_wire_midpoint_in_pec_warns():
+    issues = _microstrip_sim(1.5e-3).preflight()
+    hits = [s for s in issues if "MIDPOINT" in s and "PEC" in s]
+    assert hits, (
+        "extent=1.5mm puts the midpoint probe cell (z=1.25mm) inside the "
+        "trace [1.0,1.5]mm — the #314 warning must fire: "
+        + "\n".join(issues))
+
+
+def test_wire_midpoint_in_gap_does_not_warn():
+    issues = _microstrip_sim(1.0e-3).preflight()
+    hits = [s for s in issues if "MIDPOINT" in s]
+    assert hits == [], (
+        "extent=1.0mm keeps the midpoint (z=0.75mm) in the gap — no #314 "
+        "warning expected: " + "\n".join(hits))


### PR DESCRIPTION
Closes #314.

The existing `port_in_pec` check tests only the port START position; a wire port's V/I reference plane is its **midpoint probe cell**, and a midpoint inside PEC silently corrupts S-parameters — measured on the 2-port thru during the #308 arc: forward |S21| collapses to ~0.005–0.01 while the reverse channel reads over-unity 1.06–1.15 (the port column punches a hole in the trace and the probe samples a PEC-shorted environment).

**Implementation**: `_wire_port_midpoint_center` mirrors production exactly — the same `_wire_port_cells` rasterization on the same `WirePort`, midpoint `cells[n//2]`, and the inverse of `grid.position_to_index` including the CPML pad offset **and the Yee half-cell offset** of the E component along its own axis (that offset subtlety was caught by the repro test during development — the gate was measured before being trusted). Defensive `None` on any resolution failure so preflight can never crash a run. Warning severity, matching the surrounding validator; code `wire_port_midpoint_in_pec`.

**Tests**: the measured corruption geometry (extent 1.5 mm → midpoint z = 1.25 mm inside the trace) warns; the healthy sibling (extent 1.0 mm → z = 0.75 mm in the gap) stays clean; the committed battery thru fixture still preflights with exactly its one known advisory; preflight/guards + wire + contract suites green (55+ tests).

R3: memory=consistent (#314 measured evidence; imitate-production rule) | R2-attempts=0 | falsifier=repro-geometry test red-on-main/green-here

🤖 Generated with [Claude Code](https://claude.com/claude-code)