### PR TITLE
fix(gates): pin V173-A bit-identity lock to the undecimated harminv extractor

### DIFF
--- a/scripts/harnesses/v173a_physics_equivalence.py
+++ b/scripts/harnesses/v173a_physics_equivalence.py
@@ -87,7 +87,12 @@ def _extract_harminv_f_res(sim, n_steps: int = 3000) -> float:
     ts = np.asarray(res.time_series)[:, 0]
     dt = float(res.dt)
     # Harminv in the 1.5–3.5 GHz band (covers FR4 patch fundamental mode).
-    modes = harminv(ts, dt, f_min=1.5e9, f_max=3.5e9, min_Q=5.0)
+    # decimate=False: this harness feeds a bit-identity lock whose baseline was
+    # recorded before harminv grew band-limited auto-decimation (PR #347). The
+    # lock isolates SOLVER drift, so the measuring instrument stays pinned to
+    # the baseline-era extraction; auto-decimation shifts the extracted f_res
+    # by ~1e-4 relative on this 3000-step record, far above the 1e-6 lock.
+    modes = harminv(ts, dt, f_min=1.5e9, f_max=3.5e9, min_Q=5.0, decimate=False)
     if len(modes) == 0:
         return float("nan")
     # Pick the strongest mode by amplitude.


### PR DESCRIPTION
## What / why

The 2026-07-13 weekly slow run ([run 29236773167](https://github.com/bk-squared/rfx/actions/runs/29236773167), shard 4) failed `test_v173a_baseline_bit_identity`: Δf_res = 279 kHz (1.4×10⁻⁴ relative) vs the committed baseline, against a 10⁻⁶ gate.

**Root cause — comparator, not solver.** PR #347 changed `harminv()`'s default to band-limited auto-decimation. The V173-A harness extracts f_res through that default, so the lock's measuring instrument changed while its baseline was recorded with the undecimated extractor. The harness now pins `decimate=False`, keeping the instrument identical to the baseline era; the lock keeps doing its actual job (catching solver drift).

**Witness**: with the pin, the lock passes locally at the original 10⁻⁶ gate (`pytest -m slow_physics tests/test_v173a_physics_equivalence_slow.py` → 1 passed, 39 s) — solver output is bit-compatible with the baseline; no gate value or tolerance was touched, no baseline rebump needed.

Note: `crossval-external` in the same run was green — this was the only failure and it does not affect the examples/validation restructure (#359).

R3: memory=feedback_root_cause_before_gate_change (gate kept; instrument pinned; root cause written) | R2-attempts=1 (pre-declared: pin → expect 1e-6 green; met) | falsifier=local slow_physics run of the lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)