### PR TITLE
preflight: graded-mesh Box rasterization advisory — catches the #325 shifted-fine-band class (fixes #335)

### DIFF
--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -24,6 +24,7 @@ import numpy as np
 from rfx.grid import C0
 from rfx.core.yee import MaterialArrays
 from rfx.core.jax_utils import is_tracer
+from rfx.geometry.csg import Box
 
 
 def _fmt_len(meters: float) -> str:
@@ -1610,6 +1611,7 @@ class _PreflightMixin:
         self._validate_cfg_pec_boundary_open_structure(_w)
         self._validate_cfg_no_sources(_w)
         self._validate_cfg_nonuniform_limitations(_w, cpml_thickness)
+        self._validate_cfg_graded_box_rasterization(_w)
         self._validate_cfg_subgrid_limitations(_w)
         self._validate_cfg_conformal_fine_dx(dx)
         self._validate_cfg_adi_3d_accuracy(_w)
@@ -1621,6 +1623,58 @@ class _PreflightMixin:
 
         self._check_waveguide_port_evanescent()
         self._check_msl_port_geometry(dx, cpml_thick_lo, cpml_thick_hi)
+
+    def _validate_cfg_graded_box_rasterization(self, _w) -> None:
+        """Warn when a Box misses the fine cells implied by its z-span."""
+        if self._dz_profile is None or is_tracer(self._dz_profile):
+            return
+
+        dz = np.asarray(self._dz_profile, dtype=np.float64)
+        if dz.size == 0:
+            return
+        edges = np.concatenate(([0.0], np.cumsum(dz)))
+        centers = 0.5 * (edges[:-1] + edges[1:])
+
+        for entry in self._geometry:
+            if not isinstance(entry.shape, Box):
+                continue
+            c1, c2 = entry.shape.bounding_box()
+            z_lo, z_hi = sorted((float(c1[2]), float(c2[2])))
+            thickness = z_hi - z_lo
+            if thickness <= 0.0:
+                continue
+
+            rasterized = (centers >= z_lo) & (centers < z_hi)
+            actual = int(np.count_nonzero(rasterized))
+            local = (edges[:-1] < z_hi) & (edges[1:] > z_lo)
+            if not np.any(local):
+                continue
+            # The #325 signature is a fine band SHIFTED OUT of the Box span by
+            # smooth_grading's transition insertion — the intended fine cells
+            # then sit ADJACENT to the span, so measure min dz over a padded
+            # neighborhood (±5 cells), not the span alone (span-only misses
+            # the shifted-substrate case entirely).
+            idx = np.flatnonzero(local)
+            lo_i = max(0, int(idx[0]) - 5)
+            hi_i = min(dz.size, int(idx[-1]) + 6)
+            implied = thickness / float(np.min(dz[lo_i:hi_i]))
+
+            if actual < math.ceil(0.5 * implied) and actual <= 4:
+                _w.warn(
+                    PreflightWarning(
+                        f"Box material '{entry.material_name}' rasterizes to "
+                        f"{actual} z cells (implied {implied:.1f}) over z-span "
+                        f"[{_fmt_len(z_lo)}, {_fmt_len(z_hi)}). "
+                        "smooth_grading transition cells may have shifted the "
+                        "fine band — derive z coordinates from the actual "
+                        "fine-band edges and assert the rasterized cell count "
+                        "(issue #325)",
+                        code="graded_box_rasterization",
+                        loc=f"z=[{z_lo}, {z_hi})",
+                        source="_validate_cfg_graded_box_rasterization",
+                    ),
+                    stacklevel=3,
+                )
 
     def _validate_cfg_refplane_placement(self, _w) -> None:
         """Advisories for ``add_port(reference_plane_cells=...)`` (issue #313).

--- a/tests/test_preflight_graded_rasterization.py
+++ b/tests/test_preflight_graded_rasterization.py
@@ -1,0 +1,61 @@
+"""Preflight advisory for Boxes displaced from a graded-mesh fine band."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from rfx import Box, Simulation
+
+
+def _issues(sim):
+    return sim.preflight()
+
+
+def _has(issues, substring):
+    return any(substring in issue for issue in issues)
+
+
+def _graded_sim(z_lo: float, z_hi: float) -> Simulation:
+    dz = np.array([1.0e-3, 1.0e-3] + [0.25e-3] * 6 + [1.0e-3] * 2)
+    sim = Simulation(
+        freq_max=10e9,
+        domain=(20e-3, 20e-3, float(np.sum(dz))),
+        dx=1e-3,
+        dz_profile=dz,
+        cpml_layers=2,
+    )
+    sim.add_material("substrate", eps_r=3.5)
+    sim.add(Box((5e-3, 5e-3, z_lo), (15e-3, 15e-3, z_hi)),
+            material="substrate")
+    sim.add_source((10e-3, 10e-3, 1e-3), "ez")
+    return sim
+
+
+def test_shifted_box_warns_with_actual_and_implied_counts():
+    sim = _graded_sim(0.6e-3, 2.1e-3)
+
+    issues = _issues(sim)
+
+    assert _has(issues, "rasterizes to 1 z cells (implied 6.0)"), issues
+    assert _has(issues, "smooth_grading transition cells may have shifted"), issues
+
+
+def test_box_pinned_to_actual_fine_band_is_silent():
+    sim = _graded_sim(2.0e-3, 3.5e-3)
+
+    assert not _has(_issues(sim), "smooth_grading transition cells may have shifted")
+
+
+def test_uniform_dz_simulation_skips_check():
+    sim = Simulation(
+        freq_max=10e9,
+        domain=(20e-3, 20e-3, 6e-3),
+        dx=1e-3,
+        cpml_layers=2,
+    )
+    sim.add_material("substrate", eps_r=3.5)
+    sim.add(Box((5e-3, 5e-3, 0.5e-3), (15e-3, 15e-3, 2.0e-3)),
+            material="substrate")
+    sim.add_source((10e-3, 10e-3, 1e-3), "ez")
+
+    assert not _has(_issues(sim), "smooth_grading transition cells may have shifted")


### PR DESCRIPTION
User-facing version of the #325 lesson: with `dz_profile`, a Box placed by absolute z can silently land on far fewer/coarser cells than intended. New advisory compares the actual rasterized z-cell count against the count implied by the finest cell in a ±5-cell neighborhood of the span (neighborhood, not span-only — the fine band is typically *shifted out* of the span, which is the whole failure mode).

Acceptance on the real cv05 pair:
- buggy committed geometry → **2 warnings**: substrate 'fr4' "2 z cells (implied 6.0)" + ground 'pec' "0 z cells" (the GP literally vanishes from the mesh)
- correctly fine-band-pinned geometry → silent
- `tests/test_preflight_false_positives.py` stays green (no new false positives)

Advisory only, no behavior change, no gate touched. Closes #335; complements the agent-side rule in CLAUDE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Codex