### PR TITLE
fix(msl-e5-gate): enforce passivity ceiling in _gate_open_stub (HIT-7a)

### DIFF
--- a/scripts/diagnostics/build_msl_broad_e5_envelope.py
+++ b/scripts/diagnostics/build_msl_broad_e5_envelope.py
@@ -49,6 +49,10 @@ THRESH = dict(
     thru_max_q=1.0,
     stub_freq_err_pct=10.0,
     stub_depth_db=15.0,
+    # HIT-7a: stub-gate passivity ceiling (the THRU gate has max_q<1 but the STUB gate
+    # enforced only freq+depth). 1.05 sits above the committed notch fixture's 1.0063
+    # (MSL Yee/band-edge envelope) and catches over-unity extraction artifacts (#337 class).
+    stub_max_col_power=1.05,
     extractor_residual_norm=1e-2,
 )
 
@@ -137,9 +141,17 @@ def _gate_open_stub(case_npz: dict, summary: dict) -> dict:
     band_mean_db = float(np.mean(s21_band_db))
     depth_db = float(band_mean_db - s21_dip_db)
 
+    # HIT-7a passivity ceiling: a passive stub cannot scatter more power than it receives,
+    # so max over band+column of sum_i |S_ij|^2 must stay <= 1 (+ Yee margin). The gate
+    # documented a passive-line criterion but only the THRU gate enforced it — an over-unity
+    # stub S-matrix (extraction/normalization artifact, #337 class) previously passed.
+    s_band = s[:, :, mask]                                       # (2, 2, nband)
+    max_col_power = float(np.max(np.sum(np.abs(s_band) ** 2, axis=0)))
+
     gates = {
         "freq_err_lt_10pct": freq_err_pct < THRESH["stub_freq_err_pct"],
         "depth_gt_15db": depth_db > THRESH["stub_depth_db"],
+        "passive_col_power_le_1p05": max_col_power <= THRESH["stub_max_col_power"],
     }
     return dict(
         passed=all(gates.values()),
@@ -151,6 +163,7 @@ def _gate_open_stub(case_npz: dict, summary: dict) -> dict:
             dip_s21_dB=s21_dip_db,
             band_mean_s21_dB=band_mean_db,
             dip_depth_dB=depth_db,
+            max_col_power_over_band=max_col_power,
             n_freqs_in_band=int(mask.sum()),
         ),
     )

--- a/tests/test_msl_broad_e5_envelope_gates.py
+++ b/tests/test_msl_broad_e5_envelope_gates.py
@@ -144,6 +144,20 @@ def test_stub_off_target_freq_fails():
     assert res["gates"]["freq_err_lt_10pct"] is False
 
 
+def test_stub_over_unity_col_power_fails():
+    """HIT-7a: an over-unity stub S-matrix (extraction/normalization artifact) must fail the
+    new passivity ceiling even though freq + depth would pass — previously the stub gate
+    checked only freq+depth, so a non-physical column power > 1 slipped through unflagged."""
+    npz = _make_stub_case_npz(f_dip=10e9, dip_db=-30.0)
+    npz["s_matrix"] = npz["s_matrix"] * 1.3          # column power ~1.69 >> 1.05
+    res = _gate_open_stub(npz, _stub_summary())
+    assert not res["passed"]
+    assert res["gates"]["passive_col_power_le_1p05"] is False
+    # the passivity gate is what fails — freq + depth are untouched (isolates the new gate)
+    assert res["gates"]["freq_err_lt_10pct"] is True
+    assert res["gates"]["depth_gt_15db"] is True
+
+
 def test_stub_shallow_dip_fails():
     # Dip at right freq but only -10 dB below the band mean
     npz = _make_stub_case_npz(f_dip=10e9, dip_db=-5.0, bandwidth=2e9)


### PR DESCRIPTION
The MSL broad-E5 open-stub gate documented a passive-line criterion but enforced only freq-error + dip-depth — an over-unity stub S-matrix passed unflagged (THRU gate has `max_q<1`; STUB gate had none). Adds a column-power ceiling (`max sum_i|S_ij|^2 <= 1.05`), root-caused to the committed notch fixture's 1.0063. New falsifier test; existing passive tests stay green; 9/9 pass.

**Premise-verification found the rest of the plan stale (already landed):** HIT-2 (MSL epilogue at `_sparams.py:1846`), HIT-3 (run() warn at `_execute.py:2773/2874`), HIT-7c (#395 battery rewrite) all DONE. **HIT-7b NOT actioned — misdiagnosis**: that path is `normalize=False` waveguide (documented ~1.41 envelope), so tightening toward 1.05 would false-trip; it's already envelope-aware-guarded.

R3: memory=llm-footgun (documented-but-absent guard) + gate-can-bind-artifact (falsifier test) + root-cause-before-gate (1.05 from 1.0063 fixture) | R2=0 | falsifier=over-unity fails + passive green — PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)