### PR TITLE
test(probes): ch07 complex-target (phase) gradient gate for the Fresnel Γ helper (#404)

### DIFF
--- a/rfx/probes/fresnel.py
+++ b/rfx/probes/fresnel.py
@@ -287,6 +287,14 @@ def fresnel_reflection_coefficient(
         Complex scalar Γ(f0) de-embedded to the reference plane. Differentiable
         in ``total_series`` (and hence in the scatterer permittivity upstream).
 
+    Notes
+    -----
+    The complex output differentiates correctly through a phase-sensitive RIS loss
+    ``|Γ − Γ_target|²`` (FD-verified). Precision (ch08): Γ is formed from ``(T − I)``,
+    a difference of two similar phasors, accumulated in complex64. For a WEAK reflector
+    (``|Γ| ≲ 1e-4``) this cancellation loses digits — run the two forwards under a
+    per-test ``jax.experimental.enable_x64`` context (never flip x64 at module level).
+
     See Also
     --------
     fresnel_r_te : analytic |R_TE| ground-truth for validation.

--- a/tests/test_forward_tfsf_fresnel_groundtruth.py
+++ b/tests/test_forward_tfsf_fresnel_groundtruth.py
@@ -174,3 +174,28 @@ def test_fresnel_gamma_differentiable(fresnel_run):
     g_fd = (float(abs_gamma(4.0 + h)) - float(abs_gamma(4.0 - h))) / (2 * h)
     assert np.isfinite(g_ad), "NaN/Inf gradient (P0)"
     assert abs(g_ad - g_fd) < 0.05 * abs(g_fd) + 1e-6, f"AD={g_ad:.4e} vs FD={g_fd:.4e}"
+
+
+@pytest.mark.slow
+def test_fresnel_complex_target_gradient(fresnel_run):
+    """ch07 conjugation: the RIS loss |Γ−Γ_target|² (phase-sensitive) differentiates correctly.
+
+    Unlike |Γ|, a complex-target loss depends on BOTH Re(Γ) and Im(Γ), so its gradient
+    exercises the phase path — where a mishandled e^{±jωt} DFT-sign / Wirtinger conjugation
+    would silently corrupt the gradient (the #404 trap). FD is the ground truth.
+    """
+    sim, shape, xi, xe = fresnel_run["sim"], fresnel_run["shape"], fresnel_run["xi"], fresnel_run["xe"]
+    dists, dt, ns = fresnel_run["dists"], fresnel_run["dt"], fresnel_run["ns"]
+    inc = _series(sim, _eps_slab(shape, xi, xe, 1.0), ns, ckpt=True)
+    g_target = 0.30 * np.exp(1j * 2.5)  # arbitrary complex RIS target (amplitude + phase)
+
+    def loss(eps):
+        tot = _series(sim, jnp.ones(shape, jnp.float32).at[xi:xe, :, :].set(eps), ns, ckpt=True)
+        g = fresnel_reflection_coefficient(tot, inc, f0=F0, dt=dt, probe_distances=dists, n_gate=ns)
+        return jnp.abs(g - g_target) ** 2
+
+    g_ad = float(jax.grad(loss)(4.0))
+    h = 0.05
+    g_fd = (float(loss(4.0 + h)) - float(loss(4.0 - h))) / (2 * h)
+    assert np.isfinite(g_ad), "NaN/Inf gradient (P0)"
+    assert abs(g_ad - g_fd) < 0.06 * abs(g_fd) + 1e-6, f"complex-target AD={g_ad:.4e} vs FD={g_fd:.4e}"


### PR DESCRIPTION
Completes anyscale ch07 compliance for `rfx.probes.fresnel_reflection_coefficient` (#419).

The existing gate differentiated `|Γ|` (magnitude). A complex-target RIS loss `|Γ − Γ_target|²` depends on **both Re(Γ) and Im(Γ)**, so its gradient exercises the **phase path** — where a mishandled `e^{±jωt}` DFT-sign / Wirtinger conjugation would silently corrupt the gradient (the #404 trap). New slow gate FD-verifies it (AD==FD).

Also documents the **ch08** precision limit: `(T−I)` cancellation in complex64 loses digits for a weak reflector (`|Γ|≲1e-4`) — use a per-test x64 context (never module-level x64, per the repo rule).

Docstring- and test-only; no behavior change. Helper test suite: 1 fast synthetic contract + 7 slow physics/gradient, all green.

R3: memory=diff-planewave (ch07 = flagged remaining helper item) + gate_can_bind_artifact (FD-ground-truthed) | R2=0 | falsifier=complex-target AD-vs-FD — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)