### PR TITLE
feat(preflight): warn on unstable TFSF plane-wave + lumped RLC pairing (varactor DoF)

### DIFF
--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1725,6 +1725,7 @@ class _PreflightMixin:
         self._validate_cfg_floating_single_cell_port(_w)
         self._validate_cfg_pec_boundary_open_structure(_w)
         self._validate_cfg_no_sources(_w)
+        self._validate_cfg_tfsf_with_lumped_rlc(_w)
         self._validate_cfg_unresolved_pulse(_w, dx)
         self._validate_cfg_nonuniform_limitations(_w, cpml_thickness)
         self._validate_cfg_graded_box_rasterization(_w)
@@ -1739,6 +1740,32 @@ class _PreflightMixin:
 
         self._check_waveguide_port_evanescent()
         self._check_msl_port_geometry(dx, cpml_thick_lo, cpml_thick_hi)
+
+    def _validate_cfg_tfsf_with_lumped_rlc(self, _w) -> None:
+        """Warn: a lumped RLC element illuminated by a TFSF plane wave is unstable.
+
+        A bare ``add_lumped_rlc(...)`` element driven by a TFSF plane wave has no
+        defined series circuit, so its ADE current-tracking is ill-posed and the
+        fields diverge (measured: blow-up to ~1e35 by ~250 steps, C-independent).
+        The tunable-load (varactor) gradient IS validated for the PORT-fed lane
+        (``add_port`` + ``forward(rlc_values_override=...)`` — tests/test_lumped_rlc_ad.py),
+        not for a bare plane-wave load. For RIS/reconfigurable-surface design the
+        element must sit in a supporting PEC-gap structure (patch/aperture + gap +
+        ground) so it carries a defined current. Advisory warning (a proper gap
+        structure may be stable); see the tracking issue.
+        """
+        if self._tfsf is None or not self._lumped_rlc:
+            return
+        _w.warn(PreflightWarning(
+            "add_lumped_rlc(...) + a TFSF plane-wave source: a bare lumped element "
+            "in a plane wave has no defined series circuit and is numerically "
+            "unstable (fields diverge). Embed it in a supporting PEC-gap structure "
+            "(the RIS unit cell) so it carries a defined current. The varactor/"
+            "tunable-load gradient is validated for the PORT-fed lane (add_port + "
+            "forward(rlc_values_override=...)), not for bare plane-wave loads.",
+            code="tfsf_lumped_rlc_unstable",
+            source="_validate_cfg_tfsf_with_lumped_rlc",
+        ))
 
     def _validate_cfg_graded_box_rasterization(self, _w) -> None:
         """Warn when a Box misses the fine cells implied by its z-span."""

--- a/tests/test_preflight_tfsf_lumped.py
+++ b/tests/test_preflight_tfsf_lumped.py
@@ -1,0 +1,47 @@
+"""Preflight guard: TFSF plane-wave + lumped RLC is numerically unstable (footgun surfacing).
+
+A bare add_lumped_rlc(...) driven by a TFSF plane wave has no defined series circuit; the ADE
+current-tracking is ill-posed and the fields diverge (measured: ~1e35 by ~250 steps). The
+varactor/tunable-load gradient IS validated for the PORT-fed lane (test_lumped_rlc_ad.py); this
+guard warns when the element is instead illuminated by a bare plane wave, so the silent NaN is
+surfaced. Advisory (warning, not error): a proper PEC-gap RIS unit cell may be stable.
+"""
+import numpy as np
+
+from rfx import GaussianPulse, Simulation
+
+_CODE = "tfsf_lumped_rlc_unstable"
+
+
+def _codes(sim):
+    return {getattr(i, "code", None) for i in sim.preflight()}
+
+
+def test_tfsf_plus_lumped_rlc_warns():
+    sim = Simulation(freq_max=16e9, domain=(0.02, 0.02, 0.02), dx=0.02 / 20,
+                     boundary="cpml", cpml_layers=8, mode="3d")
+    sim.add_tfsf_source(f0=8e9, bandwidth=0.6, polarization="ez", direction="+x",
+                        waveform="modulated_gaussian")
+    sim.add_lumped_rlc(position=(0.010, 0.010, 0.010), component="ez",
+                       R=50.0, C=0.20e-12, topology="series")
+    assert _CODE in _codes(sim), "TFSF + lumped RLC should warn about the unstable pairing"
+
+
+def test_tfsf_alone_no_warning():
+    """No false positive: a TFSF plane wave with no lumped element must NOT warn."""
+    sim = Simulation(freq_max=16e9, domain=(0.02, 0.02, 0.02), dx=0.02 / 20,
+                     boundary="cpml", cpml_layers=8, mode="3d")
+    sim.add_tfsf_source(f0=8e9, bandwidth=0.6, polarization="ez", direction="+x",
+                        waveform="modulated_gaussian")
+    assert _CODE not in _codes(sim)
+
+
+def test_lumped_rlc_with_port_no_warning():
+    """No false positive: the validated PORT-fed varactor lane must NOT warn."""
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=0.02 / 15,
+                     boundary="cpml", cpml_layers=6)
+    sim.add_port(position=(0.0093, 0.0093, 0.0093), component="ez", impedance=50.0,
+                 waveform=GaussianPulse(f0=5e9, bandwidth=0.9))
+    sim.add_lumped_rlc(position=(0.0093, 0.0093, 0.0093), component="ez",
+                       R=50.0, C=0.20e-12, topology="series")
+    assert _CODE not in _codes(sim)


### PR DESCRIPTION
## Context — item: varactor / tunable-load DoF in the plane-wave lane

Premise-verification (before assuming the stale "silent no-op" memory) found:

1. **The `add_lumped_rlc + forward()` "silent no-op" is already fixed** (WP 4-E). The port-fed varactor-C gradient is validated: `test_lumped_rlc_ad.py::test_dS11_dR_dC_ad_matches_fd` (dS11²/dC AD==FD). So the "tunable-load DoF" capability exists — for a **port-fed** objective.
2. **The new gap — varactor in the TFSF plane-wave lane (the RIS condition) — diverges** for a bare element: fields blow to ~1e35 by ~step 246, **C-independent** (TFSF-only is stable). A bare lumped RLC in a plane wave has no defined series circuit ⇒ ill-posed ADE current-tracking. The real RIS use needs a supporting **PEC-gap unit cell** (patch/aperture + gap + ground) — a larger effort, **deferred** (R2/R4: not chased).

## What this PR does

Surfaces (2) as a preflight **warning** (`code=tfsf_lumped_rlc_unstable`) instead of a silent NaN, pointing users to the validated port-fed lane and the RIS-cell requirement. Advisory (warning, not error — a proper gap structure may be stable). Fires only when **both** a TFSF source and a lumped RLC are registered.

| test | checks |
|---|---|
| `test_tfsf_plus_lumped_rlc_warns` | guard fires on the unstable pairing |
| `test_tfsf_alone_no_warning` | no false positive (TFSF only) |
| `test_lumped_rlc_with_port_no_warning` | no false positive (validated port+RLC lane) |

`test_lumped_rlc_ad` + preflight regressions stay green (37 passed); lint clean.

R3: memory=dof-differentiability (no-op footgun — verified STALE) + diff-planewave (TFSF+lumped fenced — characterizes why) | R2=1 premise-check + 1 debug, STOP on instability | falsifier=guard fires + no false positives + test_lumped_rlc_ad green — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)