### PR TITLE
fix(kerr): fail-loud forward() guard + run()-Kerr wiring oracle (#403 blind spot)

### DIFF
--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -2423,6 +2423,23 @@ class _ExecuteMixin:
                 "add_lumped_rlc elements)."
             )
 
+        # Kerr χ³ (nonlinear) materials are threaded only on the run() path
+        # (uniform.py -> apply_kerr_ade).  The differentiable forward() lanes
+        # discard kerr_chi3 from _assemble_materials, so a Kerr material would
+        # silently give LINEAR physics (and a linear gradient) with no error.
+        # Fail loud rather than optimise against physics the caller did not ask
+        # for.  There is no chi3_override, so a configured Kerr material is the
+        # only way χ³ enters — self._materials is the complete signal.
+        if any(getattr(m, "chi3", 0.0) != 0.0 for m in self._materials.values()):
+            raise NotImplementedError(
+                "forward() does not support Kerr χ³ (nonlinear) materials: the "
+                "differentiable forward path ignores chi3, so the simulation "
+                "would run LINEAR physics and jax.grad would return a linear "
+                "gradient with no warning. Use run() for nonlinear simulations, "
+                "or remove the chi3 term from the material for a linear "
+                "differentiable forward."
+            )
+
         # Differentiable TFSF/plane-wave forward is wired on the uniform
         # single-device lane only (the shared scan + complex Bloch path, #404).
         # The non-uniform and distributed forward lanes have no TFSF handling and

--- a/tests/test_kerr_api_paths.py
+++ b/tests/test_kerr_api_paths.py
@@ -1,0 +1,118 @@
+"""Kerr χ³ on the public API paths: run() WIRES it, forward() GUARDS against silently
+dropping it (#403 blind spot — the emergent-propagation Kerr path was untested end-to-end).
+
+Two gaps this closes:
+
+1. ``test_nonlinear.py`` validates the single-cell ADE update formula
+   (E^{n+1}=E^n/(1+factor)) and energy-boundedness via the MANUAL update loop, but nothing
+   asserted that the public ``Simulation.run()`` API actually threads χ³ through to
+   ``apply_kerr_ade`` (simulation.py). If run() silently dropped Kerr (as forward() did),
+   every existing test would still pass. This gates that wiring.
+
+2. ``forward()`` (the differentiable path) discarded ``kerr_chi3`` from
+   ``_assemble_materials`` — a Kerr material gave LINEAR physics and a LINEAR gradient with
+   no error (a silent-wrong footgun for differentiable nonlinear design). Now guarded.
+
+WHY a wiring/monotonicity/stability oracle and NOT a quantitative SPM(Δφ) match: the naive
+pulsed-transmission-phase comparator is run-length-artifact-dominated (∠ flips sign between
+NP=30 and NP=40) AND at gateable χ³ the ADE per-step factor (dt/ε0)·χ³·E²≈0.4 is STRONGLY
+nonlinear (perturbative Δn=χ³⟨E²⟩/2n0 breaks down). A tight quantitative Kerr oracle needs a
+CW steady-state intensity comparator in the weak regime — a dedicated session (issue filed).
+This oracle instead gates the ROBUST observable: the probe field-difference norm ||E(χ³)−E(0)||
+is run-length-robust (0.8426 vs 0.8415 @ NP=30/40), domain-size INVARIANT (0.8426 across
+0.5/0.6 m × 0.06/0.10 m), null-controlled (χ³=0 ⇒ exactly 0), and monotonic in χ³
+(0.70/0.78/0.84 @ χ³=1/2/4). Harness: docs/research_notes/experiments/kerr_spm_*.py
+"""
+import numpy as np
+import pytest
+
+from rfx.api import Simulation
+from rfx.geometry import Box
+
+F0 = 5e9
+DX = 0.002
+EPS_R = 2.0
+DOMAIN = (0.50, 0.06, 0.006)
+X_IFACE, X_SLAB_END = 0.12, 0.27
+XPROBES = (0.16, 0.18, 0.20, 0.22, 0.33)
+
+
+# --------------------------------------------------------------------------- #
+# FAST: forward() must fail loud on a Kerr material (no silent linear physics).
+# --------------------------------------------------------------------------- #
+def _kerr_sim(chi3):
+    sim = Simulation(freq_max=10e9, domain=DOMAIN, dx=DX, boundary="cpml",
+                     cpml_layers=10, mode="3d")
+    sim.add_material("kerr", eps_r=EPS_R, chi3=chi3)
+    sim.add(Box((X_IFACE, -1, -1), (X_SLAB_END, 1, 1)), material="kerr")
+    sim.add_tfsf_source(f0=F0, bandwidth=0.3, amplitude=1.0, polarization="ez",
+                        direction="+x", waveform="modulated_gaussian")
+    for xp in XPROBES:
+        sim.add_probe((xp, DOMAIN[1] / 2, DOMAIN[2] / 2), component="ez")
+    return sim
+
+
+def test_forward_rejects_kerr_material():
+    """forward() with a χ³ material raises (rather than silently running LINEAR physics)."""
+    sim = _kerr_sim(0.1)
+    with pytest.raises(NotImplementedError, match="Kerr"):
+        sim.forward(n_steps=50, skip_preflight=True)
+
+
+def test_forward_guard_message_points_to_run():
+    """The guard tells the caller to use run() — the path that does thread χ³."""
+    sim = _kerr_sim(0.1)
+    with pytest.raises(NotImplementedError, match="run"):
+        sim.forward(n_steps=50, skip_preflight=True)
+
+
+def test_forward_without_kerr_is_unaffected():
+    """A χ³=0 (linear) material does NOT trip the guard — the forward path still runs."""
+    sim = _kerr_sim(0.0)  # chi3=0 ⇒ not a Kerr material
+    res = sim.forward(n_steps=50, skip_preflight=True)
+    assert res.time_series is not None and np.all(np.isfinite(res.time_series))
+
+
+# --------------------------------------------------------------------------- #
+# SLOW: run() actually applies Kerr, monotonically and stably.
+# --------------------------------------------------------------------------- #
+def _run_probe_series(chi3):
+    return np.asarray(_kerr_sim(chi3).run(num_periods=30, skip_preflight=True).time_series)
+
+
+@pytest.fixture(scope="module")
+def kerr_run_diffs():
+    base = _run_probe_series(0.0)
+    denom = float(np.linalg.norm(base))
+    diffs = {}
+    series = {0.0: base}
+    for chi3 in (1.0, 2.0, 4.0):
+        s = _run_probe_series(chi3)
+        series[chi3] = s
+        diffs[chi3] = float(np.linalg.norm(s - base)) / denom
+    return {"diffs": diffs, "series": series}
+
+
+@pytest.mark.slow
+def test_run_wires_kerr(kerr_run_diffs):
+    """run() with χ³>0 measurably changes the field vs χ³=0 — the public API threads Kerr.
+    DISCRIMINATING: if run() dropped χ³ (like forward() did), every diff would be ~0."""
+    diffs = kerr_run_diffs["diffs"]
+    for chi3, d in diffs.items():
+        assert d > 0.3, f"χ³={chi3} barely changed the field (||Δ||/||E||={d:.4f}) — Kerr not wired?"
+
+
+@pytest.mark.slow
+def test_run_kerr_monotonic_in_chi3(kerr_run_diffs):
+    """Stronger χ³ ⇒ larger field change (monotone). A wrong-sign or clipped coupling breaks this."""
+    d = kerr_run_diffs["diffs"]
+    assert d[4.0] > d[2.0] > d[1.0], f"non-monotone in χ³: {d}"
+
+
+@pytest.mark.slow
+def test_run_kerr_stable_and_bounded(kerr_run_diffs):
+    """The nonlinear run stays finite and bounded (no ADE blow-up); the change is physical,
+    not a divergence (||Δ||/||E|| well below the ~√2 two-uncorrelated-signals ceiling)."""
+    for chi3, s in kerr_run_diffs["series"].items():
+        assert np.all(np.isfinite(s)), f"non-finite field at χ³={chi3}"
+    assert kerr_run_diffs["diffs"][4.0] < 1.2, "field change looks like a blow-up, not Kerr"


### PR DESCRIPTION
## Two Kerr χ³ correctness gaps on the public API paths

### 1. `forward()` silently dropped χ³ (silent-wrong footgun → now fail-loud)
The differentiable forward lanes discard `kerr_chi3` from `_assemble_materials` (`_execute.py:2471`), so a Kerr material ran **linear physics** and `jax.grad` returned a **linear gradient with no error** — a differentiable nonlinear design would silently optimize the wrong physics. `forward()` now raises `NotImplementedError` pointing to `run()`, matching the fail-loud TFSF/`rlc_values_override` wrong-lane guards right above it. Fires **only** when a material has `chi3!=0`; linear `forward()` is unaffected (slow Fresnel forward regression stays green).

### 2. `run()`-Kerr was untested end-to-end (now gated)
`test_nonlinear.py` validates the **single-cell ADE formula** (`E^{n+1}=E^n/(1+factor)`) + energy-boundedness via the **manual** update loop — but nothing asserted the public `run()` API threads χ³ through to `apply_kerr_ade`. If `run()` had also dropped Kerr, every test still passed. This oracle gates the **robust** observable `‖E(χ³)−E(0)‖`:

| property | evidence |
|---|---|
| run-length robust | 0.8426 (NP=30) vs 0.8415 (NP=40) |
| domain-size **invariant** | 0.8426 across 0.5/0.6 m × 0.06/0.10 m |
| null-controlled | χ³=0 ⇒ exactly 0 |
| monotone in χ³ | 0.70 / 0.78 / 0.84 @ χ³=1/2/4 |
| finite / bounded | no ADE blow-up |

## Why NOT a quantitative SPM(Δφ) oracle (honest scoping)
The naive pulsed-transmission-phase comparator is **run-length-artifact-dominated** — ∠ flips sign between NP=30 (−0.18) and NP=40 (+0.10). And at gateable χ³ the ADE per-step factor `(dt/ε0)·χ³·E² ≈ 0.4` is **strongly nonlinear**, so the perturbative `Δn=χ³⟨E²⟩/2n0` breaks down. **Comparator-first**: the weak link is the measurement, not rfx's Kerr (which responds monotonically and stably). A tight quantitative Kerr oracle needs a CW steady-state intensity comparator in the weak regime — deferred to a dedicated session (issue to follow).

## Verification
- 6 tests (3 fast guard + 3 slow wiring) pass; lint clean; collection intact (+6).
- Slow `forward()` Fresnel regression: 7 passed (guard doesn't fire without a Kerr material).
- Harness (local, gitignored): `docs/research_notes/experiments/kerr_spm_*.py`

**R3**: memory=consistent-with `project_diff_planewave_inverse_design` (fail-loud forward-lane pattern) + `feedback_gate_can_bind_artifact` (added wiring gate: falsifier=run-dropping-Kerr→0 + domain-invariance 0.8426×3) | R2-attempts=1 (quantitative SPM attempted once → comparator inadequate → stopped that mechanism, shipped robust wiring oracle) | falsifier=run() dropping χ³ ⇒ all diffs 0 (discriminating test built in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)