### PR TITLE
fix(kerr): reactive ε_eff Kerr — increment-scaling replaces the dissipative absorber (#437)

### DIFF
--- a/rfx/materials/nonlinear.py
+++ b/rfx/materials/nonlinear.py
@@ -41,52 +41,54 @@ class KerrMaterial(NamedTuple):
 # ADE (Auxiliary Differential Equation) Kerr correction
 # ---------------------------------------------------------------------------
 
-def apply_kerr_ade(state, chi3_arr, dt):
-    """Apply Kerr nonlinear correction to E-field (ADE formulation).
+def apply_kerr_ade(state, e_prev, chi3_arr, eps_r_arr):
+    """Apply the instantaneous **reactive** Kerr correction to the E-field (#437).
 
-    After the standard linear E-update the nonlinear polarisation
-    current introduces an additional term:
+    A Kerr χ³ nonlinearity is a REACTIVE, intensity-dependent permittivity
+    (LOSSLESS — it changes the phase velocity, not the amplitude):
 
-        P_NL = eps0 * chi3 * |E|^2 * E
+        ε_eff = ε_r + χ³·|E|²
 
-    In discrete form the correction is:
+    The linear E-update already produced ``E_lin = E^n + ΔE`` with
+    ``ΔE = (dt/(ε0·ε_r))·(∇×H)``.  The ε_eff update is obtained algebraically by
+    scaling the **increment** (not the whole field)::
 
-        E^{n+1} -= (dt / eps0) * chi3 * |E^n|^2 * E^{n+1}
+        E^{n+1} = E^n + ΔE·ε_r/ε_eff = E^n + (E_lin − E^n) / (1 + χ³·|E^n|²/ε_r)
 
-    where ``|E^n|^2 = Ex^2 + Ey^2 + Ez^2`` evaluated component-wise
-    (co-located approximation suitable for weakly nonlinear media).
+    Scaling the increment is what makes this reactive and lossless — the
+    equilibrium field ``E^n`` is preserved and only the newly-integrated increment
+    is slowed by the higher effective permittivity.  Scaling the whole field
+    (``E → E/(1+factor)``, the pre-#437 behaviour) monotonically shrinks |E| and is
+    a nonlinear **absorber**, not reactive χ³ (phase-neutral to first order — see
+    docs/research_notes/2026-07-22_kerr_operator_defect.md).  The factor
+    ``χ³·|E^n|²/ε_r`` is dimensionless and dt-independent, as a material index
+    change must be.  ``|E^n|²`` is the co-located pre-update intensity (explicit
+    ε_eff; suitable for weakly-to-moderately nonlinear media).
 
     Parameters
     ----------
     state : FDTDState
-        State **after** the standard E-update (contains E^{n+1}).
-        The previous-step |E^n|^2 is approximated by the updated
-        field for an explicit scheme.
+        State **after** the linear E-update (contains ``E_lin``).
+    e_prev : tuple(jnp.ndarray, jnp.ndarray, jnp.ndarray)
+        The E-field components (ex, ey, ez) **before** the linear update (``E^n``),
+        used to form the increment and the pre-update intensity.
     chi3_arr : jnp.ndarray, shape (Nx, Ny, Nz)
-        Third-order susceptibility at each cell (m^2/V^2).
-        Zero where the medium is linear.
-    dt : float
-        Timestep in seconds.
+        Third-order susceptibility at each cell (m^2/V^2).  Zero where linear;
+        there the increment is scaled by 1 ⇒ the field is unchanged (byte-identical).
+    eps_r_arr : jnp.ndarray, shape (Nx, Ny, Nz)
+        Relative permittivity per cell (ε_r ≥ 1) — the ε_eff denominator.
 
     Returns
     -------
-    FDTDState with corrected E-field components.
+    FDTDState with the reactive-Kerr-corrected E-field components.
     """
-    # |E|^2 from the just-updated field.
-    e_sq = state.ex ** 2 + state.ey ** 2 + state.ez ** 2
-
-    # Correction factor: dt * chi3 / eps0 * |E|^2.
-    factor = (dt / EPS_0) * chi3_arr * e_sq
-
-    # GEO-C1: exact solve of the documented implicit relation
-    #   E^{n+1} (1 + factor) = E^n  ->  E^{n+1} = E^n / (1 + factor).
-    # The prior code used the explicit linearisation E*(1-factor) — only
-    # first-order in ``factor`` and divergent once ``factor`` is not
-    # << 1. The implicit form is the same cost and unconditionally
-    # stable for this term.
-    ex = state.ex / (1.0 + factor)
-    ey = state.ey / (1.0 + factor)
-    ez = state.ez / (1.0 + factor)
+    ex_p, ey_p, ez_p = e_prev
+    # |E^n|^2 (co-located, pre-update) so ε_eff is explicit in the increment scale.
+    e_sq = ex_p ** 2 + ey_p ** 2 + ez_p ** 2
+    denom = 1.0 + chi3_arr * e_sq / eps_r_arr        # = ε_eff / ε_r  (>= 1)
+    ex = ex_p + (state.ex - ex_p) / denom
+    ey = ey_p + (state.ey - ey_p) / denom
+    ez = ez_p + (state.ez - ez_p) / denom
 
     return state._replace(ex=ex, ey=ey, ez=ez)
 

--- a/rfx/simulation.py
+++ b/rfx/simulation.py
@@ -1233,6 +1233,10 @@ def make_core_step(ctx: _StepContext):
                         mag_src_vals[idx_m].astype(h_field.dtype))
                     st = st._replace(**{mc: h_field})
 
+            # Snapshot E^n before the linear E-update for the reactive Kerr
+            # increment (#437): E^{n+1} = E^n + (E_lin - E^n)/(1 + chi3|E^n|^2/eps_r).
+            e_prev_kerr = (st.ex, st.ey, st.ez) if ctx.use_kerr else None
+
             if ctx.use_upml:
                 if ctx.use_debye or ctx.use_lorentz:
                     raise ValueError("boundary='upml' does not yet support dispersion")
@@ -1254,9 +1258,9 @@ def make_core_step(ctx: _StepContext):
                     bloch=ctx.bloch,
                 )
 
-            # Kerr nonlinear ADE correction (after linear E-update)
+            # Reactive Kerr correction: scale the E-increment by eps_r/eps_eff (#437).
             if ctx.use_kerr:
-                st = ctx.apply_kerr_ade(st, ctx.kerr_chi3, dt)
+                st = ctx.apply_kerr_ade(st, e_prev_kerr, ctx.kerr_chi3, materials.eps_r)
 
             if ctx.use_tfsf:
                 st = ctx.apply_tfsf_e(st, ctx.tfsf_cfg, tfsf_h_state, dx, dt)

--- a/tests/test_kerr_api_paths.py
+++ b/tests/test_kerr_api_paths.py
@@ -13,15 +13,16 @@ Two gaps this closes:
    ``_assemble_materials`` — a Kerr material gave LINEAR physics and a LINEAR gradient with
    no error (a silent-wrong footgun for differentiable nonlinear design). Now guarded.
 
-WHY a wiring/monotonicity/stability oracle and NOT a quantitative SPM(Δφ) match: the naive
-pulsed-transmission-phase comparator is run-length-artifact-dominated (∠ flips sign between
-NP=30 and NP=40) AND at gateable χ³ the ADE per-step factor (dt/ε0)·χ³·E²≈0.4 is STRONGLY
-nonlinear (perturbative Δn=χ³⟨E²⟩/2n0 breaks down). A tight quantitative Kerr oracle needs a
-CW steady-state intensity comparator in the weak regime — a dedicated session (issue filed).
-This oracle instead gates the ROBUST observable: the probe field-difference norm ||E(χ³)−E(0)||
-is run-length-robust (0.8426 vs 0.8415 @ NP=30/40), domain-size INVARIANT (0.8426 across
-0.5/0.6 m × 0.06/0.10 m), null-controlled (χ³=0 ⇒ exactly 0), and monotonic in χ³
-(0.70/0.78/0.84 @ χ³=1/2/4). Harness: docs/research_notes/experiments/kerr_spm_*.py
+The run() oracle gates the REACTIVE Kerr (#437: apply_kerr_ade is now ε_eff=ε_r+χ³|E|²
+increment-scaling, lossless — NOT the pre-#437 dissipative absorber). Robust, discriminating
+observables: χ³=0 byte-identical to a linear run; the probe field-difference ‖E(χ³)−E(0)‖ is
+monotone in χ³ (0.25/0.46/0.88 @ χ³=0.5/1/2) and finite; and — the key reactive signature —
+the peak field amplitude is PRESERVED (0.93–1.14× across χ³, a lossless index change), which
+the pre-#437 dissipative operator would have driven well below 1. The exact quantitative SPM
+magnitude (matching k0·L·χ³⟨E²⟩/(2n0) to a few %) still needs a clean CW ⟨E²⟩ comparator; the
+operator's correctness against analytic ε_eff is pinned in 1D by
+docs/research_notes/experiments/kerr_reactive_1d_verify.py.
+Harness: docs/research_notes/experiments/kerr_spm_*.py, kerr_operator_decider.py.
 """
 import numpy as np
 import pytest
@@ -80,39 +81,58 @@ def _run_probe_series(chi3):
     return np.asarray(_kerr_sim(chi3).run(num_periods=30, skip_preflight=True).time_series)
 
 
+CHI3S = (0.5, 1.0, 2.0)   # moderate reactive regime (χ³=4 is strongly nonlinear)
+
+
 @pytest.fixture(scope="module")
 def kerr_run_diffs():
     base = _run_probe_series(0.0)
     denom = float(np.linalg.norm(base))
-    diffs = {}
-    series = {0.0: base}
-    for chi3 in (1.0, 2.0, 4.0):
+    peak0 = float(np.max(np.abs(base)))
+    diffs, peaks, series = {}, {}, {0.0: base}
+    for chi3 in CHI3S:
         s = _run_probe_series(chi3)
         series[chi3] = s
         diffs[chi3] = float(np.linalg.norm(s - base)) / denom
-    return {"diffs": diffs, "series": series}
+        peaks[chi3] = float(np.max(np.abs(s))) / peak0
+    return {"diffs": diffs, "peaks": peaks, "series": series}
 
 
 @pytest.mark.slow
-def test_run_wires_kerr(kerr_run_diffs):
-    """run() with χ³>0 measurably changes the field vs χ³=0 — the public API threads Kerr.
-    DISCRIMINATING: if run() dropped χ³ (like forward() did), every diff would be ~0."""
-    diffs = kerr_run_diffs["diffs"]
-    for chi3, d in diffs.items():
-        assert d > 0.3, f"χ³={chi3} barely changed the field (||Δ||/||E||={d:.4f}) — Kerr not wired?"
+def test_run_wires_kerr_byte_identity_and_change(kerr_run_diffs):
+    """χ³=0 is byte-identical to a truly-linear (no-Kerr) run, and χ³>0 measurably changes the
+    field — the public run() API threads χ³. If run() dropped it (like forward() did), the
+    χ³>0 diffs would be ~0."""
+    # byte-identity: a chi3=0 Kerr material == the same geometry with a plain linear material
+    lin = Simulation(freq_max=10e9, domain=DOMAIN, dx=DX, boundary="cpml", cpml_layers=10, mode="3d")
+    lin.add_material("lin", eps_r=EPS_R)
+    lin.add(Box((X_IFACE, -1, -1), (X_SLAB_END, 1, 1)), material="lin")
+    lin.add_tfsf_source(f0=F0, bandwidth=0.3, amplitude=1.0, polarization="ez",
+                        direction="+x", waveform="modulated_gaussian")
+    for xp in XPROBES:
+        lin.add_probe((xp, DOMAIN[1] / 2, DOMAIN[2] / 2), component="ez")
+    lin_ts = np.asarray(lin.run(num_periods=30, skip_preflight=True).time_series)
+    assert float(np.max(np.abs(kerr_run_diffs["series"][0.0] - lin_ts))) == 0.0, \
+        "chi3=0 must be byte-identical to a linear run"
+    for chi3, d in kerr_run_diffs["diffs"].items():
+        assert d > 0.15, f"χ³={chi3} barely changed the field (||Δ||={d:.4f}) — Kerr not wired?"
 
 
 @pytest.mark.slow
 def test_run_kerr_monotonic_in_chi3(kerr_run_diffs):
-    """Stronger χ³ ⇒ larger field change (monotone). A wrong-sign or clipped coupling breaks this."""
+    """Stronger χ³ ⇒ larger field change (monotone). A wrong-sign/clipped coupling breaks this."""
     d = kerr_run_diffs["diffs"]
-    assert d[4.0] > d[2.0] > d[1.0], f"non-monotone in χ³: {d}"
+    assert d[2.0] > d[1.0] > d[0.5], f"non-monotone in χ³: {d}"
 
 
 @pytest.mark.slow
-def test_run_kerr_stable_and_bounded(kerr_run_diffs):
-    """The nonlinear run stays finite and bounded (no ADE blow-up); the change is physical,
-    not a divergence (||Δ||/||E|| well below the ~√2 two-uncorrelated-signals ceiling)."""
+def test_run_kerr_reactive_lossless_and_stable(kerr_run_diffs):
+    """The KEY #437 signature: the reactive Kerr PRESERVES the field amplitude (a lossless index
+    change), unlike the pre-#437 dissipative absorber which drove |E| well below 1. Peak-amplitude
+    ratio stays near 1 across χ³, and every run is finite."""
     for chi3, s in kerr_run_diffs["series"].items():
         assert np.all(np.isfinite(s)), f"non-finite field at χ³={chi3}"
-    assert kerr_run_diffs["diffs"][4.0] < 1.2, "field change looks like a blow-up, not Kerr"
+    for chi3, r in kerr_run_diffs["peaks"].items():
+        assert 0.7 < r < 1.5, (
+            f"χ³={chi3}: peak|E| ratio {r:.3f} — reactive Kerr must preserve amplitude "
+            "(a dissipative absorber would push it far below 1)")

--- a/tests/test_nonlinear.py
+++ b/tests/test_nonlinear.py
@@ -75,95 +75,104 @@ def test_kerr_intensity_dependent():
 
 
 # ---------------------------------------------------------------------------
-# ADE-based Kerr tests (apply_kerr_ade)
+# Reactive Kerr tests (apply_kerr_ade — #437 increment-scaling ε_eff form)
+#
+# apply_kerr_ade now implements the REACTIVE index change ε_eff = ε_r + χ³|E|²
+# (lossless) by scaling the E-UPDATE INCREMENT, not the whole field:
+#   E^{n+1} = E^n + (E_lin - E^n) / (1 + χ³·|E^n|²/ε_r)
+# The pre-#437 form E_lin/(1+factor) was a nonlinear ABSORBER (reduced |E|, zero
+# phase shift) — see docs/research_notes/2026-07-22_kerr_operator_defect.md.
 # ---------------------------------------------------------------------------
 
 def test_kerr_zero_chi3_unchanged():
-    """E-field should be unchanged when chi3 is zero everywhere."""
+    """chi3=0 => increment unscaled => the post-update field is returned unchanged."""
     shape = (8, 8, 8)
-    state = init_state(shape)
-    # Set a non-zero field
-    state = state._replace(
-        ez=state.ez.at[4, 4, 4].set(1e6),
-        ex=state.ex.at[3, 3, 3].set(5e5),
+    e_prev = (jnp.zeros(shape, jnp.float32).at[4, 4, 4].set(3e5),
+              jnp.zeros(shape, jnp.float32), jnp.zeros(shape, jnp.float32))
+    state = init_state(shape)._replace(
+        ez=jnp.zeros(shape, jnp.float32).at[4, 4, 4].set(1e6),
+        ex=jnp.zeros(shape, jnp.float32).at[3, 3, 3].set(5e5),
     )
     chi3_arr = jnp.zeros(shape, dtype=jnp.float32)
-    dt = 1e-12
+    eps_r_arr = jnp.full(shape, 2.0, dtype=jnp.float32)
 
-    corrected = apply_kerr_ade(state, chi3_arr, dt)
+    corrected = apply_kerr_ade(state, e_prev, chi3_arr, eps_r_arr)
 
     np.testing.assert_array_equal(np.array(corrected.ex), np.array(state.ex))
-    np.testing.assert_array_equal(np.array(corrected.ey), np.array(state.ey))
     np.testing.assert_array_equal(np.array(corrected.ez), np.array(state.ez))
 
 
-def test_kerr_nonzero_modifies_field():
-    """Non-zero chi3 should reduce E-field magnitude (self-defocusing)."""
-    shape = (8, 8, 8)
-    state = init_state(shape)
-    e_val = 1e6  # 1 MV/m
-    state = state._replace(ez=state.ez.at[4, 4, 4].set(e_val))
+def test_kerr_reactive_increment_scaling():
+    """Non-zero chi3 scales the INCREMENT (reactive), preserving the equilibrium E^n.
 
-    chi3_val = 1e-18  # m^2/V^2
-    chi3_arr = jnp.full(shape, chi3_val, dtype=jnp.float32)
-    dt = 1e-12
-
-    corrected = apply_kerr_ade(state, chi3_arr, dt)
-
-    ez_orig = float(state.ez[4, 4, 4])
-    ez_corr = float(corrected.ez[4, 4, 4])
-
-    # The Kerr correction reduces |E| (self-defocusing for chi3 > 0).
-    assert abs(ez_corr) < abs(ez_orig), (
-        f"Kerr ADE should reduce field magnitude: {ez_corr} vs {ez_orig}"
-    )
-
-    # GEO-C1: apply_kerr_ade solves the documented implicit relation
-    # exactly — E^{n+1} = E^n / (1 + factor), not the old explicit
-    # E*(1-factor). (At this factor ~1e-7 the two agree to O(factor^2).)
-    expected_factor = (dt / EPS_0) * chi3_val * e_val ** 2
-    expected_ez = e_val / (1.0 + expected_factor)
-    np.testing.assert_allclose(ez_corr, expected_ez, rtol=1e-5)
-
-    # Cells without field should remain zero
-    assert float(corrected.ez[0, 0, 0]) == 0.0
-
-
-def test_kerr_energy_bounded():
-    """Nonlinear simulation with Kerr ADE should not diverge.
-
-    Run a small FDTD loop with a point source and Kerr material.
-    The total E-field energy should remain bounded.
+    Discriminates reactive from the pre-#437 dissipative whole-field scaling:
+      (a) zero increment (E_lin == E^n): field UNCHANGED even for chi3>0 (a whole-field
+          absorber would still shrink it);
+      (b) nonzero increment: scaled by 1/(1 + chi3|E^n|^2/eps_r), and the result stays
+          ABOVE E^n (the equilibrium is preserved — not driven toward zero).
     """
+    shape = (6, 6, 6)
+    E0, E_lin, eps_r, chi3_val = 4e5, 7e5, 2.0, 1e-12
+    e_prev = (jnp.full(shape, E0, jnp.float32),
+              jnp.zeros(shape, jnp.float32), jnp.zeros(shape, jnp.float32))
+    chi3_arr = jnp.full(shape, chi3_val, jnp.float32)
+    eps_r_arr = jnp.full(shape, eps_r, jnp.float32)
+
+    # (a) zero increment => reactive leaves the field at the equilibrium E0
+    state_eq = init_state(shape)._replace(ex=jnp.full(shape, E0, jnp.float32))
+    out_eq = apply_kerr_ade(state_eq, e_prev, chi3_arr, eps_r_arr)
+    np.testing.assert_allclose(np.array(out_eq.ex), E0, rtol=1e-6)
+
+    # (b) nonzero increment => exact increment-scaled value, still above E0
+    state = init_state(shape)._replace(ex=jnp.full(shape, E_lin, jnp.float32))
+    out = apply_kerr_ade(state, e_prev, chi3_arr, eps_r_arr)
+    factor = chi3_val * E0 ** 2 / eps_r
+    expected = E0 + (E_lin - E0) / (1.0 + factor)
+    np.testing.assert_allclose(float(out.ex[3, 3, 3]), expected, rtol=1e-5)
+    assert E0 < float(out.ex[3, 3, 3]) < E_lin       # increment shrunk, equilibrium kept
+
+
+def test_kerr_ade_differentiable():
+    """jax.grad flows through the reactive Kerr correction (differentiable design surface)."""
+    shape = (6, 6, 6)
+    e_prev = (jnp.zeros(shape, jnp.float32).at[3, 3, 3].set(2e5),
+              jnp.zeros(shape, jnp.float32), jnp.zeros(shape, jnp.float32))
+    chi3_arr = jnp.full(shape, 1e-12, jnp.float32)
+    eps_r_arr = jnp.full(shape, 2.0, jnp.float32)
+
+    def objective(e_lin_val):
+        state = init_state(shape)._replace(
+            ex=jnp.zeros(shape, jnp.float32).at[3, 3, 3].set(e_lin_val))
+        return jnp.sum(apply_kerr_ade(state, e_prev, chi3_arr, eps_r_arr).ex)
+
+    g = jax.grad(objective)(5e5)
+    assert float(jnp.abs(g)) > 0, "gradient should be non-zero"
+
+
+def test_kerr_reactive_conserves_energy():
+    """A reactive-Kerr FDTD run stays finite and LOSSLESS — the total energy does not
+    systematically drain (the pre-#437 dissipative operator would bleed it toward zero)."""
     from rfx.core.yee import update_e, update_h
 
     shape = (20, 20, 20)
-    materials = init_materials(shape)
-    state = init_state(shape)
-    dt = 1e-12
-    dx = 1e-3
+    materials = init_materials(shape)          # vacuum, lossless (sigma=0)
+    eps_r_arr = materials.eps_r
+    dt, dx = 1e-12, 1e-3
+    chi3_arr = jnp.full(shape, 0.1, jnp.float32)   # moderate: factor ~ 0.1 at |E|~1
 
-    chi3_arr = jnp.full(shape, 1e-18, dtype=jnp.float32)
+    state = init_state(shape)._replace(ez=jnp.zeros(shape, jnp.float32).at[10, 10, 10].set(1.0))
 
-    # Inject a strong initial pulse
-    state = state._replace(ez=state.ez.at[10, 10, 10].set(1e6))
-
-    max_energy = 0.0
+    energies = []
     for step in range(200):
+        e_prev = (state.ex, state.ey, state.ez)
         state = update_h(state, materials, dt, dx)
         state = update_e(state, materials, dt, dx)
-        state = apply_kerr_ade(state, chi3_arr, dt)
-
-        energy = float(jnp.sum(state.ex ** 2 + state.ey ** 2 + state.ez ** 2))
-        max_energy = max(max_energy, energy)
-
-        # Check no NaN or Inf
-        assert jnp.all(jnp.isfinite(state.ex)), f"NaN/Inf at step {step}"
-        assert jnp.all(jnp.isfinite(state.ey)), f"NaN/Inf at step {step}"
+        state = apply_kerr_ade(state, e_prev, chi3_arr, eps_r_arr)
+        energies.append(float(jnp.sum(state.ex ** 2 + state.ey ** 2 + state.ez ** 2)))
         assert jnp.all(jnp.isfinite(state.ez)), f"NaN/Inf at step {step}"
 
-    # Energy should be bounded (not growing exponentially)
-    final_energy = float(jnp.sum(state.ex ** 2 + state.ey ** 2 + state.ez ** 2))
-    assert final_energy < max_energy * 1.01, (
-        f"Energy should not grow: final={final_energy:.3e}, max={max_energy:.3e}"
-    )
+    energies = np.array(energies)
+    peak = np.max(energies)
+    # lossless: the field bounces in the PEC-like box without a systematic energy drain
+    assert energies[-1] > 0.5 * peak, (
+        f"reactive Kerr must not dissipate energy: final={energies[-1]:.3e}, peak={peak:.3e}")

--- a/tests/test_review_tier1_validation_battery.py
+++ b/tests/test_review_tier1_validation_battery.py
@@ -156,34 +156,41 @@ def test_corec2_e_update_uses_mean_spacing():
 
 def _kerr_setup():
     shape = (2, 2, 2)
-    E0 = 3.0
-    dt = 1.0e-12
-    target_factor = 0.30  # large enough that explicit vs implicit differ
-    chi3 = target_factor * EPS_0 / (dt * E0 ** 2)
-    state = _state(shape, ex=jnp.full(shape, E0, jnp.float32))
+    E0 = 3.0        # E^n (pre-update, sets the intensity |E^n|^2)
+    E_lin = 5.0     # E_lin (post-linear-update field)
+    eps_r = 2.0
+    target_factor = 0.30                     # factor = chi3*E0^2/eps_r
+    chi3 = target_factor * eps_r / E0 ** 2
+    e_prev = (jnp.full(shape, E0, jnp.float32),
+              jnp.zeros(shape, jnp.float32), jnp.zeros(shape, jnp.float32))
+    state = _state(shape, ex=jnp.full(shape, E_lin, jnp.float32))
     chi3_arr = jnp.full(shape, chi3, jnp.float32)
-    factor = (dt / EPS_0) * chi3 * E0 ** 2
-    return state, chi3_arr, dt, E0, factor
+    eps_r_arr = jnp.full(shape, eps_r, jnp.float32)
+    return state, e_prev, chi3_arr, eps_r_arr, E0, E_lin, target_factor
 
 
-def test_geoc1_kerr_ade_uses_exact_implicit_solve():
-    """GEO-C1 regression — apply_kerr_ade returns the exact implicit
-    E/(1+factor), not the old explicit E*(1-factor).
+def test_geoc1_kerr_ade_reactive_increment_solve():
+    """GEO-C1 (#437 redesign) — apply_kerr_ade scales the INCREMENT (reactive ε_eff),
+    NOT the whole field.
 
-    Was ``xfail(strict=True)`` pre-fix; passes post-fix (Stage 1,
-    2026-05-17). The reference is the analytic solution of the discrete
-    relation E^{n+1}(1+factor) = E^n stated in the apply_kerr_ade
-    docstring.
+    Reactive Kerr is ε_eff = ε_r + χ³|E|² (lossless index change).  The correct update
+    scales only the newly-integrated increment::
+
+        E^{n+1} = E^n + (E_lin - E^n) / (1 + χ³·|E^n|²/ε_r)
+
+    The pre-#437 code scaled the WHOLE field (E_lin/(1+factor)) — a nonlinear absorber
+    that reduced |E| with zero phase shift (docs/research_notes/2026-07-22_kerr_operator_defect.md).
+    This pins the reactive increment form and that it differs from the old dissipative one.
     """
-    state, chi3_arr, dt, E0, factor = _kerr_setup()
-    out = apply_kerr_ade(state, chi3_arr, dt)
+    state, e_prev, chi3_arr, eps_r_arr, E0, E_lin, factor = _kerr_setup()
+    out = apply_kerr_ade(state, e_prev, chi3_arr, eps_r_arr)
     got = float(np.asarray(out.ex)[0, 0, 0])
 
-    implicit = E0 / (1.0 + factor)
-    explicit = E0 * (1.0 - factor)
-    assert got == pytest.approx(implicit, rel=1e-4)
-    # The fix is a genuine change: explicit and implicit differ at factor=0.3.
-    assert abs(got - explicit) > 0.01 * E0
+    reactive = E0 + (E_lin - E0) / (1.0 + factor)   # increment-scaled (correct)
+    dissipative = E_lin / (1.0 + factor)            # whole-field (the old bug)
+    assert got == pytest.approx(reactive, rel=1e-4)
+    # genuinely different from the old dissipative operator at factor=0.3
+    assert abs(got - dissipative) > 0.01 * E_lin
 
 
 # ===========================================================================


### PR DESCRIPTION
## The bug (diagnosed earlier this session)
`apply_kerr_ade` was a **nonlinear absorber, not reactive χ³**: `E → E/(1+(dt/ε0)χ³|E|²)` scales the whole field down every step (energy-removing, phase-neutral to first order). Own-physics decider: Δφ = **exactly 0.0°**, |E| strictly reduced. A physical Kerr is the **lossless** index change `ε_eff = ε_r + χ³|E|²`.

## The fix (one function — not the 6 `update_e` variants)
The ε_eff update equals scaling the E-update **increment**, not the whole field:
```
E^{n+1} = E^n + (E_lin − E^n)/(1 + χ³|E^n|²/ε_r)     [= E^n + ΔE·ε_r/ε_eff, algebraically exact]
```
with the corrected **dimensionless, dt-independent** factor `χ³|E^n|²/ε_r`. `apply_kerr_ade` now takes the pre-update field `E^n` + `ε_r`; the shared scan snapshots `E^n` before the E-update, **guarded by `use_kerr`** so non-Kerr runs are literally unchanged.

## Validation
| check | result |
|---|---|
| 1D vs analytic ε_eff | increment-scaling **≡** ε_eff reference — lossless (amp 1.00) + correct reactive phase; old form dissipative (amp 0.82/0.72) |
| χ³=0 byte-identity | `max|diff| = 0.0` vs a linear run |
| 3D reactive | peak|E| **preserved** 0.93–1.14× (vs old operator's 84% field destruction) |
| SPM phase | now **first-order in χ³** (constant meas/ana ratio) vs old dissipative (ratio grew with χ³) |
| non-Kerr regression | unaffected (guarded) |

## Tests
- **GEO-C1** (`test_review_tier1`) now pins the increment solve (was the old dissipative formula).
- **`test_nonlinear`**: increment-scaling + lossless-energy + differentiability.
- **`test_kerr_api_paths`** run() oracle: byte-identity + wiring + monotonicity + the **lossless peak-amplitude signature** — the discriminator vs the old bug.
- `forward()`+Kerr stays guarded (#436); unblocking the **differentiable reactive Kerr** is a focused follow-up (the original #437-B goal, now safe on a correct operator).

Green: 15 (operator) + 6 (api-paths) + non-Kerr regression; lint clean; collection intact. Harnesses (local): `kerr_reactive_1d_verify.py`, `kerr_operator_decider.py`.

**R3**: memory=resolves the #437 Kerr-solver-defect finding | R2-attempts=1 (redesign premise-verified in 1D before 3D) | falsifier=1D increment≡analytic ε_eff + 3D lossless peak-amplitude gate (old op fails) + χ³=0 byte-identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)