### PR TITLE
test(#395): make vacuous empty-guide waveguide gates binding

### DIFF
--- a/tests/test_waveguide_broad_e5_live_anchor.py
+++ b/tests/test_waveguide_broad_e5_live_anchor.py
@@ -86,10 +86,12 @@ def _s_matrix(sim, *, normalize, num_periods=40):
 
 
 def _assert_cpml(sim):
-    # Cheap constructor guard (echoes the boundary kwarg). The REAL absorbing-
-    # boundary witness (m3 / #169) is downstream: the empty-guide |S11|≈0 in
-    # test_live_empty_guide_s21_anchor — a non-absorbing boundary could not give
-    # a matched-load reflection near zero.
+    # Cheap constructor guard (echoes the boundary kwarg). NOTE (issue #395):
+    # the empty-guide |S11|≈0 in test_live_empty_guide_s21_anchor is NOT an
+    # absorbing-boundary witness — on the flux path device==reference makes it
+    # ~0 by construction regardless of CPML quality. The real waveguide-lane
+    # PML-reflection gate is the single-run test_matched_load_s11_empty_waveguide
+    # in the validation battery.
     assert sim._boundary == "cpml", (
         f"live anchor requires a CPML (absorbing) boundary, got {sim._boundary!r}"
     )
@@ -160,12 +162,19 @@ def test_live_empty_guide_s21_anchor():
         f"LIVE empty-guide min|S21|={s21.min():.4f} < 0.98 — transmission "
         f"extraction regression in compute_waveguide_s_matrix"
     )
-    # Absorbing-boundary witness (m3 / #169): a matched empty guide reflects ~0
-    # ONLY because the boundary is genuinely absorbing — this is the real
-    # downstream CPML check (vs the constructor-echo in _assert_cpml).
+    # By-construction determinism bound (NOT a CPML witness — issue #395).
+    # On the flux path the empty-guide diagonal is
+    # |S11|^2 = |F_ref - F_dev| / |F_ref| and the empty device run equals the
+    # vacuum reference run bit-for-bit, so |S11| ~ 0 REGARDLESS of boundary
+    # quality — a crippled CPML would not move it. This asserts only that the
+    # two-run flux cancellation is deterministic. The real waveguide-lane
+    # PML-reflection gate is the single-run (normalize=False)
+    # test_matched_load_s11_empty_waveguide in the validation battery, which
+    # trebles when the CPML is crippled.
     assert s11.max() < 0.05, (
-        f"LIVE empty-guide max|S11|={s11.max():.4f} >= 0.05 — boundary is not "
-        f"absorbing as expected (or matched-load extraction regressed)"
+        f"LIVE empty-guide max|S11|={s11.max():.4f} >= 0.05 — the two-run flux "
+        f"cancellation is not deterministic (plumbing regression); this is NOT "
+        f"a CPML-absorption check (see battery test_matched_load_s11_empty_waveguide)"
     )
     assert power.max() <= 1.05, (
         f"LIVE empty-guide max(|S11|²+|S21|²)={power.max():.4f} > 1.05 — "

--- a/tests/test_waveguide_nu_sparam.py
+++ b/tests/test_waveguide_nu_sparam.py
@@ -42,7 +42,7 @@ import numpy as np
 # it permanently flips x64 ON for the whole pytest process and leaks into
 # downstream same-process tests (test_wire_*/test_verification then fail with
 # lax.scan carry-dtype TypeErrors). These NU tests need only float32 (they check
-# finite/shape/xfail, no f64-precision assertion). If a future test here needs
+# finite/shape/liveness, no f64-precision assertion). If a future test here needs
 # x64, scope it with `with jax.experimental.enable_x64(True):` like
 # tests/test_msl_sparam_ad.py — never module-level.
 
@@ -152,7 +152,9 @@ def test_nu_s_params_finite():
 
     R5: per-frequency dump — full trace, not a bare scalar.
     NOTE: with the NU-DRIVE-FIX applied, S is now physically correct (|S21|≈1,
-    |S11|≈0). Finite check still passes. Physics gate in test_nu_s_params_passive_ish.
+    |S11|≈0). Finite check still passes. Liveness/identity gate in
+    test_nu_s_params_dispatch_and_dft_liveness (real NU physics:
+    test_waveguide_nu_nontrivial.py).
     """
     res = _get_result()
     s = np.array(res.s_params)
@@ -177,31 +179,42 @@ def test_nu_s_params_finite():
 
 
 # ---------------------------------------------------------------------------
-# Test 3: physical passivity gate (fixed NU-DRIVE-FIX 2026-05-25)
+# Test 3: NU dispatch / DFT-liveness gate on the air-thru identity
+# (NOT a physical passivity gate — issue #395)
 # ---------------------------------------------------------------------------
 
 
 
-def test_nu_s_params_passive_ish():
-    """Loose passivity + activity gate for a 2-period air-filled WR-90 thru.
+def test_nu_s_params_dispatch_and_dft_liveness():
+    """NU air-thru returns the two-run identity (dispatch + DFT are live).
 
-    FIXED (NU-DRIVE-FIX 2026-05-25): _compute_waveguide_s_matrix_nu now returns
-    physical S-parameters (|S21|≈1, |S11|≈0) for a WR-90 air thru with
-    dx_profile grading. Two bugs were fixed:
+    ISSUE #395 — what this actually binds: this is an air-filled WR-90 THRU
+    with ``normalize=True``, so the device run *is* the reference run and
+    ``|S21|≈1`` / ``|S11|≈0`` hold BY CONSTRUCTION (device==reference
+    cancellation), independent of NU physics. Verified 2026-07-20: |S11|
+    range [0.0000, 0.0000], |S21| range [1.0000, 1.0000]. This is therefore
+    a DISPATCH + DFT-liveness gate — it catches the NU-DRIVE-FIX failure mode
+    (all-zero S, i.e. |S21| collapses to 0 when the DFT runs with dt=0), NOT
+    a physical passivity/reflection measurement. Real NU S-physics on a
+    device != reference geometry lives in ``test_waveguide_nu_nontrivial.py``
+    (live invariants) and the ``nu_broad_e4`` Palace replay.
+
+    FIXED (NU-DRIVE-FIX 2026-05-25): _compute_waveguide_s_matrix_nu now
+    produces the live identity instead of all-zero S. Two bugs were fixed:
       1. rfx/runners/nonuniform.py _build_waveguide_port_config_nu: missing
          dt=float(grid.dt) in init_waveguide_port call — e_inc_table/h_inc_table
          remained size-1 sentinels (dt=0 path), so _rect_dft used dt=0 → all
-         DFT outputs zero.
+         DFT outputs zero (|S21| would read 0, tripping the liveness assert).
       2. rfx/api/_sparams.py _compute_waveguide_s_matrix_nu: off-diagonal
          safe_b guard threshold 1e-30 too aggressive — NU TFSF operates at
          float32 signal level ~1e-31 (dt/dx scaling), causing the guard to
          substitute 1.0 for b_ref, breaking the b_dev/b_ref≈1 cancellation.
          Lowered to 1e-60.
 
-    Expected:
-      - max |S_ij| < 2.0  (no energy explosion)
-      - |S11| < 0.50  (low reflection for air-filled straight guide)
-      - |S21| > 0.05  (some transmission must be present)
+    Gates (liveness/identity bounds, not physics):
+      - max |S_ij| < 2.0  (no assembly explosion)
+      - |S11| < 0.50  (air-thru identity keeps the diagonal near 0)
+      - |S21| > 0.05  (DFT is live — the all-zero-S regression drops it to 0)
     """
     res = _get_result()
     s = np.array(res.s_params)
@@ -216,11 +229,13 @@ def test_nu_s_params_passive_ish():
         f"max|S|={np.abs(s).max():.4f} >= 2.0 — energy explosion in _nu run."
     )
     assert s11_mag.max() < 0.50, (
-        f"|S11| max = {s11_mag.max():.4f}; expected < 0.50 for air WR-90 thru."
+        f"|S11| max = {s11_mag.max():.4f}; air-thru two-run identity should "
+        "keep the diagonal near 0."
     )
     assert s21_mag.max() > 0.05, (
-        f"|S21| max = {s21_mag.max():.4f}; expected > 0.05 — no transmission signal. "
-        "BUG: NU path returns zero S21 while uniform path gives ~1.0."
+        f"|S21| max = {s21_mag.max():.4f}; expected > 0.05 — DFT not live. "
+        "BUG: NU path returns zero S21 (dt=0 sentinel) while the live identity "
+        "gives ~1.0."
     )
 
 
@@ -231,13 +246,15 @@ def test_nu_s_params_passive_ish():
 def test_nu_vs_uniform_finite_and_comparable():
     """Side-by-side NU vs uniform S-parameter dump (R5 mandate).
 
-    Documents the known bug: NU returns all-zero while uniform returns
-    |S21|=|S12|≈1 for the same air WR-90 geometry.
-
-    The loose numeric gate (max|delta| < 1.5) passes because both paths
-    are finite; the physics divergence is captured in test_nu_s_params_passive_ish
-    (xfail). This test is NOT marked xfail — it verifies both paths return
-    finite arrays of the same shape and that the comparison infrastructure works.
+    Post NU-DRIVE-FIX (2026-05-25) the NU and uniform air-thru paths AGREE:
+    both return the two-run identity |S21|=|S12|≈1, |S11|≈0, so the
+    per-freq deviation is ~0 (measured max|delta|=0.0000 on 2026-07-20 —
+    NOT the ~1.0 the pre-fix all-zero bug produced; the stale "NU returns
+    all-zero" note was removed in issue #395). The loose numeric gate
+    (max|delta| < 1.5) still passes and guards against an assembly-level
+    NaN/explosion on either path; it is not a physics-accuracy gate (both
+    sides are the device==reference identity, so agreement is expected by
+    construction — real NU physics is in test_waveguide_nu_nontrivial.py).
     """
     # Nonuniform result (already cached)
     res_nu = _get_result()
@@ -298,11 +315,13 @@ def test_nu_vs_uniform_finite_and_comparable():
 
     max_dev = np.abs(s_nu - s_u).max()
     print(f"\n[G-NU] max |S_nu - S_uniform| = {max_dev:.4f}")
-    # NOTE: max_dev ≈ 1.0 here due to the bug (NU gives 0, uniform gives 1).
-    # Gate is loose (< 1.5) — verifies both are finite and comparable, not correct.
+    # Post NU-DRIVE-FIX: max_dev ≈ 0 (both paths give the air-thru identity
+    # |S21|≈1, |S11|≈0). Gate is loose (< 1.5) — it verifies both are finite
+    # and assembly-comparable, not that either is physically correct.
     assert max_dev < 1.5, (
         f"NU vs uniform max deviation {max_dev:.4f} >= 1.5 — "
-        "suggests assembly-level NaN/explosion, not just the known zero-S bug."
+        "suggests assembly-level NaN/explosion (the all-zero-S regression "
+        "would show max_dev≈1.0)."
     )
 
 
@@ -322,10 +341,11 @@ def test_nu_assembly_ad_traceable():
     ASSEMBLY OUTPUT (s_params is a jax.Array whose downstream ops are
     differentiable) by differentiating a post-assembly scale parameter.
 
-    NOTE: with the current all-zero bug, grad = 0 (since |0 * scale|^2 = 0
-    for all scale). Zero is finite, so the AD traceability structural
-    requirement is met. The non-trivial gradient test will be meaningful
-    once the zero-S bug is fixed.
+    NOTE: post NU-DRIVE-FIX the assembled S is the live air-thru identity
+    (|S21|≈1), so grad(sum|S*scale|^2)|_{scale=1} = 2*sum|S|^2 ≈ 20 — finite
+    and non-zero (measured 2.0e+01 on 2026-07-20), confirming AD traceability
+    of the assembly output. (The stale "all-zero bug => grad = 0" note was
+    removed in issue #395.)
     """
     res = _get_result()
     s = res.s_params  # jax.Array

--- a/tests/test_waveguide_port_validation_battery.py
+++ b/tests/test_waveguide_port_validation_battery.py
@@ -157,68 +157,149 @@ def _s_matrix(sim, *, num_periods=40, normalize=True):
 
 
 # =============================================================================
-# Test 1 — Matched-load |S11| on an empty waveguide (industry anchor)
+# Test 1 — Matched-load |S11| reflection at the CPML termination (BINDING)
 # =============================================================================
 #
-# Empty lossless two-port waveguide with both ends absorbed by CPML.
-# There is no obstacle: the forward wave should be perfectly absorbed
-# at the far CPML and S11 should be ~0. This is the single most-telling
-# diagnostic for extractor + PML quality on the waveguide port.
+# An empty lossless guide terminated by CPML on both ends: the CPML *is*
+# the matched load. We measure the SINGLE-RUN (``normalize=False``)
+# reflection coefficient |S11| off that termination — the incident modal
+# power that fails to be absorbed and returns to the driven port. A good
+# matched load reflects ~0; a degraded absorber reflects more.
 #
-# Meep class: <1 %.  OpenEMS class: <5 %.  Current rfx target: <10 %.
+# ISSUE #395 — why NOT ``normalize=True`` here: with ``normalize=True`` on
+# an empty guide the device run *is* the reference run, so
+# ``S11 = (b_dev - b_ref)/a_inc`` is identically ZERO by construction and
+# no PML/extractor regression that touches both runs equally can move it
+# (probe 2026-07-20: cpml_layers 10 and 4 BOTH give max|S11| = 0.000000).
+# The pre-#395 gate (``normalize=True``, threshold 0.02) was therefore
+# VACUOUS — a determinism/plumbing tripwire mislabeled "the single
+# most-telling diagnostic for extractor + PML quality". Switching to the
+# single-run ``normalize=False`` reflection is a STRENGTHENING, not a
+# loosening: it is the correct tool for an absorber-quality claim and it
+# moves with the boundary (measured max|S11| = 0.156 at 10 layers vs
+# 0.418 at 4 layers). This test carries that crippled-CPML falsifier
+# inline, mirroring the phase-gate's in-test perturbation witness.
+#
+# This is the direct waveguide-lane PML-reflection witness the family
+# previously lacked. The PEC-short |S11|=1 gate (Test 7) binds the
+# extractor on TOTAL reflection; this binds the ABSORBER on near-zero
+# reflection — complementary, and neither is an identity.
+#
+# Meep class: <1 %.  OpenEMS class: <5 %. rfx single-run reflection sits
+# ~13-16 % (dominated by the source-plane Z_TE residual, not the absorber);
+# the gate binds absorber DEGRADATION, which trebles it.
 
 def test_matched_load_s11_empty_waveguide():
     freqs = np.linspace(4.5e9, 8.0e9, 10)
-    sim = _build_sim(freqs, waveform="modulated_gaussian")
-    s, sim_freqs, port_idx = _s_matrix(sim, num_periods=40, normalize=True)
+    # normalize=False: single-run wave decomposition (OpenEMS convention),
+    # the correct tool for a reflection/absorber-quality gate. The two-run
+    # normalize=True subtraction cancels ALL reflection (real included) on
+    # an empty guide, which is why the pre-#395 gate could not fail.
+    sim = _build_sim(freqs, cpml_layers=10, waveform="modulated_gaussian")
+    s, sim_freqs, port_idx = _s_matrix(sim, num_periods=40, normalize=False)
 
     s11 = np.abs(s[port_idx["left"], port_idx["left"], :])
     s22 = np.abs(s[port_idx["right"], port_idx["right"], :])
-    max_s11 = float(max(s11.max(), s22.max()))
+    max_refl = float(max(s11.max(), s22.max()))
+    min_absorbed = float(min((1.0 - s11**2).min(), (1.0 - s22**2).min()))
 
     print("\n[matched-load] |S11| per freq:", np.array2string(s11, precision=3))
     print("[matched-load] |S22| per freq:", np.array2string(s22, precision=3))
-    print(f"[matched-load] max(|S11|, |S22|) = {max_s11:.4f}")
-    print("[matched-load] Meep-class target <0.01; rfx gate <0.10")
+    print(f"[matched-load] max reflection = {max_refl:.4f}; "
+          f"min absorbed fraction (1-|S11|^2) = {min_absorbed:.4f}")
+    print("[matched-load] measured 2026-07-20: max|S11|=0.156, min_absorbed=0.976 "
+          "(10 layers); crippled 4-layer -> 0.418 / 0.825")
 
-    # Gate ratcheted 2026-04-22 from 0.10 to 0.02. Post diagonal-subtraction
-    # + CPML retune + discrete-β consistency the empty-guide matched-load
-    # measurement returns bit-identical zeros on the canonical battery
-    # geometry. 0.02 catches a regression to the pre-fix >0.05 regime.
-    assert max_s11 < 0.02, (
-        f"Matched-load |S11| too large: {max_s11:.4f} (gate 0.02). "
-        "Extractor or PML regression — check empty-guide reflection."
+    # Binding gate: reflection off the matched CPML termination. Measured
+    # 0.156 (10 layers, 2026-07-20); gate 0.20. NOT a loosening of the old
+    # 0.02 gate — that gate read a two-run identity (always 0, issue #395).
+    assert max_refl < 0.20, (
+        f"Matched-load reflection |S11|={max_refl:.4f} exceeds 0.20 — the "
+        "CPML termination is not absorbing as well as the validated "
+        "envelope, or the single-run extractor regressed."
+    )
+    # Absorbed-power witness: the matched load must absorb >=95% of the
+    # incident modal power at every frequency (measured 0.976).
+    assert min_absorbed > 0.95, (
+        f"Matched load absorbs only {min_absorbed:.4f} of incident power "
+        "(<0.95) — degraded CPML absorber."
+    )
+
+    # In-test discrimination falsifier (issue #395): the SAME geometry with
+    # a crippled 4-layer CPML must FAIL the 0.20 gate, proving this gate
+    # observes real absorber quality and is not vacuous. A regression that
+    # re-vacuumed the gate (e.g. reverting to normalize=True) would let the
+    # crippled run pass and trip this witness.
+    sim_bad = _build_sim(freqs, cpml_layers=4, waveform="modulated_gaussian")
+    s_bad, _, idx_bad = _s_matrix(sim_bad, num_periods=40, normalize=False)
+    bad_refl = float(max(
+        np.abs(s_bad[idx_bad["left"], idx_bad["left"], :]).max(),
+        np.abs(s_bad[idx_bad["right"], idx_bad["right"], :]).max(),
+    ))
+    print(f"[matched-load] crippled 4-layer CPML max reflection = {bad_refl:.4f} "
+          f"(must exceed the 0.20 gate to prove non-vacuity)")
+    assert bad_refl > 0.25, (
+        f"Crippled-CPML witness failed: 4-layer reflection {bad_refl:.4f} did "
+        "not rise clear of the 0.20 gate — the matched-load gate may have "
+        "gone vacuous again (issue #395)."
     )
 
 
 # =============================================================================
-# Test 2 — Tight passivity on empty waveguide
+# Test 2 — Passivity / energy conservation on a reflecting DUT (BINDING)
 # =============================================================================
 #
-# Tighter variant of test_passivity_two_port_empty_waveguide. The
-# existing test passes at threshold 1.15 (15% power excess allowed). For
-# an empty lossless guide a correct extractor should stay within a few
-# percent of unity. Use this as a regression lock at 1.05 — the
-# current extractor (post-retune, post-subtraction) is expected to sit
-# here or tighter.
+# Energy cannot be created: for a lossless two-port the column power
+# ``sum_i |S_ij|^2`` must stay <= 1. ISSUE #395 — the pre-#395 version
+# measured this on an EMPTY guide with ``normalize=True``, where the
+# device run *is* the reference run, so S11=0 and S21=1 exactly and the
+# column power is 1.0000 by construction (probe 2026-07-20: identical at
+# cpml_layers 10 and 4). No energy-injection bug that affects both runs
+# equally could trip it.
+#
+# Fix: put a real reflecting DUT in the guide (eps_r=4 box) so
+# device != reference, and read the ENERGY (flux) extractor
+# (``normalize='flux'``) whose |S11| and |S21| are two INDEPENDENT power
+# measurements. Their sum is a genuine conservation check. Measured max
+# column power 1.0005 (2026-07-20); a non-passive (energy-injection)
+# extractor bug pushes it above the gate.
+#
+# ``normalize=True`` is deliberately NOT used here: its diagonal |S11| on
+# a reflector carries a documented +-10-20% inflation (column power ~1.21
+# on this same obstacle) that is an extraction limitation, not physics —
+# the flux path is the honest tool for a passivity-magnitude claim.
 
-def test_tight_passivity_empty_waveguide():
+def test_tight_passivity_reflecting_dut():
     freqs = np.linspace(4.5e9, 8.0e9, 10)
-    sim = _build_sim(freqs, waveform="modulated_gaussian")
-    s, _, _ = _s_matrix(sim, num_periods=40, normalize=True)
+    obstacles = [((0.05, 0.0, 0.0), (0.07, 0.04, 0.02), 4.0)]
+    sim = _build_sim(freqs, obstacles=obstacles, waveform="modulated_gaussian")
+    s, _, port_idx = _s_matrix(sim, num_periods=40, normalize="flux")
 
+    s11 = np.abs(s[port_idx["left"], port_idx["left"], :])
+    s21 = np.abs(s[port_idx["right"], port_idx["left"], :])
     col_power = np.sum(np.abs(s) ** 2, axis=0)
     max_power = float(col_power.max())
 
-    print(f"\n[tight-passivity] max column |S|^2 = {max_power:.4f}")
-    print("[tight-passivity] gate 1.05; loose legacy gate was 1.15")
+    print(f"\n[passivity] |S11| = {np.array2string(s11, precision=3)}")
+    print(f"[passivity] |S21| = {np.array2string(s21, precision=3)}")
+    print(f"[passivity] max column |S|^2 = {max_power:.4f} (gate 1.02; measured 1.0005)")
 
-    # Gate ratcheted 2026-04-22 from 1.05 to 1.02. Current state measures
-    # 1.0000 on the canonical battery — 1.02 catches a 2% regression before
-    # the old legacy 1.15 gate would.
+    # Non-vacuity witness (issue #395): the obstacle must actually reflect
+    # AND attenuate (device != reference), else this degenerates into the
+    # old empty-guide identity. Measured max|S11|~0.73, min|S21|~0.69.
+    assert s11.max() > 0.30, (
+        f"DUT not reflecting (max|S11|={s11.max():.4f}<=0.30) — the passivity "
+        "gate would be vacuous; check the eps_r=4 obstacle was built."
+    )
+    assert s21.min() < 0.95, (
+        f"DUT not attenuating (min|S21|={s21.min():.4f}>=0.95) — transmission "
+        "should drop below unity behind an eps_r=4 step."
+    )
+    # Binding energy-conservation gate: measured 1.0005; 1.02 catches a 2%
+    # energy-injection regression on a real reflecting DUT.
     assert max_power < 1.02, (
-        f"Empty-guide passivity exceeded tight gate: {max_power:.4f} "
-        "(1.02). Extractor or PML regression."
+        f"Reflecting-DUT column power {max_power:.4f} exceeds 1.02 — "
+        "non-passive extractor (energy injection) on a lossless obstacle."
     )
 
 

--- a/tests/test_waveguide_port_validation_battery.py
+++ b/tests/test_waveguide_port_validation_battery.py
@@ -213,6 +213,12 @@ def test_matched_load_s11_empty_waveguide():
     # Binding gate: reflection off the matched CPML termination. Measured
     # 0.156 (10 layers, 2026-07-20); gate 0.20. NOT a loosening of the old
     # 0.02 gate — that gate read a two-run identity (always 0, issue #395).
+    # Headroom note: healthy 0.156 sits at ~78% of the 0.20 gate (the ~13-16%
+    # floor is the documented source-plane Z_TE residual). FDTD here is
+    # deterministic (bit-identical reruns) so this is stable in-process; if a
+    # cross-machine float-drift false-alarm ever appears, re-measure the floor
+    # and ratchet — do NOT just widen the gate (the crippled-4-layer falsifier
+    # below clears 0.25, so there is a real 0.05 separation to protect).
     assert max_refl < 0.20, (
         f"Matched-load reflection |S11|={max_refl:.4f} exceeds 0.20 — the "
         "CPML termination is not absorbing as well as the validated "

--- a/tests/test_waveguide_twoport_contract_v1.py
+++ b/tests/test_waveguide_twoport_contract_v1.py
@@ -1,10 +1,20 @@
 """Regression tests for the probe-aware normalized two-port contract.
 
-These tests lock the core physical properties of the finalized v1
-normalized waveguide S-matrix path:
-- empty guide remains reciprocal with unity transmission
-- PEC short reflects strongly without column-power blow-up
-- reference-plane knobs do not affect the normalized result
+What each test actually binds (corrected 2026-07-20, issue #395 — the
+earlier "locks the core physical properties" framing overstated the
+empty-guide cases, which are two-run identities):
+- empty guide: S11==0 / |S21|==1 hold *by construction* (device run IS the
+  reference run), so ``test_normalized_twoport_empty_is_extraction_identity``
+  is an extraction-algebra / determinism tripwire, NOT a physics gate.
+- dielectric obstacle (device != reference): reciprocity, sub-unity
+  transmission and non-zero reflection are real, falsifiable physics —
+  ``test_normalized_twoport_dielectric_binds_reciprocity_and_transmission``.
+- PEC short reflects strongly without column-power blow-up (a real gate:
+  device differs from reference).
+- reference-plane knobs preserve S-parameter MAGNITUDES on a reflecting
+  DUT (pure phase de-embedding). The de-embed PHASE-rotation sign/magnitude
+  correctness is gated separately by
+  ``tests/test_waveguide_phase_gate.py::test_deembed_step_sign_rotation_correct``.
 """
 
 from __future__ import annotations
@@ -31,6 +41,12 @@ def _build_twoport_sim(*, kind: str, left_ref=None, right_ref=None):
     if kind == "pec_short":
         sim.add_material("pec_like", eps_r=1.0, sigma=1e10)
         sim.add(Box((0.05, 0.0, 0.0), (0.055, 0.04, 0.02)), material="pec_like")
+    elif kind == "dielectric":
+        # eps_r=4 centred slab: a genuine reflecting DUT (device != reference)
+        # so the normalized S-matrix carries real reflection + sub-unity
+        # transmission — used by the binding reciprocity / ref-plane tests.
+        sim.add_material("diel", eps_r=4.0, sigma=0.0)
+        sim.add(Box((0.05, 0.0, 0.0), (0.07, 0.04, 0.02)), material="diel")
     elif kind == "empty":
         pass
     else:
@@ -65,20 +81,72 @@ def _build_twoport_sim(*, kind: str, left_ref=None, right_ref=None):
     return sim
 
 
-def test_normalized_twoport_empty_preserves_core_contract():
+def test_normalized_twoport_empty_is_extraction_identity():
+    """Empty guide: S11==0 / |S21|==1 hold BY CONSTRUCTION (not physics).
+
+    Issue #395: on an empty guide the device run *is* the reference run, so
+    ``S11 = (b_dev - b_ref)/a_inc`` is identically 0 and ``S21 = b_dev/b_ref``
+    is identically 1 for bit-identical runs — independent of PML/extractor
+    physics. This test is an extraction-algebra / determinism tripwire: it
+    fails only if the two-run subtraction/normalization plumbing breaks. The
+    tight tolerances (1e-4, far below the old 0.15 physics-looking gate)
+    reflect that the values are exact identities, not measured quantities.
+    The real physics lives in
+    ``test_normalized_twoport_dielectric_binds_reciprocity_and_transmission``.
+    """
     sim = _build_twoport_sim(kind="empty")
     result = sim.compute_waveguide_s_matrix(num_periods=40, normalize=True)
     s = np.asarray(result.s_params)
-    column_power = np.sum(np.abs(s) ** 2, axis=0)
-    recip = np.abs(np.abs(s[1, 0, :]) - np.abs(s[0, 1, :])) / np.maximum(
-        np.maximum(np.abs(s[1, 0, :]), np.abs(s[0, 1, :])),
-        1e-12,
+
+    # Identity, not physics: device==reference => exact 0 / exact 1.
+    assert float(np.max(np.abs(s[0, 0, :]))) < 1e-4, (
+        "empty-guide S11 is not the expected two-run identity 0 — the "
+        "diagonal subtraction plumbing regressed"
+    )
+    assert float(np.max(np.abs(np.abs(s[1, 0, :]) - 1.0))) < 1e-4, (
+        "empty-guide |S21| is not the expected two-run identity 1 — the "
+        "off-diagonal normalization plumbing regressed"
     )
 
-    assert float(np.mean(np.abs(s[0, 0, :]))) < 0.15
-    assert 0.98 < float(np.mean(np.abs(s[1, 0, :]))) < 1.02
-    assert float(np.mean(column_power)) < 1.05
-    assert float(np.mean(recip)) < 1e-3
+
+def test_normalized_twoport_dielectric_binds_reciprocity_and_transmission():
+    """Dielectric obstacle (device != reference): real, falsifiable physics.
+
+    Issue #395 replacement for the vacuous empty-guide contract. An eps_r=4
+    slab reflects and attenuates, so the normalized S-matrix carries genuine
+    reflection and sub-unity transmission that a physics regression can move.
+    Measured 2026-07-20 (num_periods=40, 20 freqs): mean|S11|=0.509,
+    mean|S21|=0.824, mean reciprocity error 0.0000.
+
+    Passivity is NOT asserted here: ``normalize=True`` inflates |S11| on a
+    reflector (column power ~1.21 on this obstacle, a documented extraction
+    limitation). The honest passivity gate is the flux-path
+    ``test_tight_passivity_reflecting_dut`` in the validation battery.
+    """
+    sim = _build_twoport_sim(kind="dielectric")
+    result = sim.compute_waveguide_s_matrix(num_periods=40, normalize=True)
+    s = np.asarray(result.s_params)
+
+    s11 = np.abs(s[0, 0, :])
+    s21 = np.abs(s[1, 0, :])
+    s12 = np.abs(s[0, 1, :])
+    recip = np.abs(s21 - s12) / np.maximum(np.maximum(s21, s12), 1e-12)
+
+    # Non-vacuity witness: device must differ from reference.
+    assert float(np.mean(s11)) > 0.20, (
+        f"obstacle not reflecting (mean|S11|={np.mean(s11):.3f}<=0.20) — the "
+        "gate would collapse to the empty-guide identity"
+    )
+    # Physics: obstacle attenuates transmission below unity.
+    assert 0.5 < float(np.mean(s21)) < 0.98, (
+        f"mean|S21|={np.mean(s21):.3f} outside the reflecting-DUT band "
+        "(0.5, 0.98) — an eps_r=4 step must attenuate but still transmit"
+    )
+    # Physics: Lorentz reciprocity S21==S12 on the projected TE10 subspace.
+    assert float(np.mean(recip)) < 1e-3, (
+        f"reciprocity error mean={np.mean(recip):.5f} >= 1e-3 — extractor "
+        "drive/receive asymmetry regression"
+    )
 
 
 def test_normalized_twoport_pec_short_is_strongly_reflective():
@@ -97,15 +165,61 @@ def test_normalized_twoport_pec_short_is_strongly_reflective():
     assert float(np.mean(recip)) < 1e-3
 
 
-def test_normalized_twoport_reference_plane_invariant_on_empty():
-    base = _build_twoport_sim(kind="empty").compute_waveguide_s_matrix(
+def test_normalized_twoport_reference_plane_magnitude_invariant_on_reflecting_dut():
+    """Reference-plane shift preserves |S| on a REFLECTING DUT (binding).
+
+    Issue #395: the pre-#395 test ran on an empty guide, where S11==0 and the
+    same ref_shift cancels in numerator and denominator of every two-run
+    ratio, so a wrong-magnitude reference-plane implementation still passed.
+
+    On a reflecting eps_r=4 DUT the diagonal S11 is non-zero, so the test
+    actually exercises the de-embed path. A pure phase de-embed must leave
+    the S-parameter MAGNITUDES unchanged (probe 2026-07-20: max|dmag|=0.0
+    for S11 and S21) while legitimately rotating the S11 PHASE (up to ~4.4
+    rad). A ref-plane bug that applied a real gain/attenuation instead of a
+    unit-modulus phase would change |S| and trip this gate.
+
+    Scope split (do not duplicate): the PHASE-rotation sign/magnitude
+    correctness is gated by
+    ``tests/test_waveguide_phase_gate.py::test_deembed_step_sign_rotation_correct``;
+    here we bind only that the shift is a pure phase (magnitude-preserving)
+    and that the transmission (off-diagonal) is fully invariant.
+    """
+    base = _build_twoport_sim(kind="dielectric").compute_waveguide_s_matrix(
         num_periods=40, normalize=True
     )
     shifted = _build_twoport_sim(
-        kind="empty", left_ref=0.02, right_ref=0.08
+        kind="dielectric", left_ref=0.02, right_ref=0.08
     ).compute_waveguide_s_matrix(num_periods=40, normalize=True)
 
     s_base = np.asarray(base.s_params)
     s_shift = np.asarray(shifted.s_params)
-    assert np.allclose(s_base, s_shift, rtol=1e-5, atol=1e-7)
+
+    # Non-vacuity witness: the DUT reflects, so the diagonal is genuinely
+    # exercised (the empty-guide S11==0 made the old test trivial).
+    assert float(np.max(np.abs(s_base[0, 0, :]))) > 0.20, (
+        "reference DUT is not reflecting — ref-plane magnitude invariance "
+        "would be vacuous on the S11 diagonal"
+    )
+    # Binding: pure phase de-embed => |S| unchanged for the whole matrix.
+    assert np.allclose(np.abs(s_base), np.abs(s_shift), rtol=1e-3, atol=1e-4), (
+        "reference-plane shift changed |S| on a reflecting DUT — the "
+        "de-embed is not a pure phase (wrong-magnitude ref-plane bug)"
+    )
+    # Binding: the transmission (off-diagonal) is fully complex-invariant —
+    # its exp(+jbeta d) / exp(+jbeta d) cancels in b_dev/b_ref exactly.
+    assert np.allclose(s_base[1, 0, :], s_shift[1, 0, :], rtol=1e-3, atol=1e-4), (
+        "reference-plane shift moved the complex S21 — the off-diagonal "
+        "ref_shift factors must cancel between device and reference runs"
+    )
+    # Witness that this is not merely re-checking an all-equal matrix: the
+    # diagonal PHASE *does* rotate under the shift (that is the de-embed).
+    diag_phase_shift = float(
+        np.max(np.abs(np.angle(s_shift[0, 0, :]) - np.angle(s_base[0, 0, :])))
+    )
+    assert diag_phase_shift > 0.1, (
+        f"S11 phase did not rotate under the reference-plane shift "
+        f"(max dphase={diag_phase_shift:.4f} rad) — the ref-plane knob is a "
+        "no-op, so the magnitude-invariance check above is not exercising it"
+    )
 


### PR DESCRIPTION
Fixes #395. Empty-guide normalize=True gates had device-run==reference-run → S11≡0/colpow≡1 by construction. Each now uses a can-fail observable: matched-load → normalize=False single-run reflection + absorbed power (inline crippled-CPML falsifier); passivity → reflecting εr=4 DUT (device≠reference); contract split into an honest extraction-identity tripwire + a dielectric-binding test; e5/NU relabeled as the plumbing checks they are (real physics delegated to the sound anchors). Independent review APPROVE_WITH_NITS: falsifier re-run confirmed a 60% CPML-layer cut moves the OLD observable by 0.0 but the NEW one 0.156→0.418 (gate fires); both nits (thin headroom, doubled runtime) addressed with maintainer notes. 23 passed, ruff clean.

R3: memory=research/CLAUDE.md comparator-first + physics_validation_evidence_rule | R2=0 (test-hardening) | falsifier=inline crippled-CPML witness (bad_refl>0.25) 🤖 Generated with [Claude Code](https://claude.com/claude-code)