### PR TITLE
feat(rcs): open-domain oblique TFSF (method B) + lift the oblique fence for 2.5-D ez (Item C S1-S5)

### DIFF
--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -2372,7 +2372,8 @@
       "polarization",
       "direction",
       "angle_deg",
-      "waveform"
+      "waveform",
+      "method"
     ],
     "add_thin_conductor": [
       "shape",

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -1496,6 +1496,7 @@ class Simulation(
         direction: str = "+x",
         angle_deg: float = 0.0,
         waveform: str = "differentiated_gaussian",
+        method: str = "bloch",
     ) -> "Simulation":
         """Add a normal-incidence plane-wave TFSF source.
 
@@ -1526,6 +1527,16 @@ class Simulation(
             Spectrum is a Gaussian centered at ``f0`` with 1/e
             half-width ``f0·bandwidth``. Use this for matched rfx-vs-Meep
             crossval comparisons.
+        method : {"bloch", "methodB"}
+            Oblique-incidence engine (ignored for ``angle_deg=0``, which always
+            uses the normal 1D-aux path). ``"bloch"`` (default) is the narrowband
+            complex-Bloch 2D-aux path (fields go complex64; frequency-domain
+            monitors are not transform-aware — see ``tfsf_2d.py``). ``"methodB"``
+            is the open-domain oblique path (real ``float32``, 1D-aux-along-k̂ +
+            4-edge box): the transverse axis becomes OPEN/CPML, z stays thin
+            periodic (2.5-D, z-invariant far field), and NTFF/DFT/flux monitors
+            read physical fields. ``"methodB"`` currently requires
+            ``polarization='ez'`` and a single-device uniform grid.
         """
         if self._boundary != "cpml":
             raise ValueError("TFSF plane-wave source requires boundary='cpml'")
@@ -1563,6 +1574,19 @@ class Simulation(
                 "waveform must be 'differentiated_gaussian', 'modulated_gaussian', "
                 f"or 'continuous_wave', got {waveform!r}"
             )
+        if method not in ("bloch", "methodB"):
+            raise ValueError(f"method must be 'bloch' or 'methodB', got {method!r}")
+        if method == "methodB":
+            if abs(angle_deg) <= 0.01:
+                raise ValueError(
+                    "method='methodB' is the open-domain OBLIQUE path; use a "
+                    "non-zero angle_deg (angle_deg=0 uses the normal 1D-aux path)"
+                )
+            if polarization != "ez":
+                raise NotImplementedError(
+                    "method='methodB' currently supports polarization='ez' "
+                    "(transverse=y) only; 'ey' is future work"
+                )
 
         self._tfsf = _TFSFEntry(
             f0=f0,
@@ -1573,6 +1597,7 @@ class Simulation(
             direction=direction,
             angle_deg=angle_deg,
             waveform=waveform,
+            method=method,
         )
         return self
 

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -1325,14 +1325,23 @@ class _ExecuteMixin:
                 ny=grid.ny,
                 nz=grid.nz,
                 waveform=getattr(self._tfsf, "waveform", "differentiated_gaussian"),
+                method=getattr(self._tfsf, "method", "bloch"),
             )
             # NOTE: the TFSF vacuum-boundary check runs at forward() entry via
             # _auto_preflight on the concrete config; it is NOT re-run here because
             # `materials` may be a jax tracer under jax.grad (eps_override), and the
             # check concretizes.
-            periodic_bool = (False, True, True)
-            cpml_axes_run = "x"
-            pec_axes_run = ""
+            # Open-domain oblique Method B forces OPEN transverse y (CPML) with
+            # thin-periodic z; all other TFSF keep the historical open-x/periodic-yz.
+            from rfx.sources.tfsf import is_tfsf_methodB as _is_methodB_fwd
+            if _is_methodB_fwd(tfsf_run[0]):
+                periodic_bool = (False, False, True)
+                cpml_axes_run = "xy"
+                pec_axes_run = ""
+            else:
+                periodic_bool = (False, True, True)
+                cpml_axes_run = "x"
+                pec_axes_run = ""
 
         # Stage 2 Kottke for AD-traceable PEC density (opt-in via env
         # ``RFX_PEC_OCC_KOTTKE=1``).  When enabled and

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -1105,6 +1105,7 @@ class _TFSFEntry:
     direction: str
     angle_deg: float
     waveform: str = "differentiated_gaussian"
+    method: str = "bloch"
 
 
 @dataclass(frozen=True)

--- a/rfx/rcs.py
+++ b/rfx/rcs.py
@@ -201,7 +201,9 @@ def compute_rcs(
         steps, public path, corner-inclusive kernels): peak error 0 deg at
         theta_inc=20 and 3 deg at theta_inc=40 (4 deg on the pre-fix exclusive
         kernels), gated at +/-6 deg, with a 3-7 deg peak-azimuth
-        sensitivity to domain size at fixed dx/plate/CPML (PR #461 audit) —
+        sensitivity to domain size at fixed dx/plate/CPML (PR #461 audit,
+        measured on the PRE-fix exclusive kernels; not re-measured in-tree
+        on the inclusive kernels) —
         i.e. the argmax azimuth of the broad specular lobe is NOT converged to
         ~1 deg. See ``tests/test_oblique_rcs_specular.py``. The absolute
         oblique sigma is NOT validated. Requires ``polarization='ez'`` and a

--- a/rfx/rcs.py
+++ b/rfx/rcs.py
@@ -196,10 +196,16 @@ def compute_rcs(
         illumination in the x-y plane and route through the open-domain oblique
         Method-B TFSF (2.5-D: open transverse y, thin-periodic z). Only the
         far-field PATTERN / specular direction is validated at oblique incidence
-        (specular peak phi = 180 - theta_inc at theta_obs = 90 deg, tracked to
-        ~1 deg; see ``tests/test_oblique_rcs_specular.py``); the absolute oblique
-        sigma is NOT validated. Requires ``polarization='ez'`` and a uniform grid;
-        other combos raise ``NotImplementedError`` (issue #404 arc).
+        (specular peak phi = 180 - theta_inc at theta_obs = 90 deg). Measured
+        envelope on the committed gate configuration (2.2-lambda plate, 700
+        steps, public path): peak error 0 deg at theta_inc=20 and 4 deg at
+        theta_inc=40, gated at +/-6 deg, with a 3-7 deg peak-azimuth
+        sensitivity to domain size at fixed dx/plate/CPML (PR #461 audit) —
+        i.e. the argmax azimuth of the broad specular lobe is NOT converged to
+        ~1 deg. See ``tests/test_oblique_rcs_specular.py``. The absolute
+        oblique sigma is NOT validated. Requires ``polarization='ez'`` and a
+        uniform grid; other combos raise ``NotImplementedError`` (issue #404
+        arc).
     phi_inc : float
         Incident azimuth in degrees (reserved for future oblique support).
     polarization : str

--- a/rfx/rcs.py
+++ b/rfx/rcs.py
@@ -198,8 +198,9 @@ def compute_rcs(
         far-field PATTERN / specular direction is validated at oblique incidence
         (specular peak phi = 180 - theta_inc at theta_obs = 90 deg). Measured
         envelope on the committed gate configuration (2.2-lambda plate, 700
-        steps, public path): peak error 0 deg at theta_inc=20 and 4 deg at
-        theta_inc=40, gated at +/-6 deg, with a 3-7 deg peak-azimuth
+        steps, public path, corner-inclusive kernels): peak error 0 deg at
+        theta_inc=20 and 3 deg at theta_inc=40 (4 deg on the pre-fix exclusive
+        kernels), gated at +/-6 deg, with a 3-7 deg peak-azimuth
         sensitivity to domain size at fixed dx/plate/CPML (PR #461 audit) —
         i.e. the argmax azimuth of the broad specular lobe is NOT converged to
         ~1 deg. See ``tests/test_oblique_rcs_specular.py``. The absolute

--- a/rfx/rcs.py
+++ b/rfx/rcs.py
@@ -192,9 +192,14 @@ def compute_rcs(
     bandwidth : float
         Fractional bandwidth of the pulse.
     theta_inc : float
-        Incident angle in degrees (0 = +x propagation). Only normal incidence
-        (0) is supported; a non-zero value raises ``NotImplementedError`` (the
-        oblique TFSF reflection path is unvalidated — issue #404).
+        Incident angle in degrees (0 = +x propagation). Non-zero values tilt the
+        illumination in the x-y plane and route through the open-domain oblique
+        Method-B TFSF (2.5-D: open transverse y, thin-periodic z). Only the
+        far-field PATTERN / specular direction is validated at oblique incidence
+        (specular peak phi = 180 - theta_inc at theta_obs = 90 deg, tracked to
+        ~1 deg; see ``tests/test_oblique_rcs_specular.py``); the absolute oblique
+        sigma is NOT validated. Requires ``polarization='ez'`` and a uniform grid;
+        other combos raise ``NotImplementedError`` (issue #404 arc).
     phi_inc : float
         Incident azimuth in degrees (reserved for future oblique support).
     polarization : str
@@ -293,31 +298,46 @@ def compute_rcs(
     dx = grid.dx
     dt = grid.dt
 
-    # Fail-loud guard: oblique RCS is unimplemented + unvalidated. The original
-    # #404 rationale (2D-aux injection under-tilt) is now STALE — #414 fixed the
-    # oblique 3D-Bloch injection and #422/#428 validated oblique SLAB reflection.
-    # But oblique RCS remains blocked for deeper reasons (investigation 2026-07-23):
-    #   1. the NTFF accumulator is NOT envelope/Bloch-aware, so run() itself
-    #      fail-louds on oblique+NTFF (it would DFT the complex Bloch envelope, not
-    #      the physical field) — deleting this guard only relocates that failure;
-    #   2. the periodic-Bloch path #414 dispatches to is the wrong tool for an
-    #      OPEN-DOMAIN compact scatterer (it assumes lateral periodicity), which
-    #      needs a proper 3D open-domain oblique TFSF that does not yet exist;
-    #   3. the oblique two-run incident-leakage subtraction (#280/#299) is
-    #      validated only at normal incidence, and no angle-sensitive far-field
-    #      oracle (PO plate / MoM at oblique — the PEC sphere is rotation-blind)
-    #      is wired to certify an oblique pattern.
-    # compute_rcs_jax (the differentiable post-processor) and the NTFF transform
-    # are incidence-agnostic and ready; the gap is producing a validated oblique
-    # scattered field on the box. Refuse rather than return an unvalidated number.
-    if abs(float(theta_inc)) > 1e-6:
-        raise NotImplementedError(
-            f"compute_rcs(theta_inc={theta_inc}) — oblique incidence is not "
-            "supported: no envelope-aware NTFF / open-domain oblique TFSF / "
-            "angle-sensitive oracle yet (issue #404 arc). Use theta_inc=0.0."
-        )
+    # ---- Oblique incidence routing (issue #404 arc — fork (a) S4/S5) ----
+    # theta_inc != 0 routes the illumination through the OPEN-DOMAIN oblique
+    # Method-B TFSF (real float32, dispersion-matched 1D-aux-along-k̂ + a 4-edge
+    # box; rfx/sources/tfsf_oblique_open.py), NOT the periodic complex-Bloch 2D-aux
+    # path (#414) which assumes lateral periodicity and is the wrong tool for a
+    # compact scatterer. Method B is a 2.5-D path: k̂ lies in the x-y plane, the
+    # transverse y-axis is OPEN (CPML) and z is thin/periodic (z-invariant far
+    # field), so the fields stay real and the NTFF/DFT read physical fields.
+    #
+    # VALIDATED by the specular-peak gate (tests/test_oblique_rcs_specular.py):
+    # the bistatic far-field of a finite PEC plate (normal +x) peaks at the
+    # reflection-law specular direction phi = pi - theta_inc (theta_obs = pi/2)
+    # and tracks theta_inc to ~1 deg across {0, 20, 40} deg; the theta->0 limit
+    # reduces to backscatter (= specular at normal); the specular-lobe SHAPE
+    # matches the physical-optics sinc (corr ~0.9, 3 dB beamwidth within ~1 deg).
+    # SCOPE LIMIT: only the far-field PATTERN / specular DIRECTION is validated.
+    # The ABSOLUTE oblique sigma is NOT validated — the 2.5-D strip's 3-D RCS
+    # scales with the (arbitrary) NTFF z-box height because the two z-faces cancel
+    # for x-y-plane observation, and the incident-spectrum normalization below
+    # assumes the normal-path waveform. Kept fenced for combos Method B does not
+    # support: non-ez polarization and non-uniform / distributed grids.
+    _oblique = abs(float(theta_inc)) > 1e-6
+    if _oblique:
+        if polarization != "ez":
+            raise NotImplementedError(
+                f"compute_rcs(theta_inc={theta_inc}, polarization={polarization!r}) "
+                "— oblique RCS is supported for polarization='ez' only (the "
+                "open-domain Method-B TFSF is ez / transverse-y); 'ey' is future work."
+            )
+        if getattr(grid, "dz", None) is not None:
+            raise NotImplementedError(
+                "compute_rcs oblique incidence is not supported on non-uniform "
+                "grids (Method B requires a uniform single-device grid). "
+                "Use a uniform Grid or theta_inc=0.0."
+            )
 
     # --- 1. Set up TFSF source ---
+    # angle_deg=0 ignores `method` (normal 1D-aux path, byte-identical); the
+    # oblique branch selects Method B explicitly. ny/nz are only consumed by the
+    # oblique path and ignored at normal incidence.
     tfsf_cfg, tfsf_st = init_tfsf(
         nx=grid.nx,
         dx=dx,
@@ -330,6 +350,9 @@ def compute_rcs(
         polarization=polarization,
         direction="+x",
         angle_deg=theta_inc,
+        ny=grid.ny,
+        nz=grid.nz,
+        method="methodB" if _oblique else "bloch",
     )
 
     # --- 2. Set up NTFF box just outside TFSF box ---
@@ -345,8 +368,18 @@ def compute_rcs(
     ntff_i_hi = tfsf_cfg.x_hi + ntff_offset + 1
     ntff_j_lo = fl["y_lo"] + ntff_offset
     ntff_j_hi = grid.ny - fl["y_hi"] - ntff_offset
-    ntff_k_lo = fl["z_lo"] + ntff_offset
-    ntff_k_hi = grid.nz - fl["z_hi"] - ntff_offset
+    if _oblique:
+        # Method B is 2.5-D: z is THIN + PERIODIC (no real z-CPML), so the box
+        # z-faces sit symmetric about the mid-plane with a 2-cell span rather than
+        # inset from a (nonexistent) z-CPML. The two z-faces carry identical
+        # z-invariant tangential fields with opposite outward normals, so they
+        # cancel for x-y-plane (theta_obs=pi/2) observation — the validated cut.
+        _kz = grid.nz // 2
+        ntff_k_lo = _kz - 1
+        ntff_k_hi = _kz + 1
+    else:
+        ntff_k_lo = fl["z_lo"] + ntff_offset
+        ntff_k_hi = grid.nz - fl["z_hi"] - ntff_offset
 
     # Clamp to valid range
     ntff_i_lo = max(ntff_i_lo, 1)
@@ -368,14 +401,13 @@ def compute_rcs(
     )
 
     # --- 3. Run simulation with TFSF + NTFF ---
-    result = run(
-        grid,
-        materials,
-        n_steps,
-        boundary=boundary,
-        tfsf=(tfsf_cfg, tfsf_st),
-        ntff=ntff_box,
-    )
+    # Open-domain Method B forces the transverse y-axis OPEN (CPML) with
+    # thin-periodic z; normal incidence keeps the historical full-open defaults
+    # (byte-identical: `_run_kw` collapses to the pre-relaxation call).
+    _run_kw = dict(boundary=boundary, tfsf=(tfsf_cfg, tfsf_st), ntff=ntff_box)
+    if _oblique:
+        _run_kw.update(cpml_axes="xy", periodic=(False, False, True), pec_axes="")
+    result = run(grid, materials, n_steps, **_run_kw)
 
     # --- 4. Compute far-field from NTFF data ---
     ff = compute_far_field(
@@ -408,10 +440,7 @@ def compute_rcs(
             sigma=jnp.zeros(grid.shape, dtype=jnp.float32),
             mu_r=jnp.ones(grid.shape, dtype=jnp.float32),
         )
-        ref_result = run(
-            grid, vacuum, n_steps, boundary=boundary,
-            tfsf=(tfsf_cfg, tfsf_st), ntff=ntff_box,
-        )
+        ref_result = run(grid, vacuum, n_steps, **_run_kw)
         ff_ref = compute_far_field(
             ref_result.ntff_data, ntff_box, grid, theta_obs, phi_obs,
         )

--- a/rfx/rcs.py
+++ b/rfx/rcs.py
@@ -316,9 +316,13 @@ def compute_rcs(
     # VALIDATED by the specular-peak gate (tests/test_oblique_rcs_specular.py):
     # the bistatic far-field of a finite PEC plate (normal +x) peaks at the
     # reflection-law specular direction phi = pi - theta_inc (theta_obs = pi/2)
-    # and tracks theta_inc to ~1 deg across {0, 20, 40} deg; the theta->0 limit
-    # reduces to backscatter (= specular at normal); the specular-lobe SHAPE
-    # matches the physical-optics sinc (corr ~0.9, 3 dB beamwidth within ~1 deg).
+    # across {0, 20, 40} deg, within the measured envelope in the theta_inc
+    # parameter docstring above (peak error <= 4 deg, gated +/-6 deg, 3-7 deg
+    # domain-size sensitivity — NOT ~1 deg); the theta->0 limit reduces to
+    # backscatter (= specular at normal). The +/-6 deg tolerance is ~0.2 of the
+    # 2.2-lambda plate's ~30 deg physical-optics 3 dB specular lobe at
+    # theta_inc=40 (0.886*lambda/(W*cos(theta))) — argmax on a 1 deg grid
+    # inside a broad lobe, an envelope pin, not a loose bound.
     # SCOPE LIMIT: only the far-field PATTERN / specular DIRECTION is validated.
     # The ABSOLUTE oblique sigma is NOT validated — the 2.5-D strip's 3-D RCS
     # scales with the (arbitrary) NTFF z-box height because the two z-faces cancel
@@ -339,6 +343,24 @@ def compute_rcs(
                 "grids (Method B requires a uniform single-device grid). "
                 "Use a uniform Grid or theta_inc=0.0."
             )
+        # Method B is 2.5-D: z is thin + PERIODIC and the NTFF z-box is a
+        # 2-cell midplane span, so the returned sigma is for an infinite
+        # z-periodic replication of the target sampled at the midplane. Refuse
+        # a z-varying (genuinely 3-D) target rather than return that number
+        # silently (review F4 — "refuse rather than return an unvalidated
+        # number").
+        for _mname in ("eps_r", "sigma", "mu_r"):
+            _marr = np.asarray(getattr(materials, _mname))
+            if _marr.ndim == 3 and _marr.shape[2] > 1 and not np.array_equal(
+                _marr, np.broadcast_to(_marr[:, :, :1], _marr.shape)
+            ):
+                raise NotImplementedError(
+                    f"compute_rcs(theta_inc={theta_inc}): materials.{_mname} varies "
+                    "along z, but oblique incidence uses the 2.5-D Method-B path "
+                    "(thin-periodic z, midplane NTFF) which is only meaningful for "
+                    "z-invariant targets. Make the target z-invariant or use "
+                    "theta_inc=0.0."
+                )
 
     # --- 1. Set up TFSF source ---
     # angle_deg=0 ignores `method` (normal 1D-aux path, byte-identical); the

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -499,10 +499,19 @@ def run_uniform(
             ny=grid.ny,
             nz=grid.nz,
             waveform=getattr(sim._tfsf, 'waveform', 'differentiated_gaussian'),
+            method=getattr(sim._tfsf, 'method', 'bloch'),
         )
         sim._validate_tfsf_vacuum_boundary(materials, tfsf[0])
-        periodic = (False, True, True)
-        cpml_axes = "x"
+        # Open-domain oblique Method B: k̂ in the xy-plane, so the transverse
+        # y-axis must be OPEN (CPML) and z stays thin-periodic. Every other TFSF
+        # (normal 1D-aux + Bloch 2D-aux) keeps the historical open-x / periodic-yz.
+        from rfx.sources.tfsf import is_tfsf_methodB as _is_methodB_ru
+        if _is_methodB_ru(tfsf[0]):
+            periodic = (False, False, True)
+            cpml_axes = "xy"
+        else:
+            periodic = (False, True, True)
+            cpml_axes = "x"
         # #404: an oblique (2D-aux) TFSF drives the shared solver on the complex
         # Bloch-envelope path; final `state` and point-probe time series are
         # reconstructed to physical fields after the run, but the streaming/

--- a/rfx/simulation.py
+++ b/rfx/simulation.py
@@ -658,6 +658,10 @@ def _build_step_setup(
     # per-axis phase rides the periodic roll; the physical field is
     # Re(P·exp(-j k_t·y)). Gated strictly on the 2D-aux discriminator, so normal
     # incidence and every non-TFSF run stay real float32 and byte-identical.
+    # NOTE: gated strictly on the 2D-aux (Bloch) discriminator. Open-domain
+    # oblique Method B (MethodBConfig, NOT TFSF2DConfig) intentionally bypasses
+    # this lane: it stays real float32 and its NTFF/DFT/flux monitors read
+    # physical fields, so the fail-loud below must NOT be widened to angle != 0.
     _oblique_bloch = False
     if use_tfsf:
         from rfx.sources.tfsf import is_tfsf_2d as _is_tfsf_2d_early

--- a/rfx/sources/tfsf.py
+++ b/rfx/sources/tfsf.py
@@ -48,6 +48,20 @@ def is_tfsf_2d(cfg) -> bool:
     return isinstance(cfg, TFSF2DConfig)
 
 
+def is_tfsf_methodB(cfg) -> bool:
+    """Check if TFSF config is the open-domain oblique Method-B config.
+
+    Method B (``rfx/sources/tfsf_oblique_open.py``) injects an oblique plane
+    wave into an open (CPML) 2.5-D domain (k̂ in the xy-plane, thin-z periodic)
+    using a dispersion-matched 1D-aux-along-k̂ + a 4-edge TFSF box.  Its config
+    is a NEW NamedTuple (NOT a ``TFSF2DConfig``), so ``is_tfsf_2d`` is ``False``
+    and the fields stay real ``float32`` — the complex-Bloch/NTFF-reject lane
+    never fires and NTFF/probes read physical fields.
+    """
+    from rfx.sources.tfsf_oblique_open import MethodBConfig
+    return isinstance(cfg, MethodBConfig)
+
+
 class TFSFState(NamedTuple):
     """1D auxiliary FDTD state for TFSF plane-wave generation."""
     e1d: jnp.ndarray   # Ez incident (n_1d,)
@@ -104,6 +118,7 @@ def init_tfsf(
     ny: int | None = None,
     nz: int | None = None,
     waveform: str = "differentiated_gaussian",
+    method: str = "bloch",
 ) -> tuple:
     """Initialize TFSF source.
 
@@ -173,7 +188,29 @@ def init_tfsf(
             "waveform='continuous_wave' is only supported at normal incidence "
             f"(angle_deg=0); got angle_deg={angle_deg}"
         )
-    # Dispatch to 2D auxiliary grid for oblique angles.
+    if method not in ("bloch", "methodB"):
+        raise ValueError(f"method must be 'bloch' or 'methodB', got {method!r}")
+    # Oblique open-domain Method B (real float32, 1D-aux-along-k̂ + 4-edge box).
+    # Angle alone cannot disambiguate this from the Bloch 2D-aux path, so it is
+    # selected explicitly via method='methodB'. angle_deg=0 falls through to the
+    # normal 1D-aux path below regardless of method (byte-unchanged).
+    if abs(angle_deg) > 0.01 and method == "methodB":
+        from rfx.sources.tfsf_oblique_open import init_tfsf_methodB
+        if ny is None:
+            ny = nx
+        return init_tfsf_methodB(
+            nx, ny, dx, dt,
+            nz=nz,
+            cpml_layers=cpml_layers,
+            tfsf_margin=tfsf_margin,
+            f0=f0,
+            bandwidth=bandwidth,
+            amplitude=amplitude,
+            polarization=polarization,
+            direction=direction,
+            theta_deg=angle_deg,
+        )
+    # Dispatch to 2D auxiliary grid for oblique angles (Bloch field-transform).
     # The 2D grid naturally matches the 3D numerical dispersion at any angle.
     if abs(angle_deg) > 0.01:
         from rfx.sources.tfsf_2d import init_tfsf_2d
@@ -433,6 +470,10 @@ def apply_tfsf_e(state, cfg, tfsf_st, dx: float, dt: float):
 
     Dispatches to 2D auxiliary grid version for oblique incidence.
     """
+    # Dispatch to open-domain oblique Method B (real float32, 4-edge box).
+    if is_tfsf_methodB(cfg):
+        from rfx.sources.tfsf_oblique_open import apply_methodB_e
+        return apply_methodB_e(state, cfg, tfsf_st, dx, dt)
     # Dispatch to 2D if config is TFSF2DConfig
     if is_tfsf_2d(cfg):
         from rfx.sources.tfsf_2d import apply_tfsf_2d_e
@@ -465,6 +506,10 @@ def apply_tfsf_h(state, cfg, tfsf_st, dx: float, dt: float):
 
     Dispatches to 2D auxiliary grid version for oblique incidence.
     """
+    # Dispatch to open-domain oblique Method B (real float32, 4-edge box).
+    if is_tfsf_methodB(cfg):
+        from rfx.sources.tfsf_oblique_open import apply_methodB_h
+        return apply_methodB_h(state, cfg, tfsf_st, dx, dt)
     # Dispatch to 2D if config is TFSF2DConfig
     if is_tfsf_2d(cfg):
         from rfx.sources.tfsf_2d import apply_tfsf_2d_h

--- a/rfx/sources/tfsf_oblique_open.py
+++ b/rfx/sources/tfsf_oblique_open.py
@@ -1,7 +1,8 @@
 """Open-domain oblique TFSF plane-wave source — Method B (JAX-scan-compatible).
 
-This is the ``jnp``/functional reimplementation of the *proven* numpy prototype
-``oblique_tfsf_methodB_v2.py``.  Method B injects an oblique plane wave into an
+This is the ``jnp``/functional reimplementation of a standalone numpy prototype
+(``oblique_tfsf_methodB_v2.py``, not committed).  Method B injects an oblique
+plane wave into an
 open (CPML) 2.5-D domain (``k̂`` in the xy-plane, thin-z periodic) using a
 **dispersion-matched 1D auxiliary FDTD along k̂** plus a **4-edge TFSF box**
 correction.  The incident field is a genuine discrete 1D FDTD solution whose
@@ -19,6 +20,15 @@ are ``jnp`` + functional (no numpy in-place, no python-data-dependent indexing;
 box indices are static Python ints; gather bases/weights are precomputed jnp
 arrays), so they drop straight into ``lax.scan`` in Stage 2.  This module does
 NOT touch rfx's scan / simulation.py.
+
+ONE deliberate deviation from the prototype: the transverse face extents are
+INCLUSIVE (``[y_lo, y_hi]`` / ``[x_lo, x_hi]``), not the prototype's exclusive
+``yl:yh`` / ``xl:xh``.  The exclusive slicing left the box corner nodes at
+``x_hi`` / ``y_hi`` uncorrected — 8 nodes per z-plane acting as coherent
+spurious line sources — and was itself the prototype's -37..-41 dB leakage
+floor (PR #461 review, F1).  With inclusive slices the through-run leakage
+drops to the linear-interp gather error (-59..-132 dB, exact cancellation at
+the symmetric 45 deg case); the injection angle is unchanged.
 
 Ported sign/staggering/timing verbatim from the prototype (the authoritative
 physics source):
@@ -55,9 +65,12 @@ class MethodBConfig(NamedTuple):
     and the 24 gather-table arrays are ``jnp`` (built once at init).
     """
     # --- static TFSF box indices (Python int -> compile-time slice bounds) ---
-    # Box spans x in [x_lo, x_hi) and y in [y_lo, y_hi) (prototype's exclusive
-    # yl:yh / xl:xh slicing). Corrections also touch x_lo-1, x_hi, y_lo-1, y_hi,
-    # x_hi+1, y_hi+1.
+    # Total-field region is INCLUSIVE: x in [x_lo, x_hi], y in [y_lo, y_hi] —
+    # the upper-face corrections (Hy[x_hi], Hx[.,y_hi], Ez[x_hi+1], Ez[.,y_hi+1])
+    # are only self-consistent if x_hi / y_hi are total-field nodes, so the
+    # transverse face slices must include them (see module docstring: the
+    # prototype's exclusive slicing skipped the corners and leaked).
+    # Corrections also touch x_lo-1, x_hi, y_lo-1, y_hi, x_hi+1, y_hi+1.
     x_lo: int
     x_hi: int
     y_lo: int
@@ -184,6 +197,15 @@ def init_tfsf_methodB(
         )
     if direction not in ("+x", "-x"):
         raise ValueError(f"direction must be '+x' or '-x', got {direction!r}")
+    if direction == "-x":
+        # direction_sign is stored but never consumed: the gather tables are
+        # built with +cosθ/+sinθ projections and the 1D source sits at the lo
+        # pad, so '-x' would silently inject a +x-travelling wave (review F2).
+        raise NotImplementedError(
+            "Method B supports direction='+x' only; '-x' is not wired into the "
+            "gather tables / 1D-aux layout yet. Use direction='+x' (mirror the "
+            "geometry) or the normal-incidence path."
+        )
     if not abs(theta_deg) < 90.0:
         raise ValueError(f"abs(theta_deg) must be < 90, got {theta_deg}")
     # NOTE: Method B's math is valid for the full range 0 <= |theta| < 90 (theta=0
@@ -244,8 +266,10 @@ def init_tfsf_methodB(
     def idx_H(ix, iy):
         return idx_E(ix, iy) - 0.5
 
-    iy_face = np.arange(y_lo, y_hi)      # x-faces vary iy over [y_lo, y_hi)
-    ix_face = np.arange(x_lo, x_hi)      # y-faces vary ix over [x_lo, x_hi)
+    # INCLUSIVE transverse extents — the corners x_hi / y_hi are total-field
+    # nodes and must receive their correction (module docstring, review F1).
+    iy_face = np.arange(y_lo, y_hi + 1)  # x-faces vary iy over [y_lo, y_hi]
+    ix_face = np.arange(x_lo, x_hi + 1)  # y-faces vary ix over [x_lo, x_hi]
 
     # H-face tables (gather e1d) — projection at the E-node coordinate.
     xlo_e = _gather_table(idx_E(x_lo,       iy_face), n_aux)
@@ -361,15 +385,15 @@ def apply_methodB_h(state, cfg: MethodBConfig, st: MethodBState, dx: float, dt: 
 
     # x-faces: Hy from Ez_inc (E-node projection at x_lo / x_hi+1)
     inc = _gather(e1d, cfg.xlo_e_base, cfg.xlo_e_w0, cfg.xlo_e_w1)
-    hy = hy.at[cfg.x_lo - 1, cfg.y_lo:cfg.y_hi, :].add((-ch * inc)[:, None])
+    hy = hy.at[cfg.x_lo - 1, cfg.y_lo:cfg.y_hi + 1, :].add((-ch * inc)[:, None])
     inc = _gather(e1d, cfg.xhi_e_base, cfg.xhi_e_w0, cfg.xhi_e_w1)
-    hy = hy.at[cfg.x_hi, cfg.y_lo:cfg.y_hi, :].add((ch * inc)[:, None])
+    hy = hy.at[cfg.x_hi, cfg.y_lo:cfg.y_hi + 1, :].add((ch * inc)[:, None])
 
     # y-faces: Hx from Ez_inc (E-node projection at y_lo / y_hi+1)
     inc = _gather(e1d, cfg.ylo_e_base, cfg.ylo_e_w0, cfg.ylo_e_w1)
-    hx = hx.at[cfg.x_lo:cfg.x_hi, cfg.y_lo - 1, :].add((ch * inc)[:, None])
+    hx = hx.at[cfg.x_lo:cfg.x_hi + 1, cfg.y_lo - 1, :].add((ch * inc)[:, None])
     inc = _gather(e1d, cfg.yhi_e_base, cfg.yhi_e_w0, cfg.yhi_e_w1)
-    hx = hx.at[cfg.x_lo:cfg.x_hi, cfg.y_hi, :].add((-ch * inc)[:, None])
+    hx = hx.at[cfg.x_lo:cfg.x_hi + 1, cfg.y_hi, :].add((-ch * inc)[:, None])
 
     return state._replace(hx=hx, hy=hy)
 
@@ -389,14 +413,14 @@ def apply_methodB_e(state, cfg: MethodBConfig, st: MethodBState, dx: float, dt: 
 
     # x-faces: Ez sees d(Hy)/dx ; Hy_inc = +cosθ·h1d
     inc = _gather(h1d, cfg.xlo_h_base, cfg.xlo_h_w0, cfg.xlo_h_w1)
-    ez = ez.at[cfg.x_lo, cfg.y_lo:cfg.y_hi, :].add((-ce * ct * inc)[:, None])
+    ez = ez.at[cfg.x_lo, cfg.y_lo:cfg.y_hi + 1, :].add((-ce * ct * inc)[:, None])
     inc = _gather(h1d, cfg.xhi_h_base, cfg.xhi_h_w0, cfg.xhi_h_w1)
-    ez = ez.at[cfg.x_hi + 1, cfg.y_lo:cfg.y_hi, :].add((ce * ct * inc)[:, None])
+    ez = ez.at[cfg.x_hi + 1, cfg.y_lo:cfg.y_hi + 1, :].add((ce * ct * inc)[:, None])
 
     # y-faces: Ez sees d(Hx)/dy ; Hx_inc = -sinθ·h1d
     inc = _gather(h1d, cfg.ylo_h_base, cfg.ylo_h_w0, cfg.ylo_h_w1)
-    ez = ez.at[cfg.x_lo:cfg.x_hi, cfg.y_lo, :].add((-ce * sn * inc)[:, None])
+    ez = ez.at[cfg.x_lo:cfg.x_hi + 1, cfg.y_lo, :].add((-ce * sn * inc)[:, None])
     inc = _gather(h1d, cfg.yhi_h_base, cfg.yhi_h_w0, cfg.yhi_h_w1)
-    ez = ez.at[cfg.x_lo:cfg.x_hi, cfg.y_hi + 1, :].add((ce * sn * inc)[:, None])
+    ez = ez.at[cfg.x_lo:cfg.x_hi + 1, cfg.y_hi + 1, :].add((ce * sn * inc)[:, None])
 
     return state._replace(ez=ez)

--- a/rfx/sources/tfsf_oblique_open.py
+++ b/rfx/sources/tfsf_oblique_open.py
@@ -1,0 +1,402 @@
+"""Open-domain oblique TFSF plane-wave source — Method B (JAX-scan-compatible).
+
+This is the ``jnp``/functional reimplementation of the *proven* numpy prototype
+``oblique_tfsf_methodB_v2.py``.  Method B injects an oblique plane wave into an
+open (CPML) 2.5-D domain (``k̂`` in the xy-plane, thin-z periodic) using a
+**dispersion-matched 1D auxiliary FDTD along k̂** plus a **4-edge TFSF box**
+correction.  The incident field is a genuine discrete 1D FDTD solution whose
+cell size ``d_aux`` is chosen so its numerical phase velocity matches the 3D
+grid's along k̂ (Taflove Ch. 5.6 / Schneider) — so the boundary cancellation is
+clean and the TFSF leakage is low.
+
+Design invariant (Stage-2 relevant): ``MethodBConfig`` is a NEW ``NamedTuple``,
+NOT a ``TFSF2DConfig`` subclass, so ``is_tfsf_2d(cfg)`` is ``False`` — the
+oblique-Bloch complex64/NTFF-reject lane never fires and fields stay real
+``float32``.
+
+STAGE 1 (this module + the standalone driver) only: the per-step kernels here
+are ``jnp`` + functional (no numpy in-place, no python-data-dependent indexing;
+box indices are static Python ints; gather bases/weights are precomputed jnp
+arrays), so they drop straight into ``lax.scan`` in Stage 2.  This module does
+NOT touch rfx's scan / simulation.py.
+
+Ported sign/staggering/timing verbatim from the prototype (the authoritative
+physics source):
+  * H_inc decomposition ``Hy_inc = +cosθ·h1d``, ``Hx_inc = -sinθ·h1d`` — enters
+    the E-face corrections as the ``±ce·ct`` / ``±ce·st`` factors below.
+  * H-face (Hy/Hx) corrections read Ez_inc (``e1d``) with NO angle factor.
+  * full-z-plane injection (``[:, None]`` broadcast) — the wave is z-uniform.
+  * n / n+1/2 leapfrog interleave (H-face reads e1d at n, E-face reads h1d at
+    n+1/2); 1D CPML (not a hard end-damper).
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import jax.numpy as jnp
+import numpy as np
+
+from rfx.core.yee import EPS_0, MU_0
+from rfx.sources.tfsf import TFSFState, update_tfsf_1d_h, update_tfsf_1d_e
+
+C0 = 299_792_458.0
+
+# The 1D-aux state shape is exactly the normal-path 1D FDTD state, so the reused
+# update_tfsf_1d_h/e kernels advance it unchanged.
+MethodBState = TFSFState
+
+
+class MethodBConfig(NamedTuple):
+    """Static Method-B configuration (compile-time constants for JIT/scan).
+
+    Box indices are plain Python ``int`` (compile-time slice bounds); projection
+    scalars are Python ``float`` baked at trace time; only ``b_cpml``/``c_cpml``
+    and the 24 gather-table arrays are ``jnp`` (built once at init).
+    """
+    # --- static TFSF box indices (Python int -> compile-time slice bounds) ---
+    # Box spans x in [x_lo, x_hi) and y in [y_lo, y_hi) (prototype's exclusive
+    # yl:yh / xl:xh slicing). Corrections also touch x_lo-1, x_hi, y_lo-1, y_hi,
+    # x_hi+1, y_hi+1.
+    x_lo: int
+    x_hi: int
+    y_lo: int
+    y_hi: int
+    # --- projection scalars (Python float) ---
+    cos_theta: float
+    sin_theta: float
+    d_aux: float           # dispersion-matched 1D cell size along k-hat
+    dx_1d: float           # == d_aux (reused 1D kernels read cfg.dx_1d)
+    dt: float              # baked so advance_methodB_* need no dt arg
+    angle_deg: float
+    transverse_axis: str   # "y" for ez
+    # --- 1D-aux source/CPML params (names match TFSFConfig so the 1D kernels
+    #     update_tfsf_1d_h/e duck-type over this config unchanged) ---
+    n_cpml: int
+    b_cpml: jnp.ndarray
+    c_cpml: jnp.ndarray
+    src_idx: int
+    src_amp: float
+    src_t0: float
+    src_tau: float
+    src_fcen: float
+    src_waveform: str
+    curl_sign: float          # +1.0 for ez/hy
+    electric_component: str   # "ez"
+    magnetic_component: str   # "hy"
+    direction: str
+    direction_sign: float
+    # --- 8 precomputed face-projection gather tables (jnp, static geometry) ---
+    #   naming <face>_<read>: read=e -> gather e1d (H-correction);
+    #                         read=h -> gather h1d half-node (E-correction).
+    #   each triple (base:int32, w0:float32, w1:float32); base clipped to
+    #   [0, n_aux-2] so base+1 is always in range.
+    xlo_e_base: jnp.ndarray; xlo_e_w0: jnp.ndarray; xlo_e_w1: jnp.ndarray
+    xhi_e_base: jnp.ndarray; xhi_e_w0: jnp.ndarray; xhi_e_w1: jnp.ndarray
+    ylo_e_base: jnp.ndarray; ylo_e_w0: jnp.ndarray; ylo_e_w1: jnp.ndarray
+    yhi_e_base: jnp.ndarray; yhi_e_w0: jnp.ndarray; yhi_e_w1: jnp.ndarray
+    xlo_h_base: jnp.ndarray; xlo_h_w0: jnp.ndarray; xlo_h_w1: jnp.ndarray
+    xhi_h_base: jnp.ndarray; xhi_h_w0: jnp.ndarray; xhi_h_w1: jnp.ndarray
+    ylo_h_base: jnp.ndarray; ylo_h_w0: jnp.ndarray; ylo_h_w1: jnp.ndarray
+    yhi_h_base: jnp.ndarray; yhi_h_w0: jnp.ndarray; yhi_h_w1: jnp.ndarray
+
+
+# ---------------------------------------------------------------------------
+# Dispersion-matched 1D cell size (bisection, numpy — init-time only).
+# Ported verbatim from the prototype (k_numerical / dx_aux_matched).
+# ---------------------------------------------------------------------------
+
+def _k_numerical(omega, theta, dt, dx):
+    """2D Yee numerical wavenumber |k| at angle theta (kx=|k|cosθ, ky=|k|sinθ):
+    (sin(ω dt/2)/(c dt))^2 = (sin(kx dx/2)/dx)^2 + (sin(ky dy/2)/dy)^2."""
+    rhs = (np.sin(omega * dt / 2.0) / (C0 * dt)) ** 2
+    ct, st = np.cos(theta), np.sin(theta)
+
+    def f(k):
+        return (np.sin(k * ct * dx / 2.0) / dx) ** 2 + (np.sin(k * st * dx / 2.0) / dx) ** 2 - rhs
+    lo, hi = 1e-3, np.pi / dx * 0.999
+    for _ in range(200):
+        m = 0.5 * (lo + hi)
+        lo, hi = (lo, m) if f(lo) * f(m) <= 0 else (m, hi)
+    return 0.5 * (lo + hi)
+
+
+def _dx_aux_matched(omega, k_num, dt):
+    """Delta_aux s.t. a 1D grid reproduces k_num at omega:
+    sin(ω dt/2)/(c dt) = sin(k_num·Δ/2)/Δ."""
+    rhs = np.sin(omega * dt / 2.0) / (C0 * dt)
+
+    def f(D):
+        return np.sin(k_num * D / 2.0) / D - rhs
+    lo, hi = 1e-6, 2.0 * np.pi / k_num * 0.999   # first half-period
+    for _ in range(200):
+        m = 0.5 * (lo + hi)
+        lo, hi = (lo, m) if f(lo) * f(m) <= 0 else (m, hi)
+    return 0.5 * (lo + hi)
+
+
+def _gather_table(idx: np.ndarray, n_aux: int):
+    """Build (base, w0, w1) linear-interp gather triple from float indices.
+
+    Matches the prototype's per-step ``interp``: floor -> fractional weight from
+    the UNCLIPPED floor -> clip base to [0, n_aux-2] (so base+1 <= n_aux-1).
+    Runs in numpy at init; only the int32/float32 results cross into jnp.
+    """
+    fl = np.floor(idx)
+    w1 = (idx - fl).astype(np.float32)
+    w0 = (1.0 - w1).astype(np.float32)
+    base = np.clip(fl.astype(np.int32), 0, n_aux - 2)
+    return (jnp.asarray(base, dtype=jnp.int32),
+            jnp.asarray(w0, dtype=jnp.float32),
+            jnp.asarray(w1, dtype=jnp.float32))
+
+
+def init_tfsf_methodB(
+    nx: int,
+    ny: int,
+    dx: float,
+    dt: float,
+    *,
+    nz: int | None = None,
+    cpml_layers: int = 10,
+    tfsf_margin: int = 10,
+    f0: float = 5e9,
+    bandwidth: float = 0.5,        # accepted for signature parity; Stage-1 uses
+                                   # the prototype's fixed t0=40·dt, tau=12·dt.
+    amplitude: float = 1.0,
+    polarization: str = "ez",
+    direction: str = "+x",
+    theta_deg: float = 0.0,
+) -> tuple[MethodBConfig, MethodBState]:
+    """Build the Method-B config + zero 1D-aux state (open-domain oblique TFSF).
+
+    Box offset ``off = cpml_layers + tfsf_margin`` (prototype used 20 = 10+10).
+    Box spans x in ``[off, nx-off)`` and y in ``[off, ny-off)``.  ``d_aux`` is
+    the dispersion-matched 1D cell size along k̂ at ``ω = 2π f0``.
+
+    Source timing reproduces the prototype exactly: ``t0 = 40·dt``,
+    ``tau = 12·dt``, modulated Gaussian at carrier ``f0``.
+    """
+    if polarization != "ez":
+        raise NotImplementedError(
+            "Method B currently supports polarization='ez' (transverse=y) only; "
+            "ey (transverse=z) is future work."
+        )
+    if direction not in ("+x", "-x"):
+        raise ValueError(f"direction must be '+x' or '-x', got {direction!r}")
+    if not abs(theta_deg) < 90.0:
+        raise ValueError(f"abs(theta_deg) must be < 90, got {theta_deg}")
+    # NOTE: Method B's math is valid for the full range 0 <= |theta| < 90 (theta=0
+    # reduces to normal incidence with d_aux==dx). theta=0 is used by the Stage-1
+    # port-validation gate. In Stage 2 the init_tfsf dispatch chooses methodB vs
+    # the faster normal-incidence 1D-aux path via an explicit `method` kwarg,
+    # not by rejecting theta=0 here.
+
+    theta = np.radians(theta_deg)
+    ct = float(np.cos(theta))
+    st = float(np.sin(theta))
+    omega = 2.0 * np.pi * f0
+    eta = float(np.sqrt(MU_0 / EPS_0))
+
+    # --- TFSF box (prototype: xl,xh = off, nx-off ; yl,yh = off, ny-off) ---
+    off = int(cpml_layers + tfsf_margin)
+    x_lo, x_hi = off, nx - off
+    y_lo, y_hi = off, ny - off
+    if x_lo <= 0 or x_hi >= nx - 1 or y_lo <= 0 or y_hi >= ny - 1 \
+            or x_lo >= x_hi or y_lo >= y_hi:
+        raise ValueError(
+            "TFSF margin/cpml_layers too large for the grid: "
+            f"nx={nx}, ny={ny}, cpml_layers={cpml_layers}, tfsf_margin={tfsf_margin}"
+        )
+
+    # --- dispersion-matched 1D cell size along k-hat ---
+    k_num = _k_numerical(omega, theta, dt, dx)
+    d_aux = float(_dx_aux_matched(omega, k_num, dt))
+
+    # --- 1D-aux sizing (prototype layout) ---
+    n_cpml_1d = 20
+    n_src_pad = 60                       # source sits 60 cells in from the lo end
+    d_max = (nx * ct + ny * st) * dx     # max projection over the (padded) domain
+    n_aux = int(d_max / d_aux) + 2 * n_src_pad + 4
+    src_off = n_src_pad                  # 1D index mapping projection d = 0
+
+    # --- 1D CPML profile (verbatim from prototype / rfx init_tfsf, cell=d_aux) ---
+    rho = 1.0 - np.arange(n_cpml_1d, dtype=np.float64) / max(n_cpml_1d - 1, 1)
+    sigma_max = 0.8 * 4.0 / (eta * d_aux)
+    sigma_prof = sigma_max * rho ** 3
+    alpha_prof = 0.05 * (1.0 - rho)
+    denom = sigma_prof + alpha_prof
+    b_prof = np.exp(-(sigma_prof + alpha_prof) * dt / EPS_0)
+    c_prof = np.where(denom > 1e-30, sigma_prof * (b_prof - 1.0) / denom, 0.0)
+
+    # --- source params: reproduce the prototype (t0=40·dt, w=12·dt, carrier f0) ---
+    src_t0 = 40.0 * dt
+    src_tau = 12.0 * dt
+
+    # --- gather tables ---------------------------------------------------------
+    # aux index for an E-node projection (read by H-correction, gathers e1d):
+    #   idx_E(ix, iy) = (ix*ct + iy*st)*dx / d_aux + src_off
+    # aux index for an H-node (read by E-correction, gathers h1d on half-nodes):
+    #   idx_H(ix, iy) = idx_E(ix, iy) - 0.5
+    def idx_E(ix, iy):
+        return ((ix * ct + iy * st) * dx) / d_aux + src_off
+
+    def idx_H(ix, iy):
+        return idx_E(ix, iy) - 0.5
+
+    iy_face = np.arange(y_lo, y_hi)      # x-faces vary iy over [y_lo, y_hi)
+    ix_face = np.arange(x_lo, x_hi)      # y-faces vary ix over [x_lo, x_hi)
+
+    # H-face tables (gather e1d) — projection at the E-node coordinate.
+    xlo_e = _gather_table(idx_E(x_lo,       iy_face), n_aux)
+    xhi_e = _gather_table(idx_E(x_hi + 1,   iy_face), n_aux)
+    ylo_e = _gather_table(idx_E(ix_face,    y_lo),    n_aux)
+    yhi_e = _gather_table(idx_E(ix_face,    y_hi + 1), n_aux)
+
+    # E-face tables (gather h1d, half-node) — fractional cell coord + (-0.5).
+    xlo_h = _gather_table(idx_H(x_lo - 0.5, iy_face), n_aux)
+    xhi_h = _gather_table(idx_H(x_hi + 0.5, iy_face), n_aux)
+    ylo_h = _gather_table(idx_H(ix_face,    y_lo - 0.5), n_aux)
+    yhi_h = _gather_table(idx_H(ix_face,    y_hi + 0.5), n_aux)
+
+    fdtype = jnp.float32
+    cfg = MethodBConfig(
+        x_lo=x_lo, x_hi=x_hi, y_lo=y_lo, y_hi=y_hi,
+        cos_theta=ct, sin_theta=st,
+        d_aux=d_aux, dx_1d=d_aux, dt=float(dt),
+        angle_deg=float(theta_deg), transverse_axis="y",
+        n_cpml=n_cpml_1d,
+        b_cpml=jnp.asarray(b_prof, dtype=fdtype),
+        c_cpml=jnp.asarray(c_prof, dtype=fdtype),
+        src_idx=int(src_off),
+        src_amp=float(amplitude),
+        src_t0=float(src_t0),
+        src_tau=float(src_tau),
+        src_fcen=float(f0),
+        src_waveform="modulated_gaussian",
+        curl_sign=1.0,
+        electric_component="ez",
+        magnetic_component="hy",
+        direction=direction,
+        direction_sign=1.0 if direction == "+x" else -1.0,
+        xlo_e_base=xlo_e[0], xlo_e_w0=xlo_e[1], xlo_e_w1=xlo_e[2],
+        xhi_e_base=xhi_e[0], xhi_e_w0=xhi_e[1], xhi_e_w1=xhi_e[2],
+        ylo_e_base=ylo_e[0], ylo_e_w0=ylo_e[1], ylo_e_w1=ylo_e[2],
+        yhi_e_base=yhi_e[0], yhi_e_w0=yhi_e[1], yhi_e_w1=yhi_e[2],
+        xlo_h_base=xlo_h[0], xlo_h_w0=xlo_h[1], xlo_h_w1=xlo_h[2],
+        xhi_h_base=xhi_h[0], xhi_h_w0=xhi_h[1], xhi_h_w1=xhi_h[2],
+        ylo_h_base=ylo_h[0], ylo_h_w0=ylo_h[1], ylo_h_w1=ylo_h[2],
+        yhi_h_base=yhi_h[0], yhi_h_w0=yhi_h[1], yhi_h_w1=yhi_h[2],
+    )
+
+    state = MethodBState(
+        e1d=jnp.zeros(n_aux, dtype=fdtype),
+        h1d=jnp.zeros(n_aux, dtype=fdtype),
+        psi_e_lo=jnp.zeros(n_cpml_1d, dtype=fdtype),
+        psi_e_hi=jnp.zeros(n_cpml_1d, dtype=fdtype),
+        psi_h_lo=jnp.zeros(n_cpml_1d, dtype=fdtype),
+        psi_h_hi=jnp.zeros(n_cpml_1d, dtype=fdtype),
+        step=jnp.array(0, dtype=jnp.int32),
+    )
+    return cfg, state
+
+
+# ---------------------------------------------------------------------------
+# Discriminator + aux advance (thin wrappers over the byte-identical 1D kernels)
+# ---------------------------------------------------------------------------
+
+def is_tfsf_methodB(cfg) -> bool:
+    """True iff cfg is a Method-B (open-domain oblique) config."""
+    return isinstance(cfg, MethodBConfig)
+
+
+# synonym used in the integration spec
+is_open_oblique = is_tfsf_methodB
+
+
+def advance_methodB_h(cfg: MethodBConfig, st: MethodBState) -> MethodBState:
+    """Advance the 1D-aux H field h1d^{n-1/2} -> h1d^{n+1/2} (reads e1d at n).
+
+    Reuses the byte-identical normal-path 1D kernel (curl_sign=+1 -> identical to
+    the prototype's advance_1d_h).
+    """
+    return update_tfsf_1d_h(cfg, st, cfg.dx_1d, cfg.dt)
+
+
+def advance_methodB_e(cfg: MethodBConfig, st: MethodBState, t: float) -> MethodBState:
+    """Advance the 1D-aux E field e1d^{n} -> e1d^{n+1} + source (reads h1d at n+1/2)."""
+    return update_tfsf_1d_e(cfg, st, cfg.dx_1d, cfg.dt, t)
+
+
+# Spec synonyms (Stage-2 dispatch names): dx/dt from the 3D call site are
+# ignored by the 1D kernels (they use cfg.dx_1d/cfg.dt).
+def update_open_oblique_h(cfg, st, dx, dt):
+    return update_tfsf_1d_h(cfg, st, cfg.dx_1d, cfg.dt)
+
+
+def update_open_oblique_e(cfg, st, dx, dt, t):
+    return update_tfsf_1d_e(cfg, st, cfg.dx_1d, cfg.dt, t)
+
+
+# ---------------------------------------------------------------------------
+# The genuinely new code: 4-edge TFSF box corrections onto the full z-plane.
+# jnp gather (arr[base]*w0 + arr[base+1]*w1) + functional .at[...].add.
+# ---------------------------------------------------------------------------
+
+def _gather(arr1d, base, w0, w1):
+    """Linear-interp gather; base+1 is safe (clipped to n_aux-2 at init)."""
+    return arr1d[base] * w0 + arr1d[base + 1] * w1
+
+
+def apply_methodB_h(state, cfg: MethodBConfig, st: MethodBState, dx: float, dt: float):
+    """4-edge H-field TFSF correction (call AFTER update_h, reads e1d at time n).
+
+    Reproduces the prototype (v2 lines 184-188): Hy at x_lo-1 / x_hi and Hx at
+    y_lo-1 / y_hi get ``±ch·Ez_inc`` with NO cos/sin factor (the angle enters via
+    the k̂ projection baked into the gather tables). Full-z broadcast ([:, None]).
+    """
+    ch = dt / (MU_0 * dx)
+    e1d = st.e1d
+    hx, hy = state.hx, state.hy
+
+    # x-faces: Hy from Ez_inc (E-node projection at x_lo / x_hi+1)
+    inc = _gather(e1d, cfg.xlo_e_base, cfg.xlo_e_w0, cfg.xlo_e_w1)
+    hy = hy.at[cfg.x_lo - 1, cfg.y_lo:cfg.y_hi, :].add((-ch * inc)[:, None])
+    inc = _gather(e1d, cfg.xhi_e_base, cfg.xhi_e_w0, cfg.xhi_e_w1)
+    hy = hy.at[cfg.x_hi, cfg.y_lo:cfg.y_hi, :].add((ch * inc)[:, None])
+
+    # y-faces: Hx from Ez_inc (E-node projection at y_lo / y_hi+1)
+    inc = _gather(e1d, cfg.ylo_e_base, cfg.ylo_e_w0, cfg.ylo_e_w1)
+    hx = hx.at[cfg.x_lo:cfg.x_hi, cfg.y_lo - 1, :].add((ch * inc)[:, None])
+    inc = _gather(e1d, cfg.yhi_e_base, cfg.yhi_e_w0, cfg.yhi_e_w1)
+    hx = hx.at[cfg.x_lo:cfg.x_hi, cfg.y_hi, :].add((-ch * inc)[:, None])
+
+    return state._replace(hx=hx, hy=hy)
+
+
+def apply_methodB_e(state, cfg: MethodBConfig, st: MethodBState, dx: float, dt: float):
+    """4-edge E-field TFSF correction (call AFTER update_e, reads h1d at n+1/2).
+
+    Reproduces the prototype (v2 lines 210-213). H_inc decomposition
+    ``Hy_inc = +cosθ·h1d``, ``Hx_inc = -sinθ·h1d`` enters as the ``±ce·ct`` /
+    ``±ce·st`` factors. h1d is read on half-nodes (idx_E - 0.5, baked in tables).
+    Full-z broadcast ([:, None]).
+    """
+    ce = dt / (EPS_0 * dx)
+    ct, sn = cfg.cos_theta, cfg.sin_theta
+    h1d = st.h1d
+    ez = state.ez
+
+    # x-faces: Ez sees d(Hy)/dx ; Hy_inc = +cosθ·h1d
+    inc = _gather(h1d, cfg.xlo_h_base, cfg.xlo_h_w0, cfg.xlo_h_w1)
+    ez = ez.at[cfg.x_lo, cfg.y_lo:cfg.y_hi, :].add((-ce * ct * inc)[:, None])
+    inc = _gather(h1d, cfg.xhi_h_base, cfg.xhi_h_w0, cfg.xhi_h_w1)
+    ez = ez.at[cfg.x_hi + 1, cfg.y_lo:cfg.y_hi, :].add((ce * ct * inc)[:, None])
+
+    # y-faces: Ez sees d(Hx)/dy ; Hx_inc = -sinθ·h1d
+    inc = _gather(h1d, cfg.ylo_h_base, cfg.ylo_h_w0, cfg.ylo_h_w1)
+    ez = ez.at[cfg.x_lo:cfg.x_hi, cfg.y_lo, :].add((-ce * sn * inc)[:, None])
+    inc = _gather(h1d, cfg.yhi_h_base, cfg.yhi_h_w0, cfg.yhi_h_w1)
+    ez = ez.at[cfg.x_lo:cfg.x_hi, cfg.y_hi + 1, :].add((ce * sn * inc)[:, None])
+
+    return state._replace(ez=ez)

--- a/scripts/verify_methodB_through_run.py
+++ b/scripts/verify_methodB_through_run.py
@@ -1,0 +1,109 @@
+"""Stage-2 gate (b) witness: open-domain oblique TFSF (Method B) THROUGH run().
+
+Proves that the integrated ``Simulation.run()`` scan reproduces the standalone
+Method-B prototype physics (scripts/verify_methodB_jnp.py). Builds a Simulation
+with a method='methodB' oblique TFSF, runs it via ``sim.run(...)`` with a
+per-step field snapshot, and measures — with the SAME math as the standalone —
+the time-averaged Poynting injection angle and the TFSF leakage.
+
+Standalone baseline (numpy prototype, reproduced by the jnp module):
+  normal  theta_eff~0.06 deg, Sx>0, leak -35.8 dB
+  oblique 30/45/60 -> theta_eff 30.2/45.0/59.9, leak -37.6/-40.2/-41.5 dB
+  domain-invariant 45 -> 45.01 @ny60 / 45.00 @ny100
+
+Gate (b): through run(), theta_eff ~= requested within ~1 deg AND leak < -25 dB
+(target ~ -40 dB), fields real float32.
+"""
+import os
+os.environ.setdefault("JAX_PLATFORM_NAME", "cpu")
+import sys
+sys.path.insert(0, "/root/workspace/bk-workspace/rfx-oblique-rcs")
+
+import numpy as np
+
+from rfx.api import Simulation
+from rfx.grid import Grid
+from rfx.simulation import SnapshotSpec
+
+C0 = 299_792_458.0
+DX = 0.002
+CPML = 10
+MARGIN = 10
+
+
+def run_angle_through_run(theta_deg, ny=None):
+    """Build + run a Method-B oblique TFSF via sim.run(); return (Sx, Sy, leak, dtype)."""
+    domain_y = 0.12 if ny is None else ny * DX
+    # Grid mirror only to pick n_steps / kz exactly like the standalone driver.
+    grid = Grid(freq_max=10e9, domain=(0.60, domain_y, 0.006), dx=DX, cpml_layers=CPML)
+    dt = grid.dt
+    nx, nyc, nz = grid.shape
+    kz = nz // 2
+    n_steps = int(1.6 * (nx * DX) / C0 / dt)
+
+    sim = (
+        Simulation(mode="3d", boundary="cpml", cpml_layers=CPML,
+                   freq_max=10e9, domain=(0.60, domain_y, 0.006), dx=DX)
+        .add_tfsf_source(f0=5e9, bandwidth=0.5, polarization="ez",
+                         angle_deg=theta_deg, method="methodB",
+                         waveform="modulated_gaussian", margin=MARGIN)
+    )
+    res = sim.run(
+        n_steps=n_steps,
+        snapshot=SnapshotSpec(interval=1, components=("ez", "hx", "hy"),
+                              slice_axis=2, slice_index=kz),
+    )
+
+    ez = np.asarray(res.snapshots["ez"])   # (n_steps, nx, ny)
+    hx = np.asarray(res.snapshots["hx"])
+    hy = np.asarray(res.snapshots["hy"])
+
+    # Box geometry: identical to init_tfsf_methodB (off = cpml + margin).
+    off = CPML + MARGIN
+    xl, xh = off, nx - off
+    yl, yh = off, nyc - off
+    ti0, ti1, tj0, tj1 = xl + 6, xh - 6, yl + 6, yh - 6
+
+    # Peak tracking (leak) + steady-region Poynting sum (theta_eff) — exactly
+    # the standalone's math, vectorised over the recorded step axis.
+    sf = np.max(np.abs(ez[:, 13:xl - 3, tj0:tj1]), axis=(1, 2))
+    tf = np.max(np.abs(ez[:, ti0:ti1, tj0:tj1]), axis=(1, 2))
+    sf_peak = float(np.max(sf))
+    tf_peak = float(np.max(tf))
+
+    s0 = n_steps // 3
+    ez_i = ez[s0 + 1:, ti0:ti1, tj0:tj1]
+    hx_i = hx[s0 + 1:, ti0:ti1, tj0:tj1]
+    hy_i = hy[s0 + 1:, ti0:ti1, tj0:tj1]
+    Sx = float(np.sum(-ez_i * hy_i))   # S_x = -Ez*Hy
+    Sy = float(np.sum(ez_i * hx_i))    # S_y = +Ez*Hx
+
+    leak = 20.0 * np.log10(max(sf_peak, 1e-30) / max(tf_peak, 1e-30))
+    return Sx, Sy, leak, res.state.ez.dtype
+
+
+def main():
+    print("=== GATE (b): Method B oblique TFSF THROUGH Simulation.run() ===")
+    all_ok = True
+    for th in (30.0, 45.0, 60.0):
+        Sx, Sy, leak, dtype = run_angle_through_run(th)
+        te = np.degrees(np.arctan2(Sy, Sx))
+        real_f32 = (dtype == np.float32)
+        ok = abs(te - th) < 1.5 and leak < -25.0 and Sx > 0 and real_f32
+        all_ok = all_ok and ok
+        print(f"  requested {th:4.0f} deg -> theta_eff={te:6.2f} deg, "
+              f"leak={leak:6.1f} dB, Sx={Sx:.3e} (>0), dtype={dtype} "
+              f"-> {'OK' if ok else 'FAIL'}")
+
+    print("=== domain (ny) invariance at 45 deg (physical -> unchanged) ===")
+    for ny in (60, 100):
+        Sx, Sy, leak, _ = run_angle_through_run(45.0, ny=ny)
+        te = np.degrees(np.arctan2(Sy, Sx))
+        print(f"  ny={ny}: theta_eff={te:.2f} deg, leak={leak:.1f} dB")
+
+    print("\nRESULT:", "ALL GATES OK" if all_ok else "SOME GATE FAILED")
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_methodB_through_run.py
+++ b/scripts/verify_methodB_through_run.py
@@ -1,23 +1,30 @@
 """Stage-2 gate (b) witness: open-domain oblique TFSF (Method B) THROUGH run().
 
 Proves that the integrated ``Simulation.run()`` scan reproduces the standalone
-Method-B prototype physics (scripts/verify_methodB_jnp.py). Builds a Simulation
-with a method='methodB' oblique TFSF, runs it via ``sim.run(...)`` with a
-per-step field snapshot, and measures — with the SAME math as the standalone —
-the time-averaged Poynting injection angle and the TFSF leakage.
+Method-B physics (``rfx/sources/tfsf_oblique_open.py``) in THIS checkout — the
+script imports whatever ``rfx`` is on ``sys.path``; it inserts no private
+paths. Builds a Simulation with a method='methodB' oblique TFSF, runs it via
+``sim.run(...)`` with a per-step field snapshot, and measures the time-averaged
+Poynting injection angle and the TFSF leakage.
 
-Standalone baseline (numpy prototype, reproduced by the jnp module):
-  normal  theta_eff~0.06 deg, Sx>0, leak -35.8 dB
-  oblique 30/45/60 -> theta_eff 30.2/45.0/59.9, leak -37.6/-40.2/-41.5 dB
-  domain-invariant 45 -> 45.01 @ny60 / 45.00 @ny100
+Measured through run() on the committed corner-inclusive kernels
+(see the module docstring of tfsf_oblique_open.py; the pre-fix exclusive
+kernels leaked -37.6/-40.2/-41.5 dB at 30/45/60 deg):
+  oblique 30/45/60 -> theta_eff 30.17/45.00/59.88 deg, leak -62.7/-131.6/-58.7 dB
+  (45 deg is symmetric -> exact corner cancellation, float32 round-off floor;
+  30/60 deg residual is the linear-interp gather error)
+  domain-invariant 45 -> theta_eff 45.00 @ny60 / 45.00 @ny100 (leak -131.6/-130.4 dB)
 
-Gate (b): through run(), theta_eff ~= requested within ~1 deg AND leak < -25 dB
-(target ~ -40 dB), fields real float32.
+Gate (b): through run(), theta_eff ~= requested within 1.5 deg AND leak < -25 dB,
+fields real float32.
 """
 import os
 os.environ.setdefault("JAX_PLATFORM_NAME", "cpu")
 import sys
-sys.path.insert(0, "/root/workspace/bk-workspace/rfx-oblique-rcs")
+# Verify THIS checkout's rfx (the repo the script ships in), not whatever rfx
+# happens to be installed — plain `python scripts/...` puts scripts/ (not the
+# repo root) on sys.path.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import numpy as np
 

--- a/tests/test_oblique_rcs_specular.py
+++ b/tests/test_oblique_rcs_specular.py
@@ -27,6 +27,15 @@ scope note. Validation witnesses (bigger 3λ plate, n_steps=1400): specular
 shape correlation 0.89–0.92, 3 dB beamwidth within ~1°, and RAW peak == SUBTRACTED
 peak (incident-leakage subtraction NOT needed — leakage steers to the forward
 hemisphere φ≈θ, away from the specular lobe).
+
+NOTE those witness numbers come from a DIFFERENT configuration (3λ plate,
+1400 steps, the ``_methodB_pattern`` helper's NTFF box) than the committed gate
+below (2.2λ plate, 700 steps, public ``compute_rcs`` path, which measures
+180/160/144°). The two sets are not numerically comparable — see the helper's
+docstring for the exact NTFF-box construction difference. The gate's ±6°
+tolerance reflects a measured 3–7° peak-azimuth sensitivity to domain size at
+fixed dx/plate/CPML (PR #461 audit); it is an observed envelope on an
+unconverged argmax observable, not a converged-accuracy claim.
 """
 import numpy as np
 import jax.numpy as jnp
@@ -74,9 +83,17 @@ def _peak_phi_deg(sig_linear):
 
 def _methodB_pattern(theta_deg):
     """Build the 2.5-D open-domain Method-B pipeline directly (theta=0 allowed) and
-    return (peak_phi_deg, settling_db). Mirrors what compute_rcs does internally
-    for oblique, but exercises theta=0 (the normal-reduction limit) which
-    compute_rcs routes to the normal path."""
+    return (peak_phi_deg, settling_db).
+
+    NOT a mirror of ``compute_rcs``: same pipeline components, but the NTFF box
+    is constructed differently — here the y-faces are pinned to the TFSF box
+    (``cfg.y_lo - off`` / ``cfg.y_hi + off``) while the public path derives them
+    from the CPML faces (``fl["y_lo"] + ntff_offset`` / ``grid.ny - fl["y_hi"] -
+    ntff_offset``, rcs.py) and its ``i_hi`` carries an extra +1. So peak azimuths
+    from this helper differ from the public path by a few degrees and MUST NOT be
+    numerically compared against ``compute_rcs`` results; use it only for what it
+    is here: exercising theta=0, the normal-reduction limit that ``compute_rcs``
+    routes to the normal path."""
     grid = Grid(freq_max=F0 * 3, domain=_DOMAIN, dx=DX, cpml_layers=CPML)
     nx, ny, nz = grid.shape
     cfg, st = init_tfsf_methodB(nx, ny, DX, grid.dt, nz=nz, cpml_layers=CPML,

--- a/tests/test_oblique_rcs_specular.py
+++ b/tests/test_oblique_rcs_specular.py
@@ -22,7 +22,9 @@ Scope: this validates the far-field PATTERN / specular DIRECTION only. The
 ABSOLUTE oblique σ is intentionally NOT asserted — the 2.5-D strip's 3-D RCS
 scales with the (arbitrary) NTFF z-box height because the two z-faces cancel for
 x-y-plane observation. See ``rfx/rcs.py`` (oblique routing block) for the full
-scope note. Validation witnesses (bigger 3λ plate, n_steps=1400): specular
+scope note. Validation witnesses (bigger 3λ plate, n_steps=1400; measured on
+the PRE-corner-fix exclusive-slice kernels and NOT re-measured on the shipped
+inclusive kernels — see the tfsf_oblique_open.py module docstring): specular
 180/161/140° vs predicted 180/160/140° at θ=0/20/40, settling −63…−66 dB, PO-sinc
 shape correlation 0.89–0.92, 3 dB beamwidth within ~1°, and RAW peak == SUBTRACTED
 peak (incident-leakage subtraction NOT needed — leakage steers to the forward
@@ -31,7 +33,10 @@ hemisphere φ≈θ, away from the specular lobe).
 NOTE those witness numbers come from a DIFFERENT configuration (3λ plate,
 1400 steps, the ``_methodB_pattern`` helper's NTFF box) than the committed gate
 below (2.2λ plate, 700 steps, public ``compute_rcs`` path, which measures
-180/160/144°). The two sets are not numerically comparable — see the helper's
+180/160/143° on the corner-inclusive kernels; 144° at θ=40 pre-fix, and the
+helper's θ=0 gate config settles at −52.3 dB — another marker that the witness
+block belongs to the other configuration). The two sets are not numerically
+comparable — see the helper's
 docstring for the exact NTFF-box construction difference. The gate's ±6°
 tolerance reflects a measured 3–7° peak-azimuth sensitivity to domain size at
 fixed dx/plate/CPML (PR #461 audit); it is an observed envelope on an

--- a/tests/test_oblique_rcs_specular.py
+++ b/tests/test_oblique_rcs_specular.py
@@ -35,7 +35,9 @@ below (2.2λ plate, 700 steps, public ``compute_rcs`` path, which measures
 docstring for the exact NTFF-box construction difference. The gate's ±6°
 tolerance reflects a measured 3–7° peak-azimuth sensitivity to domain size at
 fixed dx/plate/CPML (PR #461 audit); it is an observed envelope on an
-unconverged argmax observable, not a converged-accuracy claim.
+unconverged argmax observable, not a converged-accuracy claim. For scale: the
+2.2λ plate's physical-optics 3 dB specular beamwidth at θ=40 is ~30°
+(0.886·λ/(W·cosθ)), so ±6° is ~0.2 of the lobe the argmax sits in.
 """
 import numpy as np
 import jax.numpy as jnp

--- a/tests/test_oblique_rcs_specular.py
+++ b/tests/test_oblique_rcs_specular.py
@@ -1,0 +1,158 @@
+"""Validated OBLIQUE RCS — specular-peak + normal-reduction gates (#404 fork (a) S4/S5).
+
+These pin the physics that lifts the ``compute_rcs`` oblique fence: a finite PEC
+plate (normal +x, in the y-z plane, ~2.2 lambda wide in y, thin/periodic z)
+illuminated at oblique incidence by the OPEN-DOMAIN Method-B TFSF
+(``rfx/sources/tfsf_oblique_open.py``) scatters with a bistatic far-field whose
+specular lobe obeys the reflection law.
+
+Why this is the real, unfakeable gate (not the PO level)
+--------------------------------------------------------
+For a plate with normal +x and incident k̂ = (cosθ, sinθ, 0) (tilt toward +y),
+the reflection law puts the specular direction at k̂_refl = (−cosθ, sinθ, 0), i.e.
+azimuth ``phi_spec = 180 − θ`` at ``theta_obs = 90°`` (the x-y observation plane).
+The far-field peak MUST sit there and TRACK θ: a wrong injection angle or a wrong
+NTFF transform would move the peak elsewhere. This is angle-sensitive and cannot
+be faked by a normalization tweak (the peak LOCATION is normalization-invariant).
+
+At θ→0 the specular direction collapses to backscatter (φ=180°) — the
+normal-incidence reduction to the existing validated behaviour.
+
+Scope: this validates the far-field PATTERN / specular DIRECTION only. The
+ABSOLUTE oblique σ is intentionally NOT asserted — the 2.5-D strip's 3-D RCS
+scales with the (arbitrary) NTFF z-box height because the two z-faces cancel for
+x-y-plane observation. See ``rfx/rcs.py`` (oblique routing block) for the full
+scope note. Validation witnesses (bigger 3λ plate, n_steps=1400): specular
+180/161/140° vs predicted 180/160/140° at θ=0/20/40, settling −63…−66 dB, PO-sinc
+shape correlation 0.89–0.92, 3 dB beamwidth within ~1°, and RAW peak == SUBTRACTED
+peak (incident-leakage subtraction NOT needed — leakage steers to the forward
+hemisphere φ≈θ, away from the specular lobe).
+"""
+import numpy as np
+import jax.numpy as jnp
+import pytest
+
+from rfx.grid import Grid, C0
+from rfx.core.yee import MaterialArrays
+from rfx.geometry.csg import Box, rasterize
+from rfx.farfield import NTFFBox
+from rfx.sources.tfsf_oblique_open import init_tfsf_methodB
+from rfx.simulation import run, SnapshotSpec
+from rfx.rcs import compute_rcs, compute_rcs_jax, _incident_spectrum_amplitude
+
+F0 = 5e9
+LAM = C0 / F0
+DX = 0.002                 # lambda/30
+CPML = 10
+MARGIN = 10
+PLATE_W = 2.2 * LAM        # width in y
+N_STEPS = 700
+PEC_SIGMA = 1e7
+# grid ~ 76 x 130 x 24 (thin periodic z)
+_DOMAIN = (0.11, 0.218, 0.006)
+PHI = np.linspace(0.0, 2 * np.pi, 361)
+TH_OBS = np.array([np.pi / 2])   # x-y observation plane
+BACK = (np.degrees(PHI) >= 90) & (np.degrees(PHI) <= 270)  # reflection hemisphere
+
+
+def _plate_materials(grid):
+    nx, ny, nz = grid.shape
+    xc = (nx // 2) * DX
+    yc = (ny // 2) * DX
+    half = PLATE_W / 2.0
+    plate = Box(corner_lo=(xc - 0.5 * DX, yc - half, -1.0),
+                corner_hi=(xc + 0.5 * DX, yc + half, +1.0))
+    eps_r, sigma = rasterize(grid, [(plate, 1.0, PEC_SIGMA)])
+    return MaterialArrays(eps_r=eps_r, sigma=sigma,
+                          mu_r=jnp.ones(grid.shape, dtype=jnp.float32))
+
+
+def _peak_phi_deg(sig_linear):
+    """Azimuth (deg) of the specular lobe in the reflection hemisphere."""
+    return float(np.degrees(PHI)[BACK][np.argmax(np.asarray(sig_linear)[BACK])])
+
+
+def _methodB_pattern(theta_deg):
+    """Build the 2.5-D open-domain Method-B pipeline directly (theta=0 allowed) and
+    return (peak_phi_deg, settling_db). Mirrors what compute_rcs does internally
+    for oblique, but exercises theta=0 (the normal-reduction limit) which
+    compute_rcs routes to the normal path."""
+    grid = Grid(freq_max=F0 * 3, domain=_DOMAIN, dx=DX, cpml_layers=CPML)
+    nx, ny, nz = grid.shape
+    cfg, st = init_tfsf_methodB(nx, ny, DX, grid.dt, nz=nz, cpml_layers=CPML,
+                                tfsf_margin=MARGIN, f0=F0, polarization="ez",
+                                direction="+x", theta_deg=theta_deg)
+    off = 3
+    kz = nz // 2
+    box = NTFFBox.from_grid(
+        grid, i_lo=cfg.x_lo - off, i_hi=cfg.x_hi + off,
+        j_lo=cfg.y_lo - off, j_hi=cfg.y_hi + off,
+        k_lo=kz - 1, k_hi=kz + 1, freqs=jnp.asarray([F0], jnp.float32))
+    mats = _plate_materials(grid)
+    snap = SnapshotSpec(interval=8, components=("ez",), slice_axis=2, slice_index=kz)
+    res = run(grid, mats, N_STEPS, boundary="cpml", cpml_axes="xy",
+              periodic=(False, False, True), pec_axes="",
+              tfsf=(cfg, st), ntff=box, snapshot=snap)
+    e_inc = _incident_spectrum_amplitude(F0, 0.5, np.array([F0]), grid.dt, N_STEPS)
+    sig = np.asarray(compute_rcs_jax(res.ntff_data, box, grid, TH_OBS, PHI, e_inc))[0, 0, :]
+    # settling witness: end vs peak field energy in the total-field box interior
+    ez = np.asarray(res.snapshots["ez"])
+    e = ez[:, cfg.x_lo + 4:cfg.x_hi - 4, cfg.y_lo + 4:cfg.y_hi - 4]
+    energy = np.sum(e ** 2, axis=(1, 2))
+    settling = 10 * np.log10(max(energy[-1], 1e-30) / max(energy.max(), 1e-30))
+    return _peak_phi_deg(sig), float(settling)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("theta_inc", [20.0, 40.0])
+def test_oblique_specular_peak_tracks_injection_angle(theta_inc):
+    """PRIMARY unfakeable gate (via the public compute_rcs API): the bistatic
+    far-field of the PEC plate peaks at the reflection-law specular direction
+    phi = 180 - theta_inc and TRACKS the injection angle."""
+    grid = Grid(freq_max=F0 * 3, domain=_DOMAIN, dx=DX, cpml_layers=CPML)
+    mats = _plate_materials(grid)
+    res = compute_rcs(grid, mats, N_STEPS, f0=F0, bandwidth=0.5,
+                      theta_inc=theta_inc, polarization="ez",
+                      theta_obs=TH_OBS, phi_obs=PHI, freqs=np.array([F0]),
+                      cpml_layers=CPML, tfsf_margin=MARGIN, ntff_offset=3)
+    peak = _peak_phi_deg(res.rcs_linear[0, 0, :])
+    pred = 180.0 - theta_inc
+    assert abs(peak - pred) <= 6.0, (
+        f"specular peak {peak:.0f} deg not tracking predicted {pred:.0f} deg "
+        f"(theta_inc={theta_inc}); a wrong injection angle / NTFF moves the peak"
+    )
+    # the reflection lobe must dominate the reflection hemisphere over backscatter
+    sig = np.asarray(res.rcs_linear[0, 0, :])
+    back_bin = int(round((180.0 + theta_inc))) % 360
+    spec_bin = int(round(pred)) % 360
+    assert sig[spec_bin] > 5 * sig[back_bin], (
+        "specular lobe should dominate backscatter for a flat plate at oblique "
+        f"incidence (spec={sig[spec_bin]:.2e} vs back={sig[back_bin]:.2e})"
+    )
+
+
+@pytest.mark.slow
+def test_oblique_rcs_normal_reduction_to_backscatter():
+    """NORMAL-REDUCTION (comparator-first): the SAME 2.5-D Method-B pipeline at
+    theta=0 puts the specular lobe at phi=180 deg (= backscatter = specular at
+    normal incidence), with a settled ring-down. Proves the oblique path reduces
+    to the known-good normal case."""
+    peak0, settling0 = _methodB_pattern(0.0)
+    assert abs(peak0 - 180.0) <= 4.0, f"normal-incidence peak {peak0:.0f} != 180 deg"
+    assert settling0 < -35.0, f"ring-down not settled: end/peak {settling0:.1f} dB"
+    # and it still tracks at oblique through the identical direct pipeline
+    peak40, settling40 = _methodB_pattern(40.0)
+    assert abs(peak40 - 140.0) <= 6.0, f"oblique peak {peak40:.0f} != ~140 deg"
+    assert settling40 < -35.0, f"oblique ring-down not settled: {settling40:.1f} dB"
+
+
+def test_oblique_rcs_fence_kept_for_unsupported_combos():
+    """The fence is KEPT (fails loud) for combos Method B does not support:
+    non-ez polarization and non-uniform grids. Fast — raises before any run."""
+    from rfx.core.yee import init_materials
+    grid = Grid(freq_max=10e9, domain=(0.06, 0.06, 0.06), dx=0.003, cpml_layers=6)
+    mats = init_materials(grid.shape)
+    with pytest.raises(NotImplementedError, match="ez"):
+        compute_rcs(grid, mats, n_steps=10, f0=5e9, bandwidth=0.5,
+                    theta_inc=30.0, polarization="ey",
+                    theta_obs=np.array([np.pi / 2]), phi_obs=np.array([0.0]))

--- a/tests/test_oblique_rcs_specular.py
+++ b/tests/test_oblique_rcs_specular.py
@@ -39,7 +39,9 @@ block belongs to the other configuration). The two sets are not numerically
 comparable — see the helper's
 docstring for the exact NTFF-box construction difference. The gate's ±6°
 tolerance reflects a measured 3–7° peak-azimuth sensitivity to domain size at
-fixed dx/plate/CPML (PR #461 audit); it is an observed envelope on an
+fixed dx/plate/CPML (PR #461 audit, measured on the pre-corner-fix exclusive
+kernels; not re-measured in-tree on the inclusive ones); it is an observed
+envelope on an
 unconverged argmax observable, not a converged-accuracy claim. For scale: the
 2.2λ plate's physical-optics 3 dB specular beamwidth at θ=40 is ~30°
 (0.886·λ/(W·cosθ)), so ±6° is ~0.2 of the lobe the argmax sits in.

--- a/tests/test_rcs.py
+++ b/tests/test_rcs.py
@@ -319,18 +319,18 @@ class TestRCSResultStructure:
         print(f"  monostatic_rcs: {result.monostatic_rcs}")
 
 
-def test_compute_rcs_rejects_oblique_incidence():
-    """#404 fail-loud guard: a non-zero theta_inc must raise rather than silently
-    dispatch to the unvalidated oblique TFSF path."""
+def test_compute_rcs_oblique_fence_kept_for_unsupported():
+    """Post-#404-fork-(a): oblique ez now ROUTES through Method B (validated
+    specular pattern, tests/test_oblique_rcs_specular.py), but the fence is KEPT
+    for the combos Method B does not support — non-ez polarization and
+    non-uniform grids — which must still fail loud rather than return a number."""
     import pytest
     from rfx.core.yee import init_materials
 
     grid = Grid(freq_max=10e9, domain=(0.06, 0.06, 0.06), dx=0.003, cpml_layers=6)
     materials = init_materials(grid.shape)
-    with pytest.raises(NotImplementedError, match="oblique"):
+    # oblique + ey polarization is NOT supported -> must raise
+    with pytest.raises(NotImplementedError, match="ez"):
         compute_rcs(grid, materials, n_steps=10, f0=5e9, bandwidth=0.5,
-                    theta_inc=30.0, polarization="ez",
+                    theta_inc=30.0, polarization="ey",
                     theta_obs=np.array([1.0]), phi_obs=np.array([0.0]))
-    # normal incidence must NOT raise at the guard (reaches the TFSF setup)
-    # — cheap smoke: guard passes for theta_inc=0.0
-    assert abs(0.0) <= 1e-6


### PR DESCRIPTION
**Split 2 of 3** from the 8-commit Item-C branch (#451), per its own review note ("Reviewer may prefer to split (oblique-RCS feature vs crossval examples) — PI's call"). Authored in a prior session; this PR isolates the **physics/solver** half so it gets a focused review. Full original tip `0a4f1ea` preserved at `backup/oblique-rcs-item-c-full-20260725`.

**Now based on `main`** — #451 (split 1) merged as `d77174d`, so this was retargeted and rebased onto main via `git rebase --onto origin/main` (the stacked-squash recipe). The api-reference JSON merged cleanly with #449 Item B's `mu_r_override` entry; inventory verified to carry BOTH entries, gate `OK`. Re-verified after rebase: 12 passed (fast), ruff clean.

## What lands (4 commits, +845/-54)
- `7b9d4db` **method-B source** `rfx/sources/tfsf_oblique_open.py` (402 lines) — open-domain oblique TFSF: dispersion-matched 1-D aux along k-hat + 4-edge box with `r.k-hat` face projection. Real float32 fields, so NTFF/DFT read physical fields directly (no envelope-aware NTFF needed) — unlike the periodic complex-Bloch path (#414), which assumes lateral periodicity and is the wrong tool for a compact scatterer.
- `0bcac56` **Stage 2** — wired into `run()`/`forward()` via a dispatch mirroring `is_tfsf_2d`.
- `b3acd64` **fence LIFTED** — `compute_rcs(theta_inc != 0)` routes through method B for **ez + uniform grid only**. `ey` and non-uniform still raise `NotImplementedError`; `theta=0` is byte-identical to the normal path.
- `3c00bf6` **api-reference fix (added here)** — `add_tfsf_source` gained `method=`, a genuine public-surface drift that was unrecorded, so the gate was red. Regenerated; diff is exactly one entry.

## Verification (all re-run in this session, not carried over)
- `tests/test_oblique_rcs_specular.py` + oblique TFSF + RCS suites: **7 passed** (`-m slow`), **16 passed** (fast). `api reference surface: OK`. ruff clean on the gated scope (`rfx/ tests/`).
- The gate carries a **ring-down settling witness** (end/peak energy < -35 dB) and a **normal-reduction comparator** (theta=0 puts the lobe at phi=180, i.e. the known-good backscatter case).

## Added-gate audit (`feedback_gate_can_bind_artifact` mandate) — one finding for the reviewer
The rule requires a falsifier re-run **and** domain-size invariance for any newly added gate. Both were run against the public `compute_rcs` path (script: scratchpad `c2_gate_audit.py`; raw output in the review comment below).

**1. Angle discrimination (falsifier) — PASS, with a wide margin.** Cross-comparing measured patterns against the wrong prediction:

| pattern | vs pred(20)=160 | vs pred(40)=140 |
|---|---|---|
| theta=20 -> peak 160.0 | err 0.0 -> PASSES (own) | err 20.0 -> FAILS (correct) |
| theta=40 -> peak 144.0 | err 16.0 -> FAILS (correct) | err 4.0 -> PASSES (own) |

Discrimination margin (16-20 deg) is far larger than the tolerance (6 deg), so the gate genuinely measures the reflection law rather than passing vacuously.

**2. Domain-size invariance — the peak azimuth WANDERS 3-7 deg.** Enlarging the domain ~1.35x (dx, plate, CPML layers fixed):

| theta | base grid (76,130,24) | big grid (96,166,24) | shift |
|---|---|---|---|
| 20 | peak 160.0 (err 0.0), spec/back 12.9 | peak 163.0 (err 3.0), spec/back 15.9 | **3.0 deg** |
| 40 | peak 144.0 (err 4.0), spec/back 46.0 | peak 137.0 (err 3.0), spec/back 32.1 | **7.0 deg** |

Both domains pass the 6 deg gate and the specular lobe dominates backscatter throughout (13-46x), so the **reflection-law claim holds**. But the domain-dependent scatter (3-7 deg) is the *same size as the gate's own tolerance*, and at theta=40 it exceeds it. Related: the in-code docstring records `161/140 deg` via the direct `_methodB_pattern` helper while the public `compute_rcs` path gives `160/144 deg` — a consistent few-degree systematic between the two paths.

**Reading**: the argmax azimuth of a 2.2-lambda plate's broad specular lobe is genuinely sensitive at the few-degree level to finite-domain interference, so 6 deg is absorbing a systematic rather than bounding a converged number. I have **not** touched the tolerance — the no-silent-gate-loosening rule requires a written root cause first, and the gate's design is the author's call. Reviewer options: gate on a lobe **centroid** instead of argmax (less bin-interference sensitive), or keep argmax and justify the tolerance with the measured domain scatter recorded in the docstring. Note the PR that authored this claimed "tracked <=1 deg"; measured here it is 0 deg at theta=20 but 4 deg at theta=40 via the public API.

## Scope limits (in-code, unchanged from the author's version)
Only the far-field **pattern / specular direction** is validated. **Absolute oblique sigma is NOT validated** — the 2.5-D strip's 3-D RCS scales with the arbitrary NTFF z-box height (the two z-faces cancel for x-y-plane observation) and the incident-spectrum normalization assumes the normal-path waveform.

R3: memory=project_issue404_oblique_tfsf_r2stop + project_diff_planewave_inverse_design + feedback_gate_can_bind_artifact | R2-attempts=0 | falsifier=cross-prediction discrimination (PASS) + domain-size invariance (3-7 deg scatter SURFACED)

🤖 Generated with [Claude Code](https://claude.com/claude-code)