### PR TITLE
fix(tests): tier1 OPT-C1 comparator — analytic f from L_eff=(N-1)dx

### DIFF
--- a/tests/test_adi.py
+++ b/tests/test_adi.py
@@ -155,14 +155,24 @@ def test_adi_cavity_resonance():
     Analytical TM_mn resonance: f_mn = (C0/2) * sqrt((m/a)^2 + (n/b)^2)
     We target the TM_11 mode.
     """
-    a = 0.1   # 10 cm
-    b = 0.1   # 10 cm
-    f_analytical = (C0 / 2.0) * np.sqrt((1.0/a)**2 + (1.0/b)**2)
+    a = 0.1   # 10 cm (nominal)
+    b = 0.1   # 10 cm (nominal)
 
     # Grid
     dx = dy = 0.002   # 2 mm  → 50 x 50 cells
     Nx = int(round(a / dx))
     Ny = int(round(b / dy))
+
+    # COMPARATOR CONVENTION (issue #338, same class as the 3D OPT-C1
+    # comparator): _apply_pec_2d zeroes Ez at node indices 0 and Nx-1, so
+    # the PEC walls sit (Nx-1)*dx = 98 mm apart, one cell short of the
+    # nominal a = Nx*dx. The old analytic from a=100 mm was 2.04% low —
+    # consuming most of the 2% gate budget (measured peak 2.1552 GHz was
+    # 1.67% from the biased analytic but only 0.37% from the honest one).
+    # Same gate, honest reference.
+    a_eff = (Nx - 1) * dx
+    b_eff = (Ny - 1) * dy
+    f_analytical = (C0 / 2.0) * np.sqrt((1.0/a_eff)**2 + (1.0/b_eff)**2)
 
     # CFL timestep and ADI timestep (5x CFL)
     dt_cfl = _cfl_dt_2d(dx, dy)

--- a/tests/test_review_tier1_validation_battery.py
+++ b/tests/test_review_tier1_validation_battery.py
@@ -23,6 +23,7 @@ Covered: CORE-C2, GEO-C1, PROBE-C1, RIS-C2. (OPT-C1 — adi_step_3d
 from __future__ import annotations
 
 import numpy as np
+import jax
 import jax.numpy as jnp
 import pytest
 
@@ -243,31 +244,47 @@ def test_risc2_np_interp_complex_part_behavior():
 # OPT-C1 — adi_step_3d 3D PEC-cavity eigenfrequency
 # ===========================================================================
 #
-# adi_step_3d uses an LOD split that, by its own code comment
-# (adi.py:781-787), "applies the tridiagonal solve to ALL E components
-# along each axis, which adds artificial diffusion for components whose
-# curl has no derivative along that axis". The only 3D ADI tests check
-# bounded/oscillating fields — none checks a physical eigenfrequency,
-# while the 2D path has test_adi_cavity_resonance (2% gate).
+# adi_step_3d uses an LOD split that, by its own code comment (adi.py,
+# "NOTE: This simplified LOD..."), "applies the tridiagonal solve to ALL
+# E components along each axis, which adds artificial diffusion for
+# components whose curl has no derivative along that axis". The only 3D
+# ADI tests check bounded/oscillating fields — none checks a physical
+# eigenfrequency, while the 2D path has test_adi_cavity_resonance
+# (2% gate).
 #
 # This test runs a lossless 3D PEC cubic cavity at a modest CFL factor
 # (where splitting error is small) and compares the dominant resonance
 # to the analytic mode  f_mnp = (C0/2)*sqrt((m/Lx)^2+(n/Ly)^2+(p/Lz)^2).
 # A modest CFL is the FAIR setting: a structural scheme error shows up
 # even there, so a large miss is strong evidence for OPT-C1.
+#
+# COMPARATOR CONVENTION (issue #338): _apply_pec_3d zeroes tangential E
+# at node indices 0 and N-1, so the PEC walls sit L_eff = (N-1)*dx apart
+# — the fence-post convention Grid documents ("PEC walls at index 0 and
+# index N span exactly N*dx": a physical span of L needs N+1 nodes).
+# Computing f_analytic from L = N*dx biased it 9.1% low — larger than
+# the 2% gate itself, so the strict xfail could never legitimately
+# XPASS. The falsifier test below pins the corrected convention: the
+# known-good explicit Yee scheme on the SAME 12^3 node cavity lands
+# 0.21% from the corrected analytic and 8.9% from the biased one.
 
 @pytest.mark.xfail(strict=True, reason=(
     "OPT-C1: adi_step_3d LOD applies the implicit solve to off-axis E "
-    "components (artificial diffusion, adi.py:781-787). 3D PEC-cavity "
-    "eigenfrequency is expected to miss the analytic mode beyond the 2% "
-    "gate the 2D ADI path holds. Adjudication test — see roadmap Part A."))
+    "components (artificial diffusion, see adi.py LOD NOTE). Under the "
+    "honest comparator (L_eff=(N-1)*dx=55 mm -> f=3.854 GHz) the "
+    "measured 12^3-cavity peak at 2x CFL is 2.077 GHz — a 46% miss "
+    "(2026-07-13), and the mode energy itself decays within ~4 ns "
+    "(over-dissipation). Adjudication test — roadmap Part A, issue #338."))
 def test_optc1_adi_3d_cavity_eigenfrequency():
-    L = 0.06           # 60 mm cube
+    L = 0.06           # nominal 60 mm cube
     dx = dy = dz = 0.005   # 12 cells per side
     N = int(round(L / dx))
+    # Walls at nodes 0 and N-1 (node-indexed PEC, see block comment above):
+    # the honest analytic length is one cell short of the nominal L.
+    L_eff = (N - 1) * dx
 
-    # Degenerate fundamental: TE_101 / TE_011 / TE_110 of a cube.
-    f_analytic = (C0 / 2.0) * np.sqrt((1.0 / L) ** 2 + (1.0 / L) ** 2)
+    # Degenerate fundamental: TE_101 / TE_011 / TE_110 of the L_eff cube.
+    f_analytic = (C0 / 2.0) * np.sqrt((1.0 / L_eff) ** 2 + (1.0 / L_eff) ** 2)
 
     # 3D CFL limit; ADI is run at a modest factor so splitting error is small.
     dt_cfl = dx / (C0 * np.sqrt(3.0))
@@ -304,3 +321,76 @@ def test_optc1_adi_3d_cavity_eigenfrequency():
     assert rel_err < 0.02, (
         f"3D ADI cavity resonance {f_peak/1e9:.4f} GHz vs analytic "
         f"{f_analytic/1e9:.4f} GHz — error {rel_err*100:.2f}% > 2%")
+
+
+def test_optc1_falsifier_yee_matches_corrected_analytic():
+    """Falsifier for the OPT-C1 comparator length (issue #338).
+
+    The SAME 12^3 node cavity as test_optc1_adi_3d_cavity_eigenfrequency,
+    advanced by the known-good explicit Yee scheme (the test_cavity.py
+    rung: update_h / update_e / apply_pec — production PEC also zeroes
+    tangential E at nodes 0 and N-1), must resonate within the same 2%
+    gate of the CORRECTED analytic built from L_eff = (N-1)*dx.
+
+    Discrimination: had the honest cavity length been N*dx instead, the
+    Yee peak would sit ~8.9% from that analytic — asserted below, so
+    this rung fails if the comparator convention is wrong EITHER way.
+    Measured 2026-07-13: f_peak = 3.846 GHz vs corrected 3.854 GHz
+    -> 0.21% (FFT half-bin 0.28%); vs biased 3.533 GHz -> 8.87%.
+    """
+    from rfx.core.yee import init_state, init_materials, update_e, update_h
+    from rfx.boundaries.pec import apply_pec
+
+    N = 12
+    dx = 0.005
+    L_eff = (N - 1) * dx
+    f_corrected = (C0 / 2.0) * np.sqrt(2.0) / L_eff   # TE101 of L_eff cube
+    f_biased = (C0 / 2.0) * np.sqrt(2.0) / (N * dx)   # the pre-#338 analytic
+
+    dt = 0.99 * dx / (C0 * np.sqrt(3.0))
+    n_steps = 6000
+
+    state = init_state((N, N, N))
+    materials = init_materials((N, N, N))
+
+    # Same pulse width and source/probe cells as the ADI rung above.
+    tau = 16.0 * dx / (C0 * np.sqrt(3.0))
+    t0 = 4.0 * tau
+    si, sj, sk = N // 3, N // 2, N // 3
+    pi, pj, pk = 2 * N // 3, N // 2, 2 * N // 3
+
+    @jax.jit
+    def step(s):
+        s = update_h(s, materials, dt, dx)
+        s = update_e(s, materials, dt, dx)
+        return apply_pec(s)
+
+    signal = np.zeros(n_steps)
+    for n in range(n_steps):
+        t = n * dt
+        state = step(state)
+        ey = state.ey.at[si, sj, sk].add(float(np.exp(-((t - t0) / tau) ** 2)))
+        state = state._replace(ey=ey)
+        signal[n] = float(state.ey[pi, pj, pk])
+
+    assert np.max(np.abs(signal)) > 1e-9, "no probe energy — dead run"
+
+    skip = int(n_steps * 0.2)
+    late = signal[skip:]
+    freqs = np.fft.rfftfreq(len(late), d=float(dt))
+    spectrum = np.abs(np.fft.rfft(late))
+    # Search near the mode (soft-J source leaves a static Ey offset in a
+    # closed cavity — exclude DC and far-off bins, as test_cavity.py does).
+    mask = (freqs >= 0.5 * f_corrected) & (freqs <= 1.5 * f_corrected)
+    f_peak = freqs[int(np.argmax(np.where(mask, spectrum, 0.0)))]
+
+    err_corrected = abs(f_peak - f_corrected) / f_corrected
+    err_biased = abs(f_peak - f_biased) / f_biased
+    assert err_corrected < 0.02, (
+        f"Yee on the 12^3 node cavity: {f_peak/1e9:.4f} GHz vs corrected "
+        f"analytic {f_corrected/1e9:.4f} GHz — {err_corrected*100:.2f}% > 2%; "
+        "the (N-1)*dx comparator convention is wrong")
+    assert err_biased > 0.05, (
+        f"Yee peak {f_peak/1e9:.4f} GHz sits within 5% of the OLD N*dx "
+        f"analytic {f_biased/1e9:.4f} GHz — the pre-#338 comparator would "
+        "have been right after all; re-adjudicate the convention")


### PR DESCRIPTION
Closes #338

## What / why

`_apply_pec_3d` (rfx/adi.py) zeroes tangential E at node indices 0 and N-1, so the tier1 OPT-C1 adjudication cavity (12^3 nodes, dx=5mm) physically resonates over **L_eff = (N-1)·dx = 55 mm**, while the test's analytic used the nominal N·dx = 60 mm. That is a **+9.1% comparator bias inside a 2% gate** — the strict xfail could never legitimately XPASS; any XPASS would have been bias cancellation. `Grid` documents the same fence-post convention ("PEC walls at index 0 and index N span exactly N*dx", rfx/grid.py — a span of L needs N+1 nodes), and the canonical `test_pec_cavity_resonance` passes its 0.5% gate precisely because `Grid` adds that +1.

This PR fixes the comparator (never the gate):

1. **`test_optc1_adi_3d_cavity_eigenfrequency`** — `f_analytic` now built from `L_eff = (N-1)*dx`, with the node-indexed PEC convention documented in-file. Gate stays 2%.
2. **New falsifier rung `test_optc1_falsifier_yee_matches_corrected_analytic`** — the SAME 12^3 node cavity advanced by the known-good explicit Yee scheme (the `test_cavity.py` rung: `update_h`/`update_e`/`apply_pec`) must land within the same 2% gate of the corrected analytic AND >5% away from the old biased one, so the rung fails if the convention is wrong in either direction. Runs in ~4 s.
3. **Sibling 2D `test_adi_cavity_resonance`** carries the same class (`_apply_pec_2d` zeroes Ez at nodes 0 and Nx-1): fixed to `a_eff = (Nx-1)*dx = 98 mm`. Gate stays 2%.

## Measured numbers (before/after, per-bin context)

| Run | f_peak | vs old analytic | vs corrected analytic |
|---|---|---|---|
| 3D ADI, committed body (1500 steps, 2x CFL) | 2.077 GHz | 41.2% (vs 3.533 GHz) | **46.1%** (vs 3.854 GHz) |
| 3D ADI, 3000-step witness | bin 1 (near-DC) | — | — (mode decays; see below) |
| 2D ADI (1500 steps, 5x CFL) | 2.1552 GHz | 1.67% (vs 2.120 GHz) | **0.37%** (vs 2.163 GHz) |
| Yee falsifier, same 12^3 cavity (6000 steps) | 3.8463 GHz | 8.87% | **0.21%** (half-bin 0.28%) |

**OPT-C1 verdict under the honest comparator: still CONFIRMED — the strict xfail stays**, with corrected arithmetic in the marker reason. Per-bin inspection (R5): the 3D ADI probe signal is dead by ~4 ns and the 2.077 GHz feature is a broad low-Q bump; doubling the run to 3000 steps collapses the late-window argmax to the first FFT bin because the oscillation itself decays away (LOD over-dissipation) — consistent with the scheme's "do not use for quantitative results" caveat. The 2D peak is sharp, stable across 1500/3000 steps (bin width 35→18 MHz, same peak), and sits between the two analytics, much closer to the honest one.

**Why the 2D test passed before**: not a healthy margin — the 2.04% comparator bias consumed ~83% of the 2% gate budget (measured error read 1.67% when the scheme's true distance from the honest analytic is 0.37%). After the fix the test is green with a real margin, i.e. effectively tighter, no gate change.

**Why the falsifier is decisive**: same discrete object, adjudicated by a scheme validated elsewhere at 0.5% — it sits 0.21% from the (N-1)·dx analytic and 8.87% from the N·dx one; the FFT half-bin (0.28%) cannot bridge that gap. It also frees the OPT-C1 gate from the old quantization pressure (half-bin was 0.61% of the biased analytic = 31% of the 2% budget).

## Preflight

n/a — no `sim.run()`/`forward()` anywhere in this lane; the committed tests and all diagnostics drive the low-level runners (`run_adi_3d`, `run_adi_2d`, `update_h`/`update_e`/`apply_pec`) per module convention. Hand-ported sanity checks in the diagnostics and the new rung: nonzero probe energy, late-window oscillation present, peak search windowed off DC.

## Artifacts

- `scripts/diagnostics/gate_honesty_20260713/lane338-optc1/optc1_spectra.png` — 4-row figure: probe signals + normalized spectra with old/corrected analytic markers (untracked evidence area, primary checkout)
- `scripts/diagnostics/gate_honesty_20260713/lane338-optc1/{adi3d_1500,adi3d_3000,adi2d_1500,adi2d_3000,yee3d_6000}.npz` + `summary.json` — full per-bin spectra and signals
- `scripts/diagnostics/gate_honesty_20260713/lane338-optc1/{measure_optc1,plot_optc1}.py` — generating scripts

## Test runs

- `python -m pytest tests/test_review_tier1_validation_battery.py -q` → 6 passed, 1 xfailed (OPT-C1, honest), 7.3 s
- `python -m pytest tests/test_adi.py::test_adi_cavity_resonance -q -m gpu` → 1 passed, 1.6 s
- `ruff check rfx/ tests/ --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402` → clean

R3: memory=accuracy_class_sweep_20260712.md HIT-1/E5-5 (prescribes exactly this fix), feedback_root_cause_before_gate_change.md (root cause = node-fence convention; gates untouched), feedback_metric_first_skepticism.md + comparator-first rule (this IS a comparator fix; consistent) | R2-attempts=0 | falsifier=Yee-on-same-12^3-cavity rung (fails if >2% vs corrected or <5% vs biased analytic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
