### PR TITLE
docs: route user entry points to the learning path (restructure PR-6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ For the per-case metric, reproduce command, and last-touched commit, see the [be
 
 The CPU-feasible subset runs locally via `PYTHONPATH=. python scripts/run_crossval_cpu.py`, using the repo-wide exit-code convention: `0` = full pass including the external cross-check, `1` = a self-check / numeric gate failed, `2` = the external reference (e.g. Meep / OpenEMS) was unavailable, so the case is visibly skipped — never silently green.
 
-For a first read, start with `examples/crossval/05_patch_antenna.py` (patch workflow) and `examples/crossval/11_waveguide_port_wr90.py` (rectangular waveguide ports). Treat scripts outside this validated set as local diagnostics unless a public guide and support-matrix entry list them.
+To learn rfx, start with the ordered tutorials in `examples/tutorials/` (see `examples/README.md` for the learning path). The cross-validation scripts referenced above are measurement fixtures we maintain to verify accuracy — read them for evidence, not as lessons. Treat scripts outside the tutorial and validated sets as local diagnostics unless a public guide and support-matrix entry list them.
 
 ## Key Features
 

--- a/docs/public/examples/index.mdx
+++ b/docs/public/examples/index.mdx
@@ -9,13 +9,23 @@ Use these examples as starting points, not as exhaustive coverage of every impor
 
 ## Recommended entry points
 
+**Learning rfx** — start here, in order:
+
+| Script | You learn |
+|---|---|
+| `examples/quickstart/hello_world.py` | install check, the minimal simulate-and-probe loop |
+| `examples/tutorials/` (ordered in `examples/README.md`) | boundaries, materials, run control, ports & S-parameters, resonance extraction, far-field patterns, RCS |
+| `examples/inverse_design/differentiable_s11_design.py` | the differentiable design loop |
+| `examples/inverse_design/multilayer_ar_coating.py` | conservative inverse-design demo |
+
+**Verifying rfx** — the accuracy evidence, kept public for transparency:
+
 | Page or script | Why it matters |
 |---|---|
 | [Crossval First](./crossval/) | current public cross-check entry point |
 | [RF Workflows](./rf-workflows/) | practical workflow framing |
-| `examples/crossval/05_patch_antenna.py` | current patch antenna cross-check |
-| `examples/crossval/11_waveguide_port_wr90.py` | rectangular waveguide-port workflow |
-| `examples/inverse_design/multilayer_ar_coating.py` | conservative inverse-design demo |
+| `examples/crossval/05_patch_antenna.py` | patch antenna cross-check fixture |
+| `examples/crossval/11_waveguide_port_wr90.py` | rectangular waveguide-port cross-check fixture |
 
 ## How to read the example surface
 

--- a/docs/public/guide/first-patch.mdx
+++ b/docs/public/guide/first-patch.mdx
@@ -218,7 +218,9 @@ documented wire-port or microstrip-line workflow — see
 
 ## Full script
 
-The canonical patch script is `examples/crossval/05_patch_antenna.py` — the full
-workflow paired with the OpenEMS external cross-check described in
-[Tutorial: Patch Antenna Design](./tutorial-patch-antenna/). Treat it, not
-ad-hoc local scripts, as the reference path.
+The full patch workflow you just built is validated by
+`examples/crossval/05_patch_antenna.py` — our accuracy fixture paired with the
+OpenEMS external cross-check described in
+[Tutorial: Patch Antenna Design](./tutorial-patch-antenna/). That script is a
+measurement fixture, not a lesson; for learning, continue with the ordered
+tutorials in `examples/tutorials/` (see `examples/README.md`).

--- a/docs/public/guide/installation.mdx
+++ b/docs/public/guide/installation.mdx
@@ -74,3 +74,9 @@ The `dev` extra includes:
 - CPU: modern x86_64
 - GPU: NVIDIA + CUDA 12+ for acceleration
 - RAM: 4 GB minimum, 16 GB+ recommended for larger 3D runs
+
+## Next steps
+
+Run `examples/quickstart/hello_world.py` to confirm the install, then follow the
+ordered tutorials in `examples/tutorials/` — the learning path is indexed in
+`examples/README.md`.

--- a/docs/public/index.mdx
+++ b/docs/public/index.mdx
@@ -30,7 +30,7 @@ If a capability is not listed here or on the [Support Boundaries](/rfx/api/suppo
 | **GPU acceleration** | JAX/JIT execution for large 3-D grids |
 | **Differentiable workflows** | `jax.grad` through selected JAX-traced objectives; validate final RF observables through their support envelope |
 | **RF workflow tools** | materials, sources, probes, ports, S-parameter helpers, Harminv, far-field utilities |
-| **Recommended examples** | current runnable scripts under `examples/crossval/` and selected inverse-design examples |
+| **Recommended examples** | the ordered tutorials under `examples/tutorials/` (start at `examples/README.md`), plus the inverse-design examples |
 | **Support-boundary discipline** | public claims are tied to explicit guide/support-matrix envelopes, not to every importable symbol |
 
 ---

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,13 +10,17 @@ New to rfx? Run these in order; each teaches one decision a real design needs.
 | 2 | `tutorials/boundary_spec_demo.py` | choosing boundaries: CPML=open, PEC=closed (never mix roles), PMC symmetry, periodic cells |
 | 3 | `tutorials/slab_rt_flux_monitor.py` | R(f)/T(f) the right way: `add_flux_monitor` + two-run reference (why probe-FFT lies) |
 | 4 | `tutorials/nonuniform_patch_demo.py` | graded z-mesh for thin substrates + verifying where your layers actually landed |
-| 5 | `inverse_design/differentiable_s11_design.py` | the differentiable design loop: `forward` + `jax.grad` + optimizer |
-| 6 | `tutorials/artifact_report_demo.py` | exporting a shareable scene/mesh/report bundle |
+| 5 | `tutorials/materials_and_dispersion.py` | library + custom materials, why loss matters (the infinite-Q trap), Debye/Lorentz dispersion |
+| 6 | `tutorials/run_control_and_fields.py` | `n_steps` vs `num_periods` vs `until_decay`, reading the truncation warning, extracting field slices |
+| 7 | `tutorials/ports_and_sparams_101.py` | which port for which structure (all five), S11 basics, real-world pitfalls |
+| 8 | `tutorials/resonance_harminv.py` | ring-down resonance extraction, picking modes by physics (not loudness), record-length vs resolution |
+| 9 | `tutorials/antenna_farfield_pattern.py` | far-field boxes done right (half-wavelength rule), directivity vs the textbook dipole |
+| 10 | `tutorials/rcs_scattering.py` | radar cross-section with incident-reference subtraction |
+| 11 | `inverse_design/differentiable_s11_design.py` | the differentiable design loop: `forward` + `jax.grad` + optimizer |
+| 12 | `tutorials/artifact_report_demo.py` | exporting a shareable scene/mesh/report bundle |
 
 `config/microstrip_thru.yaml` shows the declarative YAML front-end for the same
-Simulation API. More tutorials (materials & dispersion, ports & S-parameters,
-far-field patterns, RCS, resonance extraction, run control) are being added on
-this lane.
+Simulation API.
 
 Read the preflight output every time — the advisories are part of the result,
 and several of them encode hard-won physics rules (lossless-dielectric Q traps,


### PR DESCRIPTION
With all ten tutorials merged (#351, #353, #354, #355), the documentation entry points now lead with learning: README 'first read' → `examples/tutorials/`; docs/public index recommends the tutorials; the examples index separates **Learning rfx** (ordered path) from **Verifying rfx** (cross-check fixtures, kept public for transparency); first-patch routes onward to the tutorials; installation gains next-steps; the examples/README table lists the full 12-step path. Public site routes unchanged (site_map 23 slugs resolve); crossval file paths untouched (relocation is the next step in the series). No internal vocabulary in any user-facing prose (grep-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)