### PR TITLE
fix(crossval): cv04 per-bin R+T ceiling + gated settling tail (#341)

### DIFF
--- a/validation/crossval/04_multilayer_fresnel.py
+++ b/validation/crossval/04_multilayer_fresnel.py
@@ -180,10 +180,49 @@ elapsed = time.time() - t0_wall
 print(f"Simulation: {elapsed:.1f}s")
 print(f"  refl max={np.max(np.abs(ts_refl)):.4e}, trans max={np.max(np.abs(ts_trans)):.4e}")
 print(f"  inc max: refl={np.max(np.abs(ts_inc_refl)):.4e}, trans={np.max(np.abs(ts_inc_trans)):.4e}")
-print(f"  Tail: refl={np.max(np.abs(ts_refl[-100:])):.2e}, trans={np.max(np.abs(ts_trans[-100:])):.2e}")
 
 # Compute scattered (reflected) field by subtracting 1D incident from total
 ts_scattered_refl = ts_refl - ts_inc_refl
+
+# -----------------------------------------------------------------------------
+# Settling-tail witness (GATED — issue #341; previously an ungated print).
+#
+# Window choice: the old window (last 100 steps) contained the direct pulse —
+# in the committed config (nx=600, 719 steps) the 1D incident at the trans
+# probe peaks at step ~544 and is still ~11% of peak inside the last 100
+# steps, so a "tail" there mostly measured the pulse itself. The last 50
+# steps are clean: measured incident there is 2.1e-4 of peak (2026-07-13,
+# committed config). The purity check below enforces that property at
+# RUNTIME, so a future change to n_steps/geometry cannot silently re-admit
+# the direct pulse into the witness window.
+#
+# Thresholds (measured envelope + headroom, committed config 2026-07-13):
+#   - window purity: incident 2.1e-4 of peak measured -> gate 1e-3 (~5x).
+#   - tails: scattered@refl 0.036, total@trans 0.051 of incident peak; this
+#     residual is the order-2 etalon echo still in flight at run end (rung
+#     C4, job 369367246779 — collapses to ~5e-5 rel at nx=1500/1940 steps).
+#     Gate 0.10 (~2x): bounds gross non-settling (CPML contamination,
+#     late-time growth, broken time gate) while accepting the documented
+#     committed-config echo residual.
+# -----------------------------------------------------------------------------
+TAIL_WINDOW = 50
+TAIL_PURITY_LIMIT = 1e-3
+TAIL_LIMIT = 0.10
+inc_peak = max(np.max(np.abs(ts_inc_refl)), np.max(np.abs(ts_inc_trans)))
+tail_inc_rel = max(np.max(np.abs(ts_inc_refl[-TAIL_WINDOW:])),
+                   np.max(np.abs(ts_inc_trans[-TAIL_WINDOW:]))) / inc_peak
+tail_refl_rel = np.max(np.abs(ts_scattered_refl[-TAIL_WINDOW:])) / inc_peak
+tail_trans_rel = np.max(np.abs(ts_trans[-TAIL_WINDOW:])) / inc_peak
+tail_window_clean = tail_inc_rel < TAIL_PURITY_LIMIT
+tail_ok = bool(tail_window_clean
+               and tail_refl_rel < TAIL_LIMIT
+               and tail_trans_rel < TAIL_LIMIT)
+print(f"  Tail witness (last {TAIL_WINDOW} steps, rel. to incident peak): "
+      f"scat_refl={tail_refl_rel:.4f}, trans={tail_trans_rel:.4f} "
+      f"(limit {TAIL_LIMIT})")
+print(f"  Tail window purity: incident={tail_inc_rel:.2e} of peak "
+      f"(limit {TAIL_PURITY_LIMIT:g}) -> "
+      f"{'clean' if tail_window_clean else 'CONTAMINATED BY DIRECT PULSE'}")
 
 # =============================================================================
 # PART 1b: Time-domain diagnostic
@@ -232,6 +271,12 @@ S_total_t = np.fft.rfft(ts_trans, n=nfft)
 S_scat_r = np.fft.rfft(ts_scattered_refl, n=nfft)
 
 inc_power = np.abs(S_inc_t)
+# NOTE (issue #341): this 2% AMPLITUDE mask admits band-edge bins whose POWER
+# denominator |S_inc|^2 is down ~2500x from peak, so ratio errors there are
+# mask-amplified — a single-bin R+T spike up to ~10 would have passed the
+# mean-only gates silently. The mask itself stays as committed (it defines
+# the evaluated band); the per-bin max|R+T-1| ceiling below now bounds the
+# amplified-bin class.
 mask = (freqs > 3e9) & (freqs < 15e9) & (inc_power > inc_power.max() * 0.02)
 
 T_rfx = np.abs(S_total_t[mask])**2 / np.abs(S_inc_t[mask])**2
@@ -257,7 +302,19 @@ print(f"  R+T mean: {np.mean(R_rfx+T_rfx):.4f}, dev max: {cons_rfx.max():.4f}")
 t_ok = T_err_rfx.mean() < 0.05
 r_ok = R_err_rfx.mean() < 0.05
 c_ok = cons_rfx.mean() < 0.05
-rfx_self_ok = bool(t_ok and r_ok and c_ok)
+
+# Per-bin energy-conservation ceiling (ADDED, issue #341; the mean gates above
+# are untouched). Root cause of the pinned envelope (rung C4, job
+# 369367246779): committed config (nx=600, 719 steps) measures
+# max|R+T-1| = 0.0487, worst bin at the 11.87 GHz mask edge, and the error is
+# ENTIRELY order-2 etalon-echo truncation — widening to nx=1500/1940 steps
+# collapses it to 0.0002 while band-mean |dT|,|dR| shift < 0.005 (negligible
+# mean-side bias). Ceiling = measured envelope + headroom; it bounds the
+# previously-silent mask-amplified single-bin spike class (up to ~10) to 6%.
+CONS_MAX_LIMIT = 0.06
+cons_max_ok = bool(cons_rfx.max() <= CONS_MAX_LIMIT)
+
+rfx_self_ok = bool(t_ok and r_ok and c_ok and cons_max_ok and tail_ok)
 
 # =============================================================================
 # PART 3: Meep simulation (OPTIONAL secondary cross-validation reference)
@@ -492,6 +549,17 @@ else:
     print(f"  {'T(f) mean error':<25} {T_err_rfx.mean():>10.4f} {0.05:>10.4f}")
     print(f"  {'R(f) mean error':<25} {R_err_rfx.mean():>10.4f} {0.05:>10.4f}")
     print(f"  {'R+T mean dev (energy)':<25} {cons_rfx.mean():>10.4f} {0.05:>10.4f}")
+
+# Gated per-bin/tail witnesses (issue #341) — rfx-only, independent of Meep
+print("\n  Gated witnesses (issue #341):")
+print(f"  {'max|R+T-1| (per-bin)':<25} {cons_rfx.max():>10.4f} "
+      f"{CONS_MAX_LIMIT:>10.4f}  [{'ok' if cons_max_ok else 'FAIL'}]")
+print(f"  {'tail scat@refl (rel)':<25} {tail_refl_rel:>10.4f} "
+      f"{TAIL_LIMIT:>10.4f}  [{'ok' if tail_refl_rel < TAIL_LIMIT else 'FAIL'}]")
+print(f"  {'tail total@trans (rel)':<25} {tail_trans_rel:>10.4f} "
+      f"{TAIL_LIMIT:>10.4f}  [{'ok' if tail_trans_rel < TAIL_LIMIT else 'FAIL'}]")
+print(f"  {'tail window purity':<25} {tail_inc_rel:>10.2e} "
+      f"{TAIL_PURITY_LIMIT:>10.0e}  [{'ok' if tail_window_clean else 'FAIL'}]")
 
 print(f"\n  rfx accuracy: {'PASS' if rfx_self_ok else 'FAIL'}")
 


### PR DESCRIPTION
Closes #341

## What / why

`validation/crossval/04_multilayer_fresnel.py` gated only band MEANS (T/R/|R+T-1| mean < 0.05) while max errors were printed but never gated, and the 2%-AMPLITUDE mask admits band-edge bins whose POWER denominator is down ~2500x — a mask-amplified single-bin R+T spike up to ~7 (the old mean budget on 170 bins) passed the committed energy gate silently. The only settling witness (tail print, last 100 steps) was ungated, and its window actually contained the direct pulse.

This PR ADDS witnesses; nothing is loosened and the committed config (nx=600, 719 steps) is untouched:

1. **Per-bin energy ceiling**: `max|R+T-1| <= 0.06` over masked bins.
2. **Gated settling-tail witness**: last-50-step window with a runtime purity check proving the direct pulse is excluded, then tail gates at 0.10 relative to the incident peak.
3. Comment at the 2% mask documenting the mask-amplification hazard the ceiling now bounds.

## Measured numbers (committed config, reproduced locally 2026-07-13)

Reproduces rung C4 (job 369367246779, log `scripts/diagnostics/sweep_confirmation_out/rungC4_cv04_wide.log` in the primary checkout) exactly:

| quantity | measured | gate |
|---|---|---|
| T(f) mean err | 0.0110 | < 0.05 (unchanged) |
| R(f) mean err | 0.0066 | < 0.05 (unchanged) |
| R+T mean dev | 0.0091 | < 0.05 (unchanged) |
| **max\|R+T-1\| (per-bin)** | **0.0487** | **<= 0.06 (NEW)** |
| **tail scat@refl (rel)** | **0.0363** | **< 0.10 (NEW)** |
| **tail total@trans (rel)** | **0.0514** | **< 0.10 (NEW)** |
| **tail window purity (incident rel)** | **2.11e-04** | **< 1e-3 (NEW)** |

Per-bin context (R5, full curve inspected — figure below): the worst bin is the LAST masked bin, f = 11.8669 GHz, where the incident amplitude is exactly at the 2% mask floor (0.0200 of peak). The top-5 worst bins are all low-inc-power bins (inc/max 0.020-0.043). The |R+T-1| curve is oscillatory lobes growing toward the high-f band edge — consistent with rung C4's root cause: the error is ENTIRELY order-2 etalon-echo truncation (widening to nx=1500/1940 steps collapses 0.0487 -> 0.0002 while band-mean |dT|,|dR| shift < 0.005). Ceiling 0.06 = measured envelope + headroom; it bounds the previously-silent spike class to 6%.

## Tail-window justification (from the inspected time-domain trace)

The old window (last 100 steps) is direct-pulse-contaminated: the 1D incident at the trans probe peaks at step 544/719 and is still 6.98e-2 (**11% of peak**) inside the last 100 steps — a "tail" there mostly measures the pulse itself (as issue #341 noted). The last-50 window is clean: measured incident 1.30e-4 abs = **2.1e-4 of peak** (the residual ~1e-4 floor is 1D-grid numerical dispersion). The new purity gate (incident < 1e-3 of peak in-window, ~5x headroom) enforces this property at RUNTIME, so future n_steps/geometry changes cannot silently re-admit the pulse. In-window tails (0.036/0.051 rel) are the order-2 etalon echo still in flight at run end — exactly the C4 truncation mechanism; gate 0.10 (~2x headroom) bounds gross non-settling (CPML contamination, late-time growth, broken time gate).

## Falsifier demonstration (not committed; log in evidence dir)

Synthetic single-bin spike injected into the saved committed-config R array, gate logic replicated:

```
single-bin R spike = 4.0 (within old mean budget):
  T/R mean err = 0.0110/0.0280, cons mean = 0.0299, cons max = 3.5909
  OLD mean-only gates: PASS  <-- silent pass
  NEW with per-bin ceiling 0.06: FAIL  <-- caught
```

(A 9.0 spike trips even the old means on 170 bins; 4.0 is squarely in the silent class — old gates PASS a physically absurd R+T ~ 4.6 bin.)

## End-to-end rerun

Final committed file rerun on the committed config: all gates green, `rfx accuracy: PASS`, exit 2 (Meep secondary reference unavailable on this box — the script's documented SKIP convention, not a failure).

## Preflight

n/a (raw-loop TFSF script, historical exception — no `sim.run`/`forward` path; the script hand-rolls TFSF + CPML directly).

## Artifacts (evidence dir, primary checkout)

`/root/workspace/byungkwan-workspace/research/rfx/scripts/diagnostics/gate_honesty_20260713/lane-341/`
- `cv04_341_r5_inspection.png` — per-bin |R+T-1| curve + worst-bin/mask-edge + tail-window justification panels
- `cv04_committed_config_stdout.log` — baseline reproduction (pre-change)
- `cv04_after_gates_stdout.log`, `cv04_final_stdout.log` — post-change end-to-end runs
- `cv04_committed_config_arrays.npz` — per-bin R, T, R+T + full time-domain traces
- `cv04_falsifier_demo.log` — spike demonstration
- `cv04_committed_04_fresnel_slab.png`, `cv04_committed_04_time_domain.png`, `04_fresnel_slab.png`, `04_time_domain.png` — regenerated script figures

R3: memory=feedback_root_cause_before_gate_change + feedback_metric_first_skepticism + rfx CLAUDE.md settling-witness rule (adds witnesses, loosens nothing) | R2-attempts=0 | falsifier=synthetic single-bin spike vs replicated gate logic (demonstrated above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
