### PR TITLE
docs(cv05): correct stale header — finite-GP box (not pec_faces) + substrate 2-cell rasterization truth (#325)

### DIFF
--- a/examples/crossval/05_patch_antenna.py
+++ b/examples/crossval/05_patch_antenna.py
@@ -7,10 +7,16 @@ substrate, probe-fed. Structurally this matches the standard OpenEMS
 "Simple Patch Antenna" tutorial.
 
 Structure (stack from bottom to top):
-  - Ground plane: PEC face at z=0 (`pec_faces={"z_lo"}` in rfx,
-    explicit PEC box in OpenEMS)
-  - FR4 substrate: εr=4.3, 1.5 mm thick (6 cells in rfx non-uniform z,
-    4 cells in OpenEMS uniform z)
+  - Ground plane: FINITE 60x55 mm PEC box below the substrate (both
+    solvers; bottom CPML absorbs radiation beneath it). NOT
+    ``pec_faces={"z_lo"}`` — an infinite boundary GP turns the antenna
+    into a cavity and shifts the resonance ~8 % high (see build_patch
+    docstring).
+  - FR4 substrate: εr=4.3, 1.5 mm nominal. NOTE: with the committed
+    graded z-mesh the substrate Box RASTERIZES to 2 coarse cells, not
+    the intended 6 fine cells (issue #325); re-pinning it onto the fine
+    band was measured to DEGRADE the resonance agreement, so the
+    committed envelope is kept as-is. (OpenEMS side: 4 uniform z-cells.)
   - Patch: PEC rectangle on top of the substrate
   - Air region above the patch (MUR / CPML open boundaries)
 


### PR DESCRIPTION
Docstring-only. The cv05 module header contradicted its own code in two load-bearing places:

1. **Ground plane**: header said `pec_faces={"z_lo"}`; the code deliberately builds a **finite 60×55 mm PEC box** (the pec_faces variant is the documented +8% cavity-shift mistake — build_patch docstring explains it). This was the last remnant of the 4-patch confusion cleanup.
2. **Substrate**: header claimed '6 cells in rfx non-uniform z'; with the committed graded mesh the substrate Box **rasterizes to 2 coarse cells** (#325). The 2026-07-11/12 investigation verdict (recorded on #325) is that re-pinning onto the fine band *degrades* the resonance agreement (split + worse vs openEMS), so the committed envelope is kept and now honestly described.

No gate/code changes. Part of the accuracy-posture honesty pass (known-issues 2026-07-12 entry).

R3: memory=#325 verdicts + project_patch_discretization_biases | R2-attempts=0 | falsifier=CI green, header matches code

🤖 Generated with [Claude Code](https://claude.com/claude-code)