### PR TITLE
fix(csg): classify is_thin by local cell width, not forward centre-spacing (#374)

### DIFF
--- a/rfx/geometry/csg.py
+++ b/rfx/geometry/csg.py
@@ -96,10 +96,30 @@ class Box:
             if coords.size <= 1:             # static (shape, not values)
                 dc_local = 1e-3
             else:
-                # Local dc from the midpoint's neighbouring cell spacing.
+                # Local cell WIDTH at the midpoint cell — the smaller of the two
+                # neighbouring centre-to-centre spacings, NOT the single forward
+                # spacing coords[k+1]-coords[k] the legacy code used (#374). At a
+                # fine/coarse grading transition the forward spacing is the mean
+                # of the two adjacent widths and over-counts, mis-classifying a
+                # shape that spans >1 fine cell as thin (which then collapses it
+                # onto a single argmin cell, losing extent). ``min`` is exact for
+                # interior cells and the fine side of a transition, and errs on
+                # the safe side (toward the volume branch, preserving extent) on
+                # the coarse side. Exact cell widths are not recoverable from
+                # centres alone; a fully exact classification would need the
+                # grid's per-cell width array threaded through mask_on_coords.
+                # On a uniform axis s_left==s_right==dx so this is bit-identical
+                # to the legacy centre-spacing.
                 k_mid = jnp.clip(
                     jnp.searchsorted(coords, mid) - 1, 0, coords.size - 2)
-                dc_local = coords[k_mid + 1] - coords[k_mid]
+                im1 = jnp.clip(k_mid - 1, 0, coords.size - 1)
+                ip1 = jnp.clip(k_mid + 1, 0, coords.size - 1)
+                s_left = coords[k_mid] - coords[im1]    # 0 at the lo end
+                s_right = coords[ip1] - coords[k_mid]   # 0 at the hi end
+                dc_local = jnp.where(
+                    (s_left > 0) & (s_right > 0),
+                    jnp.minimum(s_left, s_right),
+                    jnp.maximum(s_left, s_right))
             # Thin sheet: the single cell whose centre is nearest ``mid``.
             # (#371) On the collocated scheme, apply_pec_mask zeros tangential
             # Ex/Ey at this cell's CENTRE, so nearest-centre = minimum realized-

--- a/tests/test_thin_conductor.py
+++ b/tests/test_thin_conductor.py
@@ -435,3 +435,42 @@ def test_lossy_thin_conductor_nonuniform_ad_gate():
     assert abs(g) > 0, "#373: gradient through the lossy σ fold is zero (fold off the AD path)"
     assert abs(g - g_analytic) / g_analytic < 1e-3, \
         f"#373: grad {g:.4e} != closed form {g_analytic:.4e}"
+
+
+def test_is_thin_classification_uses_local_cell_width():
+    """#374: Box.mask_on_coords classifies thin-vs-volume by the LOCAL cell
+    width (min of the two neighbouring centre spacings), not the single forward
+    spacing. Bit-identical on a uniform axis; on a graded axis it no longer
+    over-counts the cell size at a fine/coarse transition (which collapsed a
+    >1-fine-cell shape onto a single argmin cell).
+    """
+    import jax.numpy as jnp
+    from rfx.geometry.csg import Box
+
+    zero = jnp.zeros(1)
+
+    def n_cells(coords, lo, hi):
+        m = np.asarray(Box((0, 0, lo), (0, 0, hi)).mask_on_coords(zero, zero, coords))
+        return int(m.sum())
+
+    # --- Uniform axis: unchanged (thin <= 1 cell, volume otherwise) ---
+    xu = jnp.asarray(np.arange(20) * 1e-3 + 0.5e-3)   # 1mm cells, centres at k+0.5
+    assert n_cells(xu, 5e-3, 5.2e-3) == 1              # sub-cell sheet → 1
+    assert n_cells(xu, 5e-3, 7.5e-3) == 2              # 2.5mm span → volume, 2 centres
+
+    # --- Graded axis: fine 0.5mm (cells 0-7) then coarse 1.5mm (cells 8-15) ---
+    dz = np.array([0.5e-3] * 8 + [1.5e-3] * 8)
+    edges = np.concatenate([[0.0], np.cumsum(dz)])
+    zc = jnp.asarray(0.5 * (edges[:-1] + edges[1:]))
+    zc_np = np.asarray(zc)
+
+    # A genuine sub-cell sheet still resolves to exactly one cell (the nearest).
+    z0 = 2.75e-3                                       # a fine-region centre
+    assert n_cells(zc, z0, z0) == 1
+    k = int(np.argmin(np.abs(zc_np - z0)))
+    m = np.asarray(Box((0, 0, z0), (0, 0, z0)).mask_on_coords(zero, zero, zc))
+    assert int(np.argwhere(m)[0][2]) == k             # z-index lands on nearest cell
+
+    # The local cell width at a fine-region centre is the fine size (0.5mm), so a
+    # 1.2mm-extent box there spans multiple fine cells (volume), not one.
+    assert n_cells(zc, 2.0e-3, 3.2e-3) >= 2


### PR DESCRIPTION
Resolves #374 (surfaced non-blocking during the #371 review).

## Problem
`Box.mask_on_coords._axis_mask` chose thin-vs-volume with `dc_local = coords[k+1] - coords[k]` — the single **forward** centre-to-centre spacing. Near a fine/coarse `dz_profile` transition that equals the **mean** of two adjacent cell widths, over-counting the local cell size, so a shape spanning >1 fine cell can be mis-classified as thin and collapsed onto a single argmin cell (losing extent).

## Fix
Use `min(s_left, s_right)` of the two neighbouring centre spacings as the local cell width. Exact for interior cells and the fine side of a transition; on the coarse side it under-counts, erring toward the **volume** branch (preserving extent) rather than collapsing. **Bit-identical on a uniform axis** (`s_left == s_right == dx`). A fully exact classification is not recoverable from cell centres alone and would need the grid's per-cell width array threaded through `mask_on_coords` (documented; larger change, out of scope). Thin-sheet **placement** is unchanged (argmin nearest-centre, #371).

## Gates
- **Uniform bit-identity:** geometry + thin_conductor suites green (14).
- **No rasterization / AD regression:** nonuniform_api + nonuniform_gradient + subpixel green (30); mask stays boolean/traceable.
- New test `test_is_thin_classification_uses_local_cell_width` (uniform bit-identity + graded local-width). Lint clean.

R3: memory=consistent (#374 filed; #371 established placement unaffected) | R2-attempts=0 | falsifier=the new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)