### PR TITLE
feat(forward): differentiable TFSF plane-wave inverse design (#404)

### DIFF
--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -1293,6 +1293,37 @@ class _ExecuteMixin:
         cpml_axes_run = grid.cpml_axes
         pec_axes_run = "".join(a for a in "xyz" if a not in cpml_axes_run)
 
+        # Differentiable TFSF plane-wave (#404): build the 2D/1D-aux TFSF cfg and
+        # force its boundary (transverse-periodic + CPML on the propagation axis),
+        # mirroring rfx/runners/uniform.py. The shared scan (_build_step_setup ->
+        # make_core_step) injects it and auto-activates the complex Bloch path for
+        # oblique (field_dtype -> complex64, per-axis roll phase). Gradients flow
+        # w.r.t. the scatterer materials through the same validated kernel as run().
+        tfsf_run = None
+        if self._tfsf is not None:
+            from rfx.sources.tfsf import init_tfsf as _init_tfsf_fwd
+            tfsf_run = _init_tfsf_fwd(
+                grid.nx, grid.dx, grid.dt,
+                cpml_layers=grid.cpml_layers,
+                tfsf_margin=self._tfsf.margin,
+                f0=self._tfsf.f0 if self._tfsf.f0 is not None else self._freq_max / 2,
+                bandwidth=self._tfsf.bandwidth,
+                amplitude=self._tfsf.amplitude,
+                polarization=self._tfsf.polarization,
+                direction=self._tfsf.direction,
+                angle_deg=self._tfsf.angle_deg,
+                ny=grid.ny,
+                nz=grid.nz,
+                waveform=getattr(self._tfsf, "waveform", "differentiated_gaussian"),
+            )
+            # NOTE: the TFSF vacuum-boundary check runs at forward() entry via
+            # _auto_preflight on the concrete config; it is NOT re-run here because
+            # `materials` may be a jax tracer under jax.grad (eps_override), and the
+            # check concretizes.
+            periodic_bool = (False, True, True)
+            cpml_axes_run = "x"
+            pec_axes_run = ""
+
         # Stage 2 Kottke for AD-traceable PEC density (opt-in via env
         # ``RFX_PEC_OCC_KOTTKE=1``).  When enabled and
         # ── Port-aware Kottke dilation guard (issue #82) ──────────
@@ -1372,6 +1403,7 @@ class _ExecuteMixin:
             cpml_axes=cpml_axes_run,
             pec_axes=pec_axes_run,
             periodic=periodic_bool,
+            tfsf=tfsf_run,
             debye=debye,
             lorentz=lorentz,
             sources=sources,
@@ -2358,22 +2390,6 @@ class _ExecuteMixin:
                 "S11 objectives."
             )
 
-        # TFSF plane-wave sources are not wired into the differentiable forward
-        # path: _forward_from_materials builds sources from lumped/wire ports
-        # only, so a TFSF source would be SILENTLY DROPPED (no injection → zero
-        # gradients — the "TFSF→forward silent-drop" footgun). Fail loud instead.
-        # (The distributed forward path rejects TFSF separately; guard the
-        # single-device path here so both normal and oblique TFSF are surfaced.)
-        if self._tfsf is not None and not distributed:
-            raise NotImplementedError(
-                "TFSF plane-wave sources are not wired into Simulation.forward() "
-                "— the differentiable path builds sources from lumped/wire ports "
-                "only and would silently drop the TFSF source (zero gradients). "
-                "Use run() for TFSF forward simulation (normal or oblique, #404); "
-                "differentiable TFSF/plane-wave inverse design is not yet "
-                "implemented."
-            )
-
         if port_s11_freqs is not None:
             self._validate_forward_sparameter_request()
 
@@ -2405,6 +2421,17 @@ class _ExecuteMixin:
                 "Lumped RLC component-value gradients require the uniform mesh "
                 "path (non-uniform / distributed forward do not process "
                 "add_lumped_rlc elements)."
+            )
+
+        # Differentiable TFSF/plane-wave forward is wired on the uniform
+        # single-device lane only (the shared scan + complex Bloch path, #404).
+        # The non-uniform and distributed forward lanes have no TFSF handling and
+        # would silently drop the source (zero gradients) — fail loud instead.
+        if self._tfsf is not None and plan.lane != "fwd_uniform":
+            raise NotImplementedError(
+                "Differentiable TFSF plane-wave forward is supported only on the "
+                f"uniform single-device forward lane, not {plan.lane!r}. Use a "
+                "uniform mesh + single device for TFSF/plane-wave inverse design."
             )
 
         if plan.lane == "fwd_distributed_nu":

--- a/tests/test_forward_tfsf_differentiable.py
+++ b/tests/test_forward_tfsf_differentiable.py
@@ -1,0 +1,75 @@
+"""Differentiable plane-wave (TFSF) inverse design through Simulation.forward().
+
+#404 wired oblique/normal TFSF into run(); this wires it into the DIFFERENTIABLE
+forward path (_forward_from_materials passes the aux TFSF cfg to the shared scan,
+which auto-activates the complex Bloch path for oblique). Gradients flow w.r.t.
+the scatterer permittivity through the same validated kernel as run().
+
+Previously forward() SILENTLY DROPPED a TFSF source (zero gradients — the
+"TFSF->forward silent-drop" footgun). These gates pin that it now couples AND
+produces a CORRECT gradient (finite-difference check), for normal and oblique.
+"""
+import numpy as np
+import jax
+import jax.numpy as jnp
+import pytest
+
+from rfx.api import Simulation
+
+
+def _sim(angle, waveform, bandwidth):
+    sim = Simulation(freq_max=10e9, domain=(0.3, 0.12, 0.006), dx=0.002,
+                     boundary="cpml", cpml_layers=10, mode="3d")
+    sim.add_tfsf_source(f0=5e9, bandwidth=bandwidth, polarization="ez",
+                        direction="+x", angle_deg=angle, waveform=waveform)
+    sim.add_probe((0.0, 0.0, 0.0), component="ez")  # total-field region (center)
+    return sim
+
+
+def _objective(sim, shp, n_steps, checkpoint=True):
+    xi = shp[0] // 2
+
+    def obj(eps_val):
+        eps = jnp.ones(shp, jnp.float32).at[xi:xi + 15, :, :].set(eps_val)
+        fr = sim.forward(eps_override=eps, n_steps=n_steps, checkpoint=checkpoint,
+                         skip_preflight=True)
+        return jnp.sum(jnp.abs(fr.time_series) ** 2).real
+
+    return obj
+
+
+@pytest.mark.slow
+def test_forward_tfsf_normal_gradient_matches_fd():
+    """forward() couples a normal-incidence TFSF source and returns a CORRECT
+    gradient w.r.t. the scatterer eps (checkpointed path; matches finite diff)."""
+    sim = _sim(0.0, "differentiated_gaussian", 0.5)
+    shp = sim.run(n_steps=1).state.ez.shape
+    obj = _objective(sim, shp, n_steps=600, checkpoint=True)
+
+    val = float(obj(4.0))
+    assert val > 1e-3, f"TFSF source did not couple (obj={val:.2e})"
+
+    g = float(jax.grad(obj)(4.0))
+    assert np.isfinite(g) and abs(g) > 1e-6, f"grad not finite/nonzero: {g}"
+
+    # finite-difference correctness (not just nonzero)
+    obj_fd = _objective(sim, shp, n_steps=600, checkpoint=False)
+    d = 0.02
+    fd = (float(obj_fd(4.0 + d)) - float(obj_fd(4.0 - d))) / (2 * d)
+    rel = abs(fd - g) / max(abs(fd), 1e-30)
+    assert rel < 0.05, f"grad {g:.4f} vs FD {fd:.4f} rel_err {rel*100:.1f}% > 5%"
+
+
+@pytest.mark.slow
+def test_forward_tfsf_oblique_differentiable():
+    """forward() couples an OBLIQUE TFSF source (complex Bloch path, auto-activated)
+    and produces a finite, nonzero gradient w.r.t. the scatterer eps."""
+    sim = _sim(30.0, "modulated_gaussian", 0.15)
+    shp = sim.run(n_steps=1).state.ez.shape
+    obj = _objective(sim, shp, n_steps=1400, checkpoint=True)
+
+    val = float(obj(4.0))
+    assert val > 1e-3, f"oblique TFSF did not couple (obj={val:.2e})"
+
+    g = float(jax.grad(obj)(4.0))
+    assert np.isfinite(g) and abs(g) > 1e-6, f"oblique grad not finite/nonzero: {g}"

--- a/tests/test_sparameter_support_contract.py
+++ b/tests/test_sparameter_support_contract.py
@@ -146,22 +146,16 @@ def test_forward_s11_rejects_non_port_source_only_request():
         sim.forward(n_steps=1, port_s11_freqs=np.array([1.0e9]), skip_preflight=True)
 
 
-def test_forward_rejects_tfsf_source_fail_loud():
-    """forward() must FAIL LOUD on a TFSF source, not silently drop it.
-
-    The differentiable forward path (_forward_from_materials) has no TFSF
-    handling, so a TFSF source injects nothing → zero gradients (the historical
-    "TFSF→forward silent-drop" footgun). #404 wired run() for oblique/normal TFSF
-    forward simulation; differentiable TFSF inverse-design is not implemented, so
-    forward() rejects it up front. Not oblique-specific — normal incidence too.
-    """
-    for angle in (0.0, 30.0):
-        sim = Simulation(freq_max=10e9, domain=(0.6, 0.12, 0.006), dx=0.002,
-                         boundary="cpml", cpml_layers=10, mode="3d")
-        sim.add_tfsf_source(f0=5e9, polarization="ez", direction="+x",
-                            angle_deg=angle)
-        with pytest.raises(NotImplementedError, match="TFSF.*forward"):
-            sim.forward(n_steps=1, skip_preflight=True)
+def test_forward_tfsf_nonuniform_lane_fenced():
+    """Differentiable TFSF forward is wired on the uniform single-device lane
+    (see test_forward_tfsf_differentiable.py); the non-uniform lane has no TFSF
+    handling and must fail loud rather than silently drop the source."""
+    dz = np.array([0.5e-3] * 8)  # dz_profile => non-uniform forward lane
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.004), dx=0.5e-3,
+                     dz_profile=dz, boundary="cpml", cpml_layers=6)
+    sim.add_tfsf_source(f0=10e9, polarization="ez", direction="+x")
+    with pytest.raises(NotImplementedError, match="uniform single-device"):
+        sim.forward(n_steps=1, skip_preflight=True)
 
 
 def test_preflight_sparameters_routes_forward_specialized_families():


### PR DESCRIPTION
## Summary

Wires TFSF plane-wave sources into the **differentiable** `Simulation.forward()` path, enabling gradient-based inverse design driven by a plane-wave excitation (RCS reduction, metasurface / FSS / absorber design, oblique-incidence scattering co-design) — the differentiable-EM / any-scale story. Builds on #404 (PR #414), which made oblique/normal TFSF correct in `run()`.

Previously `forward()` **silently dropped** TFSF sources (zero gradients — the "TFSF→forward silent-drop" footgun, fenced fail-loud in #414). This replaces the fence with real wiring.

## Change

- `rfx/api/_execute.py::_forward_from_materials`: when `self._tfsf` is set, build the aux TFSF cfg (`init_tfsf`, mirroring `run_uniform`), force `periodic=(False,True,True)` + `cpml_axes="x"`, and pass `tfsf=` to the shared `_run`. The scan (`_build_step_setup` → `make_core_step`) injects it and **auto-activates the complex Bloch path for oblique** (`field_dtype`→complex64 + per-axis roll phase), so gradients flow through the same validated kernel as `run()`. The vacuum-boundary check is not re-run here (materials may be a `jax` tracer under `jax.grad`); forward()'s entry preflight covers it on the concrete config.
- NU + distributed forward lanes have no TFSF handling → **lane-gated `NotImplementedError`** (mirrors the `rlc_values_override` precedent).

## Validated (pre-declared falsifiers)

| gate | result |
|---|---|
| couples (field nonzero) | ✅ normal & oblique, obj O(1–30) (was ~0) |
| AD finite/nonzero | ✅ grad 2.01 (normal), 2.47 (oblique) |
| checkpoint path | ✅ checkpoint=True == False (2.00561) |
| **gradient correct (FD)** | ✅ FD 2.00567 vs autodiff 2.00561 → **0.00% error** |
| port-only forward unbroken | ✅ 16 contract + 23 forward-AD + 149 forward-surface tests green |

Scope shipped: uniform single-device lane; NU/distributed fenced. Output = probe `time_series` (complex envelope for oblique; magnitude objectives are correct on it). Full differentiable field reconstruction / frequency-domain oblique objectives = follow-up.

Tests: `tests/test_forward_tfsf_differentiable.py` (slow — normal FD-correctness + oblique AD), NU-fence in `tests/test_sparameter_support_contract.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)