### PR TITLE
fix(sparam): default drive waveform for passive waveform-less ports in the scan S-matrix driver (closes #322)

### DIFF
--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -675,6 +675,21 @@ class _ExecuteMixin:
             # Sparam-eligible lumped/wire port — advance the multi-drive index.
             _sparam_port_idx += 1
 
+            # Effective drive decision + waveform for this pass (issue #322).
+            # A passive port (excite=False) registers waveform=None BY DESIGN
+            # (add_port only defaults the waveform when excite=True). When the
+            # S-matrix scan driver (_sparam_drive_idx; PR #258 wire reroute /
+            # #214 lumped reroute) selects such a port as the driven one,
+            # synthesize the same default excitation add_port() applies for
+            # excite=True ports — otherwise make_port_source /
+            # make_wire_port_sources hits jax.vmap(None)
+            # ("TypeError: Expected a callable value, got None").
+            _drive_this_port = _excite_this_port(pe)
+            _drive_waveform = pe.waveform
+            if _drive_this_port and _drive_waveform is None:
+                _drive_waveform = GaussianPulse(
+                    f0=self._freq_max / 2, bandwidth=0.8)
+
             if pe.extent is not None:
                 axis_map = {"ex": 0, "ey": 1, "ez": 2}
                 axis = axis_map[pe.component]
@@ -685,10 +700,10 @@ class _ExecuteMixin:
                     end=tuple(end),
                     component=pe.component,
                     impedance=pe.impedance,
-                    excitation=pe.waveform,
+                    excitation=_drive_waveform,
                 )
                 materials = setup_wire_port(grid, wp, materials)
-                if _excite_this_port(pe):
+                if _drive_this_port:
                     sources.extend(make_wire_port_sources(grid, wp, materials, n_steps))
                 wp_cells = _wire_port_cells(grid, wp)
                 for cell in wp_cells:
@@ -771,10 +786,10 @@ class _ExecuteMixin:
                 position=pe.position,
                 component=pe.component,
                 impedance=pe.impedance,
-                excitation=pe.waveform,
+                excitation=_drive_waveform,
             )
             materials = setup_lumped_port(grid, lp, materials)
-            if _excite_this_port(pe):
+            if _drive_this_port:
                 sources.append(make_port_source(grid, lp, materials, n_steps))
             idx = grid.position_to_index(pe.position)
             if pec_mask_local is not None:

--- a/tests/test_sparam_passive_port_drive.py
+++ b/tests/test_sparam_passive_port_drive.py
@@ -1,0 +1,143 @@
+"""Regression: scan S-matrix driver vs passive (excite=False) waveform-less ports.
+
+Issue #322 (weekly slow-tests shard red since 2026-07-06): a port registered
+with ``excite=False`` and no waveform stores ``waveform=None`` BY DESIGN
+(``add_port`` only defaults the waveform when ``excite=True``).  The
+production-scan S-matrix driver (``compute_lumped_wire_s_matrix_via_scan``,
+PR #258 wire reroute / #214 lumped reroute) drives EVERY sparam-eligible port
+in turn via ``_sparam_drive_idx`` — and, before the fix, built the drive-pass
+port with ``excitation=None``, crashing in ``jax.vmap(port.excitation)``
+(``TypeError: Expected a callable value, got None``) the moment the passive
+port's drive pass ran.  This is version-independent (reproduced at the CI's
+exact jax 0.6.2), NOT the jax-drift the issue title guessed.
+
+The fix synthesizes the same default excitation ``add_port`` applies for
+``excite=True`` ports (``GaussianPulse(f0=freq_max/2, bandwidth=0.8)``) when
+the driver selects a waveform-less port.  The gate here is *identity*: a
+passive waveform-less port must yield the exact same S-matrix as the same
+port registered with that default waveform explicitly (the driver drives by
+index and ignores ``excite``), so the synthesized default is provably the
+one documented — not merely "something that doesn't crash".
+
+The original crash site (``run(compute_s_params=True)`` on the config-loader
+microstrip-thru fixture) stays covered by the slow
+``tests/test_config_loader.py::test_full_run_matches_direct``; these tests
+keep the guard in the FAST suite for both port families.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from rfx.api import Simulation
+from rfx.sources.sources import GaussianPulse
+from rfx.probes.sparam_driver import compute_lumped_wire_s_matrix_via_scan
+
+# Small vacuum geometry (mirrors test_sparam_driver_matches_eager.py).
+_DOMAIN = (0.024, 0.012, 0.012)
+_DX = 1e-3
+_FREQ_MAX = 10e9
+_CPML_LAYERS = 8
+_FREQS = np.linspace(2e9, 9e9, 7)
+_N_STEPS = 500
+
+
+def _sim():
+    return Simulation(freq_max=_FREQ_MAX, domain=_DOMAIN, dx=_DX,
+                      boundary="cpml", cpml_layers=_CPML_LAYERS)
+
+
+def _default_waveform():
+    """The waveform add_port() defaults to for excite=True ports."""
+    return GaussianPulse(f0=_FREQ_MAX / 2, bandwidth=0.8)
+
+
+# ---------------------------------------------------------------------------
+# Lumped 2-port — passive waveform-less port (latent #214-reroute leg)
+# ---------------------------------------------------------------------------
+
+def test_driver_lumped_passive_port_matches_explicit_default():
+    pos0 = (0.008, 0.006, 0.006)
+    pos1 = (0.016, 0.006, 0.006)
+    wf0 = GaussianPulse(f0=5.5e9, bandwidth=4e9)
+
+    # Port 1 passive, NO waveform (stores waveform=None) — pre-fix this
+    # crashed on drive pass j=1 with jax.vmap(None).
+    sim_passive = _sim()
+    sim_passive.add_port(position=pos0, component="ez", impedance=50.0,
+                         waveform=wf0)
+    sim_passive.add_port(position=pos1, component="ez", impedance=50.0,
+                         excite=False)
+    S_passive, _ = compute_lumped_wire_s_matrix_via_scan(
+        sim_passive, _FREQS, n_steps=_N_STEPS)
+
+    # Same ports, port 1 with the documented default waveform explicit.
+    sim_explicit = _sim()
+    sim_explicit.add_port(position=pos0, component="ez", impedance=50.0,
+                          waveform=wf0)
+    sim_explicit.add_port(position=pos1, component="ez", impedance=50.0,
+                          waveform=_default_waveform())
+    S_explicit, _ = compute_lumped_wire_s_matrix_via_scan(
+        sim_explicit, _FREQS, n_steps=_N_STEPS)
+
+    assert S_passive.shape == S_explicit.shape == (2, 2, len(_FREQS))
+    assert np.all(np.isfinite(S_passive))
+    np.testing.assert_array_equal(
+        np.asarray(S_passive), np.asarray(S_explicit),
+        err_msg="passive waveform-less lumped port must be driven with the "
+                "documented add_port default waveform (identity gate)")
+
+
+# ---------------------------------------------------------------------------
+# Wire 2-port — the exact #322 crash shape (config-loader fixture layout)
+# ---------------------------------------------------------------------------
+
+def test_driver_wire_passive_port_matches_explicit_default():
+    pos0 = (0.008, 0.006, 0.0045)
+    pos1 = (0.016, 0.006, 0.0045)
+    extent = 0.003
+    wf0 = GaussianPulse(f0=5.5e9, bandwidth=4e9)
+
+    sim_passive = _sim()
+    sim_passive.add_port(position=pos0, component="ez", impedance=50.0,
+                         extent=extent, waveform=wf0)
+    sim_passive.add_port(position=pos1, component="ez", impedance=50.0,
+                         extent=extent, excite=False)
+    S_passive, _ = compute_lumped_wire_s_matrix_via_scan(
+        sim_passive, _FREQS, n_steps=_N_STEPS)
+
+    sim_explicit = _sim()
+    sim_explicit.add_port(position=pos0, component="ez", impedance=50.0,
+                          extent=extent, waveform=wf0)
+    sim_explicit.add_port(position=pos1, component="ez", impedance=50.0,
+                          extent=extent, waveform=_default_waveform())
+    S_explicit, _ = compute_lumped_wire_s_matrix_via_scan(
+        sim_explicit, _FREQS, n_steps=_N_STEPS)
+
+    assert S_passive.shape == S_explicit.shape == (2, 2, len(_FREQS))
+    assert np.all(np.isfinite(S_passive))
+    np.testing.assert_array_equal(
+        np.asarray(S_passive), np.asarray(S_explicit),
+        err_msg="passive waveform-less wire port must be driven with the "
+                "documented add_port default waveform (identity gate)")
+
+
+def test_run_compute_s_params_wire_passive_port():
+    """PUBLIC entry point the weekly lane crashed through:
+    run(compute_s_params=True) on a multi-port wire set with a passive
+    waveform-less port routes to the scan driver (PR #258 reroute,
+    rfx/runners/uniform.py) and must not crash."""
+    pos0 = (0.008, 0.006, 0.0045)
+    pos1 = (0.016, 0.006, 0.0045)
+    extent = 0.003
+    wf0 = GaussianPulse(f0=5.5e9, bandwidth=4e9)
+
+    sim = _sim()
+    sim.add_port(position=pos0, component="ez", impedance=50.0,
+                 extent=extent, waveform=wf0)
+    sim.add_port(position=pos1, component="ez", impedance=50.0,
+                 extent=extent, excite=False)
+    res = sim.run(n_steps=_N_STEPS, compute_s_params=True)
+    s = np.asarray(res.s_params)
+    assert s.shape[0] == s.shape[1] == 2
+    assert np.all(np.isfinite(s))


### PR DESCRIPTION
Closes #322 (see the diagnosis-correction comment there: the original premise — amr_surrogate + JAX drift — was falsified by the venv repro; this is a PR #258 functional regression, reproduced at the CI's exact jax 0.6.2).

**Bug**: the #258/#214 scan-driver reroutes drive every sparam-eligible port via `_sparam_drive_idx`; a passive `excite=False` port has `waveform=None` by design → the drive pass built `WirePort/LumpedPort(excitation=None)` → `jax.vmap(None)` TypeError. The weekly slow lane has been red since #258 landed (green 06-29 → red 07-06).

**Fix**: one site (`_forward_from_materials` port loop) synthesizes the default `GaussianPulse(f0=freq_max/2, bandwidth=0.8)` — identical to `add_port`'s excite=True default — when the driver selects a waveform-less port. All previously-green paths byte-unchanged (non-driven ports keep `pe.waveform`). Sweep confirmed no other reachable vmap-of-None site.

**Tests**: new `tests/test_sparam_passive_port_drive.py` — identity gates (passive-None S-matrix ≡ explicit-default S-matrix, `assert_array_equal`) for wire (the crash shape), lumped (the latent leg), and the public `run(compute_s_params=True)` entry; revert-proven (pre-fix FAIL with the exact CI TypeError). The previously-red `test_config_loader.py::test_full_run_matches_direct` now passes. Verified in BOTH the local env and a CI-matching fresh venv (py3.10/jax 0.6.2): 28 passed.

R3: memory=consistent (#258 hybrid design intact — only the drive-pass waveform synthesis added) | R2-attempts=0 | falsifier=revert-proof + the red slow test now green

🤖 Generated with [Claude Code](https://claude.com/claude-code)