### PR TITLE
post-run advisories: ring-down truncation witness + zero-coupling guard (fixes #332, #336)

### DIFF
--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -212,6 +212,66 @@ class _ExecuteMixin:
             extractor="run(compute_s_params=True)",
         )
 
+    def _warn_postrun_energy_witness(
+        self,
+        result,
+        *,
+        fixed_num_periods: bool,
+        until_decay: float | None,
+    ) -> None:
+        """Warn about measured late energy or an exactly zero excitation."""
+        import warnings
+
+        time_series = getattr(result, "time_series", None)
+        series = None if time_series is None else np.asarray(time_series)
+        has_probe_series = series is not None and series.size > 0
+
+        if has_probe_series:
+            magnitude = np.abs(series)
+            peak = float(np.max(magnitude))
+            if peak == 0.0:
+                warnings.warn(
+                    "no field energy was recorded — the source may not have "
+                    "coupled (position off-grid, wrong component, or zero "
+                    "amplitude) (issue #336)",
+                    stacklevel=3,
+                )
+                return
+
+            pulsed = any(
+                isinstance(getattr(source, "waveform", None), GaussianPulse)
+                for source in (*self._ports, *self._msl_ports)
+            )
+            open_boundary = self._boundary_spec.absorber_type in ("cpml", "upml")
+            if open_boundary and pulsed and fixed_num_periods and until_decay is None:
+                tail_samples = max(1, math.ceil(magnitude.shape[0] * 0.05))
+                tail = float(np.max(magnitude[-tail_samples:]))
+                tail_db = -math.inf if tail == 0.0 else 20.0 * math.log10(tail / peak)
+                if tail_db > -40.0:
+                    warnings.warn(
+                        f"run ended at {tail_db:.1f} dB of peak — ring-down "
+                        "truncated; Harminv/DFT/NTFF quantities may carry "
+                        "transient error; consider until_decay or more periods "
+                        "(issue #332)",
+                        stacklevel=3,
+                    )
+            return
+
+        state = getattr(result, "state", None)
+        fields = [
+            np.asarray(field)
+            for name in ("ex", "ey", "ez", "hx", "hy", "hz")
+            if (field := getattr(state, name, None)) is not None
+        ]
+        if fields and all(field.size > 0 and float(np.max(np.abs(field))) == 0.0
+                          for field in fields):
+            warnings.warn(
+                "no field energy was recorded — the source may not have "
+                "coupled (position off-grid, wrong component, or zero "
+                "amplitude) (issue #336)",
+                stacklevel=3,
+            )
+
     def _reject_refplane_ports_off_uniform_lane(self, path_name: str,
                                                 compute_s_params) -> None:
         """Fail loudly when reference-plane ports hit a non-uniform lane.
@@ -2287,6 +2347,8 @@ class _ExecuteMixin:
         -------
         Result
         """
+        fixed_num_periods = n_steps is None
+
         # ---- P1: Auto mesh when dx not specified and geometry exists ----
         if self._dx is None and self._geometry:
             self._auto_configure_mesh()
@@ -2387,6 +2449,11 @@ class _ExecuteMixin:
                 checkpoint=checkpoint,
             )
             self._warn_run_sparams_if_nonpassive(_res)
+            self._warn_postrun_energy_witness(
+                _res,
+                fixed_num_periods=fixed_num_periods,
+                until_decay=until_decay,
+            )
             _warn_if_nonfinite_result(_res, context="run")
             return _res
 
@@ -2477,5 +2544,10 @@ class _ExecuteMixin:
             field_dtype=_field_dtype,
         )
         self._warn_run_sparams_if_nonpassive(_res)
+        self._warn_postrun_energy_witness(
+            _res,
+            fixed_num_periods=fixed_num_periods,
+            until_decay=until_decay,
+        )
         _warn_if_nonfinite_result(_res, context="run")
         return _res

--- a/tests/test_postrun_energy_witness.py
+++ b/tests/test_postrun_energy_witness.py
@@ -1,0 +1,61 @@
+"""Post-run advisory coverage for issues #332 and #336."""
+
+import warnings
+
+from rfx import Simulation
+from rfx.sources.sources import GaussianPulse
+
+
+def _run(*, boundary="cpml", num_periods=0.1, amplitude=1.0):
+    sim = Simulation(
+        freq_max=10.0e9,
+        domain=(0.012, 0.012, 0.012),
+        dx=1.0e-3,
+        boundary=boundary,
+        cpml_layers=2,
+    )
+    waveform = GaussianPulse(
+        f0=5.0e9,
+        bandwidth=0.8,
+        amplitude=amplitude,
+    )
+    sim.add_source((0.006, 0.006, 0.006), "ez", waveform=waveform)
+    sim.add_probe((0.007, 0.006, 0.006), "ez")
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        result = sim.run(
+            num_periods=num_periods,
+            compute_s_params=False,
+            skip_preflight=True,
+        )
+    return result, [str(item.message) for item in recorded]
+
+
+def test_g1_warns_when_open_pulse_tail_is_hot():
+    _, messages = _run(num_periods=0.1)
+
+    assert any("truncated" in message for message in messages)
+
+
+def test_g1_is_silent_after_generous_ringdown():
+    _, messages = _run(num_periods=20.0)
+
+    assert not any("truncated" in message for message in messages)
+
+
+def test_g1_skips_pec_closed_boundary_with_hot_tail():
+    _, messages = _run(boundary="pec", num_periods=0.1)
+
+    assert not any("truncated" in message for message in messages)
+
+
+def test_g6_warns_when_source_amplitude_is_exactly_zero():
+    _, messages = _run(num_periods=1.0, amplitude=0.0)
+
+    assert any("no field energy was recorded" in message for message in messages)
+
+
+def test_g6_is_silent_for_normal_coupling():
+    _, messages = _run(num_periods=20.0)
+
+    assert not any("no field energy was recorded" in message for message in messages)


### PR DESCRIPTION
Two post-run advisories in run()'s epilogue (both return paths), warnings only:

**#332 — energy/truncation witness (G1)**: for open-boundary (CPML/UPML) + pulsed-source + fixed-num_periods runs with a probe series, report when the envelope tail (last 5%) is above −40 dB of peak: *'ring-down truncated; Harminv/DFT/NTFF quantities may carry transient error; consider until_decay'*. This is the rfx analog of openEMS's EndCriteria warning — the check that would have caught both fake-resonance incidents in the 2026-07-11/12 arc. Harminv-based settling checks were explicitly rejected (two-sided broken; known-issues 2026-07-12 entry) — this one only states a measured fact. Skips silently on PEC-closed domains, CW drives, until_decay runs.

**#336 — zero-coupling guard (G6)**: exactly-zero probe series or exactly-zero final field state → *'the source may not have coupled (position off-grid, wrong component, or zero amplitude)'*. Exact-zero test only, no thresholds — the rfx analog of openEMS's silent 'Unused primitive' port failure.

Tests: 5 new (fire/silent/scope-skip per check) + false-positive and passivity suites stay green (20 passed). Authored by Codex, reviewed by Claude (predicate verified: add_source entries live in _ports, so soft-source ring-downs are covered).

R3: memory=known-issues settling entry (harminv-check rejection honored) | R2-attempts=0 | falsifier=the five scope tests

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Codex