### PR TITLE
docs(adi): ADI solver guide + tutorial; fix 2D 50x resonance overclaim

### DIFF
--- a/docs/public/guide/adi-solver.mdx
+++ b/docs/public/guide/adi-solver.mdx
@@ -1,0 +1,90 @@
+---
+title: "ADI Solver (Experimental)"
+description: "Unconditionally stable ADI-FDTD for stiff meshes: the timestep trade, the accuracy envelope, and what is and is not yet validated."
+sidebar:
+  order: 9
+---
+
+The default `solver="yee"` is an explicit scheme. Its timestep is bounded by the
+Courant (CFL) limit, which is set by the **smallest cell in the mesh** — a thin
+substrate, a coating, or a narrow gap forces a small timestep on the whole
+domain even when the wavelength is large. That is the stiff-mesh problem.
+
+`solver="adi"` (Alternating-Direction-Implicit, the Zheng–Chen–Zhang two-sub-step
+3D scheme) is **unconditionally stable**: it stays bounded at any timestep.
+`adi_cfl_factor` sets how far past the standard limit you push. Stability is
+free; wavelength-scale accuracy is not.
+
+## When to reach for it
+
+Reach for ADI when a geometrically stiff mesh — features far below the
+wavelength — is forcing an explicit run to take an impractical number of steps,
+and you can tolerate the dispersion cost below. For ordinary
+wavelength-resolved models, the explicit Yee solver is the right default and is
+more accurate step-for-step.
+
+```python
+sim = Simulation(
+    freq_max=12e9,
+    domain=(a, b, d),
+    dx=dx,
+    boundary=BoundarySpec.uniform("pec"),
+    solver="adi",
+    adi_cfl_factor=2.0,   # accuracy setting; see the envelope below
+)
+```
+
+## The timestep trade (read before choosing `adi_cfl_factor`)
+
+The ADI scheme adds a temporal dispersion error that grows with the timestep,
+roughly as `dt²`. `adi_cfl_factor` is therefore a **throughput** knob, not an
+accuracy knob. On a lossless 3D PEC cavity at ~15 cells per wavelength:
+
+| `adi_cfl_factor` | eigenfrequency error | notes |
+|---|---|---|
+| 2 | −1.4% | at or below the 2% accuracy gate |
+| 3 | −2.8% | von Neumann analysis |
+| 5 (default) | −6.7% | von Neumann analysis; stable but coarse |
+
+The default is `5.0` — a stiff-mesh throughput default. **Set
+`adi_cfl_factor <= 2` when the resonance frequency, not the timestep, is what
+you need to be accurate.** Preflight emits an `adi_3d_accuracy` advisory
+whenever `adi_cfl_factor > 2` on a 3D grid, quoting this envelope.
+
+At finer resolution the error shrinks: the runnable demo below, at ~27 cells per
+wavelength, reads a cavity TE101 at **−0.54% (factor 2)** and **−2.6% (factor
+5)** against the analytic value, versus **−0.06%** for explicit Yee.
+
+## What is validated, and what is not
+
+- **3D accuracy is validated against an analytic oracle.** A lossless 3D PEC
+  cavity eigenfrequency matches the closed-form mode within the 2% gate at
+  `adi_cfl_factor = 2` (`tests/test_review_tier1_validation_battery.py`,
+  measured 1.2%). The 2D TMz path (`mode="2d_tmz"`) holds a 2% resonance gate at
+  5× CFL (`tests/test_adi.py::test_adi_cavity_resonance`) and is unconditionally
+  stable well beyond it.
+- **The stiff-mesh throughput advantage is not yet demonstrated.** The larger
+  timestep is a real property of an unconditionally stable scheme, but a
+  measured end-to-end speed-and-accuracy result on a genuinely stiff production
+  mesh has not been published. Do not read ADI as a validated speed-up.
+- ADI is an **experimental solver lane**. Use the explicit Yee solver for
+  claims-bearing 3D physics.
+
+## Gradients
+
+`solver="adi"` differentiates end-to-end — `jax.grad` flows through the
+tridiagonal solve — so the ADI path is usable inside an optimization loop where
+the stiff-mesh timestep matters.
+
+## Try it
+
+```bash
+python examples/tutorials/adi_solver_demo.py
+```
+
+The demo resonates a vacuum PEC cavity three ways — explicit Yee, ADI at factor
+2, ADI at factor 5 — and prints the frequency error each way, so the
+accuracy-versus-timestep trade is visible rather than asserted.
+
+_The Zheng–Chen–Zhang 3D scheme replaced the earlier LOD path in issue #338;
+earlier releases carried the older, over-dissipative LOD implementation._

--- a/docs/public/index.mdx
+++ b/docs/public/index.mdx
@@ -103,6 +103,7 @@ the checks required before reporting resonance or Q.
 - [Sources & Ports](guide/sources-ports/) — point sources, lumped/wire ports, microstrip-line ports, waveguide ports, and coaxial-line reflection for exactly one `face="top"` port within its stated limits
 - [Probes & S-Parameters](guide/probes-sparams/) — DFT probes, S-matrix helpers, Harminv, de-embedding, exports
 - [Memory Reduction](guide/memory-reduction/) — reduce FDTD/AD memory while preserving validation boundaries
+- [ADI Solver (experimental)](guide/adi-solver/) — unconditionally stable ADI-FDTD for stiff meshes, its timestep-vs-accuracy trade, and what is validated
 - [Waveguide Ports](guide/waveguide-ports/) — rectangular waveguide modal workflows
 
 ### Analysis & Validation

--- a/docs/public/site_map.json
+++ b/docs/public/site_map.json
@@ -18,6 +18,7 @@
         "rfx/guide/sources-ports",
         "rfx/guide/probes-sparams",
         "rfx/guide/memory-reduction",
+        "rfx/guide/adi-solver",
         "rfx/guide/waveguide-ports"
       ]
     },

--- a/examples/tutorials/adi_solver_demo.py
+++ b/examples/tutorials/adi_solver_demo.py
@@ -1,0 +1,154 @@
+"""ADI solver -- trade wavelength-scale accuracy for a larger timestep.
+
+The default ``solver="yee"`` is an explicit scheme: its timestep is bounded by
+the Courant (CFL) limit, which is set by the *smallest* cell in the mesh.  A
+thin layer -- a substrate a few cells thick, a coating, a narrow gap -- forces a
+tiny timestep on the *whole* domain even though the wavelength is large.  That
+is the stiff-mesh problem.
+
+The ``solver="adi"`` path (Alternating-Direction-Implicit, the Zheng-Chen-Zhang
+two-sub-step 3D scheme) is *unconditionally stable*: it stays bounded at any
+timestep.  ``adi_cfl_factor`` sets how far past the standard limit you push.
+Stability is free; accuracy is not.  The scheme adds a temporal dispersion error
+that grows with the timestep (roughly as ``dt^2``), so a large factor is a
+throughput setting, not an accuracy setting.
+
+This tutorial resonates a closed vacuum PEC cavity -- an exact analytic
+oracle -- and reads TE101 three ways: explicit Yee, ADI at ``adi_cfl_factor=2``
+(the accuracy setting), and ADI at ``adi_cfl_factor=5`` (the default throughput
+setting).  It prints the frequency error each way so the accuracy-vs-timestep
+trade is visible rather than asserted.
+
+``f_mnp = (c/2)*sqrt((m/a)^2 + (n/b)^2 + (p/d)^2)``.
+
+Scope, stated plainly:
+  - ADI is an EXPERIMENTAL solver lane.  Its 3D accuracy is validated against
+    this analytic cavity (``tests/test_review_tier1_validation_battery.py``
+    holds a 2% eigenfrequency gate at ``adi_cfl_factor=2``, ~15 cells per
+    wavelength).  Its *throughput advantage on a genuinely stiff mesh* is not
+    yet demonstrated -- do not read this demo as a speed claim.
+  - Use ``adi_cfl_factor <= 2`` for quantitative wavelength-scale results.  The
+    default ``5.0`` is a stiff-mesh throughput default and carries a visible
+    wavelength-scale error (shown below).  Large factors stay stable but are
+    quantitative only for features much coarser than the timestep.
+  - ``solver="adi"`` differentiates end-to-end (``jax.grad`` flows through the
+    tridiagonal solve); this demo does not exercise gradients.
+
+Run as::
+
+    python examples/tutorials/adi_solver_demo.py
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from rfx import GaussianPulse, Simulation
+from rfx.boundaries.spec import BoundarySpec
+from rfx.harminv import HarminvMode, harminv
+
+
+C0 = 299_792_458.0
+
+# A closed rectangular PEC cavity: a, b, d are the box edges; TE101 is a
+# length (a,d) mode.  dx resolves the ~40 mm free-space wavelength at ~27 cells,
+# comfortably inside the documented ~15-cells/wavelength envelope.
+A = 24.0e-3
+B = 12.0e-3
+D = 36.0e-3
+DX = 1.5e-3
+FREQ_MAX = 12.0e9
+
+M, N, P = 1, 0, 1
+F_TE101 = (C0 / 2.0) * np.sqrt((M / A) ** 2 + (N / B) ** 2 + (P / D) ** 2)
+
+# Same physical record length for every solver so the Harminv frequency
+# resolution (which scales as 1/record-length) is identical across the three.
+RECORD_NS = 6.9e-9
+
+
+def build_cavity(solver: str, adi_cfl_factor: float) -> Simulation:
+    """Closed vacuum PEC cavity with an off-centre TE101 source and probe."""
+    sim = Simulation(
+        freq_max=FREQ_MAX,
+        domain=(A, B, D),
+        dx=DX,
+        boundary=BoundarySpec.uniform("pec"),
+        solver=solver,
+        adi_cfl_factor=adi_cfl_factor,
+    )
+    # Off-centre positions couple to TE101 (Ey is a TE101 field component here).
+    sim.add_source(
+        (0.37 * A, 0.41 * B, 0.20 * D),
+        component="ey",
+        waveform=GaussianPulse(f0=F_TE101, bandwidth=0.9),
+    )
+    sim.add_probe((0.63 * A, 0.58 * B, 0.80 * D), component="ey")
+    return sim
+
+
+def run_and_read(label: str, solver: str, adi_cfl_factor: float) -> HarminvMode:
+    """Run one solver, quote its preflight verbatim, and read TE101."""
+    sim = build_cavity(solver, adi_cfl_factor)
+    print(f"\n[{label}] preflight (quoted verbatim, not suppressed):")
+    sim.preflight(strict=False)
+
+    # Convert the fixed physical record into a step count for this solver's dt.
+    # ADI's dt is adi_cfl_factor times larger than the 2D CFL limit, so the same
+    # physical record needs proportionally fewer steps.
+    probe_result = sim.run(n_steps=8, compute_s_params=False, skip_preflight=True)
+    dt = float(probe_result.dt)
+    n_steps = int(round(RECORD_NS / dt))
+
+    result = sim.run(n_steps=n_steps, compute_s_params=False, skip_preflight=True)
+    trace = np.asarray(result.time_series)[:, 0]
+    ring_down = trace[len(trace) // 4 :]
+    ring_down = ring_down - np.mean(ring_down)
+    modes = harminv(
+        ring_down, float(result.dt), 0.70 * F_TE101, 1.50 * F_TE101,
+        min_Q=1.0, max_modes=12,
+    )
+    physical = [m for m in modes if m.Q > 1.0 and m.amplitude > 1e-9] or list(modes)
+    if not physical:
+        raise RuntimeError(f"[{label}] Harminv returned no cavity mode")
+    te101 = min(physical, key=lambda m: abs(m.freq - F_TE101))
+    err = 100.0 * (te101.freq - F_TE101) / F_TE101
+    print(f"[{label}] dt={dt:.3e}s  {n_steps} steps  record={n_steps*dt*1e9:.2f} ns")
+    print(f"[{label}] TE101 = {te101.freq/1e9:.4f} GHz   error = {err:+.2f}%   "
+          f"Q(window) = {te101.Q:.0f}")
+    return te101
+
+
+def main() -> None:
+    lam = C0 / F_TE101
+    print("=" * 70)
+    print("ADI solver demo -- vacuum PEC cavity TE101")
+    print("=" * 70)
+    print(f"Analytic TE101      : {F_TE101/1e9:.4f} GHz")
+    print(f"Mesh                : dx = {DX*1e3:.2f} mm  "
+          f"({A/DX:.0f} x {B/DX:.0f} x {D/DX:.0f} cells, "
+          f"~{lam/DX:.0f} cells / free-space wavelength)")
+
+    yee = run_and_read("yee", "yee", 5.0)          # adi_cfl_factor ignored for yee
+    adi2 = run_and_read("adi cfl=2 (accuracy)", "adi", 2.0)
+    adi5 = run_and_read("adi cfl=5 (default)", "adi", 5.0)
+
+    def e(mode: HarminvMode) -> float:
+        return 100.0 * (mode.freq - F_TE101) / F_TE101
+
+    print("\n" + "-" * 70)
+    print("Summary -- accuracy is traded for timestep, stability is not:")
+    print(f"  explicit Yee                : {e(yee):+.2f}%  (CFL-limited dt)")
+    print(f"  ADI, adi_cfl_factor = 2     : {e(adi2):+.2f}%  (2x dt, accuracy setting)")
+    print(f"  ADI, adi_cfl_factor = 5     : {e(adi5):+.2f}%  (5x dt, default throughput)")
+    print("-" * 70)
+    print("Both ADI runs are stable at their enlarged timestep -- that is the")
+    print("unconditional-stability property.  The cfl=5 error is the documented")
+    print("wavelength-scale cost of the default; drop to <=2 when the resonance")
+    print("frequency, not the timestep, is what you need to be accurate.")
+    print("ADI is an experimental lane; its stiff-mesh throughput advantage is a")
+    print("separate, not-yet-demonstrated claim.")
+
+
+if __name__ == "__main__":
+    main()

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -303,8 +303,9 @@ class Simulation(
     solver : str
         ``"yee"`` (default) for the standard explicit scheme or
         ``"adi"`` for the ADI-FDTD path. ADI is unconditionally stable in
-        both 2D TMz (``mode="2d_tmz"``, 2% cavity-resonance gate at 50x
-        CFL) and 3D (full Zheng–Chen–Zhang two-sub-step scheme since
+        both 2D TMz (``mode="2d_tmz"``, 2% cavity-resonance gate at 5x
+        CFL, ``test_adi_cavity_resonance``; stable well beyond) and 3D
+        (full Zheng–Chen–Zhang two-sub-step scheme since
         2026-07-13, issue #338: 2% PEC-cavity eigenfrequency gate at 2x
         CFL, ~15 cells/wavelength). 3D dispersion error grows ~dt^2, so
         preflight emits an ``adi_3d_accuracy`` envelope advisory when

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1932,8 +1932,8 @@ class _PreflightMixin:
         at 5x). Runs stay unconditionally STABLE at any factor — accuracy,
         not stability, is what degrades. Advise (WARNING severity, envelope
         advisory — not an error) when ``adi_cfl_factor > 2.0`` on a 3D grid.
-        The 2D TMz path keeps its separately validated 50x envelope and is
-        not flagged here.
+        The 2D TMz path (2% resonance gate at 5x CFL, and stable — verified
+        bounded — well beyond) is not flagged here.
         """
         if self._solver != "adi" or self._mode != "3d":
             return


### PR DESCRIPTION
## What

- New public guide `docs/public/guide/adi-solver.mdx` + runnable tutorial `examples/tutorials/adi_solver_demo.py` for the **experimental** ADI solver.
- Registered in `docs/public/index.mdx` nav + `docs/public/site_map.json` (manifest gate: 25 slugs OK).
- **Correctness fix** found during the docs review: the 2D TMz *"2% cavity-resonance gate at 50x CFL"* claim is unsubstantiated. The only 2D 2%-resonance test (`test_adi_cavity_resonance`) runs at **5x** CFL; 50x is a stability witness only. Corrected in `rfx/api/__init__.py`, `rfx/api/_preflight.py`, and the guide.

## Honesty posture (experimental lane)

- Accuracy **is** validated vs the analytic cavity (tier1 test, 2% @ 2x, measured 1.2%); the **stiff-mesh throughput advantage is explicitly not-yet-demonstrated** — the docs do not claim a validated speed-up.
- Honest dt² envelope (−1.4%/−2.8%/−6.7% at 2/3/5x, von Neumann) matches the preflight advisory; the tutorial computes its numbers live (yee −0.06% / adi 2x −0.54% / adi 5x −2.58%).

## Verification

- `test_adi_cavity_resonance` passes (2D @5x <2%); `test_adi_preflight` + `test_forward_docstring_contract` 9 passed; `check_api_reference` OK; ruff clean.
- Deslop pass: independent code-reviewer agent — both files clean; its one accuracy must_fix (the 50x claim) is fixed here.

## Deploy timing (not in this PR)

Holding the remilab.ai deploy until #366 (ADI ZCZ) is released — these docs describe post-#366 behavior; PyPI 1.6.6 still ships the older LOD path. Per maintainer choice: commit to main now, deploy with the release.

R3: memory=feedback_root_cause_before_gate_change + project_adi3d_zcz_resolution | R2-attempts=0 | falsifier=test_adi_cavity_resonance @5x <2% + check_api_reference OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)