### PR TITLE
fix(preflight): accept normalize='flux' on the NU waveguide S-matrix fence

### DIFF
--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1324,7 +1324,14 @@ class _PreflightMixin:
         *,
         normalize: bool | str,
     ) -> None:
-        """Mirror ``compute_waveguide_s_matrix`` family-routing checks."""
+        """Mirror ``compute_waveguide_s_matrix`` family-routing checks.
+
+        Only the simulation-visible clauses are mirrored (``normalize`` and
+        multi-mode on the non-uniform fence); ``compute_waveguide_s_matrix``
+        call-time parameters (``subpixel_smoothing``, ``port_reference_sims``,
+        ``eps_override`` / ``sigma_override``) are not exposed to preflight and
+        stay method-only checks.
+        """
 
         if not self._waveguide_ports:
             raise ValueError(
@@ -1360,15 +1367,15 @@ class _PreflightMixin:
             )
         if self._dx_profile is not None or self._dy_profile is not None:
             unsupported = []
-            if normalize is not True:
-                unsupported.append("normalize=True is required")
+            if normalize is not True and normalize != "flux":
+                unsupported.append("normalize=True or normalize='flux' is required")
             if any(entry.n_modes > 1 for entry in entries):
                 unsupported.append("multi-mode ports (n_modes>1) are not supported")
             if unsupported:
                 raise NotImplementedError(
                     "compute_waveguide_s_matrix() on a non-uniform mesh "
-                    "(dx_profile / dy_profile) supports normalize=True "
-                    "and single-mode ports. "
+                    "(dx_profile / dy_profile) supports normalize=True or "
+                    "normalize='flux' and single-mode ports. "
                     + "; ".join(unsupported)
                     + ". Drop the dx/dy profile to use the uniform lane."
                 )

--- a/scripts/diagnostics/run_waveguide_wr90_nonuniform_broad_e5_sweep.py
+++ b/scripts/diagnostics/run_waveguide_wr90_nonuniform_broad_e5_sweep.py
@@ -7,7 +7,8 @@ adjacent-cell ratio up to 3x); geometry axis is the dielectric slab eps_r.
 
 WR-90 X-band single-mode TE10, centered slab L=4mm (no Fabry-Perot null in
 band so |S11| stays above the floor). dx=0.25mm base. Truth: analytic Airy
-(independent). NU path supports normalize=True single-mode only.
+(independent). NU path supports single-mode normalize=True or normalize='flux';
+this sweep exercises normalize=True.
 """
 from __future__ import annotations
 import json, sys, time

--- a/tests/test_sparameter_support_contract.py
+++ b/tests/test_sparameter_support_contract.py
@@ -250,3 +250,70 @@ def test_msl_nu_fence_message_parity_sparams_vs_preflight():
         "fence message drift: _sparams vs _preflight must stay byte-identical.\n"
         f"  _sparams:        {msg_sparams!r}\n  _preflight issue: {fence_issues[0]!r}"
     )
+
+
+def _nu_waveguide_sim(n_modes: int = 1) -> "Simulation":
+    sim = Simulation(
+        freq_max=12e9,
+        domain=(0.10, 0.023, 0.010),
+        dx=1e-3,
+        dy_profile=np.full(23, 1e-3),
+        boundary="cpml",
+        cpml_layers=4,
+    )
+    for x_position, direction, name in ((0.010, "+x", "wg1"), (0.090, "-x", "wg2")):
+        sim.add_waveguide_port(
+            x_position=x_position,
+            y_range=(0.0, 0.023),
+            z_range=(0.0, 0.010),
+            direction=direction,
+            f0=10e9,
+            n_modes=n_modes,
+            name=name,
+        )
+    return sim
+
+
+def test_preflight_waveguide_nu_accepts_flux_route():
+    """normalize='flux' is a supported NU waveguide route (the NU flux extractor
+    and its AD channel are wired in _sparams; graded-dy Airy fixtures cover it).
+    preflight must not red-flag a config compute_waveguide_s_matrix() accepts."""
+    report = _nu_waveguide_sim().preflight_sparameters(
+        calculator="waveguide", normalize="flux"
+    )
+    fence_issues = [str(i) for i in report.issues if "non-uniform mesh" in str(i)]
+    assert not fence_issues, (
+        f"preflight red-flags the supported NU flux route: {fence_issues}"
+    )
+
+
+@pytest.mark.parametrize(
+    "normalize, n_modes",
+    [(False, 1), (True, 2)],
+    ids=["normalize-clause", "multimode-clause"],
+)
+def test_waveguide_nu_fence_message_parity_sparams_vs_preflight(normalize, n_modes):
+    """Same governance as the MSL parity test above: the NU fence message must
+    stay byte-identical between compute_waveguide_s_matrix (_sparams) and
+    preflight_sparameters (_preflight), clause by clause. Regression lock for
+    the drift where preflight kept rejecting normalize='flux' after _sparams
+    started accepting it (uniform PR #172 flux-AD mirror on the NU lane)."""
+    sim_a = _nu_waveguide_sim(n_modes=n_modes)
+    try:
+        sim_a.compute_waveguide_s_matrix(n_steps=1, normalize=normalize)
+        msg_sparams = None
+    except NotImplementedError as e:
+        msg_sparams = str(e)
+    assert msg_sparams is not None, "_sparams must fence this config on NU"
+
+    sim_b = _nu_waveguide_sim(n_modes=n_modes)
+    report = sim_b.preflight_sparameters(calculator="waveguide", normalize=normalize)
+    fence_issues = [str(i) for i in report.issues if "non-uniform mesh" in str(i)]
+    assert len(fence_issues) == 1, (
+        f"_preflight must surface the NU fence exactly once; "
+        f"got {[str(i) for i in report.issues]}"
+    )
+    assert msg_sparams in fence_issues[0], (
+        "fence message drift: _sparams vs _preflight must stay byte-identical.\n"
+        f"  _sparams:        {msg_sparams!r}\n  _preflight issue: {fence_issues[0]!r}"
+    )


### PR DESCRIPTION
## Root cause

`compute_waveguide_s_matrix()` accepts `normalize=True` **or** `normalize='flux'` on non-uniform meshes (`_sparams.py` NU fence; the NU flux extractor + its differentiable eps/sigma AD channel are wired, covered by the graded-dy Airy fixtures and `tests/test_waveguide_nu_flux{,_ad}.py`, and `docs/guides/sparameter_support_matrix.md` explicitly says *"Prefer `normalize='flux'`"* on this lane). The preflight mirror `_validate_waveguide_sparameter_request_for_preflight` was never updated when the NU flux route landed and still required `normalize=True` only — so `preflight_sparameters(calculator="waveguide", normalize="flux")` red-flagged a supported, documented-preferred configuration with a false "not supported" message.

This is an **alignment of a stale advisory mirror, not a gate loosening**: `_sparams` (the authoritative gate) is untouched, and no committed tolerance/gate changes.

## Changes

- `rfx/api/_preflight.py`: NU fence predicate + message aligned **byte-identically** with `_sparams` (`normalize is not True and normalize != "flux"`); validator docstring now states the mirror scope (call-time-only params `subpixel_smoothing` / `port_reference_sims` / `eps_override` / `sigma_override` remain method-only checks — pre-existing behavior, now documented).
- `tests/test_sparameter_support_contract.py`: two new contract tests following the existing MSL parity idiom — (1) preflight must not red-flag the NU flux route; (2) fence-message parity `_sparams` vs `_preflight`, parametrized over both shared clauses (`normalize`, multi-mode) so any one-sided message edit fails.
- `scripts/diagnostics/run_waveguide_wr90_nonuniform_broad_e5_sweep.py`: stale docstring claim ("NU path supports normalize=True single-mode only") corrected.

## Evidence

- Contract file: **19 passed in 1.3 s** (no FDTD; fences trip at `n_steps=1`).
- Red-proof: with the `_preflight.py` hunk stashed, both new tests fail (false flux rejection + message drift); restored → 19/19 green.
- Lint (CI gate scope): `ruff check` clean on both touched gated files. Two `E401` in the diagnostics script are pre-existing and outside the `rfx/ tests/` lint gate; only its docstring was touched.
- Independent review pass: APPROVE, 0 blocker/major; both minors (mirror-scope docstring, multi-mode parity clause) addressed in this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)