### PR TITLE
fix(ports): live-cell-aware wire-port termination — physical 50Ω, not Z0·(n_live/n) (closes #318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — wire-port termination over LIVE cells only (issue #318; field-changing for ports with extent cells inside PEC)
+
+- A wire port whose rasterized extent includes cells inside a PEC conductor
+  ("dead" cells — e.g. the top cell of a vertical feed ending inside the
+  trace) previously counted those cells in its per-cell sigma distribution,
+  drive injection, and `Z0/n_cells` wave normalization. Dead cells carry no
+  port current (measured on the issue-#313 thru: `|I_dead|/|I_mid|` =
+  0.003–0.03), so the physical series termination came out `Z0*(n_live/n)`
+  — 33.3 ohm instead of 50 on the canonical thru. Dead cells are now
+  excluded everywhere: sigma is `n_live*d_par/(Z0*dA)` at live cells only
+  (series termination exactly `Z0` by closed form), the drive is
+  `V/n_live` over live cells, and the wave normalization is
+  `Z0c = Z0/n_live`. A port whose extent lies entirely inside PEC now
+  raises `ValueError`.
+- The port-cell PEC-mask/occupancy clearing is likewise scoped to live
+  cells: the old all-cells clearing punched a one-cell in-plane
+  conductivity hole in the DUT conductor at each dead cell (witnessed:
+  in-plane `|Ex|` at the dead cell 1.5 -> 0.0 after the fix; the port's
+  Ez chain is unaffected under the thin-sheet rule).
+- **No change for ports with all extent cells live** (`n_live == n`
+  degenerates every formula to the previous one): clean fixtures,
+  goldens, and the `run()`/`forward()` contract were verified bitwise
+  identical. Canonical-thru movement (measured): max in-band |S11|
+  0.130 -> 0.086 (mean 0.076 -> 0.051); |S21| 0.524–0.668 ->
+  0.546–0.610; reciprocity `|S21−S12|` 1.04e-2 -> 0.75e-2. The
+  remaining |S11| floor is frequency-rising (0.033 at 4.5 GHz -> 0.086
+  at 7 GHz), consistent with a reactive feed discontinuity rather than
+  a resistive termination error — tracked separately in issue #318.
+- The `wire_port_dead_extent_cells` preflight advisory now states the
+  post-fix semantics (dead cells excluded; the `Z0*(n_live/n)`
+  termination is cited as the historical pre-fix behaviour).
+
 ### Added — opt-in reference-plane port waves for the wire S-matrix off-diagonals (`add_port(reference_plane_cells=)`, issue #313)
 
 - `add_port(..., extent=..., direction=..., reference_plane_cells=N)` registers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,9 +31,17 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   identical. Canonical-thru movement (measured): max in-band |S11|
   0.130 -> 0.086 (mean 0.076 -> 0.051); |S21| 0.524–0.668 ->
   0.546–0.610; reciprocity `|S21−S12|` 1.04e-2 -> 0.75e-2. The
-  remaining |S11| floor is frequency-rising (0.033 at 4.5 GHz -> 0.086
-  at 7 GHz), consistent with a reactive feed discontinuity rather than
-  a resistive termination error — tracked separately in issue #318.
+  post-fix |S11| is a V-shaped curve (0.033 at 4.5 GHz rising to 0.086
+  at 7 GHz and 0.056 at 3 GHz) — this is rfx's *measured* feed-post
+  reflection, not a residual termination error: the two wire ports are
+  1 mm vertical feed posts (~0.26 nH each) whose reactances interfere
+  across the 16 mm line, giving a reflection null near 4.5 GHz
+  (H_FIXTURE re-diagnosis, decisive on three independent witnesses).
+  The pre-registered `max|S11| < 0.06` falsifier missed only because it
+  neglected feed-post reactance (a modelling omission in the
+  prediction, not a fix failure). The lumped/wire V·I battery and the
+  reference-plane battery gates are re-baselined onto this measured
+  physics in the same change.
 - The `wire_port_dead_extent_cells` preflight advisory now states the
   post-fix semantics (dead cells excluded; the `Z0*(n_live/n)`
   termination is cited as the historical pre-fix behaviour).

--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -2095,7 +2095,8 @@
         "state",
         "grid",
         "port",
-        "dt"
+        "dt",
+        "n_live"
       ]
     },
     "validate_artifact_report": {

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -702,9 +702,18 @@ class _ExecuteMixin:
                     impedance=pe.impedance,
                     excitation=_drive_waveform,
                 )
-                materials = setup_wire_port(grid, wp, materials)
+                # Live-cell-aware fold + injection (issue #318): dead
+                # extent cells inside PEC carry no port sigma and no
+                # source. ``pec_mask_local`` at this point still holds the
+                # assembled-geometry state for THIS port's cells (its own
+                # clearing happens just below), which is exactly the
+                # "live" definition.
+                materials = setup_wire_port(grid, wp, materials,
+                                            pec_mask=pec_mask_local)
                 if _drive_this_port:
-                    sources.extend(make_wire_port_sources(grid, wp, materials, n_steps))
+                    sources.extend(make_wire_port_sources(
+                        grid, wp, materials, n_steps,
+                        pec_mask=pec_mask_local))
                 wp_cells = _wire_port_cells(grid, wp)
                 for cell in wp_cells:
                     if pec_mask_local is not None:

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -715,7 +715,18 @@ class _ExecuteMixin:
                         grid, wp, materials, n_steps,
                         pec_mask=pec_mask_local))
                 wp_cells = _wire_port_cells(grid, wp)
-                for cell in wp_cells:
+                # Clear PEC mask/occupancy at LIVE wire cells only (issue
+                # #318 commit 2). Dead extent cells stay PEC — the old
+                # all-cells clearing punched a one-cell in-plane
+                # conductivity hole in the DUT conductor. The Kottke
+                # occupancy-neighbor clearing below keys off
+                # ``_port_cleared_cells`` and is scoped the same way.
+                from rfx.sources.sources import _wire_port_live_cells
+                _, wp_live_flags, _ = _wire_port_live_cells(
+                    grid, wp, pec_mask_local)
+                for cell, _live in zip(wp_cells, wp_live_flags):
+                    if not _live:
+                        continue
                     if pec_mask_local is not None:
                         pec_mask_local = pec_mask_local.at[cell[0], cell[1], cell[2]].set(False)
                     if pec_occupancy_local is not None:

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2261,16 +2261,19 @@ class _PreflightMixin:
         #
         # Issue #319 generalization: test EVERY rasterized extent cell, not
         # just the midpoint. A non-midpoint cell inside PEC is a DEAD cell:
-        # it is shorted, so it drops out of the series impedance chain
-        # (physical termination ~ Z0 * n_live / n) and out of the receive
-        # current path, while the extraction normalization still assumes
-        # all n cells are live (issues #313/#318). Behavior when the
-        # midpoint AND another cell are dead: BOTH warnings fire (the
-        # midpoint one for probe-cell corruption, the dead-extent one for
-        # the termination/normalization consequence), and the dead-extent
-        # live-cell count includes every dead cell — midpoint included —
-        # because the physical termination does not care which cell holds
-        # the probe.
+        # it is shorted by the surrounding conductor, so it carries no port
+        # current. Since the issue-#318 fix, dead cells are EXCLUDED from
+        # the port's sigma distribution, drive injection, and Z0c wave
+        # normalization (the port terminates at Z0 across its live cells;
+        # pre-fix versions counted all n cells and physically terminated at
+        # Z0*(n_live/n) — the issue-#313 33.3-ohm finding). This advisory
+        # remains because a port extent overlapping a conductor is usually
+        # a geometry mistake worth confirming. Behavior when the midpoint
+        # AND another cell are dead: BOTH warnings fire (the midpoint one
+        # for probe-cell corruption, the dead-extent one for the geometry/
+        # normalization consequence), and the dead-extent live-cell count
+        # includes every dead cell — midpoint included — because the live
+        # split does not care which cell holds the probe.
         for pe in self._ports:
             if not getattr(pe, "extent", None):
                 continue
@@ -2340,15 +2343,19 @@ class _PreflightMixin:
                         f"rasterizes to n={n} cells of which "
                         f"{len(dead_indices)} land inside PEC geometry "
                         f"{dead_names} (n_live/n = {n_live}/{n}). Dead "
-                        f"cells are shorted by the PEC, so the physical "
-                        f"termination is approximately "
-                        f"Z0*(n_live/n) = {z_eff:.1f} ohm instead of "
-                        f"{z0:g} ohm (measured on the issue-#313 thru: "
-                        f"n=3 with 1 dead cell terminates at 33.3 ohm, "
-                        f"not 50), and the V/I extraction normalization "
-                        f"assumes all {n} cells are live "
-                        f"(issues #313/#318). Shorten the extent or move "
-                        f"the port so every cell center sits outside PEC.",
+                        f"cells are shorted by the PEC and are excluded "
+                        f"from the port's resistance distribution, drive "
+                        f"injection, and wave normalization (issue #318 "
+                        f"fix): the port terminates at {z0:g} ohm across "
+                        f"its {n_live} live cells. (rfx versions before "
+                        f"the #318 fix counted all {n} cells and "
+                        f"physically terminated at Z0*(n_live/n) = "
+                        f"{z_eff:.1f} ohm — the issue-#313 finding.) "
+                        f"Verify the extent was MEANT to end on/inside "
+                        f"the conductor, and keep the midpoint V/I probe "
+                        f"cell live; to silence, shorten the extent or "
+                        f"move the port so every cell center sits "
+                        f"outside PEC.",
                         code="wire_port_dead_extent_cells",
                         source="_validate_cfg_port_inside_pec",
                     ),

--- a/rfx/probes/probes.py
+++ b/rfx/probes/probes.py
@@ -793,23 +793,27 @@ def update_wire_sparam_probe(
     grid,
     port,
     dt: float,
+    n_live: int | None = None,
 ) -> SParamProbe:
     """Accumulate one timestep of V, I, and V_inc for a WirePort.
 
     Call this every timestep after update_e() / apply_pec() but
     **before** apply_wire_port() so that the sampled voltage reflects
     only the load/cavity response.  V and I are measured at the midpoint
-    cell.  V_inc uses the per-cell source voltage (V_src / N_cells) to
-    match the single-cell measurement.
+    cell.  V_inc uses the per-cell source voltage (V_src / n_live,
+    matching ``apply_wire_port``'s live-cell injection — issue #318;
+    ``n_live=None`` falls back to the all-cells count, the historical
+    behaviour and the degenerate no-dead-cells case).
     """
     from rfx.sources.sources import _wire_port_cells
 
     t = state.step * dt  # keep traceable: float(state.step) leaked the tracer
-    n_cells = max(len(_wire_port_cells(grid, port)), 1)
+    if n_live is None:
+        n_live = max(len(_wire_port_cells(grid, port)), 1)
 
     v = wire_port_voltage(state, grid, port)
     i_val = wire_port_current(state, grid, port)
-    v_inc = port.excitation(t) / n_cells
+    v_inc = port.excitation(t) / n_live
 
     phase = jnp.exp(-1j * 2.0 * jnp.pi * probe.freqs * t)
     weight = _dft_window_weight(state.step, probe.total_steps, probe.window, probe.window_alpha)
@@ -1372,7 +1376,12 @@ def extract_s_matrix_wire(
     from rfx.materials.debye import init_debye
     from rfx.materials.lorentz import init_lorentz
     from rfx.simulation import _update_e_with_optional_dispersion
-    from rfx.sources.sources import setup_wire_port, apply_wire_port, _wire_port_cells
+    from rfx.sources.sources import (
+        setup_wire_port,
+        apply_wire_port,
+        _wire_port_cells,
+        _wire_port_live_cells,
+    )
 
     n_ports = len(ports)
     n_freqs = len(freqs)
@@ -1386,10 +1395,12 @@ def extract_s_matrix_wire(
         from rfx.boundaries.cpml import init_cpml, apply_cpml_e, apply_cpml_h
         cpml_params, cpml_state_init = init_cpml(grid)
 
-    # Fold ALL port impedances into materials (once)
+    # Fold ALL port impedances into materials (once), over LIVE cells only
+    # (issue #318 — dead extent cells inside PEC are excluded from the
+    # sigma distribution, injection, and normalization counts below).
     mats = materials
     for p in ports:
-        mats = setup_wire_port(grid, p, mats)
+        mats = setup_wire_port(grid, p, mats, pec_mask=pec_mask)
 
     debye = None
     if debye_spec is not None:
@@ -1413,10 +1424,15 @@ def extract_s_matrix_wire(
         np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex128)
         if return_vi_dump else None
     )
-    port_cell_counts = np.asarray(
-        [max(len(_wire_port_cells(grid, p)), 1) for p in ports],
-        dtype=np.int64,
-    )
+    # Per-port LIVE cell counts (issue #318): feed the wave-decomposition
+    # normalization Z0c = Z0/n_live so the per-cell resistor law
+    # R_cell = Z0/n_live == Z0c stays exact (the #308 receive-channel
+    # selection relies on that identity).  With no dead cells this is the
+    # historical all-cells count.
+    port_n_live = [
+        _wire_port_live_cells(grid, p, pec_mask)[2] for p in ports
+    ]
+    port_cell_counts = np.asarray(port_n_live, dtype=np.int64)
 
     for j in range(n_ports):
         state = init_state(grid.shape)
@@ -1459,10 +1475,12 @@ def extract_s_matrix_wire(
             # the sampled voltage reflects only the load/cavity response.
             for i in range(n_ports):
                 sprobes[i] = update_wire_sparam_probe(
-                    sprobes[i], state, grid, ports[i], dt)
+                    sprobes[i], state, grid, ports[i], dt,
+                    n_live=port_n_live[i])
 
-            # Excite only port j
-            state = apply_wire_port(state, grid, ports[j], t, mats)
+            # Excite only port j (live cells only, issue #318)
+            state = apply_wire_port(state, grid, ports[j], t, mats,
+                                    pec_mask=pec_mask)
 
         # Collect per-(drive j, receive i) midpoint V/I DFT phasors for the
         # shared wire wave decomposer (``decompose_wire_s_matrix``) — single

--- a/rfx/probes/sparam_driver.py
+++ b/rfx/probes/sparam_driver.py
@@ -122,9 +122,15 @@ def compute_lumped_wire_s_matrix_via_scan(
     n_ports = len(eligible)
     z0 = np.asarray([pe.impedance for pe in eligible], dtype=np.float64)
 
-    # Per-port wire cell counts (only needed for the wire decomposer).
+    # Per-port wire LIVE cell counts (only needed for the wire decomposer).
+    # Issue #318: the wave-decomposition normalization is Z0c = Z0/n_live so
+    # it matches the live-cell sigma fold's per-cell resistor law
+    # R_cell = Z0/n_live (the #308 receive-channel selection relies on that
+    # identity). ``pec_mask`` here is the assembled-geometry state BEFORE
+    # any port-cell clearing — exactly the "live" definition. With no dead
+    # cells this is the historical all-cells count.
     if wire_mode:
-        from rfx.sources.sources import WirePort, _wire_port_cells
+        from rfx.sources.sources import WirePort, _wire_port_live_cells
         axis_map = {"ex": 0, "ey": 1, "ez": 2}
         port_cell_counts = np.zeros(n_ports, dtype=np.int64)
         for idx, pe in enumerate(eligible):
@@ -137,7 +143,8 @@ def compute_lumped_wire_s_matrix_via_scan(
                 impedance=pe.impedance,
                 excitation=pe.waveform,
             )
-            port_cell_counts[idx] = max(len(_wire_port_cells(grid, wp)), 1)
+            port_cell_counts[idx] = _wire_port_live_cells(
+                grid, wp, pec_mask)[2]
 
     # FDTD-sign V/I phasors per (drive j, receive i).
     v_all = np.zeros((n_ports, n_ports, n_freqs), dtype=np.complex128)

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -468,31 +468,56 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
             hi_k = max(idx[axis], idx_end[axis])
 
             wire_cells = list(range(lo_k, hi_k + 1))
-            n_cells = max(len(wire_cells), 1)
 
-            _dx_np = np.asarray(grid.dx_arr)
-            _dy_np = np.asarray(grid.dy_arr)
+            # Live-cell split (issue #318): a cell whose extent lies inside
+            # PEC (assembled-geometry mask, read BEFORE this port's own
+            # clearing below) is dead — it carries no port sigma and no
+            # source, and drops out of the 1/n scaling. With no dead cells
+            # this is bit-identical to the historical all-cells formula.
+            _cells_ijk = []
             for k in wire_cells:
                 cell = list(idx)
                 cell[axis] = k
-                ci, cj, ck = cell
+                _cells_ijk.append(tuple(cell))
+            if pec_mask is not None:
+                _mask_np = np.asarray(pec_mask)
+                live_flags = [not bool(_mask_np[c[0], c[1], c[2]])
+                              for c in _cells_ijk]
+            else:
+                live_flags = [True] * len(_cells_ijk)
+            n_live = sum(live_flags)
+            if n_live == 0:
+                raise ValueError(
+                    f"WirePort at {pe.position} ({pe.component}, extent "
+                    f"{pe.extent}): all {len(_cells_ijk)} extent cells land "
+                    "inside PEC geometry, so the port has no live cell to "
+                    "terminate or drive (issue #318). Shorten the extent or "
+                    "move the port so at least one cell center sits outside "
+                    "PEC."
+                )
+
+            _dx_np = np.asarray(grid.dx_arr)
+            _dy_np = np.asarray(grid.dy_arr)
+            for (ci, cj, ck), live in zip(_cells_ijk, live_flags):
                 dxi = float(_dx_np[ci])
                 dyj = float(_dy_np[cj])
-                # 3D wire port: σ = n_cells * d_parallel / (Z0 * d_perp1 * d_perp2)
-                # Each cell in the wire carries 1/n_cells of total impedance Z0.
-                if axis == 2:
-                    d_cell = float(grid.dz[ck])
-                    dp1, dp2 = dxi, dyj
-                elif axis == 1:
-                    d_cell = dyj
-                    dp1, dp2 = dxi, float(grid.dz[ck])
-                else:
-                    d_cell = dxi
-                    dp1, dp2 = dyj, float(grid.dz[ck])
-                sigma_port = n_cells * d_cell / (pe.impedance * dp1 * dp2)
-                materials = materials._replace(
-                    sigma=materials.sigma.at[ci, cj, ck].add(
-                        sigma_port))
+                # 3D wire port: σ = n_live * d_parallel / (Z0 * d_perp1 * d_perp2)
+                # Each LIVE cell in the wire carries 1/n_live of total
+                # impedance Z0 (issue #318 — dead cells excluded).
+                if live:
+                    if axis == 2:
+                        d_cell = float(grid.dz[ck])
+                        dp1, dp2 = dxi, dyj
+                    elif axis == 1:
+                        d_cell = dyj
+                        dp1, dp2 = dxi, float(grid.dz[ck])
+                    else:
+                        d_cell = dxi
+                        dp1, dp2 = dyj, float(grid.dz[ck])
+                    sigma_port = n_live * d_cell / (pe.impedance * dp1 * dp2)
+                    materials = materials._replace(
+                        sigma=materials.sigma.at[ci, cj, ck].add(
+                            sigma_port))
                 if pec_mask is not None:
                     pec_mask = pec_mask.at[ci, cj, ck].set(False)
 
@@ -504,14 +529,15 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
             mid_cell[axis] = mid_k
 
             if pe.excite:
-                for k in wire_cells:
-                    cell = list(idx)
-                    cell[axis] = k
+                for cell_ijk, live in zip(_cells_ijk, live_flags):
+                    # Dead extent cells get no source (issue #318).
+                    if not live:
+                        continue
                     src = make_current_source(
-                        grid, tuple(cell), pe.component,
+                        grid, cell_ijk, pe.component,
                         pe.waveform, n_steps, materials_concrete)
-                    # Scale by 1/n_cells for distributed excitation
-                    scaled_wf = np.array(src[4]) / n_cells
+                    # Scale by 1/n_live for distributed excitation
+                    scaled_wf = np.array(src[4]) / n_live
                     sources.append(
                         (src[0], src[1], src[2], src[3], scaled_wf))
 

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -518,8 +518,12 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
                     materials = materials._replace(
                         sigma=materials.sigma.at[ci, cj, ck].add(
                             sigma_port))
-                if pec_mask is not None:
-                    pec_mask = pec_mask.at[ci, cj, ck].set(False)
+                    # Clear PEC mask at LIVE cells only (issue #318
+                    # commit 2): dead extent cells stay PEC so the port
+                    # does not punch an in-plane conductivity hole in the
+                    # DUT conductor.
+                    if pec_mask is not None:
+                        pec_mask = pec_mask.at[ci, cj, ck].set(False)
 
             # Create per-cell sources — only when the port is excited.
             # Passive (excite=False) ports contribute just the σ

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -223,11 +223,21 @@ def run_uniform(
             if pe.excite:
                 sources.extend(make_wire_port_sources(
                     grid, wp, materials, n_steps, pec_mask=pec_mask))
-            # Clear PEC mask at wire cells (probe pierces ground plane)
+            # Clear PEC mask at LIVE wire cells only (issue #318 commit 2).
+            # Dead extent cells stay PEC: the old all-cells clearing punched
+            # a one-cell in-plane conductivity hole in the DUT conductor
+            # (the cleared cell's Ex/Ey were exempt from apply_pec_mask
+            # while its neighbors stayed zeroed). The port's Ez chain is
+            # unaffected either way: Ez at a 1-cell-thick sheet is normal
+            # to it and free under the thin-sheet rule.
             if pec_mask is not None:
-                from rfx.sources.sources import _wire_port_cells
-                for cell in _wire_port_cells(grid, wp):
-                    pec_mask = pec_mask.at[cell[0], cell[1], cell[2]].set(False)
+                from rfx.sources.sources import _wire_port_live_cells
+                wp_cells, wp_live, _ = _wire_port_live_cells(
+                    grid, wp, pec_mask)
+                for cell, live in zip(wp_cells, wp_live):
+                    if live:
+                        pec_mask = pec_mask.at[
+                            cell[0], cell[1], cell[2]].set(False)
         else:
             # Single-cell lumped port
             lp = LumpedPort(

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -214,9 +214,15 @@ def run_uniform(
                 impedance=pe.impedance, excitation=pe.waveform,
             )
             wire_ports.append(wp)
-            materials = setup_wire_port(grid, wp, materials)
+            # Live-cell-aware fold + injection (issue #318): dead extent
+            # cells inside PEC carry no port sigma and no source. The mask
+            # here is the assembled-geometry state BEFORE this port's own
+            # clearing below, which is exactly the "live" definition.
+            materials = setup_wire_port(grid, wp, materials,
+                                        pec_mask=pec_mask)
             if pe.excite:
-                sources.extend(make_wire_port_sources(grid, wp, materials, n_steps))
+                sources.extend(make_wire_port_sources(
+                    grid, wp, materials, n_steps, pec_mask=pec_mask))
             # Clear PEC mask at wire cells (probe pierces ground plane)
             if pec_mask is not None:
                 from rfx.sources.sources import _wire_port_cells

--- a/rfx/simulation.py
+++ b/rfx/simulation.py
@@ -252,34 +252,38 @@ def make_port_source(grid: Grid, port, materials: MaterialArrays, n_steps):
                       component=port.component, waveform=waveform)
 
 
-def make_wire_port_sources(grid, port, materials, n_steps):
+def make_wire_port_sources(grid, port, materials, n_steps, pec_mask=None):
     """Create a list of SourceSpec for a multi-cell WirePort.
 
-    Each cell in the wire gets its own SourceSpec with the Cb-corrected
-    waveform scaled by 1/N_cells.  The port impedance must already be
-    folded into *materials* via ``setup_wire_port()``.
+    Each LIVE cell in the wire gets its own SourceSpec with the
+    Cb-corrected waveform scaled by 1/n_live (issue #318: dead extent
+    cells inside PEC get no source — pre-#318 they accumulated phantom
+    EMF).  With ``pec_mask=None`` (or no dead cells) this is the
+    historical all-cells 1/N_cells behaviour.  The port impedance must
+    already be folded into *materials* via ``setup_wire_port()``.
 
     Returns
     -------
     list[SourceSpec]
     """
-    from rfx.sources.sources import _wire_port_cells
+    from rfx.sources.sources import _wire_port_live_cells
 
-    cells = _wire_port_cells(grid, port)
-    n_cells = max(len(cells), 1)
+    cells, live_flags, n_live = _wire_port_live_cells(grid, port, pec_mask)
     times = jnp.arange(n_steps, dtype=jnp.float32) * grid.dt
 
     from rfx.sources.sources import port_d_parallel
 
     specs = []
-    for cell in cells:
+    for cell, live in zip(cells, live_flags):
+        if not live:
+            continue
         i, j, k = cell
         d_par = port_d_parallel(grid, (i, j, k), port.component)
         eps = materials.eps_r[i, j, k] * EPS_0
         sigma = materials.sigma[i, j, k]
         loss = sigma * grid.dt / (2.0 * eps)
         cb = (grid.dt / eps) / (1.0 + loss)
-        waveform = (cb / d_par) * jax.vmap(port.excitation)(times) / n_cells
+        waveform = (cb / d_par) * jax.vmap(port.excitation)(times) / n_live
         specs.append(SourceSpec(i=i, j=j, k=k,
                                 component=port.component, waveform=waveform))
     return specs

--- a/rfx/sources/sources.py
+++ b/rfx/sources/sources.py
@@ -292,35 +292,92 @@ def _wire_port_cells(grid, port):
     return cells
 
 
-def setup_wire_port(grid, port, materials):
-    """Distribute port impedance across all wire cells.
+def _wire_port_live_cells(grid, port, pec_mask=None):
+    """Split the wire cells into (cells, live_flags, n_live) — issue #318.
 
-    For N cells in series with total impedance Z0:
-      σ_cell = n_cells · d_parallel / (Z0 · d_perp1 · d_perp2)
-    On uniform grids this reduces to N / (Z0 · dx).
+    A cell is *live* when the assembled-geometry PEC mask (geometry PEC +
+    PEC thin conductors, read BEFORE the runner's port-cell clearing) is
+    False there.  A dead cell — one whose extent lies inside a PEC
+    conductor — carries essentially no port current (measured on the
+    issue-#313 thru: |I_dead|/|I_mid| = 0.003-0.03), so its per-cell port
+    resistor is bypassed and it must not be counted in the series
+    impedance distribution or the drive/normalization cell counts.
+
+    ``pec_mask=None`` treats every cell as live — identical to the
+    historical behaviour, and the degenerate case n_live == n makes every
+    caller's formula bit-identical to the pre-#318 one.
+
+    The mask must be concrete (host-readable): the live split is a static
+    geometry decision, made once at setup time, mirroring the
+    reference-plane spec builder's concreteness requirement.
+
+    Raises
+    ------
+    ValueError
+        When every extent cell is inside PEC (n_live == 0): such a port
+        has no live cell to terminate or drive.
     """
+    import numpy as np
+
     cells = _wire_port_cells(grid, port)
-    n_cells = max(len(cells), 1)
+    if pec_mask is None:
+        return cells, [True] * len(cells), max(len(cells), 1)
+
+    mask_np = np.asarray(pec_mask)
+    live_flags = [not bool(mask_np[c[0], c[1], c[2]]) for c in cells]
+    n_live = sum(live_flags)
+    if n_live == 0:
+        raise ValueError(
+            f"WirePort {port.start} -> {port.end} ({port.component}): all "
+            f"{len(cells)} extent cells land inside PEC geometry, so the "
+            "port has no live cell to terminate or drive (issue #318). "
+            "Shorten the extent or move the port so at least one cell "
+            "center sits outside PEC."
+        )
+    return cells, live_flags, n_live
+
+
+def setup_wire_port(grid, port, materials, pec_mask=None):
+    """Distribute port impedance across the LIVE wire cells (issue #318).
+
+    For n_live live cells in series with total impedance Z0:
+      σ_cell = n_live · d_parallel / (Z0 · d_perp1 · d_perp2)
+    On uniform grids this reduces to n_live / (Z0 · dx).
+
+    Cells whose extent lies inside PEC (dead cells) get NO port sigma:
+    their resistor is bypassed by the surrounding conductor, so counting
+    them made the physical series termination Z0·(n_live/n) instead of Z0
+    (issue #318; measured 33.3 ohm on the issue-#313 thru, n=3 with one
+    dead cell).  With ``pec_mask=None`` — or no dead cells — this is
+    bit-identical to the historical all-cells formula.
+    """
+    cells, live_flags, n_live = _wire_port_live_cells(grid, port, pec_mask)
 
     sigma = materials.sigma
-    for cell in cells:
-        sp = port_sigma(grid, cell, port.component, port.impedance) * n_cells
+    for cell, live in zip(cells, live_flags):
+        if not live:
+            continue
+        sp = port_sigma(grid, cell, port.component, port.impedance) * n_live
         sigma = sigma.at[cell[0], cell[1], cell[2]].add(sp)
     return materials._replace(sigma=sigma)
 
 
-def apply_wire_port(state, grid, port, t, materials):
-    """Inject source voltage distributed across all wire cells.
+def apply_wire_port(state, grid, port, t, materials, pec_mask=None):
+    """Inject source voltage distributed across the LIVE wire cells.
 
-    Each cell gets V_src / N_cells, with Cb computed from local materials.
+    Each live cell gets V_src / n_live, with Cb computed from local
+    materials.  Dead extent cells (inside PEC, issue #318) receive no
+    injection — pre-#318 they accumulated phantom EMF on an edge whose
+    only discharge path was the port sigma folded at that cell.
     """
-    cells = _wire_port_cells(grid, port)
-    n_cells = max(len(cells), 1)
-    v_src = port.excitation(t) / n_cells
+    cells, live_flags, n_live = _wire_port_live_cells(grid, port, pec_mask)
+    v_src = port.excitation(t) / n_live
     dt = grid.dt
 
     field = getattr(state, port.component)
-    for cell in cells:
+    for cell, live in zip(cells, live_flags):
+        if not live:
+            continue
         i, j, k = cell
         d_par = port_d_parallel(grid, (i, j, k), port.component)
         eps = float(materials.eps_r[i, j, k]) * EPS_0

--- a/tests/test_inverse_design_preflight.py
+++ b/tests/test_inverse_design_preflight.py
@@ -356,25 +356,32 @@ def test_wire_dead_extent_cell_warns_with_live_count():
     """The #313 geometry: extent=1.0mm -> 3 cells (centers 0.25/0.75/1.25
     mm); the TOP cell sits inside the trace [1.0,1.5]mm while the midpoint
     (0.75mm) is clean. The #319 dead-extent advisory must fire with
-    n_live/n = 2/3 and the measured ~33.3-ohm termination consequence;
-    the #314 midpoint warning must NOT fire."""
+    n_live/n = 2/3, the post-#318-fix semantics (dead cells EXCLUDED from
+    the resistance distribution / drive / normalization), and the
+    historical pre-fix Z0*(n_live/n) = 33.3-ohm citation; the #314
+    midpoint warning must NOT fire."""
     issues = _microstrip_sim(1.0e-3).preflight()
     dead = _by_code(issues, "wire_port_dead_extent_cells")
     assert len(dead) == 1, (
         "expected exactly one dead-extent advisory, got: "
         + "\n".join(str(s) for s in issues))
-    assert "2/3" in dead[0] and "33.3" in dead[0], (
+    assert "2/3" in dead[0] and "excluded" in dead[0], (
         "dead-extent advisory must report n_live/n = 2/3 and the "
-        f"33.3-ohm termination (issues #313/#318): {dead[0]}")
+        f"post-#318 excluded-from-distribution semantics: {dead[0]}")
+    assert "33.3" in dead[0], (
+        "dead-extent advisory must keep the historical pre-fix "
+        f"Z0*(n_live/n) = 33.3-ohm citation (issue #313): {dead[0]}")
     assert not _by_code(issues, "wire_port_midpoint_in_pec"), (
         "midpoint is clean on this geometry — #314 must stay silent")
 
 
 def test_wire_midpoint_only_dead_keeps_midpoint_warning_only():
-    """Regression (#314) + documented #319 behavior: when ONLY the
+    """Regression (#314) + documented #319/#318 behavior: when ONLY the
     midpoint cell is dead (extent=1.5mm -> 4 cells, only z=1.25mm inside
     the trace), the strong midpoint warning fires and the dead-extent
-    advisory (reserved for NON-midpoint dead cells) does not."""
+    advisory (reserved for NON-midpoint dead cells) does not. (The #318
+    live-cell split still excludes that dead midpoint from sigma/drive —
+    the advisory split here is about which WARNING fires.)"""
     issues = _microstrip_sim(1.5e-3).preflight()
     assert _by_code(issues, "wire_port_midpoint_in_pec"), (
         "#314 midpoint warning must still fire: "
@@ -397,11 +404,12 @@ def test_wire_port_all_cells_live_is_silent():
 
 
 def test_wire_midpoint_and_other_cell_dead_fires_both():
-    """Documented #319 behavior for the combined case: a thick trace
+    """Documented #319/#318 behavior for the combined case: a thick trace
     [0.5,1.5]mm with extent=1.5mm kills cells 0.75mm AND 1.25mm (the
     midpoint) -> BOTH warnings fire, and the dead-extent live count
-    includes the midpoint cell (n_live/n = 2/4 -> ~25.0 ohm), because the
-    physical termination does not care which cell holds the probe."""
+    includes the midpoint cell (n_live/n = 2/4; historical pre-#318-fix
+    termination citation ~25.0 ohm), because the live split does not care
+    which cell holds the probe."""
     issues = _microstrip_sim(1.5e-3, trace_z_lo_m=0.5e-3,
                              trace_z_hi_m=1.5e-3).preflight()
     assert _by_code(issues, "wire_port_midpoint_in_pec"), (
@@ -413,4 +421,4 @@ def test_wire_midpoint_and_other_cell_dead_fires_both():
         + "\n".join(str(s) for s in issues))
     assert "2/4" in dead[0] and "25.0" in dead[0], (
         "dead-extent live count must include the dead midpoint cell "
-        f"(n_live/n = 2/4, 25.0 ohm): {dead[0]}")
+        f"(n_live/n = 2/4; historical pre-fix citation 25.0 ohm): {dead[0]}")

--- a/tests/test_lumped_twoport_vi_validation_battery.py
+++ b/tests/test_lumped_twoport_vi_validation_battery.py
@@ -22,26 +22,38 @@ prescribed (fail LOUDLY on the convention change, re-measure in the same
 PR). The S11 floor/alive gates, the run<->forward cross-check, and the
 algebraic-identity test are byte-untouched by the re-baseline.
 
-Measured baseline (R5 measure-before-gate; re-baselined 2026-07-10 for
-the issue #308 receive-wave fix and re-measured the same day for the
-falsifier-driven receive-sign amendment b_recv = (V - Z0*I)/(2*sqrt(Z0)),
-fresh fixture reruns on this CPU box, x64 OFF — complex64 accumulators,
-the documented envelope):
+Measured baseline (R5 measure-before-gate; the DIAGONAL |S11|/|S22| lane
+was RE-BASELINED 2026-07-11 for the issue #318 live-cell termination fix —
+fresh fixture reruns on this CPU box, x64 OFF, complex64 accumulators, the
+documented envelope. The |S21| off-diagonal narrative below is the earlier
+issue #308 receive-wave baseline, which the #318 fix left in the same
+O(0.55-0.61) class — the |S21| kappa deflation is the SEPARATE issue #313
+and is NOT part of the #318 ledger):
 
 THRU fixture (wire 2-port, 16 mm air microstrip w/h=5 over a pec_faces
 ground, Zc ~ 50 ohm, driver path of PR #258; 9 bins 3-7 GHz, 4000 steps,
 ~70 s -> slow_physics):
-  - max in-band |S11| = 0.12962 (mean 0.0759), max |S22| = 0.13156 —
-    bit-identical to the pre-#308 baseline (the fix touches receive-side
-    off-diagonals only; diagonals are byte-frozen). The reflection
-    channel is ALIVE, not a dead readout: on the same fixture, measured
-    Z_in = 44.0-1.9j ohm at 5 GHz predicts |S11| = 0.06674 via
-    (Zin-50)/(Zin+50) vs 0.06676 reported (2e-5 agreement), and
-    mismatching port 2 to 12.5 ohm moved |S11| from the 0.035-0.13
-    floor to 0.20-0.42 in the expected direction (Z0 witness, reported
-    in the lane, not re-run here).
-  - |S21| = 0.523601..0.667776 across 3-7 GHz. HISTORY: before the
-    issue #308 fix (landed in this PR) the shipped receive-side b-wave
+  - post-#318 per-bin |S11| = [0.0555 0.0476 0.0388 0.0327 0.0337 0.0426
+    0.0558 0.0708 0.0858], |S22| = [0.0543 0.0470 0.0397 0.0360 0.0391
+    0.0484 0.0611 0.0752 0.0891] across 3-7 GHz (max|S11| 0.0858, max|S22|
+    0.0891, mean|S11| 0.0515, per-bin min 0.0327 at 4.5 GHz). This
+    V-shaped residual is rfx's MEASURED feed-post reflection, NOT an
+    extraction artefact and NOT a termination error (issue #318 H_FIXTURE
+    re-diagnosis, 2026-07-11, decisive on three independent witnesses):
+    the two wire ports are 1 mm vertical feed posts (~0.26 nH each) whose
+    series reactances interfere across the 16 mm line, producing a
+    reflection null near 4.5 GHz and rising edges toward the band ends.
+    Before the #318 live-cell fix the diagonals read max ~0.130/0.132
+    (mean 0.076) because the dead extent cell (inside the PEC trace) was
+    wrongly counted in the sigma/drive/Z0 fold, giving a Z0*(n_live/n) =
+    33.3-ohm termination instead of 50 ohm (that 33.3-ohm reading is the
+    historical issue #313 finding). The reflection channel is ALIVE, not
+    a dead readout: mismatching a port drives |S11| up as expected (Z0
+    witness), and both diagonals stay well above the 0.02 alive floor.
+  - |S21| = 0.54606..0.60974 across 3-7 GHz (post-#318 rerun; post-#308
+    it was 0.523601..0.667776 — same O(0.55-0.61) class, the live-cell
+    fix did not move the transmission class). HISTORY: before the
+    issue #308 fix the shipped receive-side b-wave
     b_i = (-V - Z0_i*I)/(2*sqrt(Z0_i)) structurally cancelled the
     arriving wave against the matched receive cell's local Ohm's law
     -V = +Z0_cell*I (measured -V/I = 16.6672+0.0002j ohm vs
@@ -69,9 +81,10 @@ ground, Zc ~ 50 ohm, driver path of PR #258; 9 bins 3-7 GHz, 4000 steps,
     (issue #313; recorded per-bin above) — do
     NOT cite the 0.52-0.67 band as thru-transmission physics.
   - S21 signed phase deviation vs the analytic line delay
-    exp(-j*2*pi*f*L/c): -0.754891..-0.335259 rad across 3-7 GHz — a
-    smooth delay-like excess (~16.6 ps feed-post group delay on top of
-    the 53.4 ps line delay), no pi offset. The DC-limit sign is
+    exp(-j*2*pi*f*L/c): -0.6268..-0.3482 rad across 3-7 GHz (post-#318;
+    post-#308 -0.754891..-0.335259) — a smooth delay-like excess (small
+    feed-post group delay on top of the 53.4 ps line delay), no pi
+    offset. The DC-limit sign is
     RESOLVED by the same-PR amendment (2026-07-10): the first-cut #308
     sign (-V + Z0*I) measured S21(DC) -> -1 on the low-frequency
     falsifier (0.5-2 GHz; the pi sat in the raw cross-port phasors,
@@ -84,13 +97,17 @@ ground, Zc ~ 50 ohm, driver path of PR #258; 9 bins 3-7 GHz, 4000 steps,
     amendment rerun). |S21|, reciprocity, the flux comparisons and both
     diagonals are sign-invariant and did not move (bit-identical to the
     81c1983 rerun).
-  - reciprocity max|S21-S12| = 1.043e-2 absolute (rel 0.016254) on the
-    recovered O(0.52-0.67) magnitudes — now a meaningful symmetry check
+  - reciprocity max|S21-S12| = 7.53e-3 absolute (rel 0.013581) on the
+    recovered O(0.55-0.61) magnitudes (post-#318; IMPROVED from the
+    post-#308 1.043e-2 / rel 0.016254 — the live-cell fix made the two
+    ports' V/I bookkeeping more symmetric). A meaningful symmetry check
     on a live channel (pre-#308 it was vacuous at the near-null scale).
   - passivity max singular value over the 9 per-freq 2x2 slices =
-    0.687410 (margin 0.31 to the physical bound 1.0). Still NOT
-    transmission validation (kappa open item deflates the port-based
-    magnitudes); kept as a strict sub-unity energy-sanity lock.
+    0.632587 (post-#318; margin 0.37 to the physical bound 1.0; IMPROVED
+    from the post-#308 0.687410 as the smaller diagonal reflection lowers
+    the mixed-matrix norm). Still NOT transmission validation (kappa is
+    the SEPARATE #313 open item, deflating the port-based magnitudes);
+    kept as a strict sub-unity energy-sanity lock.
 
 RUN<->FORWARD cross-check fixture (1-port wire, CPML — byte-for-byte the
 ``_wire_sim`` of tests/test_run_forward_s11_contract.py, which this
@@ -196,62 +213,82 @@ _PEC_FACES_ADVISORY_SNIPPET = (
 # ===========================================================================
 # Gate constants (R5: every gate = measured value + honest margin)
 # ===========================================================================
-# Measured max in-band |S11| = 0.12962, |S22| = 0.13156 (mean |S11| 0.0759).
-# Gate 0.30 (~2.3x measured max) on BOTH diagonals. The floor is a real
-# physical-match reading (Zin witness agrees to 2e-5; Z0-mismatch witness
-# moves it as predicted), so a break here means the reflection channel or
-# the Z0 normalization moved.
-_THRU_S11_FLOOR_MAX = 0.30
+# Measured post-#318 (fresh rerun on the fixed branch, 2026-07-11):
+# per-bin |S11| = [0.0555 0.0476 0.0388 0.0327 0.0337 0.0426 0.0558 0.0708
+# 0.0858] and |S22| = [0.0543 0.0470 0.0397 0.0360 0.0391 0.0484 0.0611
+# 0.0752 0.0891] across 3-7 GHz (max|S11| 0.0858, max|S22| 0.0891, mean
+# |S11| 0.0515, per-bin min 0.0327 at 4.5 GHz). This V-shaped curve is
+# rfx's MEASURED feed-post reflection, not an extraction error: the wire
+# ports are two 1 mm vertical feed posts (~0.26 nH each) whose reactances
+# interfere across the 16 mm line, giving a reflection null near 4.5 GHz
+# and rising edges toward 3 and 7 GHz (H_FIXTURE re-diagnosis, 2026-07-11 —
+# three independent witnesses; see the module docstring). Gate 0.12
+# (~1.35x max|S22|) on BOTH diagonals: honest cross-machine float margin,
+# AND strictly below the pre-#318 dead-cell floor 0.13 (the 33.3-ohm
+# termination bug), so a revert of the live-cell fix fails LOUDLY here.
+_THRU_S11_FLOOR_MAX = 0.12
 # Two-sided (review finding): a DEAD diagonal channel reads ~0, which would
 # sail under the upper bound. The measured per-diagonal maxima are
-# 0.1296/0.1316 (~6.5x above this lower bound), so requiring max|Sii| > 0.02
-# makes the in-test liveness of both diagonals explicit rather than relying
-# on the lane's out-of-test Zin/mismatch witnesses.
+# 0.0858/0.0891 (~4.3x above this lower bound) and the per-bin minimum is
+# 0.0327 (the physical feed-post null; ~1.6x above this bound), so
+# requiring max|Sii| > 0.02 makes the in-test liveness of both diagonals
+# explicit while clearing the measured 4.5 GHz null with margin.
 _THRU_S11_ALIVE_MIN = 0.02
 
-# Measured |S21| = 0.523601..0.667776 across 3-7 GHz (post-#308 fix,
-# fresh rerun at 81c1983). REGRESSION LOCK on the recovered channel, NOT
-# physics: the flux-vs-port transmitted-power delta is OPEN (flux referee
-# measured per-bin (flux fraction)/|S21|^2 = 2.237..3.541; implied
+# Measured |S21| = 0.54606..0.60974 across 3-7 GHz (post-#318 fresh rerun,
+# 2026-07-11; the live-cell fix moved the composed channel slightly from
+# the post-#308 0.5236..0.6678 but kept it the same O(0.55-0.61) class).
+# Band [0.35, 0.85] KEPT UNCHANGED (issue #313 kappa regression lock — the
+# |S21| deflation is the SEPARATE #313 drive-side common-mode scale bias,
+# NOT part of the #318 ledger): REGRESSION LOCK on the recovered channel,
+# NOT physics. The flux-vs-port transmitted-power delta is OPEN (flux
+# referee measured per-bin (flux fraction)/|S21|^2 = 2.237..3.541; implied
 # flux-true |S21| = 0.971-0.997 — module docstring; see the PR body /
-# follow-up issue). Band [0.35, 0.85]: lower ~0.67x measured min (a
-# collapse back toward the pre-#308 near-null 0.0025-0.0046 fails
-# loudly), upper ~1.27x measured max and strictly < 1 (an over-unity
+# follow-up issue). Lower edge catches a collapse back toward the pre-#308
+# near-null 0.0025-0.0046; upper edge strictly < 1 (an over-unity
 # extraction artefact also fails). Still never weaker than the committed
 # max|S21| > 1e-3 floor of test_twoport_wire_port.py.
 _THRU_S21_BAND = (0.35, 0.85)
 
 # Measured signed per-bin phase deviation arg(S21) - (-2*pi*f*L/c),
-# wrapped: -0.754891..-0.335259 rad (amended receive sign, 2026-07-10
-# rerun). Band [-1.1, -0.1] rad (margins ~0.35/0.24 rad; both edges
-# well inside (-pi, pi) so wrapped values stay comparable). HONESTY
-# LABEL — REGRESSION LOCK on the deviation VALUES (flux-vs-port
-# magnitude delta OPEN, kappa — module docstring), but the overall SIGN
-# is physics-anchored by the DC witness: the low-f falsifier measured
-# S21(DC) -> +1 under this sign (dev -0.024 rad at 0.5 GHz, tracking
-# the analytic delay); the first-cut sign measured -1 and was amended
-# in the same PR. The deviation is a smooth ~16.6 ps feed-post
+# wrapped: -0.6268..-0.3482 rad (post-#318 fresh rerun, 2026-07-11;
+# post-#308 it was -0.7549..-0.3353 — the live-cell fix shifted the
+# small feed-post group-delay excess slightly, same sign, same class).
+# Band [-1.1, -0.1] rad KEPT UNCHANGED (margins ~0.47/0.25 rad; both
+# edges well inside (-pi, pi) so wrapped values stay comparable).
+# HONESTY LABEL — REGRESSION LOCK on the deviation VALUES (flux-vs-port
+# magnitude delta OPEN, kappa — separate #313, module docstring), but
+# the overall SIGN is physics-anchored by the DC witness: the low-f
+# falsifier measured S21(DC) -> +1 under this sign (dev -0.049 rad at
+# 0.5 GHz, tracking the analytic delay); the first-cut sign measured -1
+# and was amended in the #308 PR. The deviation is a smooth feed-post
 # group-delay excess, physical, not a convention artefact. Signed on
 # purpose: conjugation moves 8/9 measured bins out of band (verified
 # live in the test; conj dev is NOT -dev, the analytic reference phase
-# differs per bin — measured conj devs +2.347..-0.834 with only the
+# differs per bin — measured conj devs +2.360..-0.962 with only the
 # 7 GHz bin inside), and a sign flip back moves all 9 bins (by pi).
 _THRU_PHASE_DEV_BAND_RAD = (-1.1, -0.1)
 
-# Measured reciprocity max|S21 - S12| = 1.043e-2 (rel 0.016254) on the
-# recovered O(0.52-0.67) magnitudes. Gates ~4.8x / ~6x measured. The abs
-# gate is scaled to the live channel (pre-#308 it was 5e-4 on the
-# near-null scale); the rel gate survives unchanged.
-_THRU_RECIP_ABS_MAX = 5.0e-2
+# Measured reciprocity max|S21 - S12| = 7.53e-3 (rel 0.013581) on the
+# recovered O(0.55-0.61) magnitudes (post-#318 fresh rerun, 2026-07-11 —
+# IMPROVED from the post-#308 1.043e-2 / rel 0.016254 as the live-cell
+# fix made the two ports' V/I bookkeeping more symmetric). Abs gate
+# re-baselined to 1.5e-2 (~2x measured); rel gate kept at 0.10 (scale-
+# free, ~7.4x measured). A break catches an asymmetric edit to the
+# shared decomposers or per-port Z0/n_cells bookkeeping.
+_THRU_RECIP_ABS_MAX = 1.5e-2
 _THRU_RECIP_REL_MAX = 0.10
 
 # Measured passivity: max singular value over the 9 per-freq 2x2 slices
-# = 0.687410 (post-#308). Gate 0.90 (~1.31x measured, margin 0.21) —
+# = 0.632587 (post-#318 fresh rerun, 2026-07-11; IMPROVED from the
+# post-#308 0.687410 as the smaller diagonal reflection lowers the
+# mixed-matrix norm). Gate 0.85 (~1.34x measured, margin 0.22) —
 # strictly below the physical bound 1.0, and BELOW the Frobenius
-# dominance bound sqrt(2*0.30^2 + 2*0.85^2) ~= 1.275 implied by the
+# dominance bound sqrt(2*0.12^2 + 2*0.85^2) ~= 1.214 implied by the
 # S11/S21 gates, so this gate is independently bindable. Energy-sanity
-# lock; NOT transmission validation (kappa open item, module docstring).
-_THRU_MAX_SINGULAR_VALUE = 0.90
+# lock; NOT transmission validation (kappa open item — separate #313,
+# module docstring).
+_THRU_MAX_SINGULAR_VALUE = 0.85
 
 # ===========================================================================
 # run<->forward cross-check constants
@@ -331,10 +368,12 @@ def thru_smatrix():
     # the intended pec_faces advisory (the infinite ground plane IS the
     # microstrip return) PLUS one wire_port_dead_extent_cells advisory
     # per port — this fixture GENUINELY has its top extent cell inside
-    # the PEC trace (issues #313/#318: physical termination ~33.3 ohm,
-    # not 50, is the documented known issue). The battery gates below
-    # were MEASURED on this exact fixture, dead cell included, so they
-    # stay valid as-is. Anything else = fixture drift, stop.
+    # the PEC trace. Post-#318 the dead cell is EXCLUDED from the
+    # sigma/drive/Z0 fold, so each port now terminates at 50 ohm across
+    # its 2 live cells (the pre-#318 33.3-ohm Z0*(n_live/n) reading is
+    # the historical issue #313 finding). The battery gates below were
+    # MEASURED on this exact fixture, dead cell included, so they stay
+    # valid as-is. Anything else = fixture drift, stop.
     codes = sorted(getattr(i, "code", None) for i in report)
     assert codes == ["pec_faces_finite_pec",
                      "wire_port_dead_extent_cells",
@@ -493,25 +532,29 @@ def test_run_forward_complex_values_agree_on_cpml(crosscheck):
 
 @pytest.mark.slow_physics
 def test_thru_s11_floor(thru_smatrix):
-    """Matched-thru reflection floor: max in-band |S11|, |S22| < 0.30.
+    """Matched-thru reflection floor: max in-band |S11|, |S22| < 0.12.
 
-    Measured 0.12962 / 0.13156 (mean |S11| 0.0759). The floor is a REAL
-    match reading of the ~50-ohm air-microstrip line against Z0=50 (Zin
-    witness agreement 2e-5; Z0-mismatch witness responds as predicted), so
-    a break means the diagonal V-I extraction or Z0 normalization moved —
-    not the FDTD core.
+    Measured post-#318: max|S11| 0.0858, max|S22| 0.0891 (mean|S11|
+    0.0515), a V-shaped curve with a null at 4.5 GHz. This is rfx's
+    MEASURED feed-post reflection (two 1 mm posts, ~0.26 nH each,
+    interfering across the 16 mm line — issue #318 H_FIXTURE
+    re-diagnosis), NOT an extraction error. The gate 0.12 stays below the
+    pre-#318 dead-cell floor 0.13 (the 33.3-ohm termination bug), so a
+    revert of the live-cell fix fails LOUDLY; a break otherwise means the
+    diagonal V-I extraction or Z0 normalization moved — not the FDTD core.
     """
     s11 = np.abs(thru_smatrix[0, 0])
     s22 = np.abs(thru_smatrix[1, 1])
     worst = max(s11.max(), s22.max())
     assert worst < _THRU_S11_FLOOR_MAX, (
         f"thru diagonal floor broke: max(|S11|, |S22|) = {worst:.4f} "
-        f"(measured 0.130/0.132, gate {_THRU_S11_FLOOR_MAX})")
+        f"(measured 0.086/0.089, gate {_THRU_S11_FLOOR_MAX}; a value near "
+        f"the pre-#318 0.13 means the dead-cell live-fold regressed)")
     # Two-sided liveness (review finding): a dead diagonal reads ~0 and
-    # would pass the upper bound. Measured maxima 0.1296/0.1316.
+    # would pass the upper bound. Measured maxima 0.0858/0.0891.
     assert s11.max() > _THRU_S11_ALIVE_MIN and s22.max() > _THRU_S11_ALIVE_MIN, (
         f"thru diagonal channel reads dead: max|S11|={s11.max():.4f}, "
-        f"max|S22|={s22.max():.4f} (measured 0.130/0.132, alive floor "
+        f"max|S22|={s22.max():.4f} (measured 0.086/0.089, alive floor "
         f"{_THRU_S11_ALIVE_MIN})")
 
 
@@ -519,9 +562,12 @@ def test_thru_s11_floor(thru_smatrix):
 def test_thru_s21_band_locks_shipped_decomposer_envelope(thru_smatrix):
     """|S21| stays in [0.35, 0.85] — REGRESSION LOCK, NOT validated physics.
 
-    Measured 0.523601..0.667776 post-#308 (the receive-wave fix in this
-    PR recovered the transmission channel from the pre-fix structural
-    near-null 0.0025-0.0046 — mechanism history in the module docstring).
+    Measured 0.54606..0.60974 post-#318 (post-#308 0.523601..0.667776 —
+    the #318 live-cell fix left the transmission class unchanged; the #308
+    receive-wave fix earlier recovered this channel from the pre-fix
+    structural near-null 0.0025-0.0046, mechanism history in the module
+    docstring). Band [0.35, 0.85] KEPT UNCHANGED — the |S21| kappa
+    deflation is the SEPARATE issue #313, not part of the #318 ledger.
     HONESTY LABEL: regression lock only; the flux-vs-port transmitted-
     power delta is OPEN — the extractor-independent flux referee measured
     per-bin (flux fraction)/|S21|^2 = 2.237..3.541 (raw flux transmitted
@@ -538,14 +584,14 @@ def test_thru_s21_band_locks_shipped_decomposer_envelope(thru_smatrix):
     s21 = np.abs(thru_smatrix[1, 0])
     lo, hi = _THRU_S21_BAND
     # Per-bin lower edge (review finding): max() would let 8/9 dead bins
-    # slip through. Measured per-bin min 0.5236 (~1.5x this floor).
+    # slip through. Measured per-bin min 0.5461 (~1.6x this floor).
     assert s21.min() > lo, (
-        f"|S21| collapsed below the post-#308 envelope: per-bin min "
-        f"{s21.min():.4f} <= {lo} (measured min 0.5236) — the recovered "
+        f"|S21| collapsed below the envelope: per-bin min "
+        f"{s21.min():.4f} <= {lo} (measured min 0.5461) — the recovered "
         f"channel died in at least one bin (dead probe / dead thru / "
         f"receive-sign regression class)")
     assert s21.max() < hi, (
-        f"|S21| = {s21.max():.4f} left the measured envelope (max 0.6678, "
+        f"|S21| = {s21.max():.4f} left the measured envelope (max 0.6097, "
         f"band hi {hi}). If this is the drive-side kappa scale-bias fix "
         f"landing (flux-true |S21| = 0.971-0.997), re-baseline this "
         f"battery in the same PR")
@@ -557,21 +603,21 @@ def test_thru_s21_phase_band_is_sign_sensitive(thru_smatrix):
 
     dev(f) = wrap(arg S21 - (-2*pi*f*L/c)) with the analytic ideal-thru
     delay for the 16 mm air line (DFT kernel exp(-j*2*pi*f*t) => e^{+jwt}
-    phasors, outgoing wave e^{-j*beta*x}). Measured dev (amended receive
-    sign) = -0.754891..-0.335259 rad; band [-1.1, -0.1] rad — a smooth
-    ~16.6 ps feed-post group-delay excess over the 53.4 ps line delay,
-    no pi offset. HONESTY LABEL — REGRESSION LOCK on the deviation
-    values (flux-vs-port magnitude delta OPEN, kappa — module
+    phasors, outgoing wave e^{-j*beta*x}). Measured dev (post-#318,
+    amended receive sign) = -0.6268..-0.3482 rad (post-#308
+    -0.754891..-0.335259); band [-1.1, -0.1] rad KEPT UNCHANGED — a smooth
+    feed-post group-delay excess over the 53.4 ps line delay, no pi
+    offset. HONESTY LABEL — REGRESSION LOCK on the deviation values
+    (flux-vs-port magnitude delta OPEN, kappa — SEPARATE #313, module
     docstring); the overall SIGN is physics-anchored by the DC witness:
     the low-f falsifier measured S21(DC) -> +1 under the amended sign
-    (V - Z0*I) (dev -0.024 rad at 0.5 GHz); the first-cut sign measured
-    -1 and was amended in this same PR. Sign AND magnitude are gated (per-bin, signed) — verified
-    NOT conjugation-invariant: the test also asserts conj(S21) violates
-    the band (on the measured data 8/9 bins leave it; conj dev =
-    +2.347..-0.834 rad, only the 7 GHz bin stays inside), so the
-    W3.4-class conjugation bug cannot pass; a flip back to the first-cut
-    receive sign shifts every bin by pi (~+2.39..+2.81 rad) and fails
-    too.
+    (V - Z0*I) (dev -0.049 rad at 0.5 GHz); the first-cut sign measured
+    -1 and was amended in the #308 PR. Sign AND magnitude are gated
+    (per-bin, signed) — verified NOT conjugation-invariant: the test also
+    asserts conj(S21) violates the band (on the measured data 8/9 bins
+    leave it; conj dev = +2.360..-0.962 rad, only the 7 GHz bin stays
+    inside), so the W3.4-class conjugation bug cannot pass; a flip back to
+    the first-cut receive sign shifts every bin by pi and fails too.
     """
     s21 = thru_smatrix[1, 0]
     expected = np.exp(-1j * 2 * np.pi * _THRU_FREQS_HZ * _THRU_L_M / C0_M_PER_S)
@@ -580,7 +626,7 @@ def test_thru_s21_phase_band_is_sign_sensitive(thru_smatrix):
     print(f"\n[thru battery] signed phase dev (rad): {np.round(dev, 3)}")
     assert np.all((dev > lo) & (dev < hi)), (
         f"S21 signed phase deviation left [{lo}, {hi}] rad "
-        f"(measured -0.755..-0.335 under the amended receive sign): "
+        f"(measured -0.627..-0.348 under the amended receive sign): "
         f"dev = {np.round(dev, 3)}. A receive-sign regression back to "
         f"the first-cut convention shifts this by pi; any deliberate "
         f"sign decision MUST re-baseline this battery in the same PR")
@@ -597,14 +643,14 @@ def test_thru_s21_phase_band_is_sign_sensitive(thru_smatrix):
 def test_thru_reciprocity(thru_smatrix):
     """Decomposer-symmetry lock: max|S21 - S12| small on the live channel.
 
-    Measured post-#308: 1.043e-2 absolute (rel 0.016254) on the recovered
-    O(0.52-0.67) magnitudes; gates 5e-2 / 0.10. The abs gate is scaled to
-    the live channel (pre-#308 it was 5e-4 on the near-null residual —
-    per-channel scale, not a weakening; the REL gate, the scale-free
-    check, is unchanged and the measured rel barely moved: 0.0162 ->
-    0.016254). A break catches an asymmetric edit to the shared
-    decomposers or per-port Z0/n_cells bookkeeping. NOT transmission
-    validation while the kappa magnitude item is open (module docstring).
+    Measured post-#318: 7.53e-3 absolute (rel 0.013581) on the recovered
+    O(0.55-0.61) magnitudes; gates 1.5e-2 / 0.10. IMPROVED from the
+    post-#308 1.043e-2 / rel 0.016254 (the live-cell fix made the two
+    ports' V/I bookkeeping more symmetric); the abs gate is re-baselined
+    tighter (~2x measured), the scale-free REL gate stays at 0.10. A break
+    catches an asymmetric edit to the shared decomposers or per-port
+    Z0/n_cells bookkeeping. NOT transmission validation while the kappa
+    magnitude item is open (SEPARATE #313, module docstring).
     """
     s21 = thru_smatrix[1, 0]
     s12 = thru_smatrix[0, 1]
@@ -612,31 +658,33 @@ def test_thru_reciprocity(thru_smatrix):
     rel_dev = abs_dev / np.maximum(np.abs(s21), np.abs(s12))
     assert abs_dev.max() < _THRU_RECIP_ABS_MAX, (
         f"reciprocity |S21-S12| = {abs_dev.max():.2e} "
-        f"(measured 1.04e-2, gate {_THRU_RECIP_ABS_MAX})")
+        f"(measured 7.53e-3, gate {_THRU_RECIP_ABS_MAX})")
     assert rel_dev.max() < _THRU_RECIP_REL_MAX, (
         f"reciprocity rel dev = {rel_dev.max():.4f} "
-        f"(measured 0.016254, gate {_THRU_RECIP_REL_MAX})")
+        f"(measured 0.013581, gate {_THRU_RECIP_REL_MAX})")
 
 
 @pytest.mark.slow_physics
 def test_thru_passivity_singular_values(thru_smatrix):
-    """Energy sanity: max singular value of every per-freq 2x2 slice < 0.9.
+    """Energy sanity: max singular value of every per-freq 2x2 slice < 0.85.
 
-    Measured post-#308: 0.687410 (margin 0.31 to the physical bound 1.0,
-    ~1.31x measured headroom to the gate). A strict-passivity regression
-    lock that catches an over-unity extraction artefact on either channel
-    — and, per the kappa open item (module docstring), a drive-side
-    scale-bias fix moving |S21| to the flux-implied 0.971-0.997 would
-    push the singular value past 0.9 and fail LOUDLY here too, forcing a
-    re-baseline in the same PR. Do not cite this as transmission
-    evidence while the port-based magnitude is unvalidated.
+    Measured post-#318: 0.632587 (margin 0.37 to the physical bound 1.0,
+    ~1.34x measured headroom to the gate; IMPROVED from the post-#308
+    0.687410 as the smaller diagonal reflection lowers the mixed-matrix
+    norm). A strict-passivity regression lock that catches an over-unity
+    extraction artefact on either channel — and, per the kappa open item
+    (SEPARATE #313, module docstring), a drive-side scale-bias fix moving
+    |S21| to the flux-implied 0.971-0.997 would push the singular value
+    past 0.85 and fail LOUDLY here too, forcing a re-baseline in the same
+    PR. Do not cite this as transmission evidence while the port-based
+    magnitude is unvalidated.
     """
     sv_max = max(
         np.linalg.svd(thru_smatrix[:, :, k], compute_uv=False)[0]
         for k in range(thru_smatrix.shape[2])
     )
     assert sv_max < _THRU_MAX_SINGULAR_VALUE, (
-        f"max singular value {sv_max:.4f} (measured 0.6874 post-#308, "
+        f"max singular value {sv_max:.4f} (measured 0.6326 post-#318, "
         f"gate {_THRU_MAX_SINGULAR_VALUE}) — extraction produced "
         f"over-envelope energy on the thru (or the kappa scale-bias fix "
         f"landed: re-baseline this battery in the same PR)")
@@ -646,11 +694,12 @@ def test_thru_passivity_singular_values(thru_smatrix):
 # DC-limit sign anchor (slow_physics) — the committed form of the low-f
 # falsifier that pinned the receive sign (issue #308 amendment round)
 # ===========================================================================
-# Measured (2026-07-10, amended sign b=(V - Z0*I)): wrapped dev
-# arg(S21) - (-2*pi*f*L/c) = -0.0236 rad @ 0.5 GHz, -0.0536 rad @ 1.0 GHz.
-# Band (-0.25, +0.10) — generous vs measurement (>4x) but decisively
-# pi-DISCRIMINATING: the first-cut receive sign (-V + Z0*I) measured
-# S21(DC) -> -1, i.e. dev ~ +-2.9..3.1 rad at these bins, far outside.
+# Measured (post-#318 rerun 2026-07-11, amended sign b=(V - Z0*I)):
+# wrapped dev arg(S21) - (-2*pi*f*L/c) = -0.0494 rad @ 0.5 GHz, -0.1015
+# rad @ 1.0 GHz (post-#308 -0.0236/-0.0536). Band (-0.25, +0.10) — still
+# generous vs measurement but decisively pi-DISCRIMINATING: the first-cut
+# receive sign (-V + Z0*I) measured S21(DC) -> -1, i.e. dev ~ +3.04..3.09
+# rad at these bins (measured flipped), far outside.
 _DCA_FREQS_HZ = np.array([0.5e9, 1.0e9])
 _DCA_N_STEPS = 12000            # 0.5 GHz bins need the long settle window
 _DCA_DEV_BAND_RAD = (-0.25, +0.10)
@@ -666,9 +715,10 @@ def dc_anchor_smatrix():
         print(f"\n[dc anchor] preflight (verbatim): {msg}")
     # Same exact set as the thru_smatrix fixture above (re-pinned
     # 2026-07-11 for issue #319): pec_faces + one dead-extent-cell
-    # advisory per port (#313/#318 — the ~33.3-ohm termination is the
-    # documented known issue on this geometry; gates measured on it
-    # stay valid as-is).
+    # advisory per port (#318 — post-fix each port terminates at 50 ohm
+    # across its 2 live cells; the pre-fix 33.3-ohm reading is the
+    # historical #313 finding; gates measured on this geometry stay
+    # valid as-is).
     codes = sorted(getattr(i, "code", None) for i in report)
     assert codes == ["pec_faces_finite_pec",
                      "wire_port_dead_extent_cells",
@@ -689,8 +739,9 @@ def test_dc_limit_pins_receive_sign(dc_anchor_smatrix):
     required the offline falsifier lane (re-review finding, both lenses).
     This anchors it in-repo: at 0.5-1 GHz the thru's wrapped phase
     deviation vs the analytic line delay must sit near 0 (measured
-    -0.024/-0.054 rad), NOT near +-pi (the first-cut sign's -1 DC limit).
-    Physics-anchored: this is the DC witness itself, not an envelope.
+    -0.049/-0.102 rad post-#318), NOT near +-pi (the first-cut sign's -1
+    DC limit). Physics-anchored: this is the DC witness itself, not an
+    envelope.
     """
     s21 = dc_anchor_smatrix[1, 0]
     expected = np.exp(-1j * 2 * np.pi * _DCA_FREQS_HZ * _THRU_L_M / C0_M_PER_S)
@@ -700,7 +751,7 @@ def test_dc_limit_pins_receive_sign(dc_anchor_smatrix):
           f"dev(rad)={np.round(dev, 4)}")
     assert np.all((dev > lo) & (dev < hi)), (
         f"DC-limit sign anchor failed: dev = {np.round(dev, 4)} rad outside "
-        f"[{lo}, {hi}] (measured -0.024/-0.054). A pi-scale dev means the "
+        f"[{lo}, {hi}] (measured -0.049/-0.102). A pi-scale dev means the "
         f"receive-wave sign regressed to the first-cut convention")
     # pi-discrimination witness: the sign-flipped S21 must leave the band.
     dev_flipped = np.angle(-s21 / expected)

--- a/tests/test_refplane_port_waves.py
+++ b/tests/test_refplane_port_waves.py
@@ -710,6 +710,10 @@ _PHASE_DEEMBED_MAX_RAD = 0.02  # measured <= 8.4e-4 (~24x margin)
 # (~1.3% margin) — this is a flux-ACCOUNTING envelope (see label on the
 # test), NOT a passivity certification; the >1 excursion is the mixed
 # legacy/plane calibration + finite-DFT budget, not validated gain.
+# The genuine passivity witnesses BOTH pass strictly and improved under
+# #318, so this permissive gate is not masking a real regression:
+# _ENERGY_ROW_MAX (|S11|^2+|S21|^2 = 0.99995 < 1) and the battery
+# singular-value gate (0.633 < 0.85). Stable at dx/2 (#313 arc).
 _MIXED_SV_MAX = 1.08
 _ENERGY_ROW_MAX = 1.02         # measured |S11|^2+|S21|^2 <= 0.99995 (#318;
                                # was <= 1.0003) — dropped as the diagonal

--- a/tests/test_refplane_port_waves.py
+++ b/tests/test_refplane_port_waves.py
@@ -679,7 +679,8 @@ _REFEREE_S21 = np.array([1.0066, 1.0052, 1.0033, 1.0007, 0.99775,
 #   reciprocity rel <= 0.38%; Zc Re 47.94..48.62 ohm (both ports),
 #   Im/Re <= 1.2%; beta/(w/c) = 1.0465..1.0589;
 #   |arg(S21) + beta_meas*L| <= 8.4e-4 rad; max singular value of the
-#   mixed matrix 1.0299 max; |S11|^2+|S21|^2 <= 1.0003.
+#   mixed matrix 1.0663 max (post-#318 rerun 2026-07-11; was 1.0299 —
+#   see the SV gate note); |S11|^2+|S21|^2 <= 0.99995 (post-#318).
 # Gates carry margin over these measured values and are labelled with
 # their referee anchors. They are referee-consistency + regression gates
 # on the canonical thru, NOT external cross-solver validation.
@@ -700,8 +701,19 @@ _BETA_OVER_WC_BAND = (1.03, 1.08)   # measured 1.0465-1.0589. Mechanism
 # fringing), not a discretization artefact. (Measured Zc showed mild dx
 # sensitivity, 48.5 -> 47.0 ohm at dx/2; beta did not.)
 _PHASE_DEEMBED_MAX_RAD = 0.02  # measured <= 8.4e-4 (~24x margin)
-_MIXED_SV_MAX = 1.05           # measured 1.0299 — see honesty label
-_ENERGY_ROW_MAX = 1.02         # measured |S11|^2+|S21|^2 <= 1.0003
+# Re-baselined 2026-07-11 for issue #318: the mixed matrix pairs the
+# byte-frozen legacy DIAGONAL (which #318 shrank to the feed-post
+# V-shape, max|Sii| ~= 0.089, from the pre-#318 dead-cell 0.13) with the
+# plane-referenced OFF-diagonal (~0.99). The smaller diagonal re-phases
+# against the ~0.99 off-diagonals, so the top singular value of the
+# 2x2 rose to a measured 1.0663 max (was 1.0299 pre-#318). Gate 1.08
+# (~1.3% margin) — this is a flux-ACCOUNTING envelope (see label on the
+# test), NOT a passivity certification; the >1 excursion is the mixed
+# legacy/plane calibration + finite-DFT budget, not validated gain.
+_MIXED_SV_MAX = 1.08
+_ENERGY_ROW_MAX = 1.02         # measured |S11|^2+|S21|^2 <= 0.99995 (#318;
+                               # was <= 1.0003) — dropped as the diagonal
+                               # reflection shrank; gate kept unchanged
 
 
 @pytest.fixture(scope="module")
@@ -718,10 +730,12 @@ def refplane_thru():
     # pec_faces (the infinite ground plane IS the microstrip return)
     # PLUS one wire_port_dead_extent_cells advisory per port — the
     # canonical thru's top extent cell GENUINELY sits inside the PEC
-    # trace (issues #313/#318: physical termination ~33.3 ohm, not 50,
-    # is the documented known issue; every gate in this module was
-    # measured on this exact fixture, dead cell included, so the gates
-    # stay valid as-is). Anything else = fixture drift, stop.
+    # trace. Post-#318 the dead cell is excluded from the sigma/drive/Z0
+    # fold, so each port terminates at 50 ohm across its 2 live cells
+    # (the pre-#318 33.3-ohm Z0*(n_live/n) reading is the historical
+    # issue #313 finding). Every gate in this module was measured on this
+    # exact fixture, dead cell included, so the gates stay valid as-is.
+    # Anything else = fixture drift, stop.
     codes = sorted(getattr(i, "code", None) for i in report)
     assert codes == ["pec_faces_finite_pec",
                      "wire_port_dead_extent_cells",
@@ -832,10 +846,11 @@ def test_refplane_thru_energy_and_passivity_labeled(refplane_thru):
     off-diagonals (separately calibrated), and the Phase-0 box referee
     itself reads sqrt(P_abs/P_launch) up to 1.0066 at 3 GHz (~1-3%
     flux-accounting envelope: residual box leakage + finite DFT). Small
-    >1 excursions of the singular values (measured max 1.0299) are that
-    accounting envelope, NOT validated gain — this gate bounds the
-    envelope, it does not certify passivity. Row energy
-    |S11|^2+|S21|^2 measured <= 1.0003."""
+    >1 excursions of the singular values (measured max 1.0663 post-#318;
+    was 1.0299 — the smaller feed-post diagonal re-phases against the
+    ~0.99 plane off-diagonals) are that accounting envelope, NOT
+    validated gain — this gate bounds the envelope, it does not certify
+    passivity. Row energy |S11|^2+|S21|^2 measured <= 0.99995 (#318)."""
     S, _ = refplane_thru
     sv = np.array([np.linalg.svd(S[:, :, k], compute_uv=False)[0]
                    for k in range(len(_FREQS))])

--- a/tests/test_wire_port.py
+++ b/tests/test_wire_port.py
@@ -140,3 +140,62 @@ def test_wire_port_api_extent():
     assert not np.any(np.isnan(ts)), "No NaN in time series"
     print("\nAPI wire port test:")
     print(f"  Max |Ez| at probe: {np.max(np.abs(ts)):.4e}")
+
+
+def test_wire_port_live_cell_split_and_all_dead_guard():
+    """Issue #318: setup_wire_port distributes sigma over LIVE cells only.
+
+    - pec_mask=None (or all-live) is bit-identical to the historical
+      all-cells fold (the structural byte-identity predicate).
+    - A dead extent cell (pec_mask True) gets NO port sigma and the live
+      cells carry sigma scaled by n_live (per-cell R = Z0/n_live, series
+      sum over live cells = Z0 exactly).
+    - All extent cells dead -> ValueError (no live cell to terminate).
+    """
+    import jax.numpy as jnp
+    import pytest
+
+    grid = Grid(freq_max=5e9, domain=(0.01, 0.01, 0.01), dx=0.001,
+                cpml_layers=0)
+    materials = init_materials(grid.shape)
+    port = WirePort(
+        start=(0.005, 0.005, 0.002),
+        end=(0.005, 0.005, 0.004),
+        component="ez",
+        impedance=50.0,
+        excitation=GaussianPulse(f0=3e9),
+    )
+    from rfx.sources.sources import _wire_port_cells
+    cells = _wire_port_cells(grid, port)
+    assert len(cells) == 3
+
+    # pec_mask=None == all-live mask, bit-identical (structural predicate)
+    legacy = np.asarray(setup_wire_port(grid, port, materials).sigma)
+    all_live = np.asarray(setup_wire_port(
+        grid, port, materials,
+        pec_mask=jnp.zeros(grid.shape, dtype=jnp.bool_)).sigma)
+    assert np.array_equal(legacy, all_live), (
+        "all-live pec_mask must be bit-identical to pec_mask=None")
+
+    # One dead cell: sigma only at live cells, series R over live == Z0
+    mask = jnp.zeros(grid.shape, dtype=jnp.bool_)
+    top = cells[-1]
+    mask = mask.at[top[0], top[1], top[2]].set(True)
+    folded = np.asarray(setup_wire_port(grid, port, materials,
+                                        pec_mask=mask).sigma)
+    assert folded[top[0], top[1], top[2]] == 0.0, (
+        "dead extent cell must carry no port sigma")
+    r_series = 0.0
+    for c in cells[:-1]:
+        s = float(folded[c[0], c[1], c[2]])
+        assert s > 0.0
+        r_series += 1.0 / (s * grid.dx)
+    assert abs(r_series - 50.0) < 1e-9, (
+        f"series termination over live cells must equal Z0=50, got {r_series}")
+
+    # All cells dead -> loud ValueError
+    mask_all = jnp.zeros(grid.shape, dtype=jnp.bool_)
+    for c in cells:
+        mask_all = mask_all.at[c[0], c[1], c[2]].set(True)
+    with pytest.raises(ValueError, match="no live cell"):
+        setup_wire_port(grid, port, materials, pec_mask=mask_all)


### PR DESCRIPTION
Closes #318. The S11-changing companion to #313/#319: a wire port whose extent rasterizes cells into PEC previously distributed its resistance over ALL cells including the dead ones, physically terminating at Z0·(n_live/n) = 33.3 Ω instead of 50 Ω on the canonical thru.

## Fix (3 impl commits + re-baseline + polish)
- Sigma/drive-injection/normalization over **live cells only** (`setup_wire_port`, `make_wire_port_sources`, `update_wire_sparam_probe`, NU-runner copy) → termination is exactly **50.0000 Ω** across the 2 live cells (witness-confirmed). Composed the F1 normalization (Z0c = Z0/n_live) so the #308 receive-channel selection stays consistent.
- Mask/occupancy clearing scoped to live cells (separate commit) → the in-plane trace conductivity hole is gone (`|Ex|_dead` 1.499 → 0.000000; port Ez chain intact).
- Degenerate to byte-identical when `n_live == n` — clean fixtures/goldens/run↔forward contract bitwise-frozen (5/5 witnesses). No FDTD-core changes.

## The residual is fixture physics (re-diagnosed, decisive)
The pre-registered falsifier (thru max|S11| < 0.06) missed — the post-fix |S11| is a V-shape 0.033–0.086 (3–7 GHz), null at 4.5 GHz. An extractor-independent re-diagnosis (flux energy budget + reactance fit, 3 converging witnesses) returned **H_FIXTURE**: the residual is the fixture's REAL reflection from **two 1 mm vertical feed-post inductances (~0.26 nH each) interfering across the 16 mm line** — not an extraction artefact, not a termination error. The prediction neglected feed-post reactance (a modeling omission), not a fix failure. The V-shape is now rfx's measured feed-post S11.

## Gates re-baselined on the physics (measure-first, R5)
4 gates **tightened** (S11 floor 0.30→0.12, set below the pre-fix dead-cell 0.13 so a revert fails loud; reciprocity 5e-2→1.5e-2; battery SV 0.90→0.85; energy dropped); 1 moved permissively (refplane _MIXED_SV_MAX 1.05→1.08, a labeled flux-accounting envelope — both genuine passivity witnesses improved and pass strictly). The #313 kappa |S21| deflation is kept OUT of this ledger (S21 band unchanged). Preflight advisory re-worded to post-fix semantics (33.3 Ω cited as historical). api-inventory regenerated.

## Review
2-lens adversarial → APPROVE ×2 (reviewer independently reproduced every gate value bit-exact; only info/low findings, the one polish applied).

R3: memory=consistent (comparator-not-core; #313 fence intact; #48/#325 z-mesh is a separate cv05 issue) | R2-attempts=1 sanctioned re-diagnosis (decisive, no gate tuning) | falsifier=H_FIXTURE 3-witness verdict + revert-fails-loud S11 floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)