### PR TITLE
fix(nonuniform): apply PEC thin conductors on the dz_profile path (#369)

### DIFF
--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -86,6 +86,11 @@ def assemble_materials_nu(
     # the field AD-clean (no float op enters the gradient path). Lossy
     # (non-PEC) sheets need a grid-dependent surface-conductivity fold the
     # coords path cannot yet express — warn rather than silently drop.
+    # Caveat (tracked in #371): on a GENUINELY graded dz_profile, the sheet's
+    # cell can differ by one z-layer from a matching-thickness volume box at the
+    # same nominal z, via the argmin-vs-half-open split in Box.mask_on_coords.
+    # That is a pre-existing csg rasterization issue, not introduced here; this
+    # code uses the same mask_on_coords a thin conductor always has.
     if sim._thin_conductors:
         pec_tcs = [tc for tc in sim._thin_conductors
                    if getattr(tc, "is_pec", False)]

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -57,7 +57,8 @@ def assemble_materials_nu(
     """Build material arrays and dispersion specs for non-uniform grid.
 
     Delegates to the shared rasterize_geometry() with non-uniform coordinates.
-    Now supports all shape types, Debye/Lorentz poles, chi3, and thin conductors.
+    Supports all shape types, Debye/Lorentz poles, chi3, and PEC thin
+    conductors (lossy thin conductors are not yet supported here — see below).
 
     Returns
     -------
@@ -67,8 +68,6 @@ def assemble_materials_nu(
 
     coords = coords_from_nonuniform_grid(grid)
 
-    # Thin conductors require mask(grid) which needs uniform Grid.
-    # Skip on NU path for now — the shape won't resolve.
     result = rasterize_geometry(
         sim._geometry,
         sim._resolve_material,
@@ -76,6 +75,37 @@ def assemble_materials_nu(
         pec_sigma_threshold=sim._PEC_SIGMA_THRESHOLD,
     )
     materials, debye_spec, lorentz_spec, pec_mask, _pec_shapes, _kerr_chi3 = result
+
+    # Thin conductors (#369): a PEC thin sheet rasterizes on the coords-based
+    # mask exactly like geometry PEC — ``mask_on_coords`` resolves fine on
+    # non-uniform axes, so the earlier "needs a uniform Grid, skip for now"
+    # shortcut was wrong. Before this fix the NU (dz_profile) path silently
+    # dropped EVERY thin conductor: an ``add_thin_conductor()`` PEC sheet on a
+    # graded-z grid produced no pec_mask, so the patch neither reflected nor
+    # resonated (box-PEC rang, thin-sheet decayed). ORing a boolean mask keeps
+    # the field AD-clean (no float op enters the gradient path). Lossy
+    # (non-PEC) sheets need a grid-dependent surface-conductivity fold the
+    # coords path cannot yet express — warn rather than silently drop.
+    if sim._thin_conductors:
+        pec_tcs = [tc for tc in sim._thin_conductors
+                   if getattr(tc, "is_pec", False)]
+        lossy_tcs = [tc for tc in sim._thin_conductors
+                     if not getattr(tc, "is_pec", False)]
+        if pec_tcs:
+            if pec_mask is None:
+                pec_mask = jnp.zeros(coords.shape, dtype=jnp.bool_)
+            for tc in pec_tcs:
+                pec_mask = pec_mask | tc.shape.mask_on_coords(
+                    coords.x, coords.y, coords.z)
+        if lossy_tcs:
+            import warnings as _warnings
+            _warnings.warn(
+                f"{len(lossy_tcs)} lossy (non-PEC) thin conductor(s) are not "
+                "yet supported on the non-uniform (dz_profile) path and were "
+                "skipped; use a uniform grid, or a PEC thin conductor "
+                "(sigma_bulk high enough to be treated as PEC).",
+                stacklevel=2,
+            )
     return materials, debye_spec, lorentz_spec, pec_mask
 
 

--- a/tests/test_thin_conductor.py
+++ b/tests/test_thin_conductor.py
@@ -173,6 +173,49 @@ def test_thin_conductor_nonuniform_reflects_like_box():
         f"#369 regression: PEC thin sheet must ring like a box PEC on the NU "
         f"path (box={box_e:.3e}, thin={thin_e:.3e}, ratio={thin_e / box_e:.3f})")
 
+    # R5: don't trust the aggregate energy alone — assert cell-identity on the
+    # assembled pec_mask itself, which a small cell mismatch can't hide behind a
+    # resonance that happens not to move. On a UNIFORM-valued NU profile the thin
+    # sheet and the matching-thickness box coincide cell-for-cell. (On a
+    # genuinely graded dz_profile they can diverge by one z-layer via the
+    # argmin-vs-half-open split in Box.mask_on_coords — a pre-existing csg issue,
+    # tracked in #371, NOT introduced by this fix; hence this identity is asserted
+    # only for the uniform profile.)
+    from rfx.runners.nonuniform import (build_nonuniform_grid,
+                                        assemble_materials_nu)
+
+    def nu_pec_mask(kind):
+        sim = Simulation(freq_max=10e9, domain=(L, L, 0), dx=dx, dz_profile=dz,
+                         boundary="cpml", cpml_layers=8)
+        px_lo, px_hi = L / 2 - 6 * dx, L / 2 + 6 * dx
+        py_lo, py_hi = L / 2 - 4 * dx, L / 2 + 4 * dx
+        if kind == "box":
+            sim.add(Box((px_lo, py_lo, 15 * dx), (px_hi, py_hi, 16 * dx)),
+                    material="pec")
+        else:
+            sim.add_thin_conductor(Box((px_lo, py_lo, zc), (px_hi, py_hi, zc)),
+                                   sigma_bulk=5.8e7, thickness=35e-6)
+        grid = build_nonuniform_grid(
+            sim._freq_max, sim._domain, sim._dx, sim._cpml_layers,
+            sim._dz_profile, dx_profile=sim._dx_profile,
+            dy_profile=sim._dy_profile,
+            pec_faces=(sim._boundary_spec.pec_faces()
+                       if sim._boundary_spec is not None else None),
+            pmc_faces=(sim._boundary_spec.pmc_faces()
+                       if sim._boundary_spec is not None else None),
+            cpml_axes="".join(a for a in "xyz"
+                              if a not in (sim._periodic_axes or "")),
+        )
+        return np.asarray(assemble_materials_nu(sim, grid)[3])
+
+    box_mask = nu_pec_mask("box")
+    thin_mask = nu_pec_mask("thin")
+    assert thin_mask is not None and int(thin_mask.sum()) > 0, \
+        "#369: PEC thin conductor must produce a non-empty pec_mask on the NU path"
+    assert np.array_equal(box_mask, thin_mask), \
+        ("on a uniform NU profile a PEC thin sheet and a matching-thickness box "
+         "must select identical pec_mask cells")
+
 
 def test_thin_conductor_lossy_warns_on_nonuniform():
     """A lossy (non-PEC) thin conductor is not yet supported on the NU path;

--- a/tests/test_thin_conductor.py
+++ b/tests/test_thin_conductor.py
@@ -124,3 +124,78 @@ def test_thin_conductor_api_integration():
             "Copper thin conductor should be in pec_mask"
 
     print(f"\nThin conductor API integration: OK, grid={grid.shape}")
+
+
+def test_thin_conductor_nonuniform_reflects_like_box():
+    """#369: a PEC thin conductor on the non-uniform (dz_profile) path must
+    reflect/resonate identically to a geometry PEC Box at the same cell.
+
+    Before the fix, ``assemble_materials_nu`` skipped ALL thin conductors
+    ("needs a uniform Grid"), so an ``add_thin_conductor`` PEC sheet on a
+    dz_profile grid was silently dropped — no pec_mask, no reflection: the
+    box-PEC cavity rang while the thin-sheet cavity decayed. This is an
+    end-to-end behavioural lock through the real NU run path.
+    """
+    from rfx.api import Simulation
+    from rfx.sources.sources import GaussianPulse
+
+    dx = 1.5e-3
+    N = 30
+    L = N * dx
+    dz = [dx] * N
+    zc = 15 * dx + 0.5 * dx
+
+    def late_energy(kind):
+        sim = Simulation(freq_max=10e9, domain=(L, L, 0), dx=dx, dz_profile=dz,
+                         boundary="cpml", cpml_layers=8)
+        px_lo, px_hi = L / 2 - 6 * dx, L / 2 + 6 * dx
+        py_lo, py_hi = L / 2 - 4 * dx, L / 2 + 4 * dx
+        if kind == "box":
+            sim.add(Box((px_lo, py_lo, 15 * dx), (px_hi, py_hi, 16 * dx)),
+                    material="pec")
+        else:
+            sim.add_thin_conductor(Box((px_lo, py_lo, zc), (px_hi, py_hi, zc)),
+                                   sigma_bulk=5.8e7, thickness=35e-6)
+        sim.add_source(position=(px_lo + 3 * dx, L / 2, 10 * dx),
+                       component="ez",
+                       waveform=GaussianPulse(f0=6e9, bandwidth=1.0))
+        sim.add_probe(position=(px_lo + 8 * dx, L / 2 + 2 * dx, 10 * dx),
+                      component="ez")
+        ts = np.asarray(sim.run(n_steps=250, skip_preflight=True).time_series).ravel()
+        return float(np.max(np.abs(ts[-50:])))
+
+    box_e = late_energy("box")
+    thin_e = late_energy("thin")
+    assert box_e > 0.0
+    # Identical nominal patch cell → identical late-time cavity energy.
+    # Pre-fix this ratio was <= 0.37 (thin dropped); post-fix it is ~1.0.
+    assert abs(box_e - thin_e) / box_e < 0.1, (
+        f"#369 regression: PEC thin sheet must ring like a box PEC on the NU "
+        f"path (box={box_e:.3e}, thin={thin_e:.3e}, ratio={thin_e / box_e:.3f})")
+
+
+def test_thin_conductor_lossy_warns_on_nonuniform():
+    """A lossy (non-PEC) thin conductor is not yet supported on the NU path;
+    it must warn (not silently drop) so the omission is visible."""
+    import warnings
+    from rfx.api import Simulation
+    from rfx.sources.sources import GaussianPulse
+
+    dx = 1.5e-3
+    N = 24
+    L = N * dx
+    dz = [dx] * N
+    sim = Simulation(freq_max=10e9, domain=(L, L, 0), dx=dx, dz_profile=dz,
+                     boundary="cpml", cpml_layers=6)
+    # sigma_eff below the PEC threshold → lossy branch.
+    sim.add_thin_conductor(Box((9 * dx, 9 * dx, 15.5 * dx),
+                               (15 * dx, 15 * dx, 15.5 * dx)),
+                           sigma_bulk=1.0e3, thickness=35e-6)
+    sim.add_source(position=(6 * dx, L / 2, 10 * dx), component="ez",
+                   waveform=GaussianPulse(f0=6e9, bandwidth=1.0))
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        sim.run(n_steps=10, skip_preflight=True)
+    assert any("non-uniform" in str(wi.message).lower()
+               and "thin conductor" in str(wi.message).lower() for wi in w), \
+        "lossy thin conductor on NU path must emit a skip warning"


### PR DESCRIPTION
## Summary
Fixes #369. On the non-uniform (`dz_profile`) path, `assemble_materials_nu` passed only `sim._geometry` to `rasterize_geometry` and **deliberately skipped every thin conductor** (`# Thin conductors require mask(grid) which needs uniform Grid. Skip on NU path for now`). An `add_thin_conductor()` PEC sheet on a graded-z grid was therefore **silently dropped**: no `pec_mask`, so the sheet neither reflected nor resonated. A geometry PEC `Box` at the same cell rang a cavity; the thin sheet decayed.

This is the coarse-dz regime that planar-radiator / thin-sheet work needs, so the bug blocked that lever entirely.

## Root cause (mis-attributed twice before this)
- **NOT `inv_eps=0`** — geometry PEC keeps vacuum eps too (`_compile.py` "keep eps/sigma at vacuum values"); the inv=0 mechanism only exists in the opt-in kottke path.
- **NOT the `csg.py` argmin/half-open rasterization split** — `build_z_uniform` gives uniform dz, so all rules pick the same cell and `pec_mask` was bit-identical. (That split may still be a latent bug on *genuinely* non-uniform grids — separate.)
- **Actual cause:** `dz_profile` routes to the NU runner, whose assembly never rasterized thin conductors. Confirmed by bisection: `add_thin_conductor` ≡ box-PEC in a real uniform-3D domain (ratio 1.000), diverges only under `dz_profile`.

## Fix
Rasterize PEC thin conductors onto the coords-based mask exactly like geometry PEC (`mask_on_coords` resolves fine on non-uniform axes) and OR into `pec_mask`. Boolean-mask OR only — **no float op enters the gradient path**, so AD is structurally unchanged. Lossy (non-PEC) sheets need a grid-dependent surface-conductivity fold the coords path can't yet express — they now **warn** instead of silently dropping.

## Verification
- Thin sheet now rings identically to a geometry PEC Box on the NU path: late-time energy ratio **1.000** (was ≤0.37).
- Uniform-3D path unaffected (already box==thin).
- **AD preserved**: 63 NU grad/forward tests green (`test_nonuniform_gradient`, `_forward_grad`, `_grad_sparams`, …).
- NU regression suite (28) + thin_conductor suite green.
- New regression tests: `test_thin_conductor_nonuniform_reflects_like_box` (box==thin within 10% on NU) and `test_thin_conductor_lossy_warns_on_nonuniform`.

R3: memory=consistent (supersedes an earlier same-session "mechanism unpinned" note; honors closure-forensics + AD-hard-constraint) | R2-attempts=1 (one clean verified fix) | falsifier=the two new regression tests + the 63-test NU grad suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)