### PR TITLE
chore(vessl): add oblique-phase test (#428) to the GPU validation lane

### DIFF
--- a/scripts/vessl_gpu_validate_diffplanewave.yaml
+++ b/scripts/vessl_gpu_validate_diffplanewave.yaml
@@ -37,6 +37,7 @@ run: |-
     tests/test_forward_tfsf_fresnel_groundtruth.py \
     tests/test_rcs_jax_differentiable.py \
     tests/test_oblique_fresnel_magnitude.py \
+    tests/test_oblique_fresnel_phase.py \
     tests/test_rcs_reduction_inverse_design.py \
     > "$out/validate.log" 2>&1
   rc=$?


### PR DESCRIPTION
Run 2 GREEN (15 passed) for the 4 original files with the lean-config memory fix. Adds test_oblique_fresnel_phase.py so the lane covers all 5 new slow-test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)