### PR TITLE
fix(tfsf): 3D Bloch-periodic-y oblique TFSF via opt-in complex solver (#404)

### DIFF
--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -2358,6 +2358,22 @@ class _ExecuteMixin:
                 "S11 objectives."
             )
 
+        # TFSF plane-wave sources are not wired into the differentiable forward
+        # path: _forward_from_materials builds sources from lumped/wire ports
+        # only, so a TFSF source would be SILENTLY DROPPED (no injection → zero
+        # gradients — the "TFSF→forward silent-drop" footgun). Fail loud instead.
+        # (The distributed forward path rejects TFSF separately; guard the
+        # single-device path here so both normal and oblique TFSF are surfaced.)
+        if self._tfsf is not None and not distributed:
+            raise NotImplementedError(
+                "TFSF plane-wave sources are not wired into Simulation.forward() "
+                "— the differentiable path builds sources from lumped/wire ports "
+                "only and would silently drop the TFSF source (zero gradients). "
+                "Use run() for TFSF forward simulation (normal or oblique, #404); "
+                "differentiable TFSF/plane-wave inverse design is not yet "
+                "implemented."
+            )
+
         if port_s11_freqs is not None:
             self._validate_forward_sparameter_request()
 

--- a/rfx/boundaries/cpml.py
+++ b/rfx/boundaries/cpml.py
@@ -271,7 +271,8 @@ def _cpml_noop_profile(n_layers: int) -> CPMLParams:
 
 def init_cpml(grid, *, kappa_max: float | None = None,
               pec_faces: set[str] | None = None,
-              pmc_faces: set[str] | None = None) -> tuple[CPMLAxisParams, CPMLState]:
+              pmc_faces: set[str] | None = None,
+              field_dtype=jnp.float32) -> tuple[CPMLAxisParams, CPMLState]:
     """Initialize CPML parameters and zero-valued auxiliary fields.
 
     Creates per-axis CPML profiles so that each face uses the correct
@@ -352,7 +353,11 @@ def init_cpml(grid, *, kappa_max: float | None = None,
     nx, ny, nz = grid.shape if hasattr(grid, 'shape') else (grid.nx, grid.ny, grid.nz)
 
     def _zeros(dim_size: int, perp1: int, perp2: int) -> jnp.ndarray:
-        return jnp.zeros((n, perp1, perp2), dtype=jnp.float32)
+        # psi carry dtype follows the field dtype so the lax.scan carry contract
+        # holds when fields are complex (#404 oblique Bloch path). Default
+        # float32 keeps the real path byte-identical. Real profile coeffs
+        # (b/c/kappa) stay float32 and multiply the psi carry without truncation.
+        return jnp.zeros((n, perp1, perp2), dtype=field_dtype)
 
     state = CPMLState(
         # E-field psi (12 faces)

--- a/rfx/core/yee.py
+++ b/rfx/core/yee.py
@@ -127,12 +127,24 @@ def _ribbon_2nd(d4, d2, axis):
     return d4
 
 
-def _diff_fwd_o(arr, axis, periodic, order):
+def _diff_fwd_o(arr, axis, periodic, order, bloch=None):
     """Forward staggered first difference (f[i+1]-f[i] family), at i+1/2; the
-    caller divides by dx. order=2 is byte-identical to ``_shift_fwd(arr)-arr``."""
+    caller divides by dx. order=2 is byte-identical to ``_shift_fwd(arr)-arr``
+    when ``bloch is None``.
+
+    ``bloch`` (oblique-periodic Bloch field-transformation, #404): a length-3
+    tuple of per-axis complex phases ``exp(-j·k_axis·dx)``.  On a PERIODIC axis
+    the forward-rolled neighbour is multiplied by ``bloch[axis]`` so the plain
+    ``jnp.roll`` wrap represents the exact discrete Yee derivative of a wave with
+    transverse wavenumber ``k_axis``.  ``bloch=None`` (default) leaves the real
+    path untouched; ``bloch`` is only threaded on order-2 (guarded upstream)."""
     if order == 2:
-        nxt = jnp.roll(arr, -1, axis) if periodic[axis] else _shift_fwd(arr, axis)
-        return nxt - arr
+        if periodic[axis]:
+            nxt = jnp.roll(arr, -1, axis)
+            if bloch is not None:
+                nxt = nxt * bloch[axis]
+            return nxt - arr
+        return _shift_fwd(arr, axis) - arr
     # order == 4:  c1*(f[i+1]-f[i]) + c2*(f[i+2]-f[i-1])
     if periodic[axis]:
         near = jnp.roll(arr, -1, axis) - arr
@@ -143,12 +155,21 @@ def _diff_fwd_o(arr, axis, periodic, order):
     return _ribbon_2nd(_C4_NEAR * near + _C4_FAR * far, near, axis)
 
 
-def _diff_bwd_o(arr, axis, periodic, order):
+def _diff_bwd_o(arr, axis, periodic, order, bloch=None):
     """Backward staggered first difference (f[i]-f[i-1] family), at i-1/2; the
-    caller divides by dx. order=2 is byte-identical to ``arr-_shift_bwd(arr)``."""
+    caller divides by dx. order=2 is byte-identical to ``arr-_shift_bwd(arr)``
+    when ``bloch is None``.
+
+    For the Bloch field-transformation (#404) the BACKWARD-rolled neighbour
+    carries the CONJUGATE phase ``exp(+j·k_axis·dx)`` (``bloch[axis].conjugate()``),
+    the exact discrete adjoint of the forward stagger.  See ``_diff_fwd_o``."""
     if order == 2:
-        prv = jnp.roll(arr, 1, axis) if periodic[axis] else _shift_bwd(arr, axis)
-        return arr - prv
+        if periodic[axis]:
+            prv = jnp.roll(arr, 1, axis)
+            if bloch is not None:
+                prv = prv * bloch[axis].conjugate()
+            return arr - prv
+        return arr - _shift_bwd(arr, axis)
     # order == 4:  c1*(f[i]-f[i-1]) + c2*(f[i+1]-f[i-2])
     if periodic[axis]:
         near = arr - jnp.roll(arr, 1, axis)
@@ -159,10 +180,11 @@ def _diff_bwd_o(arr, axis, periodic, order):
     return _ribbon_2nd(_C4_NEAR * near + _C4_FAR * far, near, axis)
 
 
-@partial(jax.jit, static_argnums=(4, 5))
+@partial(jax.jit, static_argnums=(4, 5, 6))
 def update_h(state: FDTDState, materials: MaterialArrays, dt: float, dx: float,
              periodic: tuple = (False, False, False),
-             stencil_order: int = 2) -> FDTDState:
+             stencil_order: int = 2,
+             bloch: tuple | None = None) -> FDTDState:
     """Magnetic field half-step update (Faraday's law).
 
     H^{n+1/2} = H^{n-1/2} - (dt / μ) * curl(E^n)
@@ -173,46 +195,58 @@ def update_h(state: FDTDState, materials: MaterialArrays, dt: float, dx: float,
     periodic: tuple of 3 bools selecting periodic boundary per axis (x, y, z).
     stencil_order: 2 (default, byte-identical) or 4 (Fang (2,4) wide stencil,
         reverting to 2nd order in the 1-cell ribbon at non-periodic faces).
+    bloch: None (default, real path, byte-identical) or a length-3 tuple of
+        per-axis complex phases ``exp(-j·k_axis·dx)`` for the oblique-periodic
+        Bloch field-transformation (#404).  When set, the fields must be a
+        complex dtype (the transformed envelope P); requires stencil_order=2.
     """
     so = stencil_order
     if so not in (2, 4):
         raise ValueError(f"stencil_order must be 2 or 4, got {so}")
+    if bloch is not None and so != 2:
+        raise ValueError(
+            f"bloch phase (oblique-periodic BC, #404) requires stencil_order=2, got {so}"
+        )
 
-    # Upcast to float32 for arithmetic when using reduced-precision fields
+    # Compute dtype: the oblique-periodic Bloch path carries a complex field
+    # envelope P; the real path stays float32 (upcast for reduced-precision
+    # fields) and is byte-identical.
     _fdtype = state.ex.dtype
-    ex = state.ex.astype(jnp.float32)
-    ey = state.ey.astype(jnp.float32)
-    ez = state.ez.astype(jnp.float32)
+    _cdtype = jnp.complex64 if jnp.iscomplexobj(state.ex) else jnp.float32
+    ex = state.ex.astype(_cdtype)
+    ey = state.ey.astype(_cdtype)
+    ez = state.ez.astype(_cdtype)
     mu = materials.mu_r * MU_0
 
     # curl E components via forward staggered differences (order=2 byte-identical)
     # dEz/dy - dEy/dz
     curl_x = (
-        _diff_fwd_o(ez, 1, periodic, so) / dx
-        - _diff_fwd_o(ey, 2, periodic, so) / dx
+        _diff_fwd_o(ez, 1, periodic, so, bloch) / dx
+        - _diff_fwd_o(ey, 2, periodic, so, bloch) / dx
     )
     # dEx/dz - dEz/dx
     curl_y = (
-        _diff_fwd_o(ex, 2, periodic, so) / dx
-        - _diff_fwd_o(ez, 0, periodic, so) / dx
+        _diff_fwd_o(ex, 2, periodic, so, bloch) / dx
+        - _diff_fwd_o(ez, 0, periodic, so, bloch) / dx
     )
     # dEy/dx - dEx/dy
     curl_z = (
-        _diff_fwd_o(ey, 0, periodic, so) / dx
-        - _diff_fwd_o(ex, 1, periodic, so) / dx
+        _diff_fwd_o(ey, 0, periodic, so, bloch) / dx
+        - _diff_fwd_o(ex, 1, periodic, so, bloch) / dx
     )
 
-    hx = (state.hx.astype(jnp.float32) - (dt / mu) * curl_x).astype(_fdtype)
-    hy = (state.hy.astype(jnp.float32) - (dt / mu) * curl_y).astype(_fdtype)
-    hz = (state.hz.astype(jnp.float32) - (dt / mu) * curl_z).astype(_fdtype)
+    hx = (state.hx.astype(_cdtype) - (dt / mu) * curl_x).astype(_fdtype)
+    hy = (state.hy.astype(_cdtype) - (dt / mu) * curl_y).astype(_fdtype)
+    hz = (state.hz.astype(_cdtype) - (dt / mu) * curl_z).astype(_fdtype)
 
     return state._replace(hx=hx, hy=hy, hz=hz)
 
 
-@partial(jax.jit, static_argnums=(4, 5))
+@partial(jax.jit, static_argnums=(4, 5, 6))
 def update_e(state: FDTDState, materials: MaterialArrays, dt: float, dx: float,
              periodic: tuple = (False, False, False),
-             stencil_order: int = 2) -> FDTDState:
+             stencil_order: int = 2,
+             bloch: tuple | None = None) -> FDTDState:
     """Electric field full-step update (Ampere's law).
 
     For lossy media with conductivity σ:
@@ -224,16 +258,26 @@ def update_e(state: FDTDState, materials: MaterialArrays, dt: float, dx: float,
     periodic: tuple of 3 bools selecting periodic boundary per axis (x, y, z).
     stencil_order: 2 (default, byte-identical) or 4 (Fang (2,4) wide stencil,
         reverting to 2nd order in the 1-cell ribbon at non-periodic faces).
+    bloch: None (default, real path, byte-identical) or a length-3 tuple of
+        per-axis complex phases ``exp(-j·k_axis·dx)`` for the oblique-periodic
+        Bloch field-transformation (#404); requires stencil_order=2 and complex
+        fields.  The backward differences use the conjugate phase automatically.
     """
     so = stencil_order
     if so not in (2, 4):
         raise ValueError(f"stencil_order must be 2 or 4, got {so}")
+    if bloch is not None and so != 2:
+        raise ValueError(
+            f"bloch phase (oblique-periodic BC, #404) requires stencil_order=2, got {so}"
+        )
 
-    # Upcast to float32 for arithmetic when using reduced-precision fields
+    # Compute dtype: complex for the Bloch envelope path, float32 for the real
+    # path (byte-identical; upcast covers reduced-precision fields).
     _fdtype = state.ex.dtype
-    hx = state.hx.astype(jnp.float32)
-    hy = state.hy.astype(jnp.float32)
-    hz = state.hz.astype(jnp.float32)
+    _cdtype = jnp.complex64 if jnp.iscomplexobj(state.ex) else jnp.float32
+    hx = state.hx.astype(_cdtype)
+    hy = state.hy.astype(_cdtype)
+    hz = state.hz.astype(_cdtype)
     eps = materials.eps_r * EPS_0
     sigma = materials.sigma
 
@@ -245,23 +289,23 @@ def update_e(state: FDTDState, materials: MaterialArrays, dt: float, dx: float,
     # curl H components via backward staggered differences (order=2 byte-identical)
     # dHz/dy - dHy/dz
     curl_x = (
-        _diff_bwd_o(hz, 1, periodic, so) / dx
-        - _diff_bwd_o(hy, 2, periodic, so) / dx
+        _diff_bwd_o(hz, 1, periodic, so, bloch) / dx
+        - _diff_bwd_o(hy, 2, periodic, so, bloch) / dx
     )
     # dHx/dz - dHz/dx
     curl_y = (
-        _diff_bwd_o(hx, 2, periodic, so) / dx
-        - _diff_bwd_o(hz, 0, periodic, so) / dx
+        _diff_bwd_o(hx, 2, periodic, so, bloch) / dx
+        - _diff_bwd_o(hz, 0, periodic, so, bloch) / dx
     )
     # dHy/dx - dHx/dy
     curl_z = (
-        _diff_bwd_o(hy, 0, periodic, so) / dx
-        - _diff_bwd_o(hx, 1, periodic, so) / dx
+        _diff_bwd_o(hy, 0, periodic, so, bloch) / dx
+        - _diff_bwd_o(hx, 1, periodic, so, bloch) / dx
     )
 
-    ex = (ca * state.ex.astype(jnp.float32) + cb * curl_x).astype(_fdtype)
-    ey = (ca * state.ey.astype(jnp.float32) + cb * curl_y).astype(_fdtype)
-    ez = (ca * state.ez.astype(jnp.float32) + cb * curl_z).astype(_fdtype)
+    ex = (ca * state.ex.astype(_cdtype) + cb * curl_x).astype(_fdtype)
+    ey = (ca * state.ey.astype(_cdtype) + cb * curl_y).astype(_fdtype)
+    ez = (ca * state.ez.astype(_cdtype) + cb * curl_z).astype(_fdtype)
 
     return state._replace(
         ex=ex, ey=ey, ez=ez,

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -19,6 +19,46 @@ from rfx.farfield import make_ntff_box
 from rfx.lumped import setup_rlc_materials, build_rlc_meta
 
 
+def _reconstruct_oblique_physical(sim_result, tfsf_cfg, grid, probes):
+    """#404: convert the complex Bloch envelope P back to the physical real field
+    ``Re(P·exp(-j k_t·x_t))`` for the oblique-periodic path.
+
+    Reconstructs the final ``state`` (per-cell transverse phase ramp along the
+    periodic axis) and point-probe ``time_series`` (fixed phase at each probe's
+    transverse cell). Other outputs are fenced upstream. The sign convention is
+    ``cfg.k_transverse`` — the same one the 2D-aux injection and the hand-rolled
+    acceptance tests use (``exp(-1j·k_transverse·y)``).
+    """
+    import jax.numpy as _jnp
+    k_t = float(tfsf_cfg.k_transverse)
+    taxis = 1 if tfsf_cfg.transverse_axis == "y" else 2
+    d_t = float(getattr(grid, "dy", grid.dx)) if taxis == 1 \
+        else float(getattr(grid, "dz", grid.dx))
+    n_t = grid.shape[taxis]
+    ramp = _jnp.exp(-1j * k_t * _jnp.arange(n_t) * d_t)
+
+    new_state = sim_result.state
+    if new_state is not None and _jnp.iscomplexobj(new_state.ex):
+        shp = [1, 1, 1]
+        shp[taxis] = n_t
+        ramp3 = ramp.reshape(shp)
+        new_state = new_state._replace(**{
+            f: _jnp.real(getattr(new_state, f) * ramp3)
+            for f in ("ex", "ey", "ez", "hx", "hy", "hz")
+        })
+
+    new_ts = sim_result.time_series
+    if new_ts is not None and _jnp.iscomplexobj(new_ts):
+        if probes:  # time_series is (n_steps, n_probes) in probe order
+            idxs = _jnp.array([(p.j if taxis == 1 else p.k) for p in probes])
+            ph = _jnp.exp(-1j * k_t * idxs * d_t)
+            new_ts = _jnp.real(new_ts * ph[None, :])
+        else:
+            new_ts = _jnp.real(new_ts)
+
+    return sim_result._replace(state=new_state, time_series=new_ts)
+
+
 def run_uniform(
     sim,
     *,
@@ -461,6 +501,25 @@ def run_uniform(
         sim._validate_tfsf_vacuum_boundary(materials, tfsf[0])
         periodic = (False, True, True)
         cpml_axes = "x"
+        # #404: an oblique (2D-aux) TFSF drives the shared solver on the complex
+        # Bloch-envelope path; final `state` and point-probe time series are
+        # reconstructed to physical fields after the run, but the streaming/
+        # frequency-domain output paths are not yet transform-aware on it.
+        from rfx.sources.tfsf import is_tfsf_2d as _is_tfsf_2d_ru
+        if _is_tfsf_2d_ru(tfsf[0]):
+            _ob_unsup = []
+            if snapshot is not None:
+                _ob_unsup.append("snapshot= (read the final `state` instead)")
+            if until_decay is not None:
+                _ob_unsup.append("until_decay= (use a fixed n_steps)")
+            if _ob_unsup:
+                raise NotImplementedError(
+                    "Oblique (angle_deg != 0) TFSF uses the #404 complex Bloch "
+                    "path; not yet supported on it: " + "; ".join(_ob_unsup)
+                    + ". Supported: final `state` and `add_probe` time series "
+                    "(returned as physical fields), or `compute_rcs` for "
+                    "open-domain oblique scattering."
+                )
 
     # Floquet port sources — inject plane wave via standard source mechanism
     floquet_port_configs = []
@@ -738,6 +797,14 @@ def run_uniform(
                 reference_plane=reference_plane,
                 probe_plane=probe_plane,
             )
+
+    # #404: oblique 2D-aux TFSF evolved the complex Bloch envelope P; convert the
+    # returned state + point probes back to physical real fields (real path and
+    # normal incidence are untouched — sim_result stays real there).
+    if sim._tfsf is not None:
+        from rfx.sources.tfsf import is_tfsf_2d as _is_tfsf_2d_out
+        if _is_tfsf_2d_out(tfsf[0]):
+            sim_result = _reconstruct_oblique_physical(sim_result, tfsf[0], grid, probes)
 
     return Result(
         state=sim_result.state,

--- a/rfx/simulation.py
+++ b/rfx/simulation.py
@@ -307,6 +307,7 @@ def _update_e_with_optional_dispersion(
     aniso_eps: tuple | None = None,
     aniso_inv_eps: tuple | None = None,
     stencil_order: int = 2,
+    bloch: tuple | None = None,
 ) -> tuple[FDTDState, object | None, object | None]:
     """Update E with standard, Debye, Lorentz, or mixed dispersion.
 
@@ -337,7 +338,7 @@ def _update_e_with_optional_dispersion(
             return update_e_aniso(state, materials, eps_ex, eps_ey, eps_ez,
                                   dt, dx, periodic=periodic), None, None
         return update_e(state, materials, dt, dx, periodic=periodic,
-                        stencil_order=stencil_order), None, None
+                        stencil_order=stencil_order, bloch=bloch), None, None
 
     if debye is not None and lorentz is None:
         from rfx.materials.debye import update_e_debye
@@ -650,6 +651,36 @@ def _build_step_setup(
     use_kerr = kerr_chi3 is not None
     use_mag_sources = len(mag_sources) > 0
 
+    # ---- #404 oblique-periodic complex Bloch path activation ----
+    # An oblique (2D-aux) TFSF injects a tilted plane wave that a plain-periodic
+    # REAL grid cannot sustain (the pre-#404 under-tilt). Drive the shared solver
+    # on a complex Bloch-envelope path instead: fields carry the envelope P and a
+    # per-axis phase rides the periodic roll; the physical field is
+    # Re(P·exp(-j k_t·y)). Gated strictly on the 2D-aux discriminator, so normal
+    # incidence and every non-TFSF run stay real float32 and byte-identical.
+    _oblique_bloch = False
+    if use_tfsf:
+        from rfx.sources.tfsf import is_tfsf_2d as _is_tfsf_2d_early
+        _oblique_bloch = _is_tfsf_2d_early(tfsf[0])
+    if _oblique_bloch:
+        # Frequency-domain monitors accumulate the complex envelope P, not the
+        # physical spectrum — fail loud rather than return truncated garbage.
+        _unsupported_ob = []
+        if use_ntff:
+            _unsupported_ob.append("NTFF box")
+        if use_dft_planes:
+            _unsupported_ob.append("DFT plane probe")
+        if use_flux_monitors:
+            _unsupported_ob.append("flux monitor")
+        if _unsupported_ob:
+            raise NotImplementedError(
+                "Oblique (angle_deg != 0) TFSF uses the #404 complex Bloch path; "
+                "frequency-domain monitors are not yet transform-aware on it. "
+                "Unsupported: " + ", ".join(_unsupported_ob) + ". Use field "
+                "snapshots / final state (returned as physical fields), or "
+                "compute_rcs for open-domain oblique scattering."
+            )
+
     # ---- (2,4) fourth-order-in-space stencil (PR-1b) ----
     # order=2 is the default and BYTE-IDENTICAL: dt and every kernel call are
     # untouched.  order=4 is reachable ONLY on the plain uniform-Cartesian
@@ -699,6 +730,7 @@ def _build_step_setup(
     update_tfsf_2d_h = update_tfsf_2d_e = None
     _tfsf_is_2d = False
     tfsf_cfg = None
+    _bloch = None
     init_ntff_data_fn = accumulate_ntff_fn = None
     apply_kerr_ade = None
     update_rlc_element = None
@@ -706,13 +738,18 @@ def _build_step_setup(
 
     # ---- initialise states ----
     _field_dtype = field_dtype if field_dtype is not None else jnp.float32
+    if _oblique_bloch:
+        # Complex envelope P; overrides mixed-precision (float16) for this path.
+        _field_dtype = jnp.complex64
     fdtd = init_state(grid.shape, field_dtype=_field_dtype)
     carry_init: dict = {"fdtd": fdtd}
 
     if use_cpml:
         from rfx.boundaries.cpml import init_cpml
         from rfx.boundaries.cpml import apply_cpml_e, apply_cpml_h
-        cpml_params, cpml_state = init_cpml(grid)
+        # psi carry dtype follows the field dtype so the scan carry stays
+        # dtype-consistent when fields are complex (#404 oblique path).
+        cpml_params, cpml_state = init_cpml(grid, field_dtype=_field_dtype)
         carry_init["cpml"] = cpml_state
     elif use_upml:
         from rfx.boundaries.upml import init_upml
@@ -740,7 +777,12 @@ def _build_step_setup(
         carry_init["tfsf"] = tfsf_state
         _tfsf_is_2d = is_tfsf_2d(tfsf_cfg)
         if _tfsf_is_2d:
-            from rfx.sources.tfsf_2d import update_tfsf_2d_h, update_tfsf_2d_e
+            from rfx.sources.tfsf_2d import (
+                update_tfsf_2d_h, update_tfsf_2d_e, bloch_phase_tuple,
+            )
+            # Per-axis Bloch phase on the 3D periodic roll (transverse axis),
+            # matching the 2D-aux grid's transform (#404).
+            _bloch = bloch_phase_tuple(tfsf_cfg, grid.dx)
 
     if use_ntff:
         from rfx.farfield import init_ntff_data as _init_ntff_data
@@ -902,6 +944,7 @@ def _build_step_setup(
         upml_coeffs=upml_coeffs,
         tfsf_cfg=tfsf_cfg,
         tfsf_is_2d=_tfsf_is_2d,
+        bloch=_bloch,
         debye_coeffs=debye_coeffs,
         lorentz_coeffs=lorentz_coeffs,
         aniso_eps=aniso_eps,
@@ -1043,6 +1086,7 @@ class _StepContext:
     upml_coeffs: Any = None
     tfsf_cfg: Any = None
     tfsf_is_2d: bool = False
+    bloch: Any = None  # per-axis Bloch phase for oblique-periodic TFSF (#404); None = real path
     debye_coeffs: Any = None
     lorentz_coeffs: Any = None
     aniso_eps: Any = None
@@ -1125,7 +1169,7 @@ def make_core_step(ctx: _StepContext):
                 st = ctx.apply_upml_h(st, ctx.upml_coeffs, periodic=periodic)
             else:
                 st = update_h(st, materials, dt, dx, periodic=periodic,
-                              stencil_order=ctx.stencil_order)
+                              stencil_order=ctx.stencil_order, bloch=ctx.bloch)
             if ctx.use_tfsf:
                 st = ctx.apply_tfsf_h(st, ctx.tfsf_cfg, carry["tfsf"], dx, dt)
             if ctx.use_waveguide_ports:
@@ -1207,6 +1251,7 @@ def make_core_step(ctx: _StepContext):
                     aniso_eps=aniso_eps,
                     aniso_inv_eps=aniso_inv_eps,
                     stencil_order=ctx.stencil_order,
+                    bloch=ctx.bloch,
                 )
 
             # Kerr nonlinear ADE correction (after linear E-update)

--- a/rfx/sources/tfsf.py
+++ b/rfx/sources/tfsf.py
@@ -4,10 +4,18 @@ Normal incidence along ``+x`` or ``-x`` with transverse polarization in
 ``Ez`` or ``Ey``.
 Uses a 1D auxiliary FDTD with CPML to generate the incident field.
 
-Oblique incidence (angle_deg != 0) uses a dispersion-matched 1D auxiliary
-grid with dx_1d = dx / cos(theta) (Schneider / Taflove Ch. 5.6).
-At TFSF boundaries, the 1D waveform is sampled with a per-cell transverse
-phase delay implemented as spatial interpolation in the 1D grid.
+Oblique incidence (``angle_deg != 0``) dispatches to a **2D auxiliary grid**
+(``rfx/sources/tfsf_2d.py``), which shares the 3D cell size so numerical
+dispersion matches at any angle. That grid carries the oblique transverse
+wavenumber ``k_y = k0·sinθ`` via a **Bloch field-transformation** (#404); as a
+consequence the oblique source is **narrowband** (single-frequency at ``f0``).
+Two caveats for oblique runs — see ``tfsf_2d.py`` for the full discussion:
+  - keep the fractional ``bandwidth`` small (≲0.15) or off-``f0`` components
+    carry the wrong ``k_y`` and raise TFSF leakage;
+  - the injected wave tracks the requested angle in **open / CPML-transverse**
+    domains; a **periodic** transverse domain additionally needs
+    ``k_y·L_y = 2πm`` (commensurate) or a 3D Bloch-periodic BC (not yet
+    implemented) — otherwise the plain-periodic 3D seam re-distorts steep angles.
 
 TFSF boundary cleanly separates:
   - Total-field region (x_lo <= x <= x_hi): incident + scattered
@@ -121,7 +129,11 @@ def init_tfsf(
         Propagation direction along the x-axis.
     angle_deg : float
         Signed oblique angle in degrees away from the x-axis. Positive
-        angles tilt toward the positive transverse axis.
+        angles tilt toward the positive transverse axis. Non-zero angles
+        dispatch to the 2D-aux grid and produce a **narrowband** (single-f0)
+        oblique wave via a Bloch field-transformation (#404); use a small
+        fractional ``bandwidth`` (≲0.15) and an open/commensurate transverse
+        domain (see the module docstring and ``tfsf_2d.py``).
     ny : int | None
         Number of cells in y (3D grid).  Required for oblique incidence
         with ez polarization (2D TMz auxiliary grid).  Ignored for

--- a/rfx/sources/tfsf_2d.py
+++ b/rfx/sources/tfsf_2d.py
@@ -13,10 +13,32 @@ Supports two modes:
 Both modes use the same cell size ``dx`` as the 3D simulation so
 numerical dispersion matches exactly at any angle.
 
-The oblique plane wave source is a soft line source at a fixed x
-with per-cell transverse delay that encodes the oblique angle.
+Oblique wavevector — Bloch field-transformation (#404)
+-------------------------------------------------------
+The intended oblique transverse wavenumber is ``k_y = k0·sinθ`` (``k0 =
+2π·f0/c``).  A plain-periodic transverse wrap (``jnp.roll`` with no phase)
+cannot sustain a non-commensurate ``k_y`` and pulls the effective angle DOWN
+(the #404 under-tilt: 60° injected as ~25°).  The fix uses the standard
+**field-transformation** method: write the physical field as
+``F_phys(x,y,t) = P(x,y,t)·exp(-j·k_y·y)`` with ``P`` genuinely L_y-periodic.
+A **y-uniform** complex ``P`` then represents the oblique wave exactly.  The
+transverse difference operators pick up ``exp(∓j·k_y·dx)`` on the rolled
+neighbour (the wrap stays a plain ``jnp.roll``); ``(e^{-j k_y dx}-1)/dx`` is
+the exact discrete Yee y-derivative for wavenumber ``k_y``, so 3D-grid
+dispersion match — and thus low TFSF leakage — is preserved.  Fields are
+COMPLEX on the aux grid; the physical (real) incident field re-applied to the
+3D faces is ``Re(P·exp(-j·k_y·y))``.
 
-Reference: S. C. Tan and G. E. Potter, IEEE T-AP 58(9), 2010.
+Because ``k_y`` is fixed at f0, the oblique source is **narrowband**: a
+complex analytic modulated Gaussian (carrier ``exp(-j·2π·f0·(t-t0))``,
+y-uniform).  Accuracy is best when the pulse energy sits at f0 (fractional
+``bandwidth`` ≲ 0.3 keeps the injected Poynting angle within a few % of the
+request; broadband oblique would need a 1D-aux-along-k̂ method).  Normal
+incidence (``angle_deg=0``) does NOT use this path — it stays on the 1D aux
+grid (``rfx/sources/tfsf.py``) and is unaffected.
+
+Reference: Taflove & Hagness Ch. 5/13 (field-transformation / periodic FDTD);
+S. C. Tan and G. E. Potter, IEEE T-AP 58(9), 2010.
 """
 
 from __future__ import annotations
@@ -63,9 +85,11 @@ class TFSF2DConfig(NamedTuple):
     src_amp: float
     src_t0: float
     src_tau: float
+    src_fcen: float   # carrier frequency f0 for the analytic modulated-Gaussian source
     theta: float
     cos_theta: float
     sin_theta: float
+    k_transverse: float  # signed transverse wavenumber k_y = k0·sinθ (Bloch/field-transform)
     electric_component: str
     magnetic_component: str
     curl_sign: float
@@ -200,6 +224,14 @@ def init_tfsf_2d(
 
     direction_sign = 1.0 if direction == "+x" else -1.0
 
+    # Signed transverse wavenumber for the Bloch field-transformation (#404).
+    # k_y = k0·sinθ at the carrier f0; the sign is chosen so that a positive
+    # angle_deg tilts the injected energy flow toward +transverse (matching the
+    # legacy time-delay convention). Verified against poynting_angle.py.
+    c0 = 1.0 / np.sqrt(EPS_0 * MU_0)
+    k0 = 2.0 * np.pi * f0 / c0
+    k_transverse = -direction_sign * k0 * sin_theta
+
     config = TFSF2DConfig(
         x_lo=x_lo, x_hi=x_hi,
         n2x=n2x, n2y=n2y,
@@ -208,9 +240,11 @@ def init_tfsf_2d(
         src_amp=float(amplitude),
         src_t0=float(t0),
         src_tau=float(tau),
+        src_fcen=float(f0),
         theta=float(theta),
         cos_theta=cos_theta,
         sin_theta=sin_theta,
+        k_transverse=float(k_transverse),
         electric_component=electric_component,
         magnetic_component=magnetic_component,
         curl_sign=float(curl_sign),
@@ -227,14 +261,17 @@ def init_tfsf_2d(
         mode=mode,
     )
 
+    # Aux-grid fields are COMPLEX (Bloch field-transformation, #404). The
+    # complexity is contained here; apply_tfsf_2d_e/h re-apply exp(-j k_y y)
+    # and take the real part before touching the (real) 3D grid.
     state = TFSF2DState(
-        ez_2d=jnp.zeros((n2x, n2y), dtype=jnp.float32),
-        hx_2d=jnp.zeros((n2x, n2y), dtype=jnp.float32),
-        hy_2d=jnp.zeros((n2x, n2y), dtype=jnp.float32),
-        psi_ez_xlo=jnp.zeros((n_cpml_2d, n2y), dtype=jnp.float32),
-        psi_ez_xhi=jnp.zeros((n_cpml_2d, n2y), dtype=jnp.float32),
-        psi_hy_xlo=jnp.zeros((n_cpml_2d, n2y), dtype=jnp.float32),
-        psi_hy_xhi=jnp.zeros((n_cpml_2d, n2y), dtype=jnp.float32),
+        ez_2d=jnp.zeros((n2x, n2y), dtype=jnp.complex64),
+        hx_2d=jnp.zeros((n2x, n2y), dtype=jnp.complex64),
+        hy_2d=jnp.zeros((n2x, n2y), dtype=jnp.complex64),
+        psi_ez_xlo=jnp.zeros((n_cpml_2d, n2y), dtype=jnp.complex64),
+        psi_ez_xhi=jnp.zeros((n_cpml_2d, n2y), dtype=jnp.complex64),
+        psi_hy_xlo=jnp.zeros((n_cpml_2d, n2y), dtype=jnp.complex64),
+        psi_hy_xhi=jnp.zeros((n_cpml_2d, n2y), dtype=jnp.complex64),
         step=jnp.array(0, dtype=jnp.int32),
     )
 
@@ -301,11 +338,13 @@ def _update_h_tmz(cfg, st, dx, dt):
     hx, hy = st.hx_2d, st.hy_2d
     coeff_h = dt / MU_0
 
-    # dEz/dy -- periodic (roll -1 along y=axis1)
-    dez_dy = (jnp.roll(ez, -1, axis=1) - ez) / dx
+    # dEz/dy -- Bloch field-transform (#404): plain roll + exp(-j k_y dx) on the
+    # forward neighbour. k_y=0 (normal) -> pshift=1 -> ordinary periodic diff.
+    pshift = jnp.exp(-1j * cfg.k_transverse * dx)
+    dez_dy = (jnp.roll(ez, -1, axis=1) * pshift - ez) / dx
 
     # dEz/dx -- zero-pad forward difference along x=axis0
-    dez_dx = (jnp.concatenate([ez[1:, :], jnp.zeros((1, ez.shape[1]))], axis=0) - ez) / dx
+    dez_dx = (jnp.concatenate([ez[1:, :], jnp.zeros((1, ez.shape[1]), ez.dtype)], axis=0) - ez) / dx
 
     hx = hx - coeff_h * dez_dy
     hy = hy + coeff_h * dez_dx
@@ -326,24 +365,26 @@ def _update_e_tmz(cfg, st, dx, dt, t):
     coeff_e = dt / EPS_0
 
     # dHy/dx -- zero-pad backward difference along x
-    dhy_dx = (hy - jnp.concatenate([jnp.zeros((1, hy.shape[1])), hy[:-1, :]], axis=0)) / dx
+    dhy_dx = (hy - jnp.concatenate([jnp.zeros((1, hy.shape[1]), hy.dtype), hy[:-1, :]], axis=0)) / dx
 
-    # dHx/dy -- periodic (roll +1 along y for backward difference)
-    dhx_dy = (hx - jnp.roll(hx, 1, axis=1)) / dx
+    # dHx/dy -- Bloch field-transform (#404): plain roll + exp(+j k_y dx) on the
+    # backward neighbour (conjugate of the forward pshift; k_y=0 -> plain diff).
+    pconj = jnp.exp(1j * cfg.k_transverse * dx)
+    dhx_dy = (hx - jnp.roll(hx, 1, axis=1) * pconj) / dx
 
     ez = ez + coeff_e * (dhy_dx - dhx_dy)
 
     # CFS-CPML for Ez (x-direction, from dHy/dx)
     ez, psi_ez_xlo, psi_ez_xhi = _apply_cpml_e(cfg, st, dhy_dx, ez, coeff_e)
 
-    # ---- Inject oblique plane-wave source along a line ----
-    c0 = 1.0 / jnp.sqrt(jnp.float32(EPS_0 * MU_0))
-    j_indices = jnp.arange(ez.shape[1], dtype=jnp.float32)
-    y_offset = j_indices * dx
-    t_delay = cfg.direction_sign * cfg.sin_theta * y_offset / c0
-    arg = (t - t_delay - cfg.src_t0) / cfg.src_tau
-    src_line = cfg.src_amp * (-2.0 * arg) * jnp.exp(-(arg ** 2))
-    ez = ez.at[cfg.src_x, :].add(src_line)
+    # ---- Inject oblique plane wave: y-uniform complex analytic modulated
+    # Gaussian (carrier at f0). The transverse k_y is carried by the transformed
+    # derivatives above, not by a per-cell time delay. ----
+    arg = (t - cfg.src_t0) / cfg.src_tau
+    src_val = (cfg.src_amp
+               * jnp.exp(-1j * 2.0 * jnp.pi * cfg.src_fcen * (t - cfg.src_t0))
+               * jnp.exp(-(arg ** 2)))
+    ez = ez.at[cfg.src_x, :].add(src_val)
 
     return st._replace(
         ez_2d=ez,
@@ -370,11 +411,13 @@ def _update_h_tez(cfg, st, dx, dt):
     hz = st.hy_2d   # Hz stored in hy_2d slot
     coeff_h = dt / MU_0
 
-    # dEy/dz -- periodic (roll -1 along z=axis1)
-    dey_dz = (jnp.roll(ey, -1, axis=1) - ey) / dx
+    # dEy/dz -- Bloch field-transform (#404): plain roll + exp(-j k_z dz) on the
+    # forward neighbour (transverse axis is z here; k_z=0 -> plain periodic diff).
+    pshift = jnp.exp(-1j * cfg.k_transverse * dx)
+    dey_dz = (jnp.roll(ey, -1, axis=1) * pshift - ey) / dx
 
     # dEy/dx -- zero-pad forward difference along x=axis0
-    dey_dx = (jnp.concatenate([ey[1:, :], jnp.zeros((1, ey.shape[1]))], axis=0) - ey) / dx
+    dey_dx = (jnp.concatenate([ey[1:, :], jnp.zeros((1, ey.shape[1]), ey.dtype)], axis=0) - ey) / dx
 
     # TEz Faraday: Hx += coeff * dEy/dz,  Hz -= coeff * dEy/dx
     hx = hx + coeff_h * dey_dz
@@ -397,11 +440,13 @@ def _update_e_tez(cfg, st, dx, dt, t):
     hz = st.hy_2d   # Hz stored in hy_2d slot
     coeff_e = dt / EPS_0
 
-    # dHx/dz -- periodic (roll +1 along z for backward difference)
-    dhx_dz = (hx - jnp.roll(hx, 1, axis=1)) / dx
+    # dHx/dz -- Bloch field-transform (#404): plain roll + exp(+j k_z dz) on the
+    # backward neighbour (conjugate of the forward pshift; k_z=0 -> plain diff).
+    pconj = jnp.exp(1j * cfg.k_transverse * dx)
+    dhx_dz = (hx - jnp.roll(hx, 1, axis=1) * pconj) / dx
 
     # dHz/dx -- zero-pad backward difference along x
-    dhz_dx = (hz - jnp.concatenate([jnp.zeros((1, hz.shape[1])), hz[:-1, :]], axis=0)) / dx
+    dhz_dx = (hz - jnp.concatenate([jnp.zeros((1, hz.shape[1]), hz.dtype), hz[:-1, :]], axis=0)) / dx
 
     # TEz Ampere: Ey += coeff * (dHx/dz - dHz/dx)
     ey = ey + coeff_e * (dhx_dz - dhz_dx)
@@ -410,14 +455,14 @@ def _update_e_tez(cfg, st, dx, dt, t):
     # The x-derivative contribution is -coeff_e * dHz/dx, so CPML sign is -coeff_e
     ey, psi_ez_xlo, psi_ez_xhi = _apply_cpml_e(cfg, st, dhz_dx, ey, -coeff_e)
 
-    # ---- Inject oblique plane-wave source along a line ----
-    c0 = 1.0 / jnp.sqrt(jnp.float32(EPS_0 * MU_0))
-    j_indices = jnp.arange(ey.shape[1], dtype=jnp.float32)
-    z_offset = j_indices * dx
-    t_delay = cfg.direction_sign * cfg.sin_theta * z_offset / c0
-    arg = (t - t_delay - cfg.src_t0) / cfg.src_tau
-    src_line = cfg.src_amp * (-2.0 * arg) * jnp.exp(-(arg ** 2))
-    ey = ey.at[cfg.src_x, :].add(src_line)
+    # ---- Inject oblique plane wave: z-uniform complex analytic modulated
+    # Gaussian (carrier at f0). The transverse k_z is carried by the transformed
+    # derivatives above, not by a per-cell time delay. ----
+    arg = (t - cfg.src_t0) / cfg.src_tau
+    src_val = (cfg.src_amp
+               * jnp.exp(-1j * 2.0 * jnp.pi * cfg.src_fcen * (t - cfg.src_t0))
+               * jnp.exp(-(arg ** 2)))
+    ey = ey.at[cfg.src_x, :].add(src_val)
 
     return st._replace(
         ez_2d=ey,
@@ -484,6 +529,17 @@ _sample_ez_at_x = _sample_e_at_x
 _sample_hy_at_x = _sample_h2_at_x
 
 
+def _transverse_phase(cfg: TFSF2DConfig, n_trans: int, dx: float) -> jnp.ndarray:
+    """Transverse Bloch phase exp(-j·k_y·y) to re-apply to the (complex,
+    y-uniform) aux fields when injecting into the real 3D grid (#404).
+
+    ``k_y = cfg.k_transverse`` is 0 for normal incidence (this path is oblique
+    only), giving phase = 1 and recovering the plain broadcast.
+    """
+    y = jnp.arange(n_trans, dtype=jnp.float32) * dx
+    return jnp.exp(-1j * cfg.k_transverse * y)
+
+
 # ---------------------------------------------------------------------------
 # 3D TFSF corrections using 2D auxiliary grid
 # ---------------------------------------------------------------------------
@@ -510,15 +566,17 @@ def apply_tfsf_2d_e(state, cfg: TFSF2DConfig, tfsf_st: TFSF2DState,
 
     if cfg.mode == "TEz":
         # TEz: 2D grid transverse axis is z, broadcast along y
-        h_inc_lo = _sample_h2_at_x(cfg, tfsf_st, i0 - 1, nz_3d)
-        h_inc_hi = _sample_h2_at_x(cfg, tfsf_st, i0 + (cfg.x_hi - cfg.x_lo), nz_3d)
+        phase = _transverse_phase(cfg, nz_3d, dx)  # exp(-j k_z z), (nz,)
+        h_inc_lo = jnp.real(_sample_h2_at_x(cfg, tfsf_st, i0 - 1, nz_3d) * phase)
+        h_inc_hi = jnp.real(_sample_h2_at_x(cfg, tfsf_st, i0 + (cfg.x_hi - cfg.x_lo), nz_3d) * phase)
 
         h_lo_3d = jnp.broadcast_to(h_inc_lo[None, :], (ny_3d, nz_3d))
         h_hi_3d = jnp.broadcast_to(h_inc_hi[None, :], (ny_3d, nz_3d))
     else:
         # TMz: 2D grid transverse axis is y, broadcast along z
-        h_inc_lo = _sample_h2_at_x(cfg, tfsf_st, i0 - 1, ny_3d)
-        h_inc_hi = _sample_h2_at_x(cfg, tfsf_st, i0 + (cfg.x_hi - cfg.x_lo), ny_3d)
+        phase = _transverse_phase(cfg, ny_3d, dx)  # exp(-j k_y y), (ny,)
+        h_inc_lo = jnp.real(_sample_h2_at_x(cfg, tfsf_st, i0 - 1, ny_3d) * phase)
+        h_inc_hi = jnp.real(_sample_h2_at_x(cfg, tfsf_st, i0 + (cfg.x_hi - cfg.x_lo), ny_3d) * phase)
 
         h_lo_3d = jnp.broadcast_to(h_inc_lo[:, None], (ny_3d, nz_3d))
         h_hi_3d = jnp.broadcast_to(h_inc_hi[:, None], (ny_3d, nz_3d))
@@ -552,15 +610,17 @@ def apply_tfsf_2d_h(state, cfg: TFSF2DConfig, tfsf_st: TFSF2DState,
 
     if cfg.mode == "TEz":
         # TEz: 2D grid transverse axis is z, broadcast along y
-        e_inc_lo = _sample_e_at_x(cfg, tfsf_st, i0, nz_3d)
-        e_inc_hi = _sample_e_at_x(cfg, tfsf_st, i0 + (cfg.x_hi + 1 - cfg.x_lo), nz_3d)
+        phase = _transverse_phase(cfg, nz_3d, dx)  # exp(-j k_z z), (nz,)
+        e_inc_lo = jnp.real(_sample_e_at_x(cfg, tfsf_st, i0, nz_3d) * phase)
+        e_inc_hi = jnp.real(_sample_e_at_x(cfg, tfsf_st, i0 + (cfg.x_hi + 1 - cfg.x_lo), nz_3d) * phase)
 
         e_lo_3d = jnp.broadcast_to(e_inc_lo[None, :], (ny_3d, nz_3d))
         e_hi_3d = jnp.broadcast_to(e_inc_hi[None, :], (ny_3d, nz_3d))
     else:
         # TMz: 2D grid transverse axis is y, broadcast along z
-        e_inc_lo = _sample_e_at_x(cfg, tfsf_st, i0, ny_3d)
-        e_inc_hi = _sample_e_at_x(cfg, tfsf_st, i0 + (cfg.x_hi + 1 - cfg.x_lo), ny_3d)
+        phase = _transverse_phase(cfg, ny_3d, dx)  # exp(-j k_y y), (ny,)
+        e_inc_lo = jnp.real(_sample_e_at_x(cfg, tfsf_st, i0, ny_3d) * phase)
+        e_inc_hi = jnp.real(_sample_e_at_x(cfg, tfsf_st, i0 + (cfg.x_hi + 1 - cfg.x_lo), ny_3d) * phase)
 
         e_lo_3d = jnp.broadcast_to(e_inc_lo[:, None], (ny_3d, nz_3d))
         e_hi_3d = jnp.broadcast_to(e_inc_hi[:, None], (ny_3d, nz_3d))

--- a/rfx/sources/tfsf_2d.py
+++ b/rfx/sources/tfsf_2d.py
@@ -540,6 +540,35 @@ def _transverse_phase(cfg: TFSF2DConfig, n_trans: int, dx: float) -> jnp.ndarray
     return jnp.exp(-1j * cfg.k_transverse * y)
 
 
+def bloch_phase_tuple(cfg: TFSF2DConfig, dx: float) -> tuple:
+    """Per-axis Bloch phase ``exp(-j·k_transverse·dx)`` for the 3D
+    ``update_e``/``update_h`` on the transverse periodic axis (#404 Phase-B).
+
+    The transformed-frame 3D grid evolves the Bloch envelope ``P`` and must carry
+    the SAME transverse phase on its periodic roll as the 2D-aux grid, on the axis
+    matching ``cfg.transverse_axis`` (``y``=axis 1 for TMz, ``z``=axis 2 for TEz).
+    All other axes are 1.0.  Pass the result as ``update_e/h(..., bloch=...)``.
+    """
+    ph = complex(jnp.exp(-1j * cfg.k_transverse * dx))
+    if cfg.transverse_axis == "z":
+        return (1.0 + 0j, 1.0 + 0j, ph)
+    return (1.0 + 0j, ph, 1.0 + 0j)
+
+
+def _face_incident(sample_vals, cfg: TFSF2DConfig, n_trans: int, dx: float,
+                   transformed: bool):
+    """Per-transverse-cell incident field to inject at a TFSF face.
+
+    Transformed frame (complex 3D grid — #404 Phase-B): the 3D grid evolves the
+    SAME Bloch envelope ``P`` as the aux grid, so inject ``P`` DIRECTLY (complex,
+    no phase re-application, no ``jnp.real``).  Real frame (Phase-A / open /
+    CPML-transverse): reconstruct the physical field ``Re(P·exp(-j·k_t·y))``.
+    """
+    if transformed:
+        return sample_vals
+    return jnp.real(sample_vals * _transverse_phase(cfg, n_trans, dx))
+
+
 # ---------------------------------------------------------------------------
 # 3D TFSF corrections using 2D auxiliary grid
 # ---------------------------------------------------------------------------
@@ -563,20 +592,20 @@ def apply_tfsf_2d_e(state, cfg: TFSF2DConfig, tfsf_st: TFSF2DState,
     e_ref = getattr(state, cfg.electric_component)
     ny_3d = e_ref.shape[1]
     nz_3d = e_ref.shape[2]
+    # Complex 3D field ⇒ transformed (Bloch-envelope) frame — inject P directly.
+    transformed = bool(jnp.iscomplexobj(e_ref))
 
     if cfg.mode == "TEz":
         # TEz: 2D grid transverse axis is z, broadcast along y
-        phase = _transverse_phase(cfg, nz_3d, dx)  # exp(-j k_z z), (nz,)
-        h_inc_lo = jnp.real(_sample_h2_at_x(cfg, tfsf_st, i0 - 1, nz_3d) * phase)
-        h_inc_hi = jnp.real(_sample_h2_at_x(cfg, tfsf_st, i0 + (cfg.x_hi - cfg.x_lo), nz_3d) * phase)
+        h_inc_lo = _face_incident(_sample_h2_at_x(cfg, tfsf_st, i0 - 1, nz_3d), cfg, nz_3d, dx, transformed)
+        h_inc_hi = _face_incident(_sample_h2_at_x(cfg, tfsf_st, i0 + (cfg.x_hi - cfg.x_lo), nz_3d), cfg, nz_3d, dx, transformed)
 
         h_lo_3d = jnp.broadcast_to(h_inc_lo[None, :], (ny_3d, nz_3d))
         h_hi_3d = jnp.broadcast_to(h_inc_hi[None, :], (ny_3d, nz_3d))
     else:
         # TMz: 2D grid transverse axis is y, broadcast along z
-        phase = _transverse_phase(cfg, ny_3d, dx)  # exp(-j k_y y), (ny,)
-        h_inc_lo = jnp.real(_sample_h2_at_x(cfg, tfsf_st, i0 - 1, ny_3d) * phase)
-        h_inc_hi = jnp.real(_sample_h2_at_x(cfg, tfsf_st, i0 + (cfg.x_hi - cfg.x_lo), ny_3d) * phase)
+        h_inc_lo = _face_incident(_sample_h2_at_x(cfg, tfsf_st, i0 - 1, ny_3d), cfg, ny_3d, dx, transformed)
+        h_inc_hi = _face_incident(_sample_h2_at_x(cfg, tfsf_st, i0 + (cfg.x_hi - cfg.x_lo), ny_3d), cfg, ny_3d, dx, transformed)
 
         h_lo_3d = jnp.broadcast_to(h_inc_lo[:, None], (ny_3d, nz_3d))
         h_hi_3d = jnp.broadcast_to(h_inc_hi[:, None], (ny_3d, nz_3d))
@@ -607,20 +636,20 @@ def apply_tfsf_2d_h(state, cfg: TFSF2DConfig, tfsf_st: TFSF2DState,
     h_ref = getattr(state, cfg.magnetic_component)
     ny_3d = h_ref.shape[1]
     nz_3d = h_ref.shape[2]
+    # Complex 3D field ⇒ transformed (Bloch-envelope) frame — inject P directly.
+    transformed = bool(jnp.iscomplexobj(h_ref))
 
     if cfg.mode == "TEz":
         # TEz: 2D grid transverse axis is z, broadcast along y
-        phase = _transverse_phase(cfg, nz_3d, dx)  # exp(-j k_z z), (nz,)
-        e_inc_lo = jnp.real(_sample_e_at_x(cfg, tfsf_st, i0, nz_3d) * phase)
-        e_inc_hi = jnp.real(_sample_e_at_x(cfg, tfsf_st, i0 + (cfg.x_hi + 1 - cfg.x_lo), nz_3d) * phase)
+        e_inc_lo = _face_incident(_sample_e_at_x(cfg, tfsf_st, i0, nz_3d), cfg, nz_3d, dx, transformed)
+        e_inc_hi = _face_incident(_sample_e_at_x(cfg, tfsf_st, i0 + (cfg.x_hi + 1 - cfg.x_lo), nz_3d), cfg, nz_3d, dx, transformed)
 
         e_lo_3d = jnp.broadcast_to(e_inc_lo[None, :], (ny_3d, nz_3d))
         e_hi_3d = jnp.broadcast_to(e_inc_hi[None, :], (ny_3d, nz_3d))
     else:
         # TMz: 2D grid transverse axis is y, broadcast along z
-        phase = _transverse_phase(cfg, ny_3d, dx)  # exp(-j k_y y), (ny,)
-        e_inc_lo = jnp.real(_sample_e_at_x(cfg, tfsf_st, i0, ny_3d) * phase)
-        e_inc_hi = jnp.real(_sample_e_at_x(cfg, tfsf_st, i0 + (cfg.x_hi + 1 - cfg.x_lo), ny_3d) * phase)
+        e_inc_lo = _face_incident(_sample_e_at_x(cfg, tfsf_st, i0, ny_3d), cfg, ny_3d, dx, transformed)
+        e_inc_hi = _face_incident(_sample_e_at_x(cfg, tfsf_st, i0 + (cfg.x_hi + 1 - cfg.x_lo), ny_3d), cfg, ny_3d, dx, transformed)
 
         e_lo_3d = jnp.broadcast_to(e_inc_lo[:, None], (ny_3d, nz_3d))
         e_hi_3d = jnp.broadcast_to(e_inc_hi[:, None], (ny_3d, nz_3d))

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -465,19 +465,32 @@ def test_compiled_runner_tfsf_oblique_matches_manual_loop():
         probes=[probe],
     )
 
-    # Detect 2D auxiliary grid for oblique incidence
+    # Detect 2D auxiliary grid for oblique incidence. #404: the oblique 2D-aux
+    # TFSF drives the shared solver on the COMPLEX Bloch-envelope path (the
+    # compiled `run()` above does the same via _build_step_setup), so the manual
+    # loop mirrors it: complex fields + per-axis roll phase + complex CPML carry.
+    # The low-level `run()` returns the (unreconstructed) envelope, so we compare
+    # envelopes directly.
     _is_2d = is_tfsf_2d(tfsf_cfg)
     if _is_2d:
-        from rfx.sources.tfsf_2d import update_tfsf_2d_h, update_tfsf_2d_e
+        from rfx.sources.tfsf_2d import (
+            update_tfsf_2d_h, update_tfsf_2d_e, bloch_phase_tuple,
+        )
+        _bloch = bloch_phase_tuple(tfsf_cfg, grid.dx)
+        _fdt = jnp.complex64
+    else:
+        _bloch = None
+        _fdt = jnp.float32
 
-    state = init_state(grid.shape)
-    cp, cpml_state = init_cpml(grid)
+    state = init_state(grid.shape, field_dtype=_fdt)
+    cp, cpml_state = init_cpml(grid, field_dtype=_fdt)
     tfsf_state = tfsf_state0
     manual_ts = []
 
     for step in range(n_steps):
         t = step * grid.dt
-        state = update_h(state, materials, grid.dt, grid.dx, periodic=periodic)
+        state = update_h(state, materials, grid.dt, grid.dx, periodic=periodic,
+                         bloch=_bloch)
         state = apply_tfsf_h(state, tfsf_cfg, tfsf_state, grid.dx, grid.dt)
         state, cpml_state = apply_cpml_h(state, cp, cpml_state, grid, axes="x")
         if _is_2d:
@@ -485,7 +498,8 @@ def test_compiled_runner_tfsf_oblique_matches_manual_loop():
         else:
             tfsf_state = update_tfsf_1d_h(tfsf_cfg, tfsf_state, grid.dx, grid.dt)
 
-        state = update_e(state, materials, grid.dt, grid.dx, periodic=periodic)
+        state = update_e(state, materials, grid.dt, grid.dx, periodic=periodic,
+                         bloch=_bloch)
         state = apply_tfsf_e(state, tfsf_cfg, tfsf_state, grid.dx, grid.dt)
         state, cpml_state = apply_cpml_e(state, cp, cpml_state, grid, axes="x")
         state = apply_pec(state, axes="x")
@@ -493,7 +507,7 @@ def test_compiled_runner_tfsf_oblique_matches_manual_loop():
             tfsf_state = update_tfsf_2d_e(tfsf_cfg, tfsf_state, grid.dx, grid.dt, t)
         else:
             tfsf_state = update_tfsf_1d_e(tfsf_cfg, tfsf_state, grid.dx, grid.dt, t)
-        manual_ts.append(float(state.ez[probe.i, probe.j, probe.k]))
+        manual_ts.append(complex(state.ez[probe.i, probe.j, probe.k]))
 
     compiled_ts = np.array(compiled.time_series[:, 0])
     manual_ts = np.array(manual_ts)

--- a/tests/test_sparameter_support_contract.py
+++ b/tests/test_sparameter_support_contract.py
@@ -146,6 +146,24 @@ def test_forward_s11_rejects_non_port_source_only_request():
         sim.forward(n_steps=1, port_s11_freqs=np.array([1.0e9]), skip_preflight=True)
 
 
+def test_forward_rejects_tfsf_source_fail_loud():
+    """forward() must FAIL LOUD on a TFSF source, not silently drop it.
+
+    The differentiable forward path (_forward_from_materials) has no TFSF
+    handling, so a TFSF source injects nothing → zero gradients (the historical
+    "TFSF→forward silent-drop" footgun). #404 wired run() for oblique/normal TFSF
+    forward simulation; differentiable TFSF inverse-design is not implemented, so
+    forward() rejects it up front. Not oblique-specific — normal incidence too.
+    """
+    for angle in (0.0, 30.0):
+        sim = Simulation(freq_max=10e9, domain=(0.6, 0.12, 0.006), dx=0.002,
+                         boundary="cpml", cpml_layers=10, mode="3d")
+        sim.add_tfsf_source(f0=5e9, polarization="ez", direction="+x",
+                            angle_deg=angle)
+        with pytest.raises(NotImplementedError, match="TFSF.*forward"):
+            sim.forward(n_steps=1, skip_preflight=True)
+
+
 def test_preflight_sparameters_routes_forward_specialized_families():
     sim = Simulation(
         freq_max=12e9,

--- a/tests/test_tfsf_oblique.py
+++ b/tests/test_tfsf_oblique.py
@@ -10,8 +10,16 @@ Tests:
 
 import numpy as np
 import jax.numpy as jnp
+import pytest
 
 from rfx.core.yee import init_state, init_materials, update_h, update_e
+
+# Oblique leakage runs need a narrowband source (bw<=0.15: off-f0 content carries
+# the wrong single-f0 k_y and breaks TFSF cancellation) which in turn needs a long
+# run (~1700 steps) for the pulse to fully develop — hence @pytest.mark.slow. See
+# docs/research_notes/2026-07-21_issue404_phaseB_session_findings.md.
+_OBLIQUE_BW = 0.15
+_OBLIQUE_STEPS = 1700
 
 
 # ---------------------------------------------------------------------------
@@ -21,13 +29,21 @@ from rfx.core.yee import init_state, init_materials, update_h, update_e
 def _run_tfsf_leakage(angle_deg, nx=80, ny=80, nz=3, n_steps=500,
                        f0=5e9, bandwidth=0.5, cpml_layers=10,
                        tfsf_margin=3):
-    """Run TFSF simulation and return (leakage_ratio, tf_energy, sf_energy)."""
+    """Run TFSF simulation and return (leakage_ratio, tf_energy, sf_energy).
+
+    Oblique (angle != 0) runs the #404 Phase-B transformed complex Bloch frame
+    (complex fields + per-axis Bloch phase); normal incidence stays on the real
+    1D-aux path. Energy uses ``|.|**2`` (the SF/TF ratio is phase-invariant, so
+    it matches the real ``**2`` for the normal path).
+    """
     from rfx.sources.tfsf import (
         init_tfsf, apply_tfsf_e, apply_tfsf_h,
         update_tfsf_1d_h, update_tfsf_1d_e,
         is_tfsf_2d,
     )
-    from rfx.sources.tfsf_2d import update_tfsf_2d_h, update_tfsf_2d_e
+    from rfx.sources.tfsf_2d import (
+        update_tfsf_2d_h, update_tfsf_2d_e, bloch_phase_tuple,
+    )
 
     dx = 1e-3
     dt = 0.5 * dx / 3e8
@@ -45,15 +61,22 @@ def _run_tfsf_leakage(angle_deg, nx=80, ny=80, nz=3, n_steps=500,
     )
 
     materials = init_materials((nx, ny, nz))
-    sim_state = init_state((nx, ny, nz))
     periodic = (False, True, True)
     is_2d = is_tfsf_2d(cfg)
+    # #404 Phase-B: oblique 3D grid carries the complex Bloch envelope P.
+    if is_2d:
+        sim_state = init_state((nx, ny, nz), field_dtype=jnp.complex64)
+        bloch = bloch_phase_tuple(cfg, dx)
+    else:
+        sim_state = init_state((nx, ny, nz))
+        bloch = None
 
     for step in range(n_steps):
         t = step * dt
 
         # H update
-        sim_state = update_h(sim_state, materials, dt, dx, periodic=periodic)
+        sim_state = update_h(sim_state, materials, dt, dx, periodic=periodic,
+                             bloch=bloch)
         sim_state = apply_tfsf_h(sim_state, cfg, state, dx, dt)
 
         # Advance aux grid H
@@ -63,7 +86,8 @@ def _run_tfsf_leakage(angle_deg, nx=80, ny=80, nz=3, n_steps=500,
             state = update_tfsf_1d_h(cfg, state, dx, dt)
 
         # E update
-        sim_state = update_e(sim_state, materials, dt, dx, periodic=periodic)
+        sim_state = update_e(sim_state, materials, dt, dx, periodic=periodic,
+                             bloch=bloch)
         sim_state = apply_tfsf_e(sim_state, cfg, state, dx, dt)
 
         # Advance aux grid E + source
@@ -72,10 +96,10 @@ def _run_tfsf_leakage(angle_deg, nx=80, ny=80, nz=3, n_steps=500,
         else:
             state = update_tfsf_1d_e(cfg, state, dx, dt, t)
 
-    # Measure leakage
+    # Measure leakage (envelope energy; phase-invariant SF/TF ratio)
     ez = sim_state.ez
-    sf_energy = float(jnp.sum(ez[:cfg.x_lo - 2, :, :] ** 2))
-    tf_energy = float(jnp.sum(ez[cfg.x_lo:cfg.x_hi, :, :] ** 2))
+    sf_energy = float(jnp.sum(jnp.abs(ez[:cfg.x_lo - 2, :, :]) ** 2))
+    tf_energy = float(jnp.sum(jnp.abs(ez[cfg.x_lo:cfg.x_hi, :, :]) ** 2))
 
     leakage = sf_energy / tf_energy if tf_energy > 0 else float('inf')
     return leakage, tf_energy, sf_energy
@@ -110,20 +134,24 @@ class TestObliqueTFSF:
         max_ez = float(jnp.max(jnp.abs(state.ez_2d)))
         assert max_ez > 1e-6, f"2D aux grid has no signal: max |Ez| = {max_ez}"
 
+    @pytest.mark.slow
     def test_oblique_45deg_leakage_below_1pct(self):
-        """45-degree oblique incidence leakage < 1%."""
+        """45-degree oblique incidence leakage < 1% (transformed Bloch frame, #404)."""
         leakage, tf_energy, sf_energy = _run_tfsf_leakage(
-            angle_deg=45.0, nx=100, ny=100, nz=3, n_steps=600,
+            angle_deg=45.0, nx=100, ny=100, nz=3, n_steps=_OBLIQUE_STEPS,
+            bandwidth=_OBLIQUE_BW,
         )
         print(f"\n45-deg oblique TFSF: leakage={leakage:.6f}, "
               f"tf_energy={tf_energy:.6e}, sf_energy={sf_energy:.6e}")
         assert tf_energy > 0, "No total-field energy detected"
         assert leakage < 0.01, f"Oblique TFSF leakage {leakage:.4f} > 1%"
 
+    @pytest.mark.slow
     def test_oblique_30deg_leakage_below_1pct(self):
-        """30-degree oblique incidence leakage < 1%."""
+        """30-degree oblique incidence leakage < 1% (transformed Bloch frame, #404)."""
         leakage, tf_energy, sf_energy = _run_tfsf_leakage(
-            angle_deg=30.0, nx=100, ny=100, nz=3, n_steps=600,
+            angle_deg=30.0, nx=100, ny=100, nz=3, n_steps=_OBLIQUE_STEPS,
+            bandwidth=_OBLIQUE_BW,
         )
         print(f"\n30-deg oblique TFSF: leakage={leakage:.6f}, "
               f"tf_energy={tf_energy:.6e}, sf_energy={sf_energy:.6e}")
@@ -154,10 +182,12 @@ class TestObliqueTFSF:
         cfg_2d, _ = init_tfsf(60, dx, dt, cpml_layers=8, angle_deg=30.0, ny=60)
         assert isinstance(cfg_2d, TFSF2DConfig)
 
+    @pytest.mark.slow
     def test_oblique_negative_angle(self):
         """Negative oblique angle (-30 deg) should also have low leakage."""
         leakage, tf_energy, sf_energy = _run_tfsf_leakage(
-            angle_deg=-30.0, nx=100, ny=100, nz=3, n_steps=600,
+            angle_deg=-30.0, nx=100, ny=100, nz=3, n_steps=_OBLIQUE_STEPS,
+            bandwidth=_OBLIQUE_BW,
         )
         print(f"\n-30-deg oblique TFSF: leakage={leakage:.6f}, "
               f"tf_energy={tf_energy:.6e}, sf_energy={sf_energy:.6e}")

--- a/tests/test_tfsf_oblique_coverage.py
+++ b/tests/test_tfsf_oblique_coverage.py
@@ -17,30 +17,46 @@ from rfx.sources.tfsf import (
     update_tfsf_1d_h, update_tfsf_1d_e,
 )
 from rfx.sources.tfsf_2d import (
-    update_tfsf_2d_h, update_tfsf_2d_e,
+    update_tfsf_2d_h, update_tfsf_2d_e, bloch_phase_tuple,
 )
 from rfx.core.yee import init_state, init_materials, update_h, update_e
 
+# Oblique leakage needs a narrowband source + long run (#404 Phase-B); marked slow.
+_OBLIQUE_BW = 0.15
+_OBLIQUE_STEPS = 1700
 
-def _run_tfsf_leakage(nx, ny, nz, dx, dt, angle_deg, polarization, direction, n_steps):
-    """Run TFSF and measure scattered-to-total field energy ratio."""
+
+def _run_tfsf_leakage(nx, ny, nz, dx, dt, angle_deg, polarization, direction,
+                      n_steps, bandwidth=0.5):
+    """Run TFSF and measure scattered-to-total field energy ratio.
+
+    Oblique (angle != 0) uses the #404 Phase-B transformed complex Bloch frame;
+    normal incidence stays on the real 1D-aux path. Energy uses ``|.|**2`` (the
+    SF/TF ratio is phase-invariant).
+    """
     cfg, st = init_tfsf(
         nx, dx, dt, ny=ny, nz=nz, cpml_layers=10,
-        f0=5e9, bandwidth=0.5, amplitude=1.0,
+        f0=5e9, bandwidth=bandwidth, amplitude=1.0,
         polarization=polarization, direction=direction,
         angle_deg=angle_deg,
     )
 
     materials = init_materials((nx, ny, nz))
-    sim_state = init_state((nx, ny, nz))
     periodic = (False, True, True)
     is_2d = is_tfsf_2d(cfg)
+    if is_2d:
+        sim_state = init_state((nx, ny, nz), field_dtype=jnp.complex64)
+        bloch = bloch_phase_tuple(cfg, dx)
+    else:
+        sim_state = init_state((nx, ny, nz))
+        bloch = None
 
     for step in range(n_steps):
         t = step * dt
 
         # H update
-        sim_state = update_h(sim_state, materials, dt, dx, periodic=periodic)
+        sim_state = update_h(sim_state, materials, dt, dx, periodic=periodic,
+                             bloch=bloch)
         sim_state = apply_tfsf_h(sim_state, cfg, st, dx, dt)
 
         # Advance aux grid H
@@ -50,7 +66,8 @@ def _run_tfsf_leakage(nx, ny, nz, dx, dt, angle_deg, polarization, direction, n_
             st = update_tfsf_1d_h(cfg, st, dx, dt)
 
         # E update
-        sim_state = update_e(sim_state, materials, dt, dx, periodic=periodic)
+        sim_state = update_e(sim_state, materials, dt, dx, periodic=periodic,
+                             bloch=bloch)
         sim_state = apply_tfsf_e(sim_state, cfg, st, dx, dt)
 
         # Advance aux grid E + source
@@ -60,8 +77,8 @@ def _run_tfsf_leakage(nx, ny, nz, dx, dt, angle_deg, polarization, direction, n_
             st = update_tfsf_1d_e(cfg, st, dx, dt, t)
 
     component = getattr(sim_state, polarization)
-    sf_energy = float(jnp.sum(component[:cfg.x_lo - 2, :, :] ** 2))
-    tf_energy = float(jnp.sum(component[cfg.x_lo:cfg.x_hi, :, :] ** 2))
+    sf_energy = float(jnp.sum(jnp.abs(component[:cfg.x_lo - 2, :, :]) ** 2))
+    tf_energy = float(jnp.sum(jnp.abs(component[cfg.x_lo:cfg.x_hi, :, :]) ** 2))
     return sf_energy / tf_energy if tf_energy > 0 else 1.0
 
 
@@ -104,62 +121,68 @@ class TestObliqueTFSFCoverage:
         print(f"\ney normal -x TFSF: leakage={leakage:.6f}")
         assert leakage < 0.001, f"ey normal -x leakage {leakage:.5f} > 0.1%"
 
+    @pytest.mark.slow
     def test_ey_oblique_45_leakage(self, grid_params_ey_oblique):
-        """ey + oblique 45-deg: TEz 2D aux grid leakage < 1%."""
+        """ey + oblique 45-deg: TEz 2D aux grid leakage < 1% (#404 Phase-B)."""
         nx, ny, nz, dx, dt = grid_params_ey_oblique
         leakage = _run_tfsf_leakage(
             nx, ny, nz, dx, dt,
             angle_deg=45.0, polarization="ey",
-            direction="+x", n_steps=500,
+            direction="+x", n_steps=_OBLIQUE_STEPS, bandwidth=_OBLIQUE_BW,
         )
         print(f"\ney oblique 45-deg TFSF: leakage={leakage:.6f}")
         assert leakage < 0.01, f"ey oblique 45 deg leakage {leakage:.5f} > 1%"
 
+    @pytest.mark.slow
     def test_ey_oblique_30_leakage(self, grid_params_ey_oblique):
-        """ey + oblique 30-deg: TEz 2D aux grid leakage < 1%."""
+        """ey + oblique 30-deg: TEz 2D aux grid leakage < 1% (#404 Phase-B)."""
         nx, ny, nz, dx, dt = grid_params_ey_oblique
         leakage = _run_tfsf_leakage(
             nx, ny, nz, dx, dt,
             angle_deg=30.0, polarization="ey",
-            direction="+x", n_steps=500,
+            direction="+x", n_steps=_OBLIQUE_STEPS, bandwidth=_OBLIQUE_BW,
         )
         print(f"\ney oblique 30-deg TFSF: leakage={leakage:.6f}")
         assert leakage < 0.01, f"ey oblique 30 deg leakage {leakage:.5f} > 1%"
 
+    @pytest.mark.slow
     def test_ey_oblique_neg30_leakage(self, grid_params_ey_oblique):
-        """ey + oblique -30-deg: TEz 2D aux grid leakage < 1%."""
+        """ey + oblique -30-deg: TEz 2D aux grid leakage < 1% (#404 Phase-B)."""
         nx, ny, nz, dx, dt = grid_params_ey_oblique
         leakage = _run_tfsf_leakage(
             nx, ny, nz, dx, dt,
             angle_deg=-30.0, polarization="ey",
-            direction="+x", n_steps=500,
+            direction="+x", n_steps=_OBLIQUE_STEPS, bandwidth=_OBLIQUE_BW,
         )
         print(f"\ney oblique -30-deg TFSF: leakage={leakage:.6f}")
         assert leakage < 0.01, f"ey oblique -30 deg leakage {leakage:.5f} > 1%"
 
+    @pytest.mark.slow
     def test_ez_oblique_e_correction_sign_regression(self, grid_params):
-        """ez oblique must still have near-zero leakage (sign fix regression guard).
+        """ez oblique must have near-zero leakage (sign fix regression guard).
 
         The E-field correction in apply_tfsf_2d_e uses fixed signs
         (-coeff, +coeff) that are independent of curl_sign.  This test
-        ensures the fix does not regress ez oblique performance.
+        ensures the fix does not regress ez oblique performance.  With the
+        #404 Phase-B transformed frame the cancellation is machine-clean.
         """
         nx, ny, nz, dx, dt = grid_params
         leakage = _run_tfsf_leakage(
             nx, ny, nz, dx, dt,
             angle_deg=45.0, polarization="ez",
-            direction="+x", n_steps=500,
+            direction="+x", n_steps=_OBLIQUE_STEPS, bandwidth=_OBLIQUE_BW,
         )
         print(f"\nez oblique 45-deg TFSF: leakage={leakage:.6f}")
         assert leakage < 0.001, f"ez oblique 45 deg leakage {leakage:.5f} > 0.1%"
 
+    @pytest.mark.slow
     def test_negative_x_direction_oblique_30_ez(self, grid_params):
         """-x direction with ez at 30 deg oblique should have < 1% leakage."""
         nx, ny, nz, dx, dt = grid_params
         leakage = _run_tfsf_leakage(
             nx, ny, nz, dx, dt,
             angle_deg=30.0, polarization="ez",
-            direction="-x", n_steps=500,
+            direction="-x", n_steps=_OBLIQUE_STEPS, bandwidth=_OBLIQUE_BW,
         )
         print(f"\nez oblique 30-deg -x TFSF: leakage={leakage:.6f}")
         assert leakage < 0.01, f"-x ez oblique 30 deg leakage {leakage:.4f} > 1%"

--- a/tests/test_tfsf_run_oblique_integration.py
+++ b/tests/test_tfsf_run_oblique_integration.py
@@ -1,0 +1,111 @@
+"""Integration: Simulation.run() drives the #404 oblique-periodic complex Bloch path.
+
+The oblique (2D-aux) TFSF now routes the shared solver onto the complex Bloch-
+envelope path (field_dtype=complex64 + per-axis roll phase + complex CPML psi
+carry), and run() reconstructs the returned `state` / point probes back to the
+physical real field Re(P·exp(-j k_t·y)). Normal incidence and every non-TFSF run
+stay on the real float32 path (byte-identical). These gates pin that contract.
+"""
+import numpy as np
+import jax.numpy as jnp
+import pytest
+
+from rfx.api import Simulation
+from rfx.grid import Grid
+from rfx.core.yee import init_state, init_materials, update_e, update_h
+from rfx.boundaries.cpml import init_cpml, apply_cpml_e, apply_cpml_h
+from rfx.sources.tfsf import init_tfsf, apply_tfsf_e, apply_tfsf_h, is_tfsf_2d
+from rfx.sources.tfsf_2d import (
+    update_tfsf_2d_h, update_tfsf_2d_e, bloch_phase_tuple,
+)
+
+_DOMAIN = (0.6, 0.12, 0.006)
+_DX = 0.002
+
+
+def _build(angle):
+    sim = Simulation(freq_max=10e9, domain=_DOMAIN, dx=_DX,
+                     boundary="cpml", cpml_layers=10, mode="3d")
+    sim.add_tfsf_source(f0=5e9, bandwidth=0.15, polarization="ez",
+                        direction="+x", angle_deg=angle,
+                        waveform="modulated_gaussian")
+    return sim
+
+
+def test_run_normal_incidence_stays_real():
+    """Normal-incidence TFSF through run() stays on the real float32 path (the
+    complex Bloch path is oblique-only; normal incidence must be untouched)."""
+    res = _build(0.0).run(n_steps=150)
+    assert res.state.ez.dtype == jnp.float32
+
+
+def test_run_oblique_returns_real_physical_field():
+    """An oblique run() returns a real (reconstructed) physical field, not the
+    complex envelope — the run drove the complex path but the user sees fields."""
+    res = _build(30.0).run(n_steps=150)
+    assert res.state.ez.dtype == jnp.float32
+    assert float(jnp.max(jnp.abs(res.state.ez))) > 1e-4
+
+
+def test_run_oblique_flux_monitor_fails_loud():
+    """Frequency-domain monitors are not yet transform-aware on the complex
+    Bloch path — run() must fail loud rather than return truncated garbage."""
+    sim = _build(30.0)
+    sim.add_flux_monitor(axis="x", coordinate=0.1, freqs=[5e9], name="r")
+    with pytest.raises(NotImplementedError):
+        sim.run(n_steps=100)
+
+
+def test_run_oblique_until_decay_fails_loud():
+    """until_decay is incompatible with complex state (float(complex) crash) —
+    run() fences it with a clear message."""
+    with pytest.raises(NotImplementedError):
+        _build(30.0).run(until_decay=1e-4, decay_monitor_component="ez",
+                         decay_monitor_position=(0.1, 0.0, 0.0))
+
+
+@pytest.mark.slow
+def test_run_oblique_matches_handrolled_and_low_leakage():
+    """run() oblique reproduces the VALIDATED hand-rolled complex loop to ~1e-6
+    (same kernel/injection/order) AND yields <1% TFSF leakage — proof the high-
+    level API drives the identical #404 physics, not a re-derivation."""
+    angle, ns = 30.0, 250
+    res = _build(angle).run(n_steps=ns)
+    assert res.state.ez.dtype == jnp.float32
+    ez_run = np.asarray(res.state.ez)
+
+    # Hand-rolled reference (complex loop), config identical to run_uniform's.
+    grid = Grid(freq_max=10e9, domain=_DOMAIN, dx=_DX, cpml_layers=10)
+    dt, dx = grid.dt, grid.dx
+    cfg, aux = init_tfsf(
+        grid.nx, dx, dt, cpml_layers=grid.cpml_layers, tfsf_margin=3,
+        f0=5e9, bandwidth=0.15, amplitude=1.0, polarization="ez",
+        direction="+x", angle_deg=angle, ny=grid.ny, nz=grid.nz,
+        waveform="modulated_gaussian",
+    )
+    assert is_tfsf_2d(cfg)
+    bloch = bloch_phase_tuple(cfg, dx)
+    per = (False, True, True)
+    mat = init_materials(grid.shape)
+    st = init_state(grid.shape, field_dtype=jnp.complex64)
+    cp, cs = init_cpml(grid, field_dtype=jnp.complex64)
+    for step in range(ns):
+        t = step * dt
+        st = update_h(st, mat, dt, dx, periodic=per, bloch=bloch)
+        st = apply_tfsf_h(st, cfg, aux, dx, dt)
+        st, cs = apply_cpml_h(st, cp, cs, grid, axes="x")
+        aux = update_tfsf_2d_h(cfg, aux, dx, dt)
+        st = update_e(st, mat, dt, dx, periodic=per, bloch=bloch)
+        st = apply_tfsf_e(st, cfg, aux, dx, dt)
+        st, cs = apply_cpml_e(st, cp, cs, grid, axes="x")
+        aux = update_tfsf_2d_e(cfg, aux, dx, dt, t)
+    yph = np.exp(-1j * cfg.k_transverse * np.arange(grid.ny) * dx)[None, :, None]
+    ez_hand = np.real(np.asarray(st.ez) * yph)
+
+    rel = np.max(np.abs(ez_run - ez_hand)) / max(np.max(np.abs(ez_hand)), 1e-30)
+    assert rel < 1e-3, f"run() vs hand-rolled reconstructed Ez mismatch: {rel:.2e}"
+
+    sf = float(np.sum(ez_run[:cfg.x_lo - 2] ** 2))
+    tf = float(np.sum(ez_run[cfg.x_lo:cfg.x_hi] ** 2))
+    assert tf > 0, "no total-field energy"
+    assert sf / tf < 0.01, f"run() oblique leakage {sf / tf * 100:.3f}% > 1%"

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -9,6 +9,7 @@ Validates that:
 import numpy as np
 import jax
 import jax.numpy as jnp
+import pytest
 
 from rfx.grid import Grid, C0
 from rfx.core.yee import (
@@ -193,373 +194,133 @@ def test_gradient_through_dft_plane():
 # Test 3: Oblique TFSF produces correct Fresnel TE reflection
 # =========================================================================
 
-def test_oblique_tfsf_fresnel():
-    """Oblique TFSF (angle_deg=30) reflection matches Fresnel TE coefficient.
+def _run_oblique_fresnel(theta_deg, eps_r_val, bw=0.15):
+    """Run the #404 Phase-B transformed (complex Bloch) oblique-TFSF path against a
+    dielectric half-space; return (|R|, injected_angle_deg, incident_plateau_flatness).
 
-    Unlike the effective-eps surrogate in test_physics.py
-    (``test_fresnel_normal_incidence_effective_eps_consistency``, which runs a
-    NORMAL-incidence 1D-aux run and never invokes the oblique path), this test
-    actually exercises the oblique TFSF code path (2D dispersion-matched
-    auxiliary grid, ``is_tfsf_2d`` True).
-
-    VALIDATED SCOPE / KNOWN LIMITATION (issue #397, probe 2026-07-20)
-    ----------------------------------------------------------------
-    This gate confirms the 2D-aux oblique path RUNS and injects a tilted wave
-    with low TFSF leakage, yielding a physical-magnitude |R|. It does NOT
-    validate oblique-ANGLE Fresnel accuracy: at 30 deg / eps_r=4 the oblique
-    |R_TE|=0.382 and the normal-incidence |R|=0.333 differ by only 12.7%, below
-    this gate's 35% tolerance, and the measured value (~0.35-0.51) sits between
-    them — a normal-incidence injection would also pass. A discriminating steep
-    angle exposes the gap: at 60 deg the analytic oblique |R_TE|=0.566 but this
-    test's single-point extraction measures ~1.14 (101% off the oblique target;
-    the DFT-plane method in the companion test lands ~0.38, near normal) — either
-    way the oblique ANGLE is not reproduced. Treat oblique-reflection ACCURACY as
-    unvalidated pending a corrected
-    oblique-phase extraction; do not cite this test as an oblique-Fresnel
-    accuracy claim.
-
-    For Ez polarization at 30 deg onto eps_r=4:
-        n1=1, n2=2, theta_i=30 deg
-        theta_t = arcsin(sin(30)/2) = 14.48 deg
-        R_TE = (cos(30) - 2*cos(14.48)) / (cos(30) + 2*cos(14.48))
-        |R_TE| ≈ 0.382
-
-    The analytic incident field at the TFSF boundary planes carries
-    the oblique phase, so the scattered field probe (outside TFSF box)
-    measures only the reflected component.
+    Extraction (robust, transformed frame): the 3D grid evolves the complex Bloch
+    envelope P.  Accumulate its f0 phasor along x with the CONJUGATE kernel
+    ``exp(+j 2 pi f0 t)`` — P is a complex ANALYTIC signal (~exp(-j 2 pi f0 t)); a
+    ``-j`` kernel yields exp(-j 4 pi f0 t) which integrates to noise (the earlier
+    |R|~=1 artifact).  Two-run subtraction ``dft_slab - dft_vac`` isolates the pure
+    reflected wave; ``|R| = <|reflected|> / <|incident|>`` over the clean vacuum
+    region between the TFSF face and the slab.  A pure incident traveling wave has a
+    FLAT ``|amplitude|`` plateau — the extractor's known-good witness.
     """
-    eps_r_val = 4.0
-    n1, n2 = 1.0, np.sqrt(eps_r_val)
-    theta_deg = 30.0
-    theta_i = np.radians(theta_deg)
-    theta_t = np.arcsin(n1 / n2 * np.sin(theta_i))
-    R_te = (n1 * np.cos(theta_i) - n2 * np.cos(theta_t)) / \
-           (n1 * np.cos(theta_i) + n2 * np.cos(theta_t))
-    R_analytic = abs(R_te)
-
-    # Use a larger transverse domain for oblique (beam tilts in y)
-    grid = Grid(freq_max=10e9, domain=(0.60, 0.12, 0.006),
-                dx=0.002, cpml_layers=10)
-    dt, dx = grid.dt, grid.dx
-    nc = grid.cpml_layers
-    periodic = (False, True, True)
-
-    tfsf_cfg, tfsf_st = init_tfsf(
-        grid.nx, dx, dt, cpml_layers=nc, tfsf_margin=5,
-        f0=5e9, bandwidth=0.3, amplitude=1.0,
-        polarization="ez", angle_deg=theta_deg,
-        ny=grid.ny,
+    from rfx.sources.tfsf_2d import (
+        update_tfsf_2d_h, update_tfsf_2d_e, bloch_phase_tuple,
     )
+    grid = Grid(freq_max=10e9, domain=(0.60, 0.12, 0.006), dx=0.002, cpml_layers=10)
+    dt, dx = grid.dt, grid.dx
+    periodic = (False, True, True)
+    f0 = 5e9
+    cfg, aux0 = init_tfsf(grid.nx, dx, dt, cpml_layers=grid.cpml_layers,
+                          tfsf_margin=5, f0=f0, bandwidth=bw, amplitude=1.0,
+                          polarization="ez", angle_deg=theta_deg, ny=grid.ny)
+    assert is_tfsf_2d(cfg)
+    bloch = bloch_phase_tuple(cfg, dx)
+    x_iface = grid.nx // 4
+    x_diel_end = cfg.x_hi - 10
+    jy, kz = grid.ny // 2, grid.nz // 2
+    slab_thick = (x_diel_end - x_iface) * dx
+    t_safe = (x_iface - cfg.x_lo) * dx / C0 + 2 * slab_thick / (C0 / np.sqrt(eps_r_val))
+    n_steps = max(min(int(t_safe / dt) - 50, 1500), 900)
 
-    # Detect 2D auxiliary grid for oblique incidence
-    _is_2d = is_tfsf_2d(tfsf_cfg)
-    if _is_2d:
-        from rfx.sources.tfsf_2d import update_tfsf_2d_h, update_tfsf_2d_e
-
-    def _update_aux_h(cfg, st):
-        if _is_2d:
-            return update_tfsf_2d_h(cfg, st, dx, dt)
-        return update_tfsf_1d_h(cfg, st, dx, dt)
-
-    def _update_aux_e(cfg, st, t_val):
-        if _is_2d:
-            return update_tfsf_2d_e(cfg, st, dx, dt, t_val)
-        return update_tfsf_1d_e(cfg, st, dx, dt, t_val)
-
-    # Dielectric slab well inside TFSF box
-    x_interface = grid.nx // 4
-    x_diel_end = tfsf_cfg.x_hi - 10
-
-    # Probe in scattered-field region
-    probe_x = tfsf_cfg.x_lo - 3
-    probe = (probe_x, grid.ny // 2, grid.nz // 2)
-
-    # For the incident reference, use a separate clean run without dielectric
-    # (since oblique TFSF uses 2D aux grid for dispersion matching)
-
-    # Avoid back-face reflection
-    slab_thick = (x_diel_end - x_interface) * dx
-    t_backface = (2 * slab_thick) / (C0 / np.sqrt(eps_r_val))
-    t_front = (x_interface - tfsf_cfg.x_lo) * dx / C0
-    t_safe = t_front + t_backface
-    n_steps = min(int(t_safe / dt) - 50, 1500)
-    n_steps = max(n_steps, 600)
-
-    def run_tfsf_sim(eps_slab):
-        """Run TFSF sim with given slab permittivity, return Ez at probe."""
+    def one(eps_slab, want_angle=False):
         mat = init_materials(grid.shape)
-        mat = mat._replace(
-            eps_r=mat.eps_r.at[x_interface:x_diel_end, :, :].set(eps_slab)
-        )
-        state = init_state(grid.shape)
+        if eps_slab > 1:
+            mat = mat._replace(
+                eps_r=mat.eps_r.at[x_iface:x_diel_end, :, :].set(eps_slab))
+        st = init_state(grid.shape, field_dtype=jnp.complex64)
         cp, cs = init_cpml(grid)
-        tfsf_state = tfsf_st
-
-        ts = np.zeros(n_steps)
+        aux = aux0
+        dft = np.zeros(grid.nx, np.complex128)
+        yph = np.exp(-1j * cfg.k_transverse * (np.arange(grid.ny) * dx))
+        Sx = Sy = 0.0
         for step in range(n_steps):
             t = step * dt
-            state = update_h(state, mat, dt, dx, periodic)
-            state = apply_tfsf_h(state, tfsf_cfg, tfsf_state, dx, dt)
-            state, cs = apply_cpml_h(state, cp, cs, grid, axes="x")
-            tfsf_state = _update_aux_h(tfsf_cfg, tfsf_state)
+            st = update_h(st, mat, dt, dx, periodic=periodic, bloch=bloch)
+            st = apply_tfsf_h(st, cfg, aux, dx, dt)
+            st, cs = apply_cpml_h(st, cp, cs, grid, axes="x")
+            aux = update_tfsf_2d_h(cfg, aux, dx, dt)
+            st = update_e(st, mat, dt, dx, periodic=periodic, bloch=bloch)
+            st = apply_tfsf_e(st, cfg, aux, dx, dt)
+            st, cs = apply_cpml_e(st, cp, cs, grid, axes="x")
+            aux = update_tfsf_2d_e(cfg, aux, dx, dt, t)
+            dft += np.asarray(st.ez[:, jy, kz]) * np.exp(1j * 2 * np.pi * f0 * t) * dt
+            if want_angle and step >= n_steps // 3:
+                xl, xh = cfg.x_lo + 20, x_iface - 15
+                ez = np.asarray(st.ez[xl:xh, :, kz]) * yph[None, :]
+                hx = np.asarray(st.hx[xl:xh, :, kz]) * yph[None, :]
+                hy = np.asarray(st.hy[xl:xh, :, kz]) * yph[None, :]
+                Sx += float(np.sum(-ez.real * hy.real))
+                Sy += float(np.sum(ez.real * hx.real))
+        ang = np.degrees(np.arctan2(Sy, Sx)) if want_angle else None
+        return dft, ang
 
-            state = update_e(state, mat, dt, dx, periodic)
-            state = apply_tfsf_e(state, tfsf_cfg, tfsf_state, dx, dt)
-            state, cs = apply_cpml_e(state, cp, cs, grid, axes="x")
-            tfsf_state = _update_aux_e(tfsf_cfg, tfsf_state, t)
-
-            ts[step] = float(state.ez[probe])
-
-        return ts
-
-    # Run with dielectric slab (reflected = scattered probe signal)
-    ts_scat = run_tfsf_sim(eps_r_val)
-
-    # Run without dielectric (incident reference — should be ~0 in scattered region)
-    ts_ref_vacuum = run_tfsf_sim(1.0)
-
-    # For incident normalization, run with dielectric and probe INSIDE total-field region
-    # The total field = incident + scattered; in the forward direction the incident dominates
-    probe_inc = (tfsf_cfg.x_lo + 5, grid.ny // 2, grid.nz // 2)
-    mat_vac = init_materials(grid.shape)
-    state = init_state(grid.shape)
-    cp, cs = init_cpml(grid)
-    tfsf_state = tfsf_st
-    ts_inc = np.zeros(n_steps)
-    for step in range(n_steps):
-        t = step * dt
-        state = update_h(state, mat_vac, dt, dx, periodic)
-        state = apply_tfsf_h(state, tfsf_cfg, tfsf_state, dx, dt)
-        state, cs = apply_cpml_h(state, cp, cs, grid, axes="x")
-        tfsf_state = _update_aux_h(tfsf_cfg, tfsf_state)
-        state = update_e(state, mat_vac, dt, dx, periodic)
-        state = apply_tfsf_e(state, tfsf_cfg, tfsf_state, dx, dt)
-        state, cs = apply_cpml_e(state, cp, cs, grid, axes="x")
-        tfsf_state = _update_aux_e(tfsf_cfg, tfsf_state, t)
-        ts_inc[step] = float(state.ez[probe_inc])
-
-    assert not np.any(np.isnan(ts_scat)), "NaN in oblique TFSF simulation"
-    assert np.max(np.abs(ts_scat)) > 1e-10, "No scattered field detected"
-
-    # Verify vacuum TFSF leakage is small
-    leak = np.max(np.abs(ts_ref_vacuum)) / np.max(np.abs(ts_inc))
-    print(f"\n  TFSF vacuum leakage: {leak:.4e}")
-    assert leak < 0.05, f"TFSF leakage too large: {leak:.4e}"
-
-    # Spectral reflection coefficient
-    freqs = np.fft.rfftfreq(n_steps, d=dt)
-    spec_inc = np.abs(np.fft.rfft(ts_inc))
-    spec_scat = np.abs(np.fft.rfft(ts_scat))
-
-    band = (freqs > 3e9) & (freqs < 7e9)
-    R_num = spec_scat[band] / np.maximum(spec_inc[band], 1e-30)
-    R_mean = np.mean(R_num)
-
-    print(f"\nOblique TFSF Fresnel (theta={theta_deg}°, eps_r={eps_r_val}):")
-    print(f"  Analytic |R_TE|: {R_analytic:.4f}")
-    print(f"  Numerical |R|:   {R_mean:.4f}")
-    print(f"  Error: {abs(R_mean - R_analytic) / R_analytic * 100:.1f}%")
-
-    # Allow 30% tolerance — diagnosed as a probe normalization artifact,
-    # NOT a 2D auxiliary grid physics error.
-    #
-    # Root cause (see tests/test_fresnel_investigation.py):
-    #   The scattered-field probe sits at x_lo-3 while the incident-field
-    #   normalization probe sits at x_lo+5.  For oblique incidence the
-    #   transverse phase front shifts between these x-positions, so the
-    #   spectral ratio at a single y-cell depends on which phase of the
-    #   oblique wavefront is sampled.  Per-y-cell analysis shows that the
-    #   best-aligned cell matches analytic |R_TE| to ~2.6%, confirming the
-    #   2D aux grid amplitude and Fresnel physics are correct.
-    #
-    # The max-over-y incident amplitude ratio (oblique/normal) is 1.02,
-    # proving the 2D grid preserves plane-wave amplitude.
-    #
-    # Tightening this tolerance would require either:
-    #   (a) matching scattered/incident probe x-positions (not possible
-    #       with TFSF: one must be inside, one outside the box), or
-    #   (b) a DFT plane probe with oblique phase de-rotation.
-    assert abs(R_mean - R_analytic) / R_analytic < 0.35, \
-        f"Oblique TFSF Fresnel error {abs(R_mean - R_analytic)/R_analytic*100:.1f}% exceeds 35%"
+    dft_vac, ang = one(1.0, want_angle=True)
+    dft_slab, _ = one(eps_r_val)
+    a, b = cfg.x_lo + 8, x_iface - 12
+    inc = np.abs(dft_vac[a:b])
+    refl = np.abs(dft_slab[a:b] - dft_vac[a:b])
+    flatness = float(inc.std() / max(inc.mean(), 1e-30))
+    R = float(refl.mean()) / max(float(inc.mean()), 1e-30)
+    return R, float(ang), flatness
 
 
-# =========================================================================
-# Test 4: Oblique TFSF Fresnel via DFT plane probe with per-cell spectral ratio
-# =========================================================================
+@pytest.mark.slow
+def test_oblique_tfsf_fresnel():
+    """Oblique TFSF (30 deg) reflection matches analytic Fresnel |R_TE| (#404 Phase-B).
 
-def test_oblique_tfsf_fresnel_plane_dft():
-    """Fresnel coefficient via multi-frequency DFT plane probe.
-
-    Uses the same oblique TFSF setup as test_oblique_tfsf_fresnel, but
-    instead of a single-point probe, records Ez on entire yz-planes at
-    the scattered and incident probe x-positions using DFT plane probes
-    at multiple frequencies spanning the excitation band.
-
-    The extraction computes per-cell spectral magnitude ratios
-    |E_scat(y,f)| / |E_inc(y,f)|, averages over the frequency band
-    per cell, then takes the median over y-cells.  This is robust to
-    the oblique phase-front mismatch that causes ~28% error with
-    single-point probes.
-
-    Validated by tests/test_fresnel_investigation.py which showed
-    per-cell spectral ratios match analytic |R_TE| to ~2.6% for the
-    best-illuminated cells.
-
-    Same VALIDATED-SCOPE caveat as ``test_oblique_tfsf_fresnel`` (issue #397):
-    at 30 deg / eps_r=4 the oblique and normal-incidence |R| are only 12.7%
-    apart (below this 15% gate), so a passing result confirms the 2D-aux path
-    runs and yields a physical-magnitude |R| but does NOT establish oblique-
-    angle accuracy (the 60 deg extraction lands near normal, ~33% off analytic).
+    With the transformed complex Bloch frame the 2D-aux oblique injection produces a
+    correctly-tilted plane wave (validated angle + machine-clean TFSF leakage), so
+    |R| now tracks the analytic TE Fresnel coefficient — the oblique-ANGLE accuracy
+    that the pre-#404 path could NOT reproduce (it measured ~normal-incidence |R|;
+    the old single-point/best-aligned extractors were oracle-fitted, giving 1.14 at
+    60 deg).  |R| is compared to R_TE at the MEASURED injected angle to separate
+    reflection accuracy from the small numerical-dispersion angle deficit; the
+    incident-plateau flatness is the extractor known-good.
     """
     eps_r_val = 4.0
     theta_deg = 30.0
-    R_analytic = fresnel_r_te(theta_deg, eps_r_val)
-    f0 = 5e9
+    R, inj_angle, flatness = _run_oblique_fresnel(theta_deg, eps_r_val)
+    R_at_injected = fresnel_r_te(inj_angle, eps_r_val)
+    R_at_request = fresnel_r_te(theta_deg, eps_r_val)
+    print(f"\nOblique TFSF Fresnel (req {theta_deg} deg, injected {inj_angle:.1f} deg,"
+          f" eps_r={eps_r_val}):")
+    print(f"  |R|={R:.4f}  R_TE@injected={R_at_injected:.4f}  "
+          f"R_TE@request={R_at_request:.4f}  flatness={flatness:.4f}")
+    assert flatness < 0.05, \
+        f"incident plateau not flat ({flatness:.3f}); |R| extractor unreliable"
+    assert abs(inj_angle - theta_deg) < 8.0, \
+        f"injected angle {inj_angle:.1f} far from requested {theta_deg}"
+    err = abs(R - R_at_injected) / R_at_injected
+    assert err < 0.12, (f"oblique |R|={R:.3f} vs analytic {R_at_injected:.3f} "
+                        f"(injected {inj_angle:.1f} deg) err {err*100:.1f}% > 12%")
 
-    # Grid setup (same as test_oblique_tfsf_fresnel)
-    grid = Grid(freq_max=10e9, domain=(0.60, 0.12, 0.006),
-                dx=0.002, cpml_layers=10)
-    dt, dx = grid.dt, grid.dx
-    nc = grid.cpml_layers
-    periodic = (False, True, True)
 
-    tfsf_cfg, tfsf_st = init_tfsf(
-        grid.nx, dx, dt, cpml_layers=nc, tfsf_margin=5,
-        f0=f0, bandwidth=0.3, amplitude=1.0,
-        polarization="ez", angle_deg=theta_deg,
-        ny=grid.ny,
-    )
+# =========================================================================
+# Test 4: Oblique Fresnel accuracy at a second angle (45 deg)
+# =========================================================================
 
-    _is_2d = is_tfsf_2d(tfsf_cfg)
-    if _is_2d:
-        from rfx.sources.tfsf_2d import update_tfsf_2d_h, update_tfsf_2d_e
+@pytest.mark.slow
+def test_oblique_tfsf_fresnel_45deg():
+    """Second-angle oblique Fresnel accuracy (45 deg) via the transformed Bloch path.
 
-    def _update_aux_h(cfg, st):
-        if _is_2d:
-            return update_tfsf_2d_h(cfg, st, dx, dt)
-        return update_tfsf_1d_h(cfg, st, dx, dt)
-
-    def _update_aux_e(cfg, st, t_val):
-        if _is_2d:
-            return update_tfsf_2d_e(cfg, st, dx, dt, t_val)
-        return update_tfsf_1d_e(cfg, st, dx, dt, t_val)
-
-    # Dielectric slab inside TFSF box
-    x_interface = grid.nx // 4
-    x_diel_end = tfsf_cfg.x_hi - 10
-
-    # Probe x-positions: scattered (outside TFSF) and incident (inside, vacuum run)
-    scat_probe_x = tfsf_cfg.x_lo - 3
-    inc_probe_x = tfsf_cfg.x_lo + 5
-
-    # Multi-frequency DFT: 20 frequencies spanning the 3-7 GHz band
-    dft_freqs = jnp.linspace(3e9, 7e9, 20, dtype=jnp.float32)
-
-    # Time limit to avoid back-face reflection
-    slab_thick = (x_diel_end - x_interface) * dx
-    t_backface = (2 * slab_thick) / (C0 / np.sqrt(eps_r_val))
-    t_front = (x_interface - tfsf_cfg.x_lo) * dx / C0
-    t_safe = t_front + t_backface
-    n_steps = min(int(t_safe / dt) - 50, 1500)
-    n_steps = max(n_steps, 600)
-
-    # --- Scattered-field simulation (with dielectric) ---
-    scat_plane = init_dft_plane_probe(
-        axis=0, index=scat_probe_x, component="ez",
-        freqs=dft_freqs, grid_shape=grid.shape,
-    )
-
-    mat = init_materials(grid.shape)
-    mat = mat._replace(
-        eps_r=mat.eps_r.at[x_interface:x_diel_end, :, :].set(eps_r_val)
-    )
-    state = init_state(grid.shape)
-    cp, cs = init_cpml(grid)
-    tfsf_state = tfsf_st
-
-    for step in range(n_steps):
-        t = step * dt
-        state = update_h(state, mat, dt, dx, periodic)
-        state = apply_tfsf_h(state, tfsf_cfg, tfsf_state, dx, dt)
-        state, cs = apply_cpml_h(state, cp, cs, grid, axes="x")
-        tfsf_state = _update_aux_h(tfsf_cfg, tfsf_state)
-
-        state = update_e(state, mat, dt, dx, periodic)
-        state = apply_tfsf_e(state, tfsf_cfg, tfsf_state, dx, dt)
-        state, cs = apply_cpml_e(state, cp, cs, grid, axes="x")
-        tfsf_state = _update_aux_e(tfsf_cfg, tfsf_state, t)
-
-        scat_plane = update_dft_plane_probe(scat_plane, state, dt)
-
-    # --- Incident reference simulation (vacuum, probe inside total-field) ---
-    inc_plane = init_dft_plane_probe(
-        axis=0, index=inc_probe_x, component="ez",
-        freqs=dft_freqs, grid_shape=grid.shape,
-    )
-
-    mat_vac = init_materials(grid.shape)
-    state = init_state(grid.shape)
-    cp, cs = init_cpml(grid)
-    tfsf_state = tfsf_st
-
-    for step in range(n_steps):
-        t = step * dt
-        state = update_h(state, mat_vac, dt, dx, periodic)
-        state = apply_tfsf_h(state, tfsf_cfg, tfsf_state, dx, dt)
-        state, cs = apply_cpml_h(state, cp, cs, grid, axes="x")
-        tfsf_state = _update_aux_h(tfsf_cfg, tfsf_state)
-
-        state = update_e(state, mat_vac, dt, dx, periodic)
-        state = apply_tfsf_e(state, tfsf_cfg, tfsf_state, dx, dt)
-        state, cs = apply_cpml_e(state, cp, cs, grid, axes="x")
-        tfsf_state = _update_aux_e(tfsf_cfg, tfsf_state, t)
-
-        inc_plane = update_dft_plane_probe(inc_plane, state, dt)
-
-    # --- Extract Fresnel coefficient via per-cell spectral ratio ---
-    # DFT plane accumulator shape: (n_freqs, ny, nz) for axis=0
-    #
-    # The "best_aligned" method selects well-illuminated cells (top 50%
-    # by incident power) and takes the minimum per-cell ratio.  For
-    # oblique TFSF with non-commensurate periodic domains, the per-cell
-    # ratio oscillates sinusoidally: the minimum corresponds to the cell
-    # where scattered/incident phase fronts are most aligned, giving
-    # the true |R|.  This was validated in test_fresnel_investigation.py
-    # (best per-cell matches analytic to ~2.6%).
-    R_aligned = extract_fresnel_from_planes(
-        scat_plane.accumulator, inc_plane.accumulator,
-        dft_freqs, freq_range=(3e9, 7e9), method="best_aligned",
-    )
-    R_bright = extract_fresnel_from_planes(
-        scat_plane.accumulator, inc_plane.accumulator,
-        dft_freqs, freq_range=(3e9, 7e9), method="bright_min",
-    )
-
-    err_aligned = abs(R_aligned - R_analytic) / R_analytic * 100
-    err_bright = abs(R_bright - R_analytic) / R_analytic * 100
-
-    print("\nOblique TFSF Fresnel — Multi-freq DFT Plane Probe:")
-    print(f"  theta = {theta_deg} deg, eps_r = {eps_r_val}")
-    print(f"  Analytic |R_TE|:       {R_analytic:.4f}")
-    print(f"  Best-aligned |R|:      {R_aligned:.4f}  (error {err_aligned:.1f}%)")
-    print(f"  Bright-min |R|:        {R_bright:.4f}  (error {err_bright:.1f}%)")
-    print("  (Single-point reference: ~28% error)")
-
-    assert R_aligned > 0.01, "DFT plane probe detected no reflection"
-    assert not np.isnan(R_aligned), "NaN in plane DFT Fresnel computation"
-
-    # Gate on the PRIMARY 'best_aligned' extractor DECLARED up front — not on
-    # whichever of {best_aligned, bright_min} happens to land closest to the
-    # analytic target. The old `min(..., key=|r - R_analytic|)` fit the
-    # estimator to the oracle: a run where the physical method drifted but the
-    # other method coincidentally matched would still pass. `best_aligned` is
-    # the method validated in test_fresnel_investigation.py (per-cell
-    # phase-aligned ratio ~2.6% on the best cells); it measures ~7.7% here
-    # (baseline 2026-07-20), well inside the 15% oblique-DFT envelope while a
-    # broken 2D-aux injection (wrong amplitude/angle) pushes it out. `R_bright`
-    # is kept as a printed diagnostic only.
-    assert err_aligned < 15.0, (
-        f"Oblique best-aligned Fresnel error {err_aligned:.1f}% exceeds 15% "
-        f"(R_aligned={R_aligned:.4f} vs analytic {R_analytic:.4f}); "
-        f"bright-min diagnostic={R_bright:.4f} ({err_bright:.1f}%)"
-    )
+    An independent angle point for the #404 |R| accuracy gate.  Replaces the former
+    plane-DFT ``best_aligned`` test, whose ``np.min``-over-cells extractor was
+    oracle-fitted (matched analytic at 30 deg by truncation coincidence, 1.14 at
+    60 deg).  Same robust two-run plateau extraction on the complex envelope.
+    """
+    eps_r_val = 4.0
+    theta_deg = 45.0
+    R, inj_angle, flatness = _run_oblique_fresnel(theta_deg, eps_r_val)
+    R_at_injected = fresnel_r_te(inj_angle, eps_r_val)
+    print(f"\nOblique TFSF Fresnel 45deg (injected {inj_angle:.1f} deg): |R|={R:.4f}"
+          f"  R_TE@injected={R_at_injected:.4f}  flatness={flatness:.4f}")
+    assert flatness < 0.06, f"incident plateau not flat ({flatness:.3f})"
+    assert abs(inj_angle - theta_deg) < 10.0, \
+        f"injected angle {inj_angle:.1f} far from requested {theta_deg}"
+    err = abs(R - R_at_injected) / R_at_injected
+    assert err < 0.15, (f"45deg oblique |R|={R:.3f} vs analytic {R_at_injected:.3f} "
+                        f"err {err*100:.1f}% > 15%")

--- a/tests/test_yee_bloch_complex_path.py
+++ b/tests/test_yee_bloch_complex_path.py
@@ -151,6 +151,45 @@ def test_oblique_injection_angle_tracks_request():
         assert ys < 1e-3, f"{req}deg envelope not y-uniform (yStd={ys:.1e})"
 
 
+def test_bloch_path_is_differentiable():
+    """AD gate (#404 new numerics path — hard constraint): jax.grad w.r.t. a
+    material permittivity flows FINITE and NONZERO through the complex+Bloch
+    update_e/h path, so oblique-periodic scattering is usable for inverse design.
+    """
+    from rfx.core.yee import init_state, init_materials
+    nx, ny = 80, 16
+    shape = (nx, ny, 1)
+    dx = 0.002
+    dt = 0.5 * dx / C0
+    f0 = 5e9
+    k0 = 2 * np.pi * f0 / C0
+    kY = -k0 * np.sin(np.radians(45.0))
+    bloch = (1.0 + 0j, complex(np.exp(-1j * kY * dx)), 1.0 + 0j)
+    per = (False, True, True)
+    tau = 1.0 / (np.pi * f0 * 0.15)
+    t0 = 5 * tau
+
+    def obj(eps_slab):
+        mat = init_materials(shape)
+        mat = mat._replace(eps_r=mat.eps_r.at[nx // 2:, :, :].set(eps_slab))
+        st = init_state(shape, field_dtype=jnp.complex64)
+
+        def body(st, step):
+            t = step * dt
+            st = update_h(st, mat, dt, dx, periodic=per, bloch=bloch)
+            st = update_e(st, mat, dt, dx, periodic=per, bloch=bloch)
+            src = jnp.exp(-1j * 2 * jnp.pi * f0 * (t - t0)) * jnp.exp(-((t - t0) / tau) ** 2)
+            st = st._replace(ez=st.ez.at[20, :, 0].add(src.astype(jnp.complex64)))
+            return st, None
+
+        st, _ = jax.lax.scan(body, st, jnp.arange(300))
+        return jnp.sum(jnp.abs(st.ez[nx // 2 - 10:nx // 2, :, 0]) ** 2).real
+
+    g = jax.grad(obj)(4.0)
+    assert np.isfinite(g), f"grad not finite: {g}"
+    assert abs(float(g)) > 0.0, "grad is zero through the complex Bloch path"
+
+
 def test_oblique_injection_angle_domain_size_invariant():
     """The fix is domain-size INVARIANT (the broken plain-periodic baseline swung
     46.9->57.6deg with transverse size). A correct Bloch BC gives the same angle

--- a/tests/test_yee_bloch_complex_path.py
+++ b/tests/test_yee_bloch_complex_path.py
@@ -1,0 +1,160 @@
+"""Bit-identity / correctness gates for the #404 Phase-B complex+Bloch yee path.
+
+The oblique-periodic Bloch field-transformation adds an OPT-IN complex path to
+``update_e``/``update_h`` (a per-axis ``bloch`` phase on the periodic rolls).
+The real path MUST stay byte-identical and the complex path MUST reduce to the
+real path at zero transverse wavenumber (bloch phase = 1).  These gates pin that
+contract so a future edit cannot silently perturb the real solver.
+"""
+import numpy as np
+import jax
+import jax.numpy as jnp
+import pytest
+
+from rfx.core.yee import (
+    FDTDState, MaterialArrays, update_e, update_h, EPS_0, MU_0,
+)
+
+C0 = 1.0 / np.sqrt(EPS_0 * MU_0)
+SHAPE = (16, 12, 10)
+
+
+def _state(dtype):
+    k = jax.random.split(jax.random.PRNGKey(404), 6)
+    r = lambda i: jax.random.normal(k[i], SHAPE, dtype=jnp.float32).astype(dtype)
+    return FDTDState(ex=r(0), ey=r(1), ez=r(2), hx=r(3), hy=r(4), hz=r(5),
+                     step=jnp.array(0, jnp.int32))
+
+
+def _materials():
+    k = jax.random.split(jax.random.PRNGKey(99), 2)
+    eps_r = 1.0 + 3.0 * jax.random.uniform(k[0], SHAPE, dtype=jnp.float32)
+    sigma = 0.01 * jax.random.uniform(k[1], SHAPE, dtype=jnp.float32)
+    return MaterialArrays(eps_r=eps_r, sigma=sigma,
+                          mu_r=jnp.ones(SHAPE, jnp.float32))
+
+
+DX = 0.002
+DT = 0.5 * DX / C0
+
+
+@pytest.mark.parametrize("periodic", [(False, False, False),
+                                      (False, True, True),
+                                      (True, True, True)])
+@pytest.mark.parametrize("order", [2, 4])
+def test_real_path_unaffected_by_new_signature(periodic, order):
+    """bloch=None (default) leaves the real float32 path byte-identical: the
+    added parameter and complex-aware dtype must not perturb the default call."""
+    mat = _materials()
+    st_a = _state(jnp.float32)
+    st_b = _state(jnp.float32)
+    for _ in range(6):
+        st_a = update_h(st_a, mat, DT, DX, periodic=periodic, stencil_order=order)
+        st_a = update_e(st_a, mat, DT, DX, periodic=periodic, stencil_order=order)
+        # explicit bloch=None must be identical to omitting it
+        st_b = update_h(st_b, mat, DT, DX, periodic=periodic, stencil_order=order,
+                        bloch=None)
+        st_b = update_e(st_b, mat, DT, DX, periodic=periodic, stencil_order=order,
+                        bloch=None)
+    for f in ("ex", "ey", "ez", "hx", "hy", "hz"):
+        assert np.array_equal(np.asarray(getattr(st_a, f)),
+                              np.asarray(getattr(st_b, f)))
+
+
+@pytest.mark.parametrize("periodic", [(False, True, True), (True, True, True)])
+def test_complex_zero_bloch_reduces_to_real(periodic):
+    """Complex fields with a unit Bloch phase (k=0) reproduce the real path in
+    their real part (the complex path is a strict superset at zero wavenumber)."""
+    mat = _materials()
+    st_r = _state(jnp.float32)
+    st_c = _state(jnp.complex64)
+    bloch = (1.0 + 0j, 1.0 + 0j, 1.0 + 0j)
+    for _ in range(6):
+        st_r = update_h(st_r, mat, DT, DX, periodic=periodic)
+        st_r = update_e(st_r, mat, DT, DX, periodic=periodic)
+        st_c = update_h(st_c, mat, DT, DX, periodic=periodic, bloch=bloch)
+        st_c = update_e(st_c, mat, DT, DX, periodic=periodic, bloch=bloch)
+    for f in ("ex", "ey", "ez", "hx", "hy", "hz"):
+        r = np.asarray(getattr(st_r, f))
+        c = np.asarray(getattr(st_c, f))
+        # ~1e-4 (not bit-level): complex64 real-channel arithmetic fuses/rounds
+        # differently from float32 (FMA/op-ordering), so the numerical reduction
+        # drifts ~1e-5 rel over 6 steps. The BYTE-identity gate is the real-path
+        # test above; this checks the complex path REDUCES to the real physics.
+        scale = max(float(np.max(np.abs(r))), 1.0)
+        assert np.allclose(r, c.real, rtol=2e-4, atol=1e-4 * scale), f
+        assert np.max(np.abs(c.imag)) < 1e-4 * scale, f"{f}: unit bloch leaked into imag"
+
+
+@pytest.mark.parametrize("fn", [update_e, update_h])
+def test_bloch_requires_order2(fn):
+    """A non-trivial Bloch phase with a 4th-order stencil is fail-loud (the wide
+    stencil's far rolls need their own phase, not implemented)."""
+    mat = _materials()
+    st = _state(jnp.complex64)
+    with pytest.raises(ValueError, match="stencil_order=2"):
+        fn(st, mat, DT, DX, periodic=(False, True, True), stencil_order=4,
+           bloch=(1.0 + 0j, 1.0 + 0.5j, 1.0 + 0j))
+
+
+def _kernel_prop_angle(theta_deg, ny=16, nx=600):
+    """Injected Poynting angle from the REAL update_e/h complex+Bloch path.
+
+    CPML-FREE, soft-source, measured in a clean interior window ahead of the
+    source before any x-boundary reflection — the trustworthy injection-angle
+    witness for #404 (the in-rfx CPML-terminated path contaminates steep angles
+    via imperfect absorption; see the Phase-B session findings)."""
+    from rfx.core.yee import init_state, init_materials
+    shape = (nx, ny, 1)
+    mat = init_materials(shape)
+    f0 = 5e9
+    k0 = 2 * np.pi * f0 / C0
+    dx = 0.002
+    dt = 0.5 * dx / C0
+    tau = 1.0 / (np.pi * f0 * 0.3)
+    t0 = 5 * tau
+    kY = -k0 * np.sin(np.radians(theta_deg))
+    bloch = (1.0 + 0j, complex(np.exp(-1j * kY * dx)), 1.0 + 0j)
+    st = init_state(shape, field_dtype=jnp.complex64)
+    yph = np.exp(-1j * kY * np.arange(ny) * dx)
+    src_x = 60
+    xl, xh = src_x + 60, src_x + 220
+    Sx = Sy = 0.0
+    for step in range(700):
+        t = step * dt
+        st = update_h(st, mat, dt, dx, periodic=(False, True, True), bloch=bloch)
+        st = update_e(st, mat, dt, dx, periodic=(False, True, True), bloch=bloch)
+        src = np.exp(-1j * 2 * np.pi * f0 * (t - t0)) * np.exp(-((t - t0) / tau) ** 2)
+        st = st._replace(ez=st.ez.at[src_x, :, 0].add(complex(src)))
+        if step >= 700 // 3:
+            ez = np.asarray(st.ez[xl:xh, :, 0]) * yph[None, :]
+            hx = np.asarray(st.hx[xl:xh, :, 0]) * yph[None, :]
+            hy = np.asarray(st.hy[xl:xh, :, 0]) * yph[None, :]
+            Sx += float(np.sum(-ez.real * hy.real))
+            Sy += float(np.sum(ez.real * hx.real))
+    # y-uniformity witness (Snell k_y conservation ⇒ envelope P uniform in y)
+    ezw = np.abs(np.asarray(st.ez[xl:xh, :, 0]))
+    ystd = float(ezw.std(axis=1).mean() / max(ezw.mean(), 1e-30))
+    return np.degrees(np.arctan2(Sy, Sx)), ystd
+
+
+def test_oblique_injection_angle_tracks_request():
+    """#404 core gate: the injected wave propagates at the REQUESTED oblique angle
+    (the original bug injected ~0.4x, e.g. 60deg->25deg). Normal is the known-good
+    (theta~0, Sx>0); 30/45/60 track within a numerical-dispersion margin (the ~5deg
+    deficit at 60deg is dx=lambda/30 dispersion, not the gross under-tilt bug)."""
+    a0, ys0 = _kernel_prop_angle(0.0)
+    assert abs(a0) < 5.0, f"normal incidence must flow along +x, got {a0:.1f}"
+    for req, lo, hi in [(30.0, 27.0, 33.0), (45.0, 41.0, 49.0), (60.0, 51.0, 62.0)]:
+        a, ys = _kernel_prop_angle(req)
+        assert lo < a < hi, f"{req}deg injected angle {a:.1f} outside [{lo},{hi}]"
+        assert ys < 1e-3, f"{req}deg envelope not y-uniform (yStd={ys:.1e})"
+
+
+def test_oblique_injection_angle_domain_size_invariant():
+    """The fix is domain-size INVARIANT (the broken plain-periodic baseline swung
+    46.9->57.6deg with transverse size). A correct Bloch BC gives the same angle
+    for commensurate and non-commensurate transverse periods."""
+    angles = [_kernel_prop_angle(60.0, ny=ny)[0] for ny in (12, 16, 24, 40)]
+    spread = max(angles) - min(angles)
+    assert spread < 2.0, f"60deg angle varies {spread:.1f}deg across ny (should be ~0): {angles}"


### PR DESCRIPTION
## Summary

Resolves **#404** (oblique-incidence TFSF injects the wrong propagation angle). Phase-A (`d3e4a64`) fixed the 2D-auxiliary injection, but the 3D grid's plain-periodic-y boundary — a phase-free `jnp.roll` — could not sustain a non-commensurate transverse wavenumber and pulled steep angles back toward normal (60° → ~25–47°, domain-size-dependent, bandwidth-invariant).

**Fix:** the shared 3D solver now optionally evolves the Bloch-transformed field envelope `P` directly (physical field `= Re(P·e^{-j k_y y})`), on an **opt-in complex path**:

- `rfx/core/yee.py` — `update_e/h` gain an optional per-axis `bloch` phase `e^{-j k_axis dx}` on the periodic rolls (backward difference uses its conjugate) plus a complex-aware compute dtype. **The real path (`bloch=None`, real fields) is byte-identical.** Order-2 only (fail-loud guard for the wide stencil).
- `rfx/sources/tfsf_2d.py` — `apply_tfsf_2d_e/h` inject the aux envelope `P` directly when the 3D grid is complex (transformed frame), skipping the Phase-A `Re(P·e^{j k_y y})` round-trip a plain-periodic real grid cannot evolve. Adds `bloch_phase_tuple()`.

## Validation (pre-declared falsifier order)

| gate | result |
|---|---|
| real-path bit-identity | 30/30 arrays byte-identical |
| injected angle, non-commensurate periodic-y | 30/45/60° → 31/46/55°, **domain-size invariant** (ny=12/16/24/40 all 54.8° vs broken baseline 46.9→57.6) |
| TFSF leakage (ez/ey, ±x, ±angle) | **0.000%** (Phase-A: 2–10%) |
| Fresnel \|R\| vs analytic R_TE | 30° → 2.0%, 45° → 4.7% |
| AD gradient through complex path | finite, nonzero |

Real-path regression (stencil, AD, cavity, physics, normal TFSF) is green.

## Notes / honest caveats

- **The earlier `|R|≈1` was a comparator bug, not the physics.** The aux source is a complex *analytic* envelope `∝e^{-j2πf₀t}`, so its f₀ amplitude needs the **conjugate** DFT kernel `e^{+j2πf₀t}`; a `−j` kernel integrates to noise. Leakage/angle gates were immune (no DFT). The old `np.min` "best-aligned" extractor was oracle-fitted and is retired from the verification gates (replaced by a two-run plateau extractor with incident-flatness as its known-good).
- **60° in-rfx `|R|` is CPML-measurement-limited** — imperfect x-CPML absorption of the steep wave creates a partial standing wave (plateau flatness 0.002→0.044). The CPML-free kernel angle (54.8°, domain-invariant) is the trustworthy witness, so `|R|` is gated at 30/45° and steep-angle physics via the kernel angle + leakage. The residual ~5° at 60° is numerical dispersion at dx=λ/30.
- **Scope:** the #404 acceptance tests hand-roll the FDTD loop, so this closes them without complexifying the production `Simulation.run()` scan body (kept minimal per Correctness>sprawl). `compute_rcs`/open-domain oblique already worked (Phase-A). High-level `Simulation.run()` oblique-periodic support is tracked as a follow-up.

## Tests

New `tests/test_yee_bloch_complex_path.py` (bit-identity, complex→real reduction, order guard, angle-track 30/45/60 + domain-size invariance) runs in the default suite; narrowband oblique leakage (`test_tfsf_oblique*.py`) and Fresnel-`|R|` accuracy (`test_verification.py`) are `@pytest.mark.slow`.

R3: memory=`project_issue404_oblique_tfsf_r2stop.md` (Phase-B is the memory-named fix; supersedes the 2026-07-20 R2-STOP with a validated Poynting comparator + plateau-`|R|` known-good) · R2-attempts=1 (one pre-declared injection attempt; the extractor DFT-sign was a named implementation defect) · falsifier=real-path bit-identity + domain-size-invariant angle gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)