### PR TITLE
fix(examples): nonuniform_patch_demo now implements the #325 lesson it claimed to teach (#381)

### DIFF
--- a/examples/tutorials/nonuniform_patch_demo.py
+++ b/examples/tutorials/nonuniform_patch_demo.py
@@ -2,22 +2,35 @@
 
 A 2.4 GHz FR4 patch antenna has a 1.5 mm substrate inside a ~100 mm domain —
 uniform cells fine enough for the substrate would waste millions of cells in
-air. This tutorial shows the practical recipe:
+air.  This tutorial shows the practical recipe AND the trap that comes with it:
 
-  - build a GRADED z mesh (``dz_profile``: fine cells across the substrate,
-    coarser in the air) with ``smooth_grading``,
-  - drive it with a broadband Gaussian Ez source and read an Ez probe,
-  - extract the resonance with ``harminv``.
+  Rule 1 — REGISTER GEOMETRY TO THE BUILT MESH, NOT THE INTENDED ONE (#325).
+     ``smooth_grading`` inserts transition cells that SHIFT the fine band in
+     absolute z.  A substrate Box placed at pre-smoothing coordinates silently
+     rasterizes onto coarse cells (here: 2 coarse cells instead of 6 fine —
+     demonstrated below, with the realized cell layout printed for both the
+     broken and the fixed placement).  The fix: derive every layer's z from
+     where the built ``dz_profile`` actually put the fine cells, keep a
+     uniform-fine BUFFER so the grading transition sits clear of the
+     resonator, and assert the realized cell count.  The committed lock for
+     this pattern is ``tests/test_issue325_uniform_fine_substrate.py``.
 
-Two rules this workflow teaches:
-  1. After ``smooth_grading``, VERIFY where your thin layers actually landed —
-     transition cells shift the fine band, and a substrate placed by absolute
-     z can silently rasterize onto coarse cells. ``sim.preflight()`` warns
-     about this (graded-box-rasterization advisory); this script prints the
-     realized cell layout so you can see it.
-  2. Non-uniform meshing trades accuracy for cells: at matched dx a graded
-     mesh is NOT more accurate than uniform — use it to make big problems
-     tractable, not to chase digits.
+  Rule 2 — NU TRADES ACCURACY FOR CELLS.  At matched dx a graded mesh is NOT
+     more accurate than uniform — use it to make big problems tractable, not
+     to chase digits.
+
+  Rule 3 — A PROPERLY RESOLVED PATCH IS MULTI-MODE.  Once the substrate is
+     truly 6 cells, harminv shows the patch's real modes (TM01 on the 38 mm
+     width and TM10 on the 29.5 mm length at comparable amplitude, plus a
+     higher mode).  Picking "the mode closest to the textbook estimate" is
+     mode-AMBIGUOUS; identifying the RADIATING mode needs the far field —
+     see ``examples/tutorials/patch_antenna_demo.py`` for that workflow.
+     This script prints the full mode list and does not gate on any single
+     frequency.
+
+Runtime: ~13 min on CPU (measured 783 s; the num_periods=120 FDTD run
+dominates and settles to -40.8 dB.  The mesh lesson itself — parts [1]-[3] —
+is grid-only arithmetic and costs nothing).
 
 Run:
   python examples/tutorials/nonuniform_patch_demo.py
@@ -43,30 +56,33 @@ OUT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 os.makedirs(OUT_DIR, exist_ok=True)
 
 # =============================================================================
-# Geometry constants (identical to 05_patch_antenna.py)
+# Geometry constants (identical to validation/crossval/05_patch_antenna.py)
 # =============================================================================
 f_design  = 2.4e9
 eps_r     = 4.3
 h_sub     = 1.5e-3
-W         = 38.0e-3
-L         = 29.5e-3
+W         = 38.0e-3            # patch width  (y)  -> TM01 resonant length
+L         = 29.5e-3            # patch length (x)  -> TM10 resonant length
 gx        = 60.0e-3
 gy        = 55.0e-3
 air_above = 25.0e-3
 air_below = 12.0e-3
 probe_inset = 8.0e-3
 
-dx   = 1.0e-3
+dx     = 1.0e-3
 n_cpml = 8
 n_sub  = 6
 dz_sub = h_sub / n_sub          # 0.25 mm
+n_buf  = 8                      # uniform-fine buffer cells on EACH side of the
+                                # stack: pushes the grading transition ~2 mm
+                                # clear of the resonator (the lock test checks
+                                # n_buf = 8/12/16 all give >= 2 mm clearance).
 
 n_below = int(math.ceil(air_below / dx))
 n_above = int(math.ceil(air_above / dx))
 
 dom_x = gx + 2 * 10e-3
 dom_y = gy + 2 * 10e-3
-dom_z = air_below + h_sub + air_above
 
 gx_lo = (dom_x - gx) / 2;  gx_hi = gx_lo + gx
 gy_lo = (dom_y - gy) / 2;  gy_hi = gy_lo + gy
@@ -75,15 +91,10 @@ patch_y_lo = dom_y / 2 - W / 2;  patch_y_hi = dom_y / 2 + W / 2
 feed_x = patch_x_lo + probe_inset
 feed_y = dom_y / 2
 
-z_gnd_lo  = air_below - dz_sub
-z_gnd_hi  = air_below
-z_sub_lo  = air_below
-z_sub_hi  = air_below + h_sub
-z_patch_lo = z_sub_hi
-z_patch_hi = z_sub_hi + dz_sub
-
 # =============================================================================
-# Analytic reference (Balanis, Ch. 14)
+# Analytic reference (Balanis, Ch. 14) — PRINTED REFERENCE ONLY, not a gate:
+# the transmission-line model is 5-8 % approximate for finite ground planes,
+# and (Rule 3) no single-frequency comparison identifies the radiating mode.
 # =============================================================================
 eps_eff = (eps_r + 1) / 2 + (eps_r - 1) / 2 * (1 + 12 * h_sub / W) ** (-0.5)
 delta_L = 0.412 * h_sub * ((eps_eff + 0.3) * (W / h_sub + 0.264)) / \
@@ -91,39 +102,121 @@ delta_L = 0.412 * h_sub * ((eps_eff + 0.3) * (W / h_sub + 0.264)) / \
 f_an = C0 / (2 * (L + 2 * delta_L) * math.sqrt(eps_eff))
 
 print("=" * 60)
-print("Nonuniform-mesh patch antenna demo — NU runner validation")
+print("Nonuniform-mesh patch demo — register geometry to the BUILT mesh")
 print("=" * 60)
-print(f"  Patch: W={W*1e3:.1f} mm, L={L*1e3:.1f} mm, εr={eps_r}")
-print(f"  Analytic f_res = {f_an/1e9:.4f} GHz")
+print(f"  Patch: W={W*1e3:.1f} mm (TM01), L={L*1e3:.1f} mm (TM10), εr={eps_r}")
+print(f"  Balanis TM10 estimate ≈ {f_an/1e9:.4f} GHz "
+      f"(approximate reference, not a gate)")
+
+
+def realized_layout(dz_profile, layers):
+    """Print the REALIZED per-layer cell layout for a built dz profile.
+
+    ``layers`` is a list of (name, z_lo, z_hi, intended_cells).  A cell
+    belongs to a layer when its centre falls inside [z_lo, z_hi).  Returns
+    True when every layer realized its intended cell count.
+    """
+    edges = np.concatenate([[0.0], np.cumsum(dz_profile)])
+    centers = 0.5 * (edges[:-1] + edges[1:])
+    print(f"  {'layer':<10} {'intended':>8} {'realized':>8}   "
+          f"realized span / cell sizes")
+    ok = True
+    for name, z_lo, z_hi, intended in layers:
+        idx = np.where((centers >= z_lo) & (centers < z_hi))[0]
+        sizes = ", ".join(f"{dz_profile[i]*1e3:.3f}" for i in idx) or "-"
+        span = (f"[{edges[idx[0]]*1e3:.2f}, {edges[idx[-1]+1]*1e3:.2f}] mm"
+                if len(idx) else "(no cells)")
+        flag = "" if len(idx) == intended else "   <-- MISREGISTERED"
+        if len(idx) != intended:
+            ok = False
+        print(f"  {name:<10} {intended:>8} {len(idx):>8}   "
+              f"{span}  dz = {sizes} mm{flag}")
+    return ok
+
 
 # =============================================================================
-# Non-uniform z mesh
+# PART 1 — THE TRAP (grid-only, costs nothing): place the stack at the
+# INTENDED pre-smoothing z and look at what actually rasterizes.
 # =============================================================================
-raw_dz = np.concatenate([
+print("\n[1] THE TRAP — geometry at fixed pre-smoothing z:")
+raw_dz_naive = np.concatenate([
     np.full(n_below, dx),       # air below GP
     np.full(1, dz_sub),         # GP cell
     np.full(n_sub, dz_sub),     # substrate
     np.full(n_above, dx),       # air above patch
 ])
-dz_profile = smooth_grading(raw_dz, max_ratio=1.3)
+dz_naive = smooth_grading(raw_dz_naive, max_ratio=1.3)
+# The intended coordinates ignore the transition cells smooth_grading inserted:
+naive_layers = [
+    ("ground",    air_below - dz_sub, air_below,                  1),
+    ("substrate", air_below,          air_below + h_sub,          n_sub),
+    ("patch",     air_below + h_sub,  air_below + h_sub + dz_sub, 1),
+]
+naive_ok = realized_layout(dz_naive, naive_layers)
+print("  => smooth_grading inserted transition cells BELOW the fine band and "
+      "shifted it up;\n     a Box at the intended z lands on coarse cells "
+      "(issue #325 — preflight's\n     graded-box-rasterization advisory "
+      "warns about exactly this class).")
+assert not naive_ok, "expected the naive placement to misregister (the lesson)"
 
-# Uniform-equivalent cell count (if everything at dz_sub)
+# =============================================================================
+# PART 2 — THE FIX: buffered fine band + z DERIVED from the built profile.
+# (Same pattern as tests/test_issue325_uniform_fine_substrate.py::
+#  build_uniform_fine_z and scripts/diagnostics/patch_tutorial_rfx.py.)
+# =============================================================================
+print("\n[2] THE FIX — buffered fine band, z derived from the built mesh:")
+raw_dz = np.concatenate([
+    np.full(n_below, dx),
+    np.full(n_buf + 1 + n_sub + 1 + n_buf, dz_sub),  # buf+GP+sub+patch+buf
+    np.full(n_above, dx),
+])
+dz_profile = smooth_grading(raw_dz, max_ratio=1.3)
+edges = np.concatenate([[0.0], np.cumsum(dz_profile)])
+fi = np.where(np.isclose(dz_profile, dz_sub, rtol=1e-6))[0]
+assert len(fi) >= 2 + n_sub + 2 * n_buf, \
+    f"fine band lost: expected >= {2 + n_sub + 2*n_buf} fine cells, got {len(fi)}"
+f0 = int(fi[0]) + n_buf                    # skip the lower buffer cells
+z_gnd_lo,   z_gnd_hi   = float(edges[f0]),     float(edges[f0 + 1])
+z_sub_lo,   z_sub_hi   = float(edges[f0 + 1]), float(edges[f0 + 1 + n_sub])
+z_patch_lo, z_patch_hi = z_sub_hi,             float(edges[f0 + 2 + n_sub])
+
+fixed_layers = [
+    ("ground",    z_gnd_lo,   z_gnd_hi,   1),
+    ("substrate", z_sub_lo,   z_sub_hi,   n_sub),
+    ("patch",     z_patch_lo, z_patch_hi, 1),
+]
+fixed_ok = realized_layout(dz_profile, fixed_layers)
+assert fixed_ok, "mesh-derived registration must realize the intended cells"
+assert abs((z_sub_hi - z_sub_lo) - h_sub) < 1e-9
+
+# transition clearance: nearest cell that is neither fine nor coarse
+centers = 0.5 * (edges[:-1] + edges[1:])
+is_trans = ~(np.isclose(dz_profile, dz_sub, rtol=1e-6) |
+             np.isclose(dz_profile, dx, rtol=1e-6))
+tc = centers[is_trans]
+clearance = (float(min(np.min(np.abs(tc - z_gnd_lo)),
+                       np.min(np.abs(tc - z_patch_hi))))
+             if len(tc) else float("inf"))
+print(f"  grading-transition clearance from the stack: {clearance*1e3:.2f} mm "
+      f"(buffer n_buf={n_buf})")
+
+# =============================================================================
+# PART 3 — mesh economics (Rule 2): what the graded mesh buys.
+# =============================================================================
 nx = int(math.ceil(dom_x / dx))
 ny = int(math.ceil(dom_y / dx))
 nz_nu = len(dz_profile)
-n_cells_nu = nx * ny * nz_nu
-
+dom_z = float(edges[-1])
 nz_uniform_equiv = int(math.ceil(dom_z / dz_sub))
-n_cells_uniform = nx * ny * nz_uniform_equiv
-ratio = n_cells_uniform / n_cells_nu
-
-print("\nMesh:")
-print(f"  NU:      {nx} x {ny} x {nz_nu} = {n_cells_nu:,} cells")
-print(f"  Uniform: {nx} x {ny} x {nz_uniform_equiv} = {n_cells_uniform:,} cells")
-print(f"  Memory saving ratio: {ratio:.2f}x")
+ratio = (nx * ny * nz_uniform_equiv) / (nx * ny * nz_nu)
+print(f"\n[3] Mesh economics: NU {nx}x{ny}x{nz_nu} vs uniform-at-dz_sub "
+      f"{nx}x{ny}x{nz_uniform_equiv}  ->  {ratio:.2f}x fewer cells")
 
 # =============================================================================
-# Build simulation
+# PART 4 — build + preflight (output is part of the result) + run.
+# FR4 is modelled lossless (sigma=0) so preflight's infinite-Q advisory will
+# fire: legitimate here — we quote mode FREQUENCIES, not absolute Q (real FR4
+# tan_delta ~0.02 would cap Q near ~50).
 # =============================================================================
 src_z   = z_sub_lo + dz_sub * 2.5
 probe_z = src_z
@@ -137,69 +230,70 @@ sim = Simulation(
     cpml_layers=n_cpml,
 )
 sim.add_material("fr4", eps_r=eps_r, sigma=0.0)
-
-# Finite ground plane
 sim.add(Box((gx_lo, gy_lo, z_gnd_lo), (gx_hi, gy_hi, z_gnd_hi)), material="pec")
-# FR4 substrate
 sim.add(Box((gx_lo, gy_lo, z_sub_lo), (gx_hi, gy_hi, z_sub_hi)), material="fr4")
-# Patch
 sim.add(Box((patch_x_lo, patch_y_lo, z_patch_lo),
             (patch_x_hi, patch_y_hi, z_patch_hi)), material="pec")
-
-# Broadband source at feed point
 sim.add_source(
     position=(feed_x, feed_y, src_z),
     component="ez",
     waveform=GaussianPulse(f0=f_design, bandwidth=1.2),
 )
-# Probe at separate substrate point (avoid source overlap)
 sim.add_probe(
     position=(dom_x / 2 + 5e-3, dom_y / 2 + 5e-3, probe_z),
     component="ez",
 )
 
-# =============================================================================
-# Run
-# =============================================================================
-print("\nRunning NU simulation (num_periods=60)...")
+print("\n[4] Preflight (advisories below are part of the result):")
+sim.preflight(strict=False)
+
+n_periods = 120   # honest witness below; ~200 periods reaches ~-50 dB
+print(f"\nRunning NU simulation (num_periods={n_periods})...")
 t0 = time.time()
-result = sim.run(num_periods=60)
-elapsed = time.time() - t0
-print(f"Done in {elapsed:.1f} s")
+result = sim.run(num_periods=n_periods)
+print(f"Done in {time.time() - t0:.1f} s")
 
 # =============================================================================
-# Harminv resonance extraction
+# PART 5 — settling witness BEFORE any frequency is quoted (#332/G1).
 # =============================================================================
 ts = np.asarray(result.time_series).ravel()
 dt_val = float(result.dt)
-
-skip = int(len(ts) * 0.3)
-signal = ts[skip:]
-print(f"\nHarminv on last {len(signal)} samples (ringdown region)...")
-
-modes = harminv(signal, dt_val, 1.5e9, 3.5e9)
-modes_good = [m for m in modes if m.Q > 2 and m.amplitude > 1e-8]
-
-if modes_good:
-    modes_good.sort(key=lambda m: abs(m.freq - f_an))
-    best = modes_good[0]
-    f_harminv = float(best.freq)
-    Q_harminv  = float(best.Q)
-    err_pct    = 100 * abs(f_harminv - f_an) / f_an
-else:
-    f_harminv = float("nan")
-    Q_harminv  = float("nan")
-    err_pct    = float("inf")
-
-print("\nResults:")
-print(f"  Analytic f_res   = {f_an/1e9:.4f} GHz")
-print(f"  Harminv f_res    = {f_harminv/1e9:.4f} GHz  (Q = {Q_harminv:.1f})")
-print(f"  Error vs analytic = {err_pct:.2f} %")
-pass_str = "PASS" if err_pct < 8.0 else "FAIL"
-print(f"  Pass criterion (<8%): {pass_str}")
+amp = np.abs(ts)
+peak = float(amp[int(len(amp) * 0.15):].max())
+end = float(amp[-max(1, len(amp) // 20):].mean())
+settle_db = (20 * math.log10(end / peak)
+             if peak > 0 and end > 0 else float("-inf"))
+print(f"\n[5] Settling witness: end/peak = {settle_db:.1f} dB "
+      f"({'OK (<-40)' if settle_db < -40 else 'UNDER-SETTLED (>-40): raise num_periods for gate-grade numbers'})")
 
 # =============================================================================
-# Plot (a): probe Ez time series
+# PART 6 — harminv: the FULL mode list (Rule 3), no single-mode gate.
+# =============================================================================
+skip = int(len(ts) * 0.3)
+signal = ts[skip:]
+modes = [m for m in harminv(signal, dt_val, 1.5e9, 3.6e9)
+         if m.Q > 2 and m.amplitude > 1e-8]
+modes.sort(key=lambda m: m.freq)
+
+print("\n[6] Harminv modes (all, sorted by frequency):")
+for m in modes:
+    print(f"  f = {m.freq/1e9:.4f} GHz   Q = {m.Q:5.1f}   amp = {m.amplitude:.2e}")
+print("""
+  Reading this honestly (Rule 3): with the substrate truly resolved to 6 cells
+  the patch shows its REAL modes — the lower one lives on the wider W=38 mm
+  dimension (TM01), the middle on L=29.5 mm (TM10, the radiating design mode),
+  plus a higher-order mode.  Their amplitudes at a single probe are comparable,
+  so "strongest" or "closest to the textbook number" would be an arbitrary,
+  geometry-sensitive pick.  Identifying the RADIATING mode takes a far-field
+  criterion (broadside beam + radiated power) — that workflow lives in
+  examples/tutorials/patch_antenna_demo.py.""")
+
+print(f"  Pass criterion of THIS tutorial: the substrate rasterized to "
+      f"{n_sub} fine cells (asserted in [2]) — the mesh lesson, not a "
+      f"frequency match.")
+
+# =============================================================================
+# PART 7 — plots: ringdown + the built dz profile with the REALIZED substrate.
 # =============================================================================
 t_axis = np.arange(len(ts)) * dt_val * 1e9   # ns
 fig, ax = plt.subplots(figsize=(8, 3))
@@ -215,19 +309,15 @@ fig.savefig(plot_ts, dpi=120)
 plt.close(fig)
 print(f"\nPlot (a): {plot_ts}")
 
-# =============================================================================
-# Plot (b): dz mesh profile (stem)
-# =============================================================================
-z_edges = np.concatenate([[0.0], np.cumsum(dz_profile)]) * 1e3   # mm
-z_centers = 0.5 * (z_edges[:-1] + z_edges[1:])
+z_centers_mm = centers * 1e3
 fig2, ax2 = plt.subplots(figsize=(8, 3))
-ax2.stem(z_centers, dz_profile * 1e3, markerfmt="C0.", basefmt="k-",
+ax2.stem(z_centers_mm, dz_profile * 1e3, markerfmt="C0.", basefmt="k-",
          linefmt="C0-")
-ax2.axvspan(air_below * 1e3, (air_below + h_sub) * 1e3,
-            alpha=0.15, color="orange", label="FR4 substrate")
+ax2.axvspan(z_sub_lo * 1e3, z_sub_hi * 1e3, alpha=0.15, color="orange",
+            label="FR4 substrate (REALIZED z)")
 ax2.set_xlabel("z (mm)")
 ax2.set_ylabel("dz (mm)")
-ax2.set_title("Non-uniform z mesh profile")
+ax2.set_title("Non-uniform z mesh — substrate shaded at its realized position")
 ax2.legend()
 fig2.tight_layout()
 plot_mesh = os.path.join(OUT_DIR, "dz_mesh_profile.png")


### PR DESCRIPTION
Resolves #381. The demo's docstring promised *"this script prints the realized cell layout so you can see it"* while the body placed every layer at **fixed pre-smoothing z** — making it a live instance of the #325 bug it lectured about (substrate built as 2 coarse cells, ground 0 cells). It also picked its harminv mode by closest-to-analytic (mode-ambiguity anti-pattern) and gated <8% against the 5–8%-approximate Balanis estimate.

## The rewrite (per #381's fix guidance — registration fix **+** honest multi-mode reframing)
A registration-only patch keeping the closest-to-analytic pick would have re-created the cv05 mode-ambiguity failure; #381's caveat forbids that. So:

| part | what it does | verified output |
|---|---|---|
| **[1] THE TRAP** (grid-only, free) | naive fixed-z profile + **realized per-layer layout print** (the promised print, now real) | ground **0** cells / substrate **2 coarse** (0.769/0.592 mm), flagged MISREGISTERED |
| **[2] THE FIX** | buffered fine band (n_buf=8) + stack z **derived from the built profile** (imitates `build_uniform_fine_z` / `patch_tutorial_rfx.py`), asserted | 1/6/1 cells at 0.250 mm; clearance 2.13 mm; **the #325 preflight advisory no longer fires** |
| **[3]** | honest mesh economics | 2.73× fewer cells vs uniform-at-dz_sub |
| **[4]** | explicit `sim.preflight()` — remaining lossless-FR4 advisory documented as intentional (frequencies quoted, not absolute Q) | 1 advisory, quoted |
| **[5]** | settling witness before any frequency (#332/G1) | **−40.8 dB OK** at num_periods=120; runtime 783 s (docstring updated) |
| **[6]** | **full mode list, no single-mode gate** (Rule 3): TM01 (W=38) / TM10 (L=29.5, radiating) / higher, comparable amplitudes; far-field radiating-mode ID delegated to `patch_antenna_demo.py` | 2.1423 / 2.6459 / 3.4441 GHz — **matches the #325 §1-B witness to the digit** |

Plot (b) substrate shading moved to the **realized** z (was drawn at the intended z where the substrate is not). The `<8%` single-mode gate is removed; this tutorial's pass criterion is the mesh lesson itself (substrate == 6 fine cells, asserted).

## Verification
Full end-to-end run exit 0 (output in the commit message); ruff clean; `examples/README.md` entry already matches the rewritten teaching.

R3: memory=consistent (#381 guidance incl. the §1-B multi-mode caveat; imitates the committed `build_uniform_fine_z` pattern) | R2-attempts=0 (lands established patterns) | falsifier=the demo's own asserts (naive MUST misregister, fixed MUST realize 1/6/1) + the absent #325 advisory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)