### PR TITLE
docs(examples): patch_antenna_demo settles by measurement (NUM_PERIODS=125); until_decay conversion R2-STOPPED as #388

### DIFF
--- a/examples/tutorials/patch_antenna_demo.py
+++ b/examples/tutorials/patch_antenna_demo.py
@@ -45,17 +45,19 @@ Honest accuracy at this deliberately coarse resolution (dx = 2 mm):
   0.08 dB of openEMS (6.71 vs 6.79 dBi), measured on this same geometry and
   mesh registration in the research frame of this fixture (95 mm of air above
   the patch, ``num_periods=250``).  This demo trims the extra air above the
-  patch to stay in the ~10-minute class and prints its own directivity so the
+  patch to stay in the ~15-minute class and prints its own directivity so the
   agreement can be checked live.
 
 Run as::
 
     python examples/tutorials/patch_antenna_demo.py
 
-Takes roughly 10 minutes on a many-core CPU.  The default ``NUM_PERIODS = 90``
-ends a few dB shy of the -40 dB settling bar, and the printed witness says so
-honestly; raise it to about 105 (a couple more minutes) for a fully settled
-run before quoting numbers anywhere that matters.
+Takes roughly 15 minutes on a many-core CPU.  ``NUM_PERIODS = 125`` is chosen
+from measurement, not hope: this fixture's probe envelope decays at about
+0.141 dB per period (measured between an instrumented 90-period run, -36.5 dB,
+and a 204-period run, -52.6 dB), which puts the -40 dB settling bar at about
+115 periods; 125 leaves ~1.4 dB of margin.  The witness below still measures
+and prints the end-of-run envelope every run — proof, not promise.
 """
 
 from __future__ import annotations
@@ -98,7 +100,7 @@ SIGMA_SUB = 2 * math.pi * 2.45e9 * EPS0 * SUB_EPS_R * TAN_DELTA
 OPENEMS_F_RES = 2.4221e9
 OPENEMS_D_DBI = 6.79
 
-# ---- Mesh and domain (coarse on purpose: dx = 2 mm, ~10 min CPU class) ----
+# ---- Mesh and domain (coarse on purpose: dx = 2 mm, ~15 min CPU class) ----
 DX = 2.0e-3
 N_CPML = 8
 N_SUB = 4                  # fine cells across the substrate thickness
@@ -106,19 +108,23 @@ DZ_SUB = SUB_THICK / N_SUB
 MARGIN_XY = 85.0e-3        # air beyond the ground-plane edge, x and y
 AIR_BELOW = 30.0e-3
 # 84 mm keeps the top NTFF face half a wavelength above the patch at F_DESIGN
-# while staying in the ~10-minute CPU class.  (The research lane behind the
+# while staying in the ~15-minute CPU class.  (The research lane behind the
 # quoted validation numbers used 95 mm of air; its lean-frame cross-check
 # moved the resonance by only 0.1 %, so the frame is not a sensitive knob.)
 AIR_ABOVE = 84.0e-3
 
-# 90 periods keeps this demo in the ~10-minute CPU class.  Measured on the
-# reference machine it ends near -36.5 dB — about 3.5 dB shy of the -40 dB
-# settling bar; the witness below prints the measured number every run and
-# says so.  Roughly 105 periods settles this fixture fully; the fully settled
-# research run of this geometry measured f_res = 2.2143 GHz and D = 6.71 dBi,
-# within 0.03 % and 0.03 dB of what the 90-period run prints — small here,
-# but check the witness before quoting anything tighter.
-NUM_PERIODS = 90
+# 125 periods settles this fixture past the -40 dB bar by measurement: the
+# probe envelope decays ~0.141 dB/period (-36.5 dB at 90 periods, -52.6 dB at
+# 204), so the bar lands near 115 periods and 125 adds margin (verified:
+# -43.1 dB SETTLED at 125 periods, reference machine, 2026-07-19).  The
+# earlier "roughly 105 settles fully" note in this file predated that slope
+# measurement and was optimistic.  The fully settled research run of this
+# geometry measured f_res = 2.2143 GHz and D = 6.71 dBi.  (A self-terminating
+# until_decay conversion was attempted and R2-STOPPED: the soft feed deposits
+# static charge across the ground-patch gap — measured floor 1.0e-2 of peak
+# interior energy, 96% in the feed column, pure E field — which the
+# total-energy criterion can never decay through.  See issue #388.)
+NUM_PERIODS = 125
 
 # Far-field bins: a ladder around the expected coarse-grid resonance plus one
 # bin near the second ring-down mode, so every harminv candidate gets a

--- a/examples/tutorials/patch_antenna_demo.py
+++ b/examples/tutorials/patch_antenna_demo.py
@@ -52,12 +52,13 @@ Run as::
 
     python examples/tutorials/patch_antenna_demo.py
 
-Takes roughly 15 minutes on a many-core CPU.  ``NUM_PERIODS = 125`` is chosen
-from measurement, not hope: this fixture's probe envelope decays at about
-0.141 dB per period (measured between an instrumented 90-period run, -36.5 dB,
-and a 204-period run, -52.6 dB), which puts the -40 dB settling bar at about
-115 periods; 125 leaves ~1.4 dB of margin.  The witness below still measures
-and prints the end-of-run envelope every run — proof, not promise.
+Takes roughly 15 minutes on a many-core CPU.  ``NUM_PERIODS = 125`` is sized
+from measurement: instrumented runs bracket the -40 dB settling bar near 115
+periods (-36.5 dB at 90 periods, -52.6 dB at 204 — an average fall of about
+0.14 dB per period, though the multi-mode tail beats rather than decaying
+linearly), and a direct verification run at 125 measured -43.1 dB, SETTLED.
+The witness below still measures and prints the end-of-run envelope every
+run — proof, not promise.
 """
 
 from __future__ import annotations
@@ -113,17 +114,21 @@ AIR_BELOW = 30.0e-3
 # moved the resonance by only 0.1 %, so the frame is not a sensitive knob.)
 AIR_ABOVE = 84.0e-3
 
-# 125 periods settles this fixture past the -40 dB bar by measurement: the
-# probe envelope decays ~0.141 dB/period (-36.5 dB at 90 periods, -52.6 dB at
-# 204), so the bar lands near 115 periods and 125 adds margin (verified:
-# -43.1 dB SETTLED at 125 periods, reference machine, 2026-07-19).  The
-# earlier "roughly 105 settles fully" note in this file predated that slope
-# measurement and was optimistic.  The fully settled research run of this
-# geometry measured f_res = 2.2143 GHz and D = 6.71 dBi.  (A self-terminating
-# until_decay conversion was attempted and R2-STOPPED: the soft feed deposits
-# static charge across the ground-patch gap — measured floor 1.0e-2 of peak
-# interior energy, 96% in the feed column, pure E field — which the
-# total-energy criterion can never decay through.  See issue #388.)
+# 125 periods settles this fixture past the -40 dB bar by direct measurement:
+# a verification run at 125 periods measured -43.1 dB, SETTLED (reference
+# machine, 2026-07-19).  Sizing rationale: measured endpoints -36.5 dB at 90
+# periods and -52.6 dB at 204 average ~0.14 dB/period, putting the bar near
+# 115 — but the multi-mode tail beats rather than decaying linearly (a
+# sibling test measured ~-45 dB at 110 on this fixture), so the shipped
+# number rests on its own measured witness, not on the slope model.  An
+# earlier revision of this file claimed "roughly 105 settles fully"; that
+# predated these measurements and was optimistic.  The fully settled research
+# run of this geometry measured f_res = 2.2143 GHz and D = 6.71 dBi.  (A
+# self-terminating until_decay conversion was attempted and abandoned after
+# two instrumented attempts: the soft feed deposits static charge across the
+# ground-patch gap — measured floor 1.0e-2 of peak interior energy, 96% in
+# the feed column, pure E field — which the total-interior-energy stop can
+# never decay through.  See issue #388.)
 NUM_PERIODS = 125
 
 # Far-field bins: a ladder around the expected coarse-grid resonance plus one


### PR DESCRIPTION
The #380 follow-up ("ship always-settled") lands via a measured period count, not `until_decay` — the conversion this branch originally attempted is R2-STOPPED with the mechanism documented in #388.

## What happened (two instrumented attempts + runner-level diagnostic)
1. `until_decay=1e-4` (GaussianPulse feed): CAP HIT at 42,000 steps — decay trace shows `min(U/peak)=1.038e-2`, never near threshold; final-state geography: 96.3% of remnant energy in the single feed xy-column, substrate-gap z-band, E-share 1.000/H 0.000 — a static charge field across the ground-patch capacitor that CPML cannot absorb. The probe meanwhile settled to −52.6 dB: the ringing decays; the criterion is hostage to the static remnant.
2. `ModulatedGaussian(bandwidth=1.2)` swap: WORSE (probe tail −14.1 dB, harminv empty) — at fractional bandwidth 1.2 the modulated pulse's DC suppression is only exp(−1/bw²)≈0.5, more DC than the differentiated pulse. Two non-closing attempts ⇒ STOP; criterion-architecture candidates filed in #388.

## What ships
`NUM_PERIODS: 90 → 125`, justified by measurement: envelope slope 0.141 dB/period (−36.5 dB @ 90, −52.6 dB @ 204) ⇒ −40 dB bar at ~115 periods. Verified run at 125: **SETTLED at −43.1 dB**, f_res 2.2149 GHz (+0.03% vs the settled research value 2.2143), D 6.68 dBi (0.03 dB vs 6.71), mode-ID unchanged (2.2 GHz radiator broadside; 2.70 GHz correctly rejected), far-field cuts figure written, wall 847 s. Also corrects the docstring's pre-slope-measurement "roughly 105 settles fully" claim and three stale "~10-minute class" wall-time references.

Preflight advisories (4, quoted verbatim in the run log and by the demo itself) are unchanged and deliberately not suppressed.

Cross-refs: #383 (NU until_decay capability — its own gates unaffected), #386 (gross bandwidth footgun; #388 shows even sane-bandwidth soft feeds floor the criterion), #388 (this arc's mechanism + fix directions).

R3: memory=project_issue169_until_decay_deferred.md(R2-STOP recorded)+rfx-known-issues #383 addendum | R2-attempts=2-STOPPED(until_decay lane); this change = documented-mapping period bump, 1 clean verification | falsifier=run the demo — witness must print SETTLED with the quoted f_res/D

🤖 Generated with [Claude Code](https://claude.com/claude-code)