### PR TITLE
feat(ports): opt-in reference-plane port waves — off-diagonal S-params anchored to a power-conserving plane (addresses #313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Added — opt-in reference-plane port waves for the wire S-matrix off-diagonals (`add_port(reference_plane_cells=)`, issue #313)
+
+- `add_port(..., extent=..., direction=..., reference_plane_cells=N)` registers
+  two line-V/I reference planes at N and 2N cells outboard (into the DUT) and
+  computes the off-diagonal `S[i, j]` (both ports opted in) from the plane
+  waves: forward/backward split with the **measured** two-plane line impedance
+  and phase-only de-embedding with the **measured** per-bin beta. The Phase-0
+  closed-box flux referee showed the port-cell wave pair does not conserve
+  power (the port plane is near-field dominated) while the plane waves close
+  the power budget; the plane path removes the drive-side |S21| deflation
+  kappa(f) = 1.49–1.86 of issue #313.
+- Default (`reference_plane_cells=None`) is **byte-identical** to the shipped
+  behaviour, and the diagonal `S_jj` always stays on the byte-frozen legacy
+  path either way — `forward()` / 1-port S11 results are unaffected.
+- Uniform-`run()`-lane only: the non-uniform and subgridded lanes raise
+  `NotImplementedError` with the opt-in set (the distributed lane does not
+  support `compute_s_params` at all, warned-unsupported).
+- Placement guidance: put BOTH planes (N and 2N cells) >= 10 cells from every
+  port (Phase-0 pre-registration rule). N=3 planes measured near-field
+  contamination on the canonical thru (Zc Im/Re to 8.2%, beta/(w/c)
+  1.16–1.20, closed-box-referee |S21| residual -3.1%); a preflight advisory
+  fires below N=10, a UserWarning fires at extraction when the measured Zc
+  shows the contamination signature, and a wrapped/non-positive measured
+  beta fails loudly instead of de-embedding with it.
+- Honesty framing (matching the docstring): the supporting numbers are from
+  the canonical 16 mm thru battery (dx = 0.5 mm, 2026-07-10) — a single
+  geometry class, not an external cross-solver validation; the diagnostics
+  (measured `zc`, `beta`, at-plane wave pairs) are exposed for inspection
+  rather than asserted as validated beyond that envelope.
+
 ### Fixed — `forward()` / `optimize()` are now wrappable in an outer `jax.jit` (blind-docs finding)
 
 - `_assemble_materials` decided whether to return the PEC mask via

--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -1683,6 +1683,7 @@
         "conformal_weights",
         "wire_port_sparams",
         "lumped_port_sparams",
+        "wire_refplane_sparams",
         "lumped_rlc",
         "kerr_chi3",
         "field_dtype",
@@ -2327,7 +2328,8 @@
       "waveform",
       "extent",
       "excite",
-      "direction"
+      "direction",
+      "reference_plane_cells"
     ],
     "add_probe": [
       "position",

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -1075,6 +1075,7 @@ class Simulation(
         extent: float | None = None,
         excite: bool = True,
         direction: str | None = None,
+        reference_plane_cells: int | None = None,
     ) -> "Simulation":
         """Add a lumped port (single-cell) or wire port (multi-cell).
 
@@ -1104,6 +1105,34 @@ class Simulation(
             processing to orient the V/I → (incoming, outgoing) wave
             decomposition. When None, the runner auto-detects from the
             port's position (closest boundary face).
+        reference_plane_cells : int or None
+            Opt-in reference-plane port waves for the wire-port S-matrix
+            OFF-diagonal extraction (issue #313). When set to an integer
+            N >= 1, ``run(compute_s_params=True)`` registers TWO line
+            V/I reference planes for this port at N and 2N cells
+            outboard (into the DUT along the line axis, i.e. opposite
+            ``direction``): gap-voltage line integrals at integer Yee
+            planes plus dual adjacent Ampere loops around the PEC signal
+            trace, accumulated in the production scan. Off-diagonal
+            ``S[i, j]`` entries whose ports BOTH opt in are then computed
+            from the plane waves — forward/backward split with the
+            MEASURED two-plane line impedance
+            ``Zc^2 = (V1^2 - V2^2)/(I1^2 - I2^2)`` (never the nominal
+            port impedance) and phase-only de-embedding to the port plane
+            with the MEASURED per-bin beta from the same two planes.
+            The Phase-0 closed-box flux referee showed the port-cell wave
+            pair does not conserve power (the port plane is near-field
+            dominated) while the plane waves close the power budget at
+            all bins; the plane path removes the drive-side |S21|
+            deflation kappa(f) = 1.49-1.86 of issue #313.
+            ``None`` (default) keeps the shipped port-cell behaviour,
+            byte-identical. The DIAGONAL ``S_jj`` always stays on the
+            byte-frozen legacy path either way, so ``forward()`` /
+            1-port S11 results are unaffected. Requires a wire port
+            (``extent=``) with an explicit ``direction`` transverse to
+            the port component, a PEC signal trace uniform across both
+            planes, and the uniform-mesh ``run()`` lane (other lanes
+            raise ``NotImplementedError``).
         """
         if self._tfsf is not None:
             raise ValueError(
@@ -1117,6 +1146,35 @@ class Simulation(
             raise ValueError(
                 f"direction must be one of '+x','-x','+y','-y' (or None), got {direction!r}"
             )
+        if reference_plane_cells is not None:
+            if extent is None:
+                raise NotImplementedError(
+                    "reference_plane_cells is only supported on wire ports "
+                    "(extent=...): the plane V/I method needs a gap-voltage "
+                    "line integral and a PEC signal trace. Single-cell "
+                    "lumped ports have no Phase-0 evidence (issue #313)."
+                )
+            if int(reference_plane_cells) != reference_plane_cells \
+                    or int(reference_plane_cells) < 1:
+                raise ValueError(
+                    "reference_plane_cells must be an integer >= 1, got "
+                    f"{reference_plane_cells!r}"
+                )
+            if direction is None:
+                raise ValueError(
+                    "reference_plane_cells requires an explicit direction= "
+                    "('+x'/'-x'/'+y'/'-y') — the reference planes go "
+                    "outboard (into the DUT), opposite the port's outward "
+                    "normal, and auto-detection is not accepted for a "
+                    "measurement-plane choice."
+                )
+            if direction[1] == component[1]:
+                raise ValueError(
+                    f"reference_plane_cells: port component {component!r} "
+                    f"lies along the line axis {direction!r} — the gap-V "
+                    "line integral must be transverse to the line."
+                )
+            reference_plane_cells = int(reference_plane_cells)
 
         if waveform is None and excite:
             waveform = GaussianPulse(f0=self._freq_max / 2, bandwidth=0.8)
@@ -1132,6 +1190,7 @@ class Simulation(
             position=position, component=component,
             impedance=impedance, waveform=waveform,
             extent=extent, excite=excite, direction=direction,
+            reference_plane_cells=reference_plane_cells,
         ))
         return self
 

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -1131,8 +1131,12 @@ class Simulation(
             1-port S11 results are unaffected. Requires a wire port
             (``extent=``) with an explicit ``direction`` transverse to
             the port component, a PEC signal trace uniform across both
-            planes, and the uniform-mesh ``run()`` lane (other lanes
-            raise ``NotImplementedError``).
+            planes, and the uniform-mesh ``run()`` lane: the
+            non-uniform and subgridded lanes raise
+            ``NotImplementedError`` with the opt-in set, and the
+            distributed lane does not support ``compute_s_params`` at
+            all (it warns that the kwarg is unsupported and ignores
+            it).
 
             Choosing N: place BOTH planes (N and 2N cells) roughly >= 10
             cells from every port so the two-plane Zc/beta measurement

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -1138,11 +1138,14 @@ class Simulation(
             cells from every port so the two-plane Zc/beta measurement
             sits outside the port near-fields — the Phase-0
             pre-registration rule. Measured on the canonical 16 mm thru
-            (dx = 0.5 mm): N=3 planes read beta/(w/c) = 1.21-1.25 and
-            Zc Im/Re up to 9% (near-field contaminated; |S21| referee
-            residual grew to -6.8% at 7 GHz), while N=10 planes read the
-            clean mid-line beta/(w/c) = 1.045-1.065 and closed the
-            closed-box referee within 1.2% at all bins.
+            (dx = 0.5 mm, gap-trimmed V, 2026-07-10 battery): N=3 planes
+            read beta/(w/c) = 1.16-1.20 and Zc = 52-53 ohm with Im/Re up
+            to 8.2% (near-field contaminated; |S21| closed-box-referee
+            residual -3.1% at 7 GHz, row energy |S11|^2+|S21|^2 up to
+            1.019), while N=10 planes read the clean mid-line
+            beta/(w/c) = 1.046-1.059 and Zc = 47.9-48.6 ohm (Im/Re <=
+            1.2%) and closed the closed-box referee within 0.9% at all
+            bins.
         """
         if self._tfsf is not None:
             raise ValueError(

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -1133,6 +1133,16 @@ class Simulation(
             the port component, a PEC signal trace uniform across both
             planes, and the uniform-mesh ``run()`` lane (other lanes
             raise ``NotImplementedError``).
+
+            Choosing N: place BOTH planes (N and 2N cells) roughly >= 10
+            cells from every port so the two-plane Zc/beta measurement
+            sits outside the port near-fields — the Phase-0
+            pre-registration rule. Measured on the canonical 16 mm thru
+            (dx = 0.5 mm): N=3 planes read beta/(w/c) = 1.21-1.25 and
+            Zc Im/Re up to 9% (near-field contaminated; |S21| referee
+            residual grew to -6.8% at 7 GHz), while N=10 planes read the
+            clean mid-line beta/(w/c) = 1.045-1.065 and closed the
+            closed-box referee within 1.2% at all bins.
         """
         if self._tfsf is not None:
             raise ValueError(

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -153,6 +153,8 @@ class _ExecuteMixin:
         s_param_n_steps=None,
     ):
         """Run simulation using SBP-SAT subgridding (JIT-compiled)."""
+        self._reject_refplane_ports_off_uniform_lane("subgridded (SBP-SAT)",
+                                                     compute_s_params)
         from rfx.runners.subgridded import run_subgridded_path
         return run_subgridded_path(
             self,
@@ -175,6 +177,8 @@ class _ExecuteMixin:
         """Run simulation on non-uniform grid with graded dz."""
         # Defense-in-depth: the NU runner does not honour stencil_order.
         self._check_stencil_order_supported()
+        self._reject_refplane_ports_off_uniform_lane("non-uniform mesh",
+                                                     compute_s_params)
         if subpixel_smoothing == "kottke_pec":
             raise NotImplementedError(
                 "subpixel_smoothing='kottke_pec' (Stage 2 unified PEC) "
@@ -193,6 +197,25 @@ class _ExecuteMixin:
             subpixel_smoothing=subpixel_smoothing,
             checkpoint=checkpoint,
         )
+
+    def _reject_refplane_ports_off_uniform_lane(self, path_name: str,
+                                                compute_s_params) -> None:
+        """Fail loudly when reference-plane ports hit a non-uniform lane.
+
+        The issue #313 plane V/I accumulators are wired only into the
+        uniform single-device production scan; silently returning legacy
+        port-cell off-diagonals on another lane would defeat the opt-in.
+        """
+        if compute_s_params is False:
+            return
+        if any(getattr(pe, "reference_plane_cells", None) is not None
+               for pe in self._ports):
+            raise NotImplementedError(
+                "add_port(reference_plane_cells=...) S-parameters are only "
+                f"supported on the uniform single-device run() lane, not "
+                f"the {path_name} lane. Drop the opt-in or use a uniform "
+                "mesh (issue #313)."
+            )
 
     @staticmethod
     def _warn_unsupported_run_kwargs(path_name: str,
@@ -617,6 +640,7 @@ class _ExecuteMixin:
         pec_occupancy_local = pec_occupancy
         lumped_port_sparam_specs: list = []
         wire_port_sparam_specs: list = []
+        wire_refplane_specs: list = []
         # Resolve a freq array once for downstream auto-build (issue #72)
         if port_s11_freqs is not None:
             _s11_freqs_arr = jnp.asarray(port_s11_freqs, dtype=jnp.float32)
@@ -688,6 +712,53 @@ class _ExecuteMixin:
                         component=pe.component,
                         freqs=_s11_freqs_arr,
                         impedance=float(pe.impedance),
+                    ))
+                # Opt-in reference-plane V/I accumulators (issue #313).
+                # Registered ONLY on the production-scan S-matrix driver
+                # path (_sparam_drive_idx is not None): the plane waves
+                # feed the OFF-diagonal S_ij and need the multi-drive
+                # sweep; forward()'s diagonal path is untouched (its S11
+                # never uses the planes), and the geometry derivation
+                # below needs concrete (non-traced) pec_mask values.
+                if (pe.reference_plane_cells is not None
+                        and _s11_freqs_arr is not None
+                        and _sparam_drive_idx is not None
+                        and wp_cells):
+                    from rfx.probes.refplane import build_wire_refplane_specs
+                    # Guard: the planes must not reach past another port
+                    # along the same line axis (they must sit on the
+                    # uniform line BETWEEN the ports).
+                    _axis_of = {"x": 0, "y": 1, "z": 2}
+                    _l_ax = _axis_of[pe.direction[1]]
+                    _sign = -1 if pe.direction[0] == "+" else +1
+                    _i_port = int(grid.position_to_index(pe.position)[_l_ax])
+                    _i_far = _i_port + _sign * 2 * int(pe.reference_plane_cells)
+                    for _other in self._ports:
+                        if _other is pe or _other.impedance == 0.0:
+                            continue
+                        _oi = int(grid.position_to_index(
+                            _other.position)[_l_ax])
+                        _in_zone = (_i_port < _oi <= _i_far) if _sign > 0 \
+                            else (_i_far <= _oi < _i_port)
+                        if _in_zone:
+                            raise ValueError(
+                                "reference_plane_cells: the reference "
+                                f"planes of the port at {pe.position} "
+                                f"(indices up to {_i_far} on axis {_l_ax}) "
+                                "reach past another port at "
+                                f"{_other.position} (index {_oi}). Reduce "
+                                "N so both planes stay on the uniform "
+                                "line between the ports.")
+                    wire_refplane_specs.extend(build_wire_refplane_specs(
+                        grid=grid,
+                        port_cells=wp_cells,
+                        e_component=pe.component,
+                        impedance=float(pe.impedance),
+                        direction=pe.direction,
+                        n_cells=int(pe.reference_plane_cells),
+                        freqs=_s11_freqs_arr,
+                        port_index=_sparam_port_idx,
+                        pec_mask=pec_mask,
                     ))
                 continue
 
@@ -993,6 +1064,7 @@ class _ExecuteMixin:
             aniso_inv_eps_smooth=(aniso_inv_eps_run is not None),
             lumped_port_sparams=lumped_port_sparam_specs or None,
             wire_port_sparams=wire_port_sparam_specs or None,
+            wire_refplane_sparams=wire_refplane_specs or None,
             lumped_rlc=rlc_metas,
             dft_planes=dft_planes if dft_planes else None,
             return_state=False,
@@ -1011,6 +1083,7 @@ class _ExecuteMixin:
             return {
                 "lumped": result.lumped_port_sparams,
                 "wire": result.wire_port_sparams,
+                "wire_refplane": result.wire_refplane_sparams,
                 "freqs": _raw_freqs,
             }
 

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -748,7 +748,12 @@ class _ExecuteMixin:
                                 "reach past another port at "
                                 f"{_other.position} (index {_oi}). Reduce "
                                 "N so both planes stay on the uniform "
-                                "line between the ports.")
+                                "line between the ports. Note: this check "
+                                "compares line-axis indices only "
+                                "(conservative), so a TRANSVERSELY "
+                                "separated port on a different parallel "
+                                "trace also trips it — the check can be "
+                                "revisited if that layout is needed.")
                     wire_refplane_specs.extend(build_wire_refplane_specs(
                         grid=grid,
                         port_cells=wp_cells,

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1617,9 +1617,73 @@ class _PreflightMixin:
         self._validate_cfg_waveguide_reference_plane(
             _w, cpml_thick_lo, cpml_thick_hi
         )
+        self._validate_cfg_refplane_placement(_w)
 
         self._check_waveguide_port_evanescent()
         self._check_msl_port_geometry(dx, cpml_thick_lo, cpml_thick_hi)
+
+    def _validate_cfg_refplane_placement(self, _w) -> None:
+        """Advisories for ``add_port(reference_plane_cells=...)`` (issue #313).
+
+        (a) ``reference_plane_cells < 10`` puts the measurement planes in the
+        port near field.  Measured on the canonical 16 mm thru (dx = 0.5 mm,
+        gap-trimmed V, 2026-07-10 battery): N=3 planes read Zc = 52-53 ohm
+        with |Im/Re| up to 8.2%, beta/(w/c) = 1.16-1.20, and a -3.1%
+        closed-box-referee |S21| residual, while N=10 planes read the clean
+        mid-line constants.  The Phase-0 pre-registration rule places BOTH
+        planes (N and 2N cells) >= 10 cells from every port.
+
+        (b) When SOME but not ALL impedance-carrying wire ports opt in, the
+        off-diagonal S entries involving a non-opted port silently stay on
+        the legacy port-cell path (only pairs where both ports opt in use
+        the plane waves) — surface that at preflight instead of letting the
+        mixed matrix pass unremarked.
+        """
+        wire_ports = [
+            pe for pe in self._ports
+            if pe.impedance != 0.0 and pe.extent is not None
+        ]
+        opted = [
+            pe for pe in wire_ports
+            if getattr(pe, "reference_plane_cells", None) is not None
+        ]
+        if not opted:
+            return
+        near = [pe for pe in opted if pe.reference_plane_cells < 10]
+        if near:
+            _w.warn(
+                PreflightWarning(
+                    f"{len(near)} reference-plane port(s) use "
+                    "reference_plane_cells < 10 — planes this close sit in "
+                    "the port near field. Measured on the canonical thru "
+                    "(dx = 0.5 mm, 2026-07-10 battery): N=3 planes read "
+                    "Zc = 52-53 ohm with |Im(Zc)/Re(Zc)| up to 8.2% and "
+                    "beta/(w/c) = 1.16-1.20 (vs the clean mid-line "
+                    "constants at N=10), and the closed-box-referee |S21| "
+                    "residual was -3.1%. The Phase-0 pre-registration rule "
+                    "(issue #313) places BOTH planes (N and 2N cells) >= 10 "
+                    "cells from every port — prefer "
+                    "reference_plane_cells >= 10 when the line length "
+                    "allows it.",
+                    code="refplane_near_field",
+                    source="_validate_cfg_refplane_placement",
+                ),
+                stacklevel=2,
+            )
+        if len(opted) != len(wire_ports):
+            _w.warn(
+                PreflightWarning(
+                    f"{len(opted)} of {len(wire_ports)} impedance-carrying "
+                    "wire ports opt into reference_plane_cells — "
+                    "off-diagonal S entries involving a non-opted port "
+                    "SILENTLY stay on the legacy port-cell path (only "
+                    "pairs where BOTH ports opt in use the plane waves). "
+                    "Opt in every wire port of the S-matrix, or none.",
+                    code="refplane_partial_optin",
+                    source="_validate_cfg_refplane_placement",
+                ),
+                stacklevel=2,
+            )
 
     def _validate_cfg_conformal_fine_dx(self, dx: float) -> None:
         """Flag the KNOWN conformal-PEC fine-mesh NaN before it wastes a run.

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -1053,6 +1053,14 @@ class _PortEntry:
     # values: "+x", "-x", "+y", "-y". None → auto-detect from position
     # at sim-build time.
     direction: str | None = None
+    # Opt-in reference-plane port waves for the wire S-matrix OFF-diagonal
+    # extraction (issue #313): when set to an integer N, the production
+    # scan registers TWO line V/I reference planes at N and 2N cells
+    # outboard (into the DUT) and the off-diagonal S_ij switch to plane
+    # waves with measured Zc/beta. None (default) = shipped port-cell
+    # behaviour, byte-identical. Diagonal S_jj always stays on the legacy
+    # path either way.
+    reference_plane_cells: int | None = None
 
 
 @dataclass(frozen=True)

--- a/rfx/probes/probes.py
+++ b/rfx/probes/probes.py
@@ -865,9 +865,13 @@ def decompose_lumped_s_matrix(v, i, z0):
 
     OPEN item: the port-based |S21| MAGNITUDE is deflated relative to the
     extractor-independent flux referee (flux-true |S21| 0.97-1.0 vs
-    0.52-0.67 here on the canonical thru); a drive-side normalization
-    scale entering ``a_j`` is under investigation — see the drive-side
-    normalization issue #313.
+    0.52-0.67 here on the canonical thru); the Phase-0 closed-box referee
+    traced it to the port-cell wave definitions themselves (near-field
+    dominated, do not conserve power) — see issue #313.  The opt-in
+    ``add_port(reference_plane_cells=N)`` reference-plane path
+    (``rfx.probes.refplane``) replaces the opted off-diagonals with line
+    plane waves; THIS default port-cell path keeps the deflation and its
+    committed regression locks unchanged.
 
     The safe-denominator guard replaces a zero incident wave by 1 (so
     S → 0 / 1 = 0 rather than NaN).  Mirrors ``extract_s_matrix`` exactly.
@@ -943,9 +947,13 @@ def decompose_wire_s_matrix(v, i, z0, port_cell_counts):
 
     OPEN item: the port-based |S21| MAGNITUDE is deflated relative to the
     extractor-independent flux referee (flux-true |S21| 0.97-1.0 vs
-    0.52-0.67 here on the canonical thru); a drive-side normalization
-    scale entering ``a_j`` is under investigation — see the drive-side
-    normalization issue #313.
+    0.52-0.67 here on the canonical thru); the Phase-0 closed-box referee
+    traced it to the port-cell wave definitions themselves (near-field
+    dominated, do not conserve power) — see issue #313.  The opt-in
+    ``add_port(reference_plane_cells=N)`` reference-plane path
+    (``rfx.probes.refplane``) replaces the opted off-diagonals with line
+    plane waves; THIS default port-cell path keeps the deflation and its
+    committed regression locks unchanged.
 
     Mirrors ``extract_s_matrix_wire`` line-for-line.
 

--- a/rfx/probes/refplane.py
+++ b/rfx/probes/refplane.py
@@ -1,0 +1,514 @@
+"""Reference-plane port waves for the lumped/wire S-matrix path (issue #313).
+
+Phase-1 implementation of the REFERENCE-PLANE architecture promoted by the
+issue #313 Phase-0 verdict (closed-box flux referee, 2026-07-10): the
+port-cell wave definitions at a wire port are near-field-dominated (0 cells
+from the discontinuity) and do not conserve power against a leak-free
+closed-box referee, while line V/I measured a few cells outboard on the
+uniform line does — the zero-free-parameter conservation identity
+``(|f|^2 - |b|^2)/Re(Zc)`` closed at +1.19% -> -0.28% at all 9 bins and the
+implied |S21| landed within ~2.5% of the box referee at all bins (shipped
+port-cell extractor: 33-47% off).  This module measures port waves at
+reference planes instead of at the port cells, for the OFF-DIAGONAL
+S-matrix entries only.
+
+Method (all conventions measured/anchored in the Phase-0 lane; constants in
+the issue #313 Phase-0 comment — do not re-derive):
+
+* Plane V = vertical-E gap line integral at an integer Yee plane N cells
+  outboard (into the DUT) along the line axis, over the same
+  component-axis cell range as the port (field is zero inside the PEC
+  trace, so dead extent cells contribute nothing).
+* Plane I = average of the two adjacent Ampere loops around the signal
+  trace at the half-planes (plane -/+ dx/2), centring I on the V plane
+  (2nd-order de-stagger).  Loop legs sit half a cell outside the PEC
+  trace bounding box (right-hand rule: positive current along the
+  +line-axis direction).
+* ``exp(+j*omega*dt/2)`` is applied to the H-derived (current) phasors at
+  extraction — the Yee leapfrog half-step.  Comparator anchor: this
+  collapses the receive-cell Ohm-law phase from +0.008..+0.018 to ~0
+  (measured, Phase 0).
+* Forward/backward split with a MEASURED two-plane line-invariant
+  ``Zc^2 = (V1^2 - V2^2)/(I1^2 - I2^2)`` (exact for any load on a uniform
+  line; measured 47.9-48.6 ohm on the canonical thru — never assume the
+  port's nominal 50 ohm).  The opt-in therefore registers TWO planes per
+  port: the reference plane at N cells outboard and a second plane at 2N
+  cells outboard.
+* Phase-only de-embedding to the port plane with MEASURED beta from the
+  same two planes (slow-wave beta/(w/c) = 1.048-1.061 measured on the
+  canonical thru — far above numerical-dispersion class, so an analytic
+  beta would be wrong).  Magnitude-neutral by construction.
+* Off-diagonals: ``S_ij = b_inc_plane(i) / a_fwd_plane(j)`` where both
+  ports opted in.  DIAGONAL ``S_jj`` always stays on the byte-frozen
+  legacy path (``decompose_wire_s_matrix`` — issue #308 conventions),
+  untouched.
+
+The scan-side DFT accumulators mirror the coax plane-V/I machinery class
+(``extract_coaxial_plane_vi_from_dft`` and the wire/lumped
+``*_sparam_accs`` carry channels in ``rfx.simulation``): static geometry is
+precomputed here into :class:`WireRefPlaneSpec`, and the production
+``jax.lax.scan`` body accumulates the rect-DFT phasors inline (same
+pre-source-injection sample point and DFT kernel as the port-cell
+accumulators).
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import numpy as np
+
+import jax.numpy as jnp
+
+_COMP_AXIS = {"ex": 0, "ey": 1, "ez": 2}
+_H_OF_AXIS = {0: "hx", 1: "hy", 2: "hz"}
+_AXIS_OF_NAME = {"x": 0, "y": 1, "z": 2}
+
+
+class WireRefPlaneSpec(NamedTuple):
+    """Static reference-plane V/I DFT spec for the compiled scan.
+
+    One spec per (port, plane slot); an opted port registers TWO
+    (``plane_slot`` 0 at ``n_cells_outboard = N`` and slot 1 at ``2N``).
+    All index fields are Python ints (static under ``jax.jit``);
+    ``freqs`` is the DFT frequency array.
+    """
+
+    port_index: int          # index into the sparam-eligible port order
+    plane_slot: int          # 0 = reference plane (N cells), 1 = Zc plane (2N)
+    n_cells_outboard: int    # this plane's offset from the port plane (cells)
+    outboard_sign: int       # +1/-1: DUT direction along the line axis
+    line_axis: int           # 0/1/2 — the transmission-line axis
+    plane_index: int         # integer Yee plane index along line_axis
+    e_component: str         # port E component ("ex"/"ey"/"ez")
+    comp_axis: int           # E-component axis
+    e_lo: int                # component-axis cell range of the gap V integral
+    e_hi: int                # (exclusive)
+    third_index: int         # fixed index on the remaining axis
+    hu_component: str        # H along u  ((a, u, v) right-handed cyclic)
+    hv_component: str        # H along v
+    u_axis: int
+    v_axis: int
+    u_lo_leg: int            # Hv legs (columns) just outside the trace bbox
+    u_hi_leg: int
+    v_lo_leg: int            # Hu legs (rows) just outside the trace bbox
+    v_hi_leg: int
+    u_span_lo: int           # Hu leg span (exclusive hi)
+    u_span_hi: int
+    v_span_lo: int           # Hv leg span (exclusive hi)
+    v_span_hi: int
+    freqs: object            # (n_freqs,) jnp.ndarray
+    impedance: float         # port Z0 (bookkeeping only — never used as Zc)
+
+
+def _tri(by_axis: dict) -> tuple:
+    """Assemble an (i, j, k) index tuple from an {axis: index-or-slice} map."""
+    return (by_axis[0], by_axis[1], by_axis[2])
+
+
+def _trace_bbox_at_plane(pec2d: np.ndarray, seed_uv: tuple[int, int]):
+    """Bounding box of the signal-trace PEC connected component in a slice.
+
+    ``pec2d`` is the (nu, nv) boolean PEC cross-section at the reference
+    plane; ``seed_uv`` is the transverse cell of the port's extent END
+    (which sits in/at the trace conductor).  If the seed cell itself is
+    not PEC, the nearest PEC cell (Euclidean) seeds the component.
+    4-connected BFS; returns (u_lo, u_hi, v_lo, v_hi) inclusive.
+    """
+    nu, nv = pec2d.shape
+    su, sv = seed_uv
+    if not (0 <= su < nu and 0 <= sv < nv):
+        raise ValueError(
+            f"reference-plane seed cell {seed_uv} outside the grid slice "
+            f"({nu}x{nv})")
+    if not pec2d[su, sv]:
+        cand = np.argwhere(pec2d)
+        if cand.size == 0:
+            raise ValueError(
+                "reference_plane_cells: no PEC conductor found in the "
+                "reference-plane cross-section — the plane V/I method "
+                "requires a PEC signal trace (uniform transmission line) "
+                "at the plane. Check the port direction and N.")
+        d2 = (cand[:, 0] - su) ** 2 + (cand[:, 1] - sv) ** 2
+        su, sv = (int(x) for x in cand[int(np.argmin(d2))])
+    # 4-connected BFS
+    seen = np.zeros_like(pec2d, dtype=bool)
+    stack = [(su, sv)]
+    seen[su, sv] = True
+    u_lo = u_hi = su
+    v_lo = v_hi = sv
+    while stack:
+        u, v = stack.pop()
+        u_lo, u_hi = min(u_lo, u), max(u_hi, u)
+        v_lo, v_hi = min(v_lo, v), max(v_hi, v)
+        for du, dv in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+            uu, vv = u + du, v + dv
+            if 0 <= uu < nu and 0 <= vv < nv and pec2d[uu, vv] \
+                    and not seen[uu, vv]:
+                seen[uu, vv] = True
+                stack.append((uu, vv))
+    return u_lo, u_hi, v_lo, v_hi
+
+
+def build_wire_refplane_specs(
+    *,
+    grid,
+    port_cells,
+    e_component: str,
+    impedance: float,
+    direction: str,
+    n_cells: int,
+    freqs,
+    port_index: int,
+    pec_mask,
+) -> tuple:
+    """Build the two per-port :class:`WireRefPlaneSpec` entries.
+
+    Parameters
+    ----------
+    grid : Grid
+    port_cells : list of (i, j, k)
+        The wire port's rasterized cells (``_wire_port_cells`` output).
+    e_component : str
+        Port E component.
+    direction : str
+        The port's OUTWARD-normal direction ("+x"/"-x"/"+y"/"-y" —
+        ``add_port`` semantics).  The reference planes go the OPPOSITE
+        way (into the DUT along the line axis).
+    n_cells : int
+        N — the reference-plane offset in cells; the second (Zc) plane
+        registers at 2N.
+    pec_mask : array-like of bool
+        The geometry PEC mask BEFORE port-cell clearing (the trace
+        conductor must be present at the plane cross-sections).
+
+    Returns
+    -------
+    (WireRefPlaneSpec, WireRefPlaneSpec)
+        Plane slot 0 (N cells outboard) and slot 1 (2N cells outboard).
+
+    Raises
+    ------
+    ValueError
+        On geometry that cannot support the method: plane out of bounds,
+        no PEC trace at a plane, or a NON-uniform line (the PEC trace
+        cross-section bounding boxes at the two planes differ — the
+        two-plane Zc invariant requires a uniform line between them).
+    """
+    if direction is None or direction not in ("+x", "-x", "+y", "-y"):
+        raise ValueError(
+            "reference_plane_cells requires an explicit port "
+            f"direction ('+x'/'-x'/'+y'/'-y'), got {direction!r}")
+    if pec_mask is None:
+        raise ValueError(
+            "reference_plane_cells: the simulation has no PEC geometry — "
+            "the plane V/I method requires a PEC signal trace (uniform "
+            "transmission line).")
+    n_cells = int(n_cells)
+    if n_cells < 1:
+        raise ValueError(f"reference_plane_cells must be >= 1, got {n_cells}")
+
+    line_axis = _AXIS_OF_NAME[direction[1]]
+    outboard_sign = -1 if direction[0] == "+" else +1
+    comp_axis = _COMP_AXIS[e_component]
+    if comp_axis == line_axis:
+        raise ValueError(
+            f"reference_plane_cells: port component {e_component!r} lies "
+            f"along the line axis {direction!r} — the gap-V line integral "
+            "must be transverse to the line.")
+    third_axis = 3 - line_axis - comp_axis
+
+    cells = [tuple(int(x) for x in c) for c in port_cells]
+    if not cells:
+        raise ValueError("reference_plane_cells: empty wire port cell list")
+    i_port = cells[0][line_axis]
+    third_index = cells[0][third_axis]
+    comp_ids = sorted(c[comp_axis] for c in cells)
+    e_lo, e_hi = comp_ids[0], comp_ids[-1] + 1
+    # The extent END cell (top of the wire — sits in/at the trace) seeds
+    # the trace connected component.  _wire_port_cells spans ascending
+    # component-axis indices from the base; the end is the last cell.
+    end_cell = max(cells, key=lambda c: c[comp_axis])
+
+    # (a, u, v) right-handed cyclic axes for the Ampere loop.
+    u_axis = (line_axis + 1) % 3
+    v_axis = (line_axis + 2) % 3
+    hu_component = _H_OF_AXIS[u_axis]
+    hv_component = _H_OF_AXIS[v_axis]
+
+    pec3d = np.asarray(pec_mask, dtype=bool)
+    shape = pec3d.shape
+
+    specs = []
+    bboxes = []
+    for slot, off in enumerate((n_cells, 2 * n_cells)):
+        plane_index = i_port + outboard_sign * off
+        if not (1 <= plane_index < shape[line_axis]):
+            raise ValueError(
+                f"reference_plane_cells: plane {slot} (index {plane_index} "
+                f"along axis {line_axis}) is outside the grid "
+                f"(n={shape[line_axis]}; the dual Ampere loops need "
+                "plane_index-1 >= 0). Reduce N or move the port.")
+        # 2D PEC cross-section with axes ordered (u, v).
+        sl = np.take(pec3d, plane_index, axis=line_axis)
+        # np.take drops line_axis; remaining axes keep their relative order.
+        rem = [a for a in (0, 1, 2) if a != line_axis]
+        pos = {a: rem.index(a) for a in rem}
+        pec2d = np.transpose(sl, (pos[u_axis], pos[v_axis]))
+        seed_uv = (end_cell[u_axis], end_cell[v_axis])
+        u_lo, u_hi, v_lo, v_hi = _trace_bbox_at_plane(pec2d, seed_uv)
+        bboxes.append((u_lo, u_hi, v_lo, v_hi))
+        # Loop legs: Hv columns half a cell outside the bbox u-faces,
+        # Hu rows half a cell outside the bbox v-faces (Yee stagger).
+        u_lo_leg, u_hi_leg = u_lo - 1, u_hi + 1
+        v_lo_leg, v_hi_leg = v_lo - 1, v_hi + 1
+        u_span_lo, u_span_hi = u_lo, u_hi + 2
+        v_span_lo, v_span_hi = v_lo, v_hi + 2
+        nu, nv = shape[u_axis], shape[v_axis]
+        if u_lo_leg < 0 or u_hi_leg >= nu or v_lo_leg < 0 or v_hi_leg >= nv \
+                or u_span_hi > nu or v_span_hi > nv:
+            raise ValueError(
+                "reference_plane_cells: the Ampere loop around the trace "
+                f"bbox u[{u_lo},{u_hi}] v[{v_lo},{v_hi}] leaves the grid "
+                f"({nu}x{nv} transverse) — the trace touches the domain "
+                "boundary at the reference plane.")
+        specs.append(WireRefPlaneSpec(
+            port_index=int(port_index),
+            plane_slot=slot,
+            n_cells_outboard=off,
+            outboard_sign=outboard_sign,
+            line_axis=line_axis,
+            plane_index=int(plane_index),
+            e_component=e_component,
+            comp_axis=comp_axis,
+            e_lo=int(e_lo),
+            e_hi=int(e_hi),
+            third_index=int(third_index),
+            hu_component=hu_component,
+            hv_component=hv_component,
+            u_axis=u_axis,
+            v_axis=v_axis,
+            u_lo_leg=int(u_lo_leg),
+            u_hi_leg=int(u_hi_leg),
+            v_lo_leg=int(v_lo_leg),
+            v_hi_leg=int(v_hi_leg),
+            u_span_lo=int(u_span_lo),
+            u_span_hi=int(u_span_hi),
+            v_span_lo=int(v_span_lo),
+            v_span_hi=int(v_span_hi),
+            freqs=freqs,
+            impedance=float(impedance),
+        ))
+    if bboxes[0] != bboxes[1]:
+        raise ValueError(
+            "reference_plane_cells: the PEC trace cross-section differs "
+            f"between the two planes (bbox {bboxes[0]} at N={n_cells} vs "
+            f"{bboxes[1]} at 2N={2*n_cells}) — the two-plane Zc invariant "
+            "requires a UNIFORM line spanning both planes. Reduce N or "
+            "move the planes onto the uniform section.")
+    return tuple(specs)
+
+
+def wire_refplane_step_vi(st, spec: WireRefPlaneSpec, dx):
+    """Per-step (V, I_minus, I_plus) at one reference plane.
+
+    Called inside the production scan body at the same pre-source-injection
+    sample point as the port-cell V/I accumulators.  The reference plane
+    sits >= 1 cell away from every source cell, so pre- vs post-injection
+    sampling is identical here (injection only touches the driven port
+    cell within a step) — this is exactly what the plane architecture
+    buys over port-cell sampling.
+
+    V = -sum(E over the gap cells) * dx (FDTD sign, potential of the
+    trace relative to the return).  I_minus / I_plus are the Ampere-loop
+    line integrals around the trace at the half-planes plane -/+ dx/2;
+    the caller averages them and applies the exp(+j*w*dt/2) half-step
+    correction AT EXTRACTION (raw phasors are accumulated uncorrected).
+    """
+    a, u, v = spec.line_axis, spec.u_axis, spec.v_axis
+    e_field = getattr(st, spec.e_component)
+    e_idx = _tri({a: spec.plane_index,
+                  spec.comp_axis: slice(spec.e_lo, spec.e_hi),
+                  3 - a - spec.comp_axis: spec.third_index})
+    v_plane = -jnp.sum(e_field[e_idx]) * dx
+
+    hv = getattr(st, spec.hv_component)
+    hu = getattr(st, spec.hu_component)
+    v_span = slice(spec.v_span_lo, spec.v_span_hi)
+    u_span = slice(spec.u_span_lo, spec.u_span_hi)
+
+    def _loop(ah):
+        s_hv = (jnp.sum(hv[_tri({a: ah, u: spec.u_hi_leg, v: v_span})])
+                - jnp.sum(hv[_tri({a: ah, u: spec.u_lo_leg, v: v_span})]))
+        s_hu = (jnp.sum(hu[_tri({a: ah, v: spec.v_hi_leg, u: u_span})])
+                - jnp.sum(hu[_tri({a: ah, v: spec.v_lo_leg, u: u_span})]))
+        return (s_hv - s_hu) * dx
+
+    return v_plane, _loop(spec.plane_index - 1), _loop(spec.plane_index)
+
+
+# ---------------------------------------------------------------------------
+# Extraction-side math (pure NumPy, complex128)
+# ---------------------------------------------------------------------------
+
+def refplane_centered_current(i_minus, i_plus, freqs, dt):
+    """Plane-centred, half-step-corrected current phasor.
+
+    Averages the two adjacent Ampere loops (centres I on the V plane) and
+    applies the Yee leapfrog ``exp(+j*w*dt/2)`` correction to the
+    H-derived phasor (comparator anchor: collapses the receive-cell
+    Ohm-law phase from +0.008..+0.018 to ~0 — Phase 0, issue #313).
+    """
+    w = 2.0 * np.pi * np.asarray(freqs, dtype=np.float64)
+    hcorr = np.exp(+1j * w * dt / 2.0)
+    return 0.5 * (np.asarray(i_minus, dtype=np.complex128)
+                  + np.asarray(i_plus, dtype=np.complex128)) * hcorr
+
+
+def refplane_zc_two_plane(v1, i1, v2, i2):
+    """Measured line impedance from the exact two-plane invariant.
+
+    ``V^2 - Zc^2 I^2 = 4 f b`` is x-invariant on a uniform line for ANY
+    load, so ``Zc^2 = (V1^2 - V2^2)/(I1^2 - I2^2)`` — parameter-free, no
+    fit.  Root sign fixed to Re(Zc) >= 0.
+    """
+    v1 = np.asarray(v1, dtype=np.complex128)
+    v2 = np.asarray(v2, dtype=np.complex128)
+    i1 = np.asarray(i1, dtype=np.complex128)
+    i2 = np.asarray(i2, dtype=np.complex128)
+    den = i1 ** 2 - i2 ** 2
+    den = np.where(np.abs(den) > 0.0, den, np.ones_like(den))
+    zc = np.sqrt((v1 ** 2 - v2 ** 2) / den)
+    return np.where(zc.real < 0.0, -zc, zc)
+
+
+def refplane_split(v, i_corr, zc, outboard_sign):
+    """(outgoing, incoming) wave pair at a plane.
+
+    With V = trace-vs-return potential and I positive along the +line
+    axis, ``(V + Zc I)/2`` travels +axis and ``(V - Zc I)/2`` travels
+    -axis.  ``outgoing`` travels outboard (away from the port, into the
+    DUT); ``incoming`` travels toward the port.
+    """
+    v = np.asarray(v, dtype=np.complex128)
+    w_plus = 0.5 * (v + zc * i_corr)
+    w_minus = 0.5 * (v - zc * i_corr)
+    if outboard_sign > 0:
+        return w_plus, w_minus
+    return w_minus, w_plus
+
+
+def refplane_beta(out_near, out_far, separation_m):
+    """Measured per-bin propagation constant from the outgoing wave.
+
+    ``out_far = out_near * exp(-j*beta*d)`` for the outboard-travelling
+    wave between the plane pair (d = N*dx), so
+    ``beta = -angle(out_far/out_near)/d`` — real, per frequency bin.
+    """
+    near = np.asarray(out_near, dtype=np.complex128)
+    far = np.asarray(out_far, dtype=np.complex128)
+    safe = np.where(np.abs(near) > 0.0, near, np.ones_like(near))
+    return -np.angle(far / safe) / float(separation_m)
+
+
+def decompose_wire_s_matrix_with_reference_planes(
+    v_all,
+    i_all,
+    z0,
+    port_cell_counts,
+    *,
+    plane_v,
+    plane_im,
+    plane_ip,
+    plane_enabled,
+    plane_offsets,
+    outboard_signs,
+    freqs,
+    dt,
+    dx,
+    return_line_diagnostics: bool = False,
+):
+    """Shared plane-aware wire S-matrix decomposition (driver + eager entry).
+
+    Starts from the byte-frozen legacy decomposition
+    (:func:`rfx.probes.probes.decompose_wire_s_matrix` — diagonals AND any
+    off-diagonal whose port pair is not fully opted in), then replaces
+    ``S[i, j]`` (i != j, both ports opted in) with the reference-plane
+    waves::
+
+        a_j (drive)   = outgoing(plane j0) * exp(+j*beta_j*N_j*dx) / sqrt(Re Zc_j)
+        b_i (receive) = incoming(plane i0) * exp(-j*beta_i*N_i*dx) / sqrt(Re Zc_i)
+        S[i, j]       = b_i / a_j
+
+    Zc_p and beta_p are measured per port from its OWN drive pass (the
+    strongest local signal; the two-plane invariant holds for any load).
+    Diagonals are never touched.
+
+    Parameters
+    ----------
+    v_all, i_all : (n_ports, n_ports, n_freqs) complex
+        Port-cell midpoint V/I phasors (legacy accumulators) —
+        ``[drive j, receive i]``.
+    plane_v, plane_im, plane_ip : (n_ports, n_ports, 2, n_freqs) complex
+        Raw plane accumulators ``[drive j, port p, plane slot]``; zeros
+        where a port did not opt in.
+    plane_enabled : (n_ports,) bool
+    plane_offsets : (n_ports,) int — N per opted port (slot 1 is at 2N).
+    outboard_signs : (n_ports,) int
+    dt, dx : float — timestep and cell size (uniform lane).
+    return_line_diagnostics : bool
+        When True also return a dict with per-port measured ``zc`` and
+        ``beta`` arrays plus the plane wave pairs (R5 inspection surface).
+    """
+    from rfx.probes.probes import decompose_wire_s_matrix
+
+    # np.array (copy): the jnp output buffer is read-only and the plane
+    # path overwrites the opted off-diagonals in place below.
+    S = np.array(
+        decompose_wire_s_matrix(v_all, i_all, z0, port_cell_counts),
+        dtype=np.complex64,
+    )
+    n_ports = S.shape[0]
+    opted = [p for p in range(n_ports) if bool(plane_enabled[p])]
+    diagnostics: dict = {"zc": {}, "beta": {}, "opted": tuple(opted)}
+    if len(opted) >= 2:
+        zc = {}
+        beta = {}
+        for p in opted:
+            i1 = refplane_centered_current(
+                plane_im[p, p, 0], plane_ip[p, p, 0], freqs, dt)
+            i2 = refplane_centered_current(
+                plane_im[p, p, 1], plane_ip[p, p, 1], freqs, dt)
+            v1 = np.asarray(plane_v[p, p, 0], dtype=np.complex128)
+            v2 = np.asarray(plane_v[p, p, 1], dtype=np.complex128)
+            zc[p] = refplane_zc_two_plane(v1, i1, v2, i2)
+            out1, _ = refplane_split(v1, i1, zc[p], outboard_signs[p])
+            out2, _ = refplane_split(v2, i2, zc[p], outboard_signs[p])
+            beta[p] = refplane_beta(out1, out2,
+                                    int(plane_offsets[p]) * float(dx))
+            diagnostics["zc"][p] = zc[p]
+            diagnostics["beta"][p] = beta[p]
+        for j in opted:
+            d_j = int(plane_offsets[j]) * float(dx)
+            vj = np.asarray(plane_v[j, j, 0], dtype=np.complex128)
+            ij = refplane_centered_current(
+                plane_im[j, j, 0], plane_ip[j, j, 0], freqs, dt)
+            out_j, _ = refplane_split(vj, ij, zc[j], outboard_signs[j])
+            a_port = (out_j * np.exp(+1j * beta[j] * d_j)
+                      / np.sqrt(zc[j].real))
+            safe_a = np.where(np.abs(a_port) > 0.0, a_port,
+                              np.ones_like(a_port))
+            for i in opted:
+                if i == j:
+                    continue  # DIAGONAL: byte-frozen legacy path, always.
+                d_i = int(plane_offsets[i]) * float(dx)
+                vi_ = np.asarray(plane_v[j, i, 0], dtype=np.complex128)
+                ii = refplane_centered_current(
+                    plane_im[j, i, 0], plane_ip[j, i, 0], freqs, dt)
+                _, in_i = refplane_split(vi_, ii, zc[i], outboard_signs[i])
+                b_port = (in_i * np.exp(-1j * beta[i] * d_i)
+                          / np.sqrt(zc[i].real))
+                S[i, j, :] = (b_port / safe_a).astype(np.complex64)
+    if return_line_diagnostics:
+        return S, diagnostics
+    return S

--- a/rfx/probes/refplane.py
+++ b/rfx/probes/refplane.py
@@ -484,7 +484,14 @@ def decompose_wire_s_matrix_with_reference_planes(
     dt, dx : float — timestep and cell size (uniform lane).
     return_line_diagnostics : bool
         When True also return a dict with per-port measured ``zc`` and
-        ``beta`` arrays plus the plane wave pairs (R5 inspection surface).
+        ``beta`` arrays plus the raw at-plane wave pairs (R5 inspection
+        surface): ``diagnostics["plane_waves"][(j, p, slot)] =
+        (outgoing, incoming)`` for drive pass ``j``, port ``p``'s plane
+        ``slot`` (0 = reference plane, 1 = 2N plane; drive-port slot-1
+        pairs and all slot-0 pairs are recorded).  These are the
+        NON-de-embedded waves at the plane — the zero-free-parameter
+        conservation identity ``(|out|^2 - |inc|^2)/Re(Zc)`` equals the
+        net line power there (Phase-0 falsifier F2).
     """
     from rfx.probes.probes import decompose_wire_s_matrix
 
@@ -496,7 +503,8 @@ def decompose_wire_s_matrix_with_reference_planes(
     )
     n_ports = S.shape[0]
     opted = [p for p in range(n_ports) if bool(plane_enabled[p])]
-    diagnostics: dict = {"zc": {}, "beta": {}, "opted": tuple(opted)}
+    diagnostics: dict = {"zc": {}, "beta": {}, "opted": tuple(opted),
+                         "plane_waves": {}}
     if len(opted) >= 2:
         zc = {}
         beta = {}
@@ -508,12 +516,14 @@ def decompose_wire_s_matrix_with_reference_planes(
             v1 = np.asarray(plane_v[p, p, 0], dtype=np.complex128)
             v2 = np.asarray(plane_v[p, p, 1], dtype=np.complex128)
             zc[p] = refplane_zc_two_plane(v1, i1, v2, i2)
-            out1, _ = refplane_split(v1, i1, zc[p], outboard_signs[p])
-            out2, _ = refplane_split(v2, i2, zc[p], outboard_signs[p])
+            out1, in1 = refplane_split(v1, i1, zc[p], outboard_signs[p])
+            out2, in2 = refplane_split(v2, i2, zc[p], outboard_signs[p])
             beta[p] = refplane_beta(out1, out2,
                                     int(plane_offsets[p]) * float(dx))
             diagnostics["zc"][p] = zc[p]
             diagnostics["beta"][p] = beta[p]
+            diagnostics["plane_waves"][(p, p, 0)] = (out1, in1)
+            diagnostics["plane_waves"][(p, p, 1)] = (out2, in2)
         for j in opted:
             d_j = int(plane_offsets[j]) * float(dx)
             vj = np.asarray(plane_v[j, j, 0], dtype=np.complex128)
@@ -531,7 +541,9 @@ def decompose_wire_s_matrix_with_reference_planes(
                 vi_ = np.asarray(plane_v[j, i, 0], dtype=np.complex128)
                 ii = refplane_centered_current(
                     plane_im[j, i, 0], plane_ip[j, i, 0], freqs, dt)
-                _, in_i = refplane_split(vi_, ii, zc[i], outboard_signs[i])
+                out_i, in_i = refplane_split(vi_, ii, zc[i],
+                                             outboard_signs[i])
+                diagnostics["plane_waves"][(j, i, 0)] = (out_i, in_i)
                 b_port = (in_i * np.exp(-1j * beta[i] * d_i)
                           / np.sqrt(zc[i].real))
                 S[i, j, :] = (b_port / safe_a).astype(np.complex64)

--- a/rfx/probes/refplane.py
+++ b/rfx/probes/refplane.py
@@ -59,6 +59,7 @@ accumulators).
 
 from __future__ import annotations
 
+import warnings
 from typing import NamedTuple
 
 import numpy as np
@@ -68,6 +69,21 @@ import jax.numpy as jnp
 _COMP_AXIS = {"ex": 0, "ey": 1, "ez": 2}
 _H_OF_AXIS = {0: "hx", 1: "hy", 2: "hz"}
 _AXIS_OF_NAME = {"x": 0, "y": 1, "z": 2}
+
+# Zc reality witness: near-field-contaminated planes show up in the measured
+# line impedance as an imaginary part (a lossless uniform line reads a
+# (near-)real Zc).  Measured provenance (canonical 16 mm thru, dx = 0.5 mm,
+# gap-trimmed V, 2026-07-10 battery): N=3 planes in the port near field read
+# max|Im(Zc)/Re(Zc)| = 8.2%; clean N=10 mid-line planes read <= 1.2%.  0.03
+# is the class boundary between those two measured classes (not a derived
+# threshold).
+_ZC_IM_RE_WARN_RATIO = 0.03
+
+# Beta wrap guard: the measured per-bin beta comes from the phase angle
+# between two planes separated by N*dx, which is unambiguous only for
+# |beta|*N*dx < pi.  Guard at 90% of the wrap limit (safety margin, not a
+# measured constant — the measurement is exactly ambiguous AT pi).
+_BETA_WRAP_GUARD_FRACTION = 0.9
 
 
 class WireRefPlaneSpec(NamedTuple):
@@ -516,10 +532,48 @@ def decompose_wire_s_matrix_with_reference_planes(
             v1 = np.asarray(plane_v[p, p, 0], dtype=np.complex128)
             v2 = np.asarray(plane_v[p, p, 1], dtype=np.complex128)
             zc[p] = refplane_zc_two_plane(v1, i1, v2, i2)
+            # Zc reality witness (see _ZC_IM_RE_WARN_RATIO provenance): a
+            # large imaginary part in the measured line impedance means the
+            # planes sit in the port near field, where reactive fields
+            # contaminate the two-plane V/I invariant.
+            _re = np.abs(zc[p].real)
+            _im_re = float(np.max(
+                np.abs(zc[p].imag) / np.where(_re > 0.0, _re, 1.0)))
+            if _im_re > _ZC_IM_RE_WARN_RATIO:
+                warnings.warn(
+                    f"reference-plane port {p}: measured line impedance has "
+                    f"max|Im(Zc)/Re(Zc)| = {_im_re:.3f} > "
+                    f"{_ZC_IM_RE_WARN_RATIO} — a lossless uniform line reads "
+                    "a (near-)real Zc, so this indicates the reference "
+                    "planes sit in the port NEAR FIELD (reactive port "
+                    "fields contaminate the two-plane V/I invariant; "
+                    "measured 8.2% at N=3 vs <= 1.2% at N=10 on the "
+                    "canonical thru). The plane off-diagonals may be "
+                    "biased; increase reference_plane_cells so both planes "
+                    "(N and 2N cells) sit >= 10 cells from every port.",
+                    UserWarning, stacklevel=2)
             out1, in1 = refplane_split(v1, i1, zc[p], outboard_signs[p])
             out2, in2 = refplane_split(v2, i2, zc[p], outboard_signs[p])
-            beta[p] = refplane_beta(out1, out2,
-                                    int(plane_offsets[p]) * float(dx))
+            d_sep = int(plane_offsets[p]) * float(dx)
+            beta[p] = refplane_beta(out1, out2, d_sep)
+            # Beta wrap guard: the two-plane phase is unambiguous only for
+            # 0 < beta*N*dx < pi.  Both N and the extraction frequencies
+            # are known here, so fail loudly instead of de-embedding with
+            # a wrapped (or unphysical non-positive) beta.
+            _bd = np.abs(beta[p]) * d_sep
+            if np.any(beta[p] <= 0.0) or np.any(
+                    _bd > _BETA_WRAP_GUARD_FRACTION * np.pi):
+                raise ValueError(
+                    f"reference-plane port {p}: the measured per-bin beta "
+                    "is non-positive or too close to the +-pi phase-wrap "
+                    "limit of the two-plane measurement "
+                    f"(min beta = {float(np.min(beta[p])):.4g} rad/m, "
+                    f"max |beta|*N*dx = {float(np.max(_bd)):.4g} rad vs "
+                    f"guard {_BETA_WRAP_GUARD_FRACTION}*pi = "
+                    f"{_BETA_WRAP_GUARD_FRACTION * np.pi:.4g} rad over the "
+                    f"plane separation N*dx = {d_sep:.4g} m). Reduce "
+                    "reference_plane_cells (N) or the top extraction "
+                    "frequency — both are known at extraction time.")
             diagnostics["zc"][p] = zc[p]
             diagnostics["beta"][p] = beta[p]
             diagnostics["plane_waves"][(p, p, 0)] = (out1, in1)

--- a/rfx/probes/refplane.py
+++ b/rfx/probes/refplane.py
@@ -15,10 +15,15 @@ S-matrix entries only.
 Method (all conventions measured/anchored in the Phase-0 lane; constants in
 the issue #313 Phase-0 comment — do not re-derive):
 
-* Plane V = vertical-E gap line integral at an integer Yee plane N cells
-  outboard (into the DUT) along the line axis, over the same
-  component-axis cell range as the port (field is zero inside the PEC
-  trace, so dead extent cells contribute nothing).
+* Plane V = vertical-E GAP line integral at an integer Yee plane N cells
+  outboard (into the DUT) along the line axis — over the port's
+  component-axis cell range TRIMMED to the cells not PEC-masked at the
+  plane column.  Measured witness (A/B vs point probes, 2026-07-10): the
+  in-trace Ez edge of a one-cell-thick PEC trace is NOT zeroed by the
+  staircase mask convention and carries ~0.21 of the gap field, so an
+  untrimmed port-extent integral mis-scales V by ~0.89 (which cancels in
+  S but corrupts the reported Zc; Phase-0 measured 47.9-48.6 ohm with
+  the 2-cell gap integral).
 * Plane I = average of the two adjacent Ampere loops around the signal
   trace at the half-planes (plane -/+ dx/2), centring I on the V plane
   (2nd-order de-stagger).  Loop legs sit half a cell outside the PEC
@@ -258,6 +263,27 @@ def build_wire_refplane_specs(
         seed_uv = (end_cell[u_axis], end_cell[v_axis])
         u_lo, u_hi, v_lo, v_hi = _trace_bbox_at_plane(pec2d, seed_uv)
         bboxes.append((u_lo, u_hi, v_lo, v_hi))
+        # GAP trim for the V line integral: keep only the port-extent
+        # cells NOT PEC-masked at the plane column.  The in-conductor Ez
+        # edge of a one-cell-thick trace is not zeroed by the staircase
+        # mask convention and carries ~0.21 of the gap field (measured
+        # A/B vs point probes) — including it re-scales V (cancels in S,
+        # corrupts the measured Zc).  The gap must be one contiguous run.
+        gap = [c for c in range(e_lo, e_hi)
+               if not pec3d[_tri({line_axis: plane_index,
+                                  comp_axis: c,
+                                  third_axis: third_index})]]
+        if not gap:
+            raise ValueError(
+                "reference_plane_cells: every port-extent cell at the "
+                f"reference plane (index {plane_index}) is inside PEC — "
+                "no gap for the V line integral.")
+        if gap[-1] - gap[0] + 1 != len(gap):
+            raise ValueError(
+                "reference_plane_cells: the non-PEC gap cells at the "
+                f"reference plane are not contiguous ({gap}) — the gap-V "
+                "line integral is ill-defined for this geometry.")
+        gap_lo, gap_hi = gap[0], gap[-1] + 1
         # Loop legs: Hv columns half a cell outside the bbox u-faces,
         # Hu rows half a cell outside the bbox v-faces (Yee stagger).
         u_lo_leg, u_hi_leg = u_lo - 1, u_hi + 1
@@ -281,8 +307,8 @@ def build_wire_refplane_specs(
             plane_index=int(plane_index),
             e_component=e_component,
             comp_axis=comp_axis,
-            e_lo=int(e_lo),
-            e_hi=int(e_hi),
+            e_lo=int(gap_lo),
+            e_hi=int(gap_hi),
             third_index=int(third_index),
             hu_component=hu_component,
             hv_component=hv_component,

--- a/rfx/probes/sparam_driver.py
+++ b/rfx/probes/sparam_driver.py
@@ -33,7 +33,8 @@ from rfx.probes.probes import (
 
 
 def compute_lumped_wire_s_matrix_via_scan(
-    sim, freqs, *, n_steps=None, return_vi_dump=False
+    sim, freqs, *, n_steps=None, return_vi_dump=False,
+    return_refplane_diagnostics=False,
 ):
     """Full lumped/wire N-port S-matrix via the production scan.
 
@@ -60,7 +61,15 @@ def compute_lumped_wire_s_matrix_via_scan(
         accumulators with the identical sign conventions, shapes
         ``(n_driven, n_ports, n_freqs)``, and field names/order as the eager
         bundle.  This lets the production-scan driver feed the existing replay
-        path byte-for-byte (item-5 Stage 2, PURE ADD).
+        path byte-for-byte (item-5 Stage 2, PURE ADD).  Not supported
+        together with reference-plane ports (raises NotImplementedError —
+        the dump schema has no plane-phasor fields).
+    return_refplane_diagnostics : bool
+        When True and any port opted into ``reference_plane_cells``
+        (issue #313), return ``(S, freqs, diagnostics)`` where
+        ``diagnostics`` carries the per-port measured Zc(f) and beta(f)
+        (R5 inspection surface).  ``(S, freqs, None)`` when no port
+        opted in.
 
     Returns
     -------
@@ -134,6 +143,14 @@ def compute_lumped_wire_s_matrix_via_scan(
     v_all = np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex128)
     i_all = np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex128)
 
+    # Opt-in reference-plane accumulators (issue #313): raw plane phasors
+    # per (drive j, port p, plane slot).  Allocated lazily on the first
+    # drive pass that returns plane data.
+    plane_v = plane_im = plane_ip = None
+    plane_enabled = np.zeros(n_ports, dtype=bool)
+    plane_offsets = np.zeros(n_ports, dtype=np.int64)
+    plane_outboard = np.zeros(n_ports, dtype=np.int64)
+
     for j in range(n_ports):
         raw = sim._forward_from_materials(
             grid,
@@ -165,6 +182,58 @@ def compute_lumped_wire_s_matrix_via_scan(
             v_dft, i_dft = vi[0], vi[1]
             v_all[j, i, :] = np.asarray(v_dft, dtype=np.complex128)
             i_all[j, i, :] = np.asarray(i_dft, dtype=np.complex128)
+
+        rp_accs = raw.get("wire_refplane")
+        if rp_accs:
+            if plane_v is None:
+                plane_v = np.zeros((n_ports, n_ports, 2, n_freqs),
+                                   dtype=np.complex128)
+                plane_im = np.zeros_like(plane_v)
+                plane_ip = np.zeros_like(plane_v)
+            for rp_spec, rp_vi in rp_accs:
+                p = int(rp_spec.port_index)
+                s = int(rp_spec.plane_slot)
+                plane_v[j, p, s, :] = np.asarray(rp_vi[0],
+                                                 dtype=np.complex128)
+                plane_im[j, p, s, :] = np.asarray(rp_vi[1],
+                                                  dtype=np.complex128)
+                plane_ip[j, p, s, :] = np.asarray(rp_vi[2],
+                                                  dtype=np.complex128)
+                plane_enabled[p] = True
+                plane_outboard[p] = int(rp_spec.outboard_sign)
+                if s == 0:
+                    plane_offsets[p] = int(rp_spec.n_cells_outboard)
+
+    if wire_mode and plane_v is not None:
+        # issue #313 reference-plane path: byte-frozen legacy diagonals +
+        # plane-wave off-diagonals where both ports opted in.  The V/I
+        # replay dump schema has no plane-phasor fields — fail loudly
+        # rather than return a dump whose replay cannot reproduce S.
+        if return_vi_dump:
+            raise NotImplementedError(
+                "return_vi_dump=True is not supported together with "
+                "add_port(reference_plane_cells=...): the midpoint V/I "
+                "replay bundle cannot reproduce the plane-wave "
+                "off-diagonals (issue #313)."
+            )
+        from rfx.probes.refplane import (
+            decompose_wire_s_matrix_with_reference_planes,
+        )
+        out = decompose_wire_s_matrix_with_reference_planes(
+            v_all, i_all, z0, port_cell_counts,
+            plane_v=plane_v, plane_im=plane_im, plane_ip=plane_ip,
+            plane_enabled=plane_enabled,
+            plane_offsets=plane_offsets,
+            outboard_signs=plane_outboard,
+            freqs=freqs,
+            dt=float(grid.dt),
+            dx=float(grid.dx),
+            return_line_diagnostics=return_refplane_diagnostics,
+        )
+        if return_refplane_diagnostics:
+            S, diag = out
+            return np.asarray(S, dtype=np.complex64), freqs, diag
+        return np.asarray(out, dtype=np.complex64), freqs
 
     if wire_mode:
         S = np.asarray(
@@ -207,4 +276,6 @@ def compute_lumped_wire_s_matrix_via_scan(
                 driven_port_indices=tuple(range(n_ports)),
             )
 
+    if return_refplane_diagnostics:
+        return S, freqs, None
     return S, freqs

--- a/rfx/simulation.py
+++ b/rfx/simulation.py
@@ -144,6 +144,11 @@ class SimResult(NamedTuple):
     lumped_port_sparams : tuple | None
         Final V/I DFT accumulators for lumped port S-params (issue #72).
         Each entry is ``(LumpedPortSParamSpec, (v_dft, i_dft))``.
+    wire_refplane_sparams : tuple | None
+        Final reference-plane V/I DFT accumulators for the opt-in wire
+        S-matrix plane path (issue #313).  Each entry is
+        ``(WireRefPlaneSpec, (v_dft, i_minus_dft, i_plus_dft))``; two
+        entries per opted port (plane slots 0 and 1).
     snapshots : dict[str, ndarray] or None
         Field snapshots keyed by component name.
     ntff_box : NTFFBox or None
@@ -162,6 +167,7 @@ class SimResult(NamedTuple):
     snapshots: dict | None = None
     ntff_box: object = None
     grid: Grid | None = None
+    wire_refplane_sparams: tuple | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -526,6 +532,8 @@ class _SimSetup(NamedTuple):
     wire_sparam_meta: tuple
     lumped_sparam_meta: tuple
     rlc_meta: tuple
+    # issue #313 opt-in reference-plane accumulators (empty when unused)
+    wire_refplane_meta: tuple
     # 8-field tuple: (axis, index, freqs, comp_names, lo1, hi1, lo2, hi2)
     flux_meta_8: tuple
     # 11-field tuple adds: total_steps, window, window_alpha
@@ -567,6 +575,7 @@ def _build_step_setup(
     field_dtype: object,
     mag_sources: list,
     stencil_order: int = 2,
+    wire_refplane_sparams: "list | None" = None,
 ) -> "_SimSetup":
     """Build the shared setup artefacts used by both ``run`` and ``run_until_decay``.
 
@@ -631,6 +640,8 @@ def _build_step_setup(
     use_aniso_inv = aniso_inv_eps is not None
     use_wire_sparams = len(wire_port_sparams) > 0
     use_lumped_sparams = len(lumped_port_sparams) > 0
+    wire_refplane_sparams = wire_refplane_sparams or []
+    use_wire_refplanes = len(wire_refplane_sparams) > 0
     use_lumped_rlc = len(lumped_rlc) > 0
     use_kerr = kerr_chi3 is not None
     use_mag_sources = len(mag_sources) > 0
@@ -773,6 +784,21 @@ def _build_step_setup(
         )
         wire_sparam_meta = tuple(wire_port_sparams)
 
+    wire_refplane_meta: tuple = ()
+    if use_wire_refplanes:
+        # Initialize V, I(-dx/2), I(+dx/2) DFT accumulators per reference
+        # plane (issue #313 opt-in; two planes per opted port).  Same
+        # accumulator dtype and rect-DFT kernel as the port-cell channels.
+        carry_init["wire_refplane_accs"] = tuple(
+            (
+                jnp.zeros(len(rp.freqs), dtype=_sparam_acc_dtype),  # v_dft
+                jnp.zeros(len(rp.freqs), dtype=_sparam_acc_dtype),  # i_minus
+                jnp.zeros(len(rp.freqs), dtype=_sparam_acc_dtype),  # i_plus
+            )
+            for rp in wire_refplane_sparams
+        )
+        wire_refplane_meta = tuple(wire_refplane_sparams)
+
     lumped_sparam_meta: tuple = ()
     if use_lumped_sparams:
         # Initialize V, I DFT accumulators per lumped port (issue #72).
@@ -863,6 +889,7 @@ def _build_step_setup(
         use_conformal=use_conformal,
         use_wire_sparams=use_wire_sparams,
         use_lumped_sparams=use_lumped_sparams,
+        use_wire_refplanes=use_wire_refplanes,
         use_lumped_rlc=use_lumped_rlc,
         use_kerr=use_kerr,
         use_mag_sources=use_mag_sources,
@@ -889,6 +916,7 @@ def _build_step_setup(
         waveguide_meta=waveguide_meta,
         wire_sparam_meta=wire_sparam_meta,
         lumped_sparam_meta=lumped_sparam_meta,
+        wire_refplane_meta=wire_refplane_meta,
         rlc_meta=rlc_meta,
         apply_cpml_h=apply_cpml_h,
         apply_cpml_e=apply_cpml_e,
@@ -917,6 +945,7 @@ def _build_step_setup(
         wire_sparam_meta=wire_sparam_meta,
         lumped_sparam_meta=lumped_sparam_meta,
         rlc_meta=rlc_meta,
+        wire_refplane_meta=wire_refplane_meta,
         flux_meta_8=flux_meta_8,
         flux_meta_11=flux_meta_11,
         dt=dt,
@@ -1032,6 +1061,10 @@ class _StepContext:
     wire_sparam_meta: tuple = ()
     lumped_sparam_meta: tuple = ()
     rlc_meta: tuple = ()
+    # issue #313 opt-in reference-plane channel (defaults keep every
+    # existing caller byte-identical)
+    use_wire_refplanes: bool = False
+    wire_refplane_meta: tuple = ()
 
     # ---- output extractors ----
     monitor_component: str = "ez"
@@ -1285,6 +1318,25 @@ def make_core_step(ctx: _StepContext):
                     i_dft_l + i_val_l * phase_l,
                 ))
 
+        # Reference-plane V/I DFT accumulation (issue #313 opt-in) — same
+        # pre-source-injection sample point and rect-DFT kernel as the
+        # port-cell channels above.  The planes sit >= 1 cell from every
+        # source cell, so pre/post-injection sampling is identical here.
+        if ctx.use_wire_refplanes:
+            from rfx.probes.refplane import wire_refplane_step_vi
+            new_refplane_accs = []
+            for accs, rp_meta in zip(carry["wire_refplane_accs"],
+                                     ctx.wire_refplane_meta):
+                v_dft_r, im_dft_r, ip_dft_r = accs
+                v_r, im_r, ip_r = wire_refplane_step_vi(st, rp_meta, dx)
+                t_f64 = t.astype(jnp.float64) if hasattr(t, 'astype') else jnp.float64(t)
+                phase_r = jnp.exp(-1j * 2.0 * jnp.pi * rp_meta.freqs.astype(jnp.float64) * t_f64).astype(jnp.complex64) * dt
+                new_refplane_accs.append((
+                    v_dft_r + v_r * phase_r,
+                    im_dft_r + im_r * phase_r,
+                    ip_dft_r + ip_r * phase_r,
+                ))
+
         # Soft sources — cast source value to field dtype to avoid
         # mixed-precision scatter warnings (float32 -> float16).
         for idx_s, (si, sj, sk, sc) in enumerate(ctx.src_meta):
@@ -1443,6 +1495,8 @@ def make_core_step(ctx: _StepContext):
             new_carry["wire_sparam_accs"] = tuple(new_wire_accs)
         if ctx.use_lumped_sparams:
             new_carry["lumped_sparam_accs"] = tuple(new_lumped_accs)
+        if ctx.use_wire_refplanes:
+            new_carry["wire_refplane_accs"] = tuple(new_refplane_accs)
         if ctx.use_lumped_rlc:
             new_carry["rlc_states"] = tuple(new_rlc_states)
 
@@ -1480,6 +1534,7 @@ def run(
     conformal_weights: tuple | None = None,
     wire_port_sparams: list | None = None,
     lumped_port_sparams: list | None = None,
+    wire_refplane_sparams: list | None = None,
     lumped_rlc: list | None = None,
     kerr_chi3: jnp.ndarray | None = None,
     field_dtype=None,
@@ -1538,6 +1593,7 @@ def run(
     waveguide_ports = waveguide_ports or []
     wire_port_sparams = wire_port_sparams or []
     lumped_port_sparams = lumped_port_sparams or []
+    wire_refplane_sparams = wire_refplane_sparams or []
     lumped_rlc = lumped_rlc or []
     mag_sources = mag_sources or []
 
@@ -1566,6 +1622,7 @@ def run(
         conformal_weights=conformal_weights,
         wire_port_sparams=wire_port_sparams,
         lumped_port_sparams=lumped_port_sparams,
+        wire_refplane_sparams=wire_refplane_sparams,
         lumped_rlc=lumped_rlc,
         kerr_chi3=kerr_chi3,
         field_dtype=field_dtype,
@@ -1579,11 +1636,13 @@ def run(
     waveguide_meta = _setup.waveguide_meta
     wire_sparam_meta = _setup.wire_sparam_meta
     lumped_sparam_meta = _setup.lumped_sparam_meta
+    wire_refplane_meta = _setup.wire_refplane_meta
     flux_meta = _setup.flux_meta_11   # 11-field: run() uses streaming DFT window
     use_snapshot = snapshot is not None
     use_flux_monitors = len(flux_monitors) > 0
     use_wire_sparams = len(wire_port_sparams) > 0
     use_lumped_sparams = len(lumped_port_sparams) > 0
+    use_wire_refplanes = len(wire_refplane_sparams) > 0
     use_dft_planes = len(dft_planes) > 0
     use_waveguide_ports = len(waveguide_ports) > 0
 
@@ -1803,6 +1862,14 @@ def run(
             for lp_meta, accs in zip(lumped_sparam_meta, final_carry["lumped_sparam_accs"])
         )
 
+    final_wire_refplanes = None
+    if use_wire_refplanes:
+        final_wire_refplanes = tuple(
+            (rp_meta, accs)
+            for rp_meta, accs in zip(wire_refplane_meta,
+                                     final_carry["wire_refplane_accs"])
+        )
+
     return SimResult(
         state=final_carry["fdtd"] if return_state else None,
         time_series=time_series,
@@ -1815,6 +1882,7 @@ def run(
         snapshots=snapshots,
         ntff_box=ntff,
         grid=grid,
+        wire_refplane_sparams=final_wire_refplanes,
     )
 
 

--- a/tests/test_refplane_port_waves.py
+++ b/tests/test_refplane_port_waves.py
@@ -1,0 +1,481 @@
+"""Validation battery for the opt-in reference-plane port waves (issue #313).
+
+Phase-1 lanes for ``add_port(reference_plane_cells=N)`` — the
+REFERENCE-PLANE architecture promoted by the issue #313 Phase-0 verdict
+(closed-box flux referee, 2026-07-10):
+
+FAST (no FDTD / tiny FDTD):
+  * extraction-math unit tests on synthetic two-wave line phasors
+    (two-plane Zc invariant, measured beta, split, phase-only de-embed,
+    byte-frozen legacy diagonals);
+  * add_port opt-in validation (wire-only, explicit transverse direction);
+  * plumbing contract on the canonical thru (two planes per opted port,
+    Phase-0-exact plane geometry, accumulator shapes);
+  * DEFAULT-PATH invariance: no opt-in => no plane registration, and
+    forward() is bitwise unaffected by the opt-in (its diagonal path
+    never touches the planes);
+  * short-run run(compute_s_params=True) wiring: diagonals bitwise equal
+    to the default path (byte-frozen), off-diagonals move (loud).
+
+SLOW (canonical 16 mm thru, 4000 steps, production driver): the plane-path
+measurement lane with gates anchored to the Phase-0 closed-box flux
+referee. LOUD RE-BASELINE (issue #313 falsifier item 8): the committed
+legacy battery |S21| regression-lock band [0.35, 0.85]
+(tests/test_lumped_twoport_vi_validation_battery.py) is EXPECTED to fail
+on the plane path — the shipped drive-side deflation kappa(f)=1.49-1.86
+disappears and |S21| moves to the flux-implied ~0.96-1.0.  That legacy
+band stays committed and green for the DEFAULT path; this module carries
+the plane-path gates with their own referee-anchored labels, and asserts
+explicitly that the plane path leaves the legacy band (proof the fix
+moves the number).
+
+Phase-0 referee numbers used as anchors (measured 2026-07-10, closed
+6-face flux boxes; see issue #313 Phase-0 comment):
+  |S21|_referee = sqrt(P_abs/P_launch) = 0.98431..1.00660 per bin
+  reference-plane arch |S21| residual vs referee: -1.18%..-2.54%
+  Zc two-plane (mid-line 13/19 mm planes): 47.85..48.63 ohm, Im/Re<=0.69%
+  beta/(w/c): 1.048..1.061 (slow-wave, far above numerical dispersion)
+
+HONESTY LABELS: the plane-path |S21| gates below are frozen from a
+measured run of THIS implementation (per-port planes at N=3 / 2N=6 cells
+outboard — nearer the ports than the Phase-0 mid-line Zc planes) and are
+labelled with their distance to the Phase-0 referee.  They are
+regression + referee-consistency gates on the canonical thru, NOT an
+external cross-solver validation (the openEMS thru remains the final
+gate per the issue #313 falsifier list).
+
+No module-level x64 flip (documented complex64 envelope).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rfx import Box, Simulation
+from rfx.boundaries.spec import Boundary, BoundarySpec
+from rfx.sources.sources import GaussianPulse
+from rfx.probes.probes import decompose_wire_s_matrix
+from rfx.probes.refplane import (
+    build_wire_refplane_specs,
+    decompose_wire_s_matrix_with_reference_planes,
+    refplane_beta,
+    refplane_centered_current,
+    refplane_split,
+    refplane_zc_two_plane,
+)
+
+C0 = 299792458.0
+
+# --- canonical thru fixture constants (byte-exact battery geometry) ---
+_DX = 0.5e-3
+_DOMAIN = (0.032, 0.020, 0.010)
+_H = 1.0e-3
+_W = 5.0e-3
+_X1, _X2 = 0.008, 0.024
+_Y_MID = _DOMAIN[1] / 2
+_L = _X2 - _X1
+_FREQS = np.linspace(3e9, 7e9, 9)
+_N_STEPS = 4000
+_PEC_FACES_ADVISORY_SNIPPET = "INFINITE PEC boundary"
+
+
+def _build_thru(reference_plane_cells: int | None = None) -> Simulation:
+    """The committed battery thru, optionally opted into the plane path."""
+    sim = Simulation(
+        freq_max=10e9, domain=_DOMAIN, dx=_DX,
+        boundary=BoundarySpec(x="cpml", y="cpml",
+                              z=Boundary(lo="pec", hi="cpml")),
+        cpml_layers=8,
+    )
+    sim.add(
+        Box((_X1 - _DX, _Y_MID - _W / 2, _H),
+            (_X2 + _DX, _Y_MID + _W / 2, _H + _DX)),
+        material="pec",
+    )
+    pulse = GaussianPulse(f0=5e9, bandwidth=0.8)
+    kw = {}
+    if reference_plane_cells is not None:
+        kw["reference_plane_cells"] = reference_plane_cells
+    sim.add_port(position=(_X1, _Y_MID, 0.0), component="ez", impedance=50.0,
+                 extent=_H, waveform=pulse, direction="-x", **kw)
+    sim.add_port(position=(_X2, _Y_MID, 0.0), component="ez", impedance=50.0,
+                 extent=_H, waveform=pulse, direction="+x", **kw)
+    return sim
+
+
+# ===========================================================================
+# FAST — extraction math on synthetic two-wave line phasors
+# ===========================================================================
+
+def _synthetic_line(freqs, zc_true, beta, dt):
+    """Helpers for a clean two-wave uniform line in DFT phasor convention.
+
+    Forward (+x) wave ``f0 e^{-j beta x}``, backward ``g0 e^{+j beta x}``;
+    V = f + g, I(+x) = (f - g)/Zc.  Raw loop currents are synthesized so
+    that ``refplane_centered_current`` (average + exp(+j w dt/2)) returns
+    the exact line current.
+    """
+    w = 2 * np.pi * np.asarray(freqs, dtype=np.float64)
+    hcorr = np.exp(+1j * w * dt / 2)
+
+    def field(x, f0, g0):
+        f = f0 * np.exp(-1j * beta * x)
+        g = g0 * np.exp(+1j * beta * x)
+        return f + g, (f - g) / zc_true
+
+    def raw(i_line):
+        return i_line / hcorr, i_line / hcorr
+
+    return field, raw
+
+
+def test_zc_beta_split_deembed_recover_synthetic_line():
+    """Two-plane Zc / measured beta / split / de-embed are exact on a
+    clean two-wave line (the algebra the scan accumulators feed)."""
+    freqs = _FREQS
+    w = 2 * np.pi * freqs
+    dt = 9.6e-13
+    dx = _DX
+    zc_true = 48.3
+    beta_true = 1.055 * w / C0     # slow-wave class, per Phase 0
+    n = 3
+    d = n * dx
+    field, raw = _synthetic_line(freqs, zc_true, beta_true, dt)
+
+    f0 = (1.0 + 0.3j) * np.ones_like(w, dtype=np.complex128)
+    g0 = 0.18 * np.exp(1j * 0.4) * f0          # backward (load reflection)
+
+    v1, i1 = field(d, f0, g0)
+    v2, i2 = field(2 * d, f0, g0)
+    im1, ip1 = raw(i1)
+    im2, ip2 = raw(i2)
+    i1c = refplane_centered_current(im1, ip1, freqs, dt)
+    i2c = refplane_centered_current(im2, ip2, freqs, dt)
+    assert np.max(np.abs(i1c - i1)) < 1e-12
+
+    zc = refplane_zc_two_plane(v1, i1c, v2, i2c)
+    assert np.max(np.abs(zc - zc_true)) < 1e-9, (
+        f"two-plane Zc invariant broke: {zc}")
+
+    out1, in1 = refplane_split(v1, i1c, zc, outboard_sign=+1)
+    out2, _ = refplane_split(v2, i2c, zc, outboard_sign=+1)
+    # outgoing = the forward (+x) wave at the plane; incoming = backward
+    assert np.max(np.abs(out1 - f0 * np.exp(-1j * beta_true * d))) < 1e-9
+    assert np.max(np.abs(in1 - g0 * np.exp(+1j * beta_true * d))) < 1e-9
+
+    beta = refplane_beta(out1, out2, d)
+    assert np.max(np.abs(beta / beta_true - 1)) < 1e-12, (
+        f"measured beta wrong: {beta / beta_true}")
+
+    # phase-only de-embed back to the port plane (x=0)
+    a_port = out1 * np.exp(+1j * beta * d)
+    assert np.max(np.abs(a_port - f0)) < 1e-9
+
+
+def _two_port_synthetic(gamma_load):
+    """Full synthetic 2-port plane dataset (drive 0 + mirrored drive 1)."""
+    freqs = _FREQS
+    w = 2 * np.pi * freqs
+    dt = 9.6e-13
+    dx = _DX
+    zc_true = 48.3
+    beta_true = 1.055 * w / C0
+    n = 3
+    d = n * dx
+    L = _L
+    field, raw = _synthetic_line(freqs, zc_true, beta_true, dt)
+
+    f0 = (1.0 + 0.3j) * np.ones_like(w, dtype=np.complex128)
+    g0 = gamma_load * f0 * np.exp(-2j * beta_true * L)
+
+    n_ports, n_freqs = 2, len(freqs)
+    plane_v = np.zeros((n_ports, n_ports, 2, n_freqs), dtype=np.complex128)
+    plane_im = np.zeros_like(plane_v)
+    plane_ip = np.zeros_like(plane_v)
+
+    def fill(j, p, slot, x, sign):
+        v, i = field(x, f0, g0)
+        im, ip = raw(sign * i)
+        plane_v[j, p, slot] = v
+        plane_im[j, p, slot] = im
+        plane_ip[j, p, slot] = ip
+
+    # drive 0: port0 (x=0, outboard +x) planes at d/2d; port1 at L-d/L-2d
+    fill(0, 0, 0, d, +1)
+    fill(0, 0, 1, 2 * d, +1)
+    fill(0, 1, 0, L - d, +1)
+    fill(0, 1, 1, L - 2 * d, +1)
+    # drive 1: mirror x -> L - x; I(+x) flips sign under the mirror
+    fill(1, 1, 0, d, -1)
+    fill(1, 1, 1, 2 * d, -1)
+    fill(1, 0, 0, L - d, -1)
+    fill(1, 0, 1, L - 2 * d, -1)
+
+    rng = np.random.default_rng(20260710)
+    v_all = (rng.normal(size=(2, 2, n_freqs))
+             + 1j * rng.normal(size=(2, 2, n_freqs)))
+    i_all = (rng.normal(size=(2, 2, n_freqs))
+             + 1j * rng.normal(size=(2, 2, n_freqs)))
+    z0 = np.array([50.0, 50.0])
+    counts = np.array([3, 3])
+    return dict(
+        freqs=freqs, dt=dt, dx=dx, n=n, beta_true=beta_true,
+        zc_true=zc_true, L=L,
+        plane_v=plane_v, plane_im=plane_im, plane_ip=plane_ip,
+        v_all=v_all, i_all=i_all, z0=z0, counts=counts,
+    )
+
+
+def test_decompose_refplane_two_port_synthetic_matched():
+    """Full wrapper on a matched synthetic thru: diagonals BITWISE equal
+    the legacy decomposer; S21 = S12 = exp(-j beta L) at complex64
+    rounding; measured Zc/beta recovered."""
+    s = _two_port_synthetic(gamma_load=0.0)
+    S_legacy = np.asarray(decompose_wire_s_matrix(
+        s["v_all"], s["i_all"], s["z0"], s["counts"]), dtype=np.complex64)
+    S, diag = decompose_wire_s_matrix_with_reference_planes(
+        s["v_all"], s["i_all"], s["z0"], s["counts"],
+        plane_v=s["plane_v"], plane_im=s["plane_im"], plane_ip=s["plane_ip"],
+        plane_enabled=np.array([True, True]),
+        plane_offsets=np.array([s["n"], s["n"]]),
+        outboard_signs=np.array([1, -1]),
+        freqs=s["freqs"], dt=s["dt"], dx=s["dx"],
+        return_line_diagnostics=True,
+    )
+    # DIAGONAL: byte-frozen legacy path, always (issue #313 hard rule).
+    assert S[0, 0].tobytes() == S_legacy[0, 0].tobytes()
+    assert S[1, 1].tobytes() == S_legacy[1, 1].tobytes()
+    for p in (0, 1):
+        assert np.max(np.abs(diag["zc"][p] - s["zc_true"])) < 1e-6
+        assert np.max(np.abs(diag["beta"][p] / s["beta_true"] - 1)) < 1e-9
+    expect = np.exp(-1j * s["beta_true"] * s["L"])
+    assert np.max(np.abs(S[1, 0] - expect)) < 1e-6
+    assert np.max(np.abs(S[0, 1] - expect)) < 1e-6
+
+
+def test_decompose_refplane_two_port_synthetic_reflective():
+    """Same wrapper with a reflective load (|Gamma|=0.18, the measured
+    Phase-0 port mismatch class): the incoming/outgoing separation must
+    still recover the exact thru transfer."""
+    s = _two_port_synthetic(gamma_load=0.18 * np.exp(1j * 0.4))
+    S = decompose_wire_s_matrix_with_reference_planes(
+        s["v_all"], s["i_all"], s["z0"], s["counts"],
+        plane_v=s["plane_v"], plane_im=s["plane_im"], plane_ip=s["plane_ip"],
+        plane_enabled=np.array([True, True]),
+        plane_offsets=np.array([s["n"], s["n"]]),
+        outboard_signs=np.array([1, -1]),
+        freqs=s["freqs"], dt=s["dt"], dx=s["dx"],
+    )
+    expect = np.exp(-1j * s["beta_true"] * s["L"])
+    assert np.max(np.abs(S[1, 0] - expect)) < 1e-6
+    assert np.max(np.abs(S[0, 1] - expect)) < 1e-6
+
+
+def test_decompose_refplane_requires_both_ports_opted():
+    """A pair with only ONE opted port keeps the legacy off-diagonals
+    (F1 / partial composition intentionally OUT of this phase)."""
+    s = _two_port_synthetic(gamma_load=0.0)
+    S_legacy = np.asarray(decompose_wire_s_matrix(
+        s["v_all"], s["i_all"], s["z0"], s["counts"]), dtype=np.complex64)
+    S = decompose_wire_s_matrix_with_reference_planes(
+        s["v_all"], s["i_all"], s["z0"], s["counts"],
+        plane_v=s["plane_v"], plane_im=s["plane_im"], plane_ip=s["plane_ip"],
+        plane_enabled=np.array([True, False]),
+        plane_offsets=np.array([s["n"], 0]),
+        outboard_signs=np.array([1, -1]),
+        freqs=s["freqs"], dt=s["dt"], dx=s["dx"],
+    )
+    assert S.tobytes() == S_legacy.tobytes()
+
+
+# ===========================================================================
+# FAST — add_port opt-in validation
+# ===========================================================================
+
+def _base_sim():
+    return Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3,
+                      boundary="cpml", cpml_layers=6)
+
+
+def test_add_port_refplane_rejects_lumped():
+    with pytest.raises(NotImplementedError, match="wire ports"):
+        _base_sim().add_port(position=(0.01, 0.01, 0.01), component="ez",
+                             impedance=50.0, direction="-x",
+                             reference_plane_cells=3)
+
+
+def test_add_port_refplane_requires_direction():
+    with pytest.raises(ValueError, match="explicit direction"):
+        _base_sim().add_port(position=(0.01, 0.01, 0.0), component="ez",
+                             impedance=50.0, extent=1e-3,
+                             reference_plane_cells=3)
+
+
+def test_add_port_refplane_rejects_direction_along_component():
+    with pytest.raises(ValueError, match="transverse"):
+        _base_sim().add_port(position=(0.01, 0.01, 0.0), component="ex",
+                             impedance=50.0, extent=1e-3, direction="+x",
+                             reference_plane_cells=3)
+
+
+def test_add_port_refplane_rejects_nonpositive_n():
+    with pytest.raises(ValueError, match=">= 1"):
+        _base_sim().add_port(position=(0.01, 0.01, 0.0), component="ez",
+                             impedance=50.0, extent=1e-3, direction="-x",
+                             reference_plane_cells=0)
+
+
+def test_nonuniform_lane_guard_fails_loudly():
+    """Reference-plane ports on the NU/subgridded lanes raise instead of
+    silently returning legacy off-diagonals."""
+    sim = _build_thru(reference_plane_cells=3)
+    with pytest.raises(NotImplementedError, match="uniform single-device"):
+        sim._reject_refplane_ports_off_uniform_lane("non-uniform mesh", None)
+    # explicit compute_s_params=False is allowed (no S-matrix requested)
+    sim._reject_refplane_ports_off_uniform_lane("non-uniform mesh", False)
+    # and a sim without the opt-in is never blocked
+    _build_thru()._reject_refplane_ports_off_uniform_lane(
+        "non-uniform mesh", None)
+
+
+# ===========================================================================
+# FAST — plumbing contract on the canonical thru (tiny FDTD)
+# ===========================================================================
+
+def _raw_drive(sim, n_steps=8, drive_idx=0):
+    grid = sim._build_grid()
+    mats, dsp, lsp, pm, _, _, _ = sim._assemble_materials(grid)
+    return sim._forward_from_materials(
+        grid, mats, dsp, lsp, n_steps=n_steps, checkpoint=False,
+        pec_mask=pm, port_s11_freqs=_FREQS,
+        _sparam_drive_idx=drive_idx, _return_raw_port_sparams=True)
+
+
+def test_refplane_registers_two_planes_per_port_with_phase0_geometry():
+    """TWO planes per opted port with the Phase-0-exact geometry.
+
+    Hand-derived indices for the canonical thru (dx=0.5mm, CPML pad 8 on
+    x/y, PEC z_lo): port 1 at x=8mm -> i=24; planes at 9.5/11.0mm ->
+    27/30; port 2 at 24mm -> i=56; planes at 22.5/21.0mm -> 53/50.  Ampere
+    loop legs half a cell outside the trace bbox (y 7.5..12.5mm -> j
+    23..32 padded; z 1.0..1.5mm -> k 2): Hz columns at j=22/33 spanning
+    k=[2,4), Hy rows at k=1/3 spanning j=[23,34) — the exact Phase-0
+    probe layout (x=9.5mm plane: legs at y=7.25/12.75mm, z=0.75/1.75mm).
+    """
+    raw = _raw_drive(_build_thru(reference_plane_cells=3))
+    rp = raw["wire_refplane"]
+    assert rp is not None and len(rp) == 4, (
+        "expected 2 ports x 2 planes registered")
+    by_key = {(s.port_index, s.plane_slot): s for s, _ in rp}
+    assert set(by_key) == {(0, 0), (0, 1), (1, 0), (1, 1)}
+
+    expected_plane_index = {(0, 0): 27, (0, 1): 30, (1, 0): 53, (1, 1): 50}
+    for key, spec in by_key.items():
+        assert spec.plane_index == expected_plane_index[key], (
+            f"plane index drifted for {key}: {spec.plane_index}")
+        assert spec.line_axis == 0 and spec.comp_axis == 2
+        assert spec.outboard_sign == (+1 if key[0] == 0 else -1)
+        assert spec.n_cells_outboard == (3 if key[1] == 0 else 6)
+        # GAP-trimmed V cells: the port extent is 3 cells (k=0,1,2) but
+        # k=2 lies inside the PEC trace at the plane column and its Ez
+        # edge is NOT mask-zeroed (measured |ez2/ez0| ~ 0.21) — the gap
+        # line integral spans the 2 live cells, exactly the Phase-0
+        # 2-cell integral that measured Zc = 47.9-48.6 ohm.
+        assert (spec.e_lo, spec.e_hi) == (0, 2)
+        assert spec.third_index == 28                # y = 10mm (padded)
+        assert (spec.u_lo_leg, spec.u_hi_leg) == (22, 33)
+        assert (spec.v_lo_leg, spec.v_hi_leg) == (1, 3)
+        assert (spec.u_span_lo, spec.u_span_hi) == (23, 34)
+        assert (spec.v_span_lo, spec.v_span_hi) == (2, 4)
+        assert spec.hu_component == "hy" and spec.hv_component == "hz"
+
+    for _, accs in rp:
+        assert len(accs) == 3
+        for a in accs:
+            assert np.asarray(a).shape == (len(_FREQS),)
+            assert np.all(np.isfinite(np.asarray(a)))
+
+
+def test_default_path_registers_no_planes():
+    raw = _raw_drive(_build_thru())
+    assert raw["wire_refplane"] is None
+
+
+def test_refplane_crossing_guard_rejects_planes_past_other_port():
+    """N large enough to reach past the far port must fail loudly."""
+    sim = _build_thru(reference_plane_cells=17)   # 2N=34 cells > 32-cell line
+    with pytest.raises(ValueError, match="reach past another port"):
+        _raw_drive(sim)
+
+
+def test_refplane_requires_pec_trace_at_plane():
+    """Planes pointing AWAY from the line (wrong direction) find no trace
+    cross-section and must fail loudly, not measure vacuum."""
+    sim = Simulation(
+        freq_max=10e9, domain=_DOMAIN, dx=_DX,
+        boundary=BoundarySpec(x="cpml", y="cpml",
+                              z=Boundary(lo="pec", hi="cpml")),
+        cpml_layers=8,
+    )
+    sim.add(
+        Box((_X1 - _DX, _Y_MID - _W / 2, _H),
+            (_X2 + _DX, _Y_MID + _W / 2, _H + _DX)),
+        material="pec",
+    )
+    pulse = GaussianPulse(f0=5e9, bandwidth=0.8)
+    # direction "+x" on port 1: outboard becomes -x, off the trace end
+    sim.add_port(position=(_X1, _Y_MID, 0.0), component="ez", impedance=50.0,
+                 extent=_H, waveform=pulse, direction="+x",
+                 reference_plane_cells=5)
+    sim.add_port(position=(_X2, _Y_MID, 0.0), component="ez", impedance=50.0,
+                 extent=_H, waveform=pulse, direction="+x",
+                 reference_plane_cells=3)
+    with pytest.raises(ValueError, match="no PEC conductor"):
+        _raw_drive(sim)
+
+
+def test_forward_bitwise_unaffected_by_optin():
+    """forward(port_s11_freqs=...) is BITWISE identical with and without
+    the opt-in: the plane registration is gated to the S-matrix driver
+    path and forward()'s diagonal extraction never touches it."""
+    f_default = _build_thru().forward(n_steps=64, port_s11_freqs=_FREQS,
+                                      skip_preflight=True)
+    f_opted = _build_thru(reference_plane_cells=3).forward(
+        n_steps=64, port_s11_freqs=_FREQS, skip_preflight=True)
+    a = np.asarray(f_default.s_params)
+    b = np.asarray(f_opted.s_params)
+    assert a.shape == b.shape and a.tobytes() == b.tobytes(), (
+        "forward() S11 changed under reference_plane_cells — the opt-in "
+        "must not touch the forward()/diagonal path")
+
+
+def test_run_short_diagonals_byte_frozen_offdiagonals_move():
+    """run(compute_s_params=True) wiring at 64 steps: the opted run's
+    DIAGONALS are bitwise equal to the default run (byte-frozen legacy
+    path) while the off-diagonals move (the plane path is actually live).
+    64 steps is a plumbing witness, not physics — magnitudes are gated in
+    the SLOW lane below."""
+    r_default = _build_thru().run(
+        n_steps=64, compute_s_params=True, s_param_freqs=_FREQS,
+        skip_preflight=True)
+    r_opted = _build_thru(reference_plane_cells=3).run(
+        n_steps=64, compute_s_params=True, s_param_freqs=_FREQS,
+        skip_preflight=True)
+    S0 = np.asarray(r_default.s_params)
+    S1 = np.asarray(r_opted.s_params)
+    assert S0.shape == S1.shape == (2, 2, len(_FREQS))
+    assert S1[0, 0].tobytes() == S0[0, 0].tobytes(), "S11 diagonal moved"
+    assert S1[1, 1].tobytes() == S0[1, 1].tobytes(), "S22 diagonal moved"
+    assert S1[1, 0].tobytes() != S0[1, 0].tobytes(), (
+        "S21 did not move — plane path not live on run()")
+    assert S1[0, 1].tobytes() != S0[0, 1].tobytes(), (
+        "S12 did not move — plane path not live on run()")
+
+
+def test_driver_vi_dump_with_planes_fails_loudly():
+    from rfx.probes.sparam_driver import compute_lumped_wire_s_matrix_via_scan
+    sim = _build_thru(reference_plane_cells=3)
+    with pytest.raises(NotImplementedError, match="return_vi_dump"):
+        compute_lumped_wire_s_matrix_via_scan(
+            sim, _FREQS, n_steps=64, return_vi_dump=True)

--- a/tests/test_refplane_port_waves.py
+++ b/tests/test_refplane_port_waves.py
@@ -504,10 +504,13 @@ def test_driver_vi_dump_with_planes_fails_loudly():
 # from port 1 and 19/14 mm from port 2) sit >= 10 cells from every port —
 # the Phase-0 pre-registration rule for the two-plane Zc/beta measurement.
 # The rejected first candidate N=3 (planes 3/6 cells) was measured
-# near-field contaminated: beta/(w/c) read 1.21-1.25 (vs mid-line
-# 1.048-1.065), Zc Im/Re grew to 9.2%, and the |S21| referee residual
-# reached -6.8% at 7 GHz (R2 stop -> placement conformed to the Phase-0
-# clean zone; one redesign, evidence-anchored).
+# near-field contaminated (R2 stop -> placement conformed to the Phase-0
+# clean zone; one redesign, evidence-anchored). Current-code (gap-trimmed
+# V) N=3 battery numbers, 2026-07-10: beta/(w/c) 1.16-1.20 (vs mid-line
+# 1.046-1.059), Zc 52.0-53.1 ohm with Im/Re to 8.2%, |S21| closed-box
+# referee residual -3.1% at 7 GHz, row energy to 1.019.  (The pre-trim
+# driver had measured beta 1.21-1.25 / Im/Re 9.2% / resid -6.8% at the
+# same placement — same class, same verdict.)
 _REFPLANE_N = 10
 
 # Phase-0 closed-box flux referee |S21| = sqrt(P_abs/P_launch), measured

--- a/tests/test_refplane_port_waves.py
+++ b/tests/test_refplane_port_waves.py
@@ -252,6 +252,21 @@ def test_decompose_refplane_two_port_synthetic_matched():
     expect = np.exp(-1j * s["beta_true"] * s["L"])
     assert np.max(np.abs(S[1, 0] - expect)) < 1e-6
     assert np.max(np.abs(S[0, 1] - expect)) < 1e-6
+    # R5 wave-pair diagnostics (Phase-0 falsifier F2 surface): the
+    # at-plane pairs are exposed and the zero-free-parameter conservation
+    # identity (|out|^2 - |inc|^2)/Re(Zc) is plane-invariant (exact on the
+    # synthetic lossless line; matched load => incoming ~ 0 at the drive).
+    d = s["n"] * s["dx"]
+    out00, in00 = diag["plane_waves"][(0, 0, 0)]
+    assert np.max(np.abs(in00)) < 1e-12
+    assert np.max(np.abs(
+        out00 - (1.0 + 0.3j) * np.exp(-1j * s["beta_true"] * d))) < 1e-9
+    p_net_0 = (np.abs(out00) ** 2 - np.abs(in00) ** 2) / diag["zc"][0].real
+    out10, in10 = diag["plane_waves"][(0, 1, 0)]
+    p_net_1 = (np.abs(in10) ** 2 - np.abs(out10) ** 2) / diag["zc"][1].real
+    # power flows drive -> load: at the receive plane the port-incoming
+    # wave carries it, and on the lossless line the two planes agree.
+    assert np.max(np.abs(p_net_1 / p_net_0 - 1)) < 1e-9
 
 
 def test_decompose_refplane_two_port_synthetic_reflective():

--- a/tests/test_refplane_port_waves.py
+++ b/tests/test_refplane_port_waves.py
@@ -173,14 +173,14 @@ def test_zc_beta_split_deembed_recover_synthetic_line():
     assert np.max(np.abs(a_port - f0)) < 1e-9
 
 
-def _two_port_synthetic(gamma_load):
+def _two_port_synthetic(gamma_load, zc_true=48.3, beta_true=None):
     """Full synthetic 2-port plane dataset (drive 0 + mirrored drive 1)."""
     freqs = _FREQS
     w = 2 * np.pi * freqs
     dt = 9.6e-13
     dx = _DX
-    zc_true = 48.3
-    beta_true = 1.055 * w / C0
+    if beta_true is None:
+        beta_true = 1.055 * w / C0
     n = 3
     d = n * dx
     L = _L
@@ -494,6 +494,161 @@ def test_driver_vi_dump_with_planes_fails_loudly():
     with pytest.raises(NotImplementedError, match="return_vi_dump"):
         compute_lumped_wire_s_matrix_via_scan(
             sim, _FREQS, n_steps=64, return_vi_dump=True)
+
+
+# ===========================================================================
+# FAST — extraction-time witnesses (Zc reality warning + beta wrap guard)
+# ===========================================================================
+
+def _decompose(s, **kw):
+    return decompose_wire_s_matrix_with_reference_planes(
+        s["v_all"], s["i_all"], s["z0"], s["counts"],
+        plane_v=s["plane_v"], plane_im=s["plane_im"], plane_ip=s["plane_ip"],
+        plane_enabled=np.array([True, True]),
+        plane_offsets=np.array([s["n"], s["n"]]),
+        outboard_signs=np.array([1, -1]),
+        freqs=s["freqs"], dt=s["dt"], dx=s["dx"], **kw)
+
+
+def test_zc_witness_warns_on_contaminated_synthetic_line():
+    """A synthetic line whose measured Zc carries the N=3 near-field
+    signature (Im/Re = 8.2%, the measured contaminated class) must warn,
+    naming the near-field mechanism and the reference_plane_cells fix."""
+    s = _two_port_synthetic(gamma_load=0.0,
+                            zc_true=48.3 * (1.0 + 0.082j))
+    with pytest.warns(UserWarning,
+                      match=r"Im\(Zc\)/Re\(Zc\).*NEAR FIELD"):
+        _decompose(s)
+
+
+def test_zc_witness_boundary_class_silent_at_one_percent():
+    """Im/Re = 1.2% is the measured CLEAN class (N=10) — below the 3%
+    class boundary, no warning."""
+    s = _two_port_synthetic(gamma_load=0.0,
+                            zc_true=48.3 * (1.0 + 0.012j))
+    import warnings as _w
+    with _w.catch_warnings(record=True) as rec:
+        _w.simplefilter("always")
+        _decompose(s)
+    assert not [r for r in rec if "Im(Zc)" in str(r.message)], (
+        "Zc witness warned inside the measured clean class")
+
+
+def test_zc_witness_silent_on_clean_line():
+    """The clean real-Zc synthetic emits no warning at all."""
+    s = _two_port_synthetic(gamma_load=0.0)
+    import warnings as _w
+    with _w.catch_warnings(record=True) as rec:
+        _w.simplefilter("always")
+        _decompose(s)
+    assert not rec, [str(r.message) for r in rec]
+
+
+def test_beta_wrap_guard_rejects_band_edge():
+    """Per-bin |beta|*N*dx above 0.9*pi (phase wrap ambiguity between the
+    plane pair) must fail loudly, telling the user to reduce N or the top
+    frequency."""
+    d = 3 * _DX
+    w = 2 * np.pi * _FREQS
+    beta_bad = (0.95 * np.pi / d) * np.ones_like(w)
+    s = _two_port_synthetic(gamma_load=0.0, beta_true=beta_bad)
+    with pytest.raises(ValueError, match=r"phase-wrap.*Reduce"):
+        _decompose(s)
+
+
+def test_beta_guard_rejects_nonpositive_beta():
+    """A non-positive measured beta (wrong-way phase progression — a wrap
+    or a broken measurement, never a physical forward wave) must fail
+    loudly rather than de-embed with it."""
+    w = 2 * np.pi * _FREQS
+    s = _two_port_synthetic(gamma_load=0.0, beta_true=-1.055 * w / C0)
+    with pytest.raises(ValueError, match="non-positive"):
+        _decompose(s)
+
+
+# ===========================================================================
+# FAST — preflight placement advisories (issue #313 Phase-0 rule)
+# ===========================================================================
+
+def test_preflight_near_field_advisory_below_n10():
+    report = _build_thru(reference_plane_cells=3).preflight()
+    near = report.by_code("refplane_near_field")
+    assert near, f"expected refplane_near_field, got {[i.code for i in report]}"
+    assert any("8.2%" in i for i in near)
+    assert not report.by_code("refplane_partial_optin"), (
+        "both ports opted in — partial-opt-in advisory must not fire")
+
+
+def test_preflight_partial_optin_advisory():
+    """Opting in only ONE of two wire ports leaves the off-diagonals on
+    the legacy path silently — preflight must say so."""
+    sim = Simulation(
+        freq_max=10e9, domain=_DOMAIN, dx=_DX,
+        boundary=BoundarySpec(x="cpml", y="cpml",
+                              z=Boundary(lo="pec", hi="cpml")),
+        cpml_layers=8,
+    )
+    sim.add(
+        Box((_X1 - _DX, _Y_MID - _W / 2, _H),
+            (_X2 + _DX, _Y_MID + _W / 2, _H + _DX)),
+        material="pec",
+    )
+    pulse = GaussianPulse(f0=5e9, bandwidth=0.8)
+    sim.add_port(position=(_X1, _Y_MID, 0.0), component="ez", impedance=50.0,
+                 extent=_H, waveform=pulse, direction="-x",
+                 reference_plane_cells=10)
+    sim.add_port(position=(_X2, _Y_MID, 0.0), component="ez", impedance=50.0,
+                 extent=_H, waveform=pulse, direction="+x")
+    report = sim.preflight()
+    partial = report.by_code("refplane_partial_optin")
+    assert partial, (
+        f"expected refplane_partial_optin, got {[i.code for i in report]}")
+    assert any("legacy" in i for i in partial)
+
+
+def test_preflight_silent_at_n10_all_opted():
+    report = _build_thru(reference_plane_cells=10).preflight()
+    assert not report.by_code("refplane_near_field")
+    assert not report.by_code("refplane_partial_optin")
+
+
+def test_preflight_silent_without_optin():
+    report = _build_thru().preflight()
+    assert not report.by_code("refplane_near_field")
+    assert not report.by_code("refplane_partial_optin")
+
+
+# ===========================================================================
+# FAST — non-uniform lane end-to-end (finding 7: grading profile + run())
+# ===========================================================================
+
+def test_nonuniform_lane_end_to_end_raises():
+    """A real graded dz_profile routed through run(compute_s_params=True)
+    hits the NU lane and must raise, not silently return legacy
+    off-diagonals (end-to-end witness for the unit-level guard above)."""
+    dz = np.concatenate([np.full(10, 0.4e-3), np.full(12, 0.5e-3)])
+    assert abs(float(np.sum(dz)) - _DOMAIN[2]) < 1e-12
+    sim = Simulation(
+        freq_max=10e9, domain=_DOMAIN, dx=_DX, dz_profile=dz,
+        boundary=BoundarySpec(x="cpml", y="cpml",
+                              z=Boundary(lo="pec", hi="cpml")),
+        cpml_layers=8,
+    )
+    sim.add(
+        Box((_X1 - _DX, _Y_MID - _W / 2, _H),
+            (_X2 + _DX, _Y_MID + _W / 2, _H + _DX)),
+        material="pec",
+    )
+    pulse = GaussianPulse(f0=5e9, bandwidth=0.8)
+    sim.add_port(position=(_X1, _Y_MID, 0.0), component="ez", impedance=50.0,
+                 extent=_H, waveform=pulse, direction="-x",
+                 reference_plane_cells=3)
+    sim.add_port(position=(_X2, _Y_MID, 0.0), component="ez", impedance=50.0,
+                 extent=_H, waveform=pulse, direction="+x",
+                 reference_plane_cells=3)
+    with pytest.raises(NotImplementedError, match="uniform single-device"):
+        sim.run(n_steps=8, compute_s_params=True, s_param_freqs=_FREQS,
+                skip_preflight=True)
 
 
 # ===========================================================================

--- a/tests/test_refplane_port_waves.py
+++ b/tests/test_refplane_port_waves.py
@@ -479,3 +479,174 @@ def test_driver_vi_dump_with_planes_fails_loudly():
     with pytest.raises(NotImplementedError, match="return_vi_dump"):
         compute_lumped_wire_s_matrix_via_scan(
             sim, _FREQS, n_steps=64, return_vi_dump=True)
+
+
+# ===========================================================================
+# SLOW physics battery (opt-in: -m slow_physics) — plane path on the thru
+# ===========================================================================
+#
+# Fixture choice N=10: both planes (10 and 20 cells outboard, x=13/18 mm
+# from port 1 and 19/14 mm from port 2) sit >= 10 cells from every port —
+# the Phase-0 pre-registration rule for the two-plane Zc/beta measurement.
+# The rejected first candidate N=3 (planes 3/6 cells) was measured
+# near-field contaminated: beta/(w/c) read 1.21-1.25 (vs mid-line
+# 1.048-1.065), Zc Im/Re grew to 9.2%, and the |S21| referee residual
+# reached -6.8% at 7 GHz (R2 stop -> placement conformed to the Phase-0
+# clean zone; one redesign, evidence-anchored).
+_REFPLANE_N = 10
+
+# Phase-0 closed-box flux referee |S21| = sqrt(P_abs/P_launch), measured
+# 2026-07-10 (leak-free 6-face boxes; issue #313 Phase-0 comment).
+_REFEREE_S21 = np.array([1.0066, 1.0052, 1.0033, 1.0007, 0.99775,
+                         0.99441, 0.99093, 0.98751, 0.98431])
+
+# Measured plane-path values (THIS implementation, gap-trimmed V, N=10,
+# 4000 steps, 2026-07-10):
+#   |S21| = 0.98251..0.99840; |S21|/referee - 1 = -0.82%..-0.18% per bin
+#   reciprocity rel <= 0.38%; Zc Re 47.94..48.62 ohm (both ports),
+#   Im/Re <= 1.2%; beta/(w/c) = 1.0465..1.0589;
+#   |arg(S21) + beta_meas*L| <= 8.4e-4 rad; max singular value of the
+#   mixed matrix 1.0299 max; |S11|^2+|S21|^2 <= 1.0003.
+# Gates carry margin over these measured values and are labelled with
+# their referee anchors. They are referee-consistency + regression gates
+# on the canonical thru, NOT external cross-solver validation.
+_S21_REFEREE_RESID_BAND = (-0.025, 0.010)   # Phase-0 arch class <= 2.5%
+_S21_LEGACY_BAND_HI = 0.85                  # committed legacy lock band hi
+_RECIP_REL_MAX = 0.02
+_ZC_RE_BAND = (46.0, 50.5)     # measured 47.9-48.6; Phase-0 mid-line
+                               # 47.85-48.63; Phase-0 pair-dependence
+                               # spread across plane pairs 44.5-51.0
+_ZC_IM_OVER_RE_MAX = 0.03      # measured <= 0.012
+_BETA_OVER_WC_BAND = (1.03, 1.08)   # measured 1.0465-1.0589; the 5-6%
+                                    # slow-wave anomaly stays FLAGGED
+                                    # (Phase-0), not explained
+_PHASE_DEEMBED_MAX_RAD = 0.02  # measured <= 8.4e-4 (~24x margin)
+_MIXED_SV_MAX = 1.05           # measured 1.0299 — see honesty label
+_ENERGY_ROW_MAX = 1.02         # measured |S11|^2+|S21|^2 <= 1.0003
+
+
+@pytest.fixture(scope="module")
+def refplane_thru():
+    """Opted thru through the production driver (~2.5 min);
+    quotes preflight verbatim; returns (S complex128, diagnostics)."""
+    from rfx.probes.sparam_driver import compute_lumped_wire_s_matrix_via_scan
+    sim = _build_thru(reference_plane_cells=_REFPLANE_N)
+    issues = [str(i) for i in sim.preflight()]
+    for msg in issues:
+        print(f"\n[refplane thru] preflight (verbatim): {msg}")
+    # Exactly the one known advisory (the infinite ground plane IS the
+    # microstrip return). Anything else = fixture drift, stop.
+    assert len(issues) == 1 and _PEC_FACES_ADVISORY_SNIPPET in issues[0], (
+        f"refplane thru preflight drifted from the baseline: {issues}")
+    S, freqs, diag = compute_lumped_wire_s_matrix_via_scan(
+        sim, _FREQS, n_steps=_N_STEPS, return_refplane_diagnostics=True)
+    S = np.asarray(S).astype(np.complex128)
+    assert S.shape == (2, 2, len(_FREQS))
+    assert np.all(np.isfinite(S))
+    with np.printoptions(precision=5, suppress=False):
+        print(f"[refplane thru] |S21|={np.abs(S[1, 0])}")
+        print(f"[refplane thru] |S21|/referee={np.abs(S[1, 0]) / _REFEREE_S21}")
+        print(f"[refplane thru] Zc0={diag['zc'][0]}")
+        print(f"[refplane thru] Zc1={diag['zc'][1]}")
+        w = 2 * np.pi * _FREQS
+        print(f"[refplane thru] beta0/(w/c)={diag['beta'][0] / (w / C0)}")
+    return S, diag
+
+
+@pytest.mark.slow_physics
+def test_refplane_thru_s21_tracks_box_referee(refplane_thru):
+    """Plane-path |S21| within the Phase-0 closed-box referee class.
+
+    HONESTY LABEL: gate band [-2.5%, +1%] per bin against the Phase-0
+    referee = the Phase-0 reference-plane-architecture residual class
+    (arch |S21| landed within 2.5% of the box referee at all bins);
+    measured here -0.82%..-0.18%. Referee-consistency on the canonical
+    thru — the external openEMS thru remains the final gate (#313)."""
+    S, _ = refplane_thru
+    resid = np.abs(S[1, 0]) / _REFEREE_S21 - 1.0
+    lo, hi = _S21_REFEREE_RESID_BAND
+    assert np.all(resid >= lo) and np.all(resid <= hi), (
+        f"plane-path |S21| left the Phase-0 referee class: resid={resid}")
+
+
+@pytest.mark.slow_physics
+def test_refplane_thru_leaves_legacy_lock_band_loudly(refplane_thru):
+    """LOUD RE-BASELINE (issue #313 falsifier item 8): the plane path
+    must move |S21| OUT of the committed legacy regression-lock band
+    ([0.35, 0.85] in test_lumped_twoport_vi_validation_battery.py, the
+    shipped kappa(f)=1.49-1.86 deflation envelope). If this fails, the
+    plane path stopped moving the number and the whole lane is void."""
+    S, _ = refplane_thru
+    s21 = np.abs(S[1, 0])
+    assert s21.min() > _S21_LEGACY_BAND_HI, (
+        f"plane-path |S21| fell back into the legacy deflation band: "
+        f"min={s21.min():.4f} <= {_S21_LEGACY_BAND_HI} — the drive-side "
+        "kappa deflation returned (issue #313)")
+
+
+@pytest.mark.slow_physics
+def test_refplane_thru_reciprocity(refplane_thru):
+    """S21 vs S12 on the symmetric thru (measured <= 0.38% rel)."""
+    S, _ = refplane_thru
+    rel = np.abs(S[1, 0] - S[0, 1]) / np.abs(S[1, 0])
+    assert np.all(rel <= _RECIP_REL_MAX), f"reciprocity broke: {rel}"
+
+
+@pytest.mark.slow_physics
+def test_refplane_thru_measured_line_constants(refplane_thru):
+    """Measured Zc and beta land in the Phase-0 mid-line class.
+
+    Zc gate [46.0, 50.5] ohm: measured 47.94-48.62 here; Phase-0
+    mid-line pair (13/19 mm) measured 47.85-48.63; the Phase-0 data's
+    pair-to-pair spread across plane pairs is 44.5-51.0 ohm (the open
+    radiating microstrip is not a perfect two-wave line), so the band is
+    a placement-sensitive consistency gate, not a universal constant.
+    beta/(w/c) gate [1.03, 1.08]: measured 1.0465-1.0589; Phase-0
+    1.048-1.061 — the 5-6% slow-wave anomaly stays FLAGGED (Phase 0),
+    this gate locks the measured class, it does not explain it."""
+    _, diag = refplane_thru
+    w = 2 * np.pi * _FREQS
+    for p in (0, 1):
+        zc = diag["zc"][p]
+        assert np.all(zc.real >= _ZC_RE_BAND[0]) \
+            and np.all(zc.real <= _ZC_RE_BAND[1]), (
+                f"port {p} Zc left the measured class: {zc.real}")
+        assert np.all(np.abs(zc.imag / zc.real) <= _ZC_IM_OVER_RE_MAX), (
+            f"port {p} Zc Im/Re too large: {zc.imag / zc.real}")
+        b = diag["beta"][p] / (w / C0)
+        assert np.all(b >= _BETA_OVER_WC_BAND[0]) \
+            and np.all(b <= _BETA_OVER_WC_BAND[1]), (
+                f"port {p} beta/(w/c) left the measured class: {b}")
+
+
+@pytest.mark.slow_physics
+def test_refplane_thru_deembedded_phase_tracks_measured_beta(refplane_thru):
+    """arg(S21) after de-embedding = -beta_meas*L to sub-milliradian
+    (measured <= 8.4e-4 rad; gate 0.02 rad, ~24x margin). This is the
+    de-embed self-consistency witness: the port-plane-referenced thru
+    phase must equal the measured line phase over the port spacing."""
+    S, diag = refplane_thru
+    beta_avg = 0.5 * (diag["beta"][0] + diag["beta"][1])
+    dev = np.angle(S[1, 0] * np.exp(1j * beta_avg * _L))
+    assert np.all(np.abs(dev) <= _PHASE_DEEMBED_MAX_RAD), (
+        f"de-embedded S21 phase left the measured-beta track: {dev}")
+
+
+@pytest.mark.slow_physics
+def test_refplane_thru_energy_and_passivity_labeled(refplane_thru):
+    """Energy/passivity envelope of the MIXED matrix — honesty label.
+
+    The matrix mixes byte-frozen legacy diagonals with plane-referenced
+    off-diagonals (separately calibrated), and the Phase-0 box referee
+    itself reads sqrt(P_abs/P_launch) up to 1.0066 at 3 GHz (~1-3%
+    flux-accounting envelope: residual box leakage + finite DFT). Small
+    >1 excursions of the singular values (measured max 1.0299) are that
+    accounting envelope, NOT validated gain — this gate bounds the
+    envelope, it does not certify passivity. Row energy
+    |S11|^2+|S21|^2 measured <= 1.0003."""
+    S, _ = refplane_thru
+    sv = np.array([np.linalg.svd(S[:, :, k], compute_uv=False)[0]
+                   for k in range(len(_FREQS))])
+    assert np.all(sv <= _MIXED_SV_MAX), f"singular values blew up: {sv}"
+    en = np.abs(S[0, 0]) ** 2 + np.abs(S[1, 0]) ** 2
+    assert np.all(en <= _ENERGY_ROW_MAX), f"row energy blew up: {en}"

--- a/tests/test_refplane_port_waves.py
+++ b/tests/test_refplane_port_waves.py
@@ -535,9 +535,15 @@ _ZC_RE_BAND = (46.0, 50.5)     # measured 47.9-48.6; Phase-0 mid-line
                                # 47.85-48.63; Phase-0 pair-dependence
                                # spread across plane pairs 44.5-51.0
 _ZC_IM_OVER_RE_MAX = 0.03      # measured <= 0.012
-_BETA_OVER_WC_BAND = (1.03, 1.08)   # measured 1.0465-1.0589; the 5-6%
-                                    # slow-wave anomaly stays FLAGGED
-                                    # (Phase-0), not explained
+_BETA_OVER_WC_BAND = (1.03, 1.08)   # measured 1.0465-1.0589. Mechanism
+# check (2026-07-10, one dx/2 rerun at fixed physical geometry and
+# identical physical plane locations on a shortened 12 mm line): the
+# slow-wave excess is dx-STABLE — 0.0781 (dx=0.5mm) -> 0.0756 (dx=0.25mm),
+# ratio 0.97, nowhere near the halving a staircase/dispersion owner
+# would show. The beta/(w/c) = 1.05-1.08 slow wave is PHYSICAL for this
+# open air-line-over-ground geometry (finite-thickness trace, non-TEM
+# fringing), not a discretization artefact. (Measured Zc showed mild dx
+# sensitivity, 48.5 -> 47.0 ohm at dx/2; beta did not.)
 _PHASE_DEEMBED_MAX_RAD = 0.02  # measured <= 8.4e-4 (~24x margin)
 _MIXED_SV_MAX = 1.05           # measured 1.0299 — see honesty label
 _ENERGY_ROW_MAX = 1.02         # measured |S11|^2+|S21|^2 <= 1.0003
@@ -620,8 +626,10 @@ def test_refplane_thru_measured_line_constants(refplane_thru):
     radiating microstrip is not a perfect two-wave line), so the band is
     a placement-sensitive consistency gate, not a universal constant.
     beta/(w/c) gate [1.03, 1.08]: measured 1.0465-1.0589; Phase-0
-    1.048-1.061 — the 5-6% slow-wave anomaly stays FLAGGED (Phase 0),
-    this gate locks the measured class, it does not explain it."""
+    1.048-1.061 — the slow wave is attributed PHYSICAL for this open
+    line by the one dx/2 mechanism check (excess dx-stable, ratio 0.97;
+    see the band comment above), so this gate locks a physical measured
+    class, not a discretization artefact."""
     _, diag = refplane_thru
     w = 2 * np.pi * _FREQS
     for p in (0, 1):


### PR DESCRIPTION
Addresses #313 (does NOT close it: the issue's final gate — the external openEMS thru referee — remains, tracked there).

## What

Opt-in `add_port(reference_plane_cells=N)` for wire ports: two gap-V/dual-Ampère-loop reference planes per port registered in the production scan (mirroring the coax plane-V/I machinery), `exp(+jωdt/2)` on H-derived phasors, forward/backward split with the **measured** two-plane Zc invariant, phase-only de-embedding with **measured** β. Off-diagonals use plane waves when both ports opt in; **diagonals and the default path are byte-frozen** (bitwise witnesses across OFF/N=3/N=10, run() and forward()).

## Why (the #313 evidence chain, all measured)

The port-cell wave definitions are physically unsalvageable for off-diagonals: Phase-0 closed-box referees showed they conserve no power at the port plane (+8→+25%), while reference-plane waves conserve to ≤1.19%. With planes enabled the canonical thru reads |S21| = 0.998→0.983 vs the leak-free referee's 1.007→0.984 (residual −0.82..−0.18% all 9 bins) — the κ(f)=1.49→1.86 deflation is gone, the 55–70% apparent energy deficit closes to 0.982–1.0003, and the legacy low-frequency magnitude defect is repaired (0.571 → 1.001 at 0.5 GHz). DC sign anchor, reciprocity ≤0.38%, Zc 47.9–48.6 Ω all hold.

## Guard rails (review round)

- Runtime **Zc-witness warning** (measured Im/Re > 3% ⇒ near-field-contaminated planes; N=3 measured 8.2% vs N=10 ≤1.2%) + **preflight advisories** for N<10 placement and partial opt-in.
- β wrap guard (ValueError past 0.9π); NU/subgridded lanes raise; distributed lane documented warned-unsupported (+ end-to-end NU test); vi-dump+planes raises.
- api-symbol inventory regenerated (the gate was red — caught in review); CHANGELOG entry with single-geometry-class honesty framing.
- N=3 near-field contamination is documented WITH numbers in the docstring — measured, not guessed.

## Process

Phase-0 measurement redesign (pre-registered decision rule) → implementation with an R5 gap-trim catch (in-trace Ez edge not mask-zeroed) and one rule-conforming placement redesign (N=3→N=10) → 8-falsifier battery vs closed-box referees → 2-lens adversarial review (2× REQUEST_CHANGES, 7 findings) → all applied → combined re-verdict APPROVE. Full evidence chain in the #313 comments.

R3: memory=consistent (public-surface contract tests + api gate run; no gate weakened) | R2-attempts=1 sanctioned placement redesign | falsifier=referee-anchored slow_physics lane + CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)