### PR TITLE
fix(crossval): cv11 implement the advertised per-freq |S11| gate honestly (#340)

### DIFF
--- a/validation/crossval/11_waveguide_port_wr90.py
+++ b/validation/crossval/11_waveguide_port_wr90.py
@@ -23,11 +23,22 @@ simultaneously before the waveguide port is cleared to Meep-class:
 
 1. **Empty WR-90 guide** (matched load)
    Reference: |S11| = 0, |S21| = 1 at every frequency above fc.
-   Accept: max|S11| < 0.02, min|S21| > 0.97.
+   Accept (gated per-frequency since 2026-07-13, issue #340):
+   max|S11| < 0.02, |S21| ∈ [0.97, 1.05] at every bin.
 
 2. **PEC short-circuit termination**
    Reference: |S11| = 1 at every frequency.
-   Accept: mean|S11| ∈ [0.97, 1.03], per-freq ∈ [0.93, 1.07].
+   Accept: band-mean ||S11|−1| < 0.05 (report() gate), per-freq
+   |S11| ∈ [0.93, 1.07], and passivity ceiling max|S11| ≤ 1.05.
+   The per-freq band and ceiling are REAL gates since 2026-07-13
+   (issue #340) — before that this line advertised a per-freq band
+   that report() never implemented (band means only). Measured
+   single-run regression envelope on 2026-07-13 (dx=1 mm, CPU,
+   normalize=False): per-bin |S11| ∈ [0.99956, 1.00000], max
+   1.0000030 at 11.14 GHz — comfortably inside the band, so the
+   documented band is pinned as-is (it is a regression envelope
+   with margin, not a physics claim; the physics reference is
+   |S11| = 1 exactly).
 
 3. **Single dielectric slab (analytic Airy reflection)**
    Geometry: uniform εr=2.0 slab of length L inside WR-90.
@@ -305,6 +316,67 @@ def run_rfx_slab(eps_r: float, slab_length_m: float) -> tuple[np.ndarray, np.nda
 # =============================================================================
 # Comparison / report
 # =============================================================================
+def per_freq_band_check(label: str, f_hz: np.ndarray, mag: np.ndarray,
+                        lo: float, hi: float,
+                        ceiling: float | None = None) -> bool:
+    """Per-frequency |S| band gate (issue #340). Returns True iff EVERY bin
+    lies in ``[lo, hi]`` (and ``<= ceiling`` when given); prints a verdict
+    line plus each violating bin.
+
+    Rationale (2026-07-13): ``report()`` gates band MEANS only, and the
+    ``normalize=False`` extractor passivity guard runs at tol=2.0, so a
+    single-bin spike up to ~1.73 could pass both layers while moving the
+    21-bin mean by only ~0.035. This closes that gap at the crossval level.
+    The ``ceiling`` is the passivity line: on a passive structure |S|
+    meaningfully above 1 is non-physical (extraction artefact or
+    instability — repo passivity rule, ``test_sparam_passivity_guard``
+    envelope class). Ceiling 1.05 is pinned from the 2026-07-13 measured
+    max|S11| = 1.0000030 (PEC short), leaving Yee/near-cutoff margin while
+    still catching the tol=2.0 blind spot.
+    """
+    mag = np.asarray(mag, dtype=float)
+    in_band = (mag >= lo) & (mag <= hi)
+    ok = bool(np.all(in_band))
+    print(f"[{label}] per-freq band [{lo:.3f}, {hi:.3f}]: "
+          f"min={mag.min():.4f} max={mag.max():.4f} "
+          f"violations={int(np.sum(~in_band))}/{mag.size} "
+          f"-> {'PASS' if ok else 'FAIL'}")
+    for i in np.flatnonzero(~in_band):
+        print(f"[{label}]   VIOLATION f={f_hz[i] / 1e9:.2f} GHz |S|={mag[i]:.4f}")
+    if ceiling is not None:
+        above = mag > ceiling
+        ok_ceil = not bool(np.any(above))
+        print(f"[{label}] passivity ceiling max|S| <= {ceiling:.2f}: "
+              f"max={mag.max():.4f} -> {'PASS' if ok_ceil else 'FAIL'}")
+        for i in np.flatnonzero(above):
+            print(f"[{label}]   PASSIVITY f={f_hz[i] / 1e9:.2f} GHz |S|={mag[i]:.4f}")
+        ok = ok and ok_ceil
+    return ok
+
+
+def _selftest_per_freq_gate() -> None:
+    """Falsifier regression pre-declared in issue #340: a synthetic 21-bin
+    |S11| array of ones with ONE bin at 1.5 must FAIL the per-freq band
+    check, and an all-ones array must PASS. Pure numpy, no simulation.
+    Runs at script start and aborts (exit 1) if the gate does not bite —
+    this proves the gate is live, not decorative.
+    """
+    f_fake = np.linspace(8.2e9, 12.4e9, 21)
+    spike = np.ones(21)
+    spike[10] = 1.5
+    if per_freq_band_check("selftest 1.5-spike (must FAIL)", f_fake, spike,
+                           0.93, 1.07, ceiling=1.05):
+        print("SELFTEST BROKEN: synthetic single-bin 1.5 spike PASSED the "
+              "per-freq band gate — gate does not bite; aborting.")
+        sys.exit(1)
+    if not per_freq_band_check("selftest all-ones (must PASS)", f_fake,
+                               np.ones(21), 0.93, 1.07, ceiling=1.05):
+        print("SELFTEST BROKEN: all-ones array FAILED the per-freq band "
+              "gate — gate rejects healthy input; aborting.")
+        sys.exit(1)
+    print("[selftest] per-freq gate bites: 1.5-spike FAILS, all-ones PASSES.")
+
+
 def report(label: str, f_hz: np.ndarray, s_rfx: np.ndarray,
            s_ref: np.ndarray, gate_mag: float, gate_phase_deg: float,
            gate_complex_diff: float | None = None,
@@ -518,6 +590,9 @@ def _summarize_vs_truth(geom: str, comp: str, s_rfx: np.ndarray,
 
 
 def main() -> int:
+    # Prove the per-freq gate bites before running any physics (#340).
+    _selftest_per_freq_gate()
+
     all_pass = True
     skipped_any = False
     meep_ref = _load_meep_reference()
@@ -551,7 +626,16 @@ def main() -> int:
         ok1 = report("empty S11", f_hz, s11, ref_s11, gate_mag=0.02, gate_phase_deg=180.0)
         ok2 = report("empty |S21|", f_hz, np.abs(s21).astype(complex),
                      np.abs(ref_s21).astype(complex), gate_mag=0.03, gate_phase_deg=180.0)
-        all_pass = all_pass and ok1 and ok2
+        # Per-frequency gates (#340): the docstring bands, now actually
+        # enforced. Measured 2026-07-13: per-bin |S11| = 0.0000 (two-run
+        # normalisation is exact on the empty guide), |S21| ∈
+        # [0.99999994, 1.00000000] — both trivially inside the bands.
+        # |S21| upper bound 1.05 doubles as the passivity ceiling.
+        ok_pf1 = per_freq_band_check("empty S11 per-freq", f_hz,
+                                     np.abs(s11), 0.0, 0.02)
+        ok_pf2 = per_freq_band_check("empty S21 per-freq", f_hz,
+                                     np.abs(s21), 0.97, 1.05, ceiling=1.05)
+        all_pass = all_pass and ok1 and ok2 and ok_pf1 and ok_pf2
         # 4-way diagnostic table (rfx | MEEP_r4 | OpenEMS_r4 | Palace_r_h2)
         s11_meep = _ref_complex(meep_block.get("empty") if meep_block else None, "s11")
         s11_openems = _ref_complex(openems_ref["block"].get("empty") if openems_ref else None, "s11")
@@ -590,12 +674,25 @@ def main() -> int:
         s11_round_trip = -np.exp(-1j * beta_v_p * 2.0 * d_pec)
         ok_phase = report("pec-short S11 round-trip phase", f_hz, s11,
                           s11_round_trip, gate_mag=0.10, gate_phase_deg=15.0)
-        all_pass = all_pass and ok_mag and ok_phase
+        # Per-frequency band + passivity ceiling (#340). The [0.93, 1.07]
+        # band was advertised in the docstring since 2026-05 but never
+        # gated; measured 2026-07-13 the per-bin envelope is
+        # [0.99956, 1.00000] (max 1.0000030 at 11.14 GHz), so the
+        # documented band is implementable as-is with wide margin.
+        # Ceiling 1.05: passive structure, |S11| > 1 is non-physical —
+        # closes the tol=2.0 extractor-guard blind spot (spikes ≤ ~1.73
+        # previously passed while moving the 21-bin mean only ~0.035).
+        ok_pf = per_freq_band_check("pec-short |S11| per-freq", f_hz,
+                                    np.abs(s11), 0.93, 1.07, ceiling=1.05)
+        all_pass = all_pass and ok_mag and ok_phase and ok_pf
         # 4-way table.  Palace gives |S11|=1.0000 here (absolute truth);
         # OpenEMS r4 lands in [0.996, 1.004]; MEEP r4 in [0.93, 1.20];
         # rfx in [0.84, 1.04].  This disproves the prior "Yee+staircase
         # common limit" hypothesis — OpenEMS (also Yee) nails it, so the
         # PEC-short |S11| error is an extractor bug specific to MEEP & rfx.
+        # (HISTORICAL: the rfx [0.84, 1.04] figure predates the 2026-04-27
+        # DROP-weight fix; measured 2026-07-13 the rfx per-bin envelope is
+        # [0.99956, 1.00000] — see the per-freq gate above, issue #340.)
         s11_meep = _ref_complex(meep_block.get("pec_short") if meep_block else None, "s11")
         s11_openems = _ref_complex(openems_ref["block"].get("pec_short") if openems_ref else None, "s11")
         s11_palace = _ref_complex(palace_ref["block"].get("pec_short") if palace_ref else None, "s11")


### PR DESCRIPTION
## What / why

`validation/crossval/11_waveguide_port_wr90.py` advertised per-frequency acceptance bands in its docstring (PEC-short `|S11| ∈ [0.93, 1.07]`; empty guide `max|S11| < 0.02`, `min|S21| > 0.97`) that `report()` never implemented — only band MEANS were gated. Combined with the `normalize=False` extractor passivity guard running at `tol=2.0` (`_sparams.py`), a single-bin spike up to ~1.73 passed both layers while moving the 21-bin mean only ~0.035 (below the 0.05 pec-short mean gate). Issue #340.

Because in-file history recorded rfx PEC-short `|S11|` spanning [0.84, 1.04] in an earlier era, the band was **measured before pinning** (per the lane spec): today's envelope fits the advertised band with wide margin, so the documented band is now a **real per-frequency gate**, plus an explicit passivity ceiling.

## Measured (2026-07-13, single run, dx = 1 mm, CPU, 21 bins 8.2–12.4 GHz)

| lane | per-bin measured | gate now enforced per bin |
|---|---|---|
| PEC-short \|S11\| (`normalize=False`) | [0.9995565, 1.0000030]; min @ 9.46 GHz, max @ 11.14 GHz | band [0.93, 1.07] **and** passivity ceiling max\|S11\| ≤ 1.05 |
| empty \|S11\| (`normalize=True`) | 0.0000000 at every bin (two-run normalisation exact on empty guide) | \|S11\| ≤ 0.02 |
| empty \|S21\| | [0.99999994, 1.00000000] | \|S21\| ∈ [0.97, 1.05] (upper bound doubles as passivity ceiling) |

Full per-bin table (10 decimal places): `scripts/diagnostics/gate_honesty_20260713/lane_340_cv11/dump_perbin.log`. Ceiling rationale: passive structure, `|S11|` meaningfully above 1 is non-physical (repo passivity rule, `test_sparam_passivity_guard` envelope class); 1.05 leaves Yee/near-cutoff margin over the measured 1.0000030 while closing the tol=2.0 blind spot. The stale in-file [0.84, 1.04] history comment is now labeled HISTORICAL with the 2026-07-13 measured envelope alongside. No committed gate was loosened; all changes add gates or tighten documentation to match code.

## Falsifier regression (pre-declared in #340)

- Pure-numpy selftest at script start: synthetic 21-bin all-ones array with ONE bin at 1.5 must FAIL the band check (and the 1.05 ceiling), all-ones must PASS — script aborts (exit 1) otherwise. Output in the healthy run: `[selftest] per-freq gate bites: 1.5-spike FAILS, all-ones PASSES.`
- End-to-end wiring witness: a temp copy with the pec-short band deliberately tightened to [0.93, 0.999] produced 21 per-bin VIOLATION lines and **exit 1** (`wiring_falsifier.log`), proving `ok_pf → all_pass → exit code` is connected.
- Healthy case unchanged: baseline exit code 0 (all external reference JSONs present on this box, all gates green) → post-fix exit code 0. Note cv11 has no exit-2 SKIP path — missing reference JSONs only suppress comparison columns; the 0/1 convention is preserved.

## Preflight (verbatim)

The `compute_waveguide_s_matrix` pipeline does **not** auto-run preflight (auto-preflight is wired into `run()/forward()/optimize()`, `rfx/api/_execute.py::_auto_preflight`), so `sim.preflight(strict=False)` was run explicitly on both cv11 geometries (`dump_perbin.log`):

Empty guide (2 issues):
> Waveguide port 'left': max measurement frequency 12.400 GHz exceeds 0.90 × fc_next=11.803 GHz (fc_TE10=6.557 GHz, fc_TE20=13.114 GHz). Evanescent TE20 contamination may exceed 1 % and registers as |S11| < 1 in a lossless structure. Restrict measurement freqs below 11.803 GHz or increase port-to-obstacle distance.

> Waveguide port 'right': max measurement frequency 12.400 GHz exceeds 0.90 × fc_next=11.803 GHz (fc_TE10=6.557 GHz, fc_TE20=13.114 GHz). Evanescent TE20 contamination may exceed 1 % and registers as |S11| < 1 in a lossless structure. Restrict measurement freqs below 11.803 GHz or increase port-to-obstacle distance.

PEC-short (3 issues): the same two port warnings, plus:
> pec_faces={y_hi, y_lo, z_hi, z_lo} creates an INFINITE PEC boundary AND the geometry contains finite PEC objects. For antennas or finite-GP structures, the pec_faces boundary makes the ground plane cover the entire domain face, which changes the physics (cavity vs radiating antenna). If you need a finite ground plane, remove pec_faces and use an explicit PEC Box instead.

(The pec_faces advisory is expected here — the PEC short IS intentionally a full-cross-section wall inside a closed waveguide. The TE20 advisory affects the top two bins; measured per-bin |S11| there is 0.99970–1.00000, inside the gate.)

Script-run warning, quoted verbatim from `postfix_run.log`:
> UserWarning: compute_waveguide_s_matrix(normalize=False): S21 and S-parameter phase include Yee numerical dispersion. For S21 accuracy and reciprocity use normalize=True. For |S11| of strong reflectors (PEC short, resonators) normalize=False is more accurate — see the normalize parameter docstring.

## Artifacts (primary checkout evidence dir)

- Figure (R5 curve inspection — flat |S11| ≈ 1.000 across all 21 bins, no spikes): `scripts/diagnostics/gate_honesty_20260713/lane_340_cv11/cv11_perbin_20260713.png`
- Per-bin arrays: `.../lane_340_cv11/cv11_perbin_20260713.npz`
- Logs: `.../lane_340_cv11/{baseline_run.log, postfix_run.log, wiring_falsifier.log, dump_perbin.log}`
- Dump script: `.../lane_340_cv11/dump_perbin.py`

Closes #340

R3: memory=feedback_root_cause_before_gate_change (adds gates from measurement, none loosened) + project_wr90_architectural_candidates (oscillation was comparator artefact — today's flat per-bin curve consistent) + feedback_never_ignore_preflight (quoted verbatim above) | R2-attempts=0 | falsifier=in-script synthetic 1.5-spike selftest aborts the script if the gate fails to bite

🤖 Generated with [Claude Code](https://claude.com/claude-code)
