### PR TITLE
feat(sources+preflight): GaussianPulse cutoff param + DC-floor warnings — the #388 mitigation increment

### DIFF
--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -291,6 +291,69 @@ class _ExecuteMixin:
                 stacklevel=3,
             )
 
+    def _warn_until_decay_dc_floor(self, *, dt, n_table: int) -> None:
+        """#388 predictor: warn when a soft source will floor ``until_decay``.
+
+        A soft current source deposits its waveform's discrete time integral
+        as a net static end-charge ``q = S/((1+loss)*dz_src)`` with
+        ``S = sum s(t_n)*dt`` — measured exactly on both the uniform and
+        non-uniform lanes (issue #388). The remnant's energy is the
+        discrete-Poisson self-energy of that charge: it does not decay and
+        CPML cannot absorb a static field, so it floors the interior-energy
+        decay criterion and ``until_decay`` cap-hits instead of stopping.
+
+        For each soft source (``impedance == 0`` port entries), compute
+        ``rel_DC = |sum s(t_n)*dt| / sum |s(t_n)|*dt`` over the planned
+        table length (``decay_max_steps`` — the decay lanes' buffer size)
+        and warn quantitatively above 1e-3 (the demo-scale GaussianPulse
+        sits at ~6e-5; a bandwidth=1.2 ModulatedGaussian at ~0.68).
+
+        Lives with the run()-path warning helpers (not preflight) because
+        ``preflight()`` does not receive run kwargs and this advisory is
+        meaningful only when ``until_decay`` is requested.
+        """
+        import warnings
+
+        from rfx.core.jax_utils import is_tracer
+
+        if is_tracer(dt):
+            return  # traced dt: advisory host math is impossible here
+        dt = float(dt)
+        if not dt > 0.0 or n_table <= 0:
+            return
+        t = np.arange(int(n_table), dtype=np.float64) * dt
+        for pe in self._ports:
+            if pe.impedance != 0.0 or not getattr(pe, "excite", True):
+                continue
+            wf = pe.waveform
+            if wf is None or isinstance(wf, str):
+                continue
+            try:
+                s = np.asarray(wf(jnp.asarray(t)), dtype=np.float64)
+            except Exception:
+                continue  # non-vectorizable CustomWaveform etc. — skip
+            if s.shape != t.shape or not np.all(np.isfinite(s)):
+                continue
+            denom = float(np.sum(np.abs(s))) * dt
+            if denom == 0.0:
+                continue
+            s_int = float(np.sum(s)) * dt
+            rel_dc = abs(s_int) / denom
+            if rel_dc > 1e-3:
+                warnings.warn(
+                    f"soft source at {pe.position} ({pe.component}): "
+                    f"waveform {type(wf).__name__} deposits relative DC "
+                    f"{rel_dc:.2e} (|sum s*dt| = {abs(s_int):.3e} over the "
+                    f"planned {int(n_table)}-step table) — the deposited "
+                    "static charge will floor the interior-energy criterion "
+                    "(a static field neither decays nor is absorbed by "
+                    "CPML); until_decay may cap-hit (issue #388). Reduce "
+                    "the waveform's DC content: a higher GaussianPulse "
+                    "cutoff (e.g. cutoff=4.5), ModulatedGaussian with "
+                    "bandwidth <= 0.5, or run with a fixed n_steps.",
+                    UserWarning, stacklevel=3,
+                )
+
     def _reject_refplane_ports_off_uniform_lane(self, path_name: str,
                                                 compute_s_params) -> None:
         """Fail loudly when reference-plane ports hit a non-uniform lane.
@@ -2366,6 +2429,13 @@ class _ExecuteMixin:
             rejects its internal ``checkpoint_every`` segmentation option
             when a decay stop is requested; that option belongs to the
             ``forward()`` lane and is not reachable through ``run()``.)
+            **DC floor (issue #388):** a soft-source waveform with net DC
+            content deposits a static end-charge whose self-energy floors
+            the interior-energy criterion; ``run()`` warns quantitatively
+            when a planned soft-source waveform's relative DC exceeds 1e-3
+            (raise the ``GaussianPulse`` cutoff, narrow a
+            ``ModulatedGaussian`` to bandwidth <= 0.5, or use a fixed
+            ``n_steps``).
         decay_check_interval : int
             Check decay every N steps (default 50).
         decay_min_steps : int
@@ -2519,6 +2589,19 @@ class _ExecuteMixin:
                         "(issue #383)",
                 },
             )
+            if _nu_until_decay is not None:
+                # #388 DC-floor predictor for the NU decay stop. The grid
+                # build is pure (no sim-state mutation) and cheap; an
+                # advisory must never block the run, so any build failure
+                # simply skips the check (the runner will surface it).
+                try:
+                    _nu_dt_for_dc = self._build_nonuniform_grid().dt
+                except Exception:
+                    _nu_dt_for_dc = None
+                if _nu_dt_for_dc is not None:
+                    self._warn_until_decay_dc_floor(
+                        dt=_nu_dt_for_dc, n_table=decay_max_steps
+                    )
             _res = self._run_nonuniform(
                 n_steps=n_steps,
                 compute_s_params=compute_s_params,
@@ -2596,6 +2679,12 @@ class _ExecuteMixin:
         # ---- Uniform path ----
         if n_steps is None:
             n_steps = grid.num_timesteps(num_periods=num_periods)
+
+        if until_decay is not None:
+            # #388 DC-floor predictor for the decay stop.
+            self._warn_until_decay_dc_floor(
+                dt=grid.dt, n_table=decay_max_steps
+            )
 
         from rfx.runners.uniform import run_uniform
         _field_dtype = jnp.float16 if self._precision == "mixed" else None

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -350,7 +350,7 @@ class _ExecuteMixin:
                     "CPML); until_decay may cap-hit (issue #388). Reduce "
                     "the waveform's DC content: a higher GaussianPulse "
                     "cutoff (e.g. cutoff=4.5), ModulatedGaussian with "
-                    "bandwidth <= 0.5, or run with a fixed n_steps.",
+                    "bandwidth <= 0.4, or run with a fixed n_steps.",
                     UserWarning, stacklevel=3,
                 )
 
@@ -2434,7 +2434,7 @@ class _ExecuteMixin:
             the interior-energy criterion; ``run()`` warns quantitatively
             when a planned soft-source waveform's relative DC exceeds 1e-3
             (raise the ``GaussianPulse`` cutoff, narrow a
-            ``ModulatedGaussian`` to bandwidth <= 0.5, or use a fixed
+            ``ModulatedGaussian`` to bandwidth <= 0.4, or use a fixed
             ``n_steps``).
         decay_check_interval : int
             Check decay every N steps (default 50).

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2743,10 +2743,13 @@ class _PreflightMixin:
         ``until_decay`` — a sub-dt spike is always broken.
 
         ``dt`` is estimated from the preflight ``dx`` via the uniform-lane
-        3D Courant formula (``Grid.courant_dt``). A concrete ``dz_profile``
-        only makes the actual dt smaller (finer cells), so the estimate
-        errs toward firing — appropriate for a mistake that misses the
-        threshold by orders of magnitude, not by percent.
+        3D Courant formula (``Grid.courant_dt``). A refining ``dz_profile``
+        makes the actual dt smaller, so the estimate errs toward firing; a
+        strictly coarsening profile can raise the NU dt above this estimate
+        by at most sqrt(3/2) ~ 1.22x (the NU dt combines per-axis minimum
+        cell sizes, ``rfx/nonuniform.py``), so the check can under-fire by
+        <= 22% — harmless against a mistake that misses the threshold by
+        ~9 orders of magnitude, not by percent.
         """
         dt = dx / (C0 * math.sqrt(3.0)) * 0.99  # Grid.courant_dt(dx, ndim=3)
         entries = list(self._ports) + list(self._msl_ports)
@@ -2754,16 +2757,31 @@ class _PreflightMixin:
             entries.append(self._tfsf)
         for entry in entries:
             wf = getattr(entry, "waveform", None)
-            if wf is None or isinstance(wf, str):
-                continue
-            try:
-                tau = float(wf.tau)
-            except (AttributeError, TypeError, ValueError,
-                    ZeroDivisionError):
-                continue
-            if not math.isfinite(tau) or tau <= 0.0:
+            tau = None
+            if wf is not None and not isinstance(wf, str):
+                try:
+                    tau = float(wf.tau)
+                except (AttributeError, TypeError, ValueError,
+                        ZeroDivisionError):
+                    tau = None
+            else:
+                # String-named waveforms (the TFSF entry's
+                # "differentiated_gaussian" / "modulated_gaussian"): both
+                # pulse families share tau = 1/(pi*f0*bandwidth), so the
+                # absolute-Hz-bandwidth footgun on
+                # add_tfsf_source(bandwidth=...) is computable from the
+                # entry's own f0/bandwidth attributes when both are set.
+                f0 = getattr(entry, "f0", None)
+                bw = getattr(entry, "bandwidth", None)
+                if f0 and bw:
+                    try:
+                        tau = 1.0 / (math.pi * float(f0) * float(bw))
+                    except (TypeError, ValueError, ZeroDivisionError):
+                        tau = None
+            if tau is None or not math.isfinite(tau) or tau <= 0.0:
                 continue
             if tau < 3.0 * dt:
+                _wf_name = wf if isinstance(wf, str) else type(wf).__name__
                 _w.warn(
                     PreflightWarning(
                         f"waveform tau={tau:.3g}s is below 3*dt "
@@ -2774,7 +2792,7 @@ class _PreflightMixin:
                         "a static charge field CPML cannot absorb "
                         "(issue #386)",
                         code="unresolved_pulse",
-                        loc=f"waveform {type(wf).__name__} at "
+                        loc=f"waveform {_wf_name} at "
                             f"{getattr(entry, 'position', None)}",
                         source="_validate_cfg_unresolved_pulse",
                     ),

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1725,6 +1725,7 @@ class _PreflightMixin:
         self._validate_cfg_floating_single_cell_port(_w)
         self._validate_cfg_pec_boundary_open_structure(_w)
         self._validate_cfg_no_sources(_w)
+        self._validate_cfg_unresolved_pulse(_w, dx)
         self._validate_cfg_nonuniform_limitations(_w, cpml_thickness)
         self._validate_cfg_graded_box_rasterization(_w)
         self._validate_cfg_subgrid_limitations(_w)
@@ -2728,6 +2729,57 @@ class _PreflightMixin:
                 ),
                 stacklevel=3,
             )
+
+    def _validate_cfg_unresolved_pulse(self, _w, dx: float) -> None:
+        """Warn when a pulse waveform is unresolved by the time step (#386).
+
+        ``tau < 3*dt`` means the sampled excitation is a sub-dt spike: the
+        pulse's spectrum extends far past the grid Nyquist limit and the
+        discrete time integral no longer cancels, so a soft source leaves a
+        static charge field that CPML cannot absorb. The canonical way to
+        get here is passing an absolute-Hz number as ``bandwidth`` where a
+        FRACTIONAL one is expected (``tau = 1/(f0*bandwidth*pi)`` then
+        misses by ~9 orders of magnitude), so this fires regardless of
+        ``until_decay`` — a sub-dt spike is always broken.
+
+        ``dt`` is estimated from the preflight ``dx`` via the uniform-lane
+        3D Courant formula (``Grid.courant_dt``). A concrete ``dz_profile``
+        only makes the actual dt smaller (finer cells), so the estimate
+        errs toward firing — appropriate for a mistake that misses the
+        threshold by orders of magnitude, not by percent.
+        """
+        dt = dx / (C0 * math.sqrt(3.0)) * 0.99  # Grid.courant_dt(dx, ndim=3)
+        entries = list(self._ports) + list(self._msl_ports)
+        if self._tfsf is not None:
+            entries.append(self._tfsf)
+        for entry in entries:
+            wf = getattr(entry, "waveform", None)
+            if wf is None or isinstance(wf, str):
+                continue
+            try:
+                tau = float(wf.tau)
+            except (AttributeError, TypeError, ValueError,
+                    ZeroDivisionError):
+                continue
+            if not math.isfinite(tau) or tau <= 0.0:
+                continue
+            if tau < 3.0 * dt:
+                _w.warn(
+                    PreflightWarning(
+                        f"waveform tau={tau:.3g}s is below 3*dt "
+                        f"(dt~{dt:.3g}s, tau/dt={tau/dt:.3g}): pulse "
+                        "unresolved by the time step — an absolute-Hz "
+                        "bandwidth was likely passed where a FRACTIONAL "
+                        "one is expected; the discrete DC residue leaves "
+                        "a static charge field CPML cannot absorb "
+                        "(issue #386)",
+                        code="unresolved_pulse",
+                        loc=f"waveform {type(wf).__name__} at "
+                            f"{getattr(entry, 'position', None)}",
+                        source="_validate_cfg_unresolved_pulse",
+                    ),
+                    stacklevel=3,
+                )
 
     def _validate_cfg_nonuniform_limitations(
         self, _w, cpml_thickness: float

--- a/rfx/config/_waveforms.py
+++ b/rfx/config/_waveforms.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 from rfx.sources.sources import GaussianPulse, ModulatedGaussian
 
-# type-string -> waveform class. Each class takes (f0, bandwidth, amplitude)
-# as its leading constructor args (ModulatedGaussian also accepts cutoff).
+# type-string -> waveform class. Each class takes (f0, bandwidth, amplitude,
+# cutoff) as its constructor args (GaussianPulse gained cutoff for the
+# issue-#388 deposited-DC mitigation).
 WAVEFORM_REGISTRY = {
     "gaussian_pulse": GaussianPulse,
     "modulated_gaussian": ModulatedGaussian,
@@ -23,7 +24,7 @@ WAVEFORM_REGISTRY = {
 # precise error on an unexpected key rather than a bare TypeError from the
 # dataclass constructor.
 _ALLOWED_KEYS = {
-    "gaussian_pulse": {"f0", "bandwidth", "amplitude"},
+    "gaussian_pulse": {"f0", "bandwidth", "amplitude", "cutoff"},
     "modulated_gaussian": {"f0", "bandwidth", "amplitude", "cutoff"},
 }
 
@@ -36,8 +37,7 @@ def waveform_from_config(cfg: dict):
     cfg : dict
         Must contain ``type`` (one of :data:`WAVEFORM_REGISTRY`) and at
         least ``f0``. Remaining keys are passed through to the waveform
-        constructor (``bandwidth``, ``amplitude``, and ``cutoff`` for
-        modulated_gaussian).
+        constructor (``bandwidth``, ``amplitude``, ``cutoff``).
 
     Returns
     -------

--- a/rfx/sources/sources.py
+++ b/rfx/sources/sources.py
@@ -58,6 +58,15 @@ class GaussianPulse:
 
     s(t) = -2 * ((t - t0) / tau) * exp(-((t - t0) / tau)^2)
 
+    The onset truncation at t=0 leaves a nonzero time integral: over the
+    sampled table, S = sum s(t_n)*dt ~ -amplitude * tau * exp(-cutoff^2).
+    A soft current source deposits exactly that integral as a net static
+    end-charge q = S/((1+loss)*dz_src) (issue #388), so the deposited DC
+    scales as e^(-cutoff^2): raising ``cutoff`` from 3.0 to 4.5 cuts the
+    deposited charge by e^(4.5^2 - 3^2) ~ 7.7e4 — about 5 decades.
+    Use a higher cutoff when a static source remnant matters (e.g. the
+    ``until_decay`` interior-energy stop on absorbing boundaries).
+
     Parameters
     ----------
     f0 : float
@@ -66,11 +75,17 @@ class GaussianPulse:
         Fractional bandwidth (0–1). Default 0.5.
     amplitude : float
         Peak amplitude (V/m). Default 1.0.
+    cutoff : float
+        Number of tau between t=0 and the pulse peak: t0 = cutoff * tau.
+        Default 3.0 (historical value; waveform values are unchanged at
+        the default). Higher values buy an e^(-cutoff^2) reduction of the
+        deposited-DC integral at the cost of a longer onset (issue #388).
     """
 
     f0: float
     bandwidth: float = 0.5
     amplitude: float = 1.0
+    cutoff: float = 3.0
 
     @property
     def tau(self) -> float:
@@ -79,8 +94,8 @@ class GaussianPulse:
 
     @property
     def t0(self) -> float:
-        """Pulse delay (3*tau ensures smooth onset)."""
-        return 3.0 * self.tau
+        """Pulse delay (cutoff*tau ensures smooth onset)."""
+        return self.cutoff * self.tau
 
     def __call__(self, t: float) -> float:
         """Evaluate pulse at time t."""
@@ -98,6 +113,14 @@ class ModulatedGaussian:
     relative to a differentiated Gaussian. A finite sampled pulse does not in
     general have an exactly zero integral, so DC-sensitive calculations should
     inspect the sampled spectrum and fields explicitly.
+
+    DC suppression is set by the envelope width: the spectrum is a Gaussian
+    centered at f0, and its value at DC relative to the carrier peak is
+    e^(-1/bandwidth^2) — about 0.5 at bandwidth=1.2 but 0.018 at
+    bandwidth=0.5. Wide fractional bandwidths therefore keep substantial DC
+    drive; when the net deposited charge of a soft source matters (e.g. the
+    ``until_decay`` interior-energy stop, issue #388), use bandwidth <= 0.5
+    or a :class:`GaussianPulse` with a higher ``cutoff``.
 
     Parameters
     ----------

--- a/rfx/sources/sources.py
+++ b/rfx/sources/sources.py
@@ -119,8 +119,10 @@ class ModulatedGaussian:
     e^(-1/bandwidth^2) — about 0.5 at bandwidth=1.2 but 0.018 at
     bandwidth=0.5. Wide fractional bandwidths therefore keep substantial DC
     drive; when the net deposited charge of a soft source matters (e.g. the
-    ``until_decay`` interior-energy stop, issue #388), use bandwidth <= 0.5
-    or a :class:`GaussianPulse` with a higher ``cutoff``.
+    ``until_decay`` interior-energy stop, issue #388), use bandwidth <= 0.4
+    (measured relative DC 4.0e-4 at the issue-#388 demo scale — below the
+    run() warning's 1e-3 threshold, which bandwidth=0.5 at ~2.6e-2 still
+    exceeds) or a :class:`GaussianPulse` with a higher ``cutoff``.
 
     Parameters
     ----------

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -198,6 +198,22 @@ def test_waveform_unknown_type_raises():
         waveform_from_config({"type": "sawtooth", "f0": 1e9})
 
 
+def test_waveform_gaussian_pulse_accepts_cutoff():
+    """The #388 DC-floor warning's primary remedy (cutoff=4.5) must be
+    reachable from the config/YAML lane for both pulse families."""
+    wf = waveform_from_config(
+        {"type": "gaussian_pulse", "f0": 2.2e9, "bandwidth": 1.2,
+         "cutoff": 4.5}
+    )
+    assert isinstance(wf, GaussianPulse)
+    assert wf.cutoff == 4.5
+    # Default stays at the byte-identical historical value.
+    wf_default = waveform_from_config(
+        {"type": "gaussian_pulse", "f0": 2.2e9, "bandwidth": 1.2}
+    )
+    assert wf_default.cutoff == 3.0
+
+
 def test_shape_box_and_unsupported():
     box = shape_from_config(
         {"shape": "box", "bounds": [[0, 0, 0], [1, 2, 3]]}

--- a/tests/test_source_dc_floor_guards.py
+++ b/tests/test_source_dc_floor_guards.py
@@ -1,0 +1,196 @@
+"""Soft-source deposited-DC guards (issues #386 / #388).
+
+Measured mechanism (issue #388, 2026-07-19, both uniform and NU lanes):
+a soft current source deposits its waveform's discrete time integral as a
+net static end-charge ``q = S/((1+loss)*dz_src)``, ``S = sum s(t_n)*dt``.
+The remnant's discrete-Poisson self-energy neither decays nor is absorbed
+by CPML, so it floors the ``until_decay`` interior-energy criterion.
+
+Locks, in order:
+1. ``GaussianPulse``'s new ``cutoff`` parameter is byte-identical to the
+   historical waveform at the default ``cutoff=3.0`` (formula replica
+   pinned from main @ 19a8063).
+2. ``cutoff=4.5`` reduces ``|sum s*dt|`` by the predicted factor
+   ``e^-(4.5^2 - 3^2)`` within 10% (scoped x64 — the target sum is ~1e-19
+   and float32 accumulation noise would swamp it; NO module-level x64).
+3. The run()-path ``until_decay`` DC-floor warning fires exactly per the
+   predeclared four-case matrix (issue #388 measured rel_DC values at the
+   demo dt = 1.2 ps: 6.0e-5 / ~e-10 / 0.68 / 4.0e-4 vs threshold 1e-3).
+4. The ``unresolved_pulse`` preflight advisory (issue #386) fires on the
+   absolute-Hz-bandwidth footgun and stays silent on the demo-class
+   fractional-bandwidth config.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+
+import numpy as np
+import jax.numpy as jnp
+import pytest
+
+from rfx import Simulation, GaussianPulse, ModulatedGaussian
+
+DEMO_DT = 1.2e-12  # the issue-#388 measurement dt (patch_antenna_demo scale)
+
+
+# ---------------------------------------------------------------------------
+# 1. cutoff default byte-identity
+# ---------------------------------------------------------------------------
+
+def _main_gaussian_pulse(t, f0, bandwidth, amplitude=1.0):
+    """Replica of main@19a8063 GaussianPulse.__call__, op-for-op.
+
+    tau = 1/(f0*bandwidth*pi); t0 = 3.0*tau (the pre-cutoff hardcoded
+    value, rfx/sources/sources.py:76-88 on main); then
+    amplitude * (-2*arg) * exp(-arg^2) with the identical jnp ops.
+    """
+    tau = 1.0 / (f0 * bandwidth * math.pi)
+    t0 = 3.0 * tau
+    arg = (t - t0) / tau
+    return amplitude * (-2.0 * arg) * jnp.exp(-(arg**2))
+
+
+def test_cutoff_default_byte_identity():
+    """Default cutoff=3.0 reproduces main's waveform bit-for-bit."""
+    t = jnp.asarray(np.arange(10_000) * DEMO_DT)
+    pulse = GaussianPulse(f0=2.2e9, bandwidth=1.2)
+
+    assert pulse.cutoff == 3.0
+    # t0 must be the exact same float product main computed (3.0 * tau).
+    assert pulse.t0 == 3.0 * pulse.tau
+
+    got = np.asarray(pulse(t))
+    want = np.asarray(_main_gaussian_pulse(t, 2.2e9, 1.2))
+    assert np.array_equal(got, want), (
+        "GaussianPulse default-cutoff waveform drifted from main's values"
+    )
+
+    # Explicit cutoff=3.0 is the same object semantics as the default.
+    explicit = np.asarray(GaussianPulse(f0=2.2e9, bandwidth=1.2, cutoff=3.0)(t))
+    assert np.array_equal(got, explicit)
+
+
+# ---------------------------------------------------------------------------
+# 2. cutoff=4.5 cuts the deposited-DC integral by e^-(4.5^2 - 3^2)
+# ---------------------------------------------------------------------------
+
+def test_cutoff_45_reduces_deposited_dc_by_predicted_factor():
+    """|sum s*dt| ratio (cutoff 4.5 vs 3) matches e^-11.25 within 10%.
+
+    x64 is scoped to this test (jax.experimental.enable_x64 context):
+    the cutoff=4.5 sum is ~1e-19 while individual samples are O(1), so a
+    float32 accumulation would be pure rounding noise. Never enable x64
+    at module level — it is process-global at pytest collection.
+    """
+    from jax.experimental import enable_x64
+
+    with enable_x64():
+        t = jnp.arange(50_000, dtype=jnp.float64) * DEMO_DT
+        s3 = np.asarray(GaussianPulse(f0=2.2e9, bandwidth=1.2)(t))
+        s45 = np.asarray(
+            GaussianPulse(f0=2.2e9, bandwidth=1.2, cutoff=4.5)(t)
+        )
+
+    s_int_3 = abs(float(np.sum(s3))) * DEMO_DT
+    s_int_45 = abs(float(np.sum(s45))) * DEMO_DT
+    assert s_int_3 > 0.0
+
+    measured_ratio = s_int_45 / s_int_3
+    predicted_ratio = math.exp(-(4.5**2 - 3.0**2))  # ~1.3e-5, ~5 decades
+    assert abs(measured_ratio / predicted_ratio - 1.0) < 0.10, (
+        f"measured {measured_ratio:.4e} vs predicted {predicted_ratio:.4e}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. until_decay DC-floor warning — predeclared four-case matrix (#388)
+# ---------------------------------------------------------------------------
+
+def _dc_floor_fires(waveform) -> list[str]:
+    sim = Simulation(freq_max=4e9, domain=(0.02, 0.02, 0.02), dx=2e-3,
+                     cpml_layers=4)
+    sim.add_source((0.01, 0.01, 0.01), "ez", waveform=waveform)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sim._warn_until_decay_dc_floor(dt=DEMO_DT, n_table=50_000)
+    return [str(w.message) for w in caught if "issue #388" in str(w.message)]
+
+
+@pytest.mark.parametrize(
+    "label, waveform, expect_fire",
+    [
+        # measured rel_DC 6.0e-5 < 1e-3
+        ("gaussian_cutoff3",
+         GaussianPulse(f0=2.2e9, bandwidth=1.2), False),
+        # ~5 decades below the cutoff=3 value
+        ("gaussian_cutoff45",
+         GaussianPulse(f0=2.2e9, bandwidth=1.2, cutoff=4.5), False),
+        # measured rel_DC 0.68 (DC suppression e^-1/bw^2 ~ 0.5 at bw=1.2)
+        ("modgaussian_bw12",
+         ModulatedGaussian(f0=2.2e9, bandwidth=1.2), True),
+        # measured rel_DC 4.0e-4 < 1e-3
+        ("modgaussian_bw04",
+         ModulatedGaussian(f0=2.2e9, bandwidth=0.4), False),
+    ],
+)
+def test_until_decay_dc_floor_matrix(label, waveform, expect_fire):
+    fired = _dc_floor_fires(waveform)
+    if expect_fire:
+        assert fired, f"{label}: expected the #388 DC-floor warning"
+        # Quantitative: the message must carry the rel_DC number.
+        assert "relative DC" in fired[0] and "cap-hit" in fired[0]
+    else:
+        assert not fired, f"{label}: unexpected #388 warning: {fired}"
+
+
+def test_until_decay_dc_floor_wired_into_run():
+    """run(until_decay=...) emits the #388 warning; a fixed-n_steps run
+    of the same sim does not (the check binds to until_decay only)."""
+    def _sim():
+        sim = Simulation(freq_max=36e9, domain=(6e-3, 6e-3, 6e-3),
+                         dx=1e-3, cpml_layers=4, boundary="cpml")
+        sim.add_source((3e-3, 3e-3, 3e-3), "ez",
+                       waveform=ModulatedGaussian(f0=30e9, bandwidth=1.2))
+        return sim
+
+    with pytest.warns(UserWarning, match="issue #388"):
+        _sim().run(until_decay=1e-3, decay_min_steps=50,
+                   decay_max_steps=300)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _sim().run(n_steps=20)
+    assert not [w for w in caught if "issue #388" in str(w.message)], (
+        "#388 DC-floor warning must fire only when until_decay is set"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. unresolved-pulse preflight advisory (#386)
+# ---------------------------------------------------------------------------
+
+def _demo_class_sim(bandwidth):
+    """patch_antenna_demo scale: dx=2mm, freq_max=4GHz, f0=2.2GHz."""
+    sim = Simulation(freq_max=4e9, domain=(0.06, 0.06, 0.03), dx=2e-3,
+                     cpml_layers=4)
+    sim.add_source((0.03, 0.03, 0.015), "ez",
+                   waveform=GaussianPulse(f0=2.2e9, bandwidth=bandwidth))
+    return sim
+
+
+def test_unresolved_pulse_fires_on_absolute_hz_bandwidth():
+    """bandwidth=2.64e9 (absolute Hz for a 1.2 fractional intent) makes
+    tau ~ 5e-20 s — a sub-dt spike; the #386 advisory must fire."""
+    codes = {getattr(i, "code", None)
+             for i in _demo_class_sim(2.64e9).preflight()}
+    assert "unresolved_pulse" in codes
+
+
+def test_unresolved_pulse_silent_on_demo_class_config():
+    """The committed demo's config (fractional bandwidth=1.2; tau ~ 0.12ns
+    vs dt ~ ps, ratio >> 3) must NOT fire."""
+    codes = {getattr(i, "code", None)
+             for i in _demo_class_sim(1.2).preflight()}
+    assert "unresolved_pulse" not in codes

--- a/tests/test_source_dc_floor_guards.py
+++ b/tests/test_source_dc_floor_guards.py
@@ -194,3 +194,25 @@ def test_unresolved_pulse_silent_on_demo_class_config():
     codes = {getattr(i, "code", None)
              for i in _demo_class_sim(1.2).preflight()}
     assert "unresolved_pulse" not in codes
+
+
+def _tfsf_sim(bandwidth):
+    """TFSF carries a string waveform name; tau comes from f0/bandwidth."""
+    sim = Simulation(freq_max=4e9, domain=(0.06, 0.06, 0.03), dx=2e-3,
+                     cpml_layers=4, boundary="cpml")
+    sim.add_tfsf_source(f0=2.2e9, bandwidth=bandwidth)
+    return sim
+
+
+def test_unresolved_pulse_fires_on_tfsf_absolute_hz_bandwidth():
+    """add_tfsf_source(bandwidth=<absolute Hz>) is the same #386 footgun;
+    the string-named waveform must not shield it from the check."""
+    codes = {getattr(i, "code", None)
+             for i in _tfsf_sim(2.64e9).preflight()}
+    assert "unresolved_pulse" in codes
+
+
+def test_unresolved_pulse_silent_on_tfsf_fractional_bandwidth():
+    codes = {getattr(i, "code", None)
+             for i in _tfsf_sim(1.2).preflight()}
+    assert "unresolved_pulse" not in codes


### PR DESCRIPTION
Fixes #386; the mitigation increment for #388 (criterion-architecture options remain tracked there).

Grounded in the measured #388 mechanism (soft-source end-charge q = Σs(tₙ)dt/((1+loss)·dz_src), exact on both lanes; static remnant = discrete-Poisson self-energy; floors the until_decay interior-energy criterion):

1. **`GaussianPulse` gains `cutoff` (default 3.0, byte-identical)** — deposited DC scales as e^(−cutoff²), so `cutoff=4.5` cuts deposited charge ~5 decades (measured: |S| ratio within 1.5% of the predicted e^(−11.25)). Field appended last (positional callers unaffected); api-reference gate OK; config lane accepts `cutoff` with a lock test.
2. **Unresolved-pulse preflight warning (#386)**: any Gaussian-family waveform with τ < 3·dt fires ("an absolute-Hz bandwidth was likely passed where a FRACTIONAL one is expected") — including TFSF entries via their f0/bandwidth attributes (fire/no-fire pair tested). The committed demo class stays silent with ~10× margin.
3. **until_decay DC-floor warning (the quantitative #388 predictor increment)**: fires only when a decay stop will actually be honoured, computing each soft source's relative DC over the planned table; threshold 1e-3. Four-case matrix locked to the investigation's measured values: GaussianPulse(cutoff=3) 6.0e-5 silent; cutoff=4.5 silent; ModulatedGaussian(bw=1.2) 0.680 FIRES; bw=0.4 4.0e-4 silent.

Review: initial BLOCK — the warning's advice ("bandwidth ≤ 0.5") did not clear its own threshold (measured bw=0.5 → rel_DC 2.6e-2). Fixed to ≤ 0.4 at all three text sites with the measured numbers in the docstrings; a user following the printed advice now actually silences the warning. All four review items applied and re-verified (battery 47 passed incl. new TFSF + config tests; byte-identity `np.array_equal = True` on a 10k-sample waveform capture; ruff clean).

R3: memory=feedback_never_ignore_preflight (advice-clears-threshold consistency) + feedback_contract_tests_for_public_surface (api-reference gate green) + #388 measured mechanism | R2-attempts=0 | falsifier=the four-case matrix + TFSF pair tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)