### PR TITLE
feat(kerr): TRUE-CW TFSF waveform + absolute-magnitude SPM oracle (closes #446)

### DIFF
--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -1506,13 +1506,20 @@ class Simulation(
 
         Parameters
         ----------
-        waveform : {"differentiated_gaussian", "modulated_gaussian"}
-            Pulse shape injected into the 1D auxiliary grid.
+        waveform : {"differentiated_gaussian", "modulated_gaussian", "continuous_wave"}
+            Pulse shape injected into the 1D auxiliary grid. (``continuous_wave``
+            is only supported at normal incidence — ``angle_deg == 0``.)
 
             ``differentiated_gaussian`` (default, legacy rfx): baseband
             pulse with no carrier, DC-free, spectrum peaks near
             ``f0·bandwidth``. Good for broadband measurements but
             spectrum extends well below ``f0``.
+
+            ``continuous_wave``: a single-frequency sinusoid at ``f0`` with a
+            raised-cosine turn-on (~8 periods), then constant amplitude. Use for
+            steady-state / narrowband measurements that need a well-defined
+            time-average ``⟨E²⟩ = A²/2`` (e.g. the quantitative Kerr SPM oracle,
+            #446). Not for broadband S-parameters — it excites only ``f0``.
 
             ``modulated_gaussian``: carrier-modulated Gaussian matching
             Meep's ``GaussianSource(frequency=f0, fwidth=f0·bandwidth)``.
@@ -1546,10 +1553,15 @@ class Simulation(
             raise ValueError(f"direction must be '+x' or '-x', got {direction!r}")
         if abs(angle_deg) >= 90.0:
             raise ValueError(f"abs(angle_deg) must be < 90, got {angle_deg}")
-        if waveform not in ("differentiated_gaussian", "modulated_gaussian"):
+        if waveform == "continuous_wave" and abs(angle_deg) != 0.0:
             raise ValueError(
-                f"waveform must be 'differentiated_gaussian' or "
-                f"'modulated_gaussian', got {waveform!r}"
+                "waveform='continuous_wave' is only supported at normal incidence "
+                f"(angle_deg=0); got angle_deg={angle_deg}"
+            )
+        if waveform not in ("differentiated_gaussian", "modulated_gaussian", "continuous_wave"):
+            raise ValueError(
+                "waveform must be 'differentiated_gaussian', 'modulated_gaussian', "
+                f"or 'continuous_wave', got {waveform!r}"
             )
 
         self._tfsf = _TFSFEntry(

--- a/rfx/materials/nonlinear.py
+++ b/rfx/materials/nonlinear.py
@@ -67,9 +67,14 @@ def apply_kerr_ade(state, e_prev, chi3_arr, eps_r_arr):
     ΔE/(1+χ³|E^n|²/ε_r)``): the increment form applies ε_eff to the E-update increment
     ``ΔE ∝ ∂ₓH``, which is 90° out of phase with E, so the χ³ correction hits the
     increment where it is smallest ⇒ it UNDERESTIMATES the self-phase-modulation index
-    shift (measured ~0.21× the (3/8)χ³A² textbook vs the D-based ~0.59×, a 2.8× gain;
-    trusted CW-SPM 3D measurement — see docs/research_notes/2026-07-23_kerr_quantitative_spm_finding.md
-    and issue #446). The pre-#437 form ``E → E/(1+factor)`` was worse still — a nonlinear
+    shift. The true-CW absolute oracle (tests/test_kerr_spm_absolute_oracle.py, #446, using
+    ``waveform='continuous_wave'`` so ⟨E²⟩=A²/2 is unambiguous) pins the D-based operator at
+    ratio ≈0.95 of the (3/8)χ³A² textbook (residual ~5% = Yee dispersion), while the increment
+    form scores ~0.33 there — the gate cleanly discriminates them. (An earlier pulsed-source
+    3D estimate read the pair as ~0.21× increment vs ~0.59× D-based — a comparator-independent
+    2.8× relative gain, but its absolute scale was biased low by the pulsed-⟨E²⟩ ambiguity that
+    #446 resolves.) See docs/research_notes/2026-07-23_kerr_quantitative_spm_finding.md.
+    The pre-#437 form ``E → E/(1+factor)`` was worse still — a nonlinear
     ABSORBER (phase-neutral to first order). χ³=0 ⇒ D_target=ε_r·E_lin, denom=ε_r ⇒
     E=E_lin (byte-identical). Stable and lossless up to strong χ³ (verified χ³≤4).
 

--- a/rfx/sources/tfsf.py
+++ b/rfx/sources/tfsf.py
@@ -142,13 +142,18 @@ def init_tfsf(
         Number of cells in z (3D grid).  Required for oblique incidence
         with ey polarization (2D TEz auxiliary grid).  Ignored for
         normal incidence and ez polarization.
-    waveform : {"differentiated_gaussian", "modulated_gaussian"}
+    waveform : {"differentiated_gaussian", "modulated_gaussian", "continuous_wave"}
         Pulse shape. ``differentiated_gaussian`` (default) is a
         baseband differentiated Gaussian with no carrier (legacy rfx
         behaviour). ``modulated_gaussian`` matches Meep's
         ``GaussianSource``:
         ``cos(2π·f0·(t-t0)) · exp(-((t-t0)/τ)²)`` with τ = 1/(π·fwidth)
-        and t0 = 5·τ (Meep default).
+        and t0 = 5·τ (Meep default). ``continuous_wave`` is a single-
+        frequency sinusoid at ``f0`` with a raised-cosine turn-on
+        (~8 periods) then constant amplitude — for steady-state /
+        narrowband measurements needing a well-defined ⟨E²⟩=A²/2 (e.g.
+        the #446 Kerr SPM oracle). NORMAL INCIDENCE ONLY (the oblique
+        2D-auxiliary path does not carry it).
 
     Returns
     -------
@@ -159,6 +164,14 @@ def init_tfsf(
         raise ValueError(
             f"waveform must be 'differentiated_gaussian', "
             f"'modulated_gaussian', or 'continuous_wave', got {waveform!r}"
+        )
+    # continuous_wave lives only in the 1D-auxiliary (normal-incidence) injector; the 2D
+    # oblique grid (init_tfsf_2d) has no waveform parameter, so reject it here rather than
+    # silently drop it (fail-loud, not right-guard-mis-gated).
+    if waveform == "continuous_wave" and abs(angle_deg) > 0.01:
+        raise ValueError(
+            "waveform='continuous_wave' is only supported at normal incidence "
+            f"(angle_deg=0); got angle_deg={angle_deg}"
         )
     # Dispatch to 2D auxiliary grid for oblique angles.
     # The 2D grid naturally matches the 3D numerical dispersion at any angle.

--- a/rfx/sources/tfsf.py
+++ b/rfx/sources/tfsf.py
@@ -155,10 +155,10 @@ def init_tfsf(
     (TFSFConfig, TFSFState) for normal incidence, or
     (TFSF2DConfig, TFSF2DState) for oblique incidence (|angle_deg| > 0.01).
     """
-    if waveform not in ("differentiated_gaussian", "modulated_gaussian"):
+    if waveform not in ("differentiated_gaussian", "modulated_gaussian", "continuous_wave"):
         raise ValueError(
-            f"waveform must be 'differentiated_gaussian' or "
-            f"'modulated_gaussian', got {waveform!r}"
+            f"waveform must be 'differentiated_gaussian', "
+            f"'modulated_gaussian', or 'continuous_wave', got {waveform!r}"
         )
     # Dispatch to 2D auxiliary grid for oblique angles.
     # The 2D grid naturally matches the 3D numerical dispersion at any angle.
@@ -244,6 +244,12 @@ def init_tfsf(
         fwidth = f0 * bandwidth
         tau = 1.0 / (np.pi * fwidth)
         t0 = 5.0 * tau
+    elif waveform == "continuous_wave":
+        # Ramped CW: a raised-cosine turn-on over t0, then constant amplitude — for
+        # steady-state / narrowband measurements where a well-defined ⟨E²⟩=A²/2 is needed
+        # (e.g. the quantitative Kerr SPM oracle, #446). t0 is the ramp duration.
+        t0 = 8.0 / f0        # ~8-period smooth turn-on
+        tau = t0             # unused by the CW branch; kept finite for the config
     else:
         tau = 1.0 / (f0 * bandwidth * np.pi)
         t0 = 3.0 * tau
@@ -395,6 +401,10 @@ def update_tfsf_1d_e(cfg: TFSFConfig, st: TFSFState, dx: float,
     if cfg.src_waveform == "modulated_gaussian":
         carrier = jnp.cos(2.0 * jnp.pi * cfg.src_fcen * (t - cfg.src_t0))
         src_val = cfg.src_amp * env * carrier
+    elif cfg.src_waveform == "continuous_wave":
+        # raised-cosine ramp 0->1 over src_t0, then constant amplitude
+        ramp = 0.5 * (1.0 - jnp.cos(jnp.pi * jnp.clip(t / cfg.src_t0, 0.0, 1.0)))
+        src_val = cfg.src_amp * ramp * jnp.sin(2.0 * jnp.pi * cfg.src_fcen * t)
     else:
         src_val = cfg.src_amp * (-2.0 * arg) * env
     e1d = e1d.at[cfg.src_idx].add(src_val)

--- a/tests/test_kerr_spm_absolute_oracle.py
+++ b/tests/test_kerr_spm_absolute_oracle.py
@@ -42,8 +42,10 @@ STEADY_FRAC = 0.45          # DFT / envelope over the last 45% (steady window, p
 
 
 def _measure(chi3, amp, domx, slab, probes):
-    """(kx, ⟨A(x)²⟩): discrete wavenumber from the f0-phasor phase slope over the steady CW window,
-    plus the mean per-probe squared fundamental amplitude — χ³-only, ε_r=1 matched region."""
+    """(kx, ⟨A(x)²⟩, settle): discrete wavenumber from the f0-phasor phase slope over the steady CW
+    window, the mean per-probe squared fundamental amplitude, and a settling witness (the fractional
+    drift of the fundamental amplitude between the first and second half of the "steady" window —
+    small ⇒ genuinely steady, not a transient) — χ³-only, ε_r=1 matched region."""
     dom = (domx, 0.06, 0.006)
     grid = Grid(freq_max=10e9, domain=dom, dx=DX, cpml_layers=10)
     dt = grid.dt
@@ -65,14 +67,19 @@ def _measure(chi3, amp, domx, slab, probes):
     phas = np.sum(win * (np.exp(-1j * W * tw) * dt)[:, None], axis=0)
     kx = abs(np.polyfit(pidx * DX, np.unwrap(np.angle(phas)), 1)[0])
     a_local = 2.0 * np.abs(phas) / T                     # per-probe fundamental amplitude
-    return kx, float(np.mean(a_local ** 2))
+    # settling witness: the amplitude of the first vs second half of the window must agree
+    h = win.shape[0] // 2
+    amp_h1 = float(np.mean([np.max(np.abs(win[:h, i])) for i in range(win.shape[1])]))
+    amp_h2 = float(np.mean([np.max(np.abs(win[h:, i])) for i in range(win.shape[1])]))
+    settle = abs(amp_h2 - amp_h1) / amp_h1
+    return kx, float(np.mean(a_local ** 2)), settle
 
 
 def _ratio(chi3, amp, domx, slab, probes, kx0):
-    kx, mean_a2 = _measure(chi3, amp, domx, slab, probes)
+    kx, mean_a2, settle = _measure(chi3, amp, domx, slab, probes)
     dkx_meas = kx - kx0
     dkx_txt = (3.0 / 8.0) * chi3 * mean_a2 * K0
-    return dkx_meas, dkx_txt, dkx_meas / dkx_txt
+    return dkx_meas, dkx_txt, dkx_meas / dkx_txt, settle
 
 
 # geometry: χ³-only slab spanning most of a CPML-terminated x-domain; probes strictly inside it
@@ -83,8 +90,8 @@ _SHORT = dict(domx=0.45, slab=(0.06, 0.39), probes=(0.12, 0.33))
 @pytest.fixture(scope="module")
 def oracle():
     # χ³=0 baseline is operator-independent (both operators are identity at χ³=0) → shared.
-    kx0_L, _ = _measure(0.0, 1.0, **_LONG)
-    dkx_meas, dkx_txt, r_dbased = _ratio(0.20, 1.0, **_LONG, kx0=kx0_L)
+    kx0_L, _, _ = _measure(0.0, 1.0, **_LONG)
+    dkx_meas, dkx_txt, r_dbased, settle = _ratio(0.20, 1.0, **_LONG, kx0=kx0_L)
 
     # falsifier: the pre-#448 increment operator (scale the E-update increment) — must NOT pass.
     shipped = _nl.apply_kerr_ade
@@ -98,16 +105,16 @@ def oracle():
                               ez=ez_p + (state.ez - ez_p) * f)
     try:
         _nl.apply_kerr_ade = _increment                  # picked up by the lazy import in run()
-        _, _, r_increment = _ratio(0.20, 1.0, **_LONG, kx0=kx0_L)
+        _, _, r_increment, _ = _ratio(0.20, 1.0, **_LONG, kx0=kx0_L)
     finally:
         _nl.apply_kerr_ade = shipped
 
     # domain-size invariance (mandate: an ADDED gate needs a falsifier + domain-invariance)
-    kx0_S, _ = _measure(0.0, 1.0, **_SHORT)
-    _, _, r_short = _ratio(0.20, 1.0, **_SHORT, kx0=kx0_S)
+    kx0_S, _, _ = _measure(0.0, 1.0, **_SHORT)
+    _, _, r_short, _ = _ratio(0.20, 1.0, **_SHORT, kx0=kx0_S)
 
     return {"dkx_meas": dkx_meas, "dkx_txt": dkx_txt, "r_dbased": r_dbased,
-            "r_increment": r_increment, "r_short": r_short}
+            "r_increment": r_increment, "r_short": r_short, "settle": settle}
 
 
 @pytest.mark.slow
@@ -145,3 +152,13 @@ def test_kerr_spm_absolute_domain_invariant(oracle):
     assert abs(oracle["r_dbased"] - oracle["r_short"]) < 0.15, (
         f"ratio moved with domain size: long={oracle['r_dbased']:.3f} short={oracle['r_short']:.3f} "
         f"(an artifact would swing; physics is invariant)")
+
+
+@pytest.mark.slow
+def test_kerr_spm_measured_at_steady_state(oracle):
+    """Settling witness: the DFT/phase-slope window is genuinely steady CW, not a transient — the
+    fundamental amplitude drifts <5% between the first and second half of the window. Guards against
+    a future domain/num_periods change silently sampling the ramp/fill transient."""
+    assert oracle["settle"] < 0.05, (
+        f"steady window not settled: amplitude drift {oracle['settle']:.3f} between window halves "
+        f"(the ⟨E²⟩=A²/2 assumption requires a steady CW plateau)")

--- a/tests/test_kerr_spm_absolute_oracle.py
+++ b/tests/test_kerr_spm_absolute_oracle.py
@@ -1,0 +1,147 @@
+"""Reactive Kerr SPM — ABSOLUTE-magnitude oracle (#446, closes the fingerprint's open gate).
+
+The sibling fingerprint oracle (test_kerr_spm_fingerprint.py) gates the *shape* of the reactive
+Kerr SPM (positive sign, first-order ∝χ³A², A² scaling) but NOT the absolute magnitude vs the
+textbook Δn=(3/8)χ³A². That was blocked (#446) by the pulsed-TFSF ⟨E²⟩ ambiguity: for a Gaussian
+pulse ⟨E²⟩ is ill-defined (peak-A²/2 vs window-mean ≈ 6× spread), so the absolute ratio could not
+be pinned. Two ingredients unblock it here:
+
+  1. TRUE-CW source (``waveform='continuous_wave'``, normal incidence): at steady state the field
+     is a single traveling wave of well-defined amplitude, so ⟨E²⟩ = A²/2 exactly.
+  2. Rigorous local comparator: the measured wavenumber is the phase slope kx = ⟨k(x)⟩ across the
+     probe span, so it integrates the LOCAL intensity. The weak reflection off the ε_eff step
+     (Γ ≈ (3/16)χ³A²) leaves a small standing-wave ripple, so the target must use ⟨A(x)²⟩ (mean of
+     the per-probe *squared* fundamental amplitude), NOT (mean A)². With ⟨A²⟩ the identity is exact:
+         kx − kx0 = k0 · (3/8) · χ³ · ⟨A(x)²⟩          [ε_r=1 ⇒ n0=1, Δn=(3/8)χ³A²].
+
+Physics: instantaneous Kerr D = ε0(ε_r E + χ³E³); for E=A cos ωt, E³=A³(¾cos ωt + ¼cos3ωt), so the
+fundamental sees ε_eff = ε_r + ¾χ³A² ⇒ Δn = (3χ³A²)/(8n0). The 3/4 is the SPM degeneracy factor.
+
+Validation (this session, CPU): the shipped D-based operator (#448) gives ratio 0.92–0.98 across
+χ³∈{0.05,0.1,0.2,0.3} (mean 0.955±0.03), domain-invariant (0.60 m→0.925, 0.45 m→0.965), while the
+pre-#448 increment operator gives 0.33 — so a gate at ratio∈[0.8,1.2] validates the D-based operator
+and rejects the increment one. The residual ~5% is Yee numerical dispersion (the χ³=0 baseline kx0
+itself sits +0.13% above the continuum k0). Harness:
+docs/research_notes/experiments/kerr_cw_spm_absolute.py
+"""
+import numpy as np
+import pytest
+
+import rfx.materials.nonlinear as _nl
+from rfx.api import Simulation
+from rfx.grid import Grid
+from rfx.geometry import Box
+
+F0 = 5e9
+W = 2 * np.pi * F0
+C0 = 299792458.0
+K0 = W / C0
+DX = 0.002
+NUM_PERIODS = 80
+STEADY_FRAC = 0.45          # DFT / envelope over the last 45% (steady window, past ramp+fill)
+
+
+def _measure(chi3, amp, domx, slab, probes):
+    """(kx, ⟨A(x)²⟩): discrete wavenumber from the f0-phasor phase slope over the steady CW window,
+    plus the mean per-probe squared fundamental amplitude — χ³-only, ε_r=1 matched region."""
+    dom = (domx, 0.06, 0.006)
+    grid = Grid(freq_max=10e9, domain=dom, dx=DX, cpml_layers=10)
+    dt = grid.dt
+    sim = Simulation(freq_max=10e9, domain=dom, dx=DX, boundary="cpml", cpml_layers=10, mode="3d")
+    sim.add_material("kerr", eps_r=1.0, chi3=chi3)
+    sim.add(Box((slab[0], -1, -1), (slab[1], 1, 1)), material="kerr")
+    sim.add_tfsf_source(f0=F0, amplitude=amp, polarization="ez", direction="+x",
+                        waveform="continuous_wave")
+    xprobes = np.arange(probes[0], probes[1], DX * 4)
+    pidx = np.array([grid.position_to_index((float(x), 0.03, 0.003))[0] for x in xprobes], float)
+    for x in xprobes:
+        sim.add_probe((float(x), 0.03, 0.003), component="ez")
+    ts = np.asarray(sim.run(num_periods=NUM_PERIODS, skip_preflight=True).time_series)
+    nt = ts.shape[0]
+    s0 = int((1.0 - STEADY_FRAC) * nt)
+    tw = np.arange(s0, nt) * dt
+    win = ts[s0:, :]
+    T = win.shape[0] * dt
+    phas = np.sum(win * (np.exp(-1j * W * tw) * dt)[:, None], axis=0)
+    kx = abs(np.polyfit(pidx * DX, np.unwrap(np.angle(phas)), 1)[0])
+    a_local = 2.0 * np.abs(phas) / T                     # per-probe fundamental amplitude
+    return kx, float(np.mean(a_local ** 2))
+
+
+def _ratio(chi3, amp, domx, slab, probes, kx0):
+    kx, mean_a2 = _measure(chi3, amp, domx, slab, probes)
+    dkx_meas = kx - kx0
+    dkx_txt = (3.0 / 8.0) * chi3 * mean_a2 * K0
+    return dkx_meas, dkx_txt, dkx_meas / dkx_txt
+
+
+# geometry: χ³-only slab spanning most of a CPML-terminated x-domain; probes strictly inside it
+_LONG = dict(domx=0.60, slab=(0.06, 0.54), probes=(0.12, 0.44))
+_SHORT = dict(domx=0.45, slab=(0.06, 0.39), probes=(0.12, 0.33))
+
+
+@pytest.fixture(scope="module")
+def oracle():
+    # χ³=0 baseline is operator-independent (both operators are identity at χ³=0) → shared.
+    kx0_L, _ = _measure(0.0, 1.0, **_LONG)
+    dkx_meas, dkx_txt, r_dbased = _ratio(0.20, 1.0, **_LONG, kx0=kx0_L)
+
+    # falsifier: the pre-#448 increment operator (scale the E-update increment) — must NOT pass.
+    shipped = _nl.apply_kerr_ade
+
+    def _increment(state, e_prev, chi3_arr, eps_r_arr):
+        ex_p, ey_p, ez_p = e_prev
+        e2 = ex_p ** 2 + ey_p ** 2 + ez_p ** 2
+        f = 1.0 / (1.0 + chi3_arr * e2 / eps_r_arr)
+        return state._replace(ex=ex_p + (state.ex - ex_p) * f,
+                              ey=ey_p + (state.ey - ey_p) * f,
+                              ez=ez_p + (state.ez - ez_p) * f)
+    try:
+        _nl.apply_kerr_ade = _increment                  # picked up by the lazy import in run()
+        _, _, r_increment = _ratio(0.20, 1.0, **_LONG, kx0=kx0_L)
+    finally:
+        _nl.apply_kerr_ade = shipped
+
+    # domain-size invariance (mandate: an ADDED gate needs a falsifier + domain-invariance)
+    kx0_S, _ = _measure(0.0, 1.0, **_SHORT)
+    _, _, r_short = _ratio(0.20, 1.0, **_SHORT, kx0=kx0_S)
+
+    return {"dkx_meas": dkx_meas, "dkx_txt": dkx_txt, "r_dbased": r_dbased,
+            "r_increment": r_increment, "r_short": r_short}
+
+
+@pytest.mark.slow
+def test_kerr_spm_absolute_magnitude(oracle):
+    """The D-based operator reproduces the textbook Δk=(3/8)χ³⟨A²⟩k0 to within ±20% (measured ≈0.93,
+    residual = Yee dispersion). Excludes the increment operator (0.33) AND the pulsed artifact (0.59)."""
+    r = oracle["r_dbased"]
+    assert 0.80 <= r <= 1.20, (
+        f"absolute SPM ratio {r:.3f} outside [0.80,1.20]: "
+        f"Δk_meas={oracle['dkx_meas']:.4f} Δk_txt={oracle['dkx_txt']:.4f}")
+
+
+@pytest.mark.slow
+def test_kerr_spm_absolute_positive_sign(oracle):
+    """Δk > 0 — a reactive index INCREASE (self-focusing). A dissipative/linear operator gives ~0."""
+    assert oracle["dkx_meas"] > 0.1, f"Δk_meas={oracle['dkx_meas']:.4f} not a clear positive shift"
+
+
+@pytest.mark.slow
+def test_kerr_spm_gate_discriminates_operator(oracle):
+    """The gate BINDS PHYSICS, not any operator: the pre-#448 increment operator underestimates the
+    magnitude (ratio ≈0.33) and FAILS the [0.8,1.2] gate — so a green here means the D-based
+    constitutive solve, not merely 'some Kerr term fired'."""
+    assert oracle["r_increment"] < 0.60, (
+        f"increment falsifier ratio {oracle['r_increment']:.3f} should be well below the "
+        f"passing band — the gate would not discriminate the operator")
+    assert oracle["r_dbased"] - oracle["r_increment"] > 0.30, (
+        f"D-based ({oracle['r_dbased']:.3f}) and increment ({oracle['r_increment']:.3f}) "
+        f"not clearly separated")
+
+
+@pytest.mark.slow
+def test_kerr_spm_absolute_domain_invariant(oracle):
+    """The ratio is a physical property, not a domain artifact: a 0.60 m and a 0.45 m domain agree."""
+    assert abs(oracle["r_dbased"] - oracle["r_short"]) < 0.15, (
+        f"ratio moved with domain size: long={oracle['r_dbased']:.3f} short={oracle['r_short']:.3f} "
+        f"(an artifact would swing; physics is invariant)")

--- a/tests/test_kerr_spm_fingerprint.py
+++ b/tests/test_kerr_spm_fingerprint.py
@@ -11,9 +11,11 @@ established, discriminating, and robust:
       gives 0. So Δk_x>0 discriminates the reactive Kerr.
   (2) FIRST-ORDER SPM: Δk_x/(χ³·A²) is CONSTANT across χ³ and A (measured ≈8.2, within 2.5%).
 
-NOT gated here: the ABSOLUTE magnitude vs textbook Δn=(3/8)χ³A². The increment operator
-underestimates it (~0.31× the naive ε_eff); the rigorous D-based update + a weak-regime absolute
-oracle are tracked in #446. Harness: docs/research_notes/experiments/kerr_cw_spm_oracle.py
+The ABSOLUTE magnitude vs textbook Δn=(3/8)χ³A² is gated separately in
+test_kerr_spm_absolute_oracle.py (#446), which uses a TRUE-CW source (waveform='continuous_wave')
+to remove the pulsed-⟨E²⟩ ambiguity and confirms the shipped D-based operator (#448) reaches
+ratio ≈0.95 (the pre-#448 increment operator underestimated it at ~0.33×).
+Harness: docs/research_notes/experiments/kerr_cw_spm_oracle.py
 """
 import numpy as np
 import pytest


### PR DESCRIPTION
## Summary

Closes **#446** — the absolute-magnitude Kerr-SPM oracle that the fingerprint oracle (#447) left open.

The blocker was the **pulsed-TFSF ⟨E²⟩ ambiguity**: for a Gaussian pulse ⟨E²⟩ is ill-defined (peak-A²/2 vs window-mean ≈ 6× spread), so the absolute ratio vs textbook `Δn=(3/8)χ³A²` could not be pinned. Two ingredients close it:

**1. `waveform="continuous_wave"` (normal-incidence TFSF)** — raised-cosine turn-on (~8 periods) then a constant-amplitude sinusoid at `f0`. At steady state the field is a single traveling wave of well-defined amplitude ⇒ `⟨E²⟩ = A²/2` exactly.
- Real/pulsed paths byte-identical (new branch only fires for the new string).
- Oblique CW rejected (the 2D-aux path doesn't support it); passes preflight.

**2. Rigorous local comparator** (`tests/test_kerr_spm_absolute_oracle.py`) — the phase slope `kx = ⟨k(x)⟩` integrates the LOCAL intensity, and the weak ε_eff-step reflection (`Γ≈(3/16)χ³A²`) leaves a standing-wave ripple, so the target uses `⟨A(x)²⟩` (mean of per-probe *squared* fundamental amplitude), not `(mean A)²`.

## Result (per-bin, R5)

Shipped D-based operator (#448) vs textbook `Δk=(3/8)χ³⟨A²⟩k0`:

| χ³ | amp | ⟨A²⟩ | Δk_meas | Δk_txt | ratio |
|----|-----|------|---------|--------|-------|
| 0.05 | 1.0 | 0.691 | +1.240 | 1.359 | 0.913 |
| 0.10 | 1.0 | 0.645 | +2.345 | 2.536 | 0.925 |
| 0.10 | 1.4 | 1.230 | +4.738 | 4.835 | 0.980 |
| 0.20 | 1.0 | 0.627 | +4.835 | 4.931 | 0.981 |
| 0.30 | 1.0 | 0.641 | +7.393 | 7.557 | 0.978 |

**mean ratio = 0.955 ± 0.030.** Residual ~5% is Yee numerical dispersion (the χ³=0 baseline `kx0` itself sits +0.13% above continuum `k0`). Contrast: the pulsed peak-A² comparator gave 0.59; the pre-#448 increment operator gives **0.33**.

## Gate provenance (feedback_gate_can_bind_artifact)

The ADDED gate ships with both mandated artifacts, **in-test**:
- **Falsifier**: the pre-#448 increment operator scores 0.33 and FAILS the `[0.8,1.2]` band — a green means the D-based constitutive solve, not merely "some Kerr term fired".
- **Domain-size invariance**: 0.60 m → 0.925, 0.45 m → 0.965 (a domain artifact would swing).

## Tests
`tests/test_kerr_spm_absolute_oracle.py` — 4 slow tests, all green (62 s CPU): absolute magnitude, positive sign, operator-discrimination (falsifier), domain invariance. Full Kerr suite + TFSF oblique/preflight suites green; lint clean.

R3: memory=project_403_oracle_campaign (CW source was the *recorded fix*, not a re-attempt of the forbidden pulsed path) | R2-attempts=0 prior on the CW mechanism (closes on attempt 1) | falsifier=increment operator 0.33 vs D-based 0.93, in-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)