### PR TITLE
S-param passivity-guard wiring: MSL epilogue, run() choke point, per-frequency amplitude advisory (fixes #337, #342)

### DIFF
--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -198,6 +198,20 @@ class _ExecuteMixin:
             checkpoint=checkpoint,
         )
 
+    @staticmethod
+    def _warn_run_sparams_if_nonpassive(result) -> None:
+        """Apply the shared lumped/wire advisory to an assembled run result."""
+        s_params = getattr(result, "s_params", None)
+        freqs = getattr(result, "freqs", None)
+        if s_params is None or freqs is None:
+            return
+        from rfx.probes.probes import warn_if_nonpassive_lumped_s11
+        warn_if_nonpassive_lumped_s11(
+            s_params,
+            freqs,
+            extractor="run(compute_s_params=True)",
+        )
+
     def _reject_refplane_ports_off_uniform_lane(self, path_name: str,
                                                 compute_s_params) -> None:
         """Fail loudly when reference-plane ports hit a non-uniform lane.
@@ -2372,6 +2386,7 @@ class _ExecuteMixin:
                 subpixel_smoothing=subpixel_smoothing,
                 checkpoint=checkpoint,
             )
+            self._warn_run_sparams_if_nonpassive(_res)
             _warn_if_nonfinite_result(_res, context="run")
             return _res
 
@@ -2461,5 +2476,6 @@ class _ExecuteMixin:
             kerr_chi3=kerr_chi3,
             field_dtype=_field_dtype,
         )
+        self._warn_run_sparams_if_nonpassive(_res)
         _warn_if_nonfinite_result(_res, context="run")
         return _res

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -92,6 +92,7 @@ def _warn_if_nonpassive_smatrix(
     extractor: str,
     strict: bool = False,
     passivity_tol: float = 0.10,
+    amplitude_eps: float = 0.05,
 ) -> None:
     """Auto-run the passivity/finiteness self-check on a freshly-extracted
     S-matrix and surface a non-physical result as a warning (or raise when
@@ -102,11 +103,11 @@ def _warn_if_nonpassive_smatrix(
     receives, so a per-column power > 1 (e.g. ``|S11| > 1`` on a one-port)
     means the *extractor* is wrong — mismeasured current sign/scale or a
     bad reference plane — and the S-parameters are untrustworthy, NOT that
-    the device is exotic. Waveguide and coaxial extractors previously had
-    no such self-check; only ``compute_msl_s_matrix`` did. Wiring the
-    existing :func:`rfx.validation.validate_port_smatrix` in here is the
-    guard that would have short-circuited the multi-session WR-90 ``|S11|``
-    chase recorded in durable memory.
+    the device is exotic. The wire, waveguide, coaxial, and MSL extractors
+    all route through this shared guard before returning. Wiring the existing
+    :func:`rfx.validation.validate_port_smatrix` in here is the guard that
+    would have short-circuited the multi-session WR-90 ``|S11|`` chase
+    recorded in durable memory.
 
     Tracer-safe: under ``jax.grad`` / ``jax.jit`` tracing ``result.s_params``
     is an abstract tracer with no concrete value, so the numpy-based check is
@@ -115,6 +116,9 @@ def _warn_if_nonpassive_smatrix(
     iteration.
     """
     s = getattr(result, "s_params", None)
+    if s is None:
+        # MSLSMatrixResult uses the historical ``S`` field name.
+        s = getattr(result, "S", None)
     if s is None:
         return
     try:
@@ -141,6 +145,28 @@ def _warn_if_nonpassive_smatrix(
         passivity_limit=1.0,
         passivity_tol=float(passivity_tol),
     )
+
+    # Independent per-frequency amplitude advisory (issue #337).  Keep this
+    # separate from the column-power gate above: normalize=False deliberately
+    # has a loose column-power tolerance, but an individual |S_ij| materially
+    # above unity is still useful evidence of an extraction/normalization
+    # artifact.  One worst-bin warning keeps a broadband result actionable
+    # without producing one warning per frequency.
+    amplitude_advisory = None
+    finite_abs = np.where(np.isfinite(s_np), np.abs(s_np), -np.inf)
+    if finite_abs.size:
+        worst_flat = int(np.argmax(finite_abs))
+        worst_index = np.unravel_index(worst_flat, finite_abs.shape)
+        worst_value = float(finite_abs[worst_index])
+        frequency_index = int(worst_index[-1])
+        if worst_value > 1.0 + float(amplitude_eps):
+            amplitude_advisory = (
+                f"{extractor}: per-frequency amplitude advisory at frequency "
+                f"index {frequency_index}: max |S| = {worst_value:.4g}; "
+                "passivity violated: extraction/normalization artifact — do "
+                "not interpret as physics; see the normalize parameter "
+                "docstring and issue #337"
+            )
     bad = [
         i for i in report.issues
         if i.code in ("passivity_violation", "nonfinite_sparams")
@@ -169,10 +195,10 @@ def _warn_if_nonpassive_smatrix(
         _SOFT_COLPOWER_FLOOR = 2.25
         hard_limit = 1.0 + float(passivity_tol)
         max_cp = report.metrics.get("max_column_power")
+        soft_advisory = None
         if max_cp is not None and _SOFT_COLPOWER_FLOOR < float(max_cp) <= hard_limit:
-            import warnings as _w
-            _w.warn(
-                f"{extractor}: max column power {float(max_cp):.4g} exceeds 1 "
+            soft_advisory = (
+                f"max column power {float(max_cp):.4g} exceeds 1 "
                 f"(non-physical for a passive structure) but stays below the "
                 f"tol={float(passivity_tol):g} extractor-broken hard limit "
                 f"({hard_limit:.4g}). This is an ADVISORY, not an error: on the "
@@ -181,9 +207,12 @@ def _warn_if_nonpassive_smatrix(
                 f"~2.0), but a column power materially above it can also signal "
                 f"a reference-plane or normalize choice or an under-resolved "
                 f"mesh. Treat these S-parameters with caution and cross-check "
-                f"(normalize='flux', finer dx) before trusting them.",
-                stacklevel=3,
+                f"(normalize='flux', finer dx) before trusting them."
             )
+        advisories = [x for x in (amplitude_advisory, soft_advisory) if x]
+        if advisories:
+            import warnings as _w
+            _w.warn(" ".join(advisories), stacklevel=3)
         return
     detail = "; ".join(f"{i.code}: {i.message}" for i in bad)
     msg = (
@@ -195,6 +224,8 @@ def _warn_if_nonpassive_smatrix(
         f"rfx.validation.validate_port_smatrix / replay_smatrix_from_vi_dump "
         f"before trusting or optimizing against these numbers."
     )
+    if amplitude_advisory:
+        msg = f"{msg} {amplitude_advisory}"
     if strict:
         raise ValueError(msg)
     import warnings as _w
@@ -1725,13 +1756,20 @@ class _SparamMixin:
                     driven_port_indices=np.arange(n_ports, dtype=np.int64),
                 )
 
-            return MSLSMatrixResult(
+            result = MSLSMatrixResult(
                 S=S,
                 freqs=np.asarray(freqs_arr),
                 Z0=Z0_per_run,
                 beta=beta_first,
                 port_names=tuple(pe.name for pe in entries),
             )
+            _warn_if_nonpassive_smatrix(
+                result,
+                extractor="compute_msl_s_matrix",
+                strict=strict_extractor,
+                passivity_tol=0.10,
+            )
+            return result
         finally:
             self._dft_planes = saved_dft
             self._msl_ports = saved_msl
@@ -2703,4 +2741,3 @@ class _SparamMixin:
                 dtype=float,
             ),
         )
-

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -152,6 +152,16 @@ def _warn_if_nonpassive_smatrix(
     # above unity is still useful evidence of an extraction/normalization
     # artifact.  One worst-bin warning keeps a broadband result actionable
     # without producing one warning per frequency.
+    # Tolerance-class-aware threshold: the loose normalize=False waveguide
+    # path (passivity_tol >= 2.0) has a DOCUMENTED validated |S11| envelope
+    # reaching ~1.41 (Yee dispersion + band edge — see the normalize docstring
+    # and the 2026-06-21 policy locks in test_sparam_passivity_guard.py), so
+    # its amplitude advisory only fires above 1.5 (still catches the eager
+    # ~1.98 spike class). Tight paths (lumped/MSL/coax/normalize=True) keep
+    # the 1 + amplitude_eps (default 1.05) threshold — the MSL documented
+    # envelope is 1.0063 and the field case that motivated issue #337 was 1.36.
+    eff_amplitude_eps = (float(amplitude_eps) if float(passivity_tol) < 2.0
+                         else max(float(amplitude_eps), 0.5))
     amplitude_advisory = None
     finite_abs = np.where(np.isfinite(s_np), np.abs(s_np), -np.inf)
     if finite_abs.size:
@@ -159,7 +169,7 @@ def _warn_if_nonpassive_smatrix(
         worst_index = np.unravel_index(worst_flat, finite_abs.shape)
         worst_value = float(finite_abs[worst_index])
         frequency_index = int(worst_index[-1])
-        if worst_value > 1.0 + float(amplitude_eps):
+        if worst_value > 1.0 + eff_amplitude_eps:
             amplitude_advisory = (
                 f"{extractor}: per-frequency amplitude advisory at frequency "
                 f"index {frequency_index}: max |S| = {worst_value:.4g}; "

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -686,16 +686,6 @@ def run_uniform(
             sim, s_param_freqs, n_steps=sp_n_steps,
         )
 
-        # Passivity self-check (tracer-safe) — surface non-physical |S|>1 in the
-        # driver-extracted lumped/wire S-matrix, matching forward() and
-        # compute_*_s_matrix (which previously had no such check on this path).
-        if s_params is not None:
-            from rfx.probes.probes import warn_if_nonpassive_lumped_s11
-            warn_if_nonpassive_lumped_s11(
-                s_params, freqs_out,
-                extractor="run(compute_s_params=True)",
-            )
-
     waveguide_ports_result = (
         {
             entry.name: cfg

--- a/tests/test_passivity_guard_wiring.py
+++ b/tests/test_passivity_guard_wiring.py
@@ -21,12 +21,13 @@ def _result(s_params):
 
 
 def test_per_frequency_amplitude_advisory_reports_worst_bin():
+    # tight tolerance class (the real student-case path is MSL, tol=0.10)
     s = np.array([[[0.2, 1.36, 0.4]]])
     with pytest.warns(UserWarning) as recorded:
         _warn_if_nonpassive_smatrix(
             _result(s),
-            extractor="compute_waveguide_s_matrix",
-            passivity_tol=2.0,
+            extractor="compute_msl_s_matrix",
+            passivity_tol=0.10,
         )
     messages = [str(item.message) for item in recorded]
     amplitude = [message for message in messages if "frequency index" in message]
@@ -58,7 +59,7 @@ def test_msl_result_uses_shared_epilogue_and_warns():
         _warn_if_nonpassive_smatrix(
             result,
             extractor="compute_msl_s_matrix",
-            passivity_tol=2.0,
+            passivity_tol=0.10,  # mirrors the actual compute_msl_s_matrix epilogue
         )
 
 
@@ -91,3 +92,28 @@ def test_run_uniform_epilogue_warns_for_patched_extractor(monkeypatch):
             skip_preflight=True,
         )
     assert result is fake_result
+
+
+def test_loose_waveguide_class_keeps_documented_envelope_silent():
+    """normalize=False waveguide (tol=2.0): the documented Yee-dispersion
+    envelope (|S11| up to ~1.41) stays SILENT on the amplitude advisory
+    (threshold 1.5 for the loose class), while the eager-spike class (~1.98)
+    still fires."""
+    import warnings as _warnings
+    from rfx.api._sparams import _warn_if_nonpassive_smatrix
+
+    ok = np.array([[[0.3, 1.41, 0.5]]])
+    with _warnings.catch_warnings(record=True) as rec:
+        _warnings.simplefilter("always")
+        _warn_if_nonpassive_smatrix(
+            _result(ok), extractor="compute_waveguide_s_matrix",
+            passivity_tol=2.0,
+        )
+    assert not any("frequency index" in str(w.message) for w in rec)
+
+    spike = np.array([[[0.3, 1.98, 0.5]]])
+    with pytest.warns(UserWarning, match="frequency index"):
+        _warn_if_nonpassive_smatrix(
+            _result(spike), extractor="compute_waveguide_s_matrix",
+            passivity_tol=2.0,
+        )

--- a/tests/test_passivity_guard_wiring.py
+++ b/tests/test_passivity_guard_wiring.py
@@ -1,0 +1,93 @@
+"""Regression coverage for issues #337 and #342 passivity wiring."""
+
+from types import SimpleNamespace
+import warnings
+
+import numpy as np
+import pytest
+
+from rfx import Simulation
+from rfx.api._spec import MSLSMatrixResult
+from rfx.api._sparams import _warn_if_nonpassive_smatrix
+from rfx.sources.sources import GaussianPulse
+
+
+def _result(s_params):
+    return SimpleNamespace(
+        s_params=np.asarray(s_params, dtype=complex),
+        freqs=np.array([1.0e9, 2.0e9, 3.0e9]),
+        port_names=("port0",),
+    )
+
+
+def test_per_frequency_amplitude_advisory_reports_worst_bin():
+    s = np.array([[[0.2, 1.36, 0.4]]])
+    with pytest.warns(UserWarning) as recorded:
+        _warn_if_nonpassive_smatrix(
+            _result(s),
+            extractor="compute_waveguide_s_matrix",
+            passivity_tol=2.0,
+        )
+    messages = [str(item.message) for item in recorded]
+    amplitude = [message for message in messages if "frequency index" in message]
+    assert len(amplitude) == 1
+    assert "frequency index 1" in amplitude[0]
+    assert "1.36" in amplitude[0]
+    assert "issue #337" in amplitude[0]
+
+
+def test_pec_short_like_1_03_column_is_silent():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_if_nonpassive_smatrix(
+            _result([[[1.03, 1.02, 1.01]]]),
+            extractor="compute_waveguide_s_matrix",
+            passivity_tol=2.0,
+        )
+
+
+def test_msl_result_uses_shared_epilogue_and_warns():
+    result = MSLSMatrixResult(
+        S=np.array([[[0.2, 1.36, 0.4]]]),
+        freqs=np.array([1.0e9, 2.0e9, 3.0e9]),
+        Z0=np.full((1, 3), 50.0),
+        beta=np.ones(3),
+        port_names=("msl0",),
+    )
+    with pytest.warns(UserWarning, match="compute_msl_s_matrix.*1.36"):
+        _warn_if_nonpassive_smatrix(
+            result,
+            extractor="compute_msl_s_matrix",
+            passivity_tol=2.0,
+        )
+
+
+def test_run_uniform_epilogue_warns_for_patched_extractor(monkeypatch):
+    sim = Simulation(
+        freq_max=3.0e9,
+        domain=(0.004, 0.004, 0.004),
+        dx=1.0e-3,
+        boundary="pec",
+    )
+    sim.add_port(
+        position=(0.002, 0.002, 0.002),
+        component="ez",
+        impedance=50.0,
+        waveform=GaussianPulse(f0=2.0e9, bandwidth=0.5),
+    )
+    fake_result = SimpleNamespace(
+        s_params=np.array([0.2, 1.36, 0.4]),
+        freqs=np.array([1.0e9, 2.0e9, 3.0e9]),
+    )
+
+    monkeypatch.setattr("rfx.runners.uniform.run_uniform", lambda *a, **k: fake_result)
+    monkeypatch.setattr("rfx.api._execute._warn_if_nonfinite_result", lambda *a, **k: None)
+
+    with pytest.warns(UserWarning, match=r"run\(compute_s_params=True\).*non-passive"):
+        result = sim.run(
+            n_steps=1,
+            compute_s_params=True,
+            s_param_freqs=fake_result.freqs,
+            skip_preflight=True,
+        )
+    assert result is fake_result

--- a/tests/test_sparam_passivity_guard.py
+++ b/tests/test_sparam_passivity_guard.py
@@ -110,21 +110,17 @@ def test_guard_is_tracer_safe_under_jax_grad():
 def test_normalize_aware_tol_tolerates_documented_overshoot():
     """compute_waveguide_s_matrix(normalize=False) has documented Yee-dispersion
     + band-edge |S11| overshoot (validated paths reach ~1.4); the loose tol used
-    on that path must not trigger the hard column-power verdict for a
-    column-power ~2.0 (|S11|~1.41) result, while the independent amplitude
-    advisory still surfaces it. Gross extractor bugs are caught under either
-    tolerance."""
+    on that path must stay SILENT on a column-power ~2.0 (|S11|~1.41) result,
+    while the tight tol used on normalize=True/"flux" still flags it. Gross
+    extractor bugs (|S11|>>1) are caught under either tol."""
     s = np.zeros((1, 1, 3), dtype=complex)
     s[0, 0, :] = np.sqrt(2.0)  # column power 2.0  (|S11| = 1.414)
-    # loose column-power tol does not hard-fail, but the independent issue
-    # #337 per-bin amplitude advisory still surfaces the over-unity value.
-    with warnings.catch_warnings(record=True) as rec:
-        warnings.simplefilter("always")
+    # loose tol (the normalize=False path) -> silent
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         _warn_if_nonpassive_smatrix(
             _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=2.0
         )
-    assert not _hard_fired(rec)
-    assert any("frequency index" in str(w.message) for w in rec)
     # tight tol (the normalize=True/"flux" path) -> warns
     with pytest.warns(UserWarning, match="passivity"):
         _warn_if_nonpassive_smatrix(
@@ -177,30 +173,26 @@ def test_soft_advisory_fires_in_the_over_unity_gap():
 
 
 def test_soft_advisory_silent_at_documented_envelope():
-    """Column power == 2.0 must not fire the legacy column-power advisory.
-
-    The issue #337 amplitude advisory remains expected for |S|=1.414.
-    """
+    """Column power == 2.0 (|S|=1.414, the documented normalize=False PEC-short
+    envelope, locked silent by test_normalize_aware_tol_...) must NOT fire the
+    soft advisory — the floor (2.25) sits above it with margin."""
     s = np.full((1, 1, 3), np.sqrt(2.0) + 0.0j)  # column power exactly 2.0
-    with warnings.catch_warnings(record=True) as rec:
-        warnings.simplefilter("always")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning => failure
         _warn_if_nonpassive_smatrix(
             _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=2.0
         )
-    assert not _soft_fired(rec)
-    assert any("frequency index" in str(w.message) for w in rec)
 
 
 def test_soft_advisory_silent_just_below_floor():
-    """Column power 2.10 stays below the legacy advisory's 2.25 floor."""
+    """Column power 2.10 (< 2.25 floor) stays silent — margin for cross-machine
+    float drift on the validated PEC-short (~2.00-2.005)."""
     s = np.full((1, 1, 3), np.sqrt(2.10) + 0.0j)
-    with warnings.catch_warnings(record=True) as rec:
-        warnings.simplefilter("always")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         _warn_if_nonpassive_smatrix(
             _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=2.0
         )
-    assert not _soft_fired(rec)
-    assert any("frequency index" in str(w.message) for w in rec)
 
 
 def test_soft_advisory_never_fires_on_tight_tol_path():

--- a/tests/test_sparam_passivity_guard.py
+++ b/tests/test_sparam_passivity_guard.py
@@ -110,17 +110,21 @@ def test_guard_is_tracer_safe_under_jax_grad():
 def test_normalize_aware_tol_tolerates_documented_overshoot():
     """compute_waveguide_s_matrix(normalize=False) has documented Yee-dispersion
     + band-edge |S11| overshoot (validated paths reach ~1.4); the loose tol used
-    on that path must stay SILENT on a column-power ~2.0 (|S11|~1.41) result,
-    while the tight tol used on normalize=True/"flux" still flags it. Gross
-    extractor bugs (|S11|>>1) are caught under either tol."""
+    on that path must not trigger the hard column-power verdict for a
+    column-power ~2.0 (|S11|~1.41) result, while the independent amplitude
+    advisory still surfaces it. Gross extractor bugs are caught under either
+    tolerance."""
     s = np.zeros((1, 1, 3), dtype=complex)
     s[0, 0, :] = np.sqrt(2.0)  # column power 2.0  (|S11| = 1.414)
-    # loose tol (the normalize=False path) -> silent
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    # loose column-power tol does not hard-fail, but the independent issue
+    # #337 per-bin amplitude advisory still surfaces the over-unity value.
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
         _warn_if_nonpassive_smatrix(
             _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=2.0
         )
+    assert not _hard_fired(rec)
+    assert any("frequency index" in str(w.message) for w in rec)
     # tight tol (the normalize=True/"flux" path) -> warns
     with pytest.warns(UserWarning, match="passivity"):
         _warn_if_nonpassive_smatrix(
@@ -173,26 +177,30 @@ def test_soft_advisory_fires_in_the_over_unity_gap():
 
 
 def test_soft_advisory_silent_at_documented_envelope():
-    """Column power == 2.0 (|S|=1.414, the documented normalize=False PEC-short
-    envelope, locked silent by test_normalize_aware_tol_...) must NOT fire the
-    soft advisory — the floor (2.25) sits above it with margin."""
+    """Column power == 2.0 must not fire the legacy column-power advisory.
+
+    The issue #337 amplitude advisory remains expected for |S|=1.414.
+    """
     s = np.full((1, 1, 3), np.sqrt(2.0) + 0.0j)  # column power exactly 2.0
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")  # any warning => failure
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
         _warn_if_nonpassive_smatrix(
             _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=2.0
         )
+    assert not _soft_fired(rec)
+    assert any("frequency index" in str(w.message) for w in rec)
 
 
 def test_soft_advisory_silent_just_below_floor():
-    """Column power 2.10 (< 2.25 floor) stays silent — margin for cross-machine
-    float drift on the validated PEC-short (~2.00-2.005)."""
+    """Column power 2.10 stays below the legacy advisory's 2.25 floor."""
     s = np.full((1, 1, 3), np.sqrt(2.10) + 0.0j)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
         _warn_if_nonpassive_smatrix(
             _result(s), extractor="compute_waveguide_s_matrix", passivity_tol=2.0
         )
+    assert not _soft_fired(rec)
+    assert any("frequency index" in str(w.message) for w in rec)
 
 
 def test_soft_advisory_never_fires_on_tight_tol_path():


### PR DESCRIPTION
Closes the three silent-pass surfaces from the accuracy sweep, all advisory-only:

1. **compute_msl_s_matrix** now runs the same `_warn_if_nonpassive_smatrix` epilogue as wire/waveguide/coax (tight class, tol=0.10) — the guard's docstring claimed this existed; it didn't. This is the path that let the student's |S11|=1.36 ship unflagged.
2. **run(compute_s_params=True)** gets a single choke-point advisory (`_warn_run_sparams_if_nonpassive`) covering BOTH the uniform and nonuniform assembly paths (the previous check lived only inside the uniform runner; relocated, not duplicated).
3. **Per-frequency amplitude advisory** in the shared guard, tolerance-class aware: threshold 1.05 on tight paths (MSL documented envelope 1.0063; field case 1.36) / **1.5 on the loose normalize=False waveguide class** — its documented Yee-dispersion envelope legitimately reaches ~1.41 (2026-06-21 policy locks restored verbatim), while the eager ~1.98 spike class still fires.

**Field acceptance** (in the review commit): the actual violating student dataset `rfx_cf_s11_dx98um.json` (max|S11|=1.3579 @ 8.45 GHz) now warns through the MSL epilogue; the clean 197 µm dataset stays silent. 25 passivity-suite tests green.

Authored by Codex; reviewed + policy correction by Claude (flat threshold would have made every healthy normalize=False strong-reflector run noisy).

No numeric behavior change, no gate value touched.

R3: memory=project_normalize_true_s11_limitation + 2026-06-21 port-review locks (policy preserved) | R2-attempts=0 | falsifier=field-acceptance pair in the review commit

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Codex