### PR TITLE
feat(kerr): differentiable forward() Kerr on the uniform lane (#437-B)

### DIFF
--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -838,6 +838,7 @@ class _ExecuteMixin:
         checkpoint_segments: int | None = None,
         pec_mask: jnp.ndarray | None = None,
         pec_occupancy: jnp.ndarray | None = None,
+        kerr_chi3: jnp.ndarray | None = None,
         port_s11_freqs: object | None = None,
         rlc_values_override: dict | None = None,
         _sparam_drive_idx: int | None = None,
@@ -1420,6 +1421,7 @@ class _ExecuteMixin:
             wire_port_sparams=wire_port_sparam_specs or None,
             wire_refplane_sparams=wire_refplane_specs or None,
             lumped_rlc=rlc_metas,
+            kerr_chi3=kerr_chi3,
             dft_planes=dft_planes if dft_planes else None,
             return_state=False,
             stencil_order=self._stencil_order,
@@ -2423,21 +2425,17 @@ class _ExecuteMixin:
                 "add_lumped_rlc elements)."
             )
 
-        # Kerr χ³ (nonlinear) materials are threaded only on the run() path
-        # (uniform.py -> apply_kerr_ade).  The differentiable forward() lanes
-        # discard kerr_chi3 from _assemble_materials, so a Kerr material would
-        # silently give LINEAR physics (and a linear gradient) with no error.
-        # Fail loud rather than optimise against physics the caller did not ask
-        # for.  There is no chi3_override, so a configured Kerr material is the
-        # only way χ³ enters — self._materials is the complete signal.
-        if any(getattr(m, "chi3", 0.0) != 0.0 for m in self._materials.values()):
+        # Reactive Kerr χ³ (#437) is threaded through the shared _run scan on the
+        # UNIFORM forward lane only.  The non-uniform / distributed forward lanes
+        # discard kerr_chi3, so a Kerr material there would silently give LINEAR
+        # physics (and a linear gradient) — fail loud on those lanes only.
+        if (plan.lane != "fwd_uniform"
+                and any(getattr(m, "chi3", 0.0) != 0.0 for m in self._materials.values())):
             raise NotImplementedError(
-                "forward() does not support Kerr χ³ (nonlinear) materials: the "
-                "differentiable forward path ignores chi3, so the simulation "
-                "would run LINEAR physics and jax.grad would return a linear "
-                "gradient with no warning. Use run() for nonlinear simulations, "
-                "or remove the chi3 term from the material for a linear "
-                "differentiable forward."
+                "forward() supports Kerr χ³ (nonlinear) materials only on the uniform "
+                f"single-device lane, not {plan.lane!r} (which discards chi3 → silent "
+                "linear physics + linear gradient). Use a uniform mesh + single device "
+                "for differentiable nonlinear (Kerr) design."
             )
 
         # Differentiable TFSF/plane-wave forward is wired on the uniform
@@ -2485,7 +2483,7 @@ class _ExecuteMixin:
         # ---- Uniform forward lane (plan.lane == "fwd_uniform") ----
         n_steps = plan.n_steps
         grid = self._build_grid()
-        materials, debye_spec, lorentz_spec, pec_mask, _, _, _ = self._assemble_materials(grid)
+        materials, debye_spec, lorentz_spec, pec_mask, _, _, kerr_chi3 = self._assemble_materials(grid)
 
         if eps_override is not None or sigma_override is not None:
             materials = MaterialArrays(
@@ -2510,6 +2508,7 @@ class _ExecuteMixin:
             checkpoint_segments=checkpoint_segments,
             pec_mask=pec_mask,
             pec_occupancy=pec_occupancy_override,
+            kerr_chi3=kerr_chi3,
             port_s11_freqs=port_s11_freqs,
             rlc_values_override=rlc_values_override,
         )

--- a/tests/test_kerr_api_paths.py
+++ b/tests/test_kerr_api_paths.py
@@ -9,9 +9,11 @@ Two gaps this closes:
    ``apply_kerr_ade`` (simulation.py). If run() silently dropped Kerr (as forward() did),
    every existing test would still pass. This gates that wiring.
 
-2. ``forward()`` (the differentiable path) discarded ``kerr_chi3`` from
-   ``_assemble_materials`` — a Kerr material gave LINEAR physics and a LINEAR gradient with
-   no error (a silent-wrong footgun for differentiable nonlinear design). Now guarded.
+2. ``forward()`` (the differentiable path) once discarded ``kerr_chi3`` from
+   ``_assemble_materials`` — a Kerr material gave LINEAR physics + a LINEAR gradient with no
+   error. It now threads χ³ through the shared ``_run`` scan on the UNIFORM lane: reactive
+   Kerr, byte-identical to run(), and differentiable through the operator (NU/distributed
+   forward lanes stay guarded — they still discard χ³).
 
 The run() oracle gates the REACTIVE Kerr (#437: apply_kerr_ade is now ε_eff=ε_r+χ³|E|²
 increment-scaling, lossless — NOT the pre-#437 dissipative absorber). Robust, discriminating
@@ -39,7 +41,8 @@ XPROBES = (0.16, 0.18, 0.20, 0.22, 0.33)
 
 
 # --------------------------------------------------------------------------- #
-# FAST: forward() must fail loud on a Kerr material (no silent linear physics).
+# forward(): the differentiable path RUNS reactive Kerr on the uniform lane (#437),
+# byte-identical to run(), and is differentiable THROUGH the Kerr operator.
 # --------------------------------------------------------------------------- #
 def _kerr_sim(chi3):
     sim = Simulation(freq_max=10e9, domain=DOMAIN, dx=DX, boundary="cpml",
@@ -53,25 +56,46 @@ def _kerr_sim(chi3):
     return sim
 
 
-def test_forward_rejects_kerr_material():
-    """forward() with a χ³ material raises (rather than silently running LINEAR physics)."""
-    sim = _kerr_sim(0.1)
-    with pytest.raises(NotImplementedError, match="Kerr"):
-        sim.forward(n_steps=50, skip_preflight=True)
-
-
-def test_forward_guard_message_points_to_run():
-    """The guard tells the caller to use run() — the path that does thread χ³."""
-    sim = _kerr_sim(0.1)
-    with pytest.raises(NotImplementedError, match="run"):
-        sim.forward(n_steps=50, skip_preflight=True)
+def test_forward_kerr_matches_run():
+    """forward()+Kerr runs on the uniform lane and is byte-identical to run() (shared _run scan
+    with the reactive apply_kerr_ade). A silent χ³-drop (the pre-#437 forward behaviour) would
+    diverge from run()."""
+    fwd = np.asarray(_kerr_sim(0.2).forward(n_steps=300, skip_preflight=True).time_series)
+    run = np.asarray(_kerr_sim(0.2).run(n_steps=300, skip_preflight=True).time_series)
+    assert np.all(np.isfinite(fwd))
+    assert float(np.max(np.abs(fwd - run))) == 0.0, "forward() Kerr must match run() (same scan)"
 
 
 def test_forward_without_kerr_is_unaffected():
-    """A χ³=0 (linear) material does NOT trip the guard — the forward path still runs."""
-    sim = _kerr_sim(0.0)  # chi3=0 ⇒ not a Kerr material
-    res = sim.forward(n_steps=50, skip_preflight=True)
+    """A χ³=0 (linear) material leaves the forward path unchanged."""
+    res = _kerr_sim(0.0).forward(n_steps=50, skip_preflight=True)
     assert res.time_series is not None and np.all(np.isfinite(res.time_series))
+
+
+@pytest.mark.slow
+def test_forward_kerr_differentiable():
+    """The forward is differentiable THROUGH the reactive Kerr operator: d(field-energy)/d(eps)
+    with a Kerr medium present matches finite difference — the differentiable nonlinear-design
+    surface (RIS/low-observable) the #437 fix unlocks."""
+    import jax
+    import jax.numpy as jnp
+    sim = _kerr_sim(0.2)
+    grid = sim._build_grid()
+    shape = grid.shape
+    xi = grid.position_to_index((X_IFACE, DOMAIN[1] / 2, DOMAIN[2] / 2))[0]
+    xe = grid.position_to_index((X_SLAB_END, DOMAIN[1] / 2, DOMAIN[2] / 2))[0]
+
+    def obj(eps_val):
+        eps = jnp.ones(shape, jnp.float32).at[xi:xe, :, :].set(eps_val)
+        ts = _kerr_sim(0.2).forward(eps_override=eps, n_steps=400, checkpoint=True,
+                                    skip_preflight=True).time_series
+        return jnp.sum(ts ** 2)
+
+    g_ad = float(jax.grad(obj)(2.0))
+    h = 0.02
+    g_fd = (float(obj(2.0 + h)) - float(obj(2.0 - h))) / (2 * h)
+    assert np.isfinite(g_ad), "NaN/Inf gradient through Kerr"
+    assert abs(g_ad - g_fd) < 0.03 * abs(g_fd) + 1e-6, f"AD={g_ad:.4e} vs FD={g_fd:.4e}"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## What
With the reactive Kerr operator landed (#440), this unblocks the **differentiable forward()** path so χ³ flows through `jax.grad` — the differentiable nonlinear-design surface (RIS / material low-observability) that motivated #437.

`forward()` previously discarded `kerr_chi3` (the #436 fail-loud guard). The uniform forward lane now threads it through the **shared `_run` scan** (which already applies the reactive `apply_kerr_ade` + the `e_prev` snapshot from #440 — **no scan change**). The guard becomes lane-specific: NU/distributed forward lanes still raise (they discard χ³), matching the TFSF/rlc pattern.

## Validation
- forward()+Kerr is **byte-identical to run()** (`max|diff| = 0.0`, n_steps=300) — same reactive scan.
- **Differentiable through the Kerr operator**: `d(field-energy)/d(eps)` with a Kerr medium → AD=−2.311 vs FD=−2.311 (**rel-err 0.03%**), finite.
- χ³=0 forward unaffected; NU/distributed forward + Kerr still guarded.

## Tests
`test_kerr_api_paths`: the forward-guard tests flip to `test_forward_kerr_matches_run` + `test_forward_kerr_differentiable` (AD==FD); the linear-forward regression is kept. 6 passed; lint clean; collection intact.

**R3**: memory=delivers the differentiable-nonlinear primitive on the correct reactive operator (#440) | R2-attempts=1 (byte-identical to run + AD==FD) | falsifier=forward-vs-run byte-identity + AD==FD; a silent χ³-drop would diverge from run()

🤖 Generated with [Claude Code](https://claude.com/claude-code)