### PR TITLE
fix(adi): fully unconditionally-stable 3D ADI (issue #338 OPT-C1)

### DIFF
--- a/rfx/adi.py
+++ b/rfx/adi.py
@@ -7,8 +7,9 @@ For thin substrates where standard Yee requires tiny dt, ADI allows
 Supports 2D TMz (Ez, Hx, Hy) and 3D (all 6 components).
 
 References:
-    T. Namiki, IEEE MTT 1999
-    F. Zheng et al., IEEE MGWL 2000
+    T. Namiki, IEEE MTT 1999 (2D); IEEE MTT 2000 (3D)
+    F. Zheng et al., IEEE MGWL 2000 (2D)
+    F. Zheng, Z. Chen, J. Zhang, IEEE Trans. MTT 48(9), 2000 (3D ZCZ scheme)
 """
 
 from __future__ import annotations
@@ -718,19 +719,34 @@ def adi_step_3d(ex, ey, ez, hx, hy, hz,
                 pec_mask=None):
     r"""Advance all 6 field components by one full 3D ADI timestep.
 
-    **EXPERIMENTAL — not a physically accurate scheme.** Uses LOD
-    (Locally One-Dimensional) splitting with 3 sequential sub-steps
-    (x, y, z implicit). Each sub-step: E tridiagonal along one axis, then
-    H back-substitution using only the implicit-axis derivative.
+    Implements the Zheng–Chen–Zhang (ZCZ) 3D ADI-FDTD scheme (F. Zheng,
+    Z. Chen, J. Zhang, IEEE Trans. MTT 48(9), 2000; identical scheme in
+    Namiki's 3D extension): two sub-steps of ``dt/2``. In each sub-step
+    every E component is implicit along exactly one axis (tridiagonal
+    Thomas solve) and every H component is updated explicitly from the
+    just-solved E; the two sub-steps swap which curl term is implicit.
 
-    Accuracy caveat: this is NOT a valid ADI step — it applies implicit
-    diffusion to off-axis E-components, triple-applies the conductivity
-    loss (dt/3 applied in all 3 sub-steps), and time-skews the Faraday
-    update. It is stable/dissipative across a wide CFL range (0.5-50x),
-    but cavity-resonance error reaches ~42% at 5x CFL from the LOD
-    splitting (2D LOD by contrast holds <2% to 50x CFL). Only divergence
-    /stability tests cover it — there is no physics-accuracy validation.
-    Do not use for quantitative results (known issue OPT-C1).
+    This is the Peaceman–Rachford alternation
+    ``(I - dt/2·A) u' = (I + dt/2·B) u`` then
+    ``(I - dt/2·B) u'' = (I + dt/2·A) u'`` with the curl split into the
+    A/B term families. With the zero-padded difference operators used
+    here, backward differences are exactly minus the transpose of forward
+    differences (boundary rows included), so both split operators are
+    skew-symmetric in the energy variables and the full-step map is
+    similar to a product of two unitary Cayley transforms — the scheme is
+    unconditionally stable for every ``dt``, PEC domain boundary included.
+
+    Accuracy envelope (measured, 12^3 PEC cavity, TE101 at ~15 cells per
+    wavelength — ``tests/test_review_tier1_validation_battery.py``):
+    eigenfrequency error is -1.4% at 2x the 3D Yee CFL limit, growing
+    ~dt^2 (Crank–Nicolson-like temporal lag) to ~ -6.7% at 5x CFL. Runs
+    at 5-50x CFL remain stable but are quantitative only for features
+    much coarser than the timestep. Use large CFL factors for stiff
+    meshes (thin substrates), not wavelength-scale resonances.
+
+    Caveat: an *internal* ``pec_mask`` is enforced by post-solve
+    projection (same approximation as the 2D path), not by exact
+    Dirichlet rows; the domain-boundary PEC is exact.
 
     Parameters
     ----------
@@ -743,14 +759,20 @@ def adi_step_3d(ex, ey, ez, hx, hy, hz,
     ex, ey, ez, hx, hy, hz : updated fields
     """
     eps = eps_r * EPS_0
-    sub_dt = dt / 3.0  # each of 3 LOD sub-steps advances dt/3
+    half_dt = dt / 2.0
 
-    # Implicit sigma integration
-    sigma_term = sigma * sub_dt / 2.0
+    # Semi-implicit conductivity integration per dt/2 sub-step
+    # (ε + σ·dt/4) E' = (ε - σ·dt/4) E + ...   — mirrors adi_step_2d.
+    sigma_term = sigma * dt / 4.0
     eps_plus = eps + sigma_term
     damping = (eps - sigma_term) / eps_plus
 
-    ds = [dx, dy, dz]
+    ce = half_dt / eps_plus          # Ampère explicit-curl factor
+    ch = half_dt / MU_0              # Faraday factor (no magnetic loss)
+    cc = half_dt * half_dt / (MU_0 * eps_plus)  # substituted mixed-term factor
+    Cx = cc / (dx * dx)              # tridiagonal coupling per axis
+    Cy = cc / (dy * dy)
+    Cz = cc / (dz * dz)
 
     def _fwd(arr, ax):
         pw = [(0, 0)] * 3
@@ -766,67 +788,62 @@ def adi_step_3d(ex, ey, ez, hx, hy, hz,
         s[ax] = slice(None, -1)
         return jnp.pad(arr, pw)[tuple(s)]
 
-    def _curl_e(ex_, ey_, ez_):
-        """curl(E) for Faraday: returns (curl_x, curl_y, curl_z)."""
-        return (
-            (_fwd(ez_, 1) - ez_) / dy - (_fwd(ey_, 2) - ey_) / dz,
-            (_fwd(ex_, 2) - ex_) / dz - (_fwd(ez_, 0) - ez_) / dx,
-            (_fwd(ey_, 0) - ey_) / dx - (_fwd(ex_, 1) - ex_) / dy,
-        )
+    def _dp(arr, ax, d):
+        """Forward difference (E -> H staggering)."""
+        return (_fwd(arr, ax) - arr) / d
 
-    def _curl_h(hx_, hy_, hz_):
-        """curl(H) for Ampere: returns (curl_x, curl_y, curl_z)."""
-        return (
-            (hz_ - _bwd(hz_, 1)) / dy - (hy_ - _bwd(hy_, 2)) / dz,
-            (hx_ - _bwd(hx_, 2)) / dz - (hz_ - _bwd(hz_, 0)) / dx,
-            (hy_ - _bwd(hy_, 0)) / dx - (hx_ - _bwd(hx_, 1)) / dy,
-        )
+    def _dm(arr, ax, d):
+        """Backward difference (H -> E staggering)."""
+        return (arr - _bwd(arr, ax)) / d
 
     # ===================================================================
-    # LOD: 3 sequential sub-steps, each implicit along one axis.
-    # Each sub-step: E tridiag along axis → H explicit update.
-    #
-    # NOTE: This simplified LOD applies the tridiagonal solve to ALL E
-    # components along each axis, which adds artificial diffusion for
-    # components whose curl has no derivative along that axis.  This
-    # trades accuracy for simplicity and unconditional stability.  The
-    # LOD splitting error grows with CFL factor; best accuracy at 2-5x
-    # CFL.  For higher CFL (>10x), expect over-dissipation and shifted
-    # resonance frequencies.
+    # Sub-step 1 (n -> n+1/2): implicit pairs (Ex,Hz|y), (Ey,Hx|z),
+    # (Ez,Hy|x). Each implicit operator is obtained by substituting the
+    # same-sub-step H update into the E equation; the -cc·Dm(Dp(E))
+    # mixed terms are the explicit remainder of that substitution.
     # ===================================================================
+    rhs_ex = damping * ex + ce * (_dm(hz, 1, dy) - _dm(hy, 2, dz)) \
+        - cc * _dm(_dp(ey, 0, dx), 1, dy)
+    rhs_ey = damping * ey + ce * (_dm(hx, 2, dz) - _dm(hz, 0, dx)) \
+        - cc * _dm(_dp(ez, 1, dy), 2, dz)
+    rhs_ez = damping * ez + ce * (_dm(hy, 0, dx) - _dm(hx, 1, dy)) \
+        - cc * _dm(_dp(ex, 2, dz), 0, dx)
+    # PEC on the RHS: a zero RHS line with zero Dirichlet ends solves to
+    # exactly zero, so face-parallel lines inside PEC faces stay PEC.
+    rhs_ex, rhs_ey, rhs_ez = _apply_pec_3d(rhs_ex, rhs_ey, rhs_ez, pec_mask)
 
-    for axis in range(3):
-        d = ds[axis]
-        C_axis = sub_dt ** 2 / (MU_0 * eps_plus * d * d)
-        coeff_e = sub_dt / eps_plus
+    ex1 = _solve_tridiag_along(ex, Cy, rhs_ex, axis=1)
+    ey1 = _solve_tridiag_along(ey, Cz, rhs_ey, axis=2)
+    ez1 = _solve_tridiag_along(ez, Cx, rhs_ez, axis=0)
+    ex1, ey1, ez1 = _apply_pec_3d(ex1, ey1, ez1, pec_mask)
 
-        # E update: tridiag along axis with curl(H) source
-        ch_x, ch_y, ch_z = _curl_h(hx, hy, hz)
-        rhs_ex = damping * ex + coeff_e * ch_x
-        rhs_ey = damping * ey + coeff_e * ch_y
-        rhs_ez = damping * ez + coeff_e * ch_z
+    # Explicit H updates: implicit-partner E at n+1/2, other E at n.
+    hx1 = hx + ch * (_dp(ey1, 2, dz) - _dp(ez, 1, dy))
+    hy1 = hy + ch * (_dp(ez1, 0, dx) - _dp(ex, 2, dz))
+    hz1 = hz + ch * (_dp(ex1, 1, dy) - _dp(ey, 0, dx))
 
-        ex = _solve_tridiag_along(ex, C_axis, rhs_ex, axis=axis)
-        ey = _solve_tridiag_along(ey, C_axis, rhs_ey, axis=axis)
-        ez = _solve_tridiag_along(ez, C_axis, rhs_ez, axis=axis)
+    # ===================================================================
+    # Sub-step 2 (n+1/2 -> n+1): implicit pairs (Ex,Hy|z), (Ey,Hz|x),
+    # (Ez,Hx|y) — the curl-term roles swap.
+    # ===================================================================
+    rhs_ex = damping * ex1 + ce * (_dm(hz1, 1, dy) - _dm(hy1, 2, dz)) \
+        - cc * _dm(_dp(ez1, 0, dx), 2, dz)
+    rhs_ey = damping * ey1 + ce * (_dm(hx1, 2, dz) - _dm(hz1, 0, dx)) \
+        - cc * _dm(_dp(ex1, 1, dy), 0, dx)
+    rhs_ez = damping * ez1 + ce * (_dm(hy1, 0, dx) - _dm(hx1, 1, dy)) \
+        - cc * _dm(_dp(ey1, 2, dz), 1, dy)
+    rhs_ex, rhs_ey, rhs_ez = _apply_pec_3d(rhs_ex, rhs_ey, rhs_ez, pec_mask)
 
-        ex, ey, ez = _apply_pec_3d(ex, ey, ez, pec_mask)
+    ex2 = _solve_tridiag_along(ex1, Cz, rhs_ex, axis=2)
+    ey2 = _solve_tridiag_along(ey1, Cx, rhs_ey, axis=0)
+    ez2 = _solve_tridiag_along(ez1, Cy, rhs_ez, axis=1)
+    ex2, ey2, ez2 = _apply_pec_3d(ex2, ey2, ez2, pec_mask)
 
-        # H back-substitution: only the implicit-axis derivative of E.
-        # Each Faraday curl term dE_j/d_axis contributes to one H component.
-        # After all 3 sub-steps, each H accumulates the full curl(E).
-        c = sub_dt / MU_0
-        if axis == 0:  # x: Hy gets +dEz/dx, Hz gets -dEy/dx
-            hy = hy + c * (_fwd(ez, 0) - ez) / dx
-            hz = hz - c * (_fwd(ey, 0) - ey) / dx
-        elif axis == 1:  # y: Hx gets -dEz/dy, Hz gets +dEx/dy
-            hx = hx - c * (_fwd(ez, 1) - ez) / dy
-            hz = hz + c * (_fwd(ex, 1) - ex) / dy
-        else:  # z: Hx gets +dEy/dz, Hy gets -dEx/dz
-            hx = hx + c * (_fwd(ey, 2) - ey) / dz
-            hy = hy - c * (_fwd(ex, 2) - ex) / dz
+    hx2 = hx1 + ch * (_dp(ey1, 2, dz) - _dp(ez2, 1, dy))
+    hy2 = hy1 + ch * (_dp(ez1, 0, dx) - _dp(ex2, 2, dz))
+    hz2 = hz1 + ch * (_dp(ex1, 1, dy) - _dp(ey2, 0, dx))
 
-    return ex, ey, ez, hx, hy, hz
+    return ex2, ey2, ez2, hx2, hy2, hz2
 
 
 def make_adi_absorbing_sigma_3d(nx, ny, nz, n_layers, dx, dy, dz, order=3):

--- a/rfx/adi.py
+++ b/rfx/adi.py
@@ -736,10 +736,11 @@ def adi_step_3d(ex, ey, ez, hx, hy, hz,
     similar to a product of two unitary Cayley transforms — the scheme is
     unconditionally stable for every ``dt``, PEC domain boundary included.
 
-    Accuracy envelope (measured, 12^3 PEC cavity, TE101 at ~15 cells per
-    wavelength — ``tests/test_review_tier1_validation_battery.py``):
-    eigenfrequency error is -1.4% at 2x the 3D Yee CFL limit, growing
-    ~dt^2 (Crank–Nicolson-like temporal lag) to ~ -6.7% at 5x CFL. Runs
+    Accuracy envelope (12^3 PEC cavity, TE101 at ~15 cells per
+    wavelength): eigenfrequency error is -1.4% at 2x the 3D Yee CFL
+    limit (test-measured, ``tests/test_review_tier1_validation_battery.py``),
+    growing ~dt^2 (Crank–Nicolson-like temporal lag) to ~ -6.7% at 5x CFL
+    (von Neumann analysis — the 5x point is not test-measured). Runs
     at 5-50x CFL remain stable but are quantitative only for features
     much coarser than the timestep. Use large CFL factors for stiff
     meshes (thin substrates), not wavelength-scale resonances.

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -302,16 +302,18 @@ class Simulation(
         for storage.
     solver : str
         ``"yee"`` (default) for the standard explicit scheme or
-        ``"adi"`` for the ADI-FDTD path. ADI is validated ONLY in 2D TMz
-        (``mode="2d_tmz"``, 2% cavity-resonance gate). The 3D ADI (LOD)
-        scheme is KNOWN-INACCURATE for physical results (a 3D PEC-cavity
-        eigenfrequency misses the analytic mode by ~41% even at 2x CFL —
-        artificial diffusion on off-axis E components); preflight emits an
-        ``adi_3d_accuracy`` warning for that combination. Use 3D ADI only
-        for qualitative stability studies.
+        ``"adi"`` for the ADI-FDTD path. ADI is unconditionally stable in
+        both 2D TMz (``mode="2d_tmz"``, 2% cavity-resonance gate at 50x
+        CFL) and 3D (full Zheng–Chen–Zhang two-sub-step scheme since
+        2026-07-13, issue #338: 2% PEC-cavity eigenfrequency gate at 2x
+        CFL, ~15 cells/wavelength). 3D dispersion error grows ~dt^2, so
+        preflight emits an ``adi_3d_accuracy`` envelope advisory when
+        ``adi_cfl_factor > 2`` on a 3D grid — large factors trade
+        wavelength-scale accuracy for stiff-mesh throughput.
     adi_cfl_factor : float
         Timestep multiplier relative to the standard 2D CFL limit when
-        ``solver="adi"``.
+        ``solver="adi"``. Default 5.0; for quantitative wavelength-scale
+        3D results prefer <= 2.0 (see ``solver``).
     stencil_order : int
         Spatial finite-difference order for the explicit Yee update: ``2``
         (default, the standard (2,2) scheme — BYTE-IDENTICAL to prior

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1915,37 +1915,41 @@ class _PreflightMixin:
             )
 
     def _validate_cfg_adi_3d_accuracy(self, _w) -> None:
-        """Warn when ``solver='adi'`` is combined with a 3D grid (OPT-C1).
+        """Advise on the 3D ADI large-timestep accuracy envelope (OPT-C1 fixed).
 
-        The 3D ADI path (``adi_step_3d``) uses an LOD split that applies the
-        implicit tridiagonal solve to ALL E components along each sweep axis —
-        artificial diffusion on components whose curl has no derivative along
-        that axis. Measured: a lossless 3D PEC cubic cavity misses the analytic
-        eigenfrequency by ~41% even at a modest 2x CFL (2.077 vs 3.533 GHz),
-        and over-dissipates ~42% at 5x CFL. The 2D TMz ADI path is unaffected
-        (holds a 2% cavity-resonance gate). Note ``mode='3d'`` is the
-        constructor DEFAULT, so ``Simulation(solver='adi')`` lands here.
+        HISTORY: until 2026-07-13 the 3D ADI path was an LOD split with
+        artificial diffusion (OPT-C1) and this validator flagged it as
+        KNOWN-INACCURATE unconditionally. ``adi_step_3d`` now implements the
+        full Zheng–Chen–Zhang two-sub-step 3D ADI (issue #338 follow-up):
+        eigenfrequency error measured 1.2% at 2x CFL on the 12^3 PEC-cavity
+        adjudication test (``tests/test_review_tier1_validation_battery.py::
+        test_optc1_adi_3d_cavity_eigenfrequency``, 2% gate, ~15 cells/wave).
 
-        WARNING severity (NOT error): 3D ADI stays runnable for qualitative
-        stability/divergence studies, and a hard-fail would block the very
-        tests characterising it. MAINTENANCE: the strict-xfail adjudication
-        test ``tests/test_review_tier1_validation_battery.py::
-        test_optc1_adi_3d_cavity_eigenfrequency`` will hard-fail (XPASS) when
-        the scheme is fixed, forcing this warning's removal.
+        What remains is the honest large-dt envelope of ANY Crank–Nicolson-
+        class implicit scheme: dispersion error grows ~dt^2, so at ~15
+        cells per wavelength the <2% eigenfrequency envelope holds only for
+        CFL factors up to ~2x (von Neumann: -1.4% at 2x, -2.8% at 3x, -6.7%
+        at 5x). Runs stay unconditionally STABLE at any factor — accuracy,
+        not stability, is what degrades. Advise (WARNING severity, envelope
+        advisory — not an error) when ``adi_cfl_factor > 2.0`` on a 3D grid.
+        The 2D TMz path keeps its separately validated 50x envelope and is
+        not flagged here.
         """
         if self._solver != "adi" or self._mode != "3d":
             return
+        if self._adi_cfl_factor <= 2.0:
+            return
         _w.warn(
             PreflightWarning(
-                "solver='adi' with a 3D grid (mode='3d' is the default): the "
-                "3D ADI (LOD) scheme is KNOWN-INACCURATE for physical "
-                "results — the implicit solve is applied to E components "
-                "whose curl has no derivative along the sweep axis "
-                "(artificial diffusion). Measured: a lossless 3D PEC cubic "
-                "cavity misses the analytic eigenfrequency by ~41% even at "
-                "2x CFL (~42% over-dissipation at 5x CFL). Use the explicit "
-                "Yee solver (solver='yee') for 3D physics; ADI is validated "
-                "only on the 2D TMz path (mode='2d_tmz', 2% resonance gate).",
+                f"solver='adi' with a 3D grid at adi_cfl_factor="
+                f"{self._adi_cfl_factor:g}: the 3D ADI scheme is "
+                f"unconditionally stable, but its dispersion error grows "
+                f"~dt^2 — at ~15 cells/wavelength the <2% eigenfrequency "
+                f"envelope holds only up to ~2x CFL (measured -1.4% at 2x; "
+                f"-2.8% at 3x, -6.7% at 5x by von Neumann analysis). Use "
+                f"adi_cfl_factor <= 2 for wavelength-scale accuracy, or "
+                f"reserve large factors for geometrically stiff meshes "
+                f"(features far below the wavelength).",
                 code="adi_3d_accuracy",
                 severity="warning",
                 source="_validate_cfg_adi_3d_accuracy",

--- a/tests/test_adi.py
+++ b/tests/test_adi.py
@@ -361,8 +361,10 @@ class TestADI3DStability:
     def test_stability_3d_pec_cavity(self, cfl_factor):
         """Fields stay bounded in a 3D PEC cavity at moderate CFL factors.
 
-        The simplified LOD scheme is stable at 2-5x CFL.  Higher factors
-        (10x+) can diverge due to the all-component tridiagonal approach.
+        The ZCZ two-sub-step 3D ADI (issue #338 follow-up, 2026-07-13) is
+        unconditionally stable; 2x and 5x are the committed rungs here
+        (10x and 50x were verified bounded as free witnesses in the #338
+        evidence run — the pre-#338 LOD scheme could diverge at 10x+).
         """
         from rfx.adi import adi_step_3d
 

--- a/tests/test_adi_preflight.py
+++ b/tests/test_adi_preflight.py
@@ -1,17 +1,22 @@
-"""Preflight must surface the KNOWN-INACCURATE 3D ADI (LOD) path (W3.8).
+"""Preflight advisory for the 3D ADI large-timestep accuracy envelope.
 
-``adi_step_3d`` applies the implicit tridiagonal solve to E components whose
-curl has no derivative along the sweep axis — artificial diffusion (OPT-C1):
-a lossless 3D PEC cubic cavity misses the analytic eigenfrequency by ~41%
-even at 2x CFL. The strict-xfail adjudication test lives in
+HISTORY (W3.8 / OPT-C1): until 2026-07-13 ``adi_step_3d`` was an LOD split
+with artificial diffusion and the ``adi_3d_accuracy`` warning flagged the
+whole 3D path as KNOWN-INACCURATE unconditionally. The scheme is now the
+full Zheng–Chen–Zhang two-sub-step 3D ADI (issue #338 follow-up); the
+adjudication test
 ``test_review_tier1_validation_battery.py::test_optc1_adi_3d_cavity_eigenfrequency``
-(it XPASSes when the scheme is fixed, forcing removal of this warning).
+passes its 2% gate at 2x CFL (measured 1.2%) and its former strict-xfail
+marker is removed.
 
-This file locks the user-facing preflight warning (code ``adi_3d_accuracy``):
-it must fire on ``solver='adi'`` + a 3D grid (note ``mode='3d'`` is the
-constructor DEFAULT, so ``Simulation(solver='adi')`` lands on the inaccurate
-path), and stay silent on the validated 2D TMz path and on the explicit Yee
-solver.
+What this file now locks is the ENVELOPE advisory that replaced the old
+blanket warning: dispersion error of the implicit scheme grows ~dt^2, so at
+~15 cells/wavelength the <2% eigenfrequency envelope holds only up to ~2x
+CFL. The ``adi_3d_accuracy`` warning must fire on ``solver='adi'`` + a 3D
+grid when ``adi_cfl_factor > 2`` (note the constructor DEFAULTS are
+``mode='3d'`` and ``adi_cfl_factor=5.0``, so a bare ``Simulation(
+solver='adi')`` is advised), and stay silent at ``adi_cfl_factor <= 2``, on
+the validated 2D TMz path, and on the explicit Yee solver.
 """
 
 from __future__ import annotations
@@ -23,28 +28,29 @@ def _codes(issues):
     return {getattr(i, "code", "") for i in issues}
 
 
-def test_adi_3d_fires_accuracy_warning():
+def test_adi_3d_large_cfl_fires_envelope_advisory():
     sim = Simulation(
         freq_max=5e9, domain=(0.06, 0.06, 0.06), dx=5e-3,
-        boundary="pec", mode="3d", solver="adi",
+        boundary="pec", mode="3d", solver="adi", adi_cfl_factor=5.0,
     )
     sim.add_source((0.03, 0.03, 0.03), "ez")
     sim.add_probe((0.02, 0.02, 0.02), "ez")
     issues = sim.preflight()
     assert "adi_3d_accuracy" in _codes(issues), (
-        f"3D ADI must warn (OPT-C1 known inaccuracy); issues: {issues!r}"
+        f"3D ADI at 5x CFL must get the dt^2-envelope advisory; "
+        f"issues: {issues!r}"
     )
     severities = {
         getattr(i, "code", ""): getattr(i, "severity", "")
         for i in issues
     }
-    # WARNING severity, not error — 3D ADI must stay runnable for the
-    # stability/divergence tests that characterise it.
+    # WARNING severity, not error — large-dt 3D ADI is a legitimate stiff-
+    # mesh tool; only wavelength-scale accuracy degrades.
     assert severities["adi_3d_accuracy"] == "warning"
 
 
-def test_adi_default_mode_fires_accuracy_warning():
-    """mode is omitted → constructor default '3d' → must still warn."""
+def test_adi_default_cfl_factor_fires_envelope_advisory():
+    """Defaults are mode='3d' AND adi_cfl_factor=5.0 -> must still advise."""
     sim = Simulation(
         freq_max=5e9, domain=(0.06, 0.06, 0.06), dx=5e-3,
         boundary="pec", solver="adi",
@@ -54,10 +60,26 @@ def test_adi_default_mode_fires_accuracy_warning():
     assert "adi_3d_accuracy" in _codes(issues)
 
 
+def test_adi_3d_within_envelope_is_silent():
+    """At adi_cfl_factor <= 2 the 3D scheme meets its 2% gate — no advisory
+    (measured 1.2% on the tier-1 adjudication cavity at 2x CFL)."""
+    sim = Simulation(
+        freq_max=5e9, domain=(0.06, 0.06, 0.06), dx=5e-3,
+        boundary="pec", mode="3d", solver="adi", adi_cfl_factor=2.0,
+    )
+    sim.add_source((0.03, 0.03, 0.03), "ez")
+    sim.add_probe((0.02, 0.02, 0.02), "ez")
+    issues = sim.preflight()
+    assert "adi_3d_accuracy" not in _codes(issues), (
+        f"3D ADI at <=2x CFL is inside the validated envelope and must NOT "
+        f"warn; issues: {issues!r}"
+    )
+
+
 def test_adi_2d_tmz_is_silent():
     sim = Simulation(
         freq_max=10e9, domain=(0.02, 0.02, 0.01),
-        boundary="pec", mode="2d_tmz", solver="adi",
+        boundary="pec", mode="2d_tmz", solver="adi", adi_cfl_factor=5.0,
     )
     sim.add_source((0.01, 0.01, 0.0), "ez")
     sim.add_probe((0.012, 0.01, 0.0), "ez")
@@ -76,5 +98,5 @@ def test_yee_3d_is_silent():
     sim.add_probe((0.02, 0.02, 0.02), "ez")
     issues = sim.preflight()
     assert "adi_3d_accuracy" not in _codes(issues), (
-        f"explicit Yee solver must NOT get the ADI warning; issues: {issues!r}"
+        f"explicit Yee solver must NOT get the ADI advisory; issues: {issues!r}"
     )

--- a/tests/test_review_tier1_validation_battery.py
+++ b/tests/test_review_tier1_validation_battery.py
@@ -16,8 +16,10 @@ Convention:
 Confirmed items here are candidates for promotion to
 ``docs/agent-memory/rfx-known-issues.md`` once a fix lands.
 
-Covered: CORE-C2, GEO-C1, PROBE-C1, RIS-C2. (OPT-C1 — adi_step_3d
-3D-cavity eigenfrequency — lives in its own slower test.)
+Covered: CORE-C2, GEO-C1, PROBE-C1, RIS-C2, OPT-C1 (adi_step_3d
+3D-cavity eigenfrequency — FIXED 2026-07-13 by the ZCZ full 3D ADI
+scheme; the former strict-xfail marker was removed on XPASS per the
+convention above).
 """
 
 from __future__ import annotations
@@ -241,22 +243,29 @@ def test_risc2_np_interp_complex_part_behavior():
 
 
 # ===========================================================================
-# OPT-C1 — adi_step_3d 3D PEC-cavity eigenfrequency
+# OPT-C1 — adi_step_3d 3D PEC-cavity eigenfrequency  (FIXED 2026-07-13)
 # ===========================================================================
 #
-# adi_step_3d uses an LOD split that, by its own code comment (adi.py,
-# "NOTE: This simplified LOD..."), "applies the tridiagonal solve to ALL
-# E components along each axis, which adds artificial diffusion for
-# components whose curl has no derivative along that axis". The only 3D
-# ADI tests check bounded/oscillating fields — none checks a physical
-# eigenfrequency, while the 2D path has test_adi_cavity_resonance
-# (2% gate).
+# HISTORY: adi_step_3d used an LOD split that, by its own code comment,
+# applied the tridiagonal solve to ALL E components along each axis —
+# artificial diffusion on components whose curl has no derivative along
+# that axis. Under the honest comparator (below) the 12^3-cavity peak at
+# 2x CFL was 2.077 GHz, a 46% miss, and the mode energy decayed within
+# ~4 ns. This test was xfail(strict) against that scheme.
+#
+# VERDICT (2026-07-13, marker removed per module convention): adi_step_3d
+# now implements the full Zheng–Chen–Zhang two-sub-step 3D ADI (issue
+# #338 follow-up — the "fully unconditionally-stable 3D ADI" the
+# 2026-05-30 R2-STOP verdict sanctioned). Measured on this test's
+# committed settings: f_peak = 3.8079 GHz vs analytic 3.8543 GHz ->
+# rel_err = 1.204% < 2% (PASS), late/early probe RMS 0.999 (the mode
+# rings; no artificial dissipation), and the CFL-5x stability rung in
+# tests/test_adi.py stays green (bounded at 10x/50x as free witnesses).
+# Evidence: scripts/diagnostics/gate_honesty_20260713/lane_338_adi_redesign/.
 #
 # This test runs a lossless 3D PEC cubic cavity at a modest CFL factor
 # (where splitting error is small) and compares the dominant resonance
 # to the analytic mode  f_mnp = (C0/2)*sqrt((m/Lx)^2+(n/Ly)^2+(p/Lz)^2).
-# A modest CFL is the FAIR setting: a structural scheme error shows up
-# even there, so a large miss is strong evidence for OPT-C1.
 #
 # COMPARATOR CONVENTION (issue #338): _apply_pec_3d zeroes tangential E
 # at node indices 0 and N-1, so the PEC walls sit L_eff = (N-1)*dx apart
@@ -268,13 +277,6 @@ def test_risc2_np_interp_complex_part_behavior():
 # known-good explicit Yee scheme on the SAME 12^3 node cavity lands
 # 0.21% from the corrected analytic and 8.9% from the biased one.
 
-@pytest.mark.xfail(strict=True, reason=(
-    "OPT-C1: adi_step_3d LOD applies the implicit solve to off-axis E "
-    "components (artificial diffusion, see adi.py LOD NOTE). Under the "
-    "honest comparator (L_eff=(N-1)*dx=55 mm -> f=3.854 GHz) the "
-    "measured 12^3-cavity peak at 2x CFL is 2.077 GHz — a 46% miss "
-    "(2026-07-13), and the mode energy itself decays within ~4 ns "
-    "(over-dissipation). Adjudication test — roadmap Part A, issue #338."))
 def test_optc1_adi_3d_cavity_eigenfrequency():
     L = 0.06           # nominal 60 mm cube
     dx = dy = dz = 0.005   # 12 cells per side


### PR DESCRIPTION
## Summary

Replaces the 3D LOD split in `adi_step_3d` — whose own comment said it "applies the tridiagonal solve to ALL E components along each axis, which adds artificial diffusion" (OPT-C1) — with the full Zheng–Chen–Zhang two-sub-step 3D ADI scheme (F. Zheng, Z. Chen, J. Zhang, IEEE Trans. MTT 48(9), 2000). Per `dt/2` sub-step, each E component gets one tridiagonal implicit solve along its correct curl axis, with the substituted same-sub-step H mixed term on the RHS; H updates explicitly from the just-solved E; the two sub-steps swap the implicit curl family (Peaceman–Rachford alternation). Public signatures of `adi_step_3d` / `run_adi_3d` unchanged; the 2D path is byte-untouched (diff hunks confined to the module docstring references and `adi_step_3d` internals).

This closes the issue #338 follow-up under the pre-declared dual gate, satisfying the recorded 2026-05-30 R2-STOP verdict in `docs/agent-memory/rfx-known-issues.md`, which sanctioned exactly one next architecture:

> "closing this needs a fully unconditionally-stable 3D ADI/LOD (proper tridiagonal implicit solve per axis with the correct stability operator) ... Next attempt must gate on BOTH the <2 % eigenfrequency AND CFL-5× stability simultaneously."

This is that architecture, gated on both criteria simultaneously. It is NOT a re-attempt of the reverted 2026-05-30 partial per-axis factorization (which left explicit curl remainders outside any Cayley pair — the mechanism of its CFL-5x divergence); here every one of the twelve curl terms sits inside one of the two implicit/explicit Cayley pairs, so the full-step map is similar to a product of two unitary Cayley transforms for every dt.

## Measured (12-cell cube, dx=5 mm, honest analytic 3.8543 GHz post-#362 comparator fix)

| Quantity | Before (LOD) | After (ZCZ) | Gate |
|---|---|---|---|
| G1 eigenfrequency @2x CFL, 1500 steps | 2.077 GHz (46.1% miss), mode decays within ~4 ns | **3.8079 GHz (1.204% miss)**, probe late/early RMS 0.999 (rings) | < 2% — **PASS** |
| G2 `test_stability_3d_pec_cavity[5.0]` (200 steps, max\|E\|) | passed (dissipative) | **0.384** | < 100 — **PASS** (18/18 file green) |
| CFL-10x boundedness (free witness, not gated) | old scheme could diverge (own docstring) | **0.338 bounded**; 50x: 0.324 bounded | recorded |
| Energy witness (lossless PEC cavity) | decays to ~0 | **final/peak = 1.000** at 2x AND 5x | recorded |
| Design-doc prediction check | — | predicted f_peak 3.807876 GHz / 1.204%; measured identical | — |

Implementation-integrity witnesses (pre-declared falsifiers from the design doc):
- Substitution residual of the implicit Ampère update with actually-solved fields: **4.3e-16** (machine eps).
- One-step production kernel vs independent NumPy reference: worst component rel. diff **2.7e-7** (float32 vs float64 scale).

Preflight context for the gate numbers, quoted verbatim (fires on the 5x-CFL API rungs in `tests/test_adi.py`, by design):

> `solver='adi' with a 3D grid at adi_cfl_factor=5: the 3D ADI scheme is unconditionally stable, but its dispersion error grows ~dt^2 — at ~15 cells/wavelength the <2% eigenfrequency envelope holds only up to ~2x CFL (measured -1.4% at 2x; -2.8% at 3x, -6.7% at 5x by von Neumann analysis). Use adi_cfl_factor <= 2 for wavelength-scale accuracy, or reserve large factors for geometrically stiff meshes (features far below the wavelength).`

One honesty note (R5): a 5x-CFL accuracy characterization run in the evidence log shows a meaningless near-DC spectral peak — that is an excitation artifact (reusing `tau = 8*dt` at 5x shrinks the source bandwidth to ~0.8 GHz, under-exciting the 3.85 GHz mode), not scheme error. The 5x accuracy envelope quoted above rests on the design-lane von Neumann analysis, and 5x is gated on stability only, exactly as the dual gate encodes.

## Adjacent surfaces updated in the same change (per design doc §5)

- `tests/test_review_tier1_validation_battery.py` — strict-xfail marker removed on XPASS with in-file verdict (module convention); comparator-convention block comment retained.
- `rfx/api/_preflight.py::_validate_cfg_adi_3d_accuracy` — blanket KNOWN-INACCURATE warning (whose docstring required removal on XPASS) replaced by the dt²-envelope advisory above (fires only at `adi_cfl_factor > 2` on 3D grids; same code `adi_3d_accuracy`, warning severity).
- `tests/test_adi_preflight.py` — rewritten to lock the new advisory behavior (5 tests).
- `rfx/api/__init__.py` — `solver` / `adi_cfl_factor` docstrings updated to the measured envelope.
- `tests/test_adi.py` — stale LOD description in the 3D stability test docstring corrected (parameters and asserts untouched; committed gates unchanged).

## Test evidence

- G1: `python -m pytest tests/test_review_tier1_validation_battery.py` — 7 passed.
- G2: `python -m pytest tests/test_adi.py -m gpu` — 18 passed (388 s CPU), including `test_stability_3d_pec_cavity[5.0]`; all 2D rungs green with 2D code untouched.
- `tests/test_adi_preflight.py` + `tests/test_forward_docstring_contract.py` — 9 passed.
- Full default fast suite — green with zero test failures, run in sharded fresh processes: shard A (all files up to `test_sbp_sat_jit.py`, only `./s/x` progress marks), `test_sbp_sat_jit.py` isolated (16 passed), shard B (`test_sbp_*`..`test_waveguide_smatrix_checkpoint.py`, only `./s/x`), `test_waveguide_smatrix_checkpoint.py` isolated (5 passed, 1 deselected), shard C final 7 files (58 passed). Sharding is the documented workaround for this box's pre-existing single-process XLA-compile segfault at ~70% of the suite (research notes 2026-06-10 / 2026-07-02: "Don't run the full suite single-process locally"; both segfaults hit ADI-unrelated compile sites — subgridding and waveguide S-matrix — and both files pass in isolation). CI runs the authoritative suite on this PR.
- `ruff check rfx/ tests/ --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402` — clean.

Artifacts (local evidence dir, primary checkout): `scripts/diagnostics/gate_honesty_20260713/lane_338_adi_redesign/` — `adi3d_design_20260713.md` (approved design), `vn_zcz_dispersion.{py,log}`, `prototype_zcz_cavity.{py,log}`, `impl_verify_zcz.{py,log}`, figure `impl_zcz_g1_spectrum_energy.png` (2x spectrum with analytic overlay; probe ring-down; energy-vs-time at 2x/5x flat at 1.000).

No committed gate or tolerance was changed; the 2% eigenfrequency gate and all stability parameters are as committed before this attempt.

R3: memory=rfx-known-issues.md 2026-05-30 R2-STOP (this PR implements its sanctioned architecture; supersede-with-link on merge) | R2-attempts=1 (single pre-declared attempt; the one in-flight defect fixed was a diagnostic-harness import-path issue, not a scheme change) | falsifier=one-step cross-implementation check vs independent NumPy reference (2.7e-7) + machine-eps substitution residual (4.3e-16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
