### PR TITLE
feat(nonuniform): until_decay energy-decay stop on the non-uniform lane (#383)

### DIFF
--- a/docs/agent/recipe-rt-measurement.mdx
+++ b/docs/agent/recipe-rt-measurement.mdx
@@ -37,11 +37,16 @@ sim.add_flux_monitor(axis="x", coordinate=trans_x, freqs=freqs_rt, name="trans")
 
 ### `run(until_decay=...)`
 
-Decay-adaptive termination (`rfx/api/_execute.py`, line 1593). Runs until the
-field at a chosen monitor position decays to `until_decay * peak`. This kwarg
-is load-bearing for accuracy: a fixed `n_steps` truncates the signal and aliases
-residual energy into the spectrum. `decay_monitor_component` and
-`decay_monitor_position` control which field and where to sample the decay.
+Decay-adaptive termination (see the `Simulation.run()` docstring for the
+authoritative lane-by-lane description). The stop criterion depends on the
+boundary: on absorbing (CPML/UPML) boundaries — including the non-uniform
+`dx/dy/dz`-profile runner — the run stops when the total interior-domain
+energy decays to `until_decay * peak` (issue #169); on closed/PEC boundaries
+the uniform runner falls back to the field at a single monitor position, and
+`decay_monitor_component` / `decay_monitor_position` control which field and
+where to sample that fallback. This kwarg is load-bearing for accuracy: a
+fixed `n_steps` truncates the signal and aliases residual energy into the
+spectrum.
 
 ### Two-run reference subtraction
 

--- a/docs/guides/simulation_methodology.md
+++ b/docs/guides/simulation_methodology.md
@@ -102,7 +102,10 @@ frequency resolution determine the required run time. Do not infer convergence
 from `n_steps` alone.
 
 On the supported uniform CPML/UPML runner, `until_decay` monitors an interior
-sum-of-squared-fields proxy outside the absorber. It does not measure total
+sum-of-squared-fields proxy outside the absorber. The non-uniform
+(`dx/dy/dz`-profile) runner supports the same stop on CPML/UPML boundaries,
+weighting each cell by its own volume; closed-boundary non-uniform runs warn
+and execute the fixed step count. The proxy does not measure total
 electromagnetic energy and does not prove convergence of every DFT,
 S-parameter, Harminv, or NTFF quantity. Other runners may reject or ignore that
 option as documented by their emitted diagnostics.

--- a/docs/public/api/simulation.mdx
+++ b/docs/public/api/simulation.mdx
@@ -139,10 +139,9 @@ observable. The non-uniform (`dx_profile` / `dy_profile` / `dz_profile`) runner
 supports the same stop on CPML/UPML boundaries, weighting each cell's squared
 fields by that cell's `dx*dy*dz` volume so graded cells contribute in
 proportion to their size. On that lane every step-sized buffer is allocated at
-`decay_max_steps`, flux monitors must keep the default rectangular DFT window,
-and `checkpoint_every` is rejected; a non-uniform run with closed boundaries
-warns and executes the fixed `n_steps` instead (that lane has no single-cell
-monitor stop). Other runners may warn or reject `until_decay`; consult the
+`decay_max_steps` and flux monitors must keep the default rectangular DFT
+window; a non-uniform run with closed boundaries warns and executes the fixed
+`n_steps` instead (that lane has no single-cell monitor stop). Other runners may warn or reject `until_decay`; consult the
 emitted message instead of assuming it was applied. Closed PEC domains do not
 normally lose their field norm, so use a fixed run length unless the model
 contains a real loss mechanism. Explicit `n_steps` remains appropriate when an

--- a/docs/public/api/simulation.mdx
+++ b/docs/public/api/simulation.mdx
@@ -74,7 +74,8 @@ sim.add_source(
 )
 sim.add_probe((0.05, 0.03, 0.0125), "ez")
 
-# until_decay is implemented on the uniform CPML/UPML runner.
+# until_decay is implemented on the uniform CPML/UPML runner and on the
+# non-uniform (dx/dy/dz-profile) runner with CPML/UPML boundaries.
 result = sim.run(until_decay=1e-3)
 ```
 
@@ -134,11 +135,18 @@ field components outside the absorber as an interior field-norm proxy. It stops
 after that proxy remains below `1e-3` of its peak for the required consecutive
 checks. This avoids a false stop at a null of a single-cell monitor, but it does
 not directly prove convergence of every DFT, S-parameter, Harminv, or NTFF
-observable. Other runners may warn or reject `until_decay`; consult the emitted
-message instead of assuming it was applied. Closed PEC domains do not normally
-lose their field norm, so use a fixed run length unless the model contains a
-real loss mechanism. Explicit `n_steps` remains appropriate when an exact
-accumulation window is required.
+observable. The non-uniform (`dx_profile` / `dy_profile` / `dz_profile`) runner
+supports the same stop on CPML/UPML boundaries, weighting each cell's squared
+fields by that cell's `dx*dy*dz` volume so graded cells contribute in
+proportion to their size. On that lane every step-sized buffer is allocated at
+`decay_max_steps`, flux monitors must keep the default rectangular DFT window,
+and `checkpoint_every` is rejected; a non-uniform run with closed boundaries
+warns and executes the fixed `n_steps` instead (that lane has no single-cell
+monitor stop). Other runners may warn or reject `until_decay`; consult the
+emitted message instead of assuming it was applied. Closed PEC domains do not
+normally lose their field norm, so use a fixed run length unless the model
+contains a real loss mechanism. Explicit `n_steps` remains appropriate when an
+exact accumulation window is required.
 
 ## Differentiable `forward(...)` path
 

--- a/docs/public/guide/farfield-rcs.md
+++ b/docs/public/guide/farfield-rcs.md
@@ -220,8 +220,8 @@ plot_rcs(result, freq_idx=0, polar=False)   # dBsm vs angle
   probe series. TFSF excitation, non-`GaussianPulse` source entries, and the
   explicit-`n_steps` example above receive no automatic tail verdict. Repeat
   the calculation with a longer duration and compare the pattern, or use
-  `until_decay` on the supported uniform CPML/UPML runner; neither method
-  replaces observable-specific convergence testing.
+  `until_decay` on the supported uniform or non-uniform CPML/UPML runners;
+  neither method replaces observable-specific convergence testing.
 - `compute_rcs` places the TFSF and NTFF boxes automatically from `cpml_layers`,
   `tfsf_margin`, and `ntff_offset` (the NTFF box sits `ntff_offset` cells outside
   the TFSF boundary); you supply only the grid and the scatterer materials.

--- a/docs/public/guide/migration.md
+++ b/docs/public/guide/migration.md
@@ -22,7 +22,7 @@ boundary, source or port, and observable restrictions.
 | Source | `EigenModeSource`, `Source` | `AddExcitation` | `add_port()`, `add_source()` |
 | S-parameters | `add_flux()` + post-processing | `CalcPort` | port-family-specific: lumped/wire `run(compute_s_params=True)`, MSL `compute_msl_s_matrix()`, waveguide `compute_waveguide_s_matrix()` |
 | Resonance finding | `harminv(...)` | Manual FFT | `result.find_resonances()` |
-| Auto-stop | `stop_when_fields_decayed` | `EndCriteria` | `run(until_decay=1e-3)` on the uniform CPML/UPML runner; use fixed `n_steps` for a closed PEC cavity |
+| Auto-stop | `stop_when_fields_decayed` | `EndCriteria` | `run(until_decay=1e-3)` on the uniform and non-uniform CPML/UPML runners; use fixed `n_steps` for a closed PEC cavity |
 | Materials | `Medium(epsilon=...)` | `AddMaterial` | `sim.add(shape, material="fr4")` or `sim.add_material(...)` |
 | PEC | `PerfectElectricalConductor` | `AddMetal` | `material="pec"` |
 | PML / ABC | `PML(thickness)` | `AddPML` | `boundary="cpml"` |

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -173,8 +173,22 @@ class _ExecuteMixin:
     def _run_nonuniform(self, *, n_steps, compute_s_params=None,
                         s_param_freqs=None,
                         subpixel_smoothing: bool | str = False,
-                        checkpoint: bool = False):
-        """Run simulation on non-uniform grid with graded dz."""
+                        checkpoint: bool = False,
+                        until_decay: float | None = None,
+                        decay_check_interval: int = 50,
+                        decay_min_steps: int = 100,
+                        decay_max_steps: int = 50_000,
+                        decay_energy_consecutive: int = 2):
+        """Run simulation on non-uniform grid with graded dz.
+
+        ``until_decay`` (issue #383) is threaded through to
+        ``run_nonuniform_path`` only when the caller has already gated on
+        absorbing boundaries — ``run()`` passes ``None`` (warn-and-drop)
+        for closed-boundary NU sims, where the interior energy does not
+        decay. ``decay_monitor_component`` / ``decay_monitor_position``
+        are NOT threaded: they parameterize the uniform lane's
+        closed/PEC point-field fallback, which has no NU counterpart.
+        """
         # Defense-in-depth: the NU runner does not honour stencil_order.
         self._check_stencil_order_supported()
         self._reject_refplane_ports_off_uniform_lane("non-uniform mesh",
@@ -196,6 +210,11 @@ class _ExecuteMixin:
             s_param_freqs=s_param_freqs,
             subpixel_smoothing=subpixel_smoothing,
             checkpoint=checkpoint,
+            until_decay=until_decay,
+            decay_check_interval=decay_check_interval,
+            decay_min_steps=decay_min_steps,
+            decay_max_steps=decay_max_steps,
+            decay_energy_consecutive=decay_energy_consecutive,
         )
 
     @staticmethod
@@ -293,7 +312,8 @@ class _ExecuteMixin:
 
     @staticmethod
     def _warn_unsupported_run_kwargs(path_name: str,
-                                     unsupported_kwargs: dict) -> None:
+                                     unsupported_kwargs: dict,
+                                     reason_overrides: dict | None = None) -> None:
         """Emit ``UserWarning`` for any Simulation.run kwarg that a given
         dispatch path drops. Only non-default values are surfaced.
 
@@ -302,6 +322,11 @@ class _ExecuteMixin:
         the drop explicit at the API boundary so users can tell their
         request was not honoured. See GitHub tracking issue for the
         feature-request backlog to actually propagate these kwargs.
+
+        ``reason_overrides`` lets a caller replace the shared per-kwarg
+        reason string with a lane-accurate one (e.g. the NU lane drops
+        ``until_decay`` only on closed boundaries, for a different reason
+        than the distributed/subgridded lanes drop it).
         """
         import warnings as _w
         # Per-kwarg "silent" values — the kwarg is dropped only if the
@@ -330,8 +355,9 @@ class _ExecuteMixin:
             "snapshot":
                 "scan-body field snapshotting is not wired on this path",
             "until_decay":
-                "scan body runs for exactly n_steps; no decay-based "
-                "termination on this path (use the uniform-mesh path)",
+                "scan body runs for exactly n_steps; decay-based "
+                "termination is supported on the uniform lane and the "
+                "absorbing-boundary (cpml/upml) non-uniform lane only",
             "conformal_pec":
                 "Dey-Mittra conformal weights are computed on a uniform "
                 "staircase mesh only",
@@ -342,6 +368,8 @@ class _ExecuteMixin:
             "s_param_n_steps":
                 "S-matrix assembly is not plumbed through this path",
         }
+        if reason_overrides:
+            reasons.update(reason_overrides)
         for kw, val in unsupported_kwargs.items():
             silent = silent_values.get(kw, (None,))
             if val in silent:
@@ -2326,6 +2354,15 @@ class _ExecuteMixin:
             — use a fixed ``n_steps`` there, see
             ``validation/crossval/03_straight_waveguide_flux.py`` and the
             :func:`rfx.simulation.run_until_decay` note).
+            **Non-uniform (dx/dy/dz-profile) meshes (issue #383):** the same
+            interior-energy stop runs on absorbing (``cpml``/``upml``)
+            boundaries via a chunked host loop over the NU scan step
+            (dV-weighted energy — per-cell ``dx*dy*dz`` — so graded cells
+            are weighted faithfully). Closed-boundary NU sims warn and run
+            the fixed ``n_steps`` (no point-field fallback on the NU lane).
+            On the NU decay path all step-sized buffers are allocated at
+            ``decay_max_steps``; flux monitors must keep the default
+            rectangular DFT window and ``checkpoint_every`` is rejected.
         decay_check_interval : int
             Check decay every N steps (default 50).
         decay_min_steps : int
@@ -2452,17 +2489,44 @@ class _ExecuteMixin:
 
         # ---- Non-uniform mesh lane ----
         if plan.lane == "run_nonuniform":
-            self._warn_unsupported_run_kwargs("non-uniform mesh", {
+            # #383: until_decay is supported on the NU lane for absorbing
+            # boundaries (the interior-energy criterion, same class as the
+            # uniform #169 stop). Closed/PEC NU domains keep warn-and-drop
+            # with a lane-accurate reason: their interior energy does not
+            # decay, and the NU lane has no point-field fallback.
+            _nu_until_decay = (
+                until_decay
+                if self._boundary in ("cpml", "upml")
+                else None
+            )
+            _nu_dropped = {
                 "snapshot": snapshot,
-                "until_decay": until_decay,
                 "conformal_pec": conformal_pec,
-            })
+            }
+            if _nu_until_decay is None:
+                _nu_dropped["until_decay"] = until_decay
+            self._warn_unsupported_run_kwargs(
+                "non-uniform mesh", _nu_dropped,
+                reason_overrides={
+                    "until_decay":
+                        "the interior-energy decay stop needs absorbing "
+                        "boundaries (cpml/upml); this closed-boundary "
+                        "non-uniform run executes a fixed n_steps, and the "
+                        "non-uniform lane has no point-field fallback "
+                        "(issue #383)",
+                },
+            )
             _res = self._run_nonuniform(
                 n_steps=n_steps,
                 compute_s_params=compute_s_params,
                 s_param_freqs=s_param_freqs,
                 subpixel_smoothing=subpixel_smoothing,
                 checkpoint=checkpoint,
+                until_decay=_nu_until_decay,
+                decay_check_interval=decay_check_interval,
+                decay_min_steps=decay_min_steps,
+                decay_max_steps=decay_max_steps,
+                decay_energy_consecutive=decay_energy_consecutive,
             )
             self._warn_run_sparams_if_nonpassive(_res)
             self._warn_postrun_energy_witness(

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -2361,8 +2361,11 @@ class _ExecuteMixin:
             are weighted faithfully). Closed-boundary NU sims warn and run
             the fixed ``n_steps`` (no point-field fallback on the NU lane).
             On the NU decay path all step-sized buffers are allocated at
-            ``decay_max_steps``; flux monitors must keep the default
-            rectangular DFT window and ``checkpoint_every`` is rejected.
+            ``decay_max_steps`` and flux monitors must keep the default
+            rectangular DFT window. (The non-uniform runner additionally
+            rejects its internal ``checkpoint_every`` segmentation option
+            when a decay stop is requested; that option belongs to the
+            ``forward()`` lane and is not reachable through ``run()``.)
         decay_check_interval : int
             Check decay every N steps (default 50).
         decay_min_steps : int

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -1646,8 +1646,11 @@ def run_nonuniform_until_decay(
         Same schema as :func:`run_nonuniform` (assembled by the shared
         :func:`_assemble_nu_result`), plus a ``"decay_checks"``
         diagnostic: a list of ``(step, U, peak_U)`` host-float tuples,
-        one per eligible energy check, so callers can verify the fire
-        condition actually held (workspace rule R5).
+        one per eligible energy check. The trace exists only on THIS
+        runner-dict return — ``run_nonuniform_path`` does not copy it
+        onto the public ``Result`` — so consumers that need to verify
+        the fire condition actually held (workspace rule R5) must call
+        this module function directly.
     """
     if check_interval < 1:
         raise ValueError(

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -1553,3 +1553,207 @@ def _assemble_nu_result(setup: _NUScanSetup, final: dict, time_series) -> dict:
 
     return result
 
+
+def run_nonuniform_until_decay(
+    grid: NonUniformGrid,
+    materials: MaterialArrays,
+    *,
+    decay_by: float = 1e-3,
+    check_interval: int = 50,
+    min_steps: int = 100,
+    max_steps: int = 50_000,
+    decay_energy_consecutive: int = 2,
+    pec_mask=None,
+    pec_occupancy=None,
+    sources: list = None,
+    probes: list = None,
+    wire_ports: list = None,
+    s_param_freqs=None,
+    debye: tuple | None = None,
+    lorentz: tuple | None = None,
+    pec_faces: set[str] | None = None,
+    pmc_faces: set[str] | None = None,
+    dft_planes: list | None = None,
+    rlc_metas: tuple = (),
+    rlc_states: tuple = (),
+    ntff_box=None,
+    ntff_data=None,
+    waveguide_ports: list | None = None,
+    tfsf: tuple | None = None,
+    flux_monitors: list | None = None,
+    emit_time_series: bool = True,
+    aniso_eps: tuple | None = None,
+) -> dict:
+    """Run non-uniform FDTD until the interior-domain energy decays (#383).
+
+    NU port of the issue #169 total-domain-energy stop criterion: a
+    Python loop drives constant-length jitted chunks (``chunk =
+    check_interval`` steps) of the SAME ``step_fn`` that
+    :func:`run_nonuniform` scans, threading the SAME carry (NTFF Kahan
+    compensation arrays included) across chunks. Per-chunk ``xs``
+    continue the GLOBAL step indices, exactly like the ``n_warmup``
+    split in :func:`run_nonuniform`, so source waveforms / DFT phases
+    are identical to a fixed-step run of the same length.
+
+    Stop criterion (absorbing boundaries — the ONLY supported class on
+    this entry point; the routing layer in ``rfx/api/_execute.py`` gates
+    on ``boundary in ('cpml', 'upml')``):
+
+    * At each chunk boundary (after ``k * check_interval`` steps), once
+      ``steps_done >= min_steps``, compute the host-side dV-weighted
+      interior energy ``U = sum((Ex^2 + ... + Hz^2) * dV)`` over the
+      non-CPML interior slice, with ``dV = dx[i] * dy[j] * dz[k]`` the
+      per-cell primal volume (all six components weighted by the primal
+      cell dV — the same staggering simplification the uniform path
+      makes; on a uniform mesh this reduces to the uniform criterion up
+      to the constant dV factor).
+    * ``peak_U`` is updated at checks only, BEFORE the compare.
+    * The stop fires after ``decay_energy_consecutive`` CONSECUTIVE
+      sub-threshold checks (``U < decay_by * peak_U``); any
+      above-threshold check resets the counter. ``>= 2`` is mandatory
+      for the same reason as the uniform path: the interior energy is
+      not null-free (transient inter-packet minima recover).
+    * ``decay_by = 0.0`` preserves the forced-N escape (``U < 0`` is
+      never true for ``U >= 0``), so the loop runs exactly
+      ``max_steps`` steps.
+    * The loop is hard-bounded by ``max_steps``; a final partial chunk
+      (shorter than ``check_interval``) is allowed so the bound is
+      exact.
+
+    Check cadence note: the uniform ``run_until_decay`` checks after
+    steps ``k * interval + 1`` (its 0-based ``step % interval == 0``
+    fires at step index ``k * interval``); the chunked NU loop checks
+    after ``k * interval`` steps. The <= 1-step cadence difference is
+    deliberate (one XLA program per chunk length) — cross-lane stop-step
+    equality is NOT a contract (host/device float order already differs
+    between the lanes).
+
+    On a closed domain (no absorbing pads) the interior energy does not
+    decay and this function runs to ``max_steps``; there is NO
+    point-field fallback on the NU lane (no legacy behavior to
+    preserve). The routing layer warn-and-drops ``until_decay`` for
+    non-absorbing NU boundaries instead of calling this.
+
+    Forward-only: this is a host loop (not ``lax.scan``); it is not
+    reachable from ``forward()``/``optimize()`` and carries no AD tape
+    contract. ``checkpoint`` / ``checkpoint_every`` / ``n_warmup`` are
+    deliberately absent from the signature (the caller raises before
+    dispatching here).
+
+    Returns
+    -------
+    dict
+        Same schema as :func:`run_nonuniform` (assembled by the shared
+        :func:`_assemble_nu_result`), plus a ``"decay_checks"``
+        diagnostic: a list of ``(step, U, peak_U)`` host-float tuples,
+        one per eligible energy check, so callers can verify the fire
+        condition actually held (workspace rule R5).
+    """
+    if check_interval < 1:
+        raise ValueError(
+            f"check_interval must be >= 1, got {check_interval}")
+    if max_steps < 1:
+        raise ValueError(f"max_steps must be >= 1, got {max_steps}")
+
+    setup = _build_nu_scan(
+        grid, materials, max_steps,
+        pec_mask=pec_mask,
+        pec_occupancy=pec_occupancy,
+        sources=sources,
+        probes=probes,
+        wire_ports=wire_ports,
+        s_param_freqs=s_param_freqs,
+        debye=debye,
+        lorentz=lorentz,
+        pec_faces=pec_faces,
+        pmc_faces=pmc_faces,
+        dft_planes=dft_planes,
+        rlc_metas=rlc_metas,
+        rlc_states=rlc_states,
+        ntff_box=ntff_box,
+        ntff_data=ntff_data,
+        waveguide_ports=waveguide_ports,
+        tfsf=tfsf,
+        flux_monitors=flux_monitors,
+        emit_time_series=emit_time_series,
+        design_mask=None,
+        aniso_eps=aniso_eps,
+    )
+    step_fn = setup.step_fn
+    carry = setup.carry_init
+
+    # Source table: pad/truncate to max_steps so every chunk slice is
+    # full-length (mirrors the uniform run_until_decay pad/truncate).
+    src_waveforms = jnp.asarray(setup.src_waveforms)
+    n_have = int(src_waveforms.shape[0])
+    if n_have < max_steps:
+        src_waveforms = jnp.pad(
+            src_waveforms, ((0, max_steps - n_have), (0, 0)))
+    elif n_have > max_steps:
+        src_waveforms = src_waveforms[:max_steps]
+
+    # One compiled program per chunk length: full chunks share one XLA
+    # executable; the final partial chunk (if any) compiles once more.
+    @jax.jit
+    def _run_chunk(carry_in, xs):
+        return jax.lax.scan(step_fn, carry_in, xs)
+
+    # Non-CPML interior slice bounds + per-cell primal volume dV
+    # (Python ints / concrete arrays — the reduction below is host-side;
+    # NonUniformGrid is always 3D).
+    _ix0, _ix1 = grid.pad_x_lo, grid.nx - grid.pad_x_hi
+    _iy0, _iy1 = grid.pad_y_lo, grid.ny - grid.pad_y_hi
+    _iz0, _iz1 = grid.pad_z_lo, grid.nz - grid.pad_z_hi
+    _dV = (
+        jnp.asarray(grid.dx_arr)[_ix0:_ix1, None, None]
+        * jnp.asarray(grid.dy_arr)[None, _iy0:_iy1, None]
+        * jnp.asarray(grid.dz)[None, None, _iz0:_iz1]
+    )
+
+    def _interior_energy(state) -> float:
+        """dV-weighted interior field energy (host float)."""
+        sx, sy, sz = (slice(_ix0, _ix1), slice(_iy0, _iy1), slice(_iz0, _iz1))
+        u = (state.ex[sx, sy, sz] ** 2 + state.ey[sx, sy, sz] ** 2
+             + state.ez[sx, sy, sz] ** 2 + state.hx[sx, sy, sz] ** 2
+             + state.hy[sx, sy, sz] ** 2 + state.hz[sx, sy, sz] ** 2)
+        return float(jnp.sum(u * _dV))
+
+    peak_U = 0.0           # running peak, updated at checks only
+    energy_below = 0       # consecutive sub-threshold energy checks
+    decay_checks: list = []
+    ys_chunks = []
+    steps_done = 0
+
+    while steps_done < max_steps:
+        this_chunk = min(int(check_interval), max_steps - steps_done)
+        xs = (
+            jnp.arange(steps_done, steps_done + this_chunk, dtype=jnp.int32),
+            src_waveforms[steps_done:steps_done + this_chunk],
+        )
+        carry, ys = _run_chunk(carry, xs)
+        ys_chunks.append(ys)
+        steps_done += this_chunk
+
+        # Interior-energy check at the chunk boundary (check-step-only —
+        # the whole-domain reduction is the expensive part).
+        if steps_done >= min_steps:
+            U = _interior_energy(carry["fdtd"])
+            if U > peak_U:
+                peak_U = U
+            decay_checks.append((steps_done, U, peak_U))
+            # decay_by=0.0 forced-N escape: U >= 0 so U < 0 never fires.
+            if U < decay_by * peak_U:
+                energy_below += 1
+                if energy_below >= decay_energy_consecutive:
+                    break
+            else:
+                energy_below = 0
+
+    # Per-chunk ys concatenate to exactly steps_done rows; the
+    # emit_time_series=False convention ((steps, 0)) is preserved
+    # because each chunk emits (this_chunk, 0).
+    time_series = jnp.concatenate(ys_chunks, axis=0)
+
+    result = _assemble_nu_result(setup, carry, time_series)
+    result["decay_checks"] = decay_checks
+    return result

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -701,7 +701,37 @@ def _update_e_nu_dispersive(
     return new_fdtd, new_debye, new_lor
 
 
-def run_nonuniform(
+class _NUScanSetup(NamedTuple):
+    """Host-side bundle built by :func:`_build_nu_scan` (#383 code motion).
+
+    Carries the scan step function, its initial carry, the stacked source
+    table, and the post-scan assembly metadata shared by
+    :func:`run_nonuniform` (single ``lax.scan``) and
+    :func:`run_nonuniform_until_decay` (chunked host loop). This tuple
+    never crosses a JAX transform boundary — ``step_fn`` is a Python
+    closure and the ``use_*`` flags are Python bools.
+    """
+    step_fn: object
+    carry_init: dict
+    src_waveforms: jnp.ndarray
+    dt: object
+    sources: list
+    probes: list
+    wire_ports: list
+    dft_planes: list
+    flux_monitors: list
+    waveguide_meta: tuple
+    wp_meta: list
+    sp_freqs: object
+    use_wire_ports: bool
+    use_dft_planes: bool
+    use_flux_monitors: bool
+    use_lumped_rlc: bool
+    use_ntff: bool
+    use_waveguide_ports: bool
+
+
+def _build_nu_scan(
     grid: NonUniformGrid,
     materials: MaterialArrays,
     n_steps: int,
@@ -724,28 +754,17 @@ def run_nonuniform(
     waveguide_ports: list | None = None,
     tfsf: tuple | None = None,
     flux_monitors: list | None = None,
-    checkpoint: bool = False,
     emit_time_series: bool = True,
-    checkpoint_every: int | None = None,
-    n_warmup: int = 0,
     design_mask: jnp.ndarray | None = None,
     aniso_eps: tuple | None = None,
-) -> dict:
-    """Run non-uniform FDTD via jax.lax.scan.
+) -> _NUScanSetup:
+    """Build the NU scan carry + step function (pure code motion, #383).
 
-    Parameters
-    ----------
-    sources : list of (i, j, k, component, waveform_array)
-    probes : list of (i, j, k, component)
-    wire_ports : list of dict with keys:
-        mid_i, mid_j, mid_k, component, impedance, waveform_array
-    s_param_freqs : (n_freqs,) array for S-param DFT
-    debye : (DebyeCoeffs, DebyeState) or None
-    lorentz : (LorentzCoeffs, LorentzState) or None
-    dft_planes : list of DFTPlaneProbe or None
-        Frequency-domain plane accumulators. The accumulation is
-        identical to the uniform path (acc += field * exp(-j2pi f t) * dt);
-        dt is scalar on both paths so no per-axis weighting is required.
+    Extracted verbatim from :func:`run_nonuniform` so the until-decay
+    entry point can drive the SAME ``step_fn`` / carry through a chunked
+    host loop. ``n_steps`` is used only to size the zero-source
+    placeholder table; the source waveform arrays themselves define the
+    table length when sources are present.
     """
     sources = sources or []
     probes = probes or []
@@ -840,6 +859,10 @@ def run_nonuniform(
         carry_init["lorentz"] = lorentz_state
 
     # Wire port S-param DFT accumulators
+    # (defaults bound unconditionally so _NUScanSetup can carry them;
+    # both stay unused unless the branch below runs — no behavior change)
+    sp_freqs = None
+    wp_meta: list = []
     if use_wire_ports and s_param_freqs is not None:
         sp_freqs = jnp.asarray(s_param_freqs, dtype=jnp.float32)
         nf = len(sp_freqs)
@@ -1212,6 +1235,102 @@ def run_nonuniform(
             new_carry["tfsf"] = tfsf_new
         return new_carry, probe_out
 
+    return _NUScanSetup(
+        step_fn=step_fn,
+        carry_init=carry_init,
+        src_waveforms=src_waveforms,
+        dt=dt,
+        sources=sources,
+        probes=probes,
+        wire_ports=wire_ports,
+        dft_planes=dft_planes,
+        flux_monitors=flux_monitors,
+        waveguide_meta=waveguide_meta,
+        wp_meta=wp_meta,
+        sp_freqs=sp_freqs,
+        use_wire_ports=use_wire_ports,
+        use_dft_planes=use_dft_planes,
+        use_flux_monitors=use_flux_monitors,
+        use_lumped_rlc=use_lumped_rlc,
+        use_ntff=use_ntff,
+        use_waveguide_ports=use_waveguide_ports,
+    )
+
+
+def run_nonuniform(
+    grid: NonUniformGrid,
+    materials: MaterialArrays,
+    n_steps: int,
+    *,
+    pec_mask=None,
+    pec_occupancy=None,
+    sources: list = None,
+    probes: list = None,
+    wire_ports: list = None,
+    s_param_freqs=None,
+    debye: tuple | None = None,
+    lorentz: tuple | None = None,
+    pec_faces: set[str] | None = None,
+    pmc_faces: set[str] | None = None,
+    dft_planes: list | None = None,
+    rlc_metas: tuple = (),
+    rlc_states: tuple = (),
+    ntff_box=None,
+    ntff_data=None,
+    waveguide_ports: list | None = None,
+    tfsf: tuple | None = None,
+    flux_monitors: list | None = None,
+    checkpoint: bool = False,
+    emit_time_series: bool = True,
+    checkpoint_every: int | None = None,
+    n_warmup: int = 0,
+    design_mask: jnp.ndarray | None = None,
+    aniso_eps: tuple | None = None,
+) -> dict:
+    """Run non-uniform FDTD via jax.lax.scan.
+
+    Parameters
+    ----------
+    sources : list of (i, j, k, component, waveform_array)
+    probes : list of (i, j, k, component)
+    wire_ports : list of dict with keys:
+        mid_i, mid_j, mid_k, component, impedance, waveform_array
+    s_param_freqs : (n_freqs,) array for S-param DFT
+    debye : (DebyeCoeffs, DebyeState) or None
+    lorentz : (LorentzCoeffs, LorentzState) or None
+    dft_planes : list of DFTPlaneProbe or None
+        Frequency-domain plane accumulators. The accumulation is
+        identical to the uniform path (acc += field * exp(-j2pi f t) * dt);
+        dt is scalar on both paths so no per-axis weighting is required.
+    """
+    setup = _build_nu_scan(
+        grid, materials, n_steps,
+        pec_mask=pec_mask,
+        pec_occupancy=pec_occupancy,
+        sources=sources,
+        probes=probes,
+        wire_ports=wire_ports,
+        s_param_freqs=s_param_freqs,
+        debye=debye,
+        lorentz=lorentz,
+        pec_faces=pec_faces,
+        pmc_faces=pmc_faces,
+        dft_planes=dft_planes,
+        rlc_metas=rlc_metas,
+        rlc_states=rlc_states,
+        ntff_box=ntff_box,
+        ntff_data=ntff_data,
+        waveguide_ports=waveguide_ports,
+        tfsf=tfsf,
+        flux_monitors=flux_monitors,
+        emit_time_series=emit_time_series,
+        design_mask=design_mask,
+        aniso_eps=aniso_eps,
+    )
+    step_fn = setup.step_fn
+    carry_init = setup.carry_init
+    src_waveforms = setup.src_waveforms
+
     xs = (jnp.arange(n_steps, dtype=jnp.int32), src_waveforms)
 
     # ---- n_warmup split --------------------------------------------------
@@ -1288,6 +1407,29 @@ def run_nonuniform(
         time_series = jnp.concatenate([warmup_ys, opt_ys], axis=0)
     else:
         time_series = opt_ys
+
+    return _assemble_nu_result(setup, final, time_series)
+
+
+def _assemble_nu_result(setup: _NUScanSetup, final: dict, time_series) -> dict:
+    """Assemble the NU result dict (pure code motion from run_nonuniform,
+    #383). Shared by :func:`run_nonuniform` and
+    :func:`run_nonuniform_until_decay` so the two paths return the exact
+    same schema (state, time_series, dt, conditional dft_planes /
+    flux_monitors / ntff_data / waveguide_ports / s_params...)."""
+    dt = setup.dt
+    dft_planes = setup.dft_planes
+    flux_monitors = setup.flux_monitors
+    wire_ports = setup.wire_ports
+    waveguide_meta = setup.waveguide_meta
+    wp_meta = setup.wp_meta
+    sp_freqs = setup.sp_freqs
+    use_wire_ports = setup.use_wire_ports
+    use_dft_planes = setup.use_dft_planes
+    use_flux_monitors = setup.use_flux_monitors
+    use_lumped_rlc = setup.use_lumped_rlc
+    use_ntff = setup.use_ntff
+    use_waveguide_ports = setup.use_waveguide_ports
 
     result = {
         "state": final["fdtd"],
@@ -1410,3 +1552,4 @@ def run_nonuniform(
         result["s_param_freqs"] = _np.array(sp_freqs)
 
     return result
+

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -9,7 +9,13 @@ from rfx.grid import C0
 from rfx.core.yee import MaterialArrays
 from rfx.materials.debye import init_debye
 from rfx.materials.lorentz import init_lorentz
-from rfx.nonuniform import NonUniformGrid, make_nonuniform_grid, run_nonuniform, make_current_source
+from rfx.nonuniform import (
+    NonUniformGrid,
+    make_nonuniform_grid,
+    run_nonuniform,
+    run_nonuniform_until_decay,
+    make_current_source,
+)
 
 
 def build_nonuniform_grid(
@@ -344,7 +350,12 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
                         n_warmup=0, design_mask=None,
                         subpixel_smoothing: bool = False,
                         attach_waveguide_flux: bool = False,
-                        strip_interior_pec: bool = False):
+                        strip_interior_pec: bool = False,
+                        until_decay: float | None = None,
+                        decay_check_interval: int = 50,
+                        decay_min_steps: int = 100,
+                        decay_max_steps: int = 50_000,
+                        decay_energy_consecutive: int = 2):
     """Run simulation on non-uniform grid with graded dz.
 
     Parameters
@@ -353,6 +364,28 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         The Simulation instance (read-only access to its fields).
     n_steps : int
         Number of timesteps.
+    until_decay : float or None
+        When not None, run via :func:`run_nonuniform_until_decay`
+        (issue #383 — NU port of the #169 interior-energy stop): every
+        step-count-sized build (source tables, waveguide port record
+        buffers, DFT planes, flux monitors) is sized with
+        ``decay_max_steps`` instead of ``n_steps``, and the scan is
+        replaced by the chunked host loop that stops when the
+        dV-weighted interior energy has decayed to this fraction of
+        peak. The routing layer only sends this on absorbing
+        (cpml/upml) boundaries. ``checkpoint`` (the jax.checkpoint grad
+        tape flag) is accepted-and-ignored on the decay path — it is a
+        forward-only host loop (mirrors the uniform run_until_decay);
+        ``checkpoint_every`` / ``n_warmup`` raise NotImplementedError
+        below. Flux monitors must use the rectangular DFT window (the
+        NU default) — a streaming windowed DFT needs the true total
+        step count in advance, which a decay-terminated run does not
+        have, so non-rect windows raise ValueError instead of silently
+        mis-windowing.
+    decay_check_interval, decay_min_steps, decay_max_steps,
+    decay_energy_consecutive :
+        Threaded to :func:`run_nonuniform_until_decay` (same semantics
+        as ``Simulation.run``'s ``decay_*`` kwargs).
     compute_s_params : bool or None
     s_param_freqs : array or None
     eps_override, sigma_override : jnp.ndarray or None
@@ -396,6 +429,45 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
                 "edges is not implemented. Use a full-plane flux monitor "
                 "(omit size=) or the uniform lane."
             )
+
+    # ---- until_decay (issue #383) fences + sizing ----
+    if until_decay is not None:
+        if checkpoint_every is not None:
+            raise NotImplementedError(
+                "checkpoint_every is not supported with until_decay on the "
+                "non-uniform path: the decay stop drives a chunked host "
+                "loop, not a single lax.scan, so segmented remat does not "
+                "apply (mirrors run_until_decay's checkpoint_segments "
+                "raise on the uniform lane). Use a fixed n_steps run for "
+                "checkpoint_every."
+            )
+        if n_warmup:
+            raise NotImplementedError(
+                "n_warmup is not supported with until_decay on the "
+                "non-uniform path: the decay stop is a forward-only host "
+                "loop, so the warmup AD-tape split does not apply."
+            )
+        for _fm in getattr(sim, "_flux_monitors", None) or []:
+            _win = getattr(_fm, "dft_window", "rect")
+            if _win != "rect":
+                raise ValueError(
+                    f"flux monitor {_fm.name!r} uses dft_window={_win!r}, "
+                    "which is not supported with until_decay on the "
+                    "non-uniform path: a streaming windowed DFT needs the "
+                    "true total step count in advance, and a "
+                    "decay-terminated run does not know it (sizing by "
+                    "decay_max_steps would silently mis-weight every "
+                    "sample). Use dft_window='rect' (the default) or a "
+                    "fixed n_steps run."
+                )
+
+    # Step-count-sized builds use ``sizing_n``: on the decay path every
+    # source table / waveguide-port record buffer / DFT accumulator is
+    # allocated for the worst case (decay_max_steps) so nothing truncates
+    # before the stop fires; stopping early is safe (the waveguide
+    # post-scan rect DFT masks by n_steps_recorded, and the streaming
+    # DFT-plane / flux / wire-port accumulators simply stop accumulating).
+    sizing_n = int(decay_max_steps) if until_decay is not None else n_steps
 
     grid = build_nonuniform_grid(
         sim._freq_max, sim._domain, sim._dx, sim._cpml_layers, sim._dz_profile,
@@ -515,7 +587,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         if pe.impedance == 0.0:
             # Current source with dV normalization
             src = make_current_source(
-                grid, idx, pe.component, pe.waveform, n_steps, materials_concrete)
+                grid, idx, pe.component, pe.waveform, sizing_n, materials_concrete)
             sources.append(src)
         elif pe.extent is not None:
             # Wire port on non-uniform grid
@@ -599,7 +671,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
                         continue
                     src = make_current_source(
                         grid, cell_ijk, pe.component,
-                        pe.waveform, n_steps, materials_concrete)
+                        pe.waveform, sizing_n, materials_concrete)
                     # Scale by 1/n_live for distributed excitation
                     scaled_wf = np.array(src[4]) / n_live
                     sources.append(
@@ -644,7 +716,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
                 pec_mask = pec_mask.at[i, j, k].set(False)
             if pe.excite:
                 src = make_current_source(
-                    grid, idx, pe.component, pe.waveform, n_steps, materials_concrete)
+                    grid, idx, pe.component, pe.waveform, sizing_n, materials_concrete)
                 sources.append(src)
 
     for pe in sim._probes:
@@ -675,7 +747,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
                     component=pe.component,
                     freqs=freqs_arr,
                     grid_shape=(grid.nx, grid.ny, grid.nz),
-                    dft_total_steps=n_steps,
+                    dft_total_steps=sizing_n,
                 )
             )
 
@@ -711,7 +783,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
                     grid_shape=(grid.nx, grid.ny, grid.nz),
                     d1=d1_arr,
                     d2=d2_arr,
-                    dft_total_steps=n_steps,
+                    dft_total_steps=sizing_n,
                     dft_window=getattr(pe, "dft_window", "rect"),
                     dft_window_alpha=getattr(pe, "dft_window_alpha", 0.25),
                 )
@@ -750,7 +822,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         for pe in sim._waveguide_ports:
             waveguide_port_cfgs.append(
                 _build_waveguide_port_config_nu(
-                    sim, pe, grid, wg_freqs, n_steps,
+                    sim, pe, grid, wg_freqs, sizing_n,
                 )
             )
 
@@ -759,7 +831,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
     # registered by compute_msl_s_matrix via add_dft_plane_probe.
     if getattr(sim, "_msl_ports", None):
         materials, pec_mask = _setup_msl_ports_nu(
-            sim, grid, materials, materials_concrete, sources, n_steps, pec_mask,
+            sim, grid, materials, materials_concrete, sources, sizing_n, pec_mask,
         )
 
     # Optional per-waveguide-port Poynting flux monitors at each port's
@@ -787,7 +859,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
                     grid_shape=(grid.nx, grid.ny, grid.nz),
                     d1=d1a,
                     d2=d2a,
-                    dft_total_steps=n_steps,
+                    dft_total_steps=sizing_n,
                     lo1=cfg.u_lo, hi1=cfg.u_hi,
                     lo2=cfg.v_lo, hi2=cfg.v_hi,
                 )
@@ -857,8 +929,7 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         )
         ntff_data_init = init_ntff_data(ntff_box)
 
-    r = run_nonuniform(
-        grid, materials, n_steps,
+    _shared_run_kwargs = dict(
         aniso_eps=aniso_eps,
         pec_mask=pec_mask,
         pec_occupancy=pec_occupancy_override,
@@ -881,12 +952,33 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
         ntff_data=ntff_data_init,
         waveguide_ports=waveguide_port_cfgs if waveguide_port_cfgs else None,
         tfsf=tfsf_pair,
-        checkpoint=checkpoint,
         emit_time_series=emit_time_series,
-        checkpoint_every=checkpoint_every,
-        n_warmup=n_warmup,
-        design_mask=design_mask,
     )
+    if until_decay is not None:
+        # #383: chunked host loop with the interior-energy stop. The
+        # fences above already rejected checkpoint_every / n_warmup /
+        # non-rect flux windows; ``checkpoint`` is accepted-and-ignored
+        # (forward-only host loop — mirrors uniform run_until_decay's
+        # treatment of the grad-tape flag); ``design_mask`` is a
+        # forward()-only kwarg and cannot reach this branch.
+        r = run_nonuniform_until_decay(
+            grid, materials,
+            decay_by=until_decay,
+            check_interval=decay_check_interval,
+            min_steps=decay_min_steps,
+            max_steps=decay_max_steps,
+            decay_energy_consecutive=decay_energy_consecutive,
+            **_shared_run_kwargs,
+        )
+    else:
+        r = run_nonuniform(
+            grid, materials, n_steps,
+            checkpoint=checkpoint,
+            checkpoint_every=checkpoint_every,
+            n_warmup=n_warmup,
+            design_mask=design_mask,
+            **_shared_run_kwargs,
+        )
 
     s_params = r.get("s_params")
     freqs_out = r.get("s_param_freqs")

--- a/tests/test_nonuniform_until_decay.py
+++ b/tests/test_nonuniform_until_decay.py
@@ -44,7 +44,7 @@ from rfx.sources.sources import GaussianPulse
 
 # Gate C envelope. Predeclared target was np.allclose(rtol=1e-6, atol=1e-10)
 # (the uniform AB-identity precedent). Measured red at first run:
-#   probe series  max abs diff 2.000e+01 on ~1.97e7 magnitudes (rel 1.251e-6)
+#   probe series  max abs diff 2.000e+01 at scale 1.9682e7 (rel 1.0161e-6)
 #   E components  max abs diff <= 3.27e-7 of the dominant E scale
 #   H components  max abs diff <= 3.15e-5 of the dominant H scale
 #     (hz is a physically-null component here — max|hz| ~ 3.5 vs
@@ -142,6 +142,12 @@ def test_nu_until_decay_fires_with_trace_and_physics_witness():
     k_dec = int(np.argmax(spec_dec))
     ratio = spec_dec[k_ref] / spec_ref[k_ref]
 
+    # NOTE: the probe sits in the deep near field (2 mm from the source,
+    # lambda ~ 30 mm at f0), so the reference spectrum peaks at the DC
+    # bin — argmax stays at k=0 even under heavy truncation, which makes
+    # the two peak-bin assertions below weak frequency gates on this
+    # fixture. They are kept as predeclared; the BINDING frequency-domain
+    # gate is the in-band sweep that follows.
     assert abs(k_dec - k_ref) <= 1, (
         f"peak bin moved by {abs(k_dec - k_ref)} bins (> 1); "
         f"U trace:\n{trace}"
@@ -149,6 +155,20 @@ def test_nu_until_decay_fires_with_trace_and_physics_witness():
     assert abs(ratio - 1.0) <= 0.02, (
         f"peak amplitude ratio {ratio:.5f} deviates more than 2% from the "
         f"3x fixed-run reference; U trace:\n{trace}"
+    )
+
+    # In-band sweep (reviewer-validated, #383 review): over every
+    # reference bin carrying >= 5% of the nonzero-bin (k >= 1) maximum,
+    # the per-bin amplitude ratio must stay within 1e-2. Measured
+    # discrimination on this exact fixture: 2.418e-3 at the true decay
+    # stop, 7.295e-3 at 90% truncation (both pass), 9.146e-2 at 70%
+    # truncation (fails) — ~30x sharper than the DC-amplitude ratio,
+    # which only degrades to 0.973 even at 70% truncation.
+    band = spec_ref >= 0.05 * float(np.max(spec_ref[1:]))
+    inband_err = float(np.max(np.abs(spec_dec[band] / spec_ref[band] - 1.0)))
+    assert inband_err <= 1e-2, (
+        f"in-band per-bin amplitude error {inband_err:.3e} exceeds 1e-2 "
+        f"vs the 3x fixed-run reference; U trace:\n{trace}"
     )
 
 

--- a/tests/test_nonuniform_until_decay.py
+++ b/tests/test_nonuniform_until_decay.py
@@ -1,0 +1,305 @@
+"""#383: until_decay on the non-uniform (dz_profile) lane.
+
+Gates (predeclared in the #383 design doc BEFORE implementation):
+
+* **Gate B** — the interior-energy stop actually fires on a small
+  graded-dz CPML NU sim, the per-check ``(step, U, peak_U)`` trace shows
+  ``decay_energy_consecutive`` consecutive sub-threshold checks
+  (workspace rule R5: the stop may not be reported without its trace),
+  and a physics witness pins the probe spectrum at the decay stop
+  against a 3x-longer fixed run (peak amplitude ratio within 2 percent,
+  peak frequency within one DFT bin).
+* **Gate C** — forced-N envelope: ``decay_by=0.0`` + ``decay_max_steps=N``
+  runs exactly N steps and matches ``run_nonuniform(n_steps=N)`` within
+  the predeclared ``np.allclose(rtol=1e-6, atol=1e-10)`` envelope (the
+  uniform scan-vs-loop precedent, tests/test_run_until_decay_ab_identity.py).
+* **Gate F** — a non-rect flux-monitor DFT window combined with
+  ``until_decay`` on the NU lane raises ``ValueError`` (a streaming
+  windowed DFT needs the true total step count in advance).
+* Routing — the public API threads ``until_decay`` on absorbing-boundary
+  NU sims without a silent-drop warning (the Gate D warn-matrix locks
+  live in tests/test_silent_drop_warnings.py).
+
+No module-level x64 config (workspace rule: x64 flips are process-global
+at collection time); nothing here needs float64.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+from rfx import Simulation
+from rfx.core.yee import init_materials
+from rfx.nonuniform import (
+    make_nonuniform_grid,
+    make_current_source,
+    position_to_index,
+    run_nonuniform,
+    run_nonuniform_until_decay,
+)
+from rfx.sources.sources import GaussianPulse
+
+# Gate C envelope. Predeclared target was np.allclose(rtol=1e-6, atol=1e-10)
+# (the uniform AB-identity precedent). Measured red at first run:
+#   probe series  max abs diff 2.000e+01 on ~1.97e7 magnitudes (rel 1.251e-6)
+#   E components  max abs diff <= 3.27e-7 of the dominant E scale
+#   H components  max abs diff <= 3.15e-5 of the dominant H scale
+#     (hz is a physically-null component here — max|hz| ~ 3.5 vs
+#     |hx|,|hy| ~ 3.7e5 — so its delta is absolute float noise of the
+#     dominant components, not a relative error of its own scale)
+# Root cause (same class as tests/test_run_until_decay_ab_identity.py on
+# the uniform lane): the decay path runs jax.jit-wrapped lax.scan chunks
+# while run_nonuniform calls lax.scan eagerly; XLA fuses/reassociates the
+# float32 Yee arithmetic differently between the two programs. The
+# chunking itself contributes ZERO error: a single full-length chunk
+# (check_interval=N) reproduces the chunked (check_interval=50) deltas
+# BYTE-IDENTICALLY (locked below by
+# test_nu_until_decay_chunking_is_bit_exact). Pinned at the measured
+# envelope with ~3x margin — scale-aware absolute gates, because a fixed
+# atol=1e-10 is meaningless for ~1e7-magnitude fields whose float32
+# noise floor is ~1e0, and per-element rtol is meaningless for the
+# physically-null hz.
+_TS_ENVELOPE = 5e-6     # x max|probe series|
+_E_ENVELOPE = 2e-6      # x dominant E-component scale
+_H_ENVELOPE = 1e-4      # x dominant H-component scale
+
+
+def _build_nu_case(n_table: int):
+    """Tiny graded-dz CPML NU sim: 24x24x32 cells, one pulsed Ez point
+    source, one Ez probe. ``n_table`` sizes the source waveform table."""
+    dz = np.array([0.4e-3] * 12 + [0.6e-3] * 12)
+    grid = make_nonuniform_grid((0.008, 0.008), dz, 0.5e-3, cpml_layers=4)
+    materials = init_materials((grid.nx, grid.ny, grid.nz))
+    pulse = GaussianPulse(f0=10e9, bandwidth=0.5)
+    src_idx = position_to_index(grid, (0.004, 0.004, 0.004))
+    src = make_current_source(grid, src_idx, "ez", pulse, n_table, materials)
+    prb = position_to_index(grid, (0.004, 0.004, 0.008)) + ("ez",)
+    return grid, materials, [src], [prb]
+
+
+def test_nu_until_decay_fires_with_trace_and_physics_witness():
+    """Gate B: stop fires, trace proves it, spectrum matches a 3x fixed run."""
+    decay_by = 1e-4
+    check_interval = 50
+    min_steps = 100
+    max_steps = 3000
+    consec = 2
+
+    grid, materials, sources, probes = _build_nu_case(max_steps)
+    r = run_nonuniform_until_decay(
+        grid, materials,
+        decay_by=decay_by,
+        check_interval=check_interval,
+        min_steps=min_steps,
+        max_steps=max_steps,
+        decay_energy_consecutive=consec,
+        sources=sources, probes=probes,
+    )
+    ts = np.asarray(r["time_series"])
+    steps_taken = ts.shape[0]
+    checks = r["decay_checks"]
+    trace = "\n".join(
+        f"  step={s:5d}  U={u:.6e}  peak_U={p:.6e}" for s, u, p in checks
+    )
+
+    # Stop fired strictly between the bounds.
+    assert min_steps <= steps_taken < max_steps, (
+        f"expected min_steps <= steps < max_steps, got {steps_taken}; "
+        f"U trace:\n{trace}"
+    )
+
+    # R5: the fire condition actually held — the last `consec` checks are
+    # all sub-threshold against the peak recorded AT that check.
+    assert len(checks) >= consec, f"too few checks; U trace:\n{trace}"
+    below = [u < decay_by * p for _, u, p in checks[-consec:]]
+    assert all(below), (
+        f"stop reported but the last {consec} checks are not all "
+        f"sub-threshold; U trace:\n{trace}"
+    )
+    # The trace is internally consistent with the loop mechanics: the
+    # stop step is the last check's step.
+    assert checks[-1][0] == steps_taken, (
+        f"last check step {checks[-1][0]} != steps_taken {steps_taken}"
+    )
+
+    # Physics witness: probe spectral peak vs a 3x-longer fixed run on
+    # the SAME grid/materials/sources (zero-padded common DFT grid).
+    n_ref = 3 * steps_taken
+    grid2, materials2, sources2, probes2 = _build_nu_case(n_ref)
+    r_ref = run_nonuniform(
+        grid2, materials2, n_ref, sources=sources2, probes=probes2,
+    )
+    ts_ref = np.asarray(r_ref["time_series"])[:, 0]
+    ts_dec = np.zeros(n_ref)
+    ts_dec[:steps_taken] = ts[:, 0]
+
+    spec_ref = np.abs(np.fft.rfft(ts_ref))
+    spec_dec = np.abs(np.fft.rfft(ts_dec))
+    k_ref = int(np.argmax(spec_ref))
+    k_dec = int(np.argmax(spec_dec))
+    ratio = spec_dec[k_ref] / spec_ref[k_ref]
+
+    assert abs(k_dec - k_ref) <= 1, (
+        f"peak bin moved by {abs(k_dec - k_ref)} bins (> 1); "
+        f"U trace:\n{trace}"
+    )
+    assert abs(ratio - 1.0) <= 0.02, (
+        f"peak amplitude ratio {ratio:.5f} deviates more than 2% from the "
+        f"3x fixed-run reference; U trace:\n{trace}"
+    )
+
+
+def test_nu_until_decay_forced_n_matches_fixed_run():
+    """Gate C: decay_by=0.0 runs exactly N steps and matches run_nonuniform."""
+    n_steps = 200
+    grid, materials, sources, probes = _build_nu_case(n_steps)
+
+    r_fixed = run_nonuniform(
+        grid, materials, n_steps, sources=sources, probes=probes,
+    )
+    r_decay = run_nonuniform_until_decay(
+        grid, materials,
+        decay_by=0.0,           # U < 0 never true -> forced-N escape
+        check_interval=50,
+        min_steps=1,            # every chunk boundary is an eligible check
+        max_steps=n_steps,
+        decay_energy_consecutive=2,
+        sources=sources, probes=probes,
+    )
+
+    ts_fixed = np.asarray(r_fixed["time_series"])
+    ts_decay = np.asarray(r_decay["time_series"])
+    assert ts_decay.shape[0] == n_steps, (
+        f"decay_by=0.0 must run exactly {n_steps} steps, got "
+        f"{ts_decay.shape[0]}"
+    )
+    # Every eligible check ran and none fired (U >= 0 on all of them).
+    checks = r_decay["decay_checks"]
+    assert [s for s, _, _ in checks] == [50, 100, 150, 200]
+    assert all(u >= 0.0 for _, u, _ in checks)
+
+    ts_scale = float(np.max(np.abs(ts_fixed)))
+    ts_delta = float(np.max(np.abs(ts_fixed - ts_decay)))
+    assert ts_delta <= _TS_ENVELOPE * ts_scale, (
+        f"probe series differ beyond the pinned envelope: "
+        f"max abs diff = {ts_delta:.3e} vs bound "
+        f"{_TS_ENVELOPE * ts_scale:.3e} (scale {ts_scale:.3e})"
+    )
+    e_scale = max(
+        float(np.max(np.abs(np.asarray(getattr(r_fixed["state"], c)))))
+        for c in ("ex", "ey", "ez")
+    )
+    h_scale = max(
+        float(np.max(np.abs(np.asarray(getattr(r_fixed["state"], c)))))
+        for c in ("hx", "hy", "hz")
+    )
+    for comp, bound in (
+        ("ex", _E_ENVELOPE * e_scale), ("ey", _E_ENVELOPE * e_scale),
+        ("ez", _E_ENVELOPE * e_scale), ("hx", _H_ENVELOPE * h_scale),
+        ("hy", _H_ENVELOPE * h_scale), ("hz", _H_ENVELOPE * h_scale),
+    ):
+        a = np.asarray(getattr(r_fixed["state"], comp))
+        b = np.asarray(getattr(r_decay["state"], comp))
+        delta = float(np.max(np.abs(a - b)))
+        assert delta <= bound, (
+            f"final {comp} differs beyond the pinned envelope: "
+            f"max abs diff = {delta:.3e} vs bound {bound:.3e}"
+        )
+
+
+def test_nu_until_decay_chunking_is_bit_exact():
+    """Chunk-boundary carry re-entry adds ZERO numerical error.
+
+    The whole Gate C delta lives in the jit(scan)-vs-eager-scan program
+    difference; the chunked host loop itself is exact. Lock that: a
+    single full-length chunk (check_interval = N, one lax.scan of N
+    steps) and a 4-chunk run (check_interval = N/4, same carry threaded
+    across chunk boundaries with global step indices) must be
+    BIT-IDENTICAL to each other.
+    """
+    n_steps = 200
+    grid, materials, sources, probes = _build_nu_case(n_steps)
+
+    def _run(ci):
+        return run_nonuniform_until_decay(
+            grid, materials,
+            decay_by=0.0, check_interval=ci, min_steps=1,
+            max_steps=n_steps, decay_energy_consecutive=2,
+            sources=sources, probes=probes,
+        )
+
+    r_one = _run(n_steps)
+    r_four = _run(n_steps // 4)
+    assert np.array_equal(
+        np.asarray(r_one["time_series"]), np.asarray(r_four["time_series"])
+    ), "chunked probe series must be bit-identical to the single-chunk run"
+    for comp in ("ex", "ey", "ez", "hx", "hy", "hz"):
+        a = np.asarray(getattr(r_one["state"], comp))
+        b = np.asarray(getattr(r_four["state"], comp))
+        assert np.array_equal(a, b), (
+            f"chunked final {comp} must be bit-identical to the "
+            f"single-chunk run"
+        )
+
+
+def _public_nu_sim():
+    dz = np.array([0.4e-3] * 12 + [0.6e-3] * 12)
+    with warnings.catch_warnings():
+        # The 1.5 grading-ratio advisory is deliberate test geometry.
+        warnings.simplefilter("ignore")
+        sim = Simulation(
+            freq_max=20e9,
+            domain=(0.008, 0.008, float(np.sum(dz))),
+            dx=0.5e-3,
+            dz_profile=dz,
+            boundary="cpml",
+            cpml_layers=4,
+        )
+    sim.add_source((0.004, 0.004, 0.004), "ez")
+    sim.add_probe((0.004, 0.004, 0.008), "ez")
+    return sim
+
+
+def test_nu_until_decay_public_api_routes_and_stops():
+    """Public run(until_decay=...) on a CPML NU sim: early stop, no drop."""
+    sim = _public_nu_sim()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        res = sim.run(
+            until_decay=1e-4,
+            decay_check_interval=50,
+            decay_min_steps=100,
+            decay_max_steps=3000,
+        )
+    steps_taken = np.asarray(res.time_series).shape[0]
+    assert 100 <= steps_taken < 3000, (
+        f"expected an early decay stop within bounds, got {steps_taken}"
+    )
+    dropped = [str(w.message) for w in caught
+               if "until_decay" in str(w.message)
+               and "silently ignored" in str(w.message)]
+    assert not dropped, (
+        f"until_decay must be honoured on the absorbing NU lane, got: "
+        f"{dropped}"
+    )
+
+
+def test_nu_until_decay_rejects_windowed_flux():
+    """Gate F: non-rect flux DFT window + until_decay raises ValueError."""
+    sim = _public_nu_sim()
+    sim.add_flux_monitor(axis="z", coordinate=0.010, dft_window="hann")
+    with pytest.raises(ValueError, match="dft_window"):
+        sim.run(until_decay=1e-3, decay_max_steps=500)
+
+
+def test_nu_until_decay_rejects_checkpoint_every():
+    """checkpoint_every + until_decay on the NU runner raises loudly."""
+    from rfx.runners.nonuniform import run_nonuniform_path
+    sim = _public_nu_sim()
+    with pytest.raises(NotImplementedError, match="checkpoint_every"):
+        run_nonuniform_path(
+            sim, n_steps=8, until_decay=1e-3, checkpoint_every=4,
+        )

--- a/tests/test_silent_drop_warnings.py
+++ b/tests/test_silent_drop_warnings.py
@@ -8,9 +8,12 @@ the NU path was fixed in commit ``1a2e6c5``; this test pins the rest of
 the class:
 
 1. **NU path**: emits an explicit ``UserWarning`` for ``snapshot``,
-   ``until_decay``, ``conformal_pec`` when set to non-default values.
+   ``conformal_pec`` when set to non-default values.
    ``subpixel_smoothing`` and ``checkpoint`` are *propagated* on the NU
-   path and therefore must NOT warn.
+   path and therefore must NOT warn. ``until_decay`` is propagated on
+   ABSORBING (cpml/upml) NU boundaries since #383 (must NOT warn there)
+   and still warn-and-drops on closed/PEC NU boundaries, with a
+   lane-accurate reason (the interior-energy stop needs an absorber).
 
 2. **Subgridded path**: emits a ``UserWarning`` for each unsupported
    kwarg (including ``subpixel_smoothing`` and ``checkpoint`` which
@@ -130,6 +133,43 @@ def test_nu_path_warns_on_dropped_kwargs(kw, val):
     assert any(kw in m and "non-uniform mesh" in m for m in msgs), (
         f"expected a non-uniform-mesh silent-drop warning for {kw}={val!r}, "
         f"got: {msgs}"
+    )
+    if kw == "until_decay":
+        # #383: _make_nu_sim is a closed (PEC, cpml_layers=0) NU sim, so
+        # the drop must carry the lane-accurate reason — the
+        # interior-energy stop needs absorbing boundaries.
+        assert any("until_decay" in m and "absorbing" in m for m in msgs), (
+            f"closed-boundary NU until_decay drop must state the "
+            f"absorbing-boundary reason (#383), got: {msgs}"
+        )
+
+
+def test_nu_path_until_decay_not_dropped_on_absorbing_boundary():
+    """#383: until_decay is propagated (no drop warning) on a CPML NU sim."""
+    dz = np.full(8, 1e-3)
+    sim = Simulation(
+        freq_max=10e9,
+        domain=(4e-3, 4e-3, 8e-3),
+        dx=1e-3,
+        dz_profile=dz,
+        boundary="cpml",
+        cpml_layers=4,
+    )
+    sim.add_source((2e-3, 2e-3, 2e-3), "ez")
+    sim.add_probe((2e-3, 2e-3, 5e-3), "ez")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sim.run(
+            until_decay=1e-3,
+            decay_check_interval=20,
+            decay_min_steps=20,
+            decay_max_steps=200,
+        )
+    msgs = [str(w.message) for w in caught]
+    assert not any("until_decay" in m and "silently ignored" in m
+                   for m in msgs), (
+        f"until_decay must be honoured on the absorbing-boundary NU path "
+        f"(#383), got: {msgs}"
     )
 
 


### PR DESCRIPTION
Fixes #383. `run(until_decay=...)` now works on the non-uniform (`dx/dy/dz_profile`) lane with absorbing (CPML/UPML) boundaries, porting the #169 total-interior-domain-energy stop criterion. Closed-boundary NU runs keep the (now accurately worded) warn-and-drop; distributed/subgridded/ADI lanes are unchanged. This is the architecture change the 2026-07-18 STOP on the PR #380 demo follow-up named as required ("wire decay stop into run_nonuniform_path via chunked-scan restructure") — it unblocks always-settled-by-construction graded-mesh resonance workflows.

## Design
- **Commit 1 — pure code motion**: `run_nonuniform` factored into `_build_nu_scan` + `_assemble_nu_result`; fixed-step behavior locked bit-identical (baseline .npz A/B: `np.array_equal` on time_series + all six fields, plus the committed NTFF exact-equality and e4/e5 envelope locks).
- **Commit 2 — the feature**: new `run_nonuniform_until_decay` = Python loop over constant-length jitted chunks (chunk = `decay_check_interval`) of the SAME step_fn, threading the SAME carry (NTFF Kahan compensation included), global step indices continued across chunks (the `n_warmup` split precedent). Stop: host-side **dV-weighted** interior energy (`dx_arr ⊗ dy_arr ⊗ dz`, interior slice from per-face pads) at chunk boundaries; peak-at-checks, `decay_energy_consecutive` consecutive sub-threshold checks to fire, `decay_by=0` forced-N escape, `decay_max_steps` hard bound. On a uniform grid the unweighted sum is implicitly volume-weighted, so per-cell dV is the faithful generalization of the #169 criterion, not a deviation.
- **Sizing**: with `until_decay` set, every step-count-sized build (source tables, waveguide port buffers + inc tables, DFT planes, flux monitors, MSL) is allocated at `decay_max_steps` — which also removes, by construction, the silent clamp-overwrite mode the uniform decay lane has when its buffers are shorter than the loop.
- **Fences**: non-rect flux DFT window + `until_decay` → `ValueError` (the windowed weight is the one total-count-dependent accumulator); `checkpoint_every`/`n_warmup` + `until_decay` → `NotImplementedError`; decay path is forward-only (`forward()`/`optimize()` signatures unchanged — AD-fence per the workspace hard constraint).

## Predeclared gates → evidence
| Gate | Result |
|---|---|
| A: bit-identity of `until_decay=None` NU path | PASS — author A/B + reviewer's independent main-vs-branch A/B (26 arrays incl. `n_warmup`/`checkpoint_every` paths) all `np.array_equal` |
| B: decay fires + R5 trace + physics witness | PASS on the single predeclared attempt — stop at step 450/3000 with two consecutive sub-threshold checks (U/peak 4.5e-6 → 4.5e-8 vs decay_by 1e-4; full trace asserted in-test); in-band spectrum vs 3× fixed run: max|ratio−1| = 2.42e-3 (gate 1e-2, reviewer-validated to fail a 70%-truncated ring-down at 9.1e-2) |
| C: forced-N equivalence | predeclared atol=1e-10 RED at O(1e7) field scale → root-caused (jit-vs-eager XLA class; single full-length chunk reproduces deltas byte-identically ⇒ chunk mechanics contribute zero — decomposition independently reproduced by the physics reviewer) → pinned at measured envelope (~3–6× margin) + new `test_nu_until_decay_chunking_is_bit_exact` exact lock |
| D: warn matrix | PASS — CPML NU no longer warns; closed NU warns with an accurate new reason; distributed/subgridded/ADI untouched |
| E: AD | PASS — full NU AD suites incl. the slow flux-AD trio (`-m ""` selection): 14 passed; wider NU battery 67 passed; uniform decay suite untouched: 17 passed |
| F: window fence | PASS — hann flux window + until_decay raises |

`ruff` clean. Reviewer sweep of remaining NU batteries (MSL-NU, broad e4/e5 envelopes, subpixel, preflight, #325 locks): 41 passed. API-reference gate + contract tests green; `run_nonuniform_until_decay` deliberately not exported (no public-surface change beyond the `run()` lane behavior).

## Independent review
Three-lane review (adversarial code / physics-R5 / docs sweep): APPROVE_WITH_NITS ×3, zero blockers. Nits applied in the final commit (binding in-band witness, envelope-comment accuracy, `checkpoint_every` doc scoping, `decay_checks` docstring precision, and the pre-existing stale `recipe-rt-measurement.mdx` until_decay passage). Accepted-as-parity notes: the absorbing gate is a boundary-string test (explicit `cpml_layers=0` + `boundary='cpml'` runs to the cap without firing — identical to the uniform lane); Gate C envelopes are host-measured — watch on the per-release GPU suite.

Known follow-ups (not in scope): `patch_antenna_demo` conversion to `until_decay` (the #380 follow-up this unblocks), and a preflight candidate for the fractional-vs-absolute `GaussianPulse.bandwidth` footgun surfaced during Gate B bring-up (absolute-Hz value ⇒ sub-dt spike ⇒ DC residue CPML cannot absorb ⇒ energy plateau).

deslop: reviewer-only ai-slop-cleaner pass over the 5 changed docs files — PASS (no overclaims, no filler; one cosmetic line-wrap nit in simulation.mdx, non-blocking).

R3: memory=project_issue169_until_decay_deferred.md(consistent)+obs10574-STOP(superseded-by-named-mechanism, linked above) | R2-attempts=1-clean(GateB); GateC=root-caused-repin, independently confirmed | falsifier=`pytest tests/test_nonuniform_until_decay.py -m ""`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
