### PR TITLE
fix(preflight): correct TFSF+lumped advisory — PEC-gap does NOT cure the divergence (#425)

### DIFF
--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -1751,25 +1751,27 @@ class _PreflightMixin:
     def _validate_cfg_tfsf_with_lumped_rlc(self, _w) -> None:
         """Warn: a lumped RLC element illuminated by a TFSF plane wave is unstable.
 
-        A bare ``add_lumped_rlc(...)`` element driven by a TFSF plane wave has no
-        defined series circuit, so its ADE current-tracking is ill-posed and the
-        fields diverge (measured: blow-up to ~1e35 by ~250 steps, C-independent).
-        The tunable-load (varactor) gradient IS validated for the PORT-fed lane
-        (``add_port`` + ``forward(rlc_values_override=...)`` — tests/test_lumped_rlc_ad.py),
-        not for a bare plane-wave load. For RIS/reconfigurable-surface design the
-        element must sit in a supporting PEC-gap structure (patch/aperture + gap +
-        ground) so it carries a defined current. Advisory warning (a proper gap
-        structure may be stable); see the tracking issue.
+        A ``add_lumped_rlc(...)`` element driven by a TFSF plane wave diverges
+        (measured: blow-up to ~1e35 by ~250 steps, C-independent). The root cause is
+        the TFSF total/scattered-field decomposition coupling into the lumped ADE
+        current, NOT a missing circuit path: embedding the element in a PEC-gap
+        structure does NOT cure it (tested 2026-07-22, #425 — a two-electrode PEC gap
+        still grows 0.1→1e25→NaN over ~800 steps; see
+        docs/research_notes/experiments/tfsf_lumped_pec_gap_stability.py). So there is
+        no geometry fix at the API level; a stable plane-wave lumped lane needs a
+        solver-level fix to the TFSF↔lumped coupling. The tunable-load (varactor)
+        gradient IS validated on the PORT-fed lane (``add_port`` +
+        ``forward(rlc_values_override=...)`` — tests/test_lumped_rlc_ad.py); use that
+        for varactor/RIS design. See the tracking issue (#425).
         """
         if self._tfsf is None or not self._lumped_rlc:
             return
         _w.warn(PreflightWarning(
-            "add_lumped_rlc(...) + a TFSF plane-wave source: a bare lumped element "
-            "in a plane wave has no defined series circuit and is numerically "
-            "unstable (fields diverge). Embed it in a supporting PEC-gap structure "
-            "(the RIS unit cell) so it carries a defined current. The varactor/"
-            "tunable-load gradient is validated for the PORT-fed lane (add_port + "
-            "forward(rlc_values_override=...)), not for bare plane-wave loads.",
+            "add_lumped_rlc(...) + a TFSF plane-wave source is numerically unstable "
+            "(fields diverge, C-independent). This is the TFSF↔lumped-ADE coupling, "
+            "not a missing circuit path — a PEC-gap structure does NOT cure it "
+            "(tested, #425). Use the validated PORT-fed lane (add_port + "
+            "forward(rlc_values_override=...)) for varactor/tunable-load design.",
             code="tfsf_lumped_rlc_unstable",
             source="_validate_cfg_tfsf_with_lumped_rlc",
         ))


### PR DESCRIPTION
## #425 step-0 stability pre-gate: architecture FALSIFIED

The verified design for #425 (varactor RIS unit cell) rested on the premise *"embed the lumped element in a PEC-gap structure so it carries a defined current → stable"* — which the preflight advisory hedged as *"a proper gap structure MAY be stable."* The step-0 stability pre-gate (mandated before spending the one-attempt) **falsifies** it:

| case | trajectory |
|---|---|
| BARE (#424 control) | max\|Ez\| 1.1e18 @ 164 steps |
| PEC-GAP (premise) | \|Ez\| thirds **0.1 → 4.6e11 → 1.06e25** @ 328 steps → **NaN** by ~800 |

The two-electrode PEC gap only delays the blow-up a few orders of magnitude, then grows exponentially to NaN. The #424 instability is **C-independent** and now shown **PEC-gap-independent** → it is the **TFSF total/scattered-field decomposition coupling into the lumped ADE**, not a missing circuit path. No API-level geometry fixes it; a stable plane-wave lumped lane needs a **solver-level fix** to the TFSF↔lumped coupling.

## Change
Corrects the advisory docstring + message: removes the false PEC-gap hope, states the root cause, and points to the **validated port-fed varactor lane** (`add_port` + `forward(rlc_values_override=...)`, `tests/test_lumped_rlc_ad.py`). Evidence harness: `docs/research_notes/experiments/tfsf_lumped_pec_gap_stability.py`.

Per the one-attempt rule, a divergence at step-0 FAILS the architecture — no attempt 2, no gap-geometry sweep (R2 family). The advisory test binds to the `code`, not the message text — still green; lint clean.

**R3**: memory=consistent-with `project_diff_planewave_inverse_design` (varactor #424/#425 guard), corrects an over-optimistic advisory with tested evidence | R2-attempts=1 (step-0 pre-gate falsified; no gap sweep) | falsifier=\|Ez\| trajectory 0.1→1e25→NaN, bare-vs-PEC-gap A/B control

🤖 Generated with [Claude Code](https://claude.com/claude-code)