### PR TITLE
fix(preflight): flag ALL wire-port extent cells inside PEC with live-cell count (closes #319)

### DIFF
--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2258,12 +2258,29 @@ class _PreflightMixin:
         # reads over-unity ~1.06-1.15, because the voltage probe samples a
         # PEC-shorted environment and the port column punches a hole in
         # the trace). Check the exact cell production will use.
+        #
+        # Issue #319 generalization: test EVERY rasterized extent cell, not
+        # just the midpoint. A non-midpoint cell inside PEC is a DEAD cell:
+        # it is shorted, so it drops out of the series impedance chain
+        # (physical termination ~ Z0 * n_live / n) and out of the receive
+        # current path, while the extraction normalization still assumes
+        # all n cells are live (issues #313/#318). Behavior when the
+        # midpoint AND another cell are dead: BOTH warnings fire (the
+        # midpoint one for probe-cell corruption, the dead-extent one for
+        # the termination/normalization consequence), and the dead-extent
+        # live-cell count includes every dead cell — midpoint included —
+        # because the physical termination does not care which cell holds
+        # the probe.
         for pe in self._ports:
             if not getattr(pe, "extent", None):
                 continue
-            mid_center = self._wire_port_midpoint_center(pe)
-            if mid_center is None:
+            rasterized = self._wire_port_cell_centers(pe)
+            if rasterized is None:
                 continue
+            centers, mid_idx = rasterized
+            mid_center = centers[mid_idx]
+
+            pec_bboxes = []
             for entry in self._geometry:
                 if entry.material_name != "pec":
                     continue
@@ -2273,25 +2290,70 @@ class _PreflightMixin:
                     c1, c2 = entry.shape.bounding_box()
                 except (NotImplementedError, TypeError):
                     continue
-                if all(c1[ax] <= mid_center[ax] <= c2[ax] for ax in range(3)):
-                    _w.warn(
-                        PreflightWarning(
-                            f"Wire port at {pe.position} (extent "
-                            f"{pe.extent}): its MIDPOINT V/I probe cell "
-                            f"(center {tuple(round(x, 6) for x in mid_center)}) "
-                            f"lands inside PEC geometry "
-                            f"'{entry.material_name}'. S-parameters from "
-                            f"this port are silently corrupted (measured: "
-                            f"near-null forward transmission + over-unity "
-                            f"reverse). Shorten/lengthen the extent or move "
-                            f"the port so the midpoint cell sits in "
-                            f"dielectric (issue #314).",
-                            code="wire_port_midpoint_in_pec",
-                            source="_validate_cfg_port_inside_pec",
-                        ),
-                        stacklevel=3,
-                    )
-                    break
+                pec_bboxes.append((entry.material_name, c1, c2))
+
+            dead_indices: list[int] = []
+            dead_names: list[str] = []
+            for idx, center in enumerate(centers):
+                for name, c1, c2 in pec_bboxes:
+                    if all(c1[ax] <= center[ax] <= c2[ax] for ax in range(3)):
+                        dead_indices.append(idx)
+                        if name not in dead_names:
+                            dead_names.append(name)
+                        break
+
+            if mid_idx in dead_indices:
+                # Kept verbatim from the #314 fix (PR #317): probe-cell
+                # corruption is the stronger, measured failure mode.
+                name = next(
+                    name for name, c1, c2 in pec_bboxes
+                    if all(c1[ax] <= mid_center[ax] <= c2[ax]
+                           for ax in range(3))
+                )
+                _w.warn(
+                    PreflightWarning(
+                        f"Wire port at {pe.position} (extent "
+                        f"{pe.extent}): its MIDPOINT V/I probe cell "
+                        f"(center {tuple(round(x, 6) for x in mid_center)}) "
+                        f"lands inside PEC geometry "
+                        f"'{name}'. S-parameters from "
+                        f"this port are silently corrupted (measured: "
+                        f"near-null forward transmission + over-unity "
+                        f"reverse). Shorten/lengthen the extent or move "
+                        f"the port so the midpoint cell sits in "
+                        f"dielectric (issue #314).",
+                        code="wire_port_midpoint_in_pec",
+                        source="_validate_cfg_port_inside_pec",
+                    ),
+                    stacklevel=3,
+                )
+
+            non_midpoint_dead = [i for i in dead_indices if i != mid_idx]
+            if non_midpoint_dead:
+                n = len(centers)
+                n_live = n - len(dead_indices)
+                z0 = getattr(pe, "impedance", 0.0) or 0.0
+                z_eff = z0 * n_live / n
+                _w.warn(
+                    PreflightWarning(
+                        f"Wire port at {pe.position} (extent {pe.extent}) "
+                        f"rasterizes to n={n} cells of which "
+                        f"{len(dead_indices)} land inside PEC geometry "
+                        f"{dead_names} (n_live/n = {n_live}/{n}). Dead "
+                        f"cells are shorted by the PEC, so the physical "
+                        f"termination is approximately "
+                        f"Z0*(n_live/n) = {z_eff:.1f} ohm instead of "
+                        f"{z0:g} ohm (measured on the issue-#313 thru: "
+                        f"n=3 with 1 dead cell terminates at 33.3 ohm, "
+                        f"not 50), and the V/I extraction normalization "
+                        f"assumes all {n} cells are live "
+                        f"(issues #313/#318). Shorten the extent or move "
+                        f"the port so every cell center sits outside PEC.",
+                        code="wire_port_dead_extent_cells",
+                        source="_validate_cfg_port_inside_pec",
+                    ),
+                    stacklevel=3,
+                )
 
         for pe in list(self._ports) + list(self._probes):
             pos = pe.position
@@ -2324,15 +2386,18 @@ class _PreflightMixin:
                     except (NotImplementedError, TypeError):
                         pass
 
-    def _wire_port_midpoint_center(self, pe):
-        """Physical center of a wire port's midpoint V/I probe cell.
+    def _wire_port_cell_centers(self, pe):
+        """Per-cell physical sample centers of a wire port's rasterization.
 
-        Mirrors the production rasterization exactly (issue #314):
+        Mirrors the production rasterization exactly (issues #314/#319):
         ``_wire_port_cells`` on the same WirePort that
-        ``forward()``/``run()`` build from this entry, midpoint =
-        ``cells[len(cells) // 2]`` (rfx/api/_execute.py). Returns None
-        when the geometry cannot be resolved (defensive: preflight must
-        never crash a run over a diagnostics helper).
+        ``forward()``/``run()`` build from this entry. Returns
+        ``(centers, midpoint_index)`` where ``centers`` is one physical
+        sample center per rasterized cell and ``midpoint_index`` is the
+        index of the midpoint V/I probe cell, ``cells[len(cells) // 2]``
+        (rfx/api/_execute.py). Returns None when the geometry cannot be
+        resolved (defensive: preflight must never crash a run over a
+        diagnostics helper).
         """
         try:
             from rfx.sources.sources import WirePort, _wire_port_cells
@@ -2345,19 +2410,21 @@ class _PreflightMixin:
             cells = _wire_port_cells(grid, wp)
             if not cells:
                 return None
-            mid = cells[len(cells) // 2]
             d = (grid.dx, getattr(grid, "dy", grid.dx),
                  getattr(grid, "dz", grid.dx))
             pad = (getattr(grid, "pad_x_lo", 0),
                    getattr(grid, "pad_y_lo", 0),
                    getattr(grid, "pad_z_lo", 0))
-            # Inverse of grid.position_to_index (index = round(pos/d) +
-            # pad_lo): node coordinate, plus the Yee half-cell offset of
-            # the E component along its own axis (where the V probe
-            # actually samples).
-            pos = [(mid[ax] - pad[ax]) * d[ax] for ax in range(3)]
-            pos[axis] += 0.5 * d[axis]
-            return tuple(pos)
+            centers = []
+            for cell in cells:
+                # Inverse of grid.position_to_index (index = round(pos/d)
+                # + pad_lo): node coordinate, plus the Yee half-cell
+                # offset of the E component along its own axis (where the
+                # V probe actually samples).
+                pos = [(cell[ax] - pad[ax]) * d[ax] for ax in range(3)]
+                pos[axis] += 0.5 * d[axis]
+                centers.append(tuple(pos))
+            return centers, len(cells) // 2
         except Exception:
             return None
 

--- a/tests/test_inverse_design_preflight.py
+++ b/tests/test_inverse_design_preflight.py
@@ -300,22 +300,32 @@ def test_zero_issue_summary_line_is_honest(capsys):
 # Issue #314: wire-port MIDPOINT V/I probe cell inside PEC
 # ---------------------------------------------------------------------------
 
-def _microstrip_sim(port_extent_m: float) -> Simulation:
+def _microstrip_sim(port_extent_m: float,
+                    trace_z_lo_m: float = 1.0e-3,
+                    trace_z_hi_m: float = 1.5e-3) -> Simulation:
     """Minimal air-microstrip: PEC trace at z in [1.0, 1.5] mm, dx=0.5 mm.
 
     A vertical ez wire port from z=0 rasterizes (production
-    ``_wire_port_cells``) to cells of 0.5 mm; extent 1.5 mm -> 4 cells,
-    midpoint cell center z = 1.25 mm INSIDE the trace (the measured #314
+    ``_wire_port_cells``) to cells of 0.5 mm with sample centers at
+    z = 0.25/0.75/1.25/... mm; extent 1.5 mm -> 4 cells, midpoint cell
+    center z = 1.25 mm INSIDE the default trace (the measured #314
     corruption case); extent 1.0 mm -> 3 cells, midpoint center z =
-    0.75 mm in the substrate gap (healthy).
+    0.75 mm in the substrate gap BUT the TOP cell (center 1.25 mm) is
+    inside the trace — the #313 dead-extent-cell geometry (issue #319).
+    ``trace_z_lo_m``/``trace_z_hi_m`` move/thicken the trace for the
+    clean and both-dead variants.
     """
     sim = Simulation(freq_max=10e9, domain=(0.016, 0.010, 0.006),
                      boundary="cpml", cpml_layers=6, dx=0.5e-3)
-    sim.add(Box((0.004, 0.003, 0.001), (0.012, 0.007, 0.0015)),
+    sim.add(Box((0.004, 0.003, trace_z_lo_m), (0.012, 0.007, trace_z_hi_m)),
             material="pec")
     sim.add_port(position=(0.008, 0.005, 0.0), component="ez",
                  impedance=50.0, extent=port_extent_m)
     return sim
+
+
+def _by_code(issues, code):
+    return [s for s in issues if getattr(s, "code", None) == code]
 
 
 def test_wire_midpoint_in_pec_warns():
@@ -328,8 +338,79 @@ def test_wire_midpoint_in_pec_warns():
 
 
 def test_wire_midpoint_in_gap_does_not_warn():
+    """extent=1.0mm keeps the MIDPOINT (z=0.75mm) in the gap — no #314
+    warning. (The top extent cell IS dead on this geometry; that is the
+    separate #319 advisory, covered below.)"""
     issues = _microstrip_sim(1.0e-3).preflight()
     hits = [s for s in issues if "MIDPOINT" in s]
     assert hits == [], (
         "extent=1.0mm keeps the midpoint (z=0.75mm) in the gap — no #314 "
         "warning expected: " + "\n".join(hits))
+
+
+# ---------------------------------------------------------------------------
+# Issue #319: non-midpoint wire-port extent cells inside PEC (dead cells)
+# ---------------------------------------------------------------------------
+
+def test_wire_dead_extent_cell_warns_with_live_count():
+    """The #313 geometry: extent=1.0mm -> 3 cells (centers 0.25/0.75/1.25
+    mm); the TOP cell sits inside the trace [1.0,1.5]mm while the midpoint
+    (0.75mm) is clean. The #319 dead-extent advisory must fire with
+    n_live/n = 2/3 and the measured ~33.3-ohm termination consequence;
+    the #314 midpoint warning must NOT fire."""
+    issues = _microstrip_sim(1.0e-3).preflight()
+    dead = _by_code(issues, "wire_port_dead_extent_cells")
+    assert len(dead) == 1, (
+        "expected exactly one dead-extent advisory, got: "
+        + "\n".join(str(s) for s in issues))
+    assert "2/3" in dead[0] and "33.3" in dead[0], (
+        "dead-extent advisory must report n_live/n = 2/3 and the "
+        f"33.3-ohm termination (issues #313/#318): {dead[0]}")
+    assert not _by_code(issues, "wire_port_midpoint_in_pec"), (
+        "midpoint is clean on this geometry — #314 must stay silent")
+
+
+def test_wire_midpoint_only_dead_keeps_midpoint_warning_only():
+    """Regression (#314) + documented #319 behavior: when ONLY the
+    midpoint cell is dead (extent=1.5mm -> 4 cells, only z=1.25mm inside
+    the trace), the strong midpoint warning fires and the dead-extent
+    advisory (reserved for NON-midpoint dead cells) does not."""
+    issues = _microstrip_sim(1.5e-3).preflight()
+    assert _by_code(issues, "wire_port_midpoint_in_pec"), (
+        "#314 midpoint warning must still fire: "
+        + "\n".join(str(s) for s in issues))
+    assert not _by_code(issues, "wire_port_dead_extent_cells"), (
+        "only the midpoint cell is dead — the dead-extent advisory is "
+        "reserved for non-midpoint dead cells")
+
+
+def test_wire_port_all_cells_live_is_silent():
+    """Trace raised to [1.5,2.0]mm: all 3 cell centers (0.25/0.75/1.25mm)
+    are live — neither wire-port-in-PEC warning fires."""
+    issues = _microstrip_sim(1.0e-3, trace_z_lo_m=1.5e-3,
+                             trace_z_hi_m=2.0e-3).preflight()
+    hits = (_by_code(issues, "wire_port_midpoint_in_pec")
+            + _by_code(issues, "wire_port_dead_extent_cells"))
+    assert hits == [], (
+        "fully-live wire port must be silent: "
+        + "\n".join(str(s) for s in hits))
+
+
+def test_wire_midpoint_and_other_cell_dead_fires_both():
+    """Documented #319 behavior for the combined case: a thick trace
+    [0.5,1.5]mm with extent=1.5mm kills cells 0.75mm AND 1.25mm (the
+    midpoint) -> BOTH warnings fire, and the dead-extent live count
+    includes the midpoint cell (n_live/n = 2/4 -> ~25.0 ohm), because the
+    physical termination does not care which cell holds the probe."""
+    issues = _microstrip_sim(1.5e-3, trace_z_lo_m=0.5e-3,
+                             trace_z_hi_m=1.5e-3).preflight()
+    assert _by_code(issues, "wire_port_midpoint_in_pec"), (
+        "midpoint (z=1.25mm) is inside the thick trace — #314 must fire: "
+        + "\n".join(str(s) for s in issues))
+    dead = _by_code(issues, "wire_port_dead_extent_cells")
+    assert len(dead) == 1, (
+        "non-midpoint cell (z=0.75mm) is also dead — #319 must fire: "
+        + "\n".join(str(s) for s in issues))
+    assert "2/4" in dead[0] and "25.0" in dead[0], (
+        "dead-extent live count must include the dead midpoint cell "
+        f"(n_live/n = 2/4, 25.0 ohm): {dead[0]}")

--- a/tests/test_lumped_twoport_vi_validation_battery.py
+++ b/tests/test_lumped_twoport_vi_validation_battery.py
@@ -321,15 +321,26 @@ def _build_thru(pulse: "GaussianPulse | None" = None) -> Simulation:
 def thru_smatrix():
     """Run the THRU once (~70 s); quote preflight verbatim; return S(2,2,9)."""
     sim = _build_thru()
-    issues = [str(i) for i in sim.preflight()]
+    report = sim.preflight()
+    issues = [str(i) for i in report]
     # Quote every preflight message verbatim BEFORE reporting numbers
     # (feedback_never_ignore_preflight).
     for msg in issues:
         print(f"\n[thru battery] preflight (verbatim): {msg}")
-    # Exactly the one known advisory (intended: the infinite ground plane
-    # IS the microstrip return). Anything else = fixture drift, stop.
-    assert len(issues) == 1 and _PEC_FACES_ADVISORY_SNIPPET in issues[0], (
+    # Exact known advisory set (re-pinned 2026-07-11 for issue #319):
+    # the intended pec_faces advisory (the infinite ground plane IS the
+    # microstrip return) PLUS one wire_port_dead_extent_cells advisory
+    # per port — this fixture GENUINELY has its top extent cell inside
+    # the PEC trace (issues #313/#318: physical termination ~33.3 ohm,
+    # not 50, is the documented known issue). The battery gates below
+    # were MEASURED on this exact fixture, dead cell included, so they
+    # stay valid as-is. Anything else = fixture drift, stop.
+    codes = sorted(getattr(i, "code", None) for i in report)
+    assert codes == ["pec_faces_finite_pec",
+                     "wire_port_dead_extent_cells",
+                     "wire_port_dead_extent_cells"], (
         f"thru fixture preflight drifted from the measured baseline: {issues}")
+    assert any(_PEC_FACES_ADVISORY_SNIPPET in m for m in issues)
 
     result = sim.run(n_steps=_THRU_N_STEPS, compute_s_params=True,
                      s_param_freqs=_THRU_FREQS_HZ)
@@ -649,11 +660,21 @@ _DCA_DEV_BAND_RAD = (-0.25, +0.10)
 def dc_anchor_smatrix():
     """Low-frequency THRU run (same geometry, f0=2.5 GHz bw=1.0 pulse)."""
     sim = _build_thru(pulse=GaussianPulse(f0=2.5e9, bandwidth=1.0))
-    issues = [str(i) for i in sim.preflight()]
+    report = sim.preflight()
+    issues = [str(i) for i in report]
     for msg in issues:
         print(f"\n[dc anchor] preflight (verbatim): {msg}")
-    assert len(issues) == 1 and _PEC_FACES_ADVISORY_SNIPPET in issues[0], (
+    # Same exact set as the thru_smatrix fixture above (re-pinned
+    # 2026-07-11 for issue #319): pec_faces + one dead-extent-cell
+    # advisory per port (#313/#318 — the ~33.3-ohm termination is the
+    # documented known issue on this geometry; gates measured on it
+    # stay valid as-is).
+    codes = sorted(getattr(i, "code", None) for i in report)
+    assert codes == ["pec_faces_finite_pec",
+                     "wire_port_dead_extent_cells",
+                     "wire_port_dead_extent_cells"], (
         f"dc-anchor fixture preflight drifted: {issues}")
+    assert any(_PEC_FACES_ADVISORY_SNIPPET in m for m in issues)
     result = sim.run(n_steps=_DCA_N_STEPS, compute_s_params=True,
                      s_param_freqs=_DCA_FREQS_HZ)
     return np.asarray(result.s_params).astype(np.complex128)

--- a/tests/test_refplane_port_waves.py
+++ b/tests/test_refplane_port_waves.py
@@ -710,13 +710,24 @@ def refplane_thru():
     quotes preflight verbatim; returns (S complex128, diagnostics)."""
     from rfx.probes.sparam_driver import compute_lumped_wire_s_matrix_via_scan
     sim = _build_thru(reference_plane_cells=_REFPLANE_N)
-    issues = [str(i) for i in sim.preflight()]
+    report = sim.preflight()
+    issues = [str(i) for i in report]
     for msg in issues:
         print(f"\n[refplane thru] preflight (verbatim): {msg}")
-    # Exactly the one known advisory (the infinite ground plane IS the
-    # microstrip return). Anything else = fixture drift, stop.
-    assert len(issues) == 1 and _PEC_FACES_ADVISORY_SNIPPET in issues[0], (
+    # Exact known advisory set (re-pinned 2026-07-11 for issue #319):
+    # pec_faces (the infinite ground plane IS the microstrip return)
+    # PLUS one wire_port_dead_extent_cells advisory per port — the
+    # canonical thru's top extent cell GENUINELY sits inside the PEC
+    # trace (issues #313/#318: physical termination ~33.3 ohm, not 50,
+    # is the documented known issue; every gate in this module was
+    # measured on this exact fixture, dead cell included, so the gates
+    # stay valid as-is). Anything else = fixture drift, stop.
+    codes = sorted(getattr(i, "code", None) for i in report)
+    assert codes == ["pec_faces_finite_pec",
+                     "wire_port_dead_extent_cells",
+                     "wire_port_dead_extent_cells"], (
         f"refplane thru preflight drifted from the baseline: {issues}")
+    assert any(_PEC_FACES_ADVISORY_SNIPPET in m for m in issues)
     S, freqs, diag = compute_lumped_wire_s_matrix_via_scan(
         sim, _FREQS, n_steps=_N_STEPS, return_refplane_diagnostics=True)
     S = np.asarray(S).astype(np.complex128)


### PR DESCRIPTION
Closes #319.

Generalizes the #314 midpoint check: every rasterized wire-port cell is now tested against PEC (production-exact rasterization via the refactored `_wire_port_cell_centers`), and non-midpoint dead cells fire a new `wire_port_dead_extent_cells` advisory reporting **n_live/n and the physical termination Z0·(n_live/n)** — citing the measured #313 case (3 cells, top cell in the trace → 33.3 Ω instead of 50 Ω). Midpoint-in-PEC keeps its stronger #314 message verbatim; both fire when both apply (2/4 → 25.0 Ω case tested).

**Honest fixture updates (the load-bearing part):** the battery, DC-anchor, and refplane thru fixtures *genuinely carry* the dead cells this validator detects (the #313 finding — their 33.3 Ω termination is the documented known issue #318, and their gates were measured ON that fixture, so gate values are untouched). Their exactly-one-advisory asserts are re-pinned to the exact new code set (1× pec_faces + 2× dead-extent) — strengthened from count-1 to exact-code-set, not loosened; measured on the actual builders before pinning.

Tests: 4 new (#313 geometry pins '2/3'+'33.3'; midpoint-only; fully-live silent; both-dead pins '2/4'+'25.0'); preflight suites 83 green, battery+refplane fast 29 green, ruff clean.

Reviewer APPROVE with two LOW pre-existing conventions noted as optional follow-ups (impedance==0 ports not skipped by the advisory loop — mirrors #317 behavior; bbox boundary-inclusive containment — consistent with all three PEC checks).

R3: memory=consistent (the #313 resolution entry explicitly queues this fix) | R2-attempts=0 | falsifier=closed-form n_live termination math on two distinct geometries

🤖 Generated with [Claude Code](https://claude.com/claude-code)