### PR TITLE
chore(examples): hygiene — stale references made honest (restructure PR-1)

### DIFF
--- a/examples/crossval/06_msl_notch_filter.py
+++ b/examples/crossval/06_msl_notch_filter.py
@@ -20,7 +20,9 @@ At f_notch ≈ c / (4 · L_stub · sqrt(εr_eff)) ≈ 3.69 GHz, the
 stub presents a virtual short circuit at the junction, creating
 a transmission zero (deep S21 notch).
 
-The canonical openEMS run (see `06_openems_ref/run_upstream_tutorial.py`)
+The canonical openEMS run (generated locally by a `06_openems_ref/`
+run-upstream script — the directory is an OPTIONAL local artifact, not
+committed; when absent this script takes the exit-2 SKIP path)
 places the notch at 3.671 GHz with |S21| ≤ −50 dB.
 
 REFERENCE DATA

--- a/examples/inverse_design/ad_gradient_demo.py
+++ b/examples/inverse_design/ad_gradient_demo.py
@@ -59,7 +59,7 @@ design_shape = tuple(hi_idx[d] - lo_idx[d] + 1 for d in range(3))
 eps_min, eps_max = region.eps_range
 
 print("=" * 70)
-print("Crossval 14: E2E Inverse Design — Slab Transmission Maximization")
+print("AD gradient self-test: E2E inverse design — slab transmission maximization")
 print("=" * 70)
 print(f"Structure: PEC cavity 60×20×20 mm, port at x=10mm, probe at x=50mm")
 print(f"Design region: dielectric slab x=[25, 35] mm, εr ∈ [{eps_min}, {eps_max}]")

--- a/examples/inverse_design/progressive_demo.py
+++ b/examples/inverse_design/progressive_demo.py
@@ -27,7 +27,7 @@ showcase aggressive convergence. For a substantive inverse-design run,
 use a resonance or far-field objective over many more iterations.
 
 Usage:
-    python examples/crossval/08_progressive_inverse_design.py
+    python examples/inverse_design/progressive_demo.py
 
 Produces ``examples/08_progressive_inverse_design.png`` with the loss
 curve (stages separated by dashed verticals) and per-stage eps_design


### PR DESCRIPTION
First of the examples/docs restructure series (plan in task #48; audit: 4-agent dependency map, every pin file:line-verified). No path moves, no behavior change — three stale-reference fixes (progressive_demo dead usage line, ad_gradient 'Crossval 14' banner, cv06's phantom 06_openems_ref/ dir now honestly documented as an optional local artifact with the exit-2 SKIP path). Local untracked debris (43 items: dead vessl launchers, orphan PNGs of deleted scripts) swept to a dated backup outside the repo.

Next in series: PR-2 creates examples/tutorials/ and promotes the four didactic scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)