### PR TITLE
fix(#371): auto-mesh thin-conductor blindness; csg thin-sheet placement is correct (Bug 1 = not-a-bug)

### DIFF
--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -389,6 +389,21 @@ class _ExecuteMixin:
             if mname not in materials_dict and mname in MATERIAL_LIBRARY:
                 materials_dict[mname] = MATERIAL_LIBRARY[mname]
 
+        # Thin conductors are PEC/lossy sheets absent from self._geometry
+        # (issue #371 Bug 2). They add no wavelength constraint, but their
+        # IN-PLANE feature size must feed the feature-based dx. Register each
+        # under a synthetic material so analyze_features() folds its bbox dims
+        # into min_thickness while classifying it by sigma (PEC vs lossy), NOT
+        # as a dielectric: sigma_bulk>=1e6 => has_pec (kept out of max_eps_r),
+        # and a sheet's zero z-extent (< 1e-12, plus the sigma<pec_threshold
+        # guard) keeps it out of z_features (no false non-uniform-z). The
+        # zero z-extent is dropped by the nonzero-dims filter, so min_thickness
+        # resolves to the in-plane extent.
+        for i, tc in enumerate(self._thin_conductors):
+            tc_mat = f"__thin_conductor_{i}__"
+            materials_dict[tc_mat] = {"eps_r": tc.eps_r, "sigma": tc.sigma_bulk}
+            geometry_pairs.append((tc.shape, tc_mat))
+
         config = auto_configure(
             geometry=geometry_pairs,
             freq_range=(self._freq_max / 10, self._freq_max),
@@ -2351,7 +2366,7 @@ class _ExecuteMixin:
         fixed_num_periods = n_steps is None
 
         # ---- P1: Auto mesh when dx not specified and geometry exists ----
-        if self._dx is None and self._geometry:
+        if self._dx is None and (self._geometry or self._thin_conductors):
             self._auto_configure_mesh()
 
         # ---- Stage 1 conformal PEC auto-routing ----

--- a/rfx/geometry/csg.py
+++ b/rfx/geometry/csg.py
@@ -101,6 +101,11 @@ class Box:
                     jnp.searchsorted(coords, mid) - 1, 0, coords.size - 2)
                 dc_local = coords[k_mid + 1] - coords[k_mid]
             # Thin sheet: the single cell whose centre is nearest ``mid``.
+            # (#371) On the collocated scheme, apply_pec_mask zeros tangential
+            # Ex/Ey at this cell's CENTRE, so nearest-centre = minimum realized-
+            # plane placement error. A matching-thickness (sub-cell) box takes
+            # this same thin branch and agrees; only a >=1-cell VOLUME box
+            # (different object) selects a different layer on a graded axis.
             nearest_idx = jnp.argmin(jnp.abs(coords - mid))
             thin_mask = jnp.zeros(coords.shape, dtype=bool).at[
                 nearest_idx].set(True)

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -86,11 +86,14 @@ def assemble_materials_nu(
     # the field AD-clean (no float op enters the gradient path). Lossy
     # (non-PEC) sheets need a grid-dependent surface-conductivity fold the
     # coords path cannot yet express — warn rather than silently drop.
-    # Caveat (tracked in #371): on a GENUINELY graded dz_profile, the sheet's
-    # cell can differ by one z-layer from a matching-thickness volume box at the
-    # same nominal z, via the argmin-vs-half-open split in Box.mask_on_coords.
-    # That is a pre-existing csg rasterization issue, not introduced here; this
-    # code uses the same mask_on_coords a thin conductor always has.
+    # #371 (resolved as not-a-placement-bug): on a graded dz_profile the sheet's
+    # cell can differ from a >=1-cell VOLUME box at the same nominal z. That is
+    # correct: a zero-thickness sheet and a one-cell-thick box are different
+    # objects. apply_pec_mask realizes the sheet's conductor at the selected
+    # cell CENTRE (collocated tangential Ex/Ey), so Box's argmin-nearest-centre
+    # thin branch minimizes the realized-plane error |centre - z0|; a genuinely
+    # matching-thickness (sub-cell) box takes the same thin branch and selects
+    # the identical layer (verified, tests/test_thin_conductor.py). No fix here.
     if sim._thin_conductors:
         pec_tcs = [tc for tc in sim._thin_conductors
                    if getattr(tc, "is_pec", False)]

--- a/tests/test_auto_config.py
+++ b/tests/test_auto_config.py
@@ -341,3 +341,40 @@ def test_thin_pec_adds_to_pec_mask():
 
     # Should complete without error — PEC sheet handled via mask
     assert result is not None
+
+
+def test_auto_mesh_thin_conductor_only_configures_dx():
+    """#371 Bug 2(a): a sim whose ONLY PEC content is a thin conductor (no dx=,
+    empty self._geometry) must auto-configure dx from the sheet's in-plane size."""
+    from rfx.api import Simulation
+    from rfx.geometry.csg import Box
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.002), boundary="pec")
+    w = 2.0e-3
+    sim.add_thin_conductor(Box((0.005, 0.005, 0.001), (0.015, 0.005 + w, 0.001)),
+                           sigma_bulk=5.8e7, thickness=35e-6)
+    assert sim._dx is None and not sim._geometry and sim._thin_conductors
+    sim._auto_configure_mesh()
+    assert sim._dx is not None, "thin-conductor-only sim must set dx (Bug 2a)"
+    # Bug 2(b): feature-driven, not the empty-geometry lambda/10 fallback.
+    assert sim._dx <= w, f"dx={sim._dx} not resolving the {w*1e3:.1f} mm feature"
+    assert sim._dx < 0.02 / 10, "dx must be finer than the empty-geometry fallback"
+
+
+def test_auto_mesh_trigger_fires_thin_only_end_to_end():
+    """#371 Bug 2(a) at the real trigger (_execute.py:2354): reaching run() with a
+    thin-only sim and no dx= must auto-configure via _auto_configure_mesh."""
+    import warnings
+    from rfx.api import Simulation
+    from rfx.sources.sources import GaussianPulse
+    from rfx.geometry.csg import Box
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.002),
+                     boundary="cpml", cpml_layers=6)
+    sim.add_thin_conductor(Box((0.006, 0.006, 0.001), (0.014, 0.009, 0.001)),
+                           sigma_bulk=5.8e7, thickness=35e-6)
+    sim.add_source(position=(0.007, 0.01, 0.001), component="ez",
+                   waveform=GaussianPulse(f0=6e9, bandwidth=1.0))
+    assert sim._dx is None
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sim.run(n_steps=5, skip_preflight=True)
+    assert sim._dx is not None, "run() trigger must auto-configure a thin-only sim"

--- a/tests/test_thin_conductor.py
+++ b/tests/test_thin_conductor.py
@@ -306,5 +306,7 @@ def test_thin_conductor_graded_matches_matching_thickness_box_not_onecell():
         f"(sheet={sheet_z}, matching-box={mbox_z})")
     # sanity: the nearest-centre layer really is the min-error placement
     assert sheet_err <= abs(float(zc[onecell_z[0]]) - z_req) + 1e-12
-    # documented: a one-cell VOLUME box is a different object -> may differ
-    assert onecell_z != sheet_z or True   # informational; not required to match
+    # A one-cell VOLUME box is a physically different object (1-cell slab vs a
+    # zero-thickness sheet); on this graded profile it lands one layer away
+    # (onecell_z=[16] vs sheet_z=[15]). That divergence is expected and correct,
+    # not a placement bug — it is exactly what #371 originally mis-read as one.

--- a/tests/test_thin_conductor.py
+++ b/tests/test_thin_conductor.py
@@ -176,11 +176,12 @@ def test_thin_conductor_nonuniform_reflects_like_box():
     # R5: don't trust the aggregate energy alone — assert cell-identity on the
     # assembled pec_mask itself, which a small cell mismatch can't hide behind a
     # resonance that happens not to move. On a UNIFORM-valued NU profile the thin
-    # sheet and the matching-thickness box coincide cell-for-cell. (On a
-    # genuinely graded dz_profile they can diverge by one z-layer via the
-    # argmin-vs-half-open split in Box.mask_on_coords — a pre-existing csg issue,
-    # tracked in #371, NOT introduced by this fix; hence this identity is asserted
-    # only for the uniform profile.)
+    # sheet and the matching-thickness box coincide cell-for-cell. (#371, resolved
+    # as not-a-placement-bug: even on a GENUINELY graded dz_profile a thin sheet
+    # and a genuinely MATCHING-THICKNESS (sub-cell) box still select the same
+    # z-layer, because both take the argmin-nearest-centre thin branch. Only a
+    # >=1-cell VOLUME box — a physically different object — lands a layer away.
+    # See test_thin_conductor_graded_matches_matching_thickness_box_not_onecell.)
     from rfx.runners.nonuniform import (build_nonuniform_grid,
                                         assemble_materials_nu)
 
@@ -242,3 +243,68 @@ def test_thin_conductor_lossy_warns_on_nonuniform():
     assert any("non-uniform" in str(wi.message).lower()
                and "thin conductor" in str(wi.message).lower() for wi in w), \
         "lossy thin conductor on NU path must emit a skip warning"
+
+
+def test_thin_conductor_graded_matches_matching_thickness_box_not_onecell():
+    """#371: on a GENUINELY graded dz_profile, a PEC thin sheet selects the same
+    z-layer as a genuinely MATCHING-THICKNESS (sub-cell) box — because both take
+    the argmin thin branch, which realizes the conductor at the nearest cell
+    CENTRE (apply_pec_mask zeros collocated tangential Ex/Ey there). A one-cell
+    VOLUME box is a different object and legitimately lands one layer away; the
+    sheet's layer is the one whose centre is NEAREST z0 (minimum realized-plane
+    error), which the one-cell box is NOT required to match.
+    """
+    import numpy as np
+    from rfx.api import Simulation
+    from rfx.runners.nonuniform import (build_nonuniform_grid,
+                                        assemble_materials_nu)
+    from rfx.geometry.rasterize import coords_from_nonuniform_grid
+    from rfx.geometry.csg import Box
+
+    dx = 0.5e-3
+    dz = [0.5e-3] * 8 + [1.5e-3] * 8          # genuinely graded: fine then coarse
+    L = 24 * dx
+    px = (L / 2 - 6 * dx, L / 2 + 6 * dx)
+    py = (L / 2 - 4 * dx, L / 2 + 4 * dx)
+    z_req = 4.1e-3
+    t = 35e-6
+
+    def nu_pec_z(add_fn):
+        sim = Simulation(freq_max=10e9, domain=(L, L, 0), dx=dx, dz_profile=dz,
+                         boundary="cpml", cpml_layers=8)
+        add_fn(sim)
+        grid = build_nonuniform_grid(
+            sim._freq_max, sim._domain, sim._dx, sim._cpml_layers, sim._dz_profile,
+            dx_profile=sim._dx_profile, dy_profile=sim._dy_profile,
+            pec_faces=(sim._boundary_spec.pec_faces() if sim._boundary_spec else None),
+            pmc_faces=(sim._boundary_spec.pmc_faces() if sim._boundary_spec else None),
+            cpml_axes="".join(a for a in "xyz" if a not in (sim._periodic_axes or "")))
+        coords = coords_from_nonuniform_grid(grid)
+        pm = np.asarray(assemble_materials_nu(sim, grid)[3])
+        zc = np.asarray(coords.z)
+        zl = sorted(set(np.argwhere(pm)[:, 2].tolist()))
+        return zl, zc
+
+    sheet_z, zc = nu_pec_z(lambda s: s.add_thin_conductor(
+        Box((px[0], py[0], z_req), (px[1], py[1], z_req)),
+        sigma_bulk=5.8e7, thickness=t))
+    mbox_z, _ = nu_pec_z(lambda s: s.add(
+        Box((px[0], py[0], z_req - t / 2), (px[1], py[1], z_req + t / 2)),
+        material="pec"))
+    onecell_z, _ = nu_pec_z(lambda s: s.add(
+        Box((px[0], py[0], 4.0e-3), (px[1], py[1], 5.5e-3)), material="pec"))
+
+    # R5 witness: realized plane (selected cell centre) vs requested z0.
+    k = sheet_z[0]
+    sheet_err = abs(float(zc[k]) - z_req)
+    nearest = int(np.argmin(np.abs(zc - z_req)))
+    assert sheet_z == [nearest], (
+        f"#371: thin sheet must land on the NEAREST-centre layer {nearest} "
+        f"(realized {float(zc[nearest])*1e3:.3f}mm); got {sheet_z}")
+    assert sheet_z == mbox_z, (
+        f"#371: sheet must equal a genuinely matching-thickness box "
+        f"(sheet={sheet_z}, matching-box={mbox_z})")
+    # sanity: the nearest-centre layer really is the min-error placement
+    assert sheet_err <= abs(float(zc[onecell_z[0]]) - z_req) + 1e-12
+    # documented: a one-cell VOLUME box is a different object -> may differ
+    assert onecell_z != sheet_z or True   # informational; not required to match


### PR DESCRIPTION
Resolves #371. Adversarial design review reversed one of the two reported bugs — the honest, evidence-backed outcome:

## Bug 1 (csg argmin/half-open split) — NOT a placement bug; NO physics change
The reported "divergence" compared a thin sheet against a **one-cell VOLUME box** — a physically different object (a zero-thickness plane vs a 1-cell-thick slab). The correct comparator is a **genuinely matching-thickness (sub-cell) box**, and against *that* the sheet selects the **same** cell.

Why `argmin` (nearest cell centre) is already correct: `apply_pec_mask` realizes a z-normal sheet by zeroing the **collocated tangential** `Ex/Ey` at the selected cell **centre** (rfx assigns materials/PEC collocated at centres). So the realized conducting plane sits at `coords.z[k]`, and the placement error is `|coords.z[k] − z0|` — which **`argmin` minimizes**. The originally-proposed "edge-containment" fix would have realized the plane 2.6–4× **farther** from the request on graded axes (witnessed), i.e. an inverted-physics regression. So `rfx/geometry/csg.py` gets a **comment-only** clarification; the `argmin` thin branch is unchanged.

This is the canonical comparator-first lesson (research/CLAUDE.md, "the bug is in the comparator/extractor 8/8 times"): the failing reference (a one-cell box oracle for a sub-cell sheet) was itself the bug. The stale caveat added in #370 (nonuniform.py) and the test comment are corrected accordingly.

**Witness (graded dz=[0.5mm]×8+[1.5mm]×8, z0=4.1mm):** thin sheet → layer 15 (realized 3.750mm, err 0.35mm); genuinely matching-thickness 35µm box → layer 15 (identical); one-cell box [4.0,5.5]mm → layer 16 (realized 4.750mm, err 0.65mm — correctly different).

## Bug 2 (auto-mesh blind to thin conductors) — real, fixed
`_auto_configure_mesh()` built `geometry_pairs` only from `self._geometry`, and the trigger (`_execute.py`) checked only `self._geometry`. So a thin-conductor-only sim with no explicit `dx=` never auto-configured (`self._dx` stayed `None`), and auto-dx was blind to the sheet's dimensions. Fix: fold thin conductors into `geometry_pairs` under a synthetic material (classified by σ — PEC kept out of `max_eps_r`, zero z-extent kept out of `z_features`, so no false grading/permittivity), and widen the trigger to `(self._geometry or self._thin_conductors)` (monotone — unchanged whenever geometry is non-empty). Verified: a thin-only sim now auto-configures a feature-driven `dx=0.5mm`.

## Gates (rfx canonical-anchor discipline)
- **Bit-identity (uniform):** csg is comment-only (argmin line byte-unchanged); `_execute` change is additive/monotone (no-op with empty `_thin_conductors`). Uniform subset + auto_config green.
- **AD hard constraint:** no float op enters any gradient path (mask stays boolean; the `_execute` fold only sets pre-run Python-float dx). NU grad/forward/grad_sparams suites green.
- **Graded-resolved (R5):** real z-layer numbers above; sheet == matching-thickness box.
- **No silent gate loosening:** no committed tolerance changed; oracle re-grounded in the realized PEC plane (physics), not box-containment.

Three independent adversarial verification passes (bit-identity+AD, graded+physics, regression+auto-mesh) each reproduced the result on their own worktree and returned SOUND. 48 targeted tests + AD suites green locally; lint clean.

R3: memory=`project_issue369_thin_conductor_dzprofile.md` (instrument the ACTUAL run path) + research/CLAUDE.md comparator-first | R2-attempts=0 (single pre-declared physics verification; the reversal is justified by new mechanism evidence — collocated tangential-E realization at cell centre — not plausibility) | falsifier=realized-plane witness (primal_err ≥ argmin_err on graded; shown) + sheet==matching-thickness-box on the real NU path (shown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)