### PR TITLE
test(#399): quantitative series-RLC oracle (f0/Q) — solver exonerated

### DIFF
--- a/tests/test_decay_rlc.py
+++ b/tests/test_decay_rlc.py
@@ -7,7 +7,7 @@ class TestDecayWithRLC:
     def test_decay_with_inductor(self):
         sim = Simulation(freq_max=5e9, domain=(0.02, 0.02, 0.02), boundary="pec")
         sim.add_source(position=(0.01, 0.01, 0.01), component="ez",
-                       waveform=GaussianPulse(f0=2.5e9, bandwidth=2.5e9))
+                       waveform=GaussianPulse(f0=2.5e9, bandwidth=0.8))
         sim.add_lumped_rlc(position=(0.01, 0.01, 0.01), component="ez",
                            R=50.0, L=10e-9, C=0, topology="series")
         sim.add_probe(position=(0.01, 0.01, 0.01), component="ez")
@@ -20,7 +20,7 @@ class TestDecayWithRLC:
     def test_decay_with_high_r_stops_early(self):
         sim = Simulation(freq_max=5e9, domain=(0.02, 0.02, 0.02), boundary="pec")
         sim.add_source(position=(0.01, 0.01, 0.01), component="ez",
-                       waveform=GaussianPulse(f0=2.5e9, bandwidth=2.5e9))
+                       waveform=GaussianPulse(f0=2.5e9, bandwidth=0.8))
         sim.add_lumped_rlc(position=(0.01, 0.01, 0.01), component="ez",
                            R=1000.0, L=0, C=0, topology="series")
         sim.add_probe(position=(0.01, 0.01, 0.01), component="ez")

--- a/tests/test_lumped_rlc.py
+++ b/tests/test_lumped_rlc.py
@@ -1,7 +1,11 @@
 """Lumped RLC element tests.
 
-Validates:
-1. Series RLC resonance frequency matches analytical f0 = 1/(2*pi*sqrt(LC))
+Validates (direction-only / smoke coverage; the quantitative f0 = 1/(2*pi*
+sqrt(LC)) and Q = (1/R)*sqrt(L/C) oracle lives in
+``test_series_rlc_current.py::test_series_rlc_current_peaks_at_f0``):
+1. Adding an LC element measurably shifts the driven-cell spectrum near f0
+   (the resonance itself is quantitatively gated on the series CURRENT, not
+   the E-field probe — see the observable note in test_series_rlc_current.py).
 2. Pure capacitor and pure inductor elements run without error
 3. Parallel RLC topology runs without error
 4. Validation catches bad inputs
@@ -242,7 +246,13 @@ class TestParallelRLC:
         assert result.time_series.shape == (200, 1)
 
     def test_parallel_rlc_resonance(self):
-        """Parallel RLC anti-resonance at f0 = 1/(2*pi*sqrt(LC))."""
+        """Parallel RLC runs and produces a non-trivial field (smoke test).
+
+        NOTE: this only checks the field is non-zero, not the anti-resonance
+        location. The quantitative resonance oracle is the series-current gate
+        in test_series_rlc_current.py; a parallel-current oracle is not yet
+        added.
+        """
         R = 200.0      # Higher R for parallel (high impedance at resonance)
         L = 10e-9      # 10 nH
         C = 1e-12      # 1 pF

--- a/tests/test_series_rlc_current.py
+++ b/tests/test_series_rlc_current.py
@@ -1,40 +1,163 @@
 """True series RLC: R, L, C share a single series current.
 
 Validates that:
-1. Series RLC shows a spectral peak near the analytical resonance
-   frequency f0 = 1/(2*pi*sqrt(LC)).
+1. The series-RLC ADE **current** resonates at the analytical frequency
+   f0 = 1/(2*pi*sqrt(LC)) with quality factor Q = (1/R)*sqrt(L/C)
+   (quantitative physics oracle, issue #399).
 2. Series and parallel topologies produce measurably different spectra.
 3. Series R+C (no inductor) produces a distinct response from pure R.
 4. Capacitor charge state is tracked correctly (non-zero after excitation).
+
+Observable note (issue #399)
+----------------------------
+The series resonance lives in the shared **series current** I_s, which peaks
+where the L and C reactances cancel (|Z| minimum). The driven-cell E-field
+probe does NOT show a peak at f0: a series RLC tapped at a single Yee cell
+loads that cell's field monotonically across the band (verified empirically —
+no local peak or notch at f0). The earlier `test_series_rlc_resonance_peak`
+claimed an E-field peak at f0 but asserted no peak *location* and drove the
+source with an absolute-Hz value in the FRACTIONAL `bandwidth` slot (a sub-dt
+spike, #386), so its "dominant peak" was a grid artefact, not f0. The gate
+below instead exercises the production ADE (`rfx.lumped._update_series`)
+directly and measures the current it produces.
 """
 
+from typing import NamedTuple
+
 import numpy as np
+import jax
+import jax.numpy as jnp
+import pytest
+
 from rfx import Simulation, GaussianPulse
-from rfx.lumped import init_rlc_state
+from rfx.materials import MaterialArrays
+from rfx.lumped import (init_rlc_state, LumpedRLCSpec, build_rlc_meta,
+                        setup_rlc_materials, _update_series)
+
+
+class _EzCell(NamedTuple):
+    """1-cell FDTD state (pytree) for driving the series-RLC ADE in isolation."""
+    ez: jnp.ndarray
+
+
+def _series_rlc_current_spectrum(R, L, C, *, dx=0.5e-3, n=40000, pad=8):
+    """Impulse response of the PRODUCTION series-RLC ADE.
+
+    Drives ``rfx.lumped._update_series`` (the exact solver update, with a real
+    ``build_rlc_meta`` dt/dx from a real Grid) with a single-sample voltage
+    impulse — a flat, broadband excitation. Because the series-RLC ADE is
+    linear, its impulse response IS the transfer function, so the |I_s(f)|
+    peak is the solver's true resonance and is independent of the drive shape
+    (non-circular: the drive imposes no frequency). All arithmetic is float32
+    (the concrete ``run()`` dtype); no module-level x64 flip.
+
+    Returns ``(freqs, |I_s(freqs)|, dt)``.
+    """
+    sim = Simulation(freq_max=5e9, domain=(0.01, 0.01, 0.01),
+                     boundary="pec", dx=dx)
+    grid = sim._build_grid()
+    shape = (grid.nx, grid.ny, grid.nz)
+    vac = MaterialArrays(eps_r=jnp.ones(shape), sigma=jnp.zeros(shape),
+                         mu_r=jnp.ones(shape))
+    spec = LumpedRLCSpec(R=R, L=L, C=C, topology="series",
+                         position=(0.005, 0.005, 0.005), component="ez")
+    mats = setup_rlc_materials(grid, spec, vac)
+    # Relocate the element to cell (0,0,0) so the driven state is a 1-cell
+    # array (cheap lax.scan); coefficients (dt, dx, gamma, ...) are unchanged.
+    meta = build_rlc_meta(grid, spec, mats)._replace(i=0, j=0, k=0)
+    dt = meta.dt
+
+    drive = np.zeros(n, dtype=np.float32)
+    drive[3] = 1.0  # single-sample impulse -> flat broadband voltage
+
+    def step(carry, e_in):
+        st, rlc = carry
+        st = st._replace(ez=st.ez.at[0, 0, 0].set(e_in))
+        st, rlc = _update_series(st, rlc, meta)
+        return (st, rlc), rlc.inductor_current
+
+    st0 = _EzCell(ez=jnp.zeros((1, 1, 1), dtype=jnp.float32))
+    (_, _), i_hist = jax.lax.scan(step, (st0, init_rlc_state()),
+                                  jnp.asarray(drive))
+    i_hist = np.asarray(i_hist)
+    nfft = n * pad
+    spec_mag = np.abs(np.fft.rfft(i_hist, n=nfft))
+    freqs = np.fft.rfftfreq(nfft, dt)
+    return freqs, spec_mag, dt
+
+
+def _interp_peak(freqs, spec_mag):
+    """Parabolic-interpolated location of the spectral peak (f > 0)."""
+    pos = freqs > 0
+    fr, sp = freqs[pos], spec_mag[pos]
+    k = int(np.argmax(sp))
+    if 0 < k < len(sp) - 1:
+        y0, y1, y2 = sp[k - 1], sp[k], sp[k + 1]
+        denom = y0 - 2.0 * y1 + y2
+        delta = 0.5 * (y0 - y2) / denom if denom != 0 else 0.0
+        return fr[k] + delta * (fr[1] - fr[0])
+    return fr[k]
+
+
+def _q_from_minus3db(freqs, spec_mag):
+    """Q from the linear-interpolated -3 dB bandwidth of the current peak."""
+    pos = freqs > 0
+    fr, sp = freqs[pos], spec_mag[pos]
+    k = int(np.argmax(sp))
+    half = sp[k] / np.sqrt(2.0)
+    lo = k
+    while lo > 0 and sp[lo] >= half:
+        lo -= 1
+    hi = k
+    while hi < len(sp) - 1 and sp[hi] >= half:
+        hi += 1
+
+    def _cross(a, b):
+        if sp[b] == sp[a]:
+            return fr[a]
+        t = (half - sp[a]) / (sp[b] - sp[a])
+        return fr[a] + t * (fr[b] - fr[a])
+
+    f_lo = _cross(lo, lo + 1)
+    f_hi = _cross(hi, hi - 1)
+    bw = f_hi - f_lo
+    return fr[k] / bw if bw > 0 else np.inf
 
 
 class TestSeriesRLCCurrent:
-    def test_series_rlc_resonance_peak(self):
-        """Series RLC should show spectral peak near f0 = 1/(2*pi*sqrt(LC))."""
-        R, L, C = 50.0, 10e-9, 1e-12
-        f0 = 1 / (2 * np.pi * np.sqrt(L * C))
-        sim = Simulation(freq_max=5e9, domain=(0.01, 0.01, 0.01), boundary="pec")
-        sim.add_source(position=(0.005, 0.005, 0.005), component="ez",
-                       waveform=GaussianPulse(f0=f0, bandwidth=f0 * 0.5))
-        sim.add_lumped_rlc(position=(0.005, 0.005, 0.005), component="ez",
-                           R=R, L=L, C=C, topology="series")
-        sim.add_probe(position=(0.005, 0.005, 0.005), component="ez")
-        result = sim.run(n_steps=5000)
-        ts = np.array(result.time_series).ravel()
-        dt = result.dt
-        freqs = np.fft.rfftfreq(len(ts), dt)
-        spectrum = np.abs(np.fft.rfft(ts))
-        mask = (freqs > f0 * 0.5) & (freqs < f0 * 1.5)
-        if np.any(mask):
-            peak_near_f0 = np.max(spectrum[mask])
-            overall_peak = np.max(spectrum[freqs > 0])
-            ratio = peak_near_f0 / overall_peak if overall_peak > 0 else 0
-            assert ratio > 0.1, f"Series RLC resonance peak weak: ratio={ratio:.3f}"
+    # (R, L, C, expected f0 GHz, expected Q) — f0 and Q are the analytic
+    # targets; the current oracle must land on both. The 3rd case moves f0
+    # (via L,C) so the gate tracks 1/(2*pi*sqrt(LC)), not a fixed number.
+    @pytest.mark.parametrize("R,L,C", [
+        (50.0, 10e-9, 1e-12),   # f0 ~ 1.592 GHz, Q = 2
+        (20.0, 10e-9, 1e-12),   # f0 ~ 1.592 GHz, Q = 5
+        (25.0, 2.5e-9, 1e-12),  # f0 ~ 3.183 GHz, Q = 2
+    ])
+    def test_series_rlc_current_peaks_at_f0(self, R, L, C):
+        """Series-RLC current peaks at f0 = 1/(2*pi*sqrt(LC)), Q = (1/R)sqrt(L/C).
+
+        Quantitative physics oracle (issue #399). Measured envelope on main
+        (float32, n=40000, x8 zero-pad): peak error <= 0.01% of f0 and Q error
+        <= 0.1% of analytic across all three cases. The gates below (peak within
+        0.5%, Q within 5%) pin that envelope with headroom for the FFT bin
+        (~0.2% of f0) and leapfrog dispersion (~1e-4 %). Do NOT loosen without a
+        root-cause: a shift here means the series-RLC ADE resonance moved.
+        """
+        f0 = 1.0 / (2.0 * np.pi * np.sqrt(L * C))
+        q_analytic = (1.0 / R) * np.sqrt(L / C)
+
+        freqs, spec_mag, dt = _series_rlc_current_spectrum(R, L, C)
+        f_peak = _interp_peak(freqs, spec_mag)
+        q_meas = _q_from_minus3db(freqs, spec_mag)
+
+        f_err = abs(f_peak - f0) / f0
+        q_err = abs(q_meas - q_analytic) / q_analytic
+        assert f_err < 5e-3, (
+            f"series-RLC current peak {f_peak/1e9:.5f} GHz vs analytic f0 "
+            f"{f0/1e9:.5f} GHz (err {100*f_err:.3f}%) — resonance off f0")
+        assert q_err < 5e-2, (
+            f"series-RLC current Q {q_meas:.4f} vs analytic {q_analytic:.4f} "
+            f"(err {100*q_err:.2f}%)")
 
     def test_series_vs_parallel_different(self):
         """Series and parallel should give different spectra."""
@@ -44,7 +167,7 @@ class TestSeriesRLCCurrent:
         for topo in ["series", "parallel"]:
             sim = Simulation(freq_max=5e9, domain=(0.01, 0.01, 0.01), boundary="pec")
             sim.add_source(position=(0.005, 0.005, 0.005), component="ez",
-                           waveform=GaussianPulse(f0=f0, bandwidth=f0))
+                           waveform=GaussianPulse(f0=f0, bandwidth=0.8))
             sim.add_lumped_rlc(position=(0.005, 0.005, 0.005), component="ez",
                                R=R, L=L, C=C, topology=topo)
             sim.add_probe(position=(0.005, 0.005, 0.005), component="ez")

--- a/tests/test_series_rlc_current.py
+++ b/tests/test_series_rlc_current.py
@@ -51,6 +51,14 @@ def _series_rlc_current_spectrum(R, L, C, *, dx=0.5e-3, n=40000, pad=8):
     (non-circular: the drive imposes no frequency). All arithmetic is float32
     (the concrete ``run()`` dtype); no module-level x64 flip.
 
+    SCOPE (review nit #399): this oracle binds the series-RLC ADE *circuit*
+    equations (f0, Q of ``_update_series``). It does NOT exercise the
+    current->E-field injection coupling that a full ``run()`` applies at the
+    element cell — that end-to-end path stays covered only by the direction-only
+    tests below. A quantitative full-``run()`` f0 gate is a warranted follow-up
+    (it needs a resolved broadband source + harminv on the driven-cell current,
+    heavier than this isolated ADE probe).
+
     Returns ``(freqs, |I_s(freqs)|, dt)``.
     """
     sim = Simulation(freq_max=5e9, domain=(0.01, 0.01, 0.01),


### PR DESCRIPTION
Fixes #399. The lumped-RLC family had no quantitative oracle; test_series_rlc_resonance_peak asserted no peak location and used a #386-degenerate excitation (measured peak 5.70 GHz vs claimed 1.59). Added an oracle driving the PRODUCTION series-RLC ADE (_update_series) with a broadband impulse: **solver exonerated** — current spectrum peaks at f0=1/(2π√(LC)) to 0.0006% and Q to (1/R)√(L/C) within 0.1%, across three R values. Falsifier: comparing to a 5%-shifted f0 fails (4.76%). Fixed the degenerate excitation (no #386 warning fires now); corrected header overclaims; kept direction-only tests as complementary. Review APPROVE_WITH_NITS (confirmed the oracle calls real _update_series, not a reimplementation); scope-documented that the current→field coupling stays a full-run() follow-up.

R3: memory=research/CLAUDE.md comparator-first | R2=0 | falsifier=5%-shifted f0 fails the gate 🤖 Generated with [Claude Code](https://claude.com/claude-code)