### PR TITLE
feat(preflight): advisory for NTFF pattern fixtures with sub-wavelength ground planes (#334)

### DIFF
--- a/docs/public/guide/farfield-rcs.md
+++ b/docs/public/guide/farfield-rcs.md
@@ -202,6 +202,17 @@ plot_rcs(result, freq_idx=0, polar=False)   # dBsm vs angle
   boundaries and MSL source positions are not included and require manual
   clearance checks. Finite geometry such as PEC sheets is included only where
   its bounding box overlaps the NTFF face tangentially.
+- The `ntff_small_ground_plane` advisory fires when an NTFF box is present
+  and the largest PEC sheet backed by an `add_source()` / lumped-wire
+  `add_port()` entry is under ~1λ across at the highest requested NTFF
+  frequency. A sub-wavelength ground plane radiates a pattern shaped by
+  ground-plane edge diffraction (broadside dip, off-axis side peaks) — that
+  is expected physics, not a solver defect. Such a fixture stays valid for
+  resonance and impedance work; for a clean broadside pattern use a ground
+  plane of at least ~1.4λ. Deliberately small ground planes are legitimate:
+  the advisory is a warning, never a blocker, so interpret the pattern
+  accordingly and continue. TFSF-illuminated plates (RCS targets) do not
+  trigger it.
 - The automatic `ring-down truncated` warning examines a recorded probe time
   series, not the NTFF accumulators. It is emitted only for an
   absorbing-boundary run with a `GaussianPulse` entry from `add_source()`,

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -428,7 +428,8 @@ class _ExecuteMixin:
 
         ``check_ntff`` gates the NTFF check family. ``run()`` passes
         ``check_ntff="advisory"`` (issue #303): the λ/4 near-field gap
-        advisories are physics-relevant to any far-field computation and
+        and sub-wavelength ground-plane (issue #334) advisories are
+        physics-relevant to any far-field computation and
         run() is the common NTFF entry point, so they are surfaced as
         warnings — but only ``forward(port_s11_freqs=...)`` / ``optimize``
         (the inverse-design entry points) hard-fail on the PEC-overlap

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1020,11 +1020,13 @@ class _PreflightMixin:
             collecting warnings.
         check_ntff : bool or "advisory"
             ``True`` (default): run the full NTFF check family (PEC-overlap
-            hard error + λ/4 / λ/2 near-field gap advisories).
-            ``"advisory"``: run only the near-field gap advisories — the
-            tier ``run()`` uses, because the λ/4 warning is physics-relevant
-            to any far-field computation while the PEC-overlap hard error
-            remains an inverse-design gate (issue #303).
+            hard error + λ/4 / λ/2 near-field gap advisories + the
+            sub-wavelength ground-plane pattern advisory, issue #334).
+            ``"advisory"``: run only the advisories — the tier ``run()``
+            uses, because the λ/4 and small-ground-plane warnings are
+            physics-relevant to any far-field computation while the
+            PEC-overlap hard error remains an inverse-design gate
+            (issue #303).
             ``False``: skip the family entirely.
         check_resolution : bool
             Run the tightened resolution check (existing _validate_mesh_quality
@@ -1422,6 +1424,11 @@ class _PreflightMixin:
         Passive DFT probes are NOT counted: they read field state without
         perturbing it, so a probe on a box face is a measurement choice,
         not a radiating/scattering culprit (issue #303).
+        CHECK 4: source backed by a PEC sheet under ~1λ across
+        (warning-severity advisory; both tiers, issue #334) — the far-field
+        pattern will be shaped by ground-plane edge diffraction. Expected
+        physics, not a solver defect; the advisory exists so a resonance
+        fixture is not mistaken for a pattern fixture.
         """
         import warnings as _w
 
@@ -1563,6 +1570,114 @@ class _PreflightMixin:
                     ),
                     stacklevel=3,
                 )
+
+        # CHECK 4 (issue #334): electrically small ground plane under a
+        # radiator. Advisory in BOTH tiers — it is pattern physics, not an
+        # inverse-design structural gate.
+        self._validate_ntff_small_ground_plane(f_max, lam_min)
+
+    def _validate_ntff_small_ground_plane(
+        self, f_max: float, lam: float,
+    ) -> None:
+        """CHECK 4 (issue #334): finite PEC sheet backing a radiator that is
+        under ~1λ across → edge-diffraction-shaped far-field pattern.
+
+        Background: a 0.48λ × 0.44λ ground plane produces a pattern dominated
+        by ground-plane edge diffraction (broadside dip, off-axis side peaks)
+        — correct physics for that geometry, but a trap when the fixture was
+        built for resonance/impedance work and its pattern is then read as a
+        solver defect. The advisory names the mechanism up front.
+
+        Predicate (warning-severity, fires at most ONCE per preflight):
+        - a PEC geometry entry is sheet-like: thin-axis extent
+          ``t <= max(λ/20, L_small/10)`` with both lateral extents >= λ/8;
+        - a radiator backs it: an ``add_source()`` / lumped-wire
+          ``add_port()`` entry sits laterally inside the sheet footprint and
+          within half a wavelength of the sheet along the thin axis
+          (image-theory coupling zone);
+        - among qualifying sheets only the LARGEST footprint is judged — in a
+          patch stack that is the ground plane, never the (intentionally
+          sub-wavelength) resonant patch element itself;
+        - fire iff that sheet's smaller lateral extent < 1λ at the highest
+          requested NTFF frequency (sub-wavelength across the whole
+          requested pattern band — the conservative direction).
+
+        λ is evaluated at ``f_max`` of the NTFF frequencies: if the sheet is
+        sub-wavelength even at the shortest requested wavelength, every bin
+        of the requested pattern carries the edge-diffraction shaping.
+
+        TFSF and MSL/waveguide/coax excitations are not counted as radiators
+        here (same scope as the CHECK 3 point list): a sub-wavelength PEC
+        plate as a scattering target is a legitimate RCS fixture, not a
+        ground-plane misuse.
+        """
+        import warnings as _w
+
+        ports = [tuple(pe.position) for pe in self._ports]
+        if not ports:
+            return
+
+        best = None  # (lateral_area, L_small, L_big, c1, c2)
+        for entry in self._geometry:
+            if entry.material_name != "pec":
+                continue
+            try:
+                c1, c2 = entry.shape.bounding_box()
+            except (NotImplementedError, TypeError, AttributeError):
+                continue
+            ext = [c2[a] - c1[a] for a in range(3)]
+            thin = min(range(3), key=lambda a: ext[a])
+            lat = [a for a in range(3) if a != thin]
+            l_small = min(ext[lat[0]], ext[lat[1]])
+            l_big = max(ext[lat[0]], ext[lat[1]])
+            # sheet-like: electrically thin, or thin relative to its own
+            # footprint (covers coarse-meshed few-cell-thick ground planes)
+            if ext[thin] > max(lam / 20.0, l_small / 10.0):
+                continue
+            # electrically non-negligible in BOTH lateral dims — wires,
+            # narrow straps and tiny pads are not ground planes
+            if l_small < lam / 8.0:
+                continue
+            backed = False
+            for pos in ports:
+                if not all(c1[a] <= pos[a] <= c2[a] for a in lat):
+                    continue
+                d = max(c1[thin] - pos[thin], pos[thin] - c2[thin], 0.0)
+                if d <= lam / 2.0:
+                    backed = True
+                    break
+            if not backed:
+                continue
+            area = ext[lat[0]] * ext[lat[1]]
+            if best is None or area > best[0]:
+                best = (area, l_small, l_big, c1, c2)
+
+        if best is None:
+            return
+        _, l_small, l_big, c1, c2 = best
+        if l_small >= lam:
+            return  # ground plane >= ~1λ both ways: clean-pattern regime
+
+        _w.warn(
+            PreflightWarning(
+                f"Far-field pattern advisory: the PEC sheet backing a source "
+                f"(bbox ({c1[0]*1e3:.1f}, {c1[1]*1e3:.1f}, {c1[2]*1e3:.1f})"
+                f"–({c2[0]*1e3:.1f}, {c2[1]*1e3:.1f}, {c2[2]*1e3:.1f}) mm) "
+                f"spans {l_big*1e3:.1f}mm × {l_small*1e3:.1f}mm = "
+                f"{l_big/lam:.2f}λ × {l_small/lam:.2f}λ at "
+                f"f_max={f_max/1e9:.2f}GHz — a ground plane under ~1λ "
+                f"across. Expect the radiation pattern to be shaped by "
+                f"ground-plane edge diffraction (broadside dip, off-axis "
+                f"side peaks). This is expected physics, not a solver "
+                f"defect, and the fixture stays fine for resonance / "
+                f"impedance work. For a clean broadside pattern enlarge the "
+                f"ground plane to at least ~1.4λ; if the small ground plane "
+                f"is intentional, interpret the pattern accordingly.",
+                code="ntff_small_ground_plane",
+                source="_validate_ntff_small_ground_plane",
+            ),
+            stacklevel=4,
+        )
 
     def _validate_simulation_config(self) -> None:
         """Comprehensive pre-simulation configuration validation.

--- a/tests/test_ntff_small_gp_advisory.py
+++ b/tests/test_ntff_small_gp_advisory.py
@@ -1,0 +1,141 @@
+"""Advisory coverage: sub-wavelength ground plane under an NTFF fixture (#334).
+
+A patch on a 60×55 mm ground plane is 0.48λ × 0.44λ at 2.4 GHz: its far-field
+pattern is ground-plane-edge-diffraction-dominated (broadside dip, off-axis
+side peaks). That is expected physics — fine for a resonance fixture, wrong to
+read as a solver defect in a pattern fixture. These tests pin the
+``ntff_small_ground_plane`` preflight advisory that names the mechanism:
+
+- fires ONCE on the cv05-class small-GP patch stack, anchored on the ground
+  plane (never the intentionally sub-wavelength patch element);
+- stays silent on the canonical >=1.4λ ground plane, without an NTFF box,
+  for a sheet with no source over it, and for a thick PEC volume;
+- wording is advisory: says "expected physics", never says "error";
+- fires in BOTH preflight tiers (full and run()'s "advisory" tier, #303).
+
+Geometry constants mirror the cv05 patch (L=29.5, W=38, h=1.5 mm) and the
+2026-07-12 far-field arc's two ground planes (60×55 mm vs 180×180 mm class).
+"""
+
+from __future__ import annotations
+
+from rfx import Box, Simulation
+
+
+FREQ_MAX = 3e9
+NTFF_FREQS = (2.4e9,)      # λ = 124.9 mm; advisory λ-reference = max(freqs)
+LAM = 3e8 / NTFF_FREQS[0]
+
+PATCH_L = 29.5e-3
+PATCH_W = 38.0e-3
+H_SUB = 1.5e-3
+GP_T = 1.0e-3              # sheet-like ground plane thickness
+
+
+def _patch_sim(gp_x: float, gp_y: float, *, with_ntff: bool = True,
+               source_over_gp: bool = True) -> Simulation:
+    """Patch-over-ground-plane stack centred in a CPML domain."""
+    margin = 0.04
+    dom = (gp_x + 2 * margin, gp_y + 2 * margin, 0.05)
+    cx, cy = dom[0] / 2, dom[1] / 2
+    z_gp_lo, z_gp_hi = 0.010, 0.010 + GP_T
+    z_patch = z_gp_hi + H_SUB
+
+    sim = Simulation(freq_max=FREQ_MAX, domain=dom, boundary="cpml",
+                     cpml_layers=4, dx=2.5e-3)
+    # ground plane (sheet) + patch element (sheet, smaller footprint)
+    sim.add(Box((cx - gp_x / 2, cy - gp_y / 2, z_gp_lo),
+                (cx + gp_x / 2, cy + gp_y / 2, z_gp_hi)), material="pec")
+    sim.add(Box((cx - PATCH_L / 2, cy - PATCH_W / 2, z_patch),
+                (cx + PATCH_L / 2, cy + PATCH_W / 2, z_patch)),
+            material="pec")
+    # feed between GP and patch: inside the patch footprint (over the GP), or
+    # laterally clear of every sheet for the "no radiator over it" case
+    if source_over_gp:
+        src_xy = (cx - PATCH_L / 2 + 8e-3, cy)
+    else:
+        src_xy = (cx - gp_x / 2 - 0.02, cy)
+    sim.add_port((src_xy[0], src_xy[1], z_gp_hi + H_SUB / 2), "ez")
+    if with_ntff:
+        sim.add_ntff_box(
+            corner_lo=(0.012, 0.012, 0.004),
+            corner_hi=(dom[0] - 0.012, dom[1] - 0.012, dom[2] - 0.012),
+            freqs=NTFF_FREQS,
+        )
+    return sim
+
+
+def _gp_issues(report):
+    return [i for i in report
+            if getattr(i, "code", None) == "ntff_small_ground_plane"]
+
+
+def test_small_gp_pattern_fixture_fires_once_on_the_ground_plane():
+    """cv05-class 60×55 mm GP (0.48λ × 0.44λ at 2.4 GHz) fires exactly once,
+    anchored on the GROUND PLANE dims — not on the sub-λ patch element."""
+    report = _patch_sim(60e-3, 55e-3).preflight()
+    issues = _gp_issues(report)
+    assert len(issues) == 1, (
+        f"expected exactly one small-GP advisory, got {issues!r}")
+    msg = str(issues[0])
+    assert "60.0mm × 55.0mm" in msg, msg   # the GP, largest qualifying sheet
+    assert "38.0mm" not in msg, (
+        "advisory anchored on the patch element, not the ground plane: " + msg)
+    assert "0.48λ × 0.44λ" in msg, msg
+
+
+def test_wording_is_advisory_expected_physics_never_error():
+    """Deliberately-small-GP designs are legitimate: the advisory must read as
+    expected physics with an interpretation hint, and must never say 'error'."""
+    report = _patch_sim(60e-3, 55e-3).preflight()
+    (issue,) = _gp_issues(report)
+    msg = str(issue)
+    assert "expected physics" in msg, msg
+    assert "edge diffraction" in msg, msg
+    assert "intentional" in msg, msg           # the legitimate-design branch
+    assert "error" not in msg.lower(), msg
+    assert getattr(issue, "severity", None) == "warning"
+    # a warning-only report must not block the errors-only launch gate
+    report.raise_for_failure()
+
+
+def test_canonical_large_gp_stays_silent():
+    """The canonical >=1.4λ pattern fixture (180×180 mm class GP at 2.4 GHz)
+    must NOT fire — even though its patch element is itself sub-wavelength."""
+    report = _patch_sim(200e-3, 200e-3).preflight()
+    assert _gp_issues(report) == [], list(report)
+
+
+def test_no_ntff_box_no_fire():
+    """Resonance/impedance use of the SAME small-GP stack is fine: without an
+    NTFF box there is no pattern to advise about."""
+    report = _patch_sim(60e-3, 55e-3, with_ntff=False).preflight()
+    assert _gp_issues(report) == [], list(report)
+
+
+def test_sheet_without_a_source_over_it_no_fire():
+    """A sub-λ PEC sheet with no radiator over it (scattering-target class)
+    must not be called a ground plane."""
+    report = _patch_sim(60e-3, 55e-3, source_over_gp=False).preflight()
+    assert _gp_issues(report) == [], list(report)
+
+
+def test_thick_pec_volume_no_fire():
+    """A 36×36×12 mm PEC VOLUME (0.4λ thick at 10 GHz) is not a sheet — the
+    clean inverse-design preflight fixture class must stay clean."""
+    sim = Simulation(freq_max=10e9, domain=(0.060, 0.060, 0.060),
+                     boundary="cpml", cpml_layers=8, dx=1.5e-3)
+    sim.add(Box((0.012, 0.012, 0.012), (0.048, 0.048, 0.024)),
+            material="pec")
+    sim.add_port((0.030, 0.030, 0.027), "ez")
+    sim.add_ntff_box(corner_lo=(0.013, 0.013, 0.044),
+                     corner_hi=(0.047, 0.047, 0.047), n_freqs=4)
+    report = sim.preflight()
+    assert _gp_issues(report) == [], list(report)
+
+
+def test_advisory_tier_fires_too():
+    """run()'s preflight tier (check_ntff="advisory", #303) must surface the
+    advisory: run() is the entry point that actually computes patterns."""
+    report = _patch_sim(60e-3, 55e-3).preflight(check_ntff="advisory")
+    assert len(_gp_issues(report)) == 1, list(report)


### PR DESCRIPTION
## What / why

Issue #334 (gate-honesty batch G3): cv05's 60×55 mm ground plane is 0.48λ at 2.4 GHz, so its far-field pattern is ground-plane-edge-diffraction-dominated (broadside dip, ±30° side peaks) — correct physics for that geometry, but it cost a full detour in the 2026-07-11/12 patch far-field arc because the pattern was read as a solver defect. This PR adds a preflight advisory (CHECK 4 in the NTFF family, code `ntff_small_ground_plane`, warning severity) that names the mechanism up front.

**Feasibility phase ran first (as the issue required); verdict GO.** Key findings:

- **Entry points**: since the #303 remediation, `run()` calls `_auto_preflight(check_ntff="advisory")`, which still executes the warning tier of `_validate_ntff_inverse_design`. The new advisory is warning-severity in BOTH tiers, so it surfaces on `sim.preflight()`, `run()` (the entry point that actually computes patterns), `forward()`, and `optimize()`.
- **Predicate shipped**: NTFF box present; among PEC geometry entries that are sheet-like (thin-axis extent ≤ max(λ/20, L_small/10), both laterals ≥ λ/8) and backed by an `add_source()`/lumped-wire `add_port()` entry (laterally inside the footprint, within λ/2 along the thin axis), judge only the LARGEST footprint; fire once iff its smaller lateral extent < 1λ at max(NTFF freqs) — i.e. sub-wavelength across the whole requested pattern band, the conservative direction.
- **The largest-qualifying-sheet rule is load-bearing**: on the canonical ≥1.4λ-GP fixture the 29.5×38 mm patch element itself is sub-wavelength with the feed in its footprint; judging every sheet would false-positive on every healthy patch fixture. Judging only the ground plane keeps the canonical fixture silent.
- **Wording**: says "expected physics, not a solver defect", never the word "error"; explicitly tells deliberately-small-GP designs the advisory can be read as an interpretation hint ("if the small ground plane is intentional, interpret the pattern accordingly"). TFSF-illuminated plates (RCS targets) are out of scope by construction (TFSF is not in the CHECK-3/4 radiator list).

## False-positive scan (full table: artifact below)

Static scan of **every** `add_ntff_box` call site (14 files across tests/, examples/, validation/): **0 fires**.

| Class | Example | Why silent |
|---|---|---|
| PEC volume under port | test_inverse_design_preflight clean fixture, 36×36×12 mm at 10 GHz | 0.4λ thick — fails sheet test |
| Sheet ≥ 1λ | test_ntff_lateral_clearance, 40×40×2 mm at 10 GHz | 1.33λ laterally |
| PEC cube | test_preflight_false_positives, 4 mm cube | fails sheet test |
| No PEC sheet / free-space dipole | 9 files | no candidate |
| Coax fixture | test_coaxial_line_calibration | no `add_source`/`add_port` entries |

Motivating-arc check (scripts/archive/20260712_patch_farfield_arc geometries, rebuilt at spec level):

- cv05-class 60×55 mm GP, NTFF 2.40–3.12 GHz → **fires once**: `0.62λ × 0.57λ at f_max=3.12GHz`, severity=warning — the exact detour case.
- canonical properGP 180×180 mm (1.56λ), NTFF 2.30–2.60 GHz → **silent**.

## Verbatim preflight output (demo fixture A, cv05-class; full log in artifacts)

No `sim.run()`/`forward()` physics numbers are reported in this PR — the change is a spec-level preflight advisory; the demo below is `sim.preflight()` output quoted verbatim (per the preflight-output-is-part-of-the-result rule):

```
  [PREFLIGHT] 'pec' z-extent 1mm = 0.4 cells — below 1 cell resolution. Use add_thin_conductor() for sub-cell PEC sheet.
  [PREFLIGHT] Zero-thickness geometry 'pec' along z-axis. On non-uniform mesh this may produce empty rasterization. Consider giving it at least one cell of thickness (2.5mm).
  [PREFLIGHT] Gap between PEC structures: 1.5mm = 0.6 cells along z — coupling may be under-resolved.
  [PREFLIGHT] NTFF box extends into CPML region along z-axis. Far-field results will be corrupted. Shrink NTFF box to interior.
  [PREFLIGHT] NTFF face x_lo is 39.00mm from geometry 'pec' — below λ/2 = 48.04mm at f_max=3.12GHz. Close to reactive near-field; far-field pattern accuracy may degrade. Move NTFF box ≥ λ/2 from radiating/scattering structures.
  (… x_hi / y_lo / y_hi / z_lo / z_hi clearance advisories, see log …)
  [PREFLIGHT] Far-field pattern advisory: the PEC sheet backing a source (bbox (55.0, 55.0, 12.0)–(115.0, 110.0, 13.0) mm) spans 60.0mm × 55.0mm = 0.62λ × 0.57λ at f_max=3.12GHz — a ground plane under ~1λ across. Expect the radiation pattern to be shaped by ground-plane edge diffraction (broadside dip, off-axis side peaks). This is expected physics, not a solver defect, and the fixture stays fine for resonance / impedance work. For a clean broadside pattern enlarge the ground plane to at least ~1.4λ; if the small ground plane is intentional, interpret the pattern accordingly.
```

(The demo fixture is a compact stand-in, so the other advisories above are properties of the demo box placement, not of this change; the same lines appear identically on the silent 180×180 mm fixture B in the log.)

## Tests / gates

- NEW `tests/test_ntff_small_gp_advisory.py`: 7 passed — positive fire (once, anchored on the GP dims, not the patch), advisory wording (`expected physics`, no `error`, `raise_for_failure()` passes), canonical-large-GP silent, no-NTFF silent, sheet-without-radiator silent, thick-PEC-volume silent, `check_ntff="advisory"` tier fires.
- Preflight family unchanged: `test_inverse_design_preflight` + `test_ntff_lateral_clearance` + `test_preflight_false_positives` + `test_preflight_structured_and_guards` + `test_ntff_sweep` → **55 passed**.
- Tutorials end-to-end + public-surface contracts: `test_tutorial_examples` ("All checks passed" counts intact) + `test_forward_docstring_contract` + `test_golden_workflow_contracts` → **15 passed**.
- `scripts/check_api_reference.py`: OK. `ruff check rfx/ tests/ …`: clean.
- No committed gate/tolerance touched; the advisory is additive.

Docs: one factual bullet added to `docs/public/guide/farfield-rcs.md` (kept mechanism-first and solver-neutral; prose pass done for no-overclaim/no-filler — reviewer pass lands with this PR review).

## Artifacts

- `scripts/diagnostics/gate_honesty_20260713/lane_334_preflight_gp_advisory/fp_scan_table.md` (full FP table)
- `scripts/diagnostics/gate_honesty_20260713/lane_334_preflight_gp_advisory/demo_preflight_output.log` (verbatim preflight output, both fixtures)
- `scripts/diagnostics/gate_honesty_20260713/lane_334_preflight_gp_advisory/demo_334_advisory.py` (reproducer; run with PYTHONPATH pinned to the repo — plain `python demo.py` imports whatever rfx sys.path finds first, which produced a false "no fire" on the first run of this lane)

(Primary-checkout untracked evidence area; no figure — this lane reports no claims-bearing physics number, the claims here are predicate evaluations and test counts, each with its log above.)

Closes #334

R3: memory=rfx-known-issues.md#303 (run() NTFF tier), feedback_never_ignore_preflight, project_patch_discretization_biases (the 2026-07-11/12 arc), project_llm_footgun_audit_results_20260708 (fix-pattern: add preflight warnings), feedback_rf_engineering_tone | R2-attempts=1 (the mid-lane "no fire" was an import-shadowing comparator artifact — sibling checkout on sys.path — diagnosed before touching the predicate) | falsifier=test_canonical_large_gp_stays_silent (a too-loose predicate reds it) + the 0/14 FP battery

🤖 Generated with [Claude Code](https://claude.com/claude-code)
