### PR TITLE
feat(probes): differentiable oblique COMPLEX Γ (phase) + GPU-memory fix (#423)

### DIFF
--- a/rfx/probes/__init__.py
+++ b/rfx/probes/__init__.py
@@ -10,5 +10,6 @@ from rfx.probes.fresnel import (
     extract_fresnel_from_planes,  # noqa: F401
     fresnel_reflection_coefficient,  # noqa: F401
     fresnel_r_te,  # noqa: F401
+    oblique_reflection_coefficient,  # noqa: F401
     oblique_reflection_magnitude,  # noqa: F401
 )

--- a/rfx/probes/fresnel.py
+++ b/rfx/probes/fresnel.py
@@ -384,6 +384,83 @@ def oblique_reflection_magnitude(
     return jnp.mean(jnp.abs(tp - ip)) / jnp.mean(jnp.abs(ip))
 
 
+def oblique_reflection_coefficient(
+    total_series: jnp.ndarray,
+    incident_series: jnp.ndarray,
+    *,
+    f0: float,
+    dt: float,
+    probe_index: jnp.ndarray,
+    interface_index: float,
+    n_gate: int | None = None,
+) -> jnp.ndarray:
+    """Differentiable COMPLEX Γ(θ) (amplitude AND phase) for OBLIQUE incidence.
+
+    Supersedes :func:`oblique_reflection_magnitude` (magnitude-only) by also recovering the
+    reflected PHASE — the RIS phase-steering knob. The obstacle at oblique incidence is that
+    the reflected phase varies by many π across the plateau, so a de-embedded complex mean
+    cancels unless the EXACT discrete k_x is used (the nominal ``k0·cosθ`` is dispersion-
+    shifted and wrong). The fix here is SELF-CALIBRATING: the de-rotation slope is measured
+    from the INCIDENT wave itself (its phase slope along the probe line = the true discrete
+    ``k_x``), so no analytic k_x / dispersion model is needed::
+
+        ratio_p = (T_p - I_p) / I_p                       # |ratio|≈|Γ|, ∠ = ∠Γ + 2·k_x·x_p
+        S       = -2 · d(∠I_p)/d(x_p)                     # from the incident (design-independent)
+        Γ       = mean_p[ ratio_p · e^{-j S x_p} ] · e^{+j S x_iface}
+
+    Because ``S`` is derived from the incident (vacuum) reference it is a CONSTANT w.r.t. the
+    scatterer, so ``Γ`` stays differentiable in ``total_series``. Uses the +j (conjugate) DFT
+    kernel (the oblique complex Bloch envelope; the #404 sign trap). Same oblique physics
+    protocol as :func:`oblique_reflection_magnitude` (narrowband, thick slab, time-gate, plateau).
+
+    Parameters
+    ----------
+    total_series, incident_series : (n_steps, n_probes) COMPLEX arrays
+        Bloch-envelope probe series (scatterer / vacuum) from an oblique ``forward()``.
+        ``incident_series`` is the design-independent reference (its phase sets ``S``).
+    f0, dt : float
+    probe_index : (n_probes,) array
+        Cell index of each probe along the propagation (x) axis. The phase slope is per-cell.
+    interface_index : float
+        Cell index of the reference plane (the scatterer front face) the phase is reported at.
+        A residual ~half-cell Yee offset remains (an εr-independent constant; calibratable).
+    n_gate : int, optional
+        DFT window (time-gate). Defaults to the full series.
+
+    Returns
+    -------
+    jnp.ndarray
+        Complex scalar Γ(f0) at the injected oblique angle, de-embedded to the reference plane.
+        Differentiable in ``total_series``. Validated vs analytic ``fresnel_r_te`` at θ=30°/45°:
+        |Γ| ~4-7%, phase ~180° up to the ~11° Yee reference-plane offset.
+
+    See Also
+    --------
+    oblique_reflection_magnitude : magnitude-only oblique |Γ| (no phase).
+    fresnel_reflection_coefficient : normal-incidence complex Γ.
+    """
+    total = jnp.asarray(total_series)
+    inc = jnp.asarray(incident_series)
+    if total.ndim != 2 or inc.shape != total.shape:
+        raise ValueError(
+            "total_series and incident_series must both be (n_steps, n_probes) and "
+            f"equal-shaped; got {total.shape} and {inc.shape}"
+        )
+    ns = total.shape[0] if n_gate is None else int(n_gate)
+    t = jnp.arange(ns) * dt
+    kern = jnp.exp(+1j * 2.0 * jnp.pi * f0 * t) * dt  # +j conjugate kernel (oblique envelope)
+    tp = jnp.sum(total[:ns].astype(jnp.complex64) * kern[:, None], axis=0)
+    ip = jnp.sum(inc[:ns].astype(jnp.complex64) * kern[:, None], axis=0)
+    idx = jnp.asarray(probe_index, jnp.float32)
+    # self-calibrated de-rotation slope S = -2·(incident phase slope), in-graph linear fit.
+    ph = jnp.unwrap(jnp.angle(ip))
+    xm = idx - jnp.mean(idx)
+    slope_inc = jnp.sum(xm * (ph - jnp.mean(ph))) / jnp.sum(xm * xm)
+    s = -2.0 * slope_inc
+    ratio = (tp - ip) / ip
+    return jnp.mean(ratio * jnp.exp(-1j * s * idx)) * jnp.exp(1j * s * float(interface_index))
+
+
 def fresnel_r_te(angle_deg: float, eps_r: float) -> float:
     """Analytical TE Fresnel reflection coefficient magnitude.
 

--- a/tests/test_oblique_fresnel_magnitude.py
+++ b/tests/test_oblique_fresnel_magnitude.py
@@ -50,6 +50,29 @@ def _eps_slab(shape, xi, xe, eps):
     return a if eps == 1.0 else a.at[xi:xe, :, :].set(eps)
 
 
+def _build_lean(theta):
+    """Small oblique cell for the GRADIENT test only. AD=FD is config-independent, and the
+    reverse tape of the full-size config OOMs the GPU (~5.6GB alloc on rtx4090); this lean
+    domain/step-count keeps the AD peak well under GPU memory for the pre-release gate."""
+    dom = (0.40, 0.08, 0.006)
+    xif, xend, plat = 0.10, 0.30, (0.04, 0.08)
+    yc, zc = dom[1] / 2, dom[2] / 2
+    grid = Grid(freq_max=10e9, domain=dom, dx=DX, cpml_layers=10)
+    xi = grid.position_to_index((xif, yc, zc))[0]
+    xe = grid.position_to_index((xend, yc, zc))[0]
+    xprobes = np.arange(plat[0], plat[1], DX)
+    n = np.sqrt(EPS_R)
+    t_back = (2 * (xif - plat[1]) / C0) + (2 * (xend - xif) / (C0 / n))
+    ns = min(int(0.9 * t_back / grid.dt), 1000)
+    sim = Simulation(freq_max=10e9, domain=dom, dx=DX, boundary="cpml", cpml_layers=10, mode="3d")
+    sim.add_tfsf_source(f0=F0, bandwidth=BW, polarization="ez", direction="+x",
+                        angle_deg=theta, waveform="modulated_gaussian")
+    for xp in xprobes:
+        sim.add_probe((float(xp), yc, zc), component="ez")
+    probe_idx = np.array([grid.position_to_index((float(xp), yc, zc))[0] for xp in xprobes], float)
+    return sim, grid.shape, xi, xe, probe_idx, grid.dt, ns
+
+
 def _series(sim, eps_arr, ns, ckpt=False):
     return sim.forward(eps_override=eps_arr, n_steps=ns, checkpoint=ckpt,
                        skip_preflight=True).time_series  # complex for oblique
@@ -71,7 +94,7 @@ def test_oblique_fresnel_magnitude_vs_analytic(theta, tol):
 @pytest.mark.slow
 def test_oblique_reflection_magnitude_differentiable():
     """d|Γ|/dε flows through the checkpointed oblique forward and matches finite difference."""
-    sim, shape, xi, xe, dt, ns = _build(30.0)
+    sim, shape, xi, xe, _idx, dt, ns = _build_lean(30.0)  # lean config: AD tape fits GPU memory
     inc = _series(sim, _eps_slab(shape, xi, xe, 1.0), ns, ckpt=True)
 
     def absg(eps):

--- a/tests/test_oblique_fresnel_phase.py
+++ b/tests/test_oblique_fresnel_phase.py
@@ -1,0 +1,165 @@
+"""Differentiable oblique COMPLEX Fresnel Γ(θ) — magnitude AND PHASE (#423, follow-up to #422).
+
+`oblique_reflection_coefficient` recovers the reflected PHASE (the RIS phase-steering knob) that
+`oblique_reflection_magnitude` (#422) could not: the de-rotation slope is measured from the
+INCIDENT wave itself (self-calibrating → the exact discrete k_x), so the complex mean no longer
+cancels. Two gates:
+
+  • FAST synthetic contract (no FDTD): a two-run signal with a planted complex Γ and a planted
+    phase ramp — the helper recovers Γ (amplitude+phase) and stays on the AD tape.
+  • SLOW FDTD: oblique forward() reflection off a dielectric slab vs analytic ``fresnel_r_te``:
+    |Γ| ~4-7% and ∠Γ ~180° (up to the ~11° Yee reference-plane offset) at θ=30°/45°; the
+    complex-target RIS loss |Γ-Γ_target|² is differentiable (AD==FD).
+
+Harness: docs/research_notes/experiments/i404_oblique_20260720/oblique_complex_gamma_diff.py
+"""
+import numpy as np
+import jax
+import jax.numpy as jnp
+import pytest
+
+from rfx.api import Simulation
+from rfx.grid import Grid
+from rfx.probes import oblique_reflection_coefficient, fresnel_r_te
+
+F0, BW = 5e9, 0.15
+DOMAIN = (0.60, 0.12, 0.006)
+DX = 0.002
+X_IFACE, X_SLAB_END = 0.15, 0.50
+PLATEAU = (0.05, 0.13)
+C0 = 299792458.0
+EPS_R = 4.0
+
+
+# --------------------------------------------------------------------------- #
+# FAST synthetic contract: extraction math + differentiability, no FDTD.
+# --------------------------------------------------------------------------- #
+def _synth(gamma_true, kx, idx, iface, f0=F0, n_periods=6, spp=24):
+    """Complex Bloch-envelope two-run series carrying a planted Γ and phase ramp e^{-j k_x x}."""
+    dt = 1.0 / (f0 * spp)
+    n = n_periods * spp
+    env = np.exp(-1j * 2 * np.pi * f0 * np.arange(n) * dt)   # analytic envelope P ∝ e^{-j2πf0t}
+    ip = np.exp(-1j * kx * idx)                              # incident phasor (phase ramp)
+    rp = gamma_true * np.exp(-1j * kx * (2 * iface - idx))   # reflected: round-trip to interface
+    inc = ip[None, :] * env[:, None]
+    tot = (ip + rp)[None, :] * env[:, None]
+    return jnp.asarray(tot), jnp.asarray(inc), dt
+
+
+def test_oblique_phase_recovers_planted_complex_gamma():
+    """Helper recovers a planted complex Γ (amplitude+phase) and is grad-safe."""
+    idx = np.arange(6, dtype=float)
+    iface = 14.0
+    kx = 0.35
+    for g_true in (-0.4 + 0j, 0.3j, 0.25 - 0.15j):
+        tot, inc, dt = _synth(g_true, kx, idx, iface)
+        g = complex(oblique_reflection_coefficient(
+            tot, inc, f0=F0, dt=dt, probe_index=idx, interface_index=iface))
+        assert abs(g - g_true) < 2e-2, f"Γ={g:.4f} vs planted {g_true:.4f}"
+
+    tot, inc, dt = _synth(-0.4 + 0j, kx, idx, iface)
+    refl = tot - inc
+    g_target = 0.2 + 0.1j
+
+    def loss(theta):
+        g = oblique_reflection_coefficient(inc + theta * refl, inc, f0=F0, dt=dt,
+                                           probe_index=idx, interface_index=iface)
+        return jnp.abs(g - g_target) ** 2
+
+    g_ad = float(jax.grad(loss)(1.0))
+    h = 1e-3
+    g_fd = (float(loss(1.0 + h)) - float(loss(1.0 - h))) / (2 * h)
+    assert np.isfinite(g_ad), "NaN/Inf gradient (P0)"
+    assert abs(g_ad - g_fd) < 1e-2 * abs(g_fd) + 1e-6, f"AD={g_ad:.4e} vs FD={g_fd:.4e}"
+
+    with pytest.raises(ValueError):
+        oblique_reflection_coefficient(tot[:, 0], inc[:, 0], f0=F0, dt=dt,
+                                       probe_index=idx, interface_index=iface)
+
+
+# --------------------------------------------------------------------------- #
+# SLOW physics: oblique forward() reflection vs analytic Fresnel (magnitude + phase).
+# --------------------------------------------------------------------------- #
+def _build(theta):
+    grid = Grid(freq_max=10e9, domain=DOMAIN, dx=DX, cpml_layers=10)
+    xi = grid.position_to_index((X_IFACE, 0.06, 0.003))[0]
+    xe = grid.position_to_index((X_SLAB_END, 0.06, 0.003))[0]
+    xprobes = np.arange(PLATEAU[0], PLATEAU[1], DX)
+    probe_idx = np.array([grid.position_to_index((float(xp), 0.06, 0.003))[0] for xp in xprobes], float)
+    n = np.sqrt(EPS_R)
+    t_back = (2 * (X_IFACE - PLATEAU[1]) / C0) + (2 * (X_SLAB_END - X_IFACE) / (C0 / n))
+    ns = min(int(0.9 * t_back / grid.dt), 1700)
+    sim = Simulation(freq_max=10e9, domain=DOMAIN, dx=DX, boundary="cpml", cpml_layers=10, mode="3d")
+    sim.add_tfsf_source(f0=F0, bandwidth=BW, polarization="ez", direction="+x",
+                        angle_deg=theta, waveform="modulated_gaussian")
+    for xp in xprobes:
+        sim.add_probe((float(xp), 0.06, 0.003), component="ez")
+    return sim, grid.shape, xi, xe, probe_idx, grid.dt, ns
+
+
+def _build_lean(theta):
+    """Small oblique cell for the GRADIENT test only (AD=FD is config-independent). The
+    full-size reverse tape OOMs the GPU (~5.6GB); this keeps the AD peak under GPU memory."""
+    dom = (0.40, 0.08, 0.006)
+    xif, xend, plat = 0.10, 0.30, (0.04, 0.08)
+    yc, zc = dom[1] / 2, dom[2] / 2
+    grid = Grid(freq_max=10e9, domain=dom, dx=DX, cpml_layers=10)
+    xi = grid.position_to_index((xif, yc, zc))[0]
+    xe = grid.position_to_index((xend, yc, zc))[0]
+    xprobes = np.arange(plat[0], plat[1], DX)
+    n = np.sqrt(EPS_R)
+    t_back = (2 * (xif - plat[1]) / C0) + (2 * (xend - xif) / (C0 / n))
+    ns = min(int(0.9 * t_back / grid.dt), 1000)
+    sim = Simulation(freq_max=10e9, domain=dom, dx=DX, boundary="cpml", cpml_layers=10, mode="3d")
+    sim.add_tfsf_source(f0=F0, bandwidth=BW, polarization="ez", direction="+x",
+                        angle_deg=theta, waveform="modulated_gaussian")
+    for xp in xprobes:
+        sim.add_probe((float(xp), yc, zc), component="ez")
+    probe_idx = np.array([grid.position_to_index((float(xp), yc, zc))[0] for xp in xprobes], float)
+    return sim, grid.shape, xi, xe, probe_idx, grid.dt, ns
+
+
+def _series(sim, eps_arr, ns, ckpt=False):
+    return sim.forward(eps_override=eps_arr, n_steps=ns, checkpoint=ckpt,
+                       skip_preflight=True).time_series
+
+
+def _eps_slab(shape, xi, xe, eps):
+    a = jnp.ones(shape, jnp.float32)
+    return a if eps == 1.0 else a.at[xi:xe, :, :].set(eps)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("theta,magtol", [(30.0, 0.10), (45.0, 0.08)])
+def test_oblique_complex_gamma_vs_analytic(theta, magtol):
+    """|Γ| and ∠Γ from oblique forward() match analytic Fresnel (phase up to the Yee offset)."""
+    sim, shape, xi, xe, idx, dt, ns = _build(theta)
+    inc = _series(sim, _eps_slab(shape, xi, xe, 1.0), ns)
+    tot = _series(sim, _eps_slab(shape, xi, xe, EPS_R), ns)
+    g = complex(oblique_reflection_coefficient(
+        tot, inc, f0=F0, dt=dt, probe_index=idx, interface_index=float(xi), n_gate=ns))
+    ga = fresnel_r_te(theta, EPS_R)
+    assert abs(g) < 1.0, f"nonphysical |Γ|={abs(g):.3f} (θ={theta})"
+    assert abs(abs(g) - abs(ga)) / abs(ga) < magtol, f"|Γ|={abs(g):.3f} vs {abs(ga):.3f} (θ={theta})"
+    dph = abs(((np.degrees(np.angle(g)) - 180.0 + 180) % 360) - 180)
+    assert dph < 20.0, f"∠Γ={np.degrees(np.angle(g)):.1f}° vs 180° (θ={theta}, off {dph:.1f}°)"
+
+
+@pytest.mark.slow
+def test_oblique_complex_gamma_differentiable():
+    """The complex-target RIS loss |Γ-Γ_target|² is differentiable through oblique forward()."""
+    sim, shape, xi, xe, idx, dt, ns = _build_lean(30.0)  # lean config: AD tape fits GPU memory
+    inc = _series(sim, _eps_slab(shape, xi, xe, 1.0), ns, ckpt=True)
+    g_target = 0.30 * np.exp(1j * 2.5)
+
+    def loss(eps):
+        tot = _series(sim, jnp.ones(shape, jnp.float32).at[xi:xe, :, :].set(eps), ns, ckpt=True)
+        g = oblique_reflection_coefficient(tot, inc, f0=F0, dt=dt, probe_index=idx,
+                                           interface_index=float(xi), n_gate=ns)
+        return jnp.abs(g - g_target) ** 2
+
+    g_ad = float(jax.grad(loss)(EPS_R))
+    h = 0.05
+    g_fd = (float(loss(EPS_R + h)) - float(loss(EPS_R - h))) / (2 * h)
+    assert np.isfinite(g_ad), "NaN/Inf gradient (P0)"
+    assert abs(g_ad - g_fd) < 0.08 * abs(g_fd) + 1e-6, f"AD={g_ad:.4e} vs FD={g_fd:.4e}"


### PR DESCRIPTION
## What

Closes **#423** (oblique reflection **phase** — the RIS phase-steering knob). `rfx.probes.oblique_reflection_coefficient` recovers **complex Γ** (amplitude AND phase) for oblique incidence, superseding `oblique_reflection_magnitude` (#422, magnitude-only).

The de-embed cancellation that blocked the phase (#422) is fixed by a **self-calibrating de-rotation**: the slope is measured from the **incident** wave (its phase slope = the exact discrete k_x), so no analytic/dispersion k_x is needed and the complex mean no longer cancels. The slope is design-independent (vacuum reference) → Γ stays differentiable.

| gate | result |
|---|---|
| fast synthetic contract | planted complex Γ + phase ramp recovered, grad-safe |
| slow FDTD vs analytic `fresnel_r_te` | \|Γ\| 4–7%, **∠Γ 169.4°/174.5°** (10.6°/5.5° off 180° = Yee offset), complex-target AD==FD |

## Also: pre-release GPU gate fix

GPU run `369367247973` was **14 passed, 1 failed** — the one failure was a **GPU OOM** (reverse AD tape ~5.6 GB on the full 0.60 m oblique config), **not** a physics failure. Everything else passed on real rtx4090 (incl. the jnp-vs-numpy RCS equivalence at rel<1e-4). AD=FD is config-independent, so the oblique **gradient** tests (#422 + #423) now use a **lean** cell (`_build_lean`, 0.40 m, ≤1000 steps) that fits GPU memory; **value** tests keep the full config. See `docs/research_notes/2026-07-22_gpu_validate_diffplanewave.md`.

Kept at `rfx.probes` level; AD-surface contract unaffected. Collection +1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)