### PR TITLE
fix(advisories): nine post-merge-review follow-ups — truncation-aware DC-floor message, cutoff threading, waveform-aware harminv windows

### DIFF
--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -415,7 +415,8 @@
         "dx_override",
         "margin_override",
         "n_steps_override",
-        "max_memory_mb"
+        "max_memory_mb",
+        "waveform"
       ]
     },
     "auto_refine": {

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -838,15 +838,23 @@ class Simulation(
         # Complex weights use two separately constructed waveforms. Their
         # quadrature is not part of the verified public polarization scope.
         if _np.isreal(jx) and _np.isreal(jy):
-            # Real Jones — simple amplitude scaling
+            # Real Jones — simple amplitude scaling. Thread the source
+            # waveform's cutoff through the reconstruction (post-#392
+            # review): dropping it silently reverted the #388/#392
+            # deposited-DC remedy (cutoff=4.5) to the default 3.0 on
+            # this path. getattr default 3.0 = GaussianPulse's default,
+            # so cutoff-less waveforms are unchanged.
             if abs(float(jx.real)) > 1e-10:
                 from rfx.sources.sources import GaussianPulse as GP
                 wx = GP(f0=waveform.f0, bandwidth=waveform.bandwidth,
-                        amplitude=waveform.amplitude * float(jx.real))
+                        amplitude=waveform.amplitude * float(jx.real),
+                        cutoff=getattr(waveform, 'cutoff', 3.0))
                 self.add_source(position, "ex", waveform=wx)
             if abs(float(jy.real)) > 1e-10:
+                from rfx.sources.sources import GaussianPulse as GP
                 wy = GP(f0=waveform.f0, bandwidth=waveform.bandwidth,
-                        amplitude=waveform.amplitude * float(jy.real))
+                        amplitude=waveform.amplitude * float(jy.real),
+                        cutoff=getattr(waveform, 'cutoff', 3.0))
                 self.add_source(position, "ey", waveform=wy)
         else:
             # Complex Jones — build carrier-modulated components.

--- a/rfx/api/_compile.py
+++ b/rfx/api/_compile.py
@@ -153,7 +153,7 @@ class _CompileMixin:
 
         # Collect per-pole masks so distinct materials do not inherit
         # each other's dispersion poles. Keyed per
-        # ``rfx.geometry.rasterize._pole_key`` (#274): pole value when
+        # ``rfx.geometry._pole_keying._pole_key`` (#274): pole value when
         # hashable (equal poles dedupe/merge as before), ``id(pole)``
         # only for unhashable traced poles. Values are (pole, mask).
         debye_masks_by_pole: dict[DebyePole | int, tuple[DebyePole, jnp.ndarray]] = {}

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -302,11 +302,24 @@ class _ExecuteMixin:
         CPML cannot absorb a static field, so it floors the interior-energy
         decay criterion and ``until_decay`` cap-hits instead of stopping.
 
-        For each soft source (``impedance == 0`` port entries), compute
+        For each soft source (``impedance == 0`` port entries, plus MSL
+        ports — the same soft-Ez deposit mechanism drives them), compute
         ``rel_DC = |sum s(t_n)*dt| / sum |s(t_n)|*dt`` over the planned
         table length (``decay_max_steps`` — the decay lanes' buffer size)
         and warn quantitatively above 1e-3 (the demo-scale GaussianPulse
         sits at ~6e-5; a bandwidth=1.2 ModulatedGaussian at ~0.68).
+
+        The message is TRUNCATION-AWARE: rel_DC over the planned table
+        conflates intrinsic waveform DC with table-truncation DC. When the
+        table ends inside the source pulse (``n_table*dt`` below the
+        pulse-completion time ``t_done = t0 + 3*tau``), the estimate is
+        truncation-dominated — the remedy is a longer ``decay_max_steps``
+        (or a fixed ``n_steps``), and raising the waveform ``cutoff``
+        makes it WORSE because it lengthens the onset (measured: default
+        pulse + decay_max_steps=200 → rel_DC 2.14e-2 pure truncation
+        artifact; cutoff=4.5 at n_table~500 fires while cutoff=3 is
+        silent). Only past pulse completion do the intrinsic-DC remedies
+        (higher cutoff / narrower ModulatedGaussian) apply.
 
         Lives with the run()-path warning helpers (not preflight) because
         ``preflight()`` does not receive run kwargs and this advisory is
@@ -322,10 +335,20 @@ class _ExecuteMixin:
         if not dt > 0.0 or n_table <= 0:
             return
         t = np.arange(int(n_table), dtype=np.float64) * dt
-        for pe in self._ports:
-            if pe.impedance != 0.0 or not getattr(pe, "excite", True):
-                continue
-            wf = pe.waveform
+        soft_entries = [
+            pe for pe in self._ports
+            if pe.impedance == 0.0 and getattr(pe, "excite", True)
+        ]
+        # MSL ports launch through the same soft-Ez deposit across the
+        # trace cross-section, so their waveform DC floors the criterion
+        # identically. Entry access mirrors the sibling #386
+        # unresolved-pulse validator: read the ``waveform`` attribute,
+        # skip string-named waveforms (below).
+        soft_entries += [
+            pe for pe in self._msl_ports if getattr(pe, "excite", True)
+        ]
+        for pe in soft_entries:
+            wf = getattr(pe, "waveform", None)
             if wf is None or isinstance(wf, str):
                 continue
             try:
@@ -339,9 +362,41 @@ class _ExecuteMixin:
                 continue
             s_int = float(np.sum(s)) * dt
             rel_dc = abs(s_int) / denom
-            if rel_dc > 1e-3:
+            if rel_dc <= 1e-3:
+                continue
+            # Pulse-completion time t_done = t0 + 3*tau (the waveform's
+            # own t0 property when present, 3*tau otherwise). A table
+            # ending before t_done makes rel_DC truncation-dominated.
+            _loc = f"{pe.position} ({getattr(pe, 'component', 'msl port')})"
+            t_done = None
+            try:
+                _tau = float(wf.tau)
+            except (AttributeError, TypeError, ValueError):
+                _tau = None
+            if _tau is not None and math.isfinite(_tau) and _tau > 0.0:
+                try:
+                    _t0 = float(wf.t0)
+                except (AttributeError, TypeError, ValueError):
+                    _t0 = 3.0 * _tau
+                t_done = _t0 + 3.0 * _tau
+            if t_done is not None and n_table * dt < t_done:
                 warnings.warn(
-                    f"soft source at {pe.position} ({pe.component}): "
+                    f"soft source at {_loc}: waveform {type(wf).__name__} "
+                    f"shows relative DC {rel_dc:.2e} over the planned "
+                    f"{int(n_table)}-step table, but the planned "
+                    f"decay_max_steps window ends inside the source pulse "
+                    f"(table {n_table * dt:.3e} s < pulse completion "
+                    f"t0+3*tau ~ {t_done:.3e} s) — the DC estimate is "
+                    "truncation-dominated, not intrinsic waveform DC; "
+                    "until_decay may cap-hit (issue #388). Increase "
+                    "decay_max_steps (or run with a fixed n_steps) so the "
+                    "table covers the full pulse; raising the waveform "
+                    "cutoff makes this WORSE (it lengthens the onset).",
+                    UserWarning, stacklevel=3,
+                )
+            else:
+                warnings.warn(
+                    f"soft source at {_loc}: "
                     f"waveform {type(wf).__name__} deposits relative DC "
                     f"{rel_dc:.2e} (|sum s*dt| = {abs(s_int):.3e} over the "
                     f"planned {int(n_table)}-step table) — the deposited "
@@ -350,9 +405,55 @@ class _ExecuteMixin:
                     "CPML); until_decay may cap-hit (issue #388). Reduce "
                     "the waveform's DC content: a higher GaussianPulse "
                     "cutoff (e.g. cutoff=4.5), ModulatedGaussian with "
-                    "bandwidth <= 0.4, or run with a fixed n_steps.",
+                    "bandwidth <= 0.4, or run with a fixed n_steps. Note: "
+                    "this advisory does NOT catch low-rel_DC floors "
+                    "amplified by thin source cells (the #388 patch class "
+                    "measured the floor at rel_DC ~6e-5) — see issue #388.",
                     UserWarning, stacklevel=3,
                 )
+
+    def _warn_decay_param_sanity(self, *, until_decay, decay_min_steps,
+                                 decay_max_steps) -> None:
+        """Behaviour-NEUTRAL sanity advisories on the decay-stop params.
+
+        Warn-only, single ``run()``-level site so both lanes that honour
+        ``until_decay`` (uniform and absorbing-boundary non-uniform) are
+        covered by one check (post-#392 review):
+
+        * ``decay_min_steps > decay_max_steps`` — every check index lies
+          past the table end, so zero energy checks occur and the run is
+          a forced ``decay_max_steps`` run (the stop can never fire).
+        * ``until_decay >= 1`` — the criterion ``U < until_decay*peak_U``
+          is satisfied while the field energy is still rising, so the
+          stop can fire immediately after ``decay_min_steps``.
+          (``until_decay == 0.0`` is the documented forced-N escape on
+          the NU lane and is deliberately not warned about.)
+        """
+        import warnings
+
+        if until_decay is None:
+            return
+        if decay_min_steps > decay_max_steps:
+            warnings.warn(
+                f"decay_min_steps ({decay_min_steps}) > decay_max_steps "
+                f"({decay_max_steps}): zero energy checks will occur — "
+                "the decay stop can never fire and this is a forced "
+                "decay_max_steps run. Lower decay_min_steps or raise "
+                "decay_max_steps.",
+                UserWarning, stacklevel=3,
+            )
+        try:
+            _ud = float(until_decay)
+        except (TypeError, ValueError):
+            return
+        if _ud >= 1.0:
+            warnings.warn(
+                f"until_decay={until_decay} >= 1: the energy criterion "
+                "(U < until_decay * peak_U) is met while the field energy "
+                "is still rising, so the stop can fire immediately after "
+                "decay_min_steps; use a fraction well below 1 (e.g. 1e-3).",
+                UserWarning, stacklevel=3,
+            )
 
     def _reject_refplane_ports_off_uniform_lane(self, path_name: str,
                                                 compute_s_params) -> None:
@@ -2435,7 +2536,9 @@ class _ExecuteMixin:
             when a planned soft-source waveform's relative DC exceeds 1e-3
             (raise the ``GaussianPulse`` cutoff, narrow a
             ``ModulatedGaussian`` to bandwidth <= 0.4, or use a fixed
-            ``n_steps``).
+            ``n_steps``). This advisory does NOT catch low-rel_DC floors
+            amplified by thin source cells (the #388 patch class measured
+            the floor at rel_DC ~6e-5) — see issue #388.
         decay_check_interval : int
             Check decay every N steps (default 50).
         decay_min_steps : int
@@ -2474,6 +2577,16 @@ class _ExecuteMixin:
         Result
         """
         fixed_num_periods = n_steps is None
+
+        # Behaviour-neutral decay-parameter sanity advisories (post-#392
+        # review): single run()-level site, before dispatch, so both lanes
+        # that honour until_decay (uniform + absorbing-boundary
+        # non-uniform) are covered by one check.
+        self._warn_decay_param_sanity(
+            until_decay=until_decay,
+            decay_min_steps=decay_min_steps,
+            decay_max_steps=decay_max_steps,
+        )
 
         # ---- P1: Auto mesh when dx not specified and geometry exists ----
         if self._dx is None and (self._geometry or self._thin_conductors):

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -632,6 +632,26 @@ def _warn_if_nonfinite_result(result, *, context: str) -> None:
     )
 
 
+def _auto_source_decay_time(fr, waveform=None) -> float:
+    """Auto Harminv window start: twice the source pulse-completion scale.
+
+    The historical hardcode was ``2.0*3.0*tau`` — the cutoff=3
+    ``GaussianPulse`` envelope (``t0 = 3*tau``). A waveform exposing its
+    own ``t0`` (``GaussianPulse``/``ModulatedGaussian``:
+    ``t0 = cutoff*tau``) makes the window scale with the actual onset —
+    ``2*t0`` = ``9*tau`` at cutoff=4.5 — instead of assuming the cutoff=3
+    envelope (post-#392 review). Without a waveform this returns
+    ``2.0*(3.0*tau)``, bitwise-identical to the historical
+    ``2.0*3.0*tau`` (scaling by 2.0 is exact in binary floating point),
+    with ``tau`` derived from the frequency range at the historical
+    bw=0.8.
+    """
+    f_center = (fr[0] + fr[1]) / 2
+    bw = 0.8
+    tau = 1.0 / (f_center * bw * np.pi)
+    return 2.0 * float(getattr(waveform, "t0", 3.0 * tau))
+
+
 class Result(NamedTuple):
     """Structured simulation result.
 
@@ -678,7 +698,8 @@ class Result(NamedTuple):
     freq_range: tuple | None = None
 
     def find_resonances(self, freq_range=None, probe_idx=0,
-                         source_decay_time=None, bandpass=None):
+                         source_decay_time=None, bandpass=None,
+                         waveform=None):
         """Extract resonant modes from probe time series via Harminv.
 
         Parameters
@@ -693,6 +714,14 @@ class Result(NamedTuple):
             Apply FFT bandpass before Harminv. Default: auto (True for
             CPML results where DC/surface-wave artifacts exist, False
             for PEC cavities where signal is clean).
+        waveform : source waveform or None
+            Used only when ``source_decay_time`` is None: when the
+            waveform exposes ``t0`` (``GaussianPulse`` /
+            ``ModulatedGaussian``: ``t0 = cutoff*tau``), the auto window
+            starts at ``2*t0`` so a longer-onset pulse (e.g.
+            ``cutoff=4.5`` → ``9*tau``) is fully skipped. Without a
+            waveform the historical cutoff=3 envelope (``2*(3*tau)``) is
+            used, bitwise-identical to the previous hardcode.
 
         Returns
         -------
@@ -721,10 +750,7 @@ class Result(NamedTuple):
             bandpass = stored_boundary == 'cpml'
 
         if source_decay_time is None:
-            f_center = (fr[0] + fr[1]) / 2
-            bw = 0.8
-            tau = 1.0 / (f_center * bw * np.pi)
-            source_decay_time = 2.0 * 3.0 * tau
+            source_decay_time = _auto_source_decay_time(fr, waveform)
 
         start = int(np.ceil(source_decay_time / self.dt))
         start = min(start, max(len(ts) - 20, 0))

--- a/rfx/auto_config.py
+++ b/rfx/auto_config.py
@@ -256,6 +256,7 @@ def auto_configure(
     margin_override: float | None = None,
     n_steps_override: int | None = None,
     max_memory_mb: float | None = None,
+    waveform=None,
 ) -> SimConfig:
     """Derive all simulation parameters from geometry + frequency range.
 
@@ -287,6 +288,14 @@ def auto_configure(
         - 8 GB GPU:  ``max_memory_mb=6000``
         - 24 GB GPU: ``max_memory_mb=18000``
         - 48 GB GPU: ``max_memory_mb=36000``
+    waveform : source waveform or None
+        Used only for the source-time term of the ``n_steps`` estimate:
+        when the waveform exposes ``t0`` (``GaussianPulse`` /
+        ``ModulatedGaussian``: ``t0 = cutoff*tau``), the source window is
+        ``2*t0`` so a longer-onset pulse (e.g. ``cutoff=4.5`` →
+        ``9*tau``) is fully covered. Without a waveform the historical
+        cutoff=3 envelope (``6*tau`` at bw=0.8) is used, bitwise-identical
+        to the previous hardcode.
 
     Returns
     -------
@@ -463,10 +472,14 @@ def auto_configure(
         dt = 0.99 * dx / (C0 * math.sqrt(3))
 
     # 5. Number of steps
-    # Source time: 6*tau for Gaussian pulse
+    # Source time: the pulse completes at t0 + cutoff*tau = 2*t0
+    # (= 6*tau for the historical cutoff=3 Gaussian envelope; the
+    # waveform's own t0, when provided, makes this cutoff-aware —
+    # e.g. 9*tau at cutoff=4.5). Default 2.0*(3.0*tau) is bitwise-
+    # identical to the historical 6*tau (doubling is exact).
     bw = 0.8  # default bandwidth
     tau = 1.0 / (f_center * bw * math.pi)
-    t_source = 6 * tau
+    t_source = 2.0 * float(getattr(waveform, "t0", 3.0 * tau))
 
     # Ring-down time: Q / (pi * f_min)
     # Compute Q from stored sigma/eps_r ratio + frequency:

--- a/rfx/geometry/_pole_keying.py
+++ b/rfx/geometry/_pole_keying.py
@@ -40,14 +40,22 @@ def _pole_key(pole):
        ``float()``-coerced fields. Value equality IS decidable here;
        a NamedTuple hashes/compares equal to the plain tuple of the
        same values, so eager-array and Python-float spellings of the
-       same pole also merge with each other.
+       same pole also merge with each other. CAVEAT: that cross-
+       spelling merge holds only for values exactly representable in
+       the array dtype — ``jnp.float32(0.1)`` ``float()``-coerces to
+       0.10000000149011612, which differs from Python ``0.1``, so the
+       two spellings key as TWO entries and overlapping geometry
+       applies the pole twice (double delta_eps on the overlap
+       cells). Spell a shared pole consistently, or use exactly
+       representable values (0.5, 1.5, ...).
     3. Fields carrying JAX TRACERS — ``id(pole)``. Value equality is
        undecidable at trace time; identity is the only stable key
        (the documented differentiable-dispersion path, #273).
-    4. Eager but not ``float()``-coercible (non-scalar fields) —
-       ``id(pole)`` plus a loud ``UserWarning``: such poles will not
-       dedupe against value-equal duplicates (fail-loud beats silent
-       double-counting).
+    4. Eager but not ``float()``-coercible — fields that are
+       non-scalar arrays OR scalars ``float()`` rejects (e.g. a
+       complex 0-d array) — ``id(pole)`` plus a loud ``UserWarning``:
+       such poles will not dedupe against value-equal duplicates
+       (fail-loud beats silent double-counting).
     """
     try:
         hash(pole)
@@ -62,8 +70,10 @@ def _pole_key(pole):
         return tuple(float(f) for f in pole)
     except (TypeError, ValueError):
         warnings.warn(
-            f"Dispersion pole {pole!r} has unhashable, non-scalar "
-            f"fields; keying its geometry mask by object identity. "
+            f"Dispersion pole {pole!r} has unhashable fields that "
+            f"cannot be coerced to float (non-scalar arrays or "
+            f"non-float-coercible scalars, e.g. a complex 0-d array); "
+            f"keying its geometry mask by object identity. "
             f"Value-equal duplicates of this pole will NOT dedupe and "
             f"can double-apply delta_eps on overlapping geometry "
             f"(issue #274).",

--- a/tests/test_auto_config.py
+++ b/tests/test_auto_config.py
@@ -378,3 +378,50 @@ def test_auto_mesh_trigger_fires_thin_only_end_to_end():
         warnings.simplefilter("ignore")
         sim.run(n_steps=5, skip_preflight=True)
     assert sim._dx is not None, "run() trigger must auto-configure a thin-only sim"
+
+
+# ---------------------------------------------------------------------------
+# Waveform-aware source-time window (post-#392 review): the n_steps
+# estimate hardcoded t_source = 6*tau (the cutoff=3 Gaussian envelope).
+# ---------------------------------------------------------------------------
+
+def test_auto_configure_waveform_default_byte_identical():
+    """waveform=None (and a cutoff=3 waveform at the internal f_center /
+    bw=0.8) reproduce the historical 6*tau n_steps exactly."""
+    import math
+    import pytest
+    from rfx import GaussianPulse
+
+    f1, f2 = 1e9, 3e9
+    base = auto_configure([], freq_range=(f1, f2))
+    explicit_none = auto_configure([], freq_range=(f1, f2), waveform=None)
+    assert explicit_none.n_steps == base.n_steps
+
+    # The load-bearing float identity: 2.0*(3.0*tau) == 6*tau bitwise.
+    f_center = (f1 + f2) / 2
+    tau = 1.0 / (f_center * 0.8 * math.pi)
+    assert 2.0 * (3.0 * tau) == 6 * tau
+
+    # A cutoff=3 waveform at the same f_center/bandwidth has t0 = 3*tau
+    # of the SAME tau -> identical n_steps.
+    wf3 = GaussianPulse(f0=f_center, bandwidth=0.8)
+    same = auto_configure([], freq_range=(f1, f2), waveform=wf3)
+    assert same.n_steps == base.n_steps
+
+
+def test_auto_configure_waveform_cutoff_extends_source_window():
+    """cutoff=4.5 -> t_source 9*tau instead of 6*tau -> strictly more
+    steps, by (2*t0_45 - 2*t0_3)/dt up to ceil rounding."""
+    import pytest
+    from rfx import GaussianPulse
+
+    f1, f2 = 1e9, 3e9
+    f_center = (f1 + f2) / 2
+    base = auto_configure([], freq_range=(f1, f2))
+    wf45 = GaussianPulse(f0=f_center, bandwidth=0.8, cutoff=4.5)
+    longer = auto_configure([], freq_range=(f1, f2), waveform=wf45)
+
+    assert longer.n_steps > base.n_steps
+    expected_extra = (2.0 * wf45.t0 - 6.0 * wf45.tau) / base.dt
+    assert longer.n_steps - base.n_steps == pytest.approx(
+        expected_extra, abs=1.0)

--- a/tests/test_dispersion_pole_keying.py
+++ b/tests/test_dispersion_pole_keying.py
@@ -411,7 +411,12 @@ def test_import_rfx_preserves_geometry_rasterize_function():
     import rfx
 
     repo_root = Path(rfx.__file__).resolve().parents[1]
-    env = dict(os.environ, PYTHONPATH=str(repo_root))
+    # Prepend to (never overwrite) the inherited PYTHONPATH — the
+    # surrounding environment may rely on it to resolve dependencies.
+    _inherited = os.environ.get("PYTHONPATH")
+    env = dict(os.environ, PYTHONPATH=(
+        str(repo_root) + os.pathsep + _inherited if _inherited
+        else str(repo_root)))
     code = (
         "import rfx\n"
         "from rfx.geometry import rasterize\n"

--- a/tests/test_result_accessors.py
+++ b/tests/test_result_accessors.py
@@ -199,3 +199,78 @@ def test_plot_smith_bad_arity_raises():
     r = _two_port()
     with pytest.raises(ValueError, match="two 1-indexed ports"):
         r.plot_smith(ports=(1,))
+
+
+# ---------------------------------------------------------------------------
+# Waveform-aware auto Harminv window (post-#392 review).
+#
+# ``find_resonances``'s auto ``source_decay_time`` hardcoded the cutoff=3
+# GaussianPulse envelope (2.0*3.0*tau). The refactor to
+# ``2.0*getattr(waveform, 't0', 3.0*tau)`` must be BITWISE-identical on
+# the default path (doubling is exact in binary floating point) and scale
+# with the waveform's own onset when one is provided.
+# ---------------------------------------------------------------------------
+
+def test_auto_harminv_window_default_bitwise_matches_historical():
+    from rfx.api._spec import _auto_source_decay_time
+    for f1, f2 in [(1e9, 5e9), (0.6e9, 12.3e9), (2.2e9, 2.9e9),
+                   (8e9, 12e9)]:
+        f_center = (f1 + f2) / 2
+        tau = 1.0 / (f_center * 0.8 * np.pi)
+        # main's exact formula, op-for-op:
+        historical = 2.0 * 3.0 * tau
+        assert _auto_source_decay_time((f1, f2)) == historical, (
+            f"default auto window drifted from main at fr=({f1}, {f2})")
+
+
+def test_two_t0_equals_six_tau_exactly_at_cutoff3():
+    """The load-bearing float identity behind the refactor: for the
+    default cutoff=3 waveform, 2*t0 == 2*(3*tau) == 6*tau EXACTLY
+    (multiplying by 2.0 is an exact exponent shift, so rounding
+    commutes: fl(6*tau) == 2*fl(3*tau))."""
+    from rfx import GaussianPulse
+    for f0 in (1e9, 2.2e9, 3.7e9, 18e9):
+        for bwv in (0.5, 0.8, 1.2):
+            wf = GaussianPulse(f0=f0, bandwidth=bwv)
+            assert 2.0 * wf.t0 == 6.0 * wf.tau
+            assert 2.0 * wf.t0 == 2.0 * 3.0 * wf.tau
+
+
+def test_auto_harminv_window_scales_with_waveform_cutoff():
+    """cutoff=4.5 waveform: the window start is 2*t0 = 9*tau of the
+    WAVEFORM's own tau — no longer the hardcoded cutoff=3 envelope."""
+    from rfx import GaussianPulse
+    from rfx.api._spec import _auto_source_decay_time
+    wf = GaussianPulse(f0=3e9, bandwidth=0.8, cutoff=4.5)
+    got = _auto_source_decay_time((1e9, 5e9), wf)
+    assert got == 2.0 * wf.t0
+    assert got == 9.0 * wf.tau  # 2*(4.5*tau); doubling is exact
+    assert got > _auto_source_decay_time((1e9, 5e9))
+
+
+def test_find_resonances_threads_waveform_to_auto_window(monkeypatch):
+    """The public method passes its ``waveform`` kwarg to the auto-window
+    helper (None on the default path)."""
+    import rfx.api._spec as spec_mod
+    from rfx import GaussianPulse
+
+    seen = {}
+    real = spec_mod._auto_source_decay_time
+
+    def spy(fr, waveform=None):
+        seen["wf"] = waveform
+        return real(fr, waveform)
+
+    monkeypatch.setattr(spec_mod, "_auto_source_decay_time", spy)
+    dt = 1e-12
+    t = np.arange(4000) * dt
+    ts = np.exp(-t / 2e-9) * np.sin(2 * np.pi * 3e9 * t)
+    r = Result(state=None, time_series=ts[:, None], s_params=None,
+               freqs=None, dt=dt, freq_range=(1e9, 5e9))
+
+    wf = GaussianPulse(f0=3e9, bandwidth=0.8, cutoff=4.5)
+    r.find_resonances(waveform=wf)
+    assert seen["wf"] is wf
+
+    r.find_resonances()
+    assert seen["wf"] is None

--- a/tests/test_silent_drop_warnings.py
+++ b/tests/test_silent_drop_warnings.py
@@ -171,6 +171,20 @@ def test_nu_path_until_decay_not_dropped_on_absorbing_boundary():
         f"until_decay must be honoured on the absorbing-boundary NU path "
         f"(#383), got: {msgs}"
     )
+    # Post-#392 review: this fixture's planned 200-step table (0.38 ns)
+    # ends inside the default source pulse (completion t0+3*tau ~
+    # 0.48 ns), so its high rel_DC (measured 2.2e-2) is a pure
+    # truncation artifact. The #388 advisory must classify it as
+    # truncation-dominated (longer decay_max_steps / fixed n_steps) —
+    # NOT recommend a higher cutoff, which lengthens the onset and
+    # makes truncation worse.
+    dc_msgs = [m for m in msgs if "issue #388" in m]
+    assert dc_msgs, "the #388 advisory should fire on this fixture"
+    assert "truncation-dominated" in dc_msgs[0], (
+        f"table-truncated rel_DC must take the truncation branch, "
+        f"got: {dc_msgs[0]}"
+    )
+    assert "higher GaussianPulse cutoff" not in dc_msgs[0]
 
 
 def test_nu_path_checkpoint_does_not_warn():

--- a/tests/test_source_dc_floor_guards.py
+++ b/tests/test_source_dc_floor_guards.py
@@ -228,6 +228,22 @@ def test_dc_floor_covers_msl_ports():
     assert "relative DC" in fired[0]
 
 
+def test_dc_floor_silent_on_passive_msl_port():
+    """A passive (excite=False) MSL port is a matched termination — it
+    deposits no source waveform, so the #388 advisory must stay silent
+    even with a high-DC waveform registered on the entry."""
+    sim = Simulation(freq_max=4e9, domain=(0.02, 0.02, 0.02), dx=2e-3,
+                     cpml_layers=4)
+    sim.add_msl_port((0.004, 0.01, 0.002), width=4e-3, height=2e-3,
+                     excite=False,
+                     waveform=ModulatedGaussian(f0=2.2e9, bandwidth=1.2))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sim._warn_until_decay_dc_floor(dt=DEMO_DT, n_table=50_000)
+    assert not [w for w in caught if "issue #388" in str(w.message)], (
+        "excite=False MSL port must not fire the #388 DC-floor warning")
+
+
 # ---------------------------------------------------------------------------
 # 3c. add_polarized_source must thread the waveform cutoff (post-#392
 #     review): the real-Jones reconstruction rebuilds GaussianPulse and
@@ -282,6 +298,19 @@ def test_sane_decay_params_do_not_warn():
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         _tiny_decay_sim().run(until_decay=1e-3, decay_min_steps=20,
+                              decay_max_steps=60)
+    msgs = [str(w.message) for w in caught]
+    assert not any("zero energy checks" in m or "still rising" in m
+                   for m in msgs), msgs
+
+
+def test_until_decay_zero_forced_n_escape_stays_silent():
+    """until_decay=0.0 is the documented forced-N escape (U < 0 never
+    fires; the run executes exactly decay_max_steps): the run()-level
+    sanity advisories must stay silent on it."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _tiny_decay_sim().run(until_decay=0.0, decay_min_steps=20,
                               decay_max_steps=60)
     msgs = [str(w.message) for w in caught]
     assert not any("zero energy checks" in m or "still rising" in m

--- a/tests/test_source_dc_floor_guards.py
+++ b/tests/test_source_dc_floor_guards.py
@@ -108,13 +108,13 @@ def test_cutoff_45_reduces_deposited_dc_by_predicted_factor():
 # 3. until_decay DC-floor warning — predeclared four-case matrix (#388)
 # ---------------------------------------------------------------------------
 
-def _dc_floor_fires(waveform) -> list[str]:
+def _dc_floor_fires(waveform, n_table=50_000) -> list[str]:
     sim = Simulation(freq_max=4e9, domain=(0.02, 0.02, 0.02), dx=2e-3,
                      cpml_layers=4)
     sim.add_source((0.01, 0.01, 0.01), "ez", waveform=waveform)
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
-        sim._warn_until_decay_dc_floor(dt=DEMO_DT, n_table=50_000)
+        sim._warn_until_decay_dc_floor(dt=DEMO_DT, n_table=n_table)
     return [str(w.message) for w in caught if "issue #388" in str(w.message)]
 
 
@@ -141,6 +141,13 @@ def test_until_decay_dc_floor_matrix(label, waveform, expect_fire):
         assert fired, f"{label}: expected the #388 DC-floor warning"
         # Quantitative: the message must carry the rel_DC number.
         assert "relative DC" in fired[0] and "cap-hit" in fired[0]
+        # All matrix fire-cases run a 50k-step table that covers the
+        # full pulse — they must take the INTRINSIC-DC branch (with its
+        # cutoff/bandwidth remedies AND the honesty note about
+        # thin-source-cell-amplified floors this advisory cannot see),
+        # not the truncation branch.
+        assert "truncation-dominated" not in fired[0]
+        assert "thin source cells" in fired[0]
     else:
         assert not fired, f"{label}: unexpected #388 warning: {fired}"
 
@@ -165,6 +172,120 @@ def test_until_decay_dc_floor_wired_into_run():
     assert not [w for w in caught if "issue #388" in str(w.message)], (
         "#388 DC-floor warning must fire only when until_decay is set"
     )
+
+
+# ---------------------------------------------------------------------------
+# 3b. truncation-aware branch (post-#392 review): rel_DC over the planned
+#     table conflates intrinsic waveform DC with table-truncation DC.
+# ---------------------------------------------------------------------------
+
+def test_dc_floor_truncation_branch_when_table_ends_inside_pulse():
+    """A 200-step table at the demo dt (0.24 ns) ends inside the default
+    pulse (completion t0+3*tau ~ 0.48 ns at f0=5 GHz, bw=0.8): the high
+    rel_DC (~1.0) is pure truncation artifact. The message must say so,
+    recommend a longer decay_max_steps / fixed n_steps, and must NOT
+    recommend raising the cutoff (that lengthens the onset and makes
+    truncation worse)."""
+    fired = _dc_floor_fires(GaussianPulse(f0=5e9, bandwidth=0.8),
+                            n_table=200)
+    assert fired, "truncated-table high rel_DC must still warn"
+    msg = fired[0]
+    assert "truncation-dominated" in msg
+    assert "decay_max_steps" in msg and "n_steps" in msg
+    assert "WORSE" in msg
+    assert "higher GaussianPulse cutoff" not in msg
+
+
+def test_dc_floor_truncation_worsens_with_higher_cutoff():
+    """Raising cutoff — the #392 intrinsic-DC remedy — makes TRUNCATION
+    worse: at n_table=400 (0.48 ns table, f0=5 GHz, bw=0.8) cutoff=3 is
+    silent (table covers the pulse, measured rel_DC 5.7e-6) while
+    cutoff=4.5 pushes completion to 7.5*tau ~ 0.60 ns past the table end
+    and fires the truncation branch (measured rel_DC 5.1e-2)."""
+    silent = _dc_floor_fires(GaussianPulse(f0=5e9, bandwidth=0.8),
+                             n_table=400)
+    assert not silent, f"cutoff=3 must be silent at n_table=400: {silent}"
+    fired = _dc_floor_fires(
+        GaussianPulse(f0=5e9, bandwidth=0.8, cutoff=4.5), n_table=400)
+    assert fired, "cutoff=4.5 must fire at n_table=400 (longer onset)"
+    assert "truncation-dominated" in fired[0]
+
+
+def test_dc_floor_covers_msl_ports():
+    """MSL ports launch via the same soft-Ez deposit mechanism; a
+    high-DC waveform on an MSL port must fire the #388 advisory
+    (post-#392 review; entry access mirrors the #386 validator)."""
+    sim = Simulation(freq_max=4e9, domain=(0.02, 0.02, 0.02), dx=2e-3,
+                     cpml_layers=4)
+    sim.add_msl_port((0.004, 0.01, 0.002), width=4e-3, height=2e-3,
+                     waveform=ModulatedGaussian(f0=2.2e9, bandwidth=1.2))
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sim._warn_until_decay_dc_floor(dt=DEMO_DT, n_table=50_000)
+    fired = [str(w.message) for w in caught
+             if "issue #388" in str(w.message)]
+    assert fired, "MSL-port high-DC waveform must fire the #388 warning"
+    assert "relative DC" in fired[0]
+
+
+# ---------------------------------------------------------------------------
+# 3c. add_polarized_source must thread the waveform cutoff (post-#392
+#     review): the real-Jones reconstruction rebuilds GaussianPulse and
+#     previously dropped cutoff — silently reverting the #392 remedy.
+# ---------------------------------------------------------------------------
+
+def test_polarized_source_threads_cutoff():
+    sim = Simulation(freq_max=4e9, domain=(0.02, 0.02, 0.02), dx=2e-3,
+                     cpml_layers=4)
+    wf = GaussianPulse(f0=2.2e9, bandwidth=1.2, cutoff=4.5)
+    sim.add_polarized_source((0.01, 0.01, 0.01), polarization="slant45",
+                             waveform=wf)
+    comps = {pe.component: pe.waveform for pe in sim._ports}
+    assert set(comps) == {"ex", "ey"}
+    for comp, w in comps.items():
+        assert w.cutoff == 4.5, (
+            f"{comp} component waveform lost cutoff (got {w.cutoff}) — "
+            f"the #392 remedy is silently ineffective on this path")
+        assert w.f0 == wf.f0 and w.bandwidth == wf.bandwidth
+
+
+# ---------------------------------------------------------------------------
+# 3d. decay-parameter sanity advisories (post-#392 review; behaviour-
+#     neutral, single run()-level site covering both honoured lanes).
+# ---------------------------------------------------------------------------
+
+def _tiny_decay_sim():
+    sim = Simulation(freq_max=36e9, domain=(6e-3, 6e-3, 6e-3),
+                     dx=1e-3, cpml_layers=4, boundary="cpml")
+    sim.add_source((3e-3, 3e-3, 3e-3), "ez")
+    return sim
+
+
+def test_decay_min_steps_above_max_steps_warns():
+    """decay_min_steps > decay_max_steps: every check index lies past
+    the table end — zero energy checks, forced decay_max_steps run."""
+    with pytest.warns(UserWarning, match="zero energy checks"):
+        _tiny_decay_sim().run(until_decay=1e-3, decay_min_steps=80,
+                              decay_max_steps=40)
+
+
+def test_until_decay_at_or_above_one_warns():
+    """until_decay >= 1: U < until_decay*peak_U is met while the energy
+    is still rising — the stop can fire immediately."""
+    with pytest.warns(UserWarning, match="still rising"):
+        _tiny_decay_sim().run(until_decay=1.5, decay_min_steps=20,
+                              decay_max_steps=60)
+
+
+def test_sane_decay_params_do_not_warn():
+    """The advisories are precise: a sane parameter set emits neither."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _tiny_decay_sim().run(until_decay=1e-3, decay_min_steps=20,
+                              decay_max_steps=60)
+    msgs = [str(w.message) for w in caught]
+    assert not any("zero energy checks" in m or "still rising" in m
+                   for m in msgs), msgs
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-ups from the independent post-merge review of the 2026-07-18/19 window (five-lane audit; findings on #330/#391/#392 surfaces). Advisory/warning/prose scope — no physics path touched; every default byte-identical (independently verified: 200k-sample bitwise sweeps on the harminv-window identity, 0 violations).

1. **Truncation-aware DC-floor message**: `_warn_until_decay_dc_floor` now classifies table-truncation DC (planned window ends inside the pulse, `t_done = t0 + 3τ`) separately from intrinsic waveform DC — the truncation branch recommends increasing `decay_max_steps` and states that raising `cutoff` makes truncation WORSE (measured: cutoff=4.5 fires at 5.1e-2 where cutoff=3 is silent, short-table regime). Boundary flip verified exact.
2. **`add_polarized_source` threads `cutoff`** (the #392 remedy was silently dropped on the real-Jones path) — and fixes a latent `NameError` on main for real-Jones inputs with zero x-component (reproduced on an extracted main tree). Note: a ModulatedGaussian input on this (already MG→GP-converting) branch now inherits MG's `cutoff=5.0` instead of main's hardcoded 3.0 — deliberate faithfulness improvement; GP and cutoff-less inputs byte-identical.
3. **MSL-port coverage** for the DC-floor advisory (same soft-Ez deposit mechanism; excite-gated, passive ports test-locked silent).
4. **Under-coverage honesty**: the advisory and run() docstring now state it does NOT catch low-rel_DC floors amplified by thin source cells (the #388 patch class at rel_DC ~6e-5).
5. **Decay-param sanity warnings** (warn-only, once per run): `decay_min_steps > decay_max_steps` and `until_decay ≥ 1`; the documented `until_decay=0.0` forced-N escape stays silent, test-locked.
6. **Waveform-aware harminv windows**: `source_decay_time = 2·t0` via optional `waveform=` kwargs on `find_resonances`/`auto_configure` (the one public-surface delta; api-reference inventory regenerated, diff = exactly the new param). Bitwise-identical at default: `2·(3τ) == 6τ` exactly (exponent-shift argument, locked op-for-op against main's formula).
7-9. Prose/pointer/test-env fixes: `_pole_keying` dtype-representability caveat + accurate fallback-warning text; `_compile.py` stale helper pointer (the #393 landmine class); subprocess-lock PYTHONPATH prepend.

Independent review of this branch: APPROVE_WITH_NITS — all substantive claims re-verified (inventory diff walked line-by-line; NameError reproduced on main; boundary probes; passive-MSL and forced-N silence probed), both nits test-locked in the final commit. Batteries: 121 passed (superset), 20 passed (touched file), api-reference OK, ruff clean.

R3: memory=feedback_never_ignore_preflight (truncation-branch advice-consistency) + no-silent-gate-loosening (inventory --write reviewed line-by-line) | R2-attempts=0 (advisory/prose engineering) | falsifier=the committed truncation-branch + four-case matrix + bitwise-identity tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)