### PR TITLE
test(#325): lock the uniform-fine substrate grid build; fail-closed on the split geometries

### DIFF
--- a/scripts/diagnostics/patch_uniform_fine_fr4_witness.py
+++ b/scripts/diagnostics/patch_uniform_fine_fr4_witness.py
@@ -1,0 +1,142 @@
+"""#325 §1-B — the physics-decisive falsifier: does the UNIFORM-FINE substrate
+build give a single clean fundamental at the cv05 FR4 operating point (vs the
+mode-split the FIRED STOP-1 graded 6-cell re-registration produced)?
+
+The grid-build lock (tests/test_issue325_uniform_fine_substrate.py) proved the
+geometry rasterizes to 6 fine cells with the grading transition held clear. This
+runs the ACTUAL FDTD harminv at the cv05 FR4 point (eps_r=4.3, 38x29.5mm patch,
+60x55mm GP, 1.5mm/6-cell substrate) at two buffer widths (N_BUF=8, 16); the
+substrate is identical, only the transition-z moves. A physical mode is
+buffer-invariant; a transition artifact moves/splits.
+
+PRE-DECLARED FALSIFIER (one R2 attempt, terminates either way):
+  CLEAN  -> adopt uniform-fine: each buffer yields ONE dominant fundamental
+           (amp >= 3x any peak OUTSIDE the known TM-family band 2.9-3.2 GHz),
+           buffer-invariant |df| <= 1.5% across N_BUF 8<->16, in the predeclared
+           band ~2.35-2.48 GHz (analytic minus the ~2.9% dx=1mm staircase, since
+           the committed coarse-clean +2.65% is a z-under-res/staircase
+           cancellation and fixing z-under-res should drop f_res below 2.5528).
+  SPLIT  -> mechanism DEAD, STOP (R2): comparable-amplitude peaks near
+           2.14/2.65/3.45 (pairwise < 3x, no single dominant) OR the dominant
+           moves > 2% across buffers. No third mesh variant; escalate to a
+           uniform-cubic stack (architecture), OR document coarse-clean as the
+           supported config (both are note-sanctioned #325 resolutions).
+
+Settling: until_decay + a -40 dB energy witness inline (a Q~55 patch needs it).
+CPU-only, no openEMS. Run:
+  PYTHONPATH=$(git rev-parse --show-toplevel) \
+  PT_FINE_BUFFER_CELLS=8  python scripts/diagnostics/patch_uniform_fine_fr4_witness.py
+"""
+import os
+import json
+
+import numpy as np
+
+os.environ.setdefault("JAX_PLATFORM_NAME", "cpu")
+from rfx import Simulation, Box  # noqa: E402
+from rfx.boundaries.spec import BoundarySpec  # noqa: E402
+from rfx.sources.sources import GaussianPulse  # noqa: E402
+from rfx.auto_config import smooth_grading  # noqa: E402
+from rfx.harminv import harminv  # noqa: E402
+
+C0 = 2.998e8
+# cv05 FR4 operating point
+EPS_R = 4.3
+H_SUB = 1.5e-3
+N_SUB = 6
+DZ_SUB = H_SUB / N_SUB
+DX = 1.0e-3
+W, L = 38.0e-3, 29.5e-3          # patch
+GX, GY = 60.0e-3, 55.0e-3        # ground plane
+PROBE_INSET = 8.0e-3
+N_CPML = 8
+N_BUF = int(os.environ.get("PT_FINE_BUFFER_CELLS", "8"))
+OUTDIR = "scripts/diagnostics/cv05_investigation_results"
+
+
+def build():
+    n_below, n_above = 12, 25
+    raw = np.concatenate([
+        np.full(n_below, DX),
+        np.full(N_BUF + 1 + N_SUB + 1 + N_BUF, DZ_SUB),
+        np.full(n_above, DX),
+    ])
+    dz = smooth_grading(raw, max_ratio=1.3)
+    edges = np.insert(np.cumsum(dz), 0, 0.0)
+    fi = np.where(np.isclose(dz, DZ_SUB, rtol=1e-6))[0]
+    f0 = int(fi[0]) + N_BUF
+    z_gnd_lo, z_gnd_hi = float(edges[f0]), float(edges[f0 + 1])
+    z_sub_lo, z_sub_hi = float(edges[f0 + 1]), float(edges[f0 + 1 + N_SUB])
+    z_patch_lo, z_patch_hi = z_sub_hi, float(edges[f0 + 1 + N_SUB + 1])
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    sub_cells = int(np.sum((centers >= z_sub_lo) & (centers < z_sub_hi)))
+    assert sub_cells == N_SUB, f"substrate {sub_cells} != {N_SUB} cells"
+
+    dom_x, dom_y = GX + 20e-3, GY + 20e-3
+    gx_lo, gy_lo = (dom_x - GX) / 2, (dom_y - GY) / 2
+    gx_hi, gy_hi = gx_lo + GX, gy_lo + GY
+    px_lo, px_hi = dom_x / 2 - L / 2, dom_x / 2 + L / 2
+    py_lo, py_hi = dom_y / 2 - W / 2, dom_y / 2 + W / 2
+    feed_x, feed_y = px_lo + PROBE_INSET, dom_y / 2
+
+    sim = Simulation(freq_max=4e9, domain=(dom_x, dom_y, 0), dx=DX,
+                     dz_profile=dz, boundary=BoundarySpec.uniform("cpml"),
+                     cpml_layers=N_CPML)
+    sim.add_material("fr4", eps_r=EPS_R, sigma=0.0)
+    sim.add(Box((gx_lo, gy_lo, z_gnd_lo), (gx_hi, gy_hi, z_gnd_hi)), material="pec")
+    sim.add(Box((gx_lo, gy_lo, z_sub_lo), (gx_hi, gy_hi, z_sub_hi)), material="fr4")
+    sim.add(Box((px_lo, py_lo, z_patch_lo), (px_hi, py_hi, z_patch_hi)), material="pec")
+    src_z = z_sub_lo + DZ_SUB * 2.5
+    sim.add_source(position=(feed_x, feed_y, src_z), component="ez",
+                   waveform=GaussianPulse(f0=2.4e9, bandwidth=1.2))
+    sim.add_probe(position=(feed_x + 4e-3, feed_y + 4e-3, src_z), component="ez")
+    return sim, z_sub_lo, z_sub_hi
+
+
+def main():
+    eps_eff = (EPS_R + 1) / 2 + (EPS_R - 1) / 2 * (1 + 12 * H_SUB / W) ** -0.5
+    dl = 0.412 * H_SUB * ((eps_eff + 0.3) * (W / H_SUB + 0.264)) / \
+        ((eps_eff - 0.258) * (W / H_SUB + 0.8))
+    f_an = C0 / (2 * (L + 2 * dl) * np.sqrt(eps_eff))
+    print(f"#325 §1-B uniform-fine FR4 witness | N_BUF={N_BUF} | "
+          f"analytic f_res={f_an/1e9:.4f} GHz")
+
+    sim, z_sub_lo, z_sub_hi = build()
+    res = sim.run(num_periods=200, skip_preflight=True)
+    ts = np.asarray(res.time_series).ravel()
+    dt = float(res.dt)
+    amp = np.abs(ts)
+    peak = float(amp[int(len(amp) * 0.15):].max())
+    end = float(amp[-max(1, len(amp) // 20):].mean())
+    settle_db = 20 * np.log10(end / peak) if peak > 0 and end > 0 else float("-inf")
+    print(f"  settling: end/peak = {settle_db:.1f} dB "
+          f"({'OK' if settle_db < -40 else 'UNDERSETTLED'})")
+
+    sig = ts[int(len(ts) * 0.3):]
+    sig = sig - sig.mean()
+    modes = [m for m in harminv(sig, dt, 1.5e9, 3.6e9)
+             if m.Q > 3 and m.amplitude > 1e-8]
+    modes.sort(key=lambda m: -m.amplitude)
+    print(f"  harminv modes (by amp): "
+          f"{[(round(m.freq/1e9, 4), round(m.Q, 1), float(f'{m.amplitude:.2e}')) for m in modes[:6]]}")
+    dom = modes[0] if modes else None
+    if dom is not None:
+        outside = [m for m in modes if not (2.9e9 <= m.freq <= 3.2e9)
+                   and m is not dom]
+        ratio = dom.amplitude / max((m.amplitude for m in outside), default=1e-30)
+        print(f"  DOMINANT: f={dom.freq/1e9:.4f} GHz Q={dom.Q:.1f} "
+              f"amp-ratio-vs-outside-TM-band={ratio:.1f}x")
+    out = dict(n_buf=N_BUF, analytic_ghz=round(f_an / 1e9, 4),
+               settle_db=round(settle_db, 1),
+               dominant_ghz=round(dom.freq / 1e9, 4) if dom else None,
+               dominant_Q=round(dom.Q, 1) if dom else None,
+               modes=[[round(m.freq / 1e9, 4), round(m.Q, 1), m.amplitude]
+                      for m in modes[:8]])
+    os.makedirs(OUTDIR, exist_ok=True)
+    path = f"{OUTDIR}/uniform_fine_fr4_nbuf{N_BUF}.json"
+    json.dump(out, open(path, "w"), indent=1)
+    print(f"  WROTE {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_issue325_uniform_fine_substrate.py
+++ b/tests/test_issue325_uniform_fine_substrate.py
@@ -1,0 +1,118 @@
+"""#325 grid-build lock: the patch substrate must rasterize to a UNIFORM-FINE
+band with the coarse<->fine grading transition held clear of the resonator.
+
+Background: cv05 (05_patch_antenna.py) placed the ground/substrate/patch stack at
+a FIXED pre-smoothing z (`air_below = 12mm`) while `smooth_grading` inserts
+transition cells that shift the fine band up — so the 1.5mm FR4 substrate built as
+2 coarse cells / 1.361mm, not 6 fine cells (#325). Re-registering the stack onto a
+6-cell band that sits ADJACENT to a grading transition was a FIRED STOP (research
+note 20260711): the transition-adjacent substrate splits the mode (2.14/2.65/3.45)
+and makes the openEMS agreement WORSE (2.65% -> 6.45%).
+
+The correct build (verified in scripts/diagnostics/patch_tutorial_rfx.py::build):
+DERIVE the stack z from where `smooth_grading` actually places the fine band, and
+insert uniform-fine BUFFER cells so the transition sits away from the resonator.
+This test locks that: substrate == n_sub fine cells AND no transition cell within
+CLEARANCE_MIN of the stack. It FAILS on the committed cv05 geometry (2 cells) and
+on the STOP-1 zero-buffer re-registration (transition adjacent) — a fails-closed
+guard so neither broken geometry can be committed silently. No FDTD / no openEMS.
+"""
+import numpy as np
+import pytest
+
+from rfx.auto_config import smooth_grading
+
+DX = 1.0e-3
+H_SUB = 1.5e-3
+N_SUB = 6
+DZ_SUB = H_SUB / N_SUB          # 0.25 mm
+N_BELOW, N_ABOVE = 12, 25
+CLEARANCE_MIN = 2.0e-3          # transition must sit >= 2mm from the stack
+
+
+def build_uniform_fine_z(n_buf, dx=DX, dz_sub=DZ_SUB, n_sub=N_SUB,
+                         n_below=N_BELOW, n_above=N_ABOVE):
+    """Uniform-fine substrate z-mesh + stack coordinates DERIVED from the built
+    grid (imitates scripts/diagnostics/patch_tutorial_rfx.py::build, the verified
+    #325 fix). Returns (dz_profile, z_gnd_lo, z_sub_lo, z_sub_hi, z_patch_hi,
+    sub_cells).
+
+    n_buf uniform-fine buffer cells on each side of the (1 GP + n_sub + 1 patch)
+    stack push the coarse<->fine grading transition n_buf cells away.
+    """
+    raw = np.concatenate([
+        np.full(n_below, dx),
+        np.full(n_buf + 1 + n_sub + 1 + n_buf, dz_sub),
+        np.full(n_above, dx),
+    ])
+    dz = smooth_grading(raw, max_ratio=1.3)
+    edges = np.insert(np.cumsum(dz), 0, 0.0)
+    fi = np.where(np.isclose(dz, dz_sub, rtol=1e-6))[0]
+    assert len(fi) >= 2 + n_sub + 2 * n_buf, \
+        f"expected >= {2 + n_sub + 2 * n_buf} fine cells, got {len(fi)}"
+    f0 = int(fi[0]) + n_buf
+    z_gnd_lo = float(edges[f0])
+    z_sub_lo = float(edges[f0 + 1])
+    z_sub_hi = float(edges[f0 + 1 + n_sub])
+    z_patch_hi = float(edges[f0 + 1 + n_sub + 1])
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    sub_cells = int(np.sum((centers >= z_sub_lo) & (centers < z_sub_hi)))
+    return dz, z_gnd_lo, z_sub_lo, z_sub_hi, z_patch_hi, sub_cells
+
+
+def _transition_clearance(dz, z_lo, z_hi, dx=DX, dz_sub=DZ_SUB):
+    """Nearest grading-transition cell (size not in {dz_sub, dx}) to [z_lo, z_hi]."""
+    edges = np.insert(np.cumsum(dz), 0, 0.0)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    is_trans = ~(np.isclose(dz, dz_sub, rtol=1e-6) | np.isclose(dz, dx, rtol=1e-6))
+    tc = centers[is_trans]
+    if not len(tc):
+        return np.inf
+    return float(min(np.min(np.abs(tc - z_lo)), np.min(np.abs(tc - z_hi))))
+
+
+@pytest.mark.parametrize("n_buf", [8, 12, 16])
+def test_uniform_fine_substrate_builds_n_sub_cells_with_clearance(n_buf):
+    """The uniform-fine build rasterizes the substrate to exactly N_SUB fine
+    cells AND keeps every grading transition >= CLEARANCE_MIN from the stack."""
+    dz, z_gnd_lo, z_sub_lo, z_sub_hi, z_patch_hi, sub_cells = \
+        build_uniform_fine_z(n_buf)
+    assert sub_cells == N_SUB, \
+        f"substrate must build {N_SUB} fine cells, got {sub_cells} (N_BUF={n_buf})"
+    assert abs((z_sub_hi - z_sub_lo) - H_SUB) < 1e-9, \
+        f"substrate thickness {(z_sub_hi - z_sub_lo)*1e3:.4f}mm != {H_SUB*1e3}mm"
+    clr = _transition_clearance(dz, z_gnd_lo, z_patch_hi)
+    assert clr >= CLEARANCE_MIN, \
+        f"grading transition too close to the resonator: {clr*1e3:.2f}mm < {CLEARANCE_MIN*1e3}mm (N_BUF={n_buf})"
+
+
+def test_committed_cv05_geometry_fails_the_lock():
+    """Fails-closed guard: the committed cv05 geometry (fixed air_below=12mm, no
+    buffer) rasterizes the substrate to 2 coarse cells — the lock must reject it."""
+    raw = np.concatenate([
+        np.full(N_BELOW, DX), np.full(1, DZ_SUB), np.full(N_SUB, DZ_SUB),
+        np.full(N_ABOVE, DX),
+    ])
+    dz = smooth_grading(raw, max_ratio=1.3)
+    edges = np.insert(np.cumsum(dz), 0, 0.0)
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    # cv05 places the substrate at the FIXED intended z = [12, 13.5] mm
+    sub_cells = int(np.sum((centers >= 12e-3) & (centers < 13.5e-3)))
+    assert sub_cells != N_SUB, \
+        "committed cv05 geometry unexpectedly builds N_SUB cells — the #325 bug " \
+        "would be gone and this guard is stale"
+    assert sub_cells == 2, \
+        f"the #325 bug should build exactly 2 coarse cells, got {sub_cells}"
+
+
+def test_zero_buffer_reregistration_has_no_clearance():
+    """Fails-closed guard against STOP-1: registering 6 fine cells with NO buffer
+    (transition adjacent to the resonator) — the split-mode geometry — must be
+    rejected by the clearance check even though its cell COUNT is correct."""
+    dz, z_gnd_lo, z_sub_lo, z_sub_hi, z_patch_hi, sub_cells = \
+        build_uniform_fine_z(n_buf=0)
+    assert sub_cells == N_SUB   # count is right...
+    clr = _transition_clearance(dz, z_gnd_lo, z_patch_hi)
+    assert clr < CLEARANCE_MIN, \
+        f"zero-buffer re-registration should have ~0 clearance (STOP-1 geometry), " \
+        f"got {clr*1e3:.2f}mm — the clearance guard is not discriminating"

--- a/tests/test_issue325_uniform_fine_substrate.py
+++ b/tests/test_issue325_uniform_fine_substrate.py
@@ -88,7 +88,16 @@ def test_uniform_fine_substrate_builds_n_sub_cells_with_clearance(n_buf):
 
 def test_committed_cv05_geometry_fails_the_lock():
     """Fails-closed guard: the committed cv05 geometry (fixed air_below=12mm, no
-    buffer) rasterizes the substrate to 2 coarse cells — the lock must reject it."""
+    buffer) rasterizes the substrate to 2 coarse cells — the lock must reject it.
+
+    NOTE (drift risk, PR #379 review): cv05's z-mesh is inline module-level code
+    (`05_patch_antenna.py`), not an importable function, so this test HAND-COPIES
+    cv05's raw_dz construction (N_BELOW=12, N_ABOVE=25, DX=1mm, fixed substrate
+    z=[12,13.5]mm — verified matching today). If cv05's air_below/dx/n_sub ever
+    change, this frozen copy would silently stop reflecting cv05. When cv05 adopts
+    build_uniform_fine_z (pending the §1-B physics witness), refactor this to
+    import cv05's real construction so the guard tracks the live geometry.
+    """
     raw = np.concatenate([
         np.full(N_BELOW, DX), np.full(1, DZ_SUB), np.full(N_SUB, DZ_SUB),
         np.full(N_ABOVE, DX),


### PR DESCRIPTION
First deliverable of the #325/#330 patch-validation redesign (design workflow + adversarial critics). A **@fast grid-build lock — no FDTD, no openEMS**.

## Root cause (verified)
cv05 places the ground/substrate/patch stack at a FIXED pre-smoothing z (`air_below=12mm`, `05_patch_antenna.py:138,161-163`) while `smooth_grading` inserts transition cells that shift the fine band up — so the 1.5mm FR4 substrate builds as **2 coarse cells, not 6 fine cells** (#325).

## The lock
Imitates the verified, already-run z-derivation in `scripts/diagnostics/patch_tutorial_rfx.py::build` (NOT reinvented — the external-example rule): DERIVE the stack z from where `smooth_grading` actually put the fine band, and add uniform-fine BUFFER cells so the coarse↔fine transition sits clear of the resonator.

| geometry | substrate cells | transition clearance | lock |
|---|---|---|---|
| uniform-fine N_BUF=8/12/16 | **6** (1.500mm) | 2.13 / 3.13 / 4.13 mm | **PASS** |
| committed cv05 (fixed air_below) | 2 coarse | — | **FAIL** (the #325 bug) |
| zero-buffer 6-cell re-registration | 6 | ~0 (adjacent) | **FAIL** (fired STOP-1) |

The zero-buffer 6-cell case is the **fired STOP-1** (research note 20260711: transition-adjacent substrate splits the mode 2.14/2.65/3.45 and worsens openEMS 2.65%→6.45%). It appears here **only as a rejection guard** — a fails-closed check so that broken geometry can't be committed silently.

## Discipline
- **Does NOT reopen STOP-1**: uniform-fine (buffered) is the note-sanctioned correct direction, genuinely untried; the zero-buffer case is a guard, not an attempt.
- The **physics-decisive** step (does the buffered geometry give a single clean fundamental at the cv05 FR4 point, vs still split) is the staged **@slow two-buffer invariance witness (§1-B)**, not this grid-only lock.

## Verification
5 passed in 0.69s, ruff clean.

R3: memory=consistent (encodes the 20260711 STOP as a guard; #325 correct-direction; imitates patch_tutorial_rfx) | R2-attempts=0 (no STOP reopened) | falsifier=lock PASSES uniform-fine, FAILS committed + STOP-1 (shown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)