### PR TITLE
feat(until_decay): measured static-remnant cap-hit advisory (#388)

### DIFF
--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -1723,6 +1723,7 @@ def run_nonuniform_until_decay(
 
     peak_U = 0.0           # running peak, updated at checks only
     energy_below = 0       # consecutive sub-threshold energy checks
+    decayed_fired = False  # #388: did the energy criterion fire (vs cap-hit)?
     decay_checks: list = []
     ys_chunks = []
     steps_done = 0
@@ -1748,9 +1749,18 @@ def run_nonuniform_until_decay(
             if U < decay_by * peak_U:
                 energy_below += 1
                 if energy_below >= decay_energy_consecutive:
+                    decayed_fired = True
                     break
             else:
                 energy_below = 0
+
+    # #388: measured static-remnant advisory on cap-hit (until_decay is absorbing-only on
+    # the NU lane too, so a cap-hit without firing means the energy criterion could not
+    # self-terminate — warn if the remnant is electrostatic). Function-local import avoids
+    # a module-level simulation<->nonuniform cycle.
+    if not decayed_fired:
+        from rfx.simulation import _warn_static_remnant_cap_hit
+        _warn_static_remnant_cap_hit(carry["fdtd"], materials, grid)
 
     # Per-chunk ys concatenate to exactly steps_done rows; the
     # emit_time_series=False convention ((steps, 0)) is preserved

--- a/rfx/simulation.py
+++ b/rfx/simulation.py
@@ -18,7 +18,7 @@ import jax.numpy as jnp
 from rfx.grid import Grid
 from rfx.core.yee import (
     FDTDState, MaterialArrays, init_state,
-    update_e, update_e_aniso, update_e_aniso_inv, update_h, EPS_0, _shift_bwd,
+    update_e, update_e_aniso, update_e_aniso_inv, update_h, EPS_0, MU_0, _shift_bwd,
     precompute_coeffs, update_he_fast,
 )
 from rfx.boundaries.pec import apply_pec, apply_pec_faces, apply_pec_occupancy
@@ -1939,6 +1939,56 @@ def run(
 # Field-decay-based stopping criterion (Python loop + JIT step)
 # ---------------------------------------------------------------------------
 
+def _warn_static_remnant_cap_hit(state, materials, grid) -> None:
+    """#388: on an ``until_decay`` CAP-HIT, warn if the interior remnant is electrostatic.
+
+    A soft current source deposits net charge; the remnant's discrete-Poisson self-energy
+    neither radiates nor is absorbed by CPML, so it floors the interior-energy criterion and
+    ``until_decay`` silently cap-hits even though the radiating field has settled. This is a
+    MEASURED post-run advisory (complements the waveform-predicted pre-run
+    :meth:`_warn_until_decay_dc_floor`, which cannot see thin-source-cell-amplified floors).
+
+    Detection uses PHYSICAL energy (½ε|E|² vs ½μ|H|²): a propagating/radiating field is
+    equipartitioned (H-share ~0.5, and its instantaneous H-energy stays ~0.2 even at an E-max
+    2f-slosh instant), while a static electrostatic remnant is E-only (H-share ~1e-10). The
+    ``H-share < 1e-2`` gate separates them with enormous margin — no false-fire on a genuine
+    still-ringing cap-hit.
+    """
+    import warnings as _w
+    is_2d = getattr(grid, "is_2d", False)  # NonUniformGrid is always 3D (no is_2d attr)
+    ix0, ix1 = grid.pad_x_lo, grid.nx - grid.pad_x_hi
+    iy0, iy1 = grid.pad_y_lo, grid.ny - grid.pad_y_hi
+    iz0, iz1 = (0, grid.nz) if is_2d else (grid.pad_z_lo, grid.nz - grid.pad_z_hi)
+    sl = (slice(ix0, ix1), slice(iy0, iy1), slice(iz0, iz1))
+    eps_r = materials.eps_r[sl]
+    mu_r = getattr(materials, "mu_r", None)
+    mu_r = mu_r[sl] if (mu_r is not None and jnp.ndim(mu_r) > 0) else 1.0
+    if is_2d:
+        e2 = state.ez[sl] ** 2
+        h2 = state.hx[sl] ** 2 + state.hy[sl] ** 2
+    else:
+        e2 = state.ex[sl] ** 2 + state.ey[sl] ** 2 + state.ez[sl] ** 2
+        h2 = state.hx[sl] ** 2 + state.hy[sl] ** 2 + state.hz[sl] ** 2
+    u_e = 0.5 * EPS_0 * float(jnp.sum(eps_r * e2))
+    u_h = 0.5 * MU_0 * float(jnp.sum(mu_r * h2))
+    tot = u_e + u_h
+    if tot <= 0.0:
+        return
+    h_share = u_h / tot
+    if h_share < 1e-2:
+        _w.warn(
+            f"run(until_decay=...) cap-hit at max_steps without the energy criterion firing, and "
+            f"{100 * (1 - h_share):.1f}% of the final interior energy is electrostatic "
+            f"(H-share {h_share:.1e}). A static soft-source charge remnant (discrete-Poisson "
+            f"self-energy that neither radiates nor is absorbed by CPML) held the interior energy "
+            f"above decay_by*peak_U while the radiating field settled, so the energy criterion "
+            f"could not self-terminate. Remedies: reduce the source's deposited DC (GaussianPulse "
+            f"cutoff / lower bandwidth), run a fixed n_steps, or confirm settling from the probe "
+            f"envelope. (issue #388)",
+            UserWarning,
+        )
+
+
 def run_until_decay(
     grid: Grid,
     materials: MaterialArrays,
@@ -2220,6 +2270,7 @@ def run_until_decay(
     peak_sq = 0.0          # closed/PEC point-field running peak
     peak_U = 0.0           # absorbing interior-energy running peak (at checks)
     energy_below = 0       # consecutive sub-threshold energy checks
+    decayed_fired = False  # #388: did the energy criterion fire (vs silently cap-hit)?
     all_probes = []
     actual_steps = 0
 
@@ -2246,6 +2297,7 @@ def run_until_decay(
                 if U < decay_by * peak_U:
                     energy_below += 1
                     if energy_below >= decay_energy_consecutive:
+                        decayed_fired = True
                         break
                 else:
                     energy_below = 0
@@ -2259,6 +2311,11 @@ def run_until_decay(
             if actual_steps >= min_steps and step % check_interval == 0 and peak_sq > 0.0:
                 if val_sq < decay_by * peak_sq:
                     break
+
+    # #388: measured static-remnant advisory on an absorbing-lane cap-hit (the energy
+    # criterion never fired). Complements the pre-run waveform-DC advisory.
+    if use_absorbing and not decayed_fired:
+        _warn_static_remnant_cap_hit(carry["fdtd"], materials, grid)
 
     # ---- assemble result ----
     time_series = jnp.stack(all_probes, axis=0)

--- a/tests/test_source_dc_floor_guards.py
+++ b/tests/test_source_dc_floor_guards.py
@@ -318,6 +318,91 @@ def test_until_decay_zero_forced_n_escape_stays_silent():
 
 
 # ---------------------------------------------------------------------------
+# 3e. MEASURED static-remnant cap-hit advisory (#388 candidate 3). Complements the
+#     pre-run waveform-DC advisory: it fires on the ACTUAL run outcome (final-state
+#     physical E/H energy share), catching thin-source-cell floors the pre-run
+#     advisory cannot predict. Physical energy (½εE² vs ½μH²) separates a static
+#     electrostatic remnant (H-share ~1e-10) from a still-ringing field (H-share ~0.2+).
+# ---------------------------------------------------------------------------
+
+def _run_capture(sim, **run_kw):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        res = sim.run(**run_kw)
+    fired = [str(w.message) for w in caught
+             if "issue #388" in str(w.message) and "H-share" in str(w.message)]
+    return len(res.time_series), fired
+
+
+def _soft_ez_sim(waveform):
+    sim = Simulation(freq_max=4e9, domain=(0.02, 0.02, 0.02), dx=1e-3,
+                     cpml_layers=4, boundary="cpml")
+    sim.add_source((0.01, 0.01, 0.01), "ez", waveform=waveform)
+    sim.add_probe((0.006, 0.006, 0.006), "ez")
+    return sim
+
+
+def test_static_remnant_cap_hit_advisory_fires():
+    """A high-DC soft source cap-hits (energy floors); the measured advisory fires."""
+    n, fired = _run_capture(_soft_ez_sim(ModulatedGaussian(f0=2.2e9, bandwidth=1.2)),
+                            until_decay=1e-3, decay_min_steps=200, decay_max_steps=1500)
+    assert n == 1500, "high-DC soft source must cap-hit (criterion cannot self-terminate)"
+    assert fired, "measured #388 static-remnant advisory must fire on the cap-hit"
+    assert "electrostatic" in fired[0] and "H-share" in fired[0]
+
+
+def test_static_remnant_advisory_silent_on_settled_run():
+    """A low-DC source settles (the criterion fires) — no cap-hit, no advisory."""
+    n, fired = _run_capture(_soft_ez_sim(GaussianPulse(f0=2.2e9, bandwidth=0.8)),
+                            until_decay=1e-3, decay_min_steps=200, decay_max_steps=1500)
+    assert n < 1500, "low-DC source should settle before the cap"
+    assert not fired, f"advisory must stay silent on a settled run: {fired}"
+
+
+def test_static_remnant_advisory_fires_on_nonuniform_lane():
+    """The NU (dz_profile) lane floors the same way (#388 measured both lanes)."""
+    dz = np.array([0.4e-3] * 4 + [0.5e-3] * 6)
+    sim = Simulation(freq_max=4e9, domain=(0.02, 0.02, 0.01), dx=1e-3, dz_profile=dz,
+                     cpml_layers=4, boundary="cpml")
+    sim.add_source((0.01, 0.01, 0.003), "ez",
+                   waveform=ModulatedGaussian(f0=2.2e9, bandwidth=1.2))
+    sim.add_probe((0.006, 0.006, 0.003), "ez")
+    n, fired = _run_capture(sim, until_decay=1e-3, decay_min_steps=200, decay_max_steps=1500)
+    assert n == 1500 and fired, f"NU cap-hit static-remnant advisory must fire (steps={n})"
+
+
+def test_static_remnant_advisory_silent_when_field_balanced():
+    """False-fire guard (the 2f-slosh concern): a genuine still-ringing cap-hit has a
+    BALANCED physical E/H share (H-share ~0.5), NOT a static remnant. Directly exercise
+    the detector on synthetic states so the threshold logic is pinned without a fixture.
+    """
+    from rfx.simulation import _warn_static_remnant_cap_hit
+    from rfx.core.yee import init_state, init_materials, EPS_0, MU_0
+    from rfx.grid import Grid
+
+    grid = Grid(freq_max=4e9, domain=(0.02, 0.02, 0.02), dx=2e-3, cpml_layers=2)
+    mats = init_materials(grid.shape)
+    st = init_state(grid.shape)
+    eta = math.sqrt(MU_0 / EPS_0)  # |E| = eta*|H| -> ½εE² == ½μH² (H-share 0.5)
+
+    # (a) balanced propagating-like field: E=eta, H=1 -> H-share ~0.5 -> SILENT
+    bal = st._replace(ex=st.ex + eta, hy=st.hy + 1.0)
+    with warnings.catch_warnings(record=True) as c:
+        warnings.simplefilter("always")
+        _warn_static_remnant_cap_hit(bal, mats, grid)
+    assert not [w for w in c if "issue #388" in str(w.message)], \
+        "balanced E/H (still-ringing) must NOT trigger the static-remnant advisory"
+
+    # (b) pure electrostatic remnant: E only, H=0 -> H-share 0 -> FIRES
+    stat = st._replace(ex=st.ex + eta)
+    with warnings.catch_warnings(record=True) as c:
+        warnings.simplefilter("always")
+        _warn_static_remnant_cap_hit(stat, mats, grid)
+    assert [w for w in c if "issue #388" in str(w.message)], \
+        "an E-only (electrostatic) remnant must trigger the advisory"
+
+
+# ---------------------------------------------------------------------------
 # 4. unresolved-pulse preflight advisory (#386)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What (#388 candidate 3)

A soft current source deposits net charge; its remnant's static self-energy neither radiates nor is absorbed by CPML, so it floors the `until_decay` interior-energy criterion and the run **silently cap-hits** even though the radiating field settled. This adds a **measured post-run advisory** (both the uniform `run_until_decay` and NU `run_nonuniform_until_decay` lanes): on a cap-hit that never fired the criterion, it computes the final-state **physical** energy share (½ε|E|² vs ½μ|H|²) and warns when the remnant is electrostatic (**H-share < 1e-2**).

Complements the pre-run waveform-DC advisory (`_warn_until_decay_dc_floor`) — that one *predicts* from the waveform and **cannot see thin-source-cell-amplified floors**; this one *measures* the actual outcome.

## Why it's safe (the 2f-slosh concern)

A propagating field is equipartitioned (H-share ~0.5; even at an E-max 2f-slosh instant its H-energy stays ~0.2), while a static remnant is E-only (**measured H-share ~1e-10**). The gate separates them with enormous margin — no false-fire on a genuine still-ringing cap-hit (pinned by a synthetic balanced-vs-E-only unit test). The **criterion itself is unchanged** (byte-identical settling; the AB scan-vs-loop lock still passes) — purely an additive warning.

## Investigated & rejected: candidate 2 (H-only criterion)

Interior E- and H-energy slosh π/2 out of phase at 2f (`∫E²∝cos²ωt`, `∫H²∝sin²ωt`), so **`∫H²` nulls twice per cycle** → an H-only settling criterion **false-fires mid-ring-down** (corrupted DFT, worse than an honest cap-hit). A damped multi-mode resonator kept `min(∫H²)/peak` only ~2.9e-2 (29× margin — too thin for high-Q). The criterion-metric self-termination (candidates 1/2) is a harder redesign left for a dedicated session; this advisory makes the failure explicit + actionable now.

| test | checks |
|---|---|
| `test_static_remnant_cap_hit_advisory_fires` | uniform high-DC cap-hit → warns |
| `test_static_remnant_advisory_silent_on_settled_run` | low-DC settle → silent |
| `test_static_remnant_advisory_fires_on_nonuniform_lane` | NU cap-hit → warns |
| `test_static_remnant_advisory_silent_when_field_balanced` | synthetic false-fire guard (balanced silent / E-only fires) |

Regression: 35 until_decay-consumer tests pass, AB byte-identity holds, full collection +4, lint clean.

R3: memory=until_decay_deferred (ships candidate #3, falsifies #2) + no-silent-gate-loosening (criterion unchanged) | R2=1 CLOSING | falsifier=fires-on-static + silent-on-balanced/settled — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)