### PR TITLE
feat(probes): differentiable oblique |Γ|(θ) magnitude helper (#404 follow-up)

### DIFF
--- a/rfx/probes/__init__.py
+++ b/rfx/probes/__init__.py
@@ -10,4 +10,5 @@ from rfx.probes.fresnel import (
     extract_fresnel_from_planes,  # noqa: F401
     fresnel_reflection_coefficient,  # noqa: F401
     fresnel_r_te,  # noqa: F401
+    oblique_reflection_magnitude,  # noqa: F401
 )

--- a/rfx/probes/fresnel.py
+++ b/rfx/probes/fresnel.py
@@ -318,6 +318,72 @@ def fresnel_reflection_coefficient(
     return jnp.mean(gamma_p)
 
 
+def oblique_reflection_magnitude(
+    total_series: jnp.ndarray,
+    incident_series: jnp.ndarray,
+    *,
+    f0: float,
+    dt: float,
+    n_gate: int | None = None,
+) -> jnp.ndarray:
+    """Differentiable |Γ|(θ) MAGNITUDE for OBLIQUE incidence from the complex Bloch envelope.
+
+    For oblique TFSF, ``Simulation.forward()`` returns the RAW complex Bloch envelope P
+    (``time_series`` is complex64), not a real physical field. Two differences from the
+    normal-incidence :func:`fresnel_reflection_coefficient`:
+
+    * **+j (conjugate) DFT kernel** — the envelope ``P(t) ∝ exp(-j2πf0t)`` has its f0 content
+      at ``-f0``, so it is extracted with ``exp(+j2πf0t)``. A ``-j`` kernel averages the
+      incident to noise ⇒ nonphysical |Γ|≫1 (the #404 trap).
+    * **magnitude ratio, de-embed-free** — ``mean|T−I| / mean|I|``. At oblique the reflected
+      phase varies by many π across the plateau, so a de-embedded COMPLEX mean cancels
+      (a wrong/nominal k_x gives |Γ|→0). The magnitude ratio is robust; the reflected phase
+      is NOT recovered here (see Notes).
+
+    Same physics protocol as :func:`fresnel_reflection_coefficient` but OBLIQUE-specific:
+    narrowband source (``bandwidth≲0.15`` — the Bloch phase ``k_y=k0 sinθ`` is single-f0),
+    finite THICK slab before the CPML, time-gate to the front-face, plateau probes.
+
+    Parameters
+    ----------
+    total_series, incident_series : (n_steps, n_probes) COMPLEX arrays
+        Bloch-envelope probe series from the scatterer and vacuum runs (oblique forward()).
+    f0, dt : float
+    n_gate : int, optional
+        DFT window (time-gate). Defaults to the full series.
+
+    Returns
+    -------
+    jnp.ndarray
+        Real scalar |Γ|(f0) at the injected oblique angle, differentiable in ``total_series``.
+
+    Notes
+    -----
+    MAGNITUDE ONLY. The reflected PHASE (complex Γ, the RIS phase-steering knob) is not
+    provided: de-embedding to the interface needs the exact DISCRETE k_x (the injected angle
+    is dispersion-shifted from the nominal, e.g. 29.5° for a 30° request), which is an open
+    follow-up. Validated vs analytic ``fresnel_r_te`` at θ=30°/45° to ~4–7%.
+
+    See Also
+    --------
+    fresnel_reflection_coefficient : normal-incidence COMPLEX Γ (amplitude + phase).
+    fresnel_r_te : analytic |R_TE|(θ) ground truth.
+    """
+    total = jnp.asarray(total_series)
+    inc = jnp.asarray(incident_series)
+    if total.ndim != 2 or inc.shape != total.shape:
+        raise ValueError(
+            "total_series and incident_series must both be (n_steps, n_probes) and "
+            f"equal-shaped; got {total.shape} and {inc.shape}"
+        )
+    ns = total.shape[0] if n_gate is None else int(n_gate)
+    t = jnp.arange(ns) * dt
+    kern = jnp.exp(+1j * 2.0 * jnp.pi * f0 * t) * dt  # +j conjugate kernel (oblique envelope)
+    tp = jnp.sum(total[:ns].astype(jnp.complex64) * kern[:, None], axis=0)
+    ip = jnp.sum(inc[:ns].astype(jnp.complex64) * kern[:, None], axis=0)
+    return jnp.mean(jnp.abs(tp - ip)) / jnp.mean(jnp.abs(ip))
+
+
 def fresnel_r_te(angle_deg: float, eps_r: float) -> float:
     """Analytical TE Fresnel reflection coefficient magnitude.
 

--- a/tests/test_oblique_fresnel_magnitude.py
+++ b/tests/test_oblique_fresnel_magnitude.py
@@ -1,0 +1,103 @@
+"""Differentiable OBLIQUE Fresnel |Γ|(θ) magnitude via forward() — ground-truth-gated.
+
+Extends the normal-incidence complex Γ helper (#419) to oblique incidence (the RIS/absorber
+condition), MAGNITUDE ONLY. forward() returns the raw complex Bloch envelope for oblique, so
+``oblique_reflection_magnitude`` uses the +j (conjugate) DFT kernel and a de-embed-free
+magnitude ratio (a de-embedded complex mean cancels at oblique — the reflected phase spans
+many π across the plateau).
+
+Validated vs analytic oblique Fresnel ``fresnel_r_te(θ,εr)``: |Γ| err 7.2% / 3.9% @ θ=30°/45°
+(εr=4); d|Γ|/dε AD==FD. 60° is CPML-contaminated (memory) so it is NOT gated. PHASE (complex
+Γ) is a documented open follow-up (needs the exact discrete k_x de-embed).
+Harness: docs/research_notes/experiments/i404_oblique_20260720/oblique_gamma_validate.py
+"""
+import numpy as np
+import jax
+import jax.numpy as jnp
+import pytest
+
+from rfx.api import Simulation
+from rfx.grid import Grid
+from rfx.probes import oblique_reflection_magnitude, fresnel_r_te
+
+F0, BW = 5e9, 0.15
+DOMAIN = (0.60, 0.12, 0.006)
+DX = 0.002
+X_IFACE, X_SLAB_END = 0.15, 0.50
+PLATEAU = (0.05, 0.13)
+C0 = 299792458.0
+EPS_R = 4.0
+
+
+def _build(theta):
+    grid = Grid(freq_max=10e9, domain=DOMAIN, dx=DX, cpml_layers=10)
+    xi = grid.position_to_index((X_IFACE, 0.06, 0.003))[0]
+    xe = grid.position_to_index((X_SLAB_END, 0.06, 0.003))[0]
+    xprobes = np.arange(PLATEAU[0], PLATEAU[1], DX)
+    n_slab = np.sqrt(EPS_R)
+    t_back = (2 * (X_IFACE - PLATEAU[1]) / C0) + (2 * (X_SLAB_END - X_IFACE) / (C0 / n_slab))
+    ns = min(int(0.9 * t_back / grid.dt), 1700)
+    sim = Simulation(freq_max=10e9, domain=DOMAIN, dx=DX, boundary="cpml", cpml_layers=10, mode="3d")
+    sim.add_tfsf_source(f0=F0, bandwidth=BW, polarization="ez", direction="+x",
+                        angle_deg=theta, waveform="modulated_gaussian")
+    for xp in xprobes:
+        sim.add_probe((float(xp), 0.06, 0.003), component="ez")
+    return sim, grid.shape, xi, xe, grid.dt, ns
+
+
+def _eps_slab(shape, xi, xe, eps):
+    a = jnp.ones(shape, jnp.float32)
+    return a if eps == 1.0 else a.at[xi:xe, :, :].set(eps)
+
+
+def _series(sim, eps_arr, ns, ckpt=False):
+    return sim.forward(eps_override=eps_arr, n_steps=ns, checkpoint=ckpt,
+                       skip_preflight=True).time_series  # complex for oblique
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("theta,tol", [(30.0, 0.10), (45.0, 0.08)])
+def test_oblique_fresnel_magnitude_vs_analytic(theta, tol):
+    """|Γ|(θ) matches analytic oblique Fresnel R_TE and is passive; +j kernel is mandatory."""
+    sim, shape, xi, xe, dt, ns = _build(theta)
+    inc = _series(sim, _eps_slab(shape, xi, xe, 1.0), ns)
+    tot = _series(sim, _eps_slab(shape, xi, xe, EPS_R), ns)
+    g = float(oblique_reflection_magnitude(tot, inc, f0=F0, dt=dt, n_gate=ns))
+    ga = abs(fresnel_r_te(theta, EPS_R))
+    assert g < 1.0, f"nonphysical |Γ|={g:.3f}≥1 (θ={theta})"
+    assert abs(g - ga) / ga < tol, f"|Γ|={g:.3f} vs R_TE={ga:.3f} (θ={theta}, {abs(g-ga)/ga*100:.1f}%)"
+
+
+@pytest.mark.slow
+def test_oblique_reflection_magnitude_differentiable():
+    """d|Γ|/dε flows through the checkpointed oblique forward and matches finite difference."""
+    sim, shape, xi, xe, dt, ns = _build(30.0)
+    inc = _series(sim, _eps_slab(shape, xi, xe, 1.0), ns, ckpt=True)
+
+    def absg(eps):
+        tot = _series(sim, jnp.ones(shape, jnp.float32).at[xi:xe, :, :].set(eps), ns, ckpt=True)
+        return oblique_reflection_magnitude(tot, inc, f0=F0, dt=dt, n_gate=ns)
+
+    g_ad = float(jax.grad(absg)(EPS_R))
+    h = 0.05
+    g_fd = (float(absg(EPS_R + h)) - float(absg(EPS_R - h))) / (2 * h)
+    assert np.isfinite(g_ad), "NaN/Inf gradient (P0)"
+    assert abs(g_ad - g_fd) < 0.05 * abs(g_fd) + 1e-6, f"AD={g_ad:.4e} vs FD={g_fd:.4e}"
+
+
+def test_oblique_magnitude_kernel_sign_and_shape_guard():
+    """FAST synthetic contract: +j kernel on a complex envelope recovers a planted |Γ|; a
+    -j kernel would average the incident to noise. Also the shape guard fires."""
+    ns, nprobe, dt = 400, 6, 1.0 / (F0 * 20)
+    t = np.arange(ns) * dt
+    env = np.exp(-1j * 2 * np.pi * F0 * t)             # analytic envelope P ∝ e^{-j2πf0t}
+    gmag_true = 0.4
+    inc = np.outer(env, np.ones(nprobe))
+    # reflected envelope with random per-probe phases (magnitude gmag_true)
+    phases = np.linspace(0, 3 * np.pi, nprobe)
+    refl = gmag_true * np.outer(env, np.exp(1j * phases))
+    tot = inc + refl
+    g = float(oblique_reflection_magnitude(jnp.asarray(tot), jnp.asarray(inc), f0=F0, dt=dt))
+    assert abs(g - gmag_true) < 1e-3, f"planted |Γ|={gmag_true} recovered {g:.4f}"
+    with pytest.raises(ValueError):
+        oblique_reflection_magnitude(jnp.asarray(tot[:, 0]), jnp.asarray(inc[:, 0]), f0=F0, dt=dt)


### PR DESCRIPTION
## What

Extends the reflection primitives to **oblique incidence** (RIS/absorber/FSS condition), **magnitude only**: `rfx.probes.oblique_reflection_magnitude`. forward() returns the raw complex Bloch envelope for oblique, so this uses the **+j (conjugate) DFT kernel** and a **de-embed-free magnitude ratio** `mean|T−I|/mean|I|`.

## Ground truth (`tests/test_oblique_fresnel_magnitude.py`)

| gate | result |
|---|---|
| vs analytic oblique Fresnel `fresnel_r_te(θ,εr=4)` | **7.2% @ θ=30°, 3.9% @ θ=45°** (physical, \|Γ\|<1) |
| d\|Γ\|/dε | **AD==FD** (checkpointed oblique forward) |
| fast synthetic contract | +j kernel recovers planted \|Γ\| on a complex envelope w/ random per-probe phases; shape guard fires |

60° excluded (CPML-contaminated, per memory). The forward() envelope is looser than the raw-loop diagnostic's 2% (shorter gated window ns=1133 vs ~1500); gates at 10%/8% pin the **measured** forward()-path envelope, not a loosened target.

## Comparator-first lesson (recorded)

The first extractor (de-embedded **complex** mean, as in the normal-incidence helper) gave |Γ|≈0.03 — I nearly blamed forward(). The known-good **raw-loop diagnostic still gave 2%**, isolating the bug to **my extractor**: at oblique the reflected phase spans **~4.6π** across the plateau, so a wrong/nominal k_x cancels the complex mean. The magnitude ratio is robust.

## Scope (honest)

**Magnitude only.** The reflected **phase** (complex Γ — the RIS phase-steering knob) is a documented **open follow-up**: de-embedding needs the exact **discrete** k_x (injected angle is dispersion-shifted, 29.5° for a 30° request). Not tweaked further (R2). This helper serves the **absorber/RAM & FSS-magnitude** oblique use cases; RIS phase steering needs the phase follow-up.

Kept at `rfx.probes` level; AD-surface contract unaffected; lint clean; collection +1.

R3: memory=#404-oblique (|R| 2-5% @30/45, 60° CPML-bad) + comparator-first (validated extractor before blaming solver) | R2=1 CLOSING for magnitude, phase deferred | falsifier=analytic oblique Fresnel + FD gradient — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)