### PR TITLE
test(#401): make module docstrings match what the tests assert

### DIFF
--- a/tests/test_boundary_cpml_asymmetric.py
+++ b/tests/test_boundary_cpml_asymmetric.py
@@ -9,12 +9,17 @@ These tests pin the PADDED-PROFILE MECHANISM shipped in
   in the padded no-op region, and σ_max at the outer-boundary end for
   the (pre-flipped) hi-face.
 
-The QUANTITATIVE physics (between-face reflection ratio R_lo/R_hi > 10
-at the source dominant frequency, control sym (16, 16) within 1.5×)
-is asserted separately in
-``tests/test_boundary_cpml_oracle.py::test_asymmetric_reflection_between_face_ratio``
-— that oracle is what makes the asymmetric-CPML claim load-bearing;
-this file only guarantees the mechanism wiring.
+The QUANTITATIVE asymmetric-CPML evidence is COEFFICIENT-LEVEL (σ_max),
+not a field-reflection ratio. ``tests/test_boundary_cpml_oracle.py`` pins
+σ_max on the 4-layer face at exactly 4× the 16-layer face
+(``test_asymmetric_sigma_max_ratio_matches_analytic``), the polynomial
+grading shape, and that the per-face σ arrays differ
+(``test_asymmetric_sigma_arrays_differ``) — that is what makes the
+asymmetric-CPML claim load-bearing. A between-face FIELD-reflection ratio
+is deliberately NOT asserted: the Gaussian source pulse (~200 steps) is
+longer than the source-to-face round trip (~30 steps), so it cannot be
+time-gated in a single asymmetric sim (see that oracle's docstring). This
+file only guarantees the mechanism wiring.
 """
 
 from __future__ import annotations

--- a/tests/test_debye.py
+++ b/tests/test_debye.py
@@ -4,7 +4,15 @@ Validates the Debye ADE implementation against analytical predictions:
 1. Coefficients match hand-computed values
 2. Debye medium slows propagation (higher effective ε at low freq)
 3. Energy is bounded (no ADE instability)
-4. Frequency-dependent permittivity matches Debye formula
+4. Dispersion is mask-selective and multi-pole capable
+
+The frequency-dependent permittivity ε(ω) itself — that the Debye ADE
+reproduces the analytic Debye formula ε(ω) = ε_∞ + Σ Δε/(1 + jωτ) — is NOT
+re-measured here. It is validated end-to-end (FDTD R(f) of a Debye slab vs a
+rigorous transfer-matrix oracle fed the identical ε(ω)) in
+``tests/test_dispersive_fresnel_validation.py::test_dispersive_fresnel_debye``
+(``slow_physics`` opt-in lane). This file pins the ADE
+coefficient / stability / masking mechanics only.
 """
 
 import numpy as np

--- a/tests/test_decay_flux_convergence.py
+++ b/tests/test_decay_flux_convergence.py
@@ -1,46 +1,54 @@
-"""Witness harness for issue #169 — ``run_until_decay`` point-field stopper
-fires before the flux-DFT has converged on low-group-velocity guided geometries.
+"""Witness harness for issue #169 — ``run_until_decay`` stop quality on
+low-group-velocity guided geometries. **RESOLVED** by Criterion A (total
+interior-domain-energy decay); this harness keeps both the historical bug
+signature and the fix honest.
 
-Root cause (verified at source, ``rfx/simulation.py:1954-1960``): the decay
-stop predicate compares the *instantaneous squared point field at one cell*
+Historical root cause (the PRE-FIX predicate): the old decay stopper compared
+the *instantaneous squared point field at one cell*
 (``val_sq = float(monitor_val) ** 2``) against ``decay_by * running_peak``.
 On a dielectric guide (cv03, eps=12) the point ``ez`` at the flux_out cell
 dips through a transient null between wave packets while the flux DFT — the
 quantity the decay run is meant to gate — is still integrating the slow tail.
-The point ratio is NON-MONOTONE (it climbs back up after the null), so it is
-not a convergence witness at all.
+That point ratio is NON-MONOTONE (it climbs back up after the null), so it was
+not a convergence witness at all, and the run stopped ~7% short of the
+converged transmission. The FIX (now shipped in ``rfx/simulation.py``) makes
+the absorbing-boundary stop gate on the whole-domain energy
+``U = Σ(E² + H²)`` over the non-CPML interior, declared decayed once
+``U < decay_by * peak_U`` on ``decay_energy_consecutive`` consecutive checks;
+whole-domain energy does not pass through per-cell interference nulls, so the
+stop now lands at the flux-converged value.
 
 Two witnesses live here:
 
 1. ``test_issue169_recorded_divergence_witness`` — FAST (<1s, no FDTD). Replays
-   the *current* point-field predicate against the committed diagnostic JSON
-   (the full cv03 trace produced by
+   the OLD point-field predicate against the committed diagnostic JSON (the
+   full cv03 trace produced by
    ``scripts/diagnostics/issue169_decay/reproduce_decay_vs_flux.py``) and pins
-   the bug signature: the predicate fires at the recorded quiet step, the
-   point ratio is non-monotone, and the flux at that stop is materially below
-   the converged value. This is an always-pass regression SENTINEL — it keeps
-   the recorded witness honest and is collectable in the fast PR lane. It does
-   NOT exercise ``simulation.py`` and so cannot itself flip when the fix lands;
-   that job belongs to test 2.
+   the historical bug signature: the predicate fires at the recorded quiet
+   step, the point ratio is non-monotone, and the flux at that stop is
+   materially below the converged value. This is an always-pass regression
+   SENTINEL that locks the recorded evidence of *why the point-field stopper
+   was wrong*; it is collectable in the fast PR lane. It does NOT exercise
+   ``simulation.py`` (pure JSON replay) and so cannot itself flip — proving the
+   live fix is test 2's job.
 
 2. ``test_issue169_decay_reaches_flux_converged_value`` — the ACCEPTANCE test.
-   It actually drives ``Simulation.run(until_decay=...)`` on the smallest
-   faithful cv03-class guided geometry that still shows the under-run, and
-   asserts the decay stop reaches the flux-converged transmission (within tol
-   of the fixed-duration truth). It is ``xfail(strict=True)`` because the bug
-   is present TODAY: it flips to PASS the moment the criterion is made
-   flux-aware (architect Candidate C — flux-residual stopping when flux
-   monitors are present). It is ``pytest.mark.gpu`` because the decay path
-   JIT-dispatches each step in a Python loop, so a faithful repro is ~50s+
-   (the cost floor is the ~2150-step point-stop, set by source cutoff + guide
-   transit — it cannot be shrunk below the fast-lane budget without destroying
-   the under-run signature; this was measured across four geometries). It
-   therefore lives in the gpu suite, matching ``test_decay_convergence.py``.
+   It drives the real ``Simulation.run(until_decay=...)`` path on the smallest
+   faithful cv03-class guided geometry that showed the under-run, and asserts
+   the decay stop now reaches the flux-converged transmission (within tol of
+   the fixed-duration truth) AND lands well past the old ~2151-step
+   point-field under-run. It PASSES on current main under Criterion A — it is a
+   plain gate, NOT ``xfail``. It is ``pytest.mark.gpu`` because the decay path
+   JIT-dispatches each step in a Python loop, so a faithful repro is ~50s+ (the
+   cost floor is the ~2150-step stop, set by source cutoff + guide transit — it
+   cannot be shrunk below the fast-lane budget without destroying the signature;
+   measured across four geometries). It therefore lives in the gpu suite,
+   matching ``test_decay_convergence.py``.
 
-IMPORTANT: this harness does NOT modify ``rfx/simulation.py`` or any core
-file. The criterion change is deferred to an explicit user go-ahead — see
-``docs/research_notes/20260613_issue169_decay_criterion.md`` for the
-architect's recommended spec and the R2 gate.
+NOTE: this harness does NOT itself modify ``rfx/simulation.py``; the Criterion A
+change landed in the core separately. See
+``docs/research_notes/20260613_issue169_decay_criterion.md`` for the original
+spec and the R2 gate.
 """
 
 import json

--- a/tests/test_lorentz.py
+++ b/tests/test_lorentz.py
@@ -2,10 +2,23 @@
 
 Validates:
 1. Coefficients match hand-computed values
-2. Drude pole constructor
-3. Lorentz medium slows propagation
-4. Energy bounded (no ADE instability)
-5. Integration with simulation runner
+2. Drude / Lorentz pole constructors
+3. Energy bounded (no ADE instability)
+4. Integration with the simulation runner (Lorentz-only + mixed Debye/Lorentz)
+5. Poles stay scoped to their own material
+
+The dispersive ε(ω) itself — that the Lorentz ADE reproduces the analytic
+Lorentz permittivity, hence the below-resonance phase-velocity slowdown — is
+NOT re-measured here. It is validated end-to-end (FDTD broadband R(f) of an
+in-band-resonant Lorentz slab vs a rigorous transfer-matrix oracle fed the
+identical ε(ω)) in
+``tests/test_dispersive_fresnel_validation.py::test_dispersive_fresnel_lorentz``
+(``slow_physics`` opt-in lane). A time-domain "slows propagation" gate is
+deliberately NOT kept here: on a small PEC-walled cavity the pulse-arrival
+peak is dominated by wall reflections (a domain-size-dependent artifact — the
+global-argmax ratio measured 1.97× at nx=200 but 0.71× at nx=400), while the
+true reflection-immune leading-edge slowdown is only ~1.19× — too weak to
+gate. This file pins the ADE coefficient / stability / runner mechanics only.
 """
 
 import numpy as np
@@ -84,105 +97,6 @@ def test_lorentz_pole_constructor():
     assert abs(pole.omega_0 - omega_0) < 1.0
     assert abs(pole.delta - d) < 1e-6
     assert abs(pole.kappa - delta_eps * omega_0**2) / (delta_eps * omega_0**2) < 1e-6
-
-
-def test_lorentz_medium_slower_propagation():
-    """Pulse in a below-resonance Lorentz medium arrives later downstream.
-
-    Arrival-time approach mirroring the Debye analog in ``test_debye.py``:
-    record ``|Ez|`` at a fixed monitor and compare the step of peak arrival.
-    Well BELOW the Lorentz resonance the medium is near-lossless with an
-    (almost) static ``Re(ε) ≈ ε_∞ + Δε``, so the pulse must arrive later than
-    in vacuum (``v ≈ c/√Re(ε)``).  Here ``ε_∞=1, Δε=8, ω₀=2π·30 GHz`` give
-    ``Re(ε) ≈ 10`` in the 10 GHz band (ω/ω₀ = 1/3, well below resonance),
-    which slows the peak arrival by ``~2×`` (measured 1.97× on CPU) while
-    retaining ~83% of the vacuum peak amplitude (near-lossless).
-
-    Unlike the Debye analog — which raises ``ε_∞`` to 4 and adds only a
-    tiny Δε pole — the slowdown here is produced by the LORENTZ pole itself
-    (both runs use ``ε_∞ = 1``), so this binds the dispersive contribution.
-    """
-    from rfx.core.yee import update_e
-
-    nx = 200
-    shape = (nx, 6, 6)
-    dx = 0.0005  # 0.5 mm
-    dt = 0.99 * dx / (C0 * np.sqrt(3))
-
-    f0 = 10e9
-    tau_pulse = 1.0 / (f0 * 0.5 * np.pi)
-    t0_pulse = 3.0 * tau_pulse
-    src_x = 20
-    mon_x = 80   # 30 mm downstream
-    cy, cz = 3, 3
-    n_steps = 600
-
-    # Below-resonance Lorentz pole: resonance at 30 GHz, Δε=8 → Re(ε)≈10 in
-    # the 10 GHz band, near-lossless (light damping δ=1 GHz).
-    lor_pole = lorentz_pole(8.0, 2.0 * np.pi * 30e9, 1e9)
-
-    peaks = {}
-    amps = {}
-    for label, use_lorentz in [("vacuum", False), ("lorentz", True)]:
-        materials = init_materials(shape)  # ε_∞ = 1 in BOTH runs
-
-        if use_lorentz:
-            coeffs, lstate = init_lorentz([lor_pole], materials, dt)
-        else:
-            coeffs, lstate = None, None
-
-        state = init_state(shape)
-        mon_series = []
-
-        for step in range(n_steps):
-            t = step * dt
-            state = update_h(state, materials, dt, dx)
-
-            if coeffs is not None:
-                state, lstate = update_e_lorentz(state, coeffs, lstate, dt, dx)
-            else:
-                state = update_e(state, materials, dt, dx)
-
-            state = apply_pec(state)
-
-            if t < 6 * t0_pulse:
-                arg = (t - t0_pulse) / tau_pulse
-                src_val = (-2.0 * arg) * np.exp(-(arg**2))
-                state = state._replace(
-                    ez=state.ez.at[src_x, :, :].add(src_val)
-                )
-
-            mon_series.append(float(state.ez[mon_x, cy, cz]))
-
-        arr = np.abs(np.array(mon_series))
-        peaks[label] = int(np.argmax(arr))
-        amps[label] = float(np.max(arr))
-
-    vac_step = peaks["vacuum"]
-    lor_step = peaks["lorentz"]
-
-    print(f"\nArrival at monitor x={mon_x} ({(mon_x-src_x)*dx*1e3:.0f} mm):")
-    print(f"  Vacuum  peak step: {vac_step}  (|Ez|={amps['vacuum']:.3e})")
-    print(f"  Lorentz peak step: {lor_step}  (|Ez|={amps['lorentz']:.3e})")
-
-    # (1) Direction: the Lorentz medium slows the pulse.
-    assert lor_step > vac_step, \
-        f"Lorentz peak ({lor_step}) should arrive after vacuum ({vac_step})"
-
-    # (2) Magnitude: peak-step ratio ~2× (measured 1.97×). Gate at 1.4×,
-    # comfortably above the near-vacuum floor (a low-Δε / no-dispersion
-    # regression collapses this toward 1.0) and below the measured value.
-    assert vac_step > 0
-    ratio = lor_step / vac_step
-    print(f"  Time ratio: {ratio:.2f}x (expected ~2x; Re(ε)≈10 → √ε≈3.2)")
-    assert ratio > 1.4, f"Expected >1.4x arrival-time ratio, got {ratio:.2f}"
-
-    # (3) R5 witness: the timed Lorentz peak is the real (near-lossless)
-    # pulse, not a decayed remnant — it retains most of the vacuum amplitude.
-    assert amps["lorentz"] > 0.5 * amps["vacuum"], (
-        f"Lorentz peak amplitude {amps['lorentz']:.3e} collapsed vs vacuum "
-        f"{amps['vacuum']:.3e}; the timed peak may be a lossy remnant"
-    )
 
 
 def test_lorentz_energy_bounded():

--- a/tests/test_lorentz.py
+++ b/tests/test_lorentz.py
@@ -86,6 +86,105 @@ def test_lorentz_pole_constructor():
     assert abs(pole.kappa - delta_eps * omega_0**2) / (delta_eps * omega_0**2) < 1e-6
 
 
+def test_lorentz_medium_slower_propagation():
+    """Pulse in a below-resonance Lorentz medium arrives later downstream.
+
+    Arrival-time approach mirroring the Debye analog in ``test_debye.py``:
+    record ``|Ez|`` at a fixed monitor and compare the step of peak arrival.
+    Well BELOW the Lorentz resonance the medium is near-lossless with an
+    (almost) static ``Re(ε) ≈ ε_∞ + Δε``, so the pulse must arrive later than
+    in vacuum (``v ≈ c/√Re(ε)``).  Here ``ε_∞=1, Δε=8, ω₀=2π·30 GHz`` give
+    ``Re(ε) ≈ 10`` in the 10 GHz band (ω/ω₀ = 1/3, well below resonance),
+    which slows the peak arrival by ``~2×`` (measured 1.97× on CPU) while
+    retaining ~83% of the vacuum peak amplitude (near-lossless).
+
+    Unlike the Debye analog — which raises ``ε_∞`` to 4 and adds only a
+    tiny Δε pole — the slowdown here is produced by the LORENTZ pole itself
+    (both runs use ``ε_∞ = 1``), so this binds the dispersive contribution.
+    """
+    from rfx.core.yee import update_e
+
+    nx = 200
+    shape = (nx, 6, 6)
+    dx = 0.0005  # 0.5 mm
+    dt = 0.99 * dx / (C0 * np.sqrt(3))
+
+    f0 = 10e9
+    tau_pulse = 1.0 / (f0 * 0.5 * np.pi)
+    t0_pulse = 3.0 * tau_pulse
+    src_x = 20
+    mon_x = 80   # 30 mm downstream
+    cy, cz = 3, 3
+    n_steps = 600
+
+    # Below-resonance Lorentz pole: resonance at 30 GHz, Δε=8 → Re(ε)≈10 in
+    # the 10 GHz band, near-lossless (light damping δ=1 GHz).
+    lor_pole = lorentz_pole(8.0, 2.0 * np.pi * 30e9, 1e9)
+
+    peaks = {}
+    amps = {}
+    for label, use_lorentz in [("vacuum", False), ("lorentz", True)]:
+        materials = init_materials(shape)  # ε_∞ = 1 in BOTH runs
+
+        if use_lorentz:
+            coeffs, lstate = init_lorentz([lor_pole], materials, dt)
+        else:
+            coeffs, lstate = None, None
+
+        state = init_state(shape)
+        mon_series = []
+
+        for step in range(n_steps):
+            t = step * dt
+            state = update_h(state, materials, dt, dx)
+
+            if coeffs is not None:
+                state, lstate = update_e_lorentz(state, coeffs, lstate, dt, dx)
+            else:
+                state = update_e(state, materials, dt, dx)
+
+            state = apply_pec(state)
+
+            if t < 6 * t0_pulse:
+                arg = (t - t0_pulse) / tau_pulse
+                src_val = (-2.0 * arg) * np.exp(-(arg**2))
+                state = state._replace(
+                    ez=state.ez.at[src_x, :, :].add(src_val)
+                )
+
+            mon_series.append(float(state.ez[mon_x, cy, cz]))
+
+        arr = np.abs(np.array(mon_series))
+        peaks[label] = int(np.argmax(arr))
+        amps[label] = float(np.max(arr))
+
+    vac_step = peaks["vacuum"]
+    lor_step = peaks["lorentz"]
+
+    print(f"\nArrival at monitor x={mon_x} ({(mon_x-src_x)*dx*1e3:.0f} mm):")
+    print(f"  Vacuum  peak step: {vac_step}  (|Ez|={amps['vacuum']:.3e})")
+    print(f"  Lorentz peak step: {lor_step}  (|Ez|={amps['lorentz']:.3e})")
+
+    # (1) Direction: the Lorentz medium slows the pulse.
+    assert lor_step > vac_step, \
+        f"Lorentz peak ({lor_step}) should arrive after vacuum ({vac_step})"
+
+    # (2) Magnitude: peak-step ratio ~2× (measured 1.97×). Gate at 1.4×,
+    # comfortably above the near-vacuum floor (a low-Δε / no-dispersion
+    # regression collapses this toward 1.0) and below the measured value.
+    assert vac_step > 0
+    ratio = lor_step / vac_step
+    print(f"  Time ratio: {ratio:.2f}x (expected ~2x; Re(ε)≈10 → √ε≈3.2)")
+    assert ratio > 1.4, f"Expected >1.4x arrival-time ratio, got {ratio:.2f}"
+
+    # (3) R5 witness: the timed Lorentz peak is the real (near-lossless)
+    # pulse, not a decayed remnant — it retains most of the vacuum amplitude.
+    assert amps["lorentz"] > 0.5 * amps["vacuum"], (
+        f"Lorentz peak amplitude {amps['lorentz']:.3e} collapsed vs vacuum "
+        f"{amps['vacuum']:.3e}; the timed peak may be a lossy remnant"
+    )
+
+
 def test_lorentz_energy_bounded():
     """Lorentz ADE should not produce energy growth."""
     shape = (20, 20, 20)

--- a/tests/test_rcs_mie_reference_gates.py
+++ b/tests/test_rcs_mie_reference_gates.py
@@ -117,7 +117,8 @@ def test_errors_self_consistent(fixture):
 # --------------------------------------------------------------------------- #
 def test_ladder_within_measured_envelope(fixture):
     """Every committed rfx-vs-Mie error is within the measured envelope gate.
-    Measured max |err| = 13.17 dB; gate_db = 15 dB (clamped to the GO floor)."""
+    Measured max |err| = 9.28 dB; gate_db = 13.9 dB (= 1.5 × measured, under
+    the 15 dB GO floor — not clamped). Values regenerated after PR #279."""
     gate = fixture["envelope"]["gate_db"]
     for rung in fixture["ka_ladder"]:
         for res in (rung["coarse"], rung["fine"]):
@@ -144,7 +145,7 @@ def test_envelope_no_regression(fixture):
 def test_convergence_witness(fixture):
     """Convergence witness: refinement (lambda/10 -> lambda/15) does not blow the
     error up beyond a measured margin. Recorded convergence_delta == |fine err| -
-    |coarse err|; measured max is +5.76 dB (refinement does NOT close the gap --
+    |coarse err|; measured max is +4.89 dB (refinement does NOT close the gap --
     an honest curved-PEC staircase floor), gated <= 6.5 dB so a future regression
     that made refinement diverge would trip."""
     deltas = fixture["envelope"]["convergence_delta_db"]

--- a/tests/test_sparam.py
+++ b/tests/test_sparam.py
@@ -1,8 +1,15 @@
-"""S-parameter extraction validation.
+"""S-parameter extraction validation (lumped-port limiting cases).
 
 Tests:
-1. Lumped port in a PEC cavity: S11 ≈ 0 dB off-resonance (full reflection)
-2. Lumped port matched load: S11 < -20 dB (absorbed by port impedance)
+1. Lumped port in a PEC cavity: S11 near 0 dB in-band (full reflection).
+   A lossless PEC cavity dissipates nothing, so |S11| ≈ 1; pinned as a
+   loose limiting-case bound (mid-band mean |S11| > -3 dB).
+2. Lumped port injects energy: E and H fields become non-zero after
+   driving the port (excitation smoke test).
+
+There is NO matched-load absorption gate (S11 < -20 dB) here: a lumped port
+terminated in its own impedance in an open (CPML) domain is not exercised in
+this file, so that absorption physics is not asserted.
 """
 
 import numpy as np


### PR DESCRIPTION
Fixes #401. Module headers promised validations absent from the files (audit-misleading). Corrected: debye ε(ω) (cross-ref the TMM Fresnel gate that already covers it), sparam matched-load (absent → header lists only what exists), boundary_cpml_asymmetric (named oracle didn't exist → point to the coefficient-level one), decay_flux_convergence (#169 described as current bug → RESOLVED), rcs_mie (stale pre-#279 numbers → fixture values). **Review caught a blocker, now fixed:** the first attempt ADDED a Lorentz propagation-slowdown gate that bound a PEC-wall reflection artifact (1.97× with walls, only 1.19× boundary-free — fails its own 1.4 gate; domain-doubling flips the metric 1.971→0.712, proving it tracks the walls). Dropped it and cross-referenced the rigorous TMM Lorentz R(f) gate instead (mirrors the Debye treatment). 12 passed.

R3: memory=no-overclaiming (writing rules) | R2=0 | falsifier=domain-doubling invariance test on any retained slowdown claim (the removed one failed it) 🤖 Generated with [Claude Code](https://claude.com/claude-code)