### PR TITLE
test(#396): resolution-honest resonance gates (harminv) — surfaces hidden ~2% discretization error

### DIFF
--- a/scripts/stage1_nu_cavity_physics_gate.py
+++ b/scripts/stage1_nu_cavity_physics_gate.py
@@ -12,6 +12,14 @@ This is a clean physics/CFL/report gate, not a dielectric-interface
 accuracy claim: TM110 has p=0, so the resonance mainly validates that
 non-uniform fine z cells do not corrupt the closed-cavity RF result.
 
+The resonance is extracted with the validated ``rfx.harminv`` Matrix-Pencil
+estimator, NOT rfft-argmax. At ``num_periods=20`` the record is only ~10 cycles
+of f_tm110, so FFT bins span 10% of f and argmax can place the peak only to ±5%
+— the sub-0.1% "error" it used to print was bin-quantization luck (issue #396).
+harminv resolves far below the bin width, exposing the fixture's true ~2.5%
+NU-air-cavity discretization error (consistent with the sibling analytic gate
+``test_nonuniform_cavity_accuracy.py``: 2.66% @ dx=1mm, gated 4%).
+
 Run:
     python scripts/stage1_nu_cavity_physics_gate.py
 """
@@ -29,12 +37,13 @@ import numpy as np
 from rfx import GaussianPulse, Simulation
 from rfx.auto_config import smooth_grading
 from rfx.grid import C0
+from rfx.harminv import harminv
 
 
 @dataclass(frozen=True)
 class Stage1NUGateResult:
     analytic_freq_hz: float
-    fft_peak_hz: float
+    resonance_hz: float
     resonance_error_pct: float
     cells: int
     uniform_fine_cells: int
@@ -45,15 +54,30 @@ class Stage1NUGateResult:
     preflight_issues: tuple[str, ...]
 
 
-def _fft_peak(time_series: np.ndarray, dt: float, center_hz: float) -> float:
-    spectrum = np.abs(np.fft.rfft(time_series))
-    freqs = np.fft.rfftfreq(len(time_series), d=dt)
-    mask = (freqs >= 0.7 * center_hz) & (freqs <= 1.3 * center_hz)
-    if not np.any(mask):
-        raise RuntimeError("FFT search band contains no bins")
-    band_freqs = freqs[mask]
-    band_spec = spectrum[mask]
-    return float(band_freqs[int(np.argmax(band_spec))])
+def _harminv_peak(
+    time_series: np.ndarray,
+    dt: float,
+    center_hz: float,
+    source_decay_time: float,
+) -> float:
+    """Resonant frequency via the validated Matrix-Pencil estimator (rfx.harminv).
+
+    Replaces rfft-argmax. At num_periods=20 the record is only ~10 cycles of
+    f_tm110, so FFT bins are 10% of f and argmax resolves the peak only to ±5%
+    (issue #396); harminv resolves far below the bin width. The Gaussian
+    excitation region is skipped so the fit sees a clean ring-down.
+    """
+    ts = np.asarray(time_series).ravel()
+    start = int(np.ceil(source_decay_time / dt))
+    start = min(start, max(len(ts) - 20, 0))
+    ring = ts[start:] - np.mean(ts[start:])
+    modes = harminv(ring, dt, 0.7 * center_hz, 1.3 * center_hz)
+    if not modes:
+        raise RuntimeError("harminv found no resonance in the TM110 band")
+    # Band is ±30% wide and harminv resolves <0.05%, so nearest-to-analytic is an
+    # unambiguous mode ID, not a bin-snap toward the expected value.
+    mode = min(modes, key=lambda m: abs(m.freq - center_hz))
+    return float(mode.freq)
 
 
 def run_gate() -> Stage1NUGateResult:
@@ -73,10 +97,11 @@ def run_gate() -> Stage1NUGateResult:
         boundary="pec",
         cpml_layers=0,
     )
+    waveform = GaussianPulse(f0=f_tm110, bandwidth=0.8)
     sim.add_source(
         (a / 3.0, b / 3.0, d / 2.0),
         "ez",
-        waveform=GaussianPulse(f0=f_tm110, bandwidth=0.8),
+        waveform=waveform,
     )
     sim.add_probe((2.0 * a / 3.0, 2.0 * b / 3.0, d / 2.0), "ez")
 
@@ -86,7 +111,8 @@ def run_gate() -> Stage1NUGateResult:
     if not np.all(np.isfinite(ts)) or float(np.max(np.abs(ts))) <= 0.0:
         raise RuntimeError("non-uniform cavity run produced invalid or zero signal")
 
-    peak_hz = _fft_peak(ts, float(result.dt), f_tm110)
+    # Skip 2×t0 (t0 = cutoff*tau = the pulse peak) so harminv fits the ring-down.
+    peak_hz = _harminv_peak(ts, float(result.dt), f_tm110, 2.0 * waveform.t0)
     err_pct = 100.0 * abs(peak_hz - f_tm110) / f_tm110
     seg_gb = report.ad_memory.ad_segmented_gb if report.ad_memory else None
     if seg_gb is None:
@@ -94,7 +120,7 @@ def run_gate() -> Stage1NUGateResult:
 
     gate = Stage1NUGateResult(
         analytic_freq_hz=f_tm110,
-        fft_peak_hz=peak_hz,
+        resonance_hz=peak_hz,
         resonance_error_pct=float(err_pct),
         cells=report.cells,
         uniform_fine_cells=report.uniform_fine_cells,
@@ -111,9 +137,18 @@ def run_gate() -> Stage1NUGateResult:
         raise AssertionError(
             f"cell savings {gate.cell_savings_factor:.2f}x below 40x gate"
         )
-    if gate.resonance_error_pct > 1.0:
+    # Resolution-honest gate. harminv measures ~2.54% error here (HIGH; a one-cell
+    # effective-a registration effect, stable across record lengths 20→160 periods
+    # and confirmed by zero-padded-FFT + parabolic-peak ≈2.58%). This is a MEASURED
+    # NU-air-cavity discretization envelope, consistent with the sibling analytic
+    # gate test_nonuniform_cavity_accuracy.py (2.66% @ dx=1mm, gated 4%). The old
+    # "1%" gate was luck: the true 5.433 GHz peak snapped down into the 5.298 GHz
+    # bin (0.03%). 3.5% = measured 2.54% + margin; harminv resolves <0.05% so this
+    # now actually binds a real regression, unlike the ±5% argmax window (#396).
+    if gate.resonance_error_pct > 3.5:
         raise AssertionError(
-            f"resonance error {gate.resonance_error_pct:.3f}% exceeds 1% gate"
+            f"resonance error {gate.resonance_error_pct:.3f}% exceeds the "
+            f"resolution-honest 3.5% NU-cavity discretization envelope"
         )
     if gate.segmented_ad_gb >= gate.full_ad_gb:
         raise AssertionError(
@@ -127,7 +162,7 @@ def main() -> int:
     gate = run_gate()
     print("Stage 1 NU cavity physics gate: PASS")
     print(f"  analytic TM110:       {gate.analytic_freq_hz/1e9:.6f} GHz")
-    print(f"  FDTD FFT peak:        {gate.fft_peak_hz/1e9:.6f} GHz")
+    print(f"  FDTD harminv peak:    {gate.resonance_hz/1e9:.6f} GHz")
     print(f"  resonance error:      {gate.resonance_error_pct:.4f} %")
     print(f"  cells:                {gate.cells:,}")
     print(f"  uniform-fine cells:   {gate.uniform_fine_cells:,}")

--- a/scripts/stage1_nu_cavity_physics_gate.py
+++ b/scripts/stage1_nu_cavity_physics_gate.py
@@ -139,7 +139,8 @@ def run_gate() -> Stage1NUGateResult:
         )
     # Resolution-honest gate. harminv measures ~2.54% error here (HIGH; a one-cell
     # effective-a registration effect, stable across record lengths 20→160 periods
-    # and confirmed by zero-padded-FFT + parabolic-peak ≈2.58%). This is a MEASURED
+    # and corroborated by zero-padded-FFT + parabolic-peak ~2.55-2.58% (the exact
+    # secondary number is window/pad-factor dependent). This is a MEASURED
     # NU-air-cavity discretization envelope, consistent with the sibling analytic
     # gate test_nonuniform_cavity_accuracy.py (2.66% @ dx=1mm, gated 4%). The old
     # "1%" gate was luck: the true 5.433 GHz peak snapped down into the 5.298 GHz

--- a/tests/test_cavity.py
+++ b/tests/test_cavity.py
@@ -7,7 +7,10 @@ For TM_110 mode (m=1, n=1, p=0) with a=b=0.1m, d=0.05m:
   f_110 = (c / 2) * sqrt((1/0.1)^2 + (1/0.1)^2) = c * sqrt(2) / 0.2
         ≈ 2.1213 GHz
 
-Exit criterion: resonant frequency error ≤ 0.5%.
+Exit criterion: resonant frequency error within the resolution-honest
+discretization envelope (2.5%), measured with the ``rfx.harminv`` Matrix-Pencil
+estimator rather than rfft-argmax. See ``test_pec_cavity_resonance`` for why the
+old "0.5%" gate was FFT-bin-quantization luck, not a real bound (issue #396).
 """
 
 import jax.numpy as jnp
@@ -47,9 +50,14 @@ def test_analytical_tm110(cavity_params):
 
 
 def test_pec_cavity_resonance(cavity_params):
-    """FDTD simulation of PEC cavity should match TM110 within 0.5%.
+    """FDTD PEC cavity TM110 resonance, measured with harminv (not rfft-argmax).
 
-    This is the primary Stage 1 exit criterion.
+    This is the primary Stage 1 exit criterion. The frequency is extracted with
+    the validated ``rfx.harminv`` Matrix-Pencil estimator, which resolves far
+    below the FFT bin width (locked by ``test_harminv_estimator.py``). The prior
+    version used ``rfft`` argmax, whose 125 MHz bins span 5.9% of f_res: it could
+    only place the peak to ±3%, so the reported 0.22% error was bin-quantization
+    luck (issue #396). harminv exposes the fixture's TRUE resonance.
     """
     a, b, d = cavity_params["a"], cavity_params["b"], cavity_params["d"]
     f_analytical = analytical_tm_freq(a, b, d, m=1, n=1, p=0)
@@ -97,24 +105,39 @@ def test_pec_cavity_resonance(cavity_params):
         # Record probe
         time_series[n] = float(state.ez[probe_i, probe_j, probe_k])
 
-    # FFT to find resonant frequency
-    spectrum = np.abs(np.fft.rfft(time_series))
-    freqs = np.fft.rfftfreq(num_steps, d=dt)
+    # Resolve the resonant frequency with the validated Matrix-Pencil estimator
+    # (rfx.harminv), NOT rfft-argmax. Skip the Gaussian excitation region so the
+    # fit sees a clean ring-down (t0 = cutoff*tau is the pulse peak).
+    from rfx.harminv import harminv
 
-    # Find peak near expected resonance (skip DC)
-    search_lo = f_analytical * 0.5
-    search_hi = f_analytical * 1.5
-    mask = (freqs >= search_lo) & (freqs <= search_hi)
-    masked_spectrum = np.where(mask, spectrum, 0.0)
-    peak_idx = np.argmax(masked_spectrum)
-    f_fdtd = freqs[peak_idx]
+    start = int(np.ceil(2.0 * pulse.t0 / dt))
+    ringdown = time_series[start:] - np.mean(time_series[start:])
+    modes = harminv(ringdown, dt, f_analytical * 0.7, f_analytical * 1.3)
+    assert modes, "harminv found no resonance in the TM110 band"
+    # The search band is wide (±30%) and harminv resolves <0.05%, so nearest-to-
+    # analytic is an unambiguous mode ID, not a bin-snap toward the expected value.
+    mode = min(modes, key=lambda m: abs(m.freq - f_analytical))
+    f_fdtd = mode.freq
 
     error = abs(f_fdtd - f_analytical) / f_analytical
-    print(f"Analytical: {f_analytical / 1e9:.4f} GHz")
-    print(f"FDTD:       {f_fdtd / 1e9:.4f} GHz")
-    print(f"Error:      {error * 100:.2f}%")
+    print(f"Analytical:     {f_analytical / 1e9:.4f} GHz")
+    print(f"FDTD (harminv): {f_fdtd / 1e9:.6f} GHz  (Q={mode.Q:.3g})")
+    print(f"Error:          {error * 100:.3f}%")
 
-    assert error < 0.005, f"Resonance error {error*100:.2f}% exceeds 0.5% threshold"
+    # Resolution-honest gate. This bounds a MEASURED Yee discretization +
+    # PEC-boundary-registration error, NOT an FFT-bin window. On main harminv
+    # reads 2.0794 GHz => 1.91% low; independently confirmed by zero-padded-FFT +
+    # parabolic-peak (1.84%) and by convergence under refinement (1.91% @ this dx
+    # -> 0.47% at 2× dx), proving it is genuine discretization, not extraction
+    # noise. The old 0.5% "gate" passed only by luck: the true 2.08 GHz peak
+    # rounded up into the 2.1244 GHz bin (0.22%). 2.5% = measured 1.91% + margin;
+    # because harminv resolves <0.05% this now actually binds — a regression past
+    # ~2.5% fails, which the argmax gate never could (issue #396).
+    assert error < 0.025, (
+        f"PEC cavity TM110 resonance error {error*100:.3f}% exceeds the "
+        f"resolution-honest 2.5% discretization envelope "
+        f"(harminv f={f_fdtd/1e9:.4f} GHz vs analytic {f_analytical/1e9:.4f} GHz)"
+    )
 
 
 def test_pec_zeros_boundary():

--- a/tests/test_cavity.py
+++ b/tests/test_cavity.py
@@ -127,8 +127,9 @@ def test_pec_cavity_resonance(cavity_params):
     # Resolution-honest gate. This bounds a MEASURED Yee discretization +
     # PEC-boundary-registration error, NOT an FFT-bin window. On main harminv
     # reads 2.0794 GHz => 1.91% low; independently confirmed by zero-padded-FFT +
-    # parabolic-peak (1.84%) and by convergence under refinement (1.91% @ this dx
-    # -> 0.47% at 2× dx), proving it is genuine discretization, not extraction
+    # parabolic-peak (~1.8-1.9%, method-dependent) and by convergence under mesh
+    # REFINEMENT (1.91% at this dx -> ~0.47% at half dx / 2x resolution),
+    # proving it is genuine discretization, not extraction
     # noise. The old 0.5% "gate" passed only by luck: the true 2.08 GHz peak
     # rounded up into the 2.1244 GHz bin (0.22%). 2.5% = measured 1.91% + margin;
     # because harminv resolves <0.05% this now actually binds — a regression past

--- a/tests/test_stage1_nu_physics_gate.py
+++ b/tests/test_stage1_nu_physics_gate.py
@@ -9,5 +9,8 @@ def test_stage1_nu_cavity_physics_gate_passes():
     gate = run_gate()
     assert gate.preflight_issues == ()
     assert gate.cell_savings_factor >= 40.0
-    assert gate.resonance_error_pct <= 1.0
+    # Resolution-honest envelope: harminv (not rfft-argmax) measures ~2.54% real
+    # NU-air-cavity discretization error here; the gate binds at 3.5% (issue #396,
+    # matching run_gate's own assertion). The old 1% gate was FFT-bin luck.
+    assert gate.resonance_error_pct <= 3.5
     assert gate.segmented_ad_gb < gate.full_ad_gb


### PR DESCRIPTION
Fixes #396. Raw rfft-argmax asserted 0.5%/1% tolerances finer than its own FFT bins (5.9%/10% of f_res) → the tight numbers were bin luck. Replaced with the validated harminv estimator (resolves <0.05%). **Physics finding surfaced (not tuned away):** once the bins stop hiding it, the PEC cavity is ~1.9% LOW (Yee dispersion + boundary registration; converges to ~0.47% at 2× resolution) and the NU air cavity ~2.5% HIGH (1-cell effective-a registration; stable across record lengths; agrees with sibling test 2.66%). Two independent estimators + refinement convergence confirm real physics. Gates re-pinned at measured-error + margin (2.5%/3.5%) — nominally wider but genuinely STRONGER (harminv catches a 2% shift the argmax gate was blind to; review re-ran this falsifier verbatim). APPROVE_WITH_NITS, both wording nits fixed.

R3: memory=feedback_root_cause_before_gate_change (root-caused, not a silent loosen) | R2=0 | falsifier=+5% shift fails harminv, passes argmax 🤖 Generated with [Claude Code](https://claude.com/claude-code)