### PR TITLE
feat(rcs): differentiable compute_rcs_jax on the AD tape (#404 follow-up)

### DIFF
--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -76,7 +76,7 @@ from rfx.farfield import (
     radiation_pattern, directivity,
     axial_ratio, axial_ratio_dB, polarization_tilt, polarization_sense,
 )
-from rfx.rcs import compute_rcs, RCSResult
+from rfx.rcs import compute_rcs, compute_rcs_jax, RCSResult
 from rfx.antenna import (
     antenna_gain, antenna_gain_dB, antenna_efficiency,
     half_power_beamwidth, front_to_back_ratio,
@@ -268,7 +268,7 @@ __all__ = [
     "extract_waveguide_s_matrix", "extract_waveguide_sparams",
     "extract_waveguide_s11", "extract_waveguide_s21",
     "extract_s_matrix_wire", "compute_floquet_s_params",
-    "compute_rcs", "RCSResult",
+    "compute_rcs", "compute_rcs_jax", "RCSResult",
     # materials / dispersion / fitting
     "DebyePole", "LorentzPole", "drude_pole", "lorentz_pole",
     "ThinConductor", "MATERIAL_LIBRARY",

--- a/rfx/rcs.py
+++ b/rfx/rcs.py
@@ -29,7 +29,7 @@ import numpy as np
 from rfx.grid import Grid
 from rfx.core.yee import MaterialArrays
 from rfx.farfield import (
-    FarFieldResult, NTFFBox, compute_far_field,
+    FarFieldResult, NTFFBox, compute_far_field, compute_far_field_jax,
 )
 from rfx.sources.tfsf import init_tfsf
 from rfx.simulation import run
@@ -101,6 +101,60 @@ def _incident_spectrum_amplitude(
         amplitudes[i] = np.sum(waveform * phase) * dt
 
     return amplitudes
+
+
+def compute_rcs_jax(
+    ntff_data,
+    box: NTFFBox,
+    grid: Grid,
+    theta,
+    phi,
+    e_inc_amplitude,
+):
+    """JAX-differentiable RCS(θ,φ) from NTFF data — the AD counterpart of ``compute_rcs``.
+
+    ``compute_rcs`` orchestrates (TFSF setup → ``run`` → far-field → RCS) with a numpy
+    post-processor, so it is NOT on the AD tape. This function is the differentiable
+    POST-PROCESSING half: given ``ntff_data`` accumulated by a differentiable
+    ``run(..., tfsf=…, ntff=…)`` (whose accumulators flow through the ``lax.scan`` AD
+    tape w.r.t. the scatterer materials), it returns σ as a ``jnp`` array so
+    ``jax.grad`` flows scatterer-ε → RCS. It is the primitive behind differentiable
+    RCS-reduction / -shaping inverse design.
+
+    Same formula as ``compute_rcs`` (σ = 4π·|E_far|²/|E_inc|², ``compute_far_field``'s
+    ``E_θ``/``E_φ`` already carry the ``jk/4π`` factor so ``|E_θ|²+|E_φ|²`` is the
+    r-scaled scattered power), evaluated with ``compute_far_field_jax``. For the
+    monostatic (backscatter) bin at normal +x incidence pass ``theta=[π/2], phi=[π]``.
+
+    Parameters
+    ----------
+    ntff_data : NTFFData
+        NTFF surface accumulators from ``run(..., tfsf=…, ntff=…)`` (JAX arrays, on tape).
+    box : NTFFBox
+    grid : Grid
+    theta, phi : arrays in radians
+        Observation directions. Backscatter for +x incidence is ``(π/2, π)``.
+    e_inc_amplitude : (n_freqs,) complex array
+        Incident plane-wave spectral amplitude for normalization — source-only, hence a
+        CONSTANT for the gradient. Use :func:`_incident_spectrum_amplitude`
+        (``f0, bandwidth, freqs, dt, n_steps``) with the same TFSF waveform.
+
+    Returns
+    -------
+    jnp.ndarray
+        ``rcs_linear`` (n_freqs, n_theta, n_phi) in m², differentiable in ``ntff_data``
+        (hence in the scatterer permittivity upstream). Take ``10·log10`` for dBsm.
+
+    See Also
+    --------
+    compute_rcs : the numpy orchestrator (Mie-validated monostatic bin).
+    compute_far_field_jax : the differentiable far-field this builds on.
+    """
+    ff = compute_far_field_jax(ntff_data, box, grid, theta, phi)
+    power_scat = jnp.abs(ff.E_theta) ** 2 + jnp.abs(ff.E_phi) ** 2  # (nf, nθ, nφ)
+    power_inc = jnp.abs(jnp.asarray(e_inc_amplitude)) ** 2          # (nf,)
+    safe_power_inc = jnp.where(power_inc > 0, power_inc, 1e-30)
+    return 4.0 * jnp.pi * power_scat / safe_power_inc[:, None, None]
 
 
 def compute_rcs(

--- a/tests/test_ad_surface_contract.py
+++ b/tests/test_ad_surface_contract.py
@@ -86,7 +86,13 @@ AD_CLASSIFICATION = {
     ),
     "compute_rcs": (
         NOT_TRACEABLE,
-        "numpy RCS post-processor on top of compute_far_field",
+        "numpy RCS post-processor on top of compute_far_field; the AD path is compute_rcs_jax",
+    ),
+    "compute_rcs_jax": (
+        GRAD_SAFE,
+        "differentiable RCS post-processor on compute_far_field_jax; equivalence to the "
+        "Mie-validated numpy compute_rcs + FD-convergent gradient: "
+        "tests/test_rcs_jax_differentiable.py::test_rcs_jax_gradient_fd_convergence",
     ),
     "compute_floquet_s_params": (
         GRAD_SAFE,

--- a/tests/test_rcs_jax_differentiable.py
+++ b/tests/test_rcs_jax_differentiable.py
@@ -1,0 +1,113 @@
+"""Differentiable RCS (``compute_rcs_jax``) — equivalence to the validated numpy path + gradient.
+
+``compute_rcs`` is a numpy orchestrator (not on the AD tape); its monostatic bin is
+Mie-validated (#280). ``compute_rcs_jax`` is the differentiable POST-PROCESSOR on
+``compute_far_field_jax``, so ``jax.grad`` flows scatterer-ε → RCS for RCS-reduction /
+-shaping inverse design.
+
+Three gates (ground truths):
+  • ``test_rcs_jax_equals_numpy_on_same_ntff_data`` — jnp RCS reproduces the numpy RCS
+    formula on the SAME NTFF data (exact; inherits the Mie validation of the numpy path).
+  • ``test_rcs_jax_matches_validated_orchestrator`` — the replicated TFSF+NTFF setup
+    reproduces ``compute_rcs(...).monostatic_rcs`` (ties the harness to the validated path).
+  • ``test_rcs_jax_gradient_fd_convergence`` — dσ_backscatter/dε is finite and central-FD
+    CONVERGES to AD as h→0. σ(ε) sits near a backscatter maximum here (strongly curved), so
+    a single large-h FD is unreliable (ch07 doctrine: step-sweep, not single-h).
+
+Harness: docs/research_notes/experiments/i404_oblique_20260720/rcs_jax_validate.py
+"""
+import numpy as np
+import jax
+import jax.numpy as jnp
+import pytest
+
+from rfx.grid import Grid
+from rfx.core.yee import init_materials
+from rfx.farfield import NTFFBox, compute_far_field
+from rfx.sources.tfsf import init_tfsf
+from rfx.simulation import run
+from rfx.rcs import compute_rcs, compute_rcs_jax, _incident_spectrum_amplitude
+
+F0, BW = 10e9, 0.5
+CPML = 8
+N_STEPS = 220
+DOMAIN = (0.09, 0.09, 0.09)
+DX = 0.003
+FREQS = np.array([F0])
+TH_B, PH_B = np.array([np.pi / 2]), np.array([np.pi])  # backscatter for +x incidence
+
+
+def _materials(grid, eps_scale):
+    mb = init_materials(grid.shape)
+    sx, sy, sz = grid.shape
+    block = np.zeros(grid.shape, np.float32)
+    block[sx // 2 - 3:sx // 2 + 3, sy // 2 - 3:sy // 2 + 3, sz // 2 - 3:sz // 2 + 3] = 1.0
+    return mb._replace(eps_r=mb.eps_r + eps_scale * 3.0 * jnp.asarray(block))  # ε_r=4 @ scale=1
+
+
+def _setup_run(grid, materials):
+    cfg, st = init_tfsf(nx=grid.nx, dx=grid.dx, dt=grid.dt, cpml_layers=CPML, tfsf_margin=3,
+                        f0=F0, bandwidth=BW, amplitude=1.0, polarization="ez",
+                        direction="+x", angle_deg=0.0)
+    fl = getattr(grid, "face_layers", None) or {k: CPML for k in
+                 ("x_lo", "x_hi", "y_lo", "y_hi", "z_lo", "z_hi")}
+    box = NTFFBox.from_grid(
+        grid,
+        i_lo=max(cfg.x_lo - 1, 1), i_hi=min(cfg.x_hi + 2, grid.nx - 2),
+        j_lo=max(fl["y_lo"] + 1, 1), j_hi=min(grid.ny - fl["y_hi"] - 1, grid.ny - 2),
+        k_lo=max(fl["z_lo"] + 1, 1), k_hi=min(grid.nz - fl["z_hi"] - 1, grid.nz - 2),
+        freqs=jnp.array(FREQS, jnp.float32))
+    return run(grid, materials, N_STEPS, boundary="cpml", tfsf=(cfg, st), ntff=box).ntff_data, box
+
+
+@pytest.fixture(scope="module")
+def rcs_run():
+    grid = Grid(freq_max=15e9, domain=DOMAIN, dx=DX, cpml_layers=CPML)
+    e_inc = _incident_spectrum_amplitude(F0, BW, FREQS, grid.dt, N_STEPS)
+    mats = _materials(grid, 1.0)
+    ntff_data, box = _setup_run(grid, mats)
+    return {"grid": grid, "e_inc": e_inc, "mats": mats, "ntff_data": ntff_data, "box": box}
+
+
+@pytest.mark.slow
+def test_rcs_jax_equals_numpy_on_same_ntff_data(rcs_run):
+    """jnp RCS == numpy RCS formula on the SAME NTFF data (inherits the Mie validation)."""
+    g, box, e_inc, nd = rcs_run["grid"], rcs_run["box"], rcs_run["e_inc"], rcs_run["ntff_data"]
+    ff = compute_far_field(nd, box, g, TH_B, PH_B)
+    p = np.abs(np.asarray(ff.E_theta)[:, 0, 0]) ** 2 + np.abs(np.asarray(ff.E_phi)[:, 0, 0]) ** 2
+    sig_numpy = 4 * np.pi * p / np.abs(e_inc) ** 2
+    sig_jax = np.asarray(compute_rcs_jax(nd, box, g, TH_B, PH_B, e_inc))[:, 0, 0]
+    assert abs(sig_jax[0] - sig_numpy[0]) < 1e-4 * abs(sig_numpy[0]), \
+        f"σ_jax={sig_jax[0]:.6e} vs σ_numpy={sig_numpy[0]:.6e}"
+
+
+@pytest.mark.slow
+def test_rcs_jax_matches_validated_orchestrator(rcs_run):
+    """compute_rcs_jax monostatic reproduces compute_rcs(...).monostatic_rcs (the Mie-validated bin)."""
+    g, box, e_inc, nd, mats = (rcs_run["grid"], rcs_run["box"], rcs_run["e_inc"],
+                               rcs_run["ntff_data"], rcs_run["mats"])
+    res = compute_rcs(g, mats, N_STEPS, f0=F0, bandwidth=BW, freqs=FREQS,
+                      theta_obs=TH_B, phi_obs=PH_B)
+    sig_jax = float(np.asarray(compute_rcs_jax(nd, box, g, TH_B, PH_B, e_inc))[0, 0, 0])
+    mono_jax = 10 * np.log10(max(sig_jax, 1e-30))
+    assert abs(float(res.monostatic_rcs[0]) - mono_jax) < 0.05, \
+        f"compute_rcs mono={float(res.monostatic_rcs[0]):.3f} vs jax mono={mono_jax:.3f} dBsm"
+
+
+@pytest.mark.slow
+def test_rcs_jax_gradient_fd_convergence(rcs_run):
+    """dσ_backscatter/dε is finite and central-FD CONVERGES to AD (ch07 step-sweep)."""
+    g, e_inc = rcs_run["grid"], rcs_run["e_inc"]
+
+    def sigma_of(eps_scale):
+        nd, bx = _setup_run(g, _materials(g, eps_scale))
+        return compute_rcs_jax(nd, bx, g, TH_B, PH_B, e_inc)[0, 0, 0]
+
+    g_ad = float(jax.grad(sigma_of)(1.0))
+    assert np.isfinite(g_ad) and abs(g_ad) > 1e-9, f"gradient collapsed/NaN: {g_ad}"
+    errs = []
+    for h in (0.01, 0.005):  # σ(ε) is curved near ε=1 => small h needed
+        g_fd = (float(sigma_of(1.0 + h)) - float(sigma_of(1.0 - h))) / (2 * h)
+        errs.append(abs(g_ad - g_fd) / abs(g_ad))
+    assert errs[1] < errs[0], f"central-FD not converging to AD: {errs}"
+    assert errs[1] < 0.05, f"smallest-h FD error {errs[1]*100:.1f}% (AD={g_ad:.3e})"


### PR DESCRIPTION
## What

`compute_rcs` is a numpy orchestrator (not on the AD tape). **`compute_rcs_jax`** is the differentiable **post-processor** on `compute_far_field_jax` — `jax.grad` flows scatterer-ε → RCS, the primitive for **RCS-reduction / -shaping inverse design**. Same formula (σ=4π|E_far|²/|E_inc|²); the incident spectrum is source-only (a constant for the gradient). Exported top-level; AD-surface contract updated (grad-safe + gradient-test pointer); `compute_rcs` now notes "the AD path is compute_rcs_jax".

## Ground truth (`tests/test_rcs_jax_differentiable.py`, slow, 16s)

| gate | result |
|---|---|
| **Equivalence** — jnp RCS == numpy RCS on the SAME `ntff_data` | rel **6e-7** (inherits the #280 Mie validation) |
| **Mie tie-in** — replicated setup reproduces `compute_rcs(...).monostatic_rcs` | Δ **0.000 dBsm** |
| **Gradient** — dσ_backscatter/dε, FD step-sweep | AD finite; central-FD **converges** 20%→5.1%→**1.4%** (h=.02/.01/.005) |

## Comparator-first note

The gradient first looked wrong (single-h FD 55% off). Validating the **comparator** (ch07 FD step-sweep, not the solver AD) showed σ(ε) sits near a **backscatter maximum** — strongly curved, so large-h central FD is unreliable; FD converges to AD as h→0. **AD was correct.** The gate uses the convergence witness, not a single h.

## Scope
Normal incidence (backscatter) only — the oblique TFSF/NTFF path stays fenced at the `compute_rcs` orchestrator (#404/#413). `compute_rcs_jax` is a pure post-processor; validity follows the run that produced `ntff_data`.

Existing RCS suite (40 tests) + AD-surface/golden-workflow contracts stay green; lint clean.

## R3 audit
memory=#280 (monostatic Mie-validated, leakage nulls at backscatter) + NTFF-directivity-lane (compute_far_field_jax grad-safe) + dof-differentiability (adds the missing RCS AD path) | R2=1 CLOSING (FD "miss" = comparator artifact, resolved by step-sweep) | falsifier=equivalence-to-Mie-validated-numpy + FD-convergent gradient — both PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)