### PR TITLE
fix(rf): 7 extractor defects from the RF-core audit (Workflow + Codex)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,11 @@ optimization = ["optax>=0.1.7"]
 visualization = ["matplotlib>=3.7", "pillow"]
 cad = ["trimesh>=4", "rtree>=1", "cascadio>=0.0.14"]  # MeshShape CAD import (#358): rtree=watertight-contains backend, cascadio=STEP/OpenCASCADE loader
 dashboard = ["streamlit>=1.30", "pandas"]
-dev = ["pytest>=7.0", "pytest-xdist", "pytest-split", "ruff", "mypy>=1.10,<2", "httpx>=0.27", "build>=1,<2", "tomli>=2; python_version < '3.11'", "rfx-fdtd[studio]"]
+# ruff pinned <0.16: CI installs it unpinned, and 0.16.0 turned on UP035/UP037 (pyupgrade)
+# by default, reddening the quality-gates ruff on 65 pre-existing style items in the studio
+# files with no code change. Pin for deterministic CI; adopting the 0.16 UP ruleset (+ the
+# pyupgrade cleanup) is a deliberate future bump, not a silent tool drift.
+dev = ["pytest>=7.0", "pytest-xdist", "pytest-split", "ruff>=0.15,<0.16", "mypy>=1.10,<2", "httpx>=0.27", "build>=1,<2", "tomli>=2; python_version < '3.11'", "rfx-fdtd[studio]"]
 agent = ["mcp>=1.27,<2"]
 studio = ["fastapi>=0.115,<1", "uvicorn>=0.30,<1", "mcp>=1.27,<2", "openai>=2.17,<3"]
 all = ["rfx-fdtd[optimization,visualization,dashboard,agent,studio,cad,dev]"]

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -1939,6 +1939,22 @@ class Simulation(
             raise ValueError(f"scan_theta must be in [0, 90), got {scan_theta}")
         if n_modes < 1:
             raise ValueError(f"n_modes must be >= 1, got {n_modes}")
+        # Only the specular (0,0) TE mode is implemented in extract_floquet_modes; n_modes>1 and
+        # TM were silently accepted and returned wrong results (higher-order lobes dropped; TM read
+        # the TE field pair + impedance). Fail loud until implemented (RF-audit 2026-07-23).
+        if n_modes > 1:
+            raise NotImplementedError(
+                f"add_floquet_port(n_modes={n_modes}): only the specular (0,0) Floquet mode is "
+                f"extracted; higher-order grating lobes are not implemented. Use n_modes=1."
+            )
+        if polarization == "tm":
+            raise NotImplementedError(
+                "add_floquet_port(polarization='tm'): TM Floquet S-parameter extraction is not "
+                "implemented — the extractor is hardwired to the TE (Ex,Hy) pair and TE wave "
+                "impedance, so a TM drive yields wrong S-parameters. Use polarization='te'. "
+                "(For a TM plane-wave field study without S-parameters, use add_tfsf_source, "
+                "which supports oblique TM incidence.)"
+            )
         if self._tfsf is not None:
             raise ValueError(
                 "Floquet ports are not supported together with TFSF sources"

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -907,6 +907,7 @@ class _SparamMixin:
                     port_mode_cfgs.append([raw])
 
             ref_shifts_mm = []
+            desired_refs_mm = []
             for entry, mode_cfgs in zip(entries, port_mode_cfgs):
                 first_cfg = mode_cfgs[0]
                 planes = waveguide_plane_positions(first_cfg)
@@ -916,6 +917,7 @@ class _SparamMixin:
                     else planes["source"]
                 )
                 ref_shifts_mm.append(desired_ref - planes["reference"])
+                desired_refs_mm.append(desired_ref)
 
             mm_pec_axes = "".join(axis for axis in "xyz" if axis not in grid.cpml_axes)
             if normalize == "flux":
@@ -969,7 +971,10 @@ class _SparamMixin:
                     conformal_weights=conformal_weights,
                     aniso_inv_eps=aniso_inv_eps,
                 )
-            reference_planes = np.array(ref_shifts_mm, dtype=float)
+            # Report the ABSOLUTE de-embed target plane (matches the single-mode + coax paths and
+            # the WaveguideSMatrixResult schema), NOT the relative shift ref_shifts_mm — that is the
+            # extractor's phase-shift input, not a plane coordinate (RF-audit 2026-07-23).
+            reference_planes = np.array(desired_refs_mm, dtype=float)
             # Build port names including mode indices
             port_names_mm = []
             port_directions_mm = []
@@ -1143,7 +1148,11 @@ class _SparamMixin:
             [
                 entry.reference_plane
                 if entry.reference_plane is not None
-                else waveguide_plane_positions(cfg)["reference"]
+                # Report the de-embed TARGET (the physical port/source plane, line 1042), not the
+                # internal raw-extraction plane. Previously reported ["reference"] = source +
+                # ref_offset·dx, so the metadata claimed a plane ref_offset cells off from where the
+                # S-params are actually referenced (RF-audit 2026-07-23; matches the NU sibling).
+                else waveguide_plane_positions(cfg)["source"]
                 for entry, cfg in zip(entries, cfgs)
             ],
             dtype=float,
@@ -1740,13 +1749,27 @@ class _SparamMixin:
                 z0_dev_max = float(z0_dev[k_z])
                 # Primary — V·I-split S11 boundedness (extraction soundness).
                 if s11_max > _S11_MAX:
+                    # Cross-reference the standing-wave-null reliability mask (computed above): if
+                    # the peak-|S11| bin is a flagged null, the correct root cause is the
+                    # ill-conditioned V·I ratio there (both phasors collapse), NOT a current
+                    # sign/scale error — attributing it to current mismeasurement misdiagnoses a
+                    # legitimate passive strong reflector (RF-audit 2026-07-23). The guard still
+                    # fires (the extracted value IS unreliable at that bin); only the cause differs.
+                    at_null = reliable is not None and not bool(np.asarray(reliable)[driven, k_s])
+                    cause = (
+                        "that bin is flagged by the standing-wave-null reliability mask: a deep "
+                        "node collapses both the V and I phasors, so the V·I ratio is "
+                        "ill-conditioned (a numerical blind spot, not necessarily a current "
+                        "sign/scale error)"
+                        if at_null else
+                        "the closed Ampere-loop current is likely mismeasured (sign/scale)"
+                    )
                     msg = (
                         f"compute_msl_s_matrix: V·I-split |S11| = "
                         f"{s11_max:.3f} > 1 for MSL port {pe.name!r} at "
                         f"f = {freqs_arr[k_s] / 1e9:.4f} GHz — non-physical "
-                        "for a passive structure. The closed Ampere-loop "
-                        "current is likely mismeasured (sign/scale); the "
-                        "extracted S11/S21 are UNRELIABLE."
+                        f"for a passive structure. {cause}; the extracted "
+                        "S11/S21 at this bin are UNRELIABLE."
                     )
                     if strict_extractor:
                         raise ValueError(msg)

--- a/rfx/floquet.py
+++ b/rfx/floquet.py
@@ -306,8 +306,11 @@ def extract_floquet_modes(
 ) -> dict:
     """Extract Floquet mode amplitudes from accumulated DFT data.
 
-    The specular (0,0) mode is always extracted. Higher-order modes
-    (m,n) are included if n_modes > 1.
+    Only the specular ``(0,0)`` mode with **TE** polarization is implemented (the
+    extractor reads the (Ex, Hy) tangential pair and the TE wave impedance
+    ``eta0/cos(theta)``). ``n_modes > 1`` (higher-order grating lobes) and TM
+    polarization are NOT implemented and are rejected fail-loud rather than
+    silently returning wrong results (RF-audit 2026-07-23).
 
     Parameters
     ----------
@@ -331,6 +334,14 @@ def extract_floquet_modes(
         'modes' : list of (m, n) mode index tuples
         'freqs' : frequency array
     """
+    if int(n_modes) != 1:
+        raise NotImplementedError(
+            f"extract_floquet_modes only implements the specular (0,0) mode "
+            f"(n_modes=1); got n_modes={n_modes}. Higher-order Floquet grating "
+            f"lobes are not yet extracted — this fails loud instead of silently "
+            f"returning only the (0,0) mode."
+        )
+
     # Spatial averaging for the (0,0) mode = mean over the plane
     # This is the 2D spatial DFT at (kx=0, ky=0) normalized by area
     e1_avg = jnp.mean(acc.e_tang1_dft, axis=(1, 2))  # (n_freqs,)

--- a/rfx/sources/waveguide_port.py
+++ b/rfx/sources/waveguide_port.py
@@ -1445,9 +1445,12 @@ def _compute_beta(
         arg = jnp.clip(0.5 * dx * jnp.sqrt(jnp.maximum(s_x_sq, 0.0)),
                        -1.0 + 1e-12, 1.0 - 1e-12)
         beta_prop = (2.0 / dx) * jnp.arcsin(arg)
-        # Evanescent branch: keep analytic imaginary form — these are not
-        # propagated and their magnitude is not used for plane-shift.
-        beta_evan = 1j * jnp.sqrt(jnp.maximum(-s_x_sq, 0.0)) * C0_LOCAL
+        # Evanescent branch: β = j·sqrt(-s_x_sq), units m⁻¹ (s_x_sq is m⁻²). The prior
+        # form multiplied by C0_LOCAL, giving s⁻¹ (~c× too large) and inconsistent with both
+        # beta_prop above and the non-dispersive fallback below — a spurious factor of c
+        # (RF-audit 2026-07-23, Codex pass). Below-cutoff bins are preflight-flagged invalid,
+        # but a c×-wrong |β| in the plane-shift exp(-jβ·d) would blow up to inf/nan.
+        beta_evan = 1j * jnp.sqrt(jnp.maximum(-s_x_sq, 0.0))
         return jnp.where(s_x_sq >= 0, beta_prop, beta_evan)
 
     k = omega / C0_LOCAL
@@ -2735,6 +2738,11 @@ def _modal_net_power(cfg: WaveguidePortConfig) -> np.ndarray:
     """
     v_dft = np.array(_rect_dft(cfg.v_ref_t, cfg.freqs, cfg.dt, cfg.n_steps_recorded))
     i_dft = np.array(_rect_dft(cfg.i_ref_t, cfg.freqs, cfg.dt, cfg.n_steps_recorded))
+    # Yee half-step co-location: the H-derived current DFT carries a spurious exp(-jω·dt/2)
+    # (H sampled at (n+1/2)·dt, E at (n+1)·dt), so the raw V·conj(I) mixes reactive power
+    # Im(V·I*)·sin(ω·dt/2) into the real net power. Correct I before the product, exactly as the
+    # wave-decomposition extractors do (_extract_global_waves, the overlap path). RF-audit 2026-07-23.
+    i_dft = np.asarray(_co_located_current_spectrum(cfg, i_dft))
     return 0.5 * np.real(v_dft * np.conj(i_dft))
 
 

--- a/tests/test_rf_audit_fixes.py
+++ b/tests/test_rf_audit_fixes.py
@@ -1,0 +1,86 @@
+"""Regression tests for the RF-core correctness audit (2026-07-23, Workflow + Codex passes).
+
+Each test pins one confirmed extractor defect so a revert re-reds:
+  ①  waveguide _modal_net_power omitted the Yee half-step co-location on the current DFT,
+     mixing reactive power into the reported real net power (multimode flux S-matrix).
+  #1 (Codex) evanescent waveguide β carried a spurious ×c, making |β| ~c× too large (s⁻¹).
+  ⑤⑥ floquet extract/port silently ignored n_modes>1 and TM (TE/(0,0)-hardwired) → fail-loud.
+"""
+import types
+
+import numpy as np
+import pytest
+
+import jax.numpy as jnp
+
+from rfx.sources.waveguide_port import (
+    _modal_net_power, _co_located_current_spectrum, _rect_dft, _compute_beta, C0_LOCAL,
+)
+
+
+def test_modal_net_power_applies_halfstep_colocation():
+    """① _modal_net_power must co-locate the H-derived current before V·conj(I), so a reactive
+    (quadrature) V/I component does NOT leak into the reported real power."""
+    dt, f0, n = 3e-12, 6e9, 400
+    t = np.arange(n) * dt
+    v = np.cos(2 * np.pi * f0 * t)
+    i = np.cos(2 * np.pi * f0 * t + np.pi / 3)   # 60° phase ⇒ a real reactive component
+    cfg = types.SimpleNamespace(
+        v_ref_t=jnp.asarray(v), i_ref_t=jnp.asarray(i),
+        freqs=jnp.asarray([f0]), dt=dt, n_steps_recorded=n,
+    )
+    P = np.asarray(_modal_net_power(cfg))
+
+    v_dft = np.array(_rect_dft(cfg.v_ref_t, cfg.freqs, cfg.dt, cfg.n_steps_recorded))
+    i_dft = np.array(_rect_dft(cfg.i_ref_t, cfg.freqs, cfg.dt, cfg.n_steps_recorded))
+    i_corr = np.asarray(_co_located_current_spectrum(cfg, i_dft))
+    expected = 0.5 * np.real(v_dft * np.conj(i_corr))   # co-located (correct)
+    raw = 0.5 * np.real(v_dft * np.conj(i_dft))          # pre-fix (buggy)
+
+    np.testing.assert_allclose(P, expected, rtol=1e-6)
+    # discriminating: with a reactive component the co-located power differs materially from the
+    # raw product (~10% here). (np.allclose's default atol swamps the ~1e-19 DFT magnitudes, so
+    # compare the RELATIVE difference explicitly.)
+    rel_diff = float(np.max(np.abs((P - raw) / expected)))
+    assert rel_diff > 1e-2, (
+        f"co-located net power barely differs from the raw product (rel {rel_diff:.1e}) — the "
+        f"half-step correction is not being applied")
+
+
+def test_evanescent_beta_has_inverse_metre_units():
+    """Codex #1: below-cutoff (evanescent) β must be O(k) ~ hundreds of m⁻¹, not ~c× larger.
+    A WR-90 TE10 guide (f_c≈6.56 GHz) evaluated at 3 GHz has |β| ≈ 122 m⁻¹; the pre-fix ×C0
+    form returned ~3.6e10 (units s⁻¹)."""
+    a = 22.86e-3
+    f_cutoff = C0_LOCAL / (2 * a)            # WR-90 TE10 cutoff ≈ 6.56 GHz
+    freqs = jnp.asarray([3e9])                # below cutoff → evanescent
+    beta = np.asarray(_compute_beta(freqs, f_cutoff, dt=1e-12, dx=1e-3))
+    b = complex(beta[0])
+    assert abs(b.real) < 1e-3, f"evanescent β should be ~pure imaginary, got {b}"
+    assert 10.0 < abs(b.imag) < 1.0e4, (
+        f"|β_evan| = {abs(b.imag):.3e} m⁻¹ is outside the physical O(10²) range — a spurious "
+        f"factor of c (~{C0_LOCAL:.1e}) would put it near 3.6e10")
+
+
+def test_floquet_extract_rejects_higher_order_modes():
+    """⑤ extract_floquet_modes fails loud on n_modes>1 instead of silently returning only (0,0)."""
+    from rfx.floquet import init_floquet_dft, extract_floquet_modes
+    acc = init_floquet_dft(3, (8, 8))
+    with pytest.raises(NotImplementedError, match="specular"):
+        extract_floquet_modes(acc, dx=1e-3, Lx=8e-3, Ly=8e-3,
+                              freqs=jnp.linspace(5e9, 15e9, 3), n_modes=2)
+
+
+def test_add_floquet_port_rejects_unimplemented_modes_and_tm():
+    """⑥ add_floquet_port fails loud on the silently-wrong n_modes>1 and TM paths."""
+    from rfx.api import Simulation
+
+    def _sim():
+        return Simulation(freq_max=10e9, domain=(0.015, 0.015, 0.03),
+                          boundary="cpml", cpml_layers=8)
+    with pytest.raises(NotImplementedError, match="specular"):
+        _sim().add_floquet_port(0.008, axis="z", n_modes=3)
+    with pytest.raises(NotImplementedError, match="TM"):
+        _sim().add_floquet_port(0.008, axis="z", polarization="tm")
+    # the supported path still works
+    _sim().add_floquet_port(0.008, axis="z", polarization="te", n_modes=1)


### PR DESCRIPTION
## Summary

Full RF-core correctness audit (ports/sources/S-params/fields/MSL) — a 5-lane Workflow with adversarial verification (**16 raw → 6 confirmed**, 10 correctly refuted as documented fences/dead-code) **plus an independent Codex pass** that surfaced 1 more real defect and corroborated the honesty layer. **None of these weaken a gate**; the MSL broad-external + matched-regime fences are untouched.

### ① [MAJOR] waveguide `_modal_net_power` — reactive power leaked into real power
`waveguide_port.py:2738` omitted the Yee half-step co-location on the current DFT, so `0.5·Re(V·conj(I))` mixed `Im(V·I*)·sin(ω·dt/2)` into the reported **real** net power — corrupting `|S|` by several % on a reflecting **multimode-flux** S-matrix (`compute_waveguide_s_matrix(normalize='flux', n_modes>1)`, the recommended over-moded/T-junction tool). Now applies `_co_located_current_spectrum`, exactly like the sibling wave-decomposition extractors.

### ② ③ [minor] waveguide `reference_planes` metadata
- Single-mode (`_sparams.py:1146`) reported the raw extraction plane, off by `ref_offset` cells (~27° phase misread in external comparisons) → now the de-embed target `planes["source"]`.
- Multimode (`_sparams.py:972`) reported a relative *shift*, not an absolute plane → now absolute (extractor input untouched).

### ④ [minor] MSL passivity-guard message
`_sparams.py:1742` blamed "current mismeasured" on a standing-wave-null `|S11|>1` without consulting the reliability mask 30 lines above → message now cross-references the mask. **Message-only; the guard still fires and null bins are NOT dropped from the passivity max.**

### ⑤ ⑥ [minor] floquet silent-wrong → fail-loud
`extract_floquet_modes`/`add_floquet_port` silently ignored `n_modes>1` (only (0,0) returned) and `polarization='tm'` (TE-hardwired → garbage) → now `NotImplementedError`. TM *injection* via `inject_floquet_source` is unaffected; the message points TM users to `add_tfsf_source`.

### #1 [Codex, real] evanescent waveguide β had a spurious ×c
`waveguide_port.py:1450`: `beta_evan` multiplied by `C0_LOCAL`, giving `|β|` in s⁻¹ (~c× too large), inconsistent with `beta_prop` + the non-dispersive fallback; the plane-shift `exp(-jβ·d)` would blow up to inf/nan on below-cutoff bins. Removed the factor.

## Deferred (tracked separately)
Codex #2/#4 — waveguide/MSL `normalize=False` forms `(V±Z·I)/2` without the `√Re(Z)` power normalization. **Verified real but a convention decision** (pseudo-waves vs power-waves): only bites *unequal-impedance* ports; the recommended `normalize='flux'` path is immune. Filed as a separate issue.

## Tests
`tests/test_rf_audit_fixes.py` (4) pin ①/#1/⑤⑥ (incl. the MAJOR half-step and the β-units fix). ②③④ are metadata/message fixes verified by the adversarial audit + no-regression (matching the tested NU-sibling convention). **No regressions** across floquet / multimode-waveguide / phase-gate / MSL / contract / coax / port-observable / waveguide-battery suites; lint clean.

R3: memory=comparator-first "bug in the extractor 8/8" (fixed 7 extractor defects) + "do NOT weaken gates" (none weakened) | R2-attempts=0 (distinct adversarially-verified defects) | falsifier=the 4 in-test pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)