### PR TITLE
fix(nonuniform): support lossy thin conductors on the dz_profile path (#373)

### DIFF
--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -105,14 +105,36 @@ def assemble_materials_nu(
             for tc in pec_tcs:
                 pec_mask = pec_mask | tc.shape.mask_on_coords(
                     coords.x, coords.y, coords.z)
-        if lossy_tcs:
-            import warnings as _warnings
-            _warnings.warn(
-                f"{len(lossy_tcs)} lossy (non-PEC) thin conductor(s) are not "
-                "yet supported on the non-uniform (dz_profile) path and were "
-                "skipped; use a uniform grid, or a PEC thin conductor "
-                "(sigma_bulk high enough to be treated as PEC).",
-                stacklevel=2,
+        # #373: lossy (non-PEC) thin conductors fold into sigma using the LOCAL
+        # cell size NORMAL to the sheet, not a uniform grid.dx. The sheet has
+        # bulk conductivity sigma_bulk and physical thickness t but occupies one
+        # Yee cell of size d_norm along its normal; preserving the sheet
+        # resistance R_s = 1/(sigma_bulk*t) needs sigma_eff = sigma_bulk*t/d_norm
+        # with d_norm the LOCAL cell size at the sheet's cell (grid.dz varies on
+        # a graded mesh). AD-safe: sigma_eff is a smooth function of the
+        # sigma_bulk*t DoF times a grid constant, and jnp.where keeps the
+        # sigma field (an AD-live material) differentiable.
+        for tc in lossy_tcs:
+            lo = getattr(tc.shape, "corner_lo", None)
+            hi = getattr(tc.shape, "corner_hi", None)
+            if lo is None or hi is None:
+                import warnings as _warnings
+                _warnings.warn(
+                    "lossy thin conductor with a non-Box shape is not yet "
+                    "supported on the non-uniform path and was skipped.",
+                    stacklevel=2)
+                continue
+            extents = [float(hi[i]) - float(lo[i]) for i in range(3)]
+            n_axis = min(range(3), key=lambda i: extents[i])  # sheet normal axis
+            d_norm = jnp.asarray((grid.dx_arr, grid.dy_arr, grid.dz)[n_axis])
+            bshape = [1, 1, 1]
+            bshape[n_axis] = int(d_norm.shape[0])
+            sigma_eff = tc.sigma_bulk * (tc.thickness / d_norm.reshape(bshape))
+            m = tc.shape.mask_on_coords(coords.x, coords.y, coords.z)
+            materials = MaterialArrays(
+                eps_r=jnp.where(m, tc.eps_r, materials.eps_r),
+                sigma=jnp.where(m, sigma_eff, materials.sigma),
+                mu_r=materials.mu_r,
             )
     return materials, debye_spec, lorentz_spec, pec_mask
 

--- a/tests/test_thin_conductor.py
+++ b/tests/test_thin_conductor.py
@@ -218,9 +218,12 @@ def test_thin_conductor_nonuniform_reflects_like_box():
          "must select identical pec_mask cells")
 
 
-def test_thin_conductor_lossy_warns_on_nonuniform():
-    """A lossy (non-PEC) thin conductor is not yet supported on the NU path;
-    it must warn (not silently drop) so the omission is visible."""
+def test_thin_conductor_lossy_nonuniform_runs_no_skip_warn():
+    """#373: a lossy (non-PEC) thin conductor now RUNS end-to-end on the NU
+    (dz_profile) path (folded into sigma), no longer warning-and-skipping.
+    (Superseded the earlier #370 warn-and-skip lock — end-to-end coverage
+    complementing the unit-level test_lossy_thin_conductor_nonuniform_uses_local_dz.)
+    """
     import warnings
     from rfx.api import Simulation
     from rfx.sources.sources import GaussianPulse
@@ -239,10 +242,11 @@ def test_thin_conductor_lossy_warns_on_nonuniform():
                    waveform=GaussianPulse(f0=6e9, bandwidth=1.0))
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        sim.run(n_steps=10, skip_preflight=True)
-    assert any("non-uniform" in str(wi.message).lower()
-               and "thin conductor" in str(wi.message).lower() for wi in w), \
-        "lossy thin conductor on NU path must emit a skip warning"
+        res = sim.run(n_steps=10, skip_preflight=True)
+    assert res is not None, "lossy thin conductor on NU must run end-to-end"
+    assert not any("not yet supported" in str(wi.message).lower()
+                   and "thin conductor" in str(wi.message).lower() for wi in w), \
+        "#373: lossy thin conductor on NU must no longer warn-and-skip"
 
 
 def test_thin_conductor_graded_matches_matching_thickness_box_not_onecell():
@@ -310,3 +314,64 @@ def test_thin_conductor_graded_matches_matching_thickness_box_not_onecell():
     # zero-thickness sheet); on this graded profile it lands one layer away
     # (onecell_z=[16] vs sheet_z=[15]). That divergence is expected and correct,
     # not a placement bug — it is exactly what #371 originally mis-read as one.
+
+
+def test_lossy_thin_conductor_nonuniform_uses_local_dz():
+    """#373: a LOSSY (non-PEC) thin conductor on the non-uniform (dz_profile)
+    path folds into sigma using the LOCAL cell size normal to the sheet, not a
+    uniform grid.dx — so the sheet resistance R_s = 1/(sigma_bulk*t) is
+    preserved on a graded mesh. Before this, lossy sheets warned and were
+    silently skipped on the NU path.
+    """
+    import warnings
+    from rfx.api import Simulation
+    from rfx.runners.nonuniform import (build_nonuniform_grid,
+                                        assemble_materials_nu)
+
+    dx = 0.5e-3
+    dz = [0.5e-3] * 8 + [1.5e-3] * 8       # graded: coarse region has dz=3*dx
+    L = 24 * dx
+    zc = 8.0e-3                            # deep in the coarse (1.5mm) region
+    sigma_bulk, t = 1.0e3, 35e-6          # lossy: sigma_eff << PEC threshold
+
+    sim = Simulation(freq_max=10e9, domain=(L, L, 0), dx=dx, dz_profile=dz,
+                     boundary="cpml", cpml_layers=6)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        sim.add_thin_conductor(Box((6 * dx, 6 * dx, zc), (18 * dx, 18 * dx, zc)),
+                               sigma_bulk=sigma_bulk, thickness=t)
+        grid = build_nonuniform_grid(
+            sim._freq_max, sim._domain, sim._dx, sim._cpml_layers,
+            sim._dz_profile, dx_profile=sim._dx_profile,
+            dy_profile=sim._dy_profile,
+            pec_faces=(sim._boundary_spec.pec_faces()
+                       if sim._boundary_spec is not None else None),
+            pmc_faces=(sim._boundary_spec.pmc_faces()
+                       if sim._boundary_spec is not None else None),
+            cpml_axes="".join(a for a in "xyz"
+                              if a not in (sim._periodic_axes or "")))
+        sigma = np.asarray(assemble_materials_nu(sim, grid)[0].sigma)
+
+    assert not any("not yet supported" in str(wi.message).lower() for wi in w), \
+        "#373: lossy thin conductor on NU must no longer warn-and-skip"
+
+    nz = np.argwhere(sigma > 0)
+    assert len(nz) > 0, "#373: lossy thin conductor produced no sigma cells"
+    k = int(nz[0][2])
+    dz_local = float(np.asarray(grid.dz)[k])
+    assert abs(dz_local - 1.5e-3) < 1e-9, "sheet must land in the coarse region"
+    sigma_cell = float(sigma[tuple(nz[len(nz) // 2])])
+
+    # Uses LOCAL dz (1.5mm), NOT the uniform grid.dx (0.5mm, which would be 3x).
+    sigma_local = sigma_bulk * t / dz_local
+    sigma_uniform_bug = sigma_bulk * t / dx
+    assert abs(sigma_cell - sigma_local) / sigma_local < 1e-4, \
+        f"sigma_eff must use local dz ({sigma_local:.3e}), got {sigma_cell:.3e}"
+    assert abs(sigma_cell - sigma_uniform_bug) / sigma_uniform_bug > 0.5, \
+        "sigma_eff must NOT use the uniform grid.dx (the pre-fix bug)"
+
+    # Sheet resistance preserved: R_s = 1/(sigma_eff * dz_local) = 1/(sigma_bulk*t).
+    R_s = 1.0 / (sigma_cell * dz_local)
+    R_s_true = 1.0 / (sigma_bulk * t)
+    assert abs(R_s - R_s_true) / R_s_true < 1e-3, \
+        f"sheet resistance not preserved: {R_s:.3f} vs {R_s_true:.3f}"

--- a/tests/test_thin_conductor.py
+++ b/tests/test_thin_conductor.py
@@ -375,3 +375,63 @@ def test_lossy_thin_conductor_nonuniform_uses_local_dz():
     R_s_true = 1.0 / (sigma_bulk * t)
     assert abs(R_s - R_s_true) / R_s_true < 1e-3, \
         f"sheet resistance not preserved: {R_s:.3f} vs {R_s_true:.3f}"
+
+
+def test_lossy_thin_conductor_nonuniform_ad_gate():
+    """#373 AD gate (hard constraint): the lossy σ fold must stay on the
+    gradient path. Differentiate through assemble_materials_nu w.r.t. the
+    sheet thickness (thickness avoids the is_pec Python-bool routing on
+    sigma_bulk) and check the gradient is finite, non-zero, and matches the
+    closed form d/dt Σσ = n_cells · sigma_bulk / dz_local.
+    """
+    import jax
+    import jax.numpy as jnp
+    from rfx.api import Simulation
+    from rfx.materials.thin_conductor import ThinConductor
+    from rfx.runners.nonuniform import (build_nonuniform_grid,
+                                        assemble_materials_nu)
+
+    dx = 0.5e-3
+    dz = [0.5e-3] * 8 + [1.5e-3] * 8
+    L = 24 * dx
+    zc = 8.0e-3                      # coarse region, dz_local = 1.5mm
+    sigma_bulk, t0 = 1.0e3, 35e-6
+
+    sim = Simulation(freq_max=10e9, domain=(L, L, 0), dx=dx, dz_profile=dz,
+                     boundary="cpml", cpml_layers=6)
+    sim.add_thin_conductor(Box((6 * dx, 6 * dx, zc), (18 * dx, 18 * dx, zc)),
+                           sigma_bulk=sigma_bulk, thickness=t0)
+    shape = sim._thin_conductors[0].shape
+    grid = build_nonuniform_grid(
+        sim._freq_max, sim._domain, sim._dx, sim._cpml_layers, sim._dz_profile,
+        dx_profile=sim._dx_profile, dy_profile=sim._dy_profile,
+        pec_faces=(sim._boundary_spec.pec_faces()
+                   if sim._boundary_spec is not None else None),
+        pmc_faces=(sim._boundary_spec.pmc_faces()
+                   if sim._boundary_spec is not None else None),
+        cpml_axes="".join(a for a in "xyz"
+                          if a not in (sim._periodic_axes or "")))
+
+    # Closed form computed from the CONCRETE state first (before grad mutates
+    # the conductor): Σσ = n_cells · sigma_bulk · t / dz_local
+    # ⇒ dΣσ/dt = n_cells · sigma_bulk / dz_local.
+    sigma0 = np.asarray(assemble_materials_nu(sim, grid)[0].sigma)
+    n_cells = int((sigma0 > 0).sum())
+    k = int(np.argwhere(sigma0 > 0)[0][2])
+    dz_local = float(np.asarray(grid.dz)[k])
+    g_analytic = n_cells * sigma_bulk / dz_local
+
+    def loss(thickness):
+        sim._thin_conductors[0] = ThinConductor(
+            shape=shape, sigma_bulk=sigma_bulk, thickness=thickness)
+        return jnp.sum(assemble_materials_nu(sim, grid)[0].sigma)
+
+    g = float(jax.grad(loss)(t0))
+    # restore the concrete conductor so the mutated (traced) one does not leak.
+    sim._thin_conductors[0] = ThinConductor(
+        shape=shape, sigma_bulk=sigma_bulk, thickness=t0)
+
+    assert np.isfinite(g), "#373: gradient through the lossy σ fold is non-finite"
+    assert abs(g) > 0, "#373: gradient through the lossy σ fold is zero (fold off the AD path)"
+    assert abs(g - g_analytic) / g_analytic < 1e-3, \
+        f"#373: grad {g:.4e} != closed form {g_analytic:.4e}"


### PR DESCRIPTION
Resolves #373. Follow-up to #369/#370 (PEC thin conductors now work on the NU path); **lossy** (non-PEC, σ<1e6) thin conductors were still warning-and-skipping there.

## Root cause
`apply_thin_conductor` (thin_conductor.py:104) folds a lossy sheet as `sigma_eff = sigma_bulk * (thickness / grid.dx)` — assuming a **uniform** `grid.dx`. On a graded `dz_profile` the local cell size normal to the sheet ≠ `grid.dx`, so the fold is wrong; the NU path deliberately skipped lossy sheets rather than apply a wrong σ.

## Fix
`assemble_materials_nu` now folds each lossy thin conductor into `materials.sigma` using the **local cell size along the sheet's normal axis** (argmin of the Box extents → `grid.dx_arr`/`dy_arr`/`dz` at that axis), preserving the sheet resistance `R_s = 1/(sigma_bulk·t)` on any graded profile.

## Verification
- **Physics (R5):** a lossy sheet placed in a coarse (dz=1.5 mm) region of a graded profile folds to `sigma_eff = sigma_bulk·t/1.5mm = 23.3`, **not** the uniform-`grid.dx` value (70, 3× too high). `R_s = 1/(sigma_eff·dz_local) = 1/(sigma_bulk·t) = 28.57 Ω/sq` preserved.
- **AD (hard constraint):** `sigma_eff` is a smooth function of the `sigma_bulk·t` DoF × a grid constant; `jnp.where` keeps the AD-live σ field differentiable. NU grad/forward/grad_sparams suites green (17 passed).
- **Uniform bit-identity:** `assemble_materials_nu` is NU-only — the uniform path is untouched. thin_conductor + auto_config + nonuniform_api suites green; lint clean.
- **Tests:** `test_lossy_thin_conductor_nonuniform_uses_local_dz` (unit: local-dz + R_s + must-not-use-grid.dx) and the repurposed end-to-end run test (formerly the #370 warn-and-skip lock).

Non-Box lossy shapes still warn-and-skip (rare). Out of scope (issue #373 E-C corner, negligible): auto-mesh could fold a lossy *vertically-oriented* sheet into `z_features`; not touched (validated thin conductors are xy-sheets).

R3: memory=consistent (#373 filed; #370 warn was this fix's placeholder) | R2-attempts=0 (one clean verified implementation) | falsifier=the new local-dz/R_s test + the NU grad suite (AD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)