### PR TITLE
harminv: band-limited auto-decimation — N=95k post-processing from ~100 min to 0.51 s (fixes #345)

### DIFF
--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -1029,7 +1029,8 @@
         "pencil_parameter",
         "min_Q",
         "max_modes",
-        "sv_threshold"
+        "sv_threshold",
+        "decimate"
       ]
     },
     "harminv_from_probe": {

--- a/rfx/harminv.py
+++ b/rfx/harminv.py
@@ -20,6 +20,11 @@ from __future__ import annotations
 from typing import NamedTuple
 
 import numpy as np
+from scipy.signal import decimate as scipy_decimate
+
+
+DECIMATION_GUARD = 8
+_MAX_DECIMATION_STAGE = 13
 
 
 class HarminvMode(NamedTuple):
@@ -42,6 +47,7 @@ def harminv(
     min_Q: float = 1.0,
     max_modes: int = 50,
     sv_threshold: float = 1e-3,
+    decimate: str | bool = "auto",
 ) -> list[HarminvMode]:
     """Extract resonant modes via the Matrix Pencil Method.
 
@@ -73,12 +79,39 @@ def harminv(
         Maximum modes to return.
     sv_threshold : float
         Singular value threshold for rank determination.
+    decimate : {"auto", False}
+        Automatically reduce oversampled, band-limited inputs before matrix
+        pencil analysis. With the default ``"auto"``, decimation is applied
+        when ``1 / dt > 8 * f_max`` using a target factor of
+        ``int(1 / dt / (4 * f_max))``. Anti-aliased, zero-phase FIR stages of
+        at most 13 are used, and the effective timestep is passed to the core
+        algorithm. Set to ``False`` to retain every input sample. This avoids
+        redundant work because the estimator scales approximately as
+        :math:`O(N^{2.7})`, while retaining the record's time span and hence
+        its frequency resolution.
 
     Returns
     -------
     list of HarminvMode, sorted by amplitude (strongest first).
     """
+    if decimate not in ("auto", False):
+        raise ValueError("decimate must be 'auto' or False")
+
     y = np.asarray(signal, dtype=np.complex128).ravel()
+    amplitude_signal = y
+    amplitude_dt = dt
+    effective_sv_threshold = sv_threshold
+    if decimate == "auto" and 1.0 / dt > DECIMATION_GUARD * f_max:
+        target_factor = int(1.0 / dt / (4.0 * f_max))
+        factors = _decimation_factors(target_factor)
+        for factor in factors:
+            y = scipy_decimate(y, factor, ftype="fir", zero_phase=True)
+            dt *= factor
+        # Signal singular values shrink with the reduced sample count while
+        # broadband noise does not shrink at the same rate. Preserve the
+        # original rank-selection meaning across the resampling operation.
+        effective_sv_threshold *= np.sqrt(target_factor)
+
     N = len(y)
     if N < 10:
         return []
@@ -101,7 +134,7 @@ def harminv(
 
     # Determine effective rank from singular values
     sv_norm = sv / sv[0] if sv[0] > 0 else sv
-    rank = max(1, int(np.sum(sv_norm > sv_threshold)))
+    rank = max(1, int(np.sum(sv_norm > effective_sv_threshold)))
     rank = min(rank, max_modes, len(sv))
 
     # Truncate to rank
@@ -147,9 +180,12 @@ def harminv(
             continue
 
         # Amplitude: project signal onto this mode
-        n_arr = np.arange(N)
-        basis = lam ** n_arr  # z^n
-        amp_complex = np.dot(y, basis.conj()) / np.dot(basis, basis.conj())
+        n_arr = np.arange(len(amplitude_signal))
+        amplitude_lam = np.exp(s * amplitude_dt)
+        basis = amplitude_lam**n_arr  # z^n at the original sample rate
+        amp_complex = np.dot(amplitude_signal, basis.conj()) / np.dot(
+            basis, basis.conj()
+        )
         amplitude = abs(amp_complex)
         phase = np.angle(amp_complex)
 
@@ -181,6 +217,20 @@ def harminv(
     # Sort by amplitude
     deduped.sort(key=lambda m: m.amplitude, reverse=True)
     return deduped[:max_modes]
+
+
+def _decimation_factors(target: int) -> list[int]:
+    """Return the largest <= target factor composed of stages no larger than 13."""
+    for effective_factor in range(target, 1, -1):
+        remainder = effective_factor
+        factors = []
+        for factor in range(_MAX_DECIMATION_STAGE, 1, -1):
+            while remainder % factor == 0:
+                factors.append(factor)
+                remainder //= factor
+        if remainder == 1:
+            return factors
+    return []
 
 
 def harminv_from_probe(

--- a/tests/test_harminv_decimation.py
+++ b/tests/test_harminv_decimation.py
@@ -1,0 +1,61 @@
+"""Regression tests for band-limited Harminv auto-decimation."""
+
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from rfx.harminv import HarminvMode, harminv
+
+_DT = 1.2e-12
+_F_MIN = 2.0e9
+_F_MAX = 3.5e9
+_TONES = (
+    (2.2e9, 60.0, 1.0),
+    (2.8e9, 40.0, 0.3),
+)
+
+
+def _ringdown(n: int, dt: float = _DT) -> np.ndarray:
+    t = np.arange(n) * dt
+    signal = np.zeros(n)
+    for frequency, quality_factor, amplitude in _TONES:
+        decay = np.pi * frequency / quality_factor
+        signal += amplitude * np.exp(-decay * t) * np.cos(2 * np.pi * frequency * t)
+    return signal
+
+
+def _nearest(modes: list[HarminvMode], frequency: float) -> HarminvMode:
+    return min(modes, key=lambda mode: abs(mode.freq - frequency))
+
+
+def test_auto_decimation_preserves_modes_and_is_fast():
+    undecimated = harminv(_ringdown(5000), _DT, _F_MIN, _F_MAX, decimate=False)
+
+    start = time.perf_counter()
+    automatic = harminv(_ringdown(20000), _DT, _F_MIN, _F_MAX, decimate="auto")
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 5.0, f"auto-decimated Harminv took {elapsed:.2f} s"
+    for frequency, quality_factor, _ in _TONES:
+        short_mode = _nearest(undecimated, frequency)
+        full_mode = _nearest(automatic, frequency)
+        assert abs(full_mode.freq - short_mode.freq) / short_mode.freq < 2e-3
+        assert abs(full_mode.Q - short_mode.Q) / short_mode.Q < 0.1
+        assert (
+            abs(full_mode.amplitude - short_mode.amplitude) / short_mode.amplitude
+            < 0.05
+        )
+        assert abs(full_mode.freq - frequency) / frequency < 2e-3
+        assert abs(full_mode.Q - quality_factor) / quality_factor < 0.1
+
+
+def test_auto_decimation_is_bit_comparable_when_sampling_is_near_band():
+    dt = 1.0 / (7.0 * _F_MAX)
+    signal = _ringdown(1000, dt)
+
+    automatic = harminv(signal, dt, _F_MIN, _F_MAX, decimate="auto")
+    undecimated = harminv(signal, dt, _F_MIN, _F_MAX, decimate=False)
+
+    assert automatic == undecimated


### PR DESCRIPTION
The matrix-pencil estimator scales ~O(N^2.7) while FDTD ring-downs are massively oversampled (content ≤ the search band, e.g. 3.5 GHz, sampled at fs ≈ 833 GHz). This decimates anti-aliased (zero-phase FIR, stages ≤13) down to fs ≥ 4·f_max before the pencil, keeping the record's time span (frequency resolution ∝ 1/T unchanged) and projecting mode AMPLITUDES on the original undecimated series (amplitudes/phases unaffected).

**Acceptance ladder (2-mode synthetic, dt=1.2 ps, truth f=2.2/2.8 GHz Q=60/40):**

| N | before | after | recovery |
|---|---|---|---|
| 2,000 | 0.44 s | 0.00 s | 2.1985 / 2.7920 |
| 20,000 | 91.8 s | **0.03 s** | 2.2000 / 2.7995, Q 60.1/39.6 |
| 40,000 | DNF (>13 min) | 0.17 s | same |
| 95,000 | ~100 min (extrapolated) | **0.51 s** | f exact to 4 digits, Q within 1% |

Longer records now IMPROVE accuracy instead of becoming untractable — this was the actual bottleneck behind the 60–150-minute diagnostic walls this week (the GPU FDTD share was ~40 s; kernel measures 0.45–3.9 GC/s, docs/agent-memory/throughput_baseline.md).

Opt-out: `decimate=False` (default `'auto'`, guard: only when fs > 8·f_max). scipy is already a core dependency. Tests: equivalence + no-op-path + existing harminv suite (8 passed). Authored by Codex, reviewed by Claude.

R3: memory=throughput_baseline.md ladder | R2-attempts=0 | falsifier=the acceptance ladder in this description

🤖 Generated with [Claude Code](https://claude.com/claude-code) + Codex