### PR TITLE
test(rcs): oblique (theta,phi) observation-grid equivalence for compute_rcs_jax (Item C step 1)

### DIFF
--- a/rfx/rcs.py
+++ b/rfx/rcs.py
@@ -293,16 +293,28 @@ def compute_rcs(
     dx = grid.dx
     dt = grid.dt
 
-    # Fail-loud guard (#404): a non-zero theta_inc silently dispatches init_tfsf
-    # to the 2D-aux oblique path, whose reflection accuracy is UNVALIDATED (the
-    # extracted |R| does not track the injection angle — issue #404, R2-STOP
-    # 2026-07-20). Only normal incidence is supported here; refuse rather than
-    # return an unvalidated oblique RCS.
+    # Fail-loud guard: oblique RCS is unimplemented + unvalidated. The original
+    # #404 rationale (2D-aux injection under-tilt) is now STALE — #414 fixed the
+    # oblique 3D-Bloch injection and #422/#428 validated oblique SLAB reflection.
+    # But oblique RCS remains blocked for deeper reasons (investigation 2026-07-23):
+    #   1. the NTFF accumulator is NOT envelope/Bloch-aware, so run() itself
+    #      fail-louds on oblique+NTFF (it would DFT the complex Bloch envelope, not
+    #      the physical field) — deleting this guard only relocates that failure;
+    #   2. the periodic-Bloch path #414 dispatches to is the wrong tool for an
+    #      OPEN-DOMAIN compact scatterer (it assumes lateral periodicity), which
+    #      needs a proper 3D open-domain oblique TFSF that does not yet exist;
+    #   3. the oblique two-run incident-leakage subtraction (#280/#299) is
+    #      validated only at normal incidence, and no angle-sensitive far-field
+    #      oracle (PO plate / MoM at oblique — the PEC sphere is rotation-blind)
+    #      is wired to certify an oblique pattern.
+    # compute_rcs_jax (the differentiable post-processor) and the NTFF transform
+    # are incidence-agnostic and ready; the gap is producing a validated oblique
+    # scattered field on the box. Refuse rather than return an unvalidated number.
     if abs(float(theta_inc)) > 1e-6:
         raise NotImplementedError(
             f"compute_rcs(theta_inc={theta_inc}) — oblique incidence is not "
-            "supported: the oblique TFSF path's reflection accuracy is "
-            "unvalidated (issue #404). Use theta_inc=0.0 (normal incidence)."
+            "supported: no envelope-aware NTFF / open-domain oblique TFSF / "
+            "angle-sensitive oracle yet (issue #404 arc). Use theta_inc=0.0."
         )
 
     # --- 1. Set up TFSF source ---

--- a/tests/test_rcs_jax_differentiable.py
+++ b/tests/test_rcs_jax_differentiable.py
@@ -111,3 +111,24 @@ def test_rcs_jax_gradient_fd_convergence(rcs_run):
         errs.append(abs(g_ad - g_fd) / abs(g_ad))
     assert errs[1] < errs[0], f"central-FD not converging to AD: {errs}"
     assert errs[1] < 0.05, f"smallest-h FD error {errs[1]*100:.1f}% (AD={g_ad:.3e})"
+
+
+@pytest.mark.slow
+def test_rcs_jax_equals_numpy_on_oblique_observation_grid(rcs_run):
+    """compute_rcs_jax == the numpy far-field formula over a FULL (theta,phi)
+    OBSERVATION grid, not just the backscatter bin — closes the AD-path coverage
+    hole (compute_far_field_jax was pinned at a single direction). The NTFF
+    transform is incidence-agnostic (it only integrates the tangential fields on
+    the box), so this jax==numpy equivalence holds at every observation direction
+    regardless of the injection angle; it is a prerequisite for a future oblique
+    RCS objective, decoupled from the (still-fenced) oblique INJECTION path."""
+    g, box, e_inc, nd = rcs_run["grid"], rcs_run["box"], rcs_run["e_inc"], rcs_run["ntff_data"]
+    th = np.linspace(0.05, np.pi - 0.05, 7)      # 7 polar angles across the sphere
+    ph = np.linspace(0.0, 2 * np.pi, 9)[:-1]     # 8 azimuths (drop duplicate 2*pi)
+    ff = compute_far_field(nd, box, g, th, ph)
+    p = np.abs(np.asarray(ff.E_theta)) ** 2 + np.abs(np.asarray(ff.E_phi)) ** 2  # (nf,nθ,nφ)
+    sig_numpy = 4 * np.pi * p / (np.abs(e_inc) ** 2)[:, None, None]
+    sig_jax = np.asarray(compute_rcs_jax(nd, box, g, th, ph, e_inc))
+    assert sig_jax.shape == sig_numpy.shape == (len(FREQS), len(th), len(ph))
+    rel = np.abs(sig_jax - sig_numpy) / (np.abs(sig_numpy) + 1e-30)
+    assert np.max(rel) < 1e-4, f"max rel diff over (θ,φ) grid = {np.max(rel):.2e}"


### PR DESCRIPTION
**Split from the 8-commit Item-C branch** per the review note in the previous body ("Reviewer may prefer to split (oblique-RCS feature vs crossval examples) — PI's call"). This PR is now **only** commit `a0cd0fa` — the low-risk AD-coverage test + comment refresh. The oblique fence remains **in place** here.

The other 7 commits are preserved and split into follow-up PRs (see below); nothing was discarded — the full 8-commit tip `0a4f1ea` is also kept at branch `backup/oblique-rcs-item-c-full-20260725`.

## Changes (2 files, +40/-7)
- **`compute_rcs_jax` oblique observation-grid equivalence** (`tests/test_rcs_jax_differentiable.py`): the jax-vs-numpy far-field equivalence was pinned only at the backscatter bin `(pi/2, pi)`. Adds `test_rcs_jax_equals_numpy_on_oblique_observation_grid` — equivalence over a full 7x8 `(theta,phi)` grid to `<1e-4`. The NTFF transform is incidence-agnostic, so the differentiable post-processor is now validated at *every* observation direction, independent of the injection fence.
- **Refresh the stale oblique fence comment** (`rfx/rcs.py`): the original #404 rationale (2D-aux under-tilt) is stale — #414 fixed oblique injection and #422/#428 validated oblique slab reflection. The comment now records the actual blockers. **Guard behavior unchanged** — `theta_inc != 0` still raises.

## Verification (re-run, not self-reported)
- `tests/test_rcs_jax_differentiable.py -m slow` — 4 passed; `tests/test_rcs.py` — 4 passed.
- **Added-gate falsifier** (per `feedback_gate_can_bind_artifact`): perturbing the jax path by 0.1% makes the new equivalence gate FAIL, so it binds the real two-implementation agreement rather than passing vacuously.
- `api reference surface: OK`; ruff clean. Rebased onto current main (`cd8f6e2`), so the stale `run`/`run_until_decay` api-reference drift fixed by #458 no longer applies.

## Follow-ups carrying the rest of the branch
- **Oblique fence lift** (`48ec29b` + `4a0ba3a` + `d18208e`): method-B open-domain oblique TFSF + wiring + the `ez`/uniform fence lift and its specular-peak gate. Needs an api-reference regeneration (`add_tfsf_source` gained params — a genuine public-surface drift, currently unrecorded).
- **Cross-solver validation campaign** (`514d266` + `e66e528` + `03ed489` + `0a4f1ea`): the Sheen LPF / rect cavity / patch studies + the Palace referee. These sit under `scripts/crossval/`, which is outside the repo's crossval governance — `tests/test_crossval_manifest_contract.py` requires every `validation/crossval/*.py` to carry a manifest entry (role, evidence levels, references, claim scope), so the move needs an honest per-study classification rather than a path rename.

R3: memory=project_diff_planewave_inverse_design + feedback_gate_can_bind_artifact | R2-attempts=0 | falsifier=0.1% jax-path perturbation trips the new <1e-4 gate (verified FAILED)