### PR TITLE
test(studio): importorskip fastapi/mcp/httpx — bare envs skip at collection instead of aborting the GPU suite

### DIFF
--- a/tests/test_mcp_contract.py
+++ b/tests/test_mcp_contract.py
@@ -6,6 +6,12 @@ import os
 from pathlib import Path
 import sys
 
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("mcp")
+pytest.importorskip("httpx")
+
 from rfx.studio.api import create_app
 
 

--- a/tests/test_operations_security_isolation.py
+++ b/tests/test_operations_security_isolation.py
@@ -5,6 +5,10 @@ from pathlib import Path
 
 import pytest
 
+pytest.importorskip("fastapi")
+pytest.importorskip("mcp")
+pytest.importorskip("httpx")
+
 from rfx.experiments import ExperimentService
 from rfx.operations import (
     backup_workspace,

--- a/tests/test_provider_journey_smoke.py
+++ b/tests/test_provider_journey_smoke.py
@@ -6,6 +6,10 @@ import time
 
 import pytest
 
+pytest.importorskip("fastapi")
+pytest.importorskip("mcp")
+pytest.importorskip("httpx")
+
 from rfx.studio.api import create_app
 
 

--- a/tests/test_studio_api.py
+++ b/tests/test_studio_api.py
@@ -7,6 +7,10 @@ import zipfile
 
 import pytest
 
+pytest.importorskip("fastapi")
+pytest.importorskip("mcp")
+pytest.importorskip("httpx")
+
 from rfx.studio.api import create_app
 from rfx.studio.cli import build_parser, validate_launch_security
 


### PR DESCRIPTION
The post-#385 GPU-suite cadence run (VESSL 369367247541) failed at COLLECTION in 5.22 s — `ModuleNotFoundError: No module named 'mcp'` while importing `rfx.studio.api` in four test files, aborting `pytest -m gpu` before any GPU test executed (`2197 deselected, 4 errors`). The gpu-suite image installs only scipy/h5py/matplotlib/pytest; `mcp`/`fastapi`/`httpx` are `studio`/`agent`/`dev` extras, and `-m gpu` still imports every test module during collection.

Fix: `pytest.importorskip("fastapi"/"mcp"/"httpx")` before the studio imports in the four files, matching the repo's optional-dependency pattern (`test_visualize_3d.py`'s plotly guard, which skipped cleanly in the same log).

Verification (both directions):
- shim-simulated absent `mcp` (ImportError module on PYTHONPATH): `4 skipped in 0.31s` — was 4 collection errors + suite interrupt
- deps present: `17 passed in 21.35s`
- ruff clean

Not a #385 regression — the studio test files predate that merge and were never collectible on the bare gpu-suite image. GPU suite will be relaunched once this merges.

R3: memory=missing-external⇒visible-SKIP convention (consistent; plotly precedent) | R2-attempts=1 (gpu-suite launch; identified defect = unguarded optional imports) | falsifier=relaunched suite reaches the gpu pytest run

🤖 Generated with [Claude Code](https://claude.com/claude-code)