### PR TITLE
feat(interop): rfx-design-ir/v1 design document + first external-solver emitter (openEMS)

### DIFF
--- a/docs/design_notes/geometry_setup_interop.md
+++ b/docs/design_notes/geometry_setup_interop.md
@@ -183,6 +183,33 @@ Measured in this environment, not assumed:
   live-session generator would licence-gate CI and be unusable for the actual
   workflow. Generation must need no licence.
 
+### The highest-severity translation hazard, measured
+
+**rfx adds CPML *outside* the user domain; openEMS PML consumes cells *inside*
+the mesh extent.** A naive translation therefore buries the structure in the
+absorber and compares against a different problem — the dominant historical
+failure class in this repo (comparator/fixture divergence, not solver physics).
+
+Measured with `domain=(0.01, 0.01, 0.01)`, `dx=1e-3`:
+
+| `cpml_layers` | grid shape | `axis_pads` |
+|---|---|---|
+| 0 | (11, 11, 11) | (0, 0, 0) |
+| 8 | (27, 27, 27) = 11 + 2×8 | (8, 8, 8) |
+| 16 | (43, 43, 43) = 11 + 2×16 | (16, 16, 16) |
+
+So the user's `domain` is entirely physical and the absorber is extra cells
+beyond it, consistent with `rfx/grid.py:133` — `(idx - axis_pads[ax]) * dx`
+recovers user-domain coordinates, i.e. index 0 lies outside the domain. An
+openEMS emitter must span `domain + 2 × cpml_layers × dx` per absorbing axis and
+let `PML_<N>` eat the added margin.
+
+(Noted while verifying: the subgrid PML-overlap warning at
+`rfx/api/__init__.py:627-650` tests `z_lo < pml_thickness` / `z_hi > domain_z -
+pml_thickness`, which reads the absorber as living *inside* the domain — the
+opposite frame from the grid builder. The subgrid path is experimental and
+parked (PR #90), so this is recorded rather than chased.)
+
 ### Acceptance target for the first emitter (verified to exist)
 
 `tests/test_msl_notch_e4_comparison_gates.py` + `tests/fixtures/msl_notch_e4/`

--- a/docs/design_notes/geometry_setup_interop.md
+++ b/docs/design_notes/geometry_setup_interop.md
@@ -1,0 +1,163 @@
+# Geometry / setup export–import interop
+
+Status: **PROVISIONAL — under construction.** The primitive-level codecs are
+implemented and contract-tested; the design document, the external-solver
+emitters, and the import direction are not yet landed. Nothing here is a
+validated claim about agreement with another solver.
+Date: 2026-07-25. Branch: `feat/geometry-setup-interop`.
+
+## Question
+
+Can an rfx design (geometry **and** setup — materials, excitations,
+observables, mesh directives) be exported to another EM solver, and can a
+design authored in another tool be brought into rfx?
+
+## Premise check first — what already exists
+
+Two premises that looked true from a stale checkout turned out to be false, and
+both change the plan. They are recorded here because the wrong version was
+briefly acted on.
+
+**1. rfx already has CAD import.** `rfx/geometry/mesh_import.py` provides
+`MeshShape`, which loads watertight STL / OBJ / PLY through `trimesh` and
+STEP / STP through the optional `cascadio` OpenCASCADE backend (`cad` extra in
+`pyproject.toml`). Landed via #453 / #456; issue #358 is closed. The asymmetry
+is therefore **import exists, export does not** — not "no CAD support".
+
+**2. rfx already has four setup-serialisation layers.** Every one of them is
+box-or-bbox-level, so none can rebuild its own input:
+
+| layer | geometry fidelity |
+|---|---|
+| `rfx/io.py:869` `export_geometry_json` | class name + bounding box |
+| `rfx/artifacts.py:274,311` `build_scene_artifact` | pops `shape`, keeps `shape_type` + bounding box |
+| `rfx/config/_shapes.py:15` | `_SUPPORTED_SHAPES = ("box",)` |
+| `rfx/experiments/canonical.py:752` | `"P0 supports box geometry"`, geometry as `bounds_m` |
+
+Measured demonstration (run on this branch):
+
+```python
+sim.add(Cylinder(center=(0.010, 0.006, 0.0008), radius=3e-4,
+                 height=1.5e-3, axis="z"), material="pec")
+```
+
+`build_scene_artifact(sim)["geometry"][1]` →
+
+```json
+{"id": "geometry-1", "kind": "geometry", "type": "_GeometryEntry",
+ "shape_type": "Cylinder",
+ "bounding_box": [[0.0097, 0.0057, 5.0e-05], [0.0103, 0.0063, 0.00155]],
+ "material_name": "pec"}
+```
+
+`radius`, `height`, `axis` and `center` are absent; the via is indistinguishable
+from a `Box` with the same bounds. That is the concrete gap this work closes.
+
+## Decisions
+
+**D1 — The primitive-level codec is a shared leaf, not a fifth layer.**
+All four layers above lack the same thing: a way to record a shape's
+*constructor parameters*. `rfx/interop/_shapes.py` supplies it for all six CSG
+primitives, and `rfx/interop/_materials.py` does the same for `MaterialSpec`
+including Debye/Lorentz pole parameters (which `artifacts.py:245` reduces to
+`{"present", "count"}`). Consolidating the four layers onto these codecs is
+follow-up work, not a prerequisite.
+
+**D2 — Vocabulary: `kind` + snake_case.** The repo already names shapes twice —
+`config/_shapes.py` uses `shape: "box"`, `canonical.py` uses `kind: "box"`. The
+codec uses `kind` with snake_case names (`box`, `cylinder`, `sphere`,
+`polyline_wire`, `via`, `curved_patch`) so a third spelling is not created.
+Parameter names stay the *constructor* names, because that is what makes the
+registry pinnable against each live class signature; per-layer spellings of a
+box (`bounds`, `bounds_m`) remain adapter concerns for those layers.
+
+**D3 — Two profiles, two names.** The rfx→rfx document is round-trip complete
+and its gate is structural equality. An external-solver projection is a
+*separate*, explicitly lossy artifact that carries its own list of
+approximations. There is no single schema with a "portable-ish" flag, because a
+reader cannot tell which fields survived.
+
+**D4 — Refuse, never approximate.** Anything not representable exactly raises
+`UnsupportedDesignFeature` naming the entry and index. No `warnings.warn`-and-
+drop, no bounding-box fallback. `MeshShape` is refused by the codec today: a
+triangle mesh is not parameter-describable the way a CSG primitive is, and
+degrading it to a bounding box would produce a different structure under the
+same name.
+
+**D5 — The container decision is deferred, deliberately.**
+`CanonicalExperimentSpec` (`rfx-experiment/v2`) is the strongest existing
+foundation — versioned, with schema migrations, a closed-world validator, an
+sha256 + semantic fingerprint, a working importer (`build_simulation()`), and
+Python emission. Folding the design document into it is the likely endpoint,
+but it is a governed schema with a published JSON Schema and existing
+consumers, so widening its geometry beyond `box` deserves an explicit decision
+rather than a side effect of this branch.
+
+## Non-portable state (must be marked, not hidden)
+
+These round-trip correctly inside rfx but are meaningless to another solver.
+An external emitter that ships them silently would produce a comparison against
+a structure the other solver never built.
+
+- `_cpml_kappa_max` and the CPML profile constants hard-coded in
+  `rfx/boundaries/cpml.py` — absorber behaviour is not portable; CPML layer
+  *counts* have per-solver cell semantics.
+- `_coaxial_terminations`, `_coaxial_open_terminations`,
+  `_coaxial_pec_end_caps` — offsets are **cell-relative**, not physical
+  coordinates.
+- `_msl_ports.n_probe_offset` / `n_probe_spacing` — cell counts derived from
+  `_dx` at registration time.
+- `_refinement` — the SBP-SAT subgrid path, experimental and falsified in 3D
+  (PR #90). Round-trip for rfx; never project outward.
+- `_precision`, `_solver` (`yee`/`adi`), `_adi_cfl_factor`, `_stencil_order` —
+  rfx solver controls with no counterpart.
+- `_tfsf` — a plane-wave projection onto CST/HFSS is an approximation with a
+  different absorber story, not a translation.
+
+## Boundaries that constrain honest claims
+
+- **`MeshShape` is off the AD path.** It rasterises host-side through
+  `trimesh.contains` (`rfx/geometry/mesh_import.py:149`), so it cannot be
+  traced or JIT-compiled. A CAD-sourced design can round-trip, but it cannot
+  carry gradients — which matters because the project's standing tie-breaker is
+  that AD-traceability is non-negotiable.
+- **Traced mesh profiles cannot be exported.** `_dx_profile` / `_dy_profile`
+  may be a JAX tracer on the differentiable-mesh path
+  (`rfx/api/__init__.py:387-393`); exporting a tracer is meaningless, so it
+  must refuse.
+- **The S-parameter drivers rewrite builder state.** `rfx/api/_sparams.py`
+  temporarily mutates `_dz_profile`, `_msl_ports`, `_ports`, `_dft_planes` and
+  `_waveguide_ports`, then restores them. Exporting mid-driver captures a
+  synthetic configuration.
+- **Derived state is never a source of truth.** `Grid` / `NonUniformGrid`,
+  `dt`, `axis_pads` and preflight verdicts are excluded from the document. A
+  design description that carries `dt` invites a reader to trust it.
+- **Config-layer fences are narrower than the Python API.** The YAML path
+  supports `box` only, defers waveguide / coaxial / floquet / msl / tfsf ports
+  (`rfx/config/loader.py:47-53`), and takes scalar boundary strings rather than
+  a per-face `BoundarySpec`. Any claim of "full-fidelity export through the
+  config layer" would be an overclaim today.
+
+## Why this earns a slot under "correctness > feature sprawl"
+
+The cross-solver validation campaign's cost centre is building each structure
+twice — once in rfx and once by hand in openEMS / Meep / Palace — and keeping
+the two identical. `scripts/diagnostics/build_sheen_lpf_palace_referee.py` and
+the Palace mesh builder are exactly that hand-porting. The repo's own rules
+(`.claude/rules/rfx-feature-discovery.md`: never hand-roll an external-solver
+crossval setup; `CLAUDE.md`: comparator first) identify comparator/fixture
+divergence — not solver physics — as the dominant historical failure class. A
+generated, single-source setup attacks that class directly.
+
+## Status of each piece
+
+| piece | status |
+|---|---|
+| shape codec, 6/6 primitives, registry pinned to live signatures | implemented, contract-tested |
+| material codec incl. dispersion poles | implemented, contract-tested |
+| `MeshShape` / subclass / impostor-class refusals | implemented, tested |
+| design document (`Simulation` ⇄ document) | **in progress** |
+| published JSON Schema for the document | **in progress** |
+| external-solver emitters (PyAEDT / CST VBA / openEMS / Meep) | **not started** |
+| import direction (GDSII, CST history list, PyAEDT enumeration) | **researched only** |
+| consolidation of the four existing serialisers | **not started** |

--- a/docs/design_notes/geometry_setup_interop.md
+++ b/docs/design_notes/geometry_setup_interop.md
@@ -210,6 +210,34 @@ pml_thickness`, which reads the absorber as living *inside* the domain — the
 opposite frame from the grid builder. The subgrid path is experimental and
 parked (PR #90), so this is recorded rather than chased.)
 
+### The ceiling on any emitted-setup agreement claim
+
+Port models differ **structurally** between rfx and openEMS, and the repo has
+already measured the size of it. This bounds what an emitter may claim, before
+any physics is in question:
+
+- rfx's wire/lumped port is a **point feed** (one vertical cell column from
+  ground to trace, the `extent`); openEMS's `MSLPort` occupies a **span** along
+  the propagation axis (6 cells in the upstream `MSL_NotchFilter.py` tutorial).
+  `port_w_cells` has **no rfx counterpart**, so it is an emitter parameter and an
+  assumption the reader must be shown, not a derived quantity.
+- The **direction convention inverts**: rfx's `direction` names the outward
+  (away-from-the-line) normal, while openEMS derives propagation from
+  `sign(stop - start)` with both ports pointing *into* the shared trace. A wrong
+  sign yields a plausible-looking S21 with the wrong reference sense.
+- **≈0.20 in |S| is the measured port-convention gap**
+  (`scripts/diagnostics/build_wire_openems_broad_envelope.py:12-16`: the
+  tolerance is deliberately loose "because the wire-port mid-cell convention has
+  known mismatch with openEMS's lumped-port multi-cell averaging", and broad
+  calibrated E5 still requires resolving the wire-port absolute calibration
+  convention).
+
+That 0.20 is **looser than the cv06b mean gate (0.13)** and comparable to its max
+gate (0.25). So: a passing comparison of an emitted setup is not evidence that
+the port models agree, and **structural equivalence of a generated setup is not
+evidence of physics agreement** at all. The emitter's job is to remove
+hand-porting divergence, not to produce agreement.
+
 ### Acceptance target for the first emitter (verified to exist)
 
 `tests/test_msl_notch_e4_comparison_gates.py` + `tests/fixtures/msl_notch_e4/`

--- a/docs/design_notes/geometry_setup_interop.md
+++ b/docs/design_notes/geometry_setup_interop.md
@@ -84,6 +84,17 @@ triangle mesh is not parameter-describable the way a CSG primitive is, and
 degrading it to a bounding box would produce a different structure under the
 same name.
 
+**D4a — Geometry order is semantic state, not presentation.** `Simulation.add`
+appends to an **ordered, last-write-wins paint list**: `rfx/geometry/csg.py:321`
+— *"Applied in order; later shapes overwrite earlier ones."* The boolean helpers
+`union` / `difference` / `intersection` exist in `rfx/geometry/csg.py` but are
+**not** used by the simulation path (no call sites in `rfx/api/` or `rfx/core/`;
+they are exported for direct use and exercised only in `tests/test_geometry.py`).
+Consequences: the document must preserve entry order exactly, and an emitter
+targeting a solver with a boolean solid model (HFSS) cannot translate overlaps
+mechanically — overlapping paint has no boolean equivalent, so the projection
+must either ask or refuse rather than silently pick a subtraction order.
+
 **D5 — The container decision is deferred, deliberately.**
 `CanonicalExperimentSpec` (`rfx-experiment/v2`) is the strongest existing
 foundation — versioned, with schema migrations, a closed-world validator, an

--- a/docs/design_notes/geometry_setup_interop.md
+++ b/docs/design_notes/geometry_setup_interop.md
@@ -50,8 +50,10 @@ sim.add(Cylinder(center=(0.010, 0.006, 0.0008), radius=3e-4,
  "material_name": "pec"}
 ```
 
-`radius`, `height`, `axis` and `center` are absent; the via is indistinguishable
-from a `Box` with the same bounds. That is the concrete gap this work closes.
+`radius`, `height`, `axis` and `center` are absent; the cylinder is
+indistinguishable from a `Box` with the same bounds. That is the concrete gap
+this work closes. (The quoted entry is the second geometry entry of a two-entry
+scene — a substrate box plus this cylinder — hence `geometry-1`.)
 
 ## Decisions
 
@@ -84,16 +86,30 @@ triangle mesh is not parameter-describable the way a CSG primitive is, and
 degrading it to a bounding box would produce a different structure under the
 same name.
 
-**D4a — Geometry order is semantic state, not presentation.** `Simulation.add`
-appends to an **ordered, last-write-wins paint list**: `rfx/geometry/csg.py:321`
-— *"Applied in order; later shapes overwrite earlier ones."* The boolean helpers
-`union` / `difference` / `intersection` exist in `rfx/geometry/csg.py` but are
-**not** used by the simulation path (no call sites in `rfx/api/` or `rfx/core/`;
-they are exported for direct use and exercised only in `tests/test_geometry.py`).
-Consequences: the document must preserve entry order exactly, and an emitter
-targeting a solver with a boolean solid model (HFSS) cannot translate overlaps
-mechanically — overlapping paint has no boolean equivalent, so the projection
-must either ask or refuse rather than silently pick a subtraction order.
+**D4a — Geometry order is semantic state, but the rule is not uniform
+last-write-wins.** Two distinct composition rules run in the same loop
+(`rfx/api/_compile.py:162-174`, the live path — note `rasterize()`'s
+"later shapes overwrite earlier ones" docstring at `rfx/geometry/csg.py:321`
+describes a function the simulation path never calls):
+
+- **Dielectric paint is last-write-wins.** `eps_r`/`sigma`/`mu_r` are written
+  with `jnp.where(mask, ...)`, so a later overlapping entry overwrites an
+  earlier one.
+- **PEC is a union and is order-independent.** When `mat.sigma >=
+  _PEC_SIGMA_THRESHOLD` the loop does `pec_mask = pec_mask | mask` and **skips
+  the dielectric paint entirely**; `pec_mask` is initialised once
+  (`_compile.py:139`) and only ever OR'd again (`:168`, `:234` for thin
+  conductors). So a dielectric added after an overlapping PEC shape does **not**
+  erase it — PEC wins regardless of order.
+
+An emitter built on uniform last-write-wins would therefore mistranslate every
+PEC-over-dielectric overlap, which is most PCB stackups. The conclusion stands
+and gets stronger: entry order is semantic state the document must preserve
+exactly, and an emitter targeting a boolean solid modeller (HFSS) must ask or
+refuse rather than silently pick a subtraction order. The boolean helpers
+`union` / `difference` / `intersection` are defined at `csg.py:298,302,306` and
+have **zero call sites anywhere in `rfx/`** — they are exercised only in
+`tests/test_geometry.py`.
 
 **D5 — The container decision is deferred, deliberately.**
 `CanonicalExperimentSpec` (`rfx-experiment/v2`) is the strongest existing

--- a/docs/design_notes/geometry_setup_interop.md
+++ b/docs/design_notes/geometry_setup_interop.md
@@ -172,10 +172,10 @@ a structure the other solver never built.
 The cross-solver validation campaign's cost centre is building each structure
 twice — once in rfx and once by hand in openEMS / Meep / Palace — and keeping
 the two identical. `scripts/diagnostics/build_sheen_lpf_palace_referee.py` and
-the Palace mesh builder are exactly that hand-porting. The repo's own rules
-(`.claude/rules/rfx-feature-discovery.md`: never hand-roll an external-solver
-crossval setup; `CLAUDE.md`: comparator first) identify comparator/fixture
-divergence — not solver physics — as the dominant historical failure class. A
+the Palace mesh builder are exactly that hand-porting. The project's standing rules (never hand-roll an external-solver crossval
+setup; comparator first — see `docs/guides/simulation_methodology.md` and the
+crossval manifest's evidence rule) identify comparator/fixture divergence —
+not solver physics — as the dominant historical failure class. A
 generated, single-source setup attacks that class directly.
 
 ## Target order, and why openEMS is first
@@ -309,12 +309,13 @@ Both come from the target-API survey and neither has a defensible default:
 ## Verification status of the scaffolding (measured on this branch)
 
 - `ruff check rfx/ tests/ --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402` → clean
-- codec contract tests → 53 passed
+- codec contract tests → 71 passed (grew from 53 as the two in-development
+  reviews' value-validation and stray-key fixes landed with their tests)
 - `python scripts/check_api_reference.py` → `api reference surface: OK`
   (the pinned surface is untouched because nothing was added to `rfx/__init__.py`)
-- wheel build ships the package: `rfx/interop/{__init__,_errors,_materials,_shapes}.py`
-  present in `rfx_fdtd-1.6.6-py3-none-any.whl` (setuptools `include = ["rfx*"]`
-  auto-discovery, so no packaging change was needed)
+- wheel build ships the package: `rfx/interop/{__init__,_design,_errors,_materials,_shapes,_validate}.py`
+  and `rfx/interop/emitters/{__init__,openems}.py` (setuptools `include = ["rfx*"]`
+  auto-discovery picks up both subpackages, so no packaging change was needed)
 - cv06b gate family → 13 passed (the baseline the emitter work must not disturb)
 
 ## Status of each piece

--- a/docs/design_notes/geometry_setup_interop.md
+++ b/docs/design_notes/geometry_setup_interop.md
@@ -160,6 +160,73 @@ crossval setup; `CLAUDE.md`: comparator first) identify comparator/fixture
 divergence — not solver physics — as the dominant historical failure class. A
 generated, single-source setup attacks that class directly.
 
+## Target order, and why openEMS is first
+
+Measured in this environment, not assumed:
+
+- **openEMS is installed and executes.** `/usr/bin/openEMS`, Python bindings
+  importable, and a 10-timestep 9261-cell run completes (1.24 MCells/s, writes
+  `et`/`ht`). It is therefore the **only** target whose generated script we can
+  verify end to end here. CST and HFSS cannot be verified at all without a
+  licence.
+- Boundary-condition string is `'PML_<N>'`, **not** `'PML-<N>'` — the hyphen form
+  raises "Unknown boundary condition". Confirmed by running it. `PML_<N>` is
+  parameterised, so `cpml_layers=16` → `'PML_16'`.
+- **CST is the closest *semantic* match** even though it cannot be verified
+  here: `DispModelEps` accepts `Debye1st`/`Debye2nd`/`Lorentz`/`NonLinearKerr`,
+  `FloquetPort` takes scan θ/φ directly, `Port.ReferencePlaneDistance` is
+  exactly rfx's de-embedding, and `Solver.SteadyStateLimit` is rfx's settling
+  criterion. But the CST Python API is a *driver*: models are built by pushing
+  **VBA** through `add_to_history`, so a CST emitter must emit VBA.
+- **Generated artifacts must be plain-text scripts, runnable later on a
+  licensed machine.** PyAEDT requires a legally licensed local AEDT, so a
+  live-session generator would licence-gate CI and be unusable for the actual
+  workflow. Generation must need no licence.
+
+### Acceptance target for the first emitter (verified to exist)
+
+`tests/test_msl_notch_e4_comparison_gates.py` + `tests/fixtures/msl_notch_e4/`
+already hold a committed physical openEMS dx = 50 µm reference for the cv06b
+microstrip open-stub notch, alongside the rfx result at matched geometry. The
+test runs no FDTD (the ~65 min rfx run is committed as a fixture) and the whole
+gate family is green on this branch (13 tests, 0.12 s).
+
+Committed gates: notch-frequency agreement **≤ 7 %** (characterised ~6 %),
+off-notch |S21| mean abs diff **≤ 0.13** and max **≤ 0.25** over 2.5–6 GHz,
+passivity **≤ 1.05** for both solvers, notch depth **< −20 dB**, plus a sign
+constraint (rfx notch above openEMS — part of the committed characterisation).
+A Palace FEM referee lands at ~3.631 GHz, closest to rfx (+0.1 %), which
+retired the earlier open-end-fringing interpretation.
+
+The fixture's `meta` block carries the full parametric geometry
+(`eps_r=3.66`, `h_sub=0.254 mm`, `w_trace=0.6 mm`, `l_line=5.0 mm`,
+`l_stub=12.0 mm`, `dx=50 µm`, 2–7 GHz × 50 points, `nrts=600000`,
+`end_criteria=1e-4`, domain 7.0 × 16.232 × 1.754 mm), so the emitter has a
+numeric target to reproduce rather than a narrative one.
+
+## Decisions that need a human, not a default
+
+Both come from the target-API survey and neither has a defensible default:
+
+1. **HFSS paint-order → boolean rewriting.** rfx's overlapping paint (D4a) has
+   no boolean equivalent; choosing a subtraction order silently would change the
+   structure. Ask or refuse.
+2. **The MSL port recipe.** rfx extracts via an N-probe spatial fit; HFSS offers
+   wave vs lumped ports with v/h factors and a choice of `Zpi` / `Zwave` /
+   `Zpv`. Which of those rfx's number should be compared against is a physics
+   decision, not a mapping detail.
+
+## Verification status of the scaffolding (measured on this branch)
+
+- `ruff check rfx/ tests/ --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402` → clean
+- codec contract tests → 53 passed
+- `python scripts/check_api_reference.py` → `api reference surface: OK`
+  (the pinned surface is untouched because nothing was added to `rfx/__init__.py`)
+- wheel build ships the package: `rfx/interop/{__init__,_errors,_materials,_shapes}.py`
+  present in `rfx_fdtd-1.6.6-py3-none-any.whl` (setuptools `include = ["rfx*"]`
+  auto-discovery, so no packaging change was needed)
+- cv06b gate family → 13 passed (the baseline the emitter work must not disturb)
+
 ## Status of each piece
 
 | piece | status |

--- a/docs/design_notes/geometry_setup_interop.md
+++ b/docs/design_notes/geometry_setup_interop.md
@@ -256,7 +256,24 @@ the port models agree, and **structural equivalence of a generated setup is not
 evidence of physics agreement** at all. The emitter's job is to remove
 hand-porting divergence, not to produce agreement.
 
-### Acceptance target for the first emitter (verified to exist)
+### What the openEMS emitter was actually gated on
+
+**Not cv06b.** The emitter is gated on **executability**, on a coarse two-port
+PEC cavity: an emitted script is written to disk, run as a subprocess under
+openEMS, and the artifact is asserted to be finite, passive (≤ 1.05), to have a
+non-empty `approximations` list, to show a non-zero incident peak (so the ports
+really are on-grid — openEMS silently drops an off-grid excitation), and to give
+`|S11| > 0.9` as a lossless closed cavity must. Every one of those is a statement
+about the emitted artifact, not about rfx.
+
+A physics-agreement comparison against the committed cv06b reference was
+**deliberately not attempted**: dx = 50 µm over that domain is ~1.6 M cells ×
+600 k timesteps, and a coarse stand-in would not be evidence. The next
+well-defined step is cheaper and more diagnostic anyway — compare a *generated*
+openEMS setup against the repo's *hand-written* one at the same mesh, where any
+difference is emitter fidelity rather than solver physics.
+
+### The cv06b reference that a future physics comparison would use
 
 `tests/test_msl_notch_e4_comparison_gates.py` + `tests/fixtures/msl_notch_e4/`
 already hold a committed physical openEMS dx = 50 µm reference for the cv06b
@@ -315,3 +332,43 @@ Both come from the target-API survey and neither has a defensible default:
 | import direction (GDSII, CST history list, PyAEDT enumeration) | **researched only** |
 | consolidation of the four existing serialisers | **not started** |
 | physics agreement against `tests/fixtures/msl_notch_e4/` | **not attempted** — cv06b at dx = 50 µm is ~1.6M cells × 600k steps; a coarse run would not be evidence |
+
+## Corrections to the target-API survey (found while implementing)
+
+The survey report was the emitter's specification, and implementing against it
+surfaced three errors in it. Recorded here because the report itself is a
+scratch artifact and these are the durable parts.
+
+1. **The two rfx port builders use OPPOSITE direction conventions.** The survey
+   claimed `add_msl_port(direction=...)` maps to an openEMS `MSLPort` whose
+   `stop - start` sign is the negation of the rfx direction. That is true for
+   `add_port` but **not** for `add_msl_port`:
+   - `add_port` — direction is the **outward normal**: *"Outward-normal
+     direction of the port (from the port cell into the external world)"*
+     (`rfx/api/__init__.py:1116`). openEMS propagation points *into* the line,
+     so the negation is correct here.
+   - `add_msl_port` — direction is the **propagation direction**: *"Direction
+     the launched wave propagates away from the feed plane"*
+     (`rfx/sources/msl_port.py:51`). No negation.
+   Getting this wrong yields a plausible-looking S21 with the wrong reference
+   sense, so it is pinned by a test asserting the physical consequence (both
+   spans land strictly inside the port-to-port interval) rather than an
+   arithmetic sign.
+2. **The survey's recommended excitation guard `uf_inc <= 1e-9` would
+   false-fire.** Measured `incident_peak_abs` on runs that produced correct
+   S-parameters: **1.93e-12** (PEC cavity) and **1.79e-13** (MSL thru). That
+   threshold is live in
+   `scripts/diagnostics/build_coaxial_line_openems_broad_comparison.py:214-223`
+   and is worth auditing before it is reused. The emitter instead tests for
+   zero/non-finite plus an independent port time-trace witness.
+3. **Pinning mesh lines at conductor faces is wrong for a faithful uniform-mesh
+   projection.** rfx rasterises geometry against the uniform grid, so inserting
+   lines at conductor faces hands openEMS a mesh rfx never used. Only *port*
+   edges are pinned (openEMS drops an off-grid excitation outright), snapped
+   with the same `round(pos/dx)` rule as `Grid.position_to_index`.
+
+Also worth knowing, because it is indistinguishable from a real failure in the
+log: openEMS prints `Unused primitive (type: Box) ... msl_feed_N` whenever the
+design's own trace already covers the MSL port span. Benign when both are PEC —
+but it is the *same* log line as the port-was-dropped failure mode, so the
+incident-peak witness is what actually discriminates.

--- a/docs/design_notes/geometry_setup_interop.md
+++ b/docs/design_notes/geometry_setup_interop.md
@@ -1,9 +1,11 @@
 # Geometry / setup export–import interop
 
-Status: **PROVISIONAL — under construction.** The primitive-level codecs are
-implemented and contract-tested; the design document, the external-solver
-emitters, and the import direction are not yet landed. Nothing here is a
-validated claim about agreement with another solver.
+Status: **PROVISIONAL.** The rfx⇄rfx design document and the first external
+emitter (openEMS) are implemented and contract-tested; the import direction is
+researched only. **Nothing here is a validated claim about agreement with
+another solver** — the openEMS emitter is proven *executable*, not *agreeing*,
+and the port models are known to differ by ~0.20 in |S| before any physics is in
+question (see the ceiling section below).
 Date: 2026-07-25. Branch: `feat/geometry-setup-interop`.
 
 ## Question
@@ -305,8 +307,11 @@ Both come from the target-API survey and neither has a defensible default:
 | shape codec, 6/6 primitives, registry pinned to live signatures | implemented, contract-tested |
 | material codec incl. dispersion poles | implemented, contract-tested |
 | `MeshShape` / subclass / impostor-class refusals | implemented, tested |
-| design document (`Simulation` ⇄ document) | **in progress** |
-| published JSON Schema for the document | **in progress** |
-| external-solver emitters (PyAEDT / CST VBA / openEMS / Meep) | **not started** |
+| design document (`Simulation` ⇄ document, `rfx-design-ir/v1`) | implemented; round trip gated over 16 fixtures by an all-attribute diff whose non-vacuity is itself proven by 7 mutation tests |
+| completeness ledgers | implemented: a new `Simulation.__init__` attribute or `add_*` method reds a test until a decision is recorded |
+| published JSON Schema for the document | implemented, pinned to the code and validated against every design fixture |
+| openEMS emitter | implemented; **executability** proven by an emitted script that actually runs under openEMS and returns finite, passive S-parameters. Shapes are limited to `box`/`cylinder` — the rest refuse because no translation of them has ever been checked against a known-good result in this repo |
+| CST VBA / PyAEDT / Meep emitters | **not started** (CST needs VBA emission; neither CST nor HFSS can be verified here without a licence) |
 | import direction (GDSII, CST history list, PyAEDT enumeration) | **researched only** |
 | consolidation of the four existing serialisers | **not started** |
+| physics agreement against `tests/fixtures/msl_notch_e4/` | **not attempted** — cv06b at dx = 50 µm is ~1.6M cells × 600k steps; a coarse run would not be evidence |

--- a/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
+++ b/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://remilab.ai/rfx/schemas/rfx-design-ir-v1.schema.json",
   "title": "rfx design IR v1",
-  "description": "Round-trip-complete description of an rfx Simulation's DESIGN state, emitted by rfx.interop.design_to_dict and consumed by rfx.interop.simulation_from_design. This is the rfx-to-rfx profile: its gate is structural equality after a round trip. An external-solver projection is a SEPARATE, explicitly lossy artifact and is not described by this schema. Derived state (Grid, dt, axis_pads), preflight verdicts, results, and run-time controls (n_steps, until_decay, compute_s_params, eps_override, ...) are deliberately absent: a design description that carries them invites a reader to trust them. Anything that cannot be represented exactly is refused at export time with UnsupportedDesignFeature rather than approximated.",
+  "description": "Round-trip-complete description of an rfx Simulation's DESIGN state, emitted by rfx.interop.design_to_dict and consumed by rfx.interop.simulation_from_design. This is the rfx-to-rfx profile: its gate is structural equality after a round trip. An external-solver projection is a SEPARATE, explicitly lossy artifact and is not described by this schema. Derived state (Grid, dt, axis_pads), preflight verdicts, results, and run-time controls (n_steps, until_decay, compute_s_params, eps_override, ...) are deliberately absent: a design description that carries them invites a reader to trust them. Anything that cannot be represented exactly is refused at export time with UnsupportedDesignFeature rather than approximated. SCOPE OF A PASS: this schema pins the document LAYER — key sets, value types, and the closed vocabularies the codecs enforce (shape kind, waveform kind, boundary token, array container). It does NOT re-encode builder fences, which are enforced on import by the Simulation builders the importer drives. A schema-valid document can still be refused (a Floquet port with n_modes > 1 raises the builder's own NotImplementedError), so validating means 'well-formed', never 'physically supported'.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -28,23 +28,82 @@
     },
     "rfx_version": {
       "type": "string",
+      "minLength": 1,
       "description": "Provenance only. It records which rfx wrote the document; it is not a compatibility contract."
     },
     "domain": {
       "type": "object",
-      "description": "Physical extent and reduction mode. The extent is the USER domain: rfx adds CPML cells OUTSIDE it (measured: domain 10 mm at dx 1 mm gives grid 11 cells at cpml_layers=0 and 11+2N otherwise), so an external emitter must span domain + 2*cpml_layers*dx per absorbing axis."
+      "description": "Physical extent and reduction mode. The extent is the USER domain: rfx adds CPML cells OUTSIDE it (measured: domain 10 mm at dx 1 mm gives grid 11 cells at cpml_layers=0 and 11+2N otherwise), so an external emitter must span domain + 2*cpml_layers*dx per absorbing axis.",
+      "additionalProperties": false,
+      "required": ["freq_max", "extent", "mode"],
+      "properties": {
+        "freq_max": { "type": "number", "exclusiveMinimum": 0 },
+        "extent": { "$ref": "#/$defs/vec3" },
+        "mode": { "type": "string", "minLength": 1 }
+      }
     },
     "mesh": {
       "type": "object",
-      "description": "Cell size and optional per-axis graded profiles. Profiles are emitted value-by-value with their dtype and array namespace, never summarised: rfx synthesises the domain extent from float(np.sum(profile)), so a truncated profile silently changes the domain. A profile that is a JAX tracer is refused, because a traced profile is a differentiable design variable with no concrete value to record."
+      "description": "Cell size and optional per-axis graded profiles. Profiles are emitted value-by-value with their dtype and array namespace, never summarised: rfx synthesises the domain extent from float(np.sum(profile)), so a truncated profile silently changes the domain. A profile that is a JAX tracer is refused, because a traced profile is a differentiable design variable with no concrete value to record.",
+      "additionalProperties": false,
+      "required": ["dx", "dx_profile", "dy_profile", "dz_profile"],
+      "properties": {
+        "dx": {
+          "type": ["number", "null"],
+          "description": "Boundary cell size in metres. null is the auto-mesh path: the mesh choice is deferred to auto_configure inside run(), which writes back _dx, _dz_profile and _domain. Exporting the same script before and after a run therefore yields different documents, and both are faithful."
+        },
+        "dx_profile": { "$ref": "#/$defs/array_or_null" },
+        "dy_profile": { "$ref": "#/$defs/array_or_null" },
+        "dz_profile": { "$ref": "#/$defs/array_or_null" }
+      }
     },
     "boundary": {
       "type": "object",
-      "description": "Authoritative per-face BoundarySpec plus the derived legacy scalar view. _boundary, _pec_faces and _periodic_axes are derived from the spec, except that _periodic_axes is also mutated as a side effect by add_floquet_port, so it is emitted explicitly rather than re-derived on import."
+      "description": "Authoritative per-face BoundarySpec plus the derived legacy scalar view. _boundary, _pec_faces and _periodic_axes are derived from the spec, except that _periodic_axes is also mutated as a side effect by add_floquet_port, so it is emitted explicitly rather than re-derived on import.",
+      "additionalProperties": false,
+      "required": ["spec", "legacy"],
+      "properties": {
+        "spec": {
+          "type": "object",
+          "description": "BoundarySpec.to_dict() verbatim; authoritative.",
+          "additionalProperties": false,
+          "required": ["x", "y", "z"],
+          "properties": {
+            "x": { "$ref": "#/$defs/boundary_axis" },
+            "y": { "$ref": "#/$defs/boundary_axis" },
+            "z": { "$ref": "#/$defs/boundary_axis" }
+          }
+        },
+        "legacy": {
+          "type": "object",
+          "description": "The legacy views are NOT merely redundant, which is why the importer reads them rather than re-deriving everything from the spec. Measured: boundary='pec' leaves _pec_faces empty while BoundarySpec.uniform('pec') produces the identical _boundary_spec but derives all six faces; and set_periodic_axes('xyz') leaves _boundary='cpml' with a non-zero layer count while the all-periodic spec would derive 'pec' and 0. This section is what lets the importer reproduce the construction PATH, not just the spec.",
+          "additionalProperties": false,
+          "required": ["boundary", "cpml_layers", "cpml_kappa_max", "pec_faces", "periodic_axes"],
+          "properties": {
+            "boundary": { "type": "string", "minLength": 1 },
+            "cpml_layers": { "type": "integer", "minimum": 0 },
+            "cpml_kappa_max": { "type": "number" },
+            "pec_faces": {
+              "type": "array",
+              "uniqueItems": true,
+              "items": { "enum": ["x_lo", "x_hi", "y_lo", "y_hi", "z_lo", "z_hi"] }
+            },
+            "periodic_axes": { "type": "string", "pattern": "^x?y?z?$" }
+          }
+        }
+      }
     },
     "solver": {
       "type": "object",
-      "description": "rfx-only solver controls (precision, solver, adi_cfl_factor, stencil_order). These round-trip in rfx and have no counterpart in openEMS/Meep/CST/HFSS; they appear in non_portable."
+      "description": "rfx-only solver controls (precision, solver, adi_cfl_factor, stencil_order). These round-trip in rfx and have no counterpart in openEMS/Meep/CST/HFSS; they appear in non_portable.",
+      "additionalProperties": false,
+      "required": ["precision", "solver", "adi_cfl_factor", "stencil_order"],
+      "properties": {
+        "precision": { "type": "string", "minLength": 1 },
+        "solver": { "type": "string", "minLength": 1 },
+        "adi_cfl_factor": { "type": "number" },
+        "stencil_order": { "type": "integer" }
+      }
     },
     "materials": {
       "type": "object",
@@ -88,7 +147,8 @@
     },
     "material_library": {
       "type": "object",
-      "description": "Library entries the design referenced, recorded so a document does not depend on the writer's library version."
+      "description": "Library entries the design referenced, recorded so a document does not depend on the writer's library version. Provenance, not applied state: the importer verifies each value against the live MATERIAL_LIBRARY and refuses on drift, but does not register them — the original design did not either. Same payload as `materials`.",
+      "additionalProperties": { "$ref": "#/properties/materials/additionalProperties" }
     },
     "geometry": {
       "type": "array",
@@ -105,7 +165,18 @@
     },
     "thin_conductors": {
       "type": "array",
-      "description": "Thin-conductor sheet entries (shape plus sigma_bulk / thickness / eps_r). Routed to a PEC mask when the effective conductivity is high enough."
+      "description": "Thin-conductor sheet entries (shape plus sigma_bulk / thickness / eps_r). Routed to a PEC mask when the effective conductivity is high enough.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["shape", "sigma_bulk", "thickness", "eps_r"],
+        "properties": {
+          "shape": { "$ref": "#/$defs/shape" },
+          "sigma_bulk": { "type": "number" },
+          "thickness": { "type": "number" },
+          "eps_r": { "type": "number" }
+        }
+      }
     },
     "excitations": {
       "type": "object",
@@ -125,29 +196,283 @@
         "lumped_rlc"
       ],
       "properties": {
-        "soft_sources": { "type": "array" },
-        "lumped_ports": { "type": "array" },
+        "soft_sources": {
+          "type": "array",
+          "description": "add_source() entries. Only the three fields add_source can set are recorded: an impedance-0 entry carrying extent / excite / direction / reference_plane_cells was not built through the public API and is refused at export.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["position", "component", "waveform"],
+            "properties": {
+              "position": { "$ref": "#/$defs/vec3" },
+              "component": { "type": "string", "minLength": 1 },
+              "waveform": { "$ref": "#/$defs/waveform_or_null" }
+            }
+          }
+        },
+        "lumped_ports": {
+          "type": "array",
+          "description": "add_port() entries: single-cell lumped ports (extent null) and multi-cell wire ports.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "position",
+              "component",
+              "impedance",
+              "waveform",
+              "extent",
+              "excite",
+              "direction",
+              "reference_plane_cells"
+            ],
+            "properties": {
+              "position": { "$ref": "#/$defs/vec3" },
+              "component": { "type": "string", "minLength": 1 },
+              "impedance": { "type": "number", "exclusiveMinimum": 0 },
+              "waveform": { "$ref": "#/$defs/waveform_or_null" },
+              "extent": { "type": ["number", "null"] },
+              "excite": { "type": "boolean" },
+              "direction": { "type": ["string", "null"] },
+              "reference_plane_cells": {
+                "type": ["integer", "null"],
+                "description": "NON-PORTABLE: a cell count, not a physical measurement-plane distance."
+              }
+            }
+          }
+        },
         "msl_ports": {
           "type": "array",
-          "description": "n_probe_offset and n_probe_spacing are CELL COUNTS derived from dx at registration time, not physical lengths; they appear in non_portable."
+          "description": "n_probe_offset and n_probe_spacing are CELL COUNTS derived from dx at registration time, not physical lengths; they appear in non_portable.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "position",
+              "width",
+              "height",
+              "direction",
+              "impedance",
+              "waveform",
+              "excite",
+              "n_probe_offset",
+              "n_probe_spacing",
+              "n_probes",
+              "mode",
+              "eps_r_sub"
+            ],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "position": { "$ref": "#/$defs/vec3" },
+              "width": { "type": "number" },
+              "height": { "type": "number" },
+              "direction": { "type": "string", "minLength": 1 },
+              "impedance": { "type": "number" },
+              "waveform": { "$ref": "#/$defs/waveform_or_null" },
+              "excite": { "type": "boolean" },
+              "n_probe_offset": { "type": "integer" },
+              "n_probe_spacing": { "type": "integer" },
+              "n_probes": { "type": "integer" },
+              "mode": { "type": "string", "minLength": 1 },
+              "eps_r_sub": { "type": ["number", "null"] }
+            }
+          }
         },
-        "waveguide_ports": { "type": "array" },
-        "coaxial_ports": { "type": "array" },
+        "waveguide_ports": {
+          "type": "array",
+          "description": "probe_offset and ref_offset are cell counts from the source plane, not physical distances. `waveform` here is a waveform NAME (a string the runner resolves), not a waveform object like the lumped/MSL/coaxial families carry.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "x_position",
+              "y_range",
+              "z_range",
+              "x_range",
+              "mode",
+              "mode_type",
+              "direction",
+              "freqs",
+              "n_freqs",
+              "f0",
+              "bandwidth",
+              "amplitude",
+              "probe_offset",
+              "ref_offset",
+              "calibration_preset",
+              "reference_plane",
+              "probe_plane",
+              "n_modes",
+              "waveform",
+              "mode_profile"
+            ],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "x_position": { "type": "number" },
+              "y_range": { "$ref": "#/$defs/vec2_or_null" },
+              "z_range": { "$ref": "#/$defs/vec2_or_null" },
+              "x_range": { "$ref": "#/$defs/vec2_or_null" },
+              "mode": { "$ref": "#/$defs/ivec2" },
+              "mode_type": { "type": "string", "minLength": 1 },
+              "direction": { "type": "string", "minLength": 1 },
+              "freqs": { "$ref": "#/$defs/array_or_null" },
+              "n_freqs": { "type": "integer" },
+              "f0": { "type": ["number", "null"] },
+              "bandwidth": { "type": "number" },
+              "amplitude": { "type": "number" },
+              "probe_offset": { "type": "integer" },
+              "ref_offset": { "type": "integer" },
+              "calibration_preset": { "type": ["string", "null"] },
+              "reference_plane": { "type": ["number", "null"] },
+              "probe_plane": { "type": ["number", "null"] },
+              "n_modes": { "type": "integer" },
+              "waveform": { "type": "string", "minLength": 1 },
+              "mode_profile": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "coaxial_ports": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "position",
+              "face",
+              "pin_length",
+              "pin_radius",
+              "outer_radius",
+              "impedance",
+              "excitation"
+            ],
+            "properties": {
+              "position": { "$ref": "#/$defs/vec3" },
+              "face": { "type": "string", "minLength": 1 },
+              "pin_length": { "type": "number" },
+              "pin_radius": { "type": "number" },
+              "outer_radius": { "type": "number" },
+              "impedance": { "type": "number" },
+              "excitation": { "$ref": "#/$defs/waveform_or_null" }
+            }
+          }
+        },
         "coaxial_matched_loads": {
           "type": "array",
-          "description": "Offsets are cell-relative, not physical coordinates; see non_portable."
+          "description": "Offsets are cell-relative, not physical coordinates; see non_portable. target_impedance is always the resolved number, never the add_coaxial_matched_load(target_impedance=None) sentinel that the builder fills from the port's closed-form Z_TEM.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["port_index", "target_impedance", "axial_offset_cells"],
+            "properties": {
+              "port_index": { "type": "integer", "minimum": 0 },
+              "target_impedance": { "type": "number" },
+              "axial_offset_cells": { "type": "integer" }
+            }
+          }
         },
-        "coaxial_open_terminations": { "type": "array" },
-        "coaxial_pec_end_caps": { "type": "array" },
+        "coaxial_open_terminations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["port_index", "pin_retract_cells"],
+            "properties": {
+              "port_index": { "type": "integer", "minimum": 0 },
+              "pin_retract_cells": { "type": "integer" }
+            }
+          }
+        },
+        "coaxial_pec_end_caps": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["port_index", "axial_offset_cells"],
+            "properties": {
+              "port_index": { "type": "integer", "minimum": 0 },
+              "axial_offset_cells": { "type": "integer" }
+            }
+          }
+        },
         "floquet_ports": {
           "type": "array",
-          "description": "Import goes through add_floquet_port, so the builder's fences still fire: a document tampered to n_modes > 1 raises the builder's own NotImplementedError rather than widening the fence."
+          "description": "Import goes through add_floquet_port, so the builder's fences still fire: a document tampered to n_modes > 1 raises the builder's own NotImplementedError rather than widening the fence.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "position",
+              "axis",
+              "scan_theta",
+              "scan_phi",
+              "polarization",
+              "n_modes",
+              "freqs",
+              "n_freqs",
+              "f0",
+              "bandwidth",
+              "amplitude"
+            ],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "position": { "type": "number" },
+              "axis": { "type": "string", "minLength": 1 },
+              "scan_theta": { "type": "number" },
+              "scan_phi": { "type": "number" },
+              "polarization": { "type": "string", "minLength": 1 },
+              "n_modes": { "type": "integer" },
+              "freqs": { "$ref": "#/$defs/array_or_null" },
+              "n_freqs": { "type": "integer" },
+              "f0": { "type": ["number", "null"] },
+              "bandwidth": { "type": "number" },
+              "amplitude": { "type": "number" }
+            }
+          }
         },
         "tfsf": {
           "type": ["object", "null"],
-          "description": "Total-field/scattered-field plane wave. Projecting this onto a commercial solver's plane-wave source is an approximation with a different absorber story, not a translation."
+          "description": "Total-field/scattered-field plane wave. Projecting this onto a commercial solver's plane-wave source is an approximation with a different absorber story, not a translation. `margin` is in cells, and `waveform` is a pulse-shape NAME resolved by the 1-D auxiliary grid.",
+          "additionalProperties": false,
+          "required": [
+            "f0",
+            "bandwidth",
+            "amplitude",
+            "margin",
+            "polarization",
+            "direction",
+            "angle_deg",
+            "waveform"
+          ],
+          "properties": {
+            "f0": { "type": ["number", "null"] },
+            "bandwidth": { "type": "number" },
+            "amplitude": { "type": "number" },
+            "margin": { "type": "integer" },
+            "polarization": { "type": "string", "minLength": 1 },
+            "direction": { "type": "string", "minLength": 1 },
+            "angle_deg": { "type": "number" },
+            "waveform": { "type": "string", "minLength": 1 }
+          }
         },
-        "lumped_rlc": { "type": "array" }
+        "lumped_rlc": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["R", "L", "C", "topology", "position", "component"],
+            "properties": {
+              "R": { "type": "number", "minimum": 0 },
+              "L": { "type": "number", "minimum": 0 },
+              "C": { "type": "number", "minimum": 0 },
+              "topology": { "type": "string", "minLength": 1 },
+              "position": { "$ref": "#/$defs/vec3" },
+              "component": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
       }
     },
     "observables": {
@@ -157,34 +482,163 @@
       "properties": {
         "probes": {
           "type": "array",
-          "description": "add_vector_probe expands to six flat entries inside rfx itself, so the vector grouping is already lost upstream; only the flat entries round-trip."
+          "description": "add_vector_probe expands to six flat entries inside rfx itself, so the vector grouping is already lost upstream; only the flat entries round-trip.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["position", "component"],
+            "properties": {
+              "position": { "$ref": "#/$defs/vec3" },
+              "component": { "type": "string", "minLength": 1 }
+            }
+          }
         },
-        "dft_planes": { "type": "array" },
-        "flux_monitors": { "type": "array" },
+        "dft_planes": {
+          "type": "array",
+          "description": "freqs is null when the design deferred the frequency grid to n_freqs; the (null, n_freqs) pair is emitted as-is because collapsing either way changes which bins are computed.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "axis", "coordinate", "component", "freqs", "n_freqs"],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "axis": { "type": "string", "minLength": 1 },
+              "coordinate": { "type": "number" },
+              "component": { "type": "string", "minLength": 1 },
+              "freqs": { "$ref": "#/$defs/array_or_null" },
+              "n_freqs": { "type": "integer" }
+            }
+          }
+        },
+        "flux_monitors": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "name",
+              "axis",
+              "coordinate",
+              "freqs",
+              "n_freqs",
+              "size",
+              "center",
+              "dft_window",
+              "dft_window_alpha"
+            ],
+            "properties": {
+              "name": { "type": "string", "minLength": 1 },
+              "axis": { "type": "string", "minLength": 1 },
+              "coordinate": { "type": "number" },
+              "freqs": { "$ref": "#/$defs/array_or_null" },
+              "n_freqs": { "type": "integer" },
+              "size": { "$ref": "#/$defs/vec2_or_null" },
+              "center": { "$ref": "#/$defs/vec2_or_null" },
+              "dft_window": { "type": "string", "minLength": 1 },
+              "dft_window_alpha": { "type": "number" }
+            }
+          }
+        },
         "ntff": {
           "type": ["object", "null"],
-          "description": "freqs is emitted as an explicit array because n_freqs is defaulted at registration and is not recoverable from the stored tuple."
+          "description": "freqs is emitted as an explicit array because n_freqs is defaulted at registration and is not recoverable from the stored tuple. It is therefore never null here, unlike the deferred (null, n_freqs) pairs the DFT-plane and flux families allow.",
+          "additionalProperties": false,
+          "required": ["corner_lo", "corner_hi", "freqs"],
+          "properties": {
+            "corner_lo": { "$ref": "#/$defs/vec3" },
+            "corner_hi": { "$ref": "#/$defs/vec3" },
+            "freqs": { "$ref": "#/$defs/array_payload" }
+          }
         }
       }
     },
     "refinement": {
       "type": ["object", "null"],
-      "description": "SBP-SAT subgrid directives. Experimental and falsified in 3D (PR #90): round-trip inside rfx, never project outward."
+      "description": "SBP-SAT subgrid directives. Experimental and falsified in 3D (PR #90): round-trip inside rfx, never project outward.",
+      "additionalProperties": false,
+      "required": ["z_range", "ratio", "xy_margin", "tau", "validation", "topology"],
+      "properties": {
+        "z_range": { "$ref": "#/$defs/vec2" },
+        "ratio": { "type": "integer" },
+        "xy_margin": { "type": ["number", "null"] },
+        "tau": { "type": "number" },
+        "validation": { "type": "string", "minLength": 1 },
+        "topology": { "type": "string", "minLength": 1 }
+      }
     },
     "non_portable": {
       "type": "array",
-      "description": "DERIVED annotation, not independent state: the paths in this document whose meaning does not survive a translation, each with the reason. An external emitter must consult this and refuse or record an explicit approximation; it must not ship these silently.",
+      "description": "DERIVED annotation, not independent state: the paths in this document whose meaning does not survive a translation, each with the reason. An external emitter must consult this and refuse or record an explicit approximation; it must not ship these silently. Nothing is applied from it on import, but it IS verified — the importer re-exports and compares, so the list cannot be edited away to make rfx-only state look portable. Sorted by path.",
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "required": ["path", "reason"],
         "properties": {
-          "path": { "type": "string" },
-          "reason": { "type": "string" }
+          "path": { "type": "string", "minLength": 1 },
+          "reason": { "type": "string", "minLength": 1 }
         }
       }
     }
   },
   "$defs": {
+    "vec2": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": { "type": "number" }
+    },
+    "vec2_or_null": {
+      "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/vec2" }]
+    },
+    "vec3": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": { "type": "number" }
+    },
+    "ivec2": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 2,
+      "items": { "type": "integer" }
+    },
+    "array_payload": {
+      "type": "object",
+      "description": "A 1-D numeric array recorded value by value, never summarised. The container and dtype are part of the record because Simulation.__init__ synthesises the domain extent from float(np.sum(profile)): a float32 profile reloaded as float64 shifts the extent in the last ULPs and breaks the repo's bit-identity gates. dtype is REQUIRED for the numpy and jax containers and FORBIDDEN for list and tuple, which carry no dtype. Contrast rfx.artifacts._profile_summary, which emits {present, shape, min, max, sum} — a summary that cannot be rebuilt.",
+      "additionalProperties": false,
+      "required": ["container", "values"],
+      "properties": {
+        "container": { "enum": ["list", "tuple", "numpy", "jax"] },
+        "dtype": { "type": "string", "minLength": 1 },
+        "values": { "type": "array", "items": { "type": "number" } }
+      },
+      "if": {
+        "properties": { "container": { "enum": ["numpy", "jax"] } },
+        "required": ["container"]
+      },
+      "then": { "required": ["container", "dtype", "values"] },
+      "else": { "not": { "required": ["dtype"] } }
+    },
+    "array_or_null": {
+      "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/array_payload" }]
+    },
+    "boundary_axis": {
+      "type": "object",
+      "description": "Boundary.to_dict() for one axis. lo_thickness / hi_thickness appear only when set, and only absorbing faces may carry them; conformal appears only when true, and only on a symmetric PEC axis.",
+      "additionalProperties": false,
+      "required": ["lo", "hi"],
+      "properties": {
+        "lo": { "$ref": "#/$defs/boundary_token" },
+        "hi": { "$ref": "#/$defs/boundary_token" },
+        "lo_thickness": { "type": "integer", "minimum": 0 },
+        "hi_thickness": { "type": "integer", "minimum": 0 },
+        "conformal": { "const": true }
+      }
+    },
+    "boundary_token": {
+      "enum": ["cpml", "upml", "pec", "pmc", "periodic"],
+      "description": "rfx.boundaries.spec.BOUNDARY_TOKENS. pmc and the per-axis conformal flag are rfx-only."
+    },
     "shape": {
       "type": "object",
       "additionalProperties": false,
@@ -196,9 +650,168 @@
         },
         "params": {
           "type": "object",
-          "description": "Constructor arguments for the named kind. Vectors are JSON arrays of finite numbers; the importer restores the tuple types the primitives declare so a round-tripped frozen dataclass compares equal. NaN, infinity and JAX tracers are refused at the codec layer, where the parameter name is still known."
+          "description": "Constructor arguments for the named kind. Vectors are JSON arrays of finite numbers; the importer restores the tuple types the primitives declare so a round-tripped frozen dataclass compares equal. NaN, infinity and JAX tracers are refused at the codec layer, where the parameter name is still known. The allOf below pins the exact parameter set per kind, so a shape gaining or losing a constructor argument fails validation rather than passing as a loose object."
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "kind": { "const": "box" } }, "required": ["kind"] },
+          "then": {
+            "properties": {
+              "params": {
+                "additionalProperties": false,
+                "required": ["corner_lo", "corner_hi"],
+                "properties": {
+                  "corner_lo": { "$ref": "#/$defs/vec3" },
+                  "corner_hi": { "$ref": "#/$defs/vec3" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "kind": { "const": "cylinder" } }, "required": ["kind"] },
+          "then": {
+            "properties": {
+              "params": {
+                "additionalProperties": false,
+                "required": ["center", "radius", "height", "axis"],
+                "properties": {
+                  "center": { "$ref": "#/$defs/vec3" },
+                  "radius": { "type": "number" },
+                  "height": { "type": "number" },
+                  "axis": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "kind": { "const": "sphere" } }, "required": ["kind"] },
+          "then": {
+            "properties": {
+              "params": {
+                "additionalProperties": false,
+                "required": ["center", "radius"],
+                "properties": {
+                  "center": { "$ref": "#/$defs/vec3" },
+                  "radius": { "type": "number" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "kind": { "const": "polyline_wire" } }, "required": ["kind"] },
+          "then": {
+            "properties": {
+              "params": {
+                "additionalProperties": false,
+                "required": ["points", "radius"],
+                "properties": {
+                  "points": { "type": "array", "items": { "$ref": "#/$defs/vec3" } },
+                  "radius": { "type": "number" }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "kind": { "const": "via" } }, "required": ["kind"] },
+          "then": {
+            "properties": {
+              "params": {
+                "additionalProperties": false,
+                "required": ["center", "drill_radius", "pad_radius", "layers", "material"],
+                "properties": {
+                  "center": { "$ref": "#/$defs/vec2" },
+                  "drill_radius": { "type": "number" },
+                  "pad_radius": { "type": "number" },
+                  "layers": { "type": "array", "items": { "$ref": "#/$defs/vec2" } },
+                  "material": {
+                    "type": "string",
+                    "description": "Via carries its OWN material in addition to the material= handed to Simulation.add(). Both are recorded; resolving the two is the caller's decision, not something the codec may silently pick."
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": { "properties": { "kind": { "const": "curved_patch" } }, "required": ["kind"] },
+          "then": {
+            "properties": {
+              "params": {
+                "additionalProperties": false,
+                "required": ["center", "length", "width", "radius", "axis"],
+                "properties": {
+                  "center": { "$ref": "#/$defs/vec3" },
+                  "length": { "type": "number" },
+                  "width": { "type": "number" },
+                  "radius": { "type": "number" },
+                  "axis": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "waveform": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "params"],
+      "description": "An excitation waveform recorded as its dataclass parameters. CustomWaveform is deliberately absent: it wraps a Python callable, which has no serialisable form — and because add_polarized_source builds a CustomWaveform closure for a complex Jones vector, that also refuses a circularly polarised source (already unrecoverable from _ports inside rfx itself). Note the waveguide-port and TFSF families do NOT use this payload: they store a waveform NAME as a plain string.",
+      "properties": {
+        "kind": { "enum": ["cw_source", "gaussian_pulse", "modulated_gaussian"] },
+        "params": { "type": "object" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "kind": { "const": "gaussian_pulse" } }, "required": ["kind"] },
+          "then": { "properties": { "params": { "$ref": "#/$defs/gaussian_params" } } }
+        },
+        {
+          "if": {
+            "properties": { "kind": { "const": "modulated_gaussian" } },
+            "required": ["kind"]
+          },
+          "then": { "properties": { "params": { "$ref": "#/$defs/gaussian_params" } } }
+        },
+        {
+          "if": { "properties": { "kind": { "const": "cw_source" } }, "required": ["kind"] },
+          "then": {
+            "properties": {
+              "params": {
+                "additionalProperties": false,
+                "required": ["f0", "amplitude", "ramp_steps"],
+                "properties": {
+                  "f0": { "type": "number" },
+                  "amplitude": { "type": "number" },
+                  "ramp_steps": { "type": "integer" }
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "gaussian_params": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["f0", "bandwidth", "amplitude", "cutoff"],
+      "properties": {
+        "f0": { "type": "number" },
+        "bandwidth": { "type": "number" },
+        "amplitude": { "type": "number" },
+        "cutoff": {
+          "type": "number",
+          "description": "Number of tau between t=0 and the pulse peak. Load-bearing, not cosmetic: the deposited-DC integral scales as e^(-cutoff^2) (issue #388), so dropping it would silently change the static source remnant."
         }
       }
+    },
+    "waveform_or_null": {
+      "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/waveform" }]
     }
   }
 }

--- a/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
+++ b/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
@@ -1210,7 +1210,7 @@
         "pmc",
         "periodic"
       ],
-      "description": "rfx.boundaries.spec.BOUNDARY_TOKENS. pmc and the per-axis conformal flag are rfx-only."
+      "description": "rfx.boundaries.spec.BOUNDARY_TOKENS. Portability differs per token: pec/pmc/cpml/upml all have openEMS counterparts (this branch's emitter maps pmc to 'PMC'), while the per-axis conformal flag is rfx-only and the emitter refuses it rather than emitting a staircased face. Note that a shared token name does not mean a shared formulation: rfx CPML and openEMS PML are different absorbers at the same layer count, which is why the absorber appears in non_portable."
     },
     "shape": {
       "type": "object",

--- a/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
+++ b/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://remilab.ai/rfx/schemas/rfx-design-ir-v1.schema.json",
   "title": "rfx design IR v1",
-  "description": "Round-trip-complete description of an rfx Simulation's DESIGN state, emitted by rfx.interop.design_to_dict and consumed by rfx.interop.simulation_from_design. This is the rfx-to-rfx profile: its gate is structural equality after a round trip. An external-solver projection is a SEPARATE, explicitly lossy artifact and is not described by this schema. Derived state (Grid, dt, axis_pads), preflight verdicts, results, and run-time controls (n_steps, until_decay, compute_s_params, eps_override, ...) are deliberately absent: a design description that carries them invites a reader to trust them. Anything that cannot be represented exactly is refused at export time with UnsupportedDesignFeature rather than approximated. SCOPE OF A PASS: this schema pins the document LAYER — key sets, value types, and the closed vocabularies the codecs enforce (shape kind, waveform kind, boundary token, array container). It does NOT re-encode builder fences, which are enforced on import by the Simulation builders the importer drives. A schema-valid document can still be refused (a Floquet port with n_modes > 1 raises the builder's own NotImplementedError), so validating means 'well-formed', never 'physically supported'.",
+  "description": "Round-trip-complete description of an rfx Simulation's DESIGN state, emitted by rfx.interop.design_to_dict and consumed by rfx.interop.simulation_from_design. This is the rfx-to-rfx profile: its gate is structural equality after a round trip. An external-solver projection is a SEPARATE, explicitly lossy artifact and is not described by this schema. Derived state (Grid, dt, axis_pads), preflight verdicts, results, and run-time controls (n_steps, until_decay, compute_s_params, eps_override, ...) are deliberately absent: a design description that carries them invites a reader to trust them. Anything that cannot be represented exactly is refused at export time with UnsupportedDesignFeature rather than approximated. SCOPE OF A PASS: this schema pins the document LAYER \u2014 key sets, value types, and the closed vocabularies the codecs enforce (shape kind, waveform kind, boundary token, array container). It does NOT re-encode builder fences, which are enforced on import by the Simulation builders the importer drives. A schema-valid document can still be refused (a Floquet port with n_modes > 1 raises the builder's own NotImplementedError), so validating means 'well-formed', never 'physically supported'.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -35,60 +35,125 @@
       "type": "object",
       "description": "Physical extent and reduction mode. The extent is the USER domain: rfx adds CPML cells OUTSIDE it (measured: domain 10 mm at dx 1 mm gives grid 11 cells at cpml_layers=0 and 11+2N otherwise), so an external emitter must span domain + 2*cpml_layers*dx per absorbing axis.",
       "additionalProperties": false,
-      "required": ["freq_max", "extent", "mode"],
+      "required": [
+        "freq_max",
+        "extent",
+        "mode"
+      ],
       "properties": {
-        "freq_max": { "type": "number", "exclusiveMinimum": 0 },
-        "extent": { "$ref": "#/$defs/vec3" },
-        "mode": { "type": "string", "minLength": 1 }
+        "freq_max": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "extent": {
+          "$ref": "#/$defs/vec3"
+        },
+        "mode": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "mesh": {
       "type": "object",
       "description": "Cell size and optional per-axis graded profiles. Profiles are emitted value-by-value with their dtype and array namespace, never summarised: rfx synthesises the domain extent from float(np.sum(profile)), so a truncated profile silently changes the domain. A profile that is a JAX tracer is refused, because a traced profile is a differentiable design variable with no concrete value to record.",
       "additionalProperties": false,
-      "required": ["dx", "dx_profile", "dy_profile", "dz_profile"],
+      "required": [
+        "dx",
+        "dx_profile",
+        "dy_profile",
+        "dz_profile"
+      ],
       "properties": {
         "dx": {
-          "type": ["number", "null"],
+          "type": [
+            "number",
+            "null"
+          ],
           "description": "Boundary cell size in metres. null is the auto-mesh path: the mesh choice is deferred to auto_configure inside run(), which writes back _dx, _dz_profile and _domain. Exporting the same script before and after a run therefore yields different documents, and both are faithful."
         },
-        "dx_profile": { "$ref": "#/$defs/array_or_null" },
-        "dy_profile": { "$ref": "#/$defs/array_or_null" },
-        "dz_profile": { "$ref": "#/$defs/array_or_null" }
+        "dx_profile": {
+          "$ref": "#/$defs/array_or_null"
+        },
+        "dy_profile": {
+          "$ref": "#/$defs/array_or_null"
+        },
+        "dz_profile": {
+          "$ref": "#/$defs/array_or_null"
+        }
       }
     },
     "boundary": {
       "type": "object",
       "description": "Authoritative per-face BoundarySpec plus the derived legacy scalar view. _boundary, _pec_faces and _periodic_axes are derived from the spec, except that _periodic_axes is also mutated as a side effect by add_floquet_port, so it is emitted explicitly rather than re-derived on import.",
       "additionalProperties": false,
-      "required": ["spec", "legacy"],
+      "required": [
+        "spec",
+        "legacy"
+      ],
       "properties": {
         "spec": {
           "type": "object",
           "description": "BoundarySpec.to_dict() verbatim; authoritative.",
           "additionalProperties": false,
-          "required": ["x", "y", "z"],
+          "required": [
+            "x",
+            "y",
+            "z"
+          ],
           "properties": {
-            "x": { "$ref": "#/$defs/boundary_axis" },
-            "y": { "$ref": "#/$defs/boundary_axis" },
-            "z": { "$ref": "#/$defs/boundary_axis" }
+            "x": {
+              "$ref": "#/$defs/boundary_axis"
+            },
+            "y": {
+              "$ref": "#/$defs/boundary_axis"
+            },
+            "z": {
+              "$ref": "#/$defs/boundary_axis"
+            }
           }
         },
         "legacy": {
           "type": "object",
           "description": "The legacy views are NOT merely redundant, which is why the importer reads them rather than re-deriving everything from the spec. Measured: boundary='pec' leaves _pec_faces empty while BoundarySpec.uniform('pec') produces the identical _boundary_spec but derives all six faces; and set_periodic_axes('xyz') leaves _boundary='cpml' with a non-zero layer count while the all-periodic spec would derive 'pec' and 0. This section is what lets the importer reproduce the construction PATH, not just the spec.",
           "additionalProperties": false,
-          "required": ["boundary", "cpml_layers", "cpml_kappa_max", "pec_faces", "periodic_axes"],
+          "required": [
+            "boundary",
+            "cpml_layers",
+            "cpml_kappa_max",
+            "pec_faces",
+            "periodic_axes"
+          ],
           "properties": {
-            "boundary": { "type": "string", "minLength": 1 },
-            "cpml_layers": { "type": "integer", "minimum": 0 },
-            "cpml_kappa_max": { "type": "number" },
+            "boundary": {
+              "type": "string",
+              "minLength": 1
+            },
+            "cpml_layers": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "cpml_kappa_max": {
+              "type": "number"
+            },
             "pec_faces": {
               "type": "array",
               "uniqueItems": true,
-              "items": { "enum": ["x_lo", "x_hi", "y_lo", "y_hi", "z_lo", "z_hi"] }
+              "items": {
+                "enum": [
+                  "x_lo",
+                  "x_hi",
+                  "y_lo",
+                  "y_hi",
+                  "z_lo",
+                  "z_hi"
+                ]
+              }
             },
-            "periodic_axes": { "type": "string", "pattern": "^x?y?z?$" }
+            "periodic_axes": {
+              "type": "string",
+              "pattern": "^x?y?z?$"
+            }
           }
         }
       }
@@ -97,12 +162,27 @@
       "type": "object",
       "description": "rfx-only solver controls (precision, solver, adi_cfl_factor, stencil_order). These round-trip in rfx and have no counterpart in openEMS/Meep/CST/HFSS; they appear in non_portable.",
       "additionalProperties": false,
-      "required": ["precision", "solver", "adi_cfl_factor", "stencil_order"],
+      "required": [
+        "precision",
+        "solver",
+        "adi_cfl_factor",
+        "stencil_order"
+      ],
       "properties": {
-        "precision": { "type": "string", "minLength": 1 },
-        "solver": { "type": "string", "minLength": 1 },
-        "adi_cfl_factor": { "type": "number" },
-        "stencil_order": { "type": "integer" }
+        "precision": {
+          "type": "string",
+          "minLength": 1
+        },
+        "solver": {
+          "type": "string",
+          "minLength": 1
+        },
+        "adi_cfl_factor": {
+          "type": "number"
+        },
+        "stencil_order": {
+          "type": "integer"
+        }
       }
     },
     "materials": {
@@ -111,34 +191,72 @@
       "additionalProperties": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["eps_r", "sigma", "mu_r", "chi3", "debye_poles", "lorentz_poles"],
+        "required": [
+          "eps_r",
+          "sigma",
+          "mu_r",
+          "chi3",
+          "debye_poles",
+          "lorentz_poles"
+        ],
         "properties": {
-          "eps_r": { "type": "number" },
-          "sigma": { "type": "number" },
-          "mu_r": { "type": "number" },
-          "chi3": { "type": "number" },
+          "eps_r": {
+            "type": "number"
+          },
+          "sigma": {
+            "type": "number"
+          },
+          "mu_r": {
+            "type": "number"
+          },
+          "chi3": {
+            "type": "number"
+          },
           "debye_poles": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "type": "object",
               "additionalProperties": false,
-              "required": ["delta_eps", "tau"],
+              "required": [
+                "delta_eps",
+                "tau"
+              ],
               "properties": {
-                "delta_eps": { "type": "number" },
-                "tau": { "type": "number" }
+                "delta_eps": {
+                  "type": "number"
+                },
+                "tau": {
+                  "type": "number"
+                }
               }
             }
           },
           "lorentz_poles": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "items": {
               "type": "object",
               "additionalProperties": false,
-              "required": ["omega_0", "delta", "kappa"],
+              "required": [
+                "omega_0",
+                "delta",
+                "kappa"
+              ],
               "properties": {
-                "omega_0": { "type": "number" },
-                "delta": { "type": "number" },
-                "kappa": { "type": "number" }
+                "omega_0": {
+                  "type": "number"
+                },
+                "delta": {
+                  "type": "number"
+                },
+                "kappa": {
+                  "type": "number"
+                }
               }
             }
           }
@@ -147,8 +265,10 @@
     },
     "material_library": {
       "type": "object",
-      "description": "Library entries the design referenced, recorded so a document does not depend on the writer's library version. Provenance, not applied state: the importer verifies each value against the live MATERIAL_LIBRARY and refuses on drift, but does not register them — the original design did not either. Same payload as `materials`.",
-      "additionalProperties": { "$ref": "#/properties/materials/additionalProperties" }
+      "description": "Library entries the design referenced, recorded so a document does not depend on the writer's library version. Provenance, not applied state: the importer verifies each value against the live MATERIAL_LIBRARY and refuses on drift, but does not register them \u2014 the original design did not either. Same payload as `materials`.",
+      "additionalProperties": {
+        "$ref": "#/properties/materials/additionalProperties"
+      }
     },
     "geometry": {
       "type": "array",
@@ -156,10 +276,17 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["shape", "material_name"],
+        "required": [
+          "shape",
+          "material_name"
+        ],
         "properties": {
-          "shape": { "$ref": "#/$defs/shape" },
-          "material_name": { "type": "string" }
+          "shape": {
+            "$ref": "#/$defs/shape"
+          },
+          "material_name": {
+            "type": "string"
+          }
         }
       }
     },
@@ -169,12 +296,25 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["shape", "sigma_bulk", "thickness", "eps_r"],
+        "required": [
+          "shape",
+          "sigma_bulk",
+          "thickness",
+          "eps_r"
+        ],
         "properties": {
-          "shape": { "$ref": "#/$defs/shape" },
-          "sigma_bulk": { "type": "number" },
-          "thickness": { "type": "number" },
-          "eps_r": { "type": "number" }
+          "shape": {
+            "$ref": "#/$defs/shape"
+          },
+          "sigma_bulk": {
+            "type": "number"
+          },
+          "thickness": {
+            "type": "number"
+          },
+          "eps_r": {
+            "type": "number"
+          }
         }
       }
     },
@@ -202,11 +342,22 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["position", "component", "waveform"],
+            "required": [
+              "position",
+              "component",
+              "waveform"
+            ],
             "properties": {
-              "position": { "$ref": "#/$defs/vec3" },
-              "component": { "type": "string", "minLength": 1 },
-              "waveform": { "$ref": "#/$defs/waveform_or_null" }
+              "position": {
+                "$ref": "#/$defs/vec3"
+              },
+              "component": {
+                "type": "string",
+                "minLength": 1
+              },
+              "waveform": {
+                "$ref": "#/$defs/waveform_or_null"
+              }
             }
           }
         },
@@ -227,15 +378,40 @@
               "reference_plane_cells"
             ],
             "properties": {
-              "position": { "$ref": "#/$defs/vec3" },
-              "component": { "type": "string", "minLength": 1 },
-              "impedance": { "type": "number", "exclusiveMinimum": 0 },
-              "waveform": { "$ref": "#/$defs/waveform_or_null" },
-              "extent": { "type": ["number", "null"] },
-              "excite": { "type": "boolean" },
-              "direction": { "type": ["string", "null"] },
+              "position": {
+                "$ref": "#/$defs/vec3"
+              },
+              "component": {
+                "type": "string",
+                "minLength": 1
+              },
+              "impedance": {
+                "type": "number",
+                "exclusiveMinimum": 0
+              },
+              "waveform": {
+                "$ref": "#/$defs/waveform_or_null"
+              },
+              "extent": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "excite": {
+                "type": "boolean"
+              },
+              "direction": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
               "reference_plane_cells": {
-                "type": ["integer", "null"],
+                "type": [
+                  "integer",
+                  "null"
+                ],
                 "description": "NON-PORTABLE: a cell count, not a physical measurement-plane distance."
               }
             }
@@ -263,19 +439,51 @@
               "eps_r_sub"
             ],
             "properties": {
-              "name": { "type": "string", "minLength": 1 },
-              "position": { "$ref": "#/$defs/vec3" },
-              "width": { "type": "number" },
-              "height": { "type": "number" },
-              "direction": { "type": "string", "minLength": 1 },
-              "impedance": { "type": "number" },
-              "waveform": { "$ref": "#/$defs/waveform_or_null" },
-              "excite": { "type": "boolean" },
-              "n_probe_offset": { "type": "integer" },
-              "n_probe_spacing": { "type": "integer" },
-              "n_probes": { "type": "integer" },
-              "mode": { "type": "string", "minLength": 1 },
-              "eps_r_sub": { "type": ["number", "null"] }
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "position": {
+                "$ref": "#/$defs/vec3"
+              },
+              "width": {
+                "type": "number"
+              },
+              "height": {
+                "type": "number"
+              },
+              "direction": {
+                "type": "string",
+                "minLength": 1
+              },
+              "impedance": {
+                "type": "number"
+              },
+              "waveform": {
+                "$ref": "#/$defs/waveform_or_null"
+              },
+              "excite": {
+                "type": "boolean"
+              },
+              "n_probe_offset": {
+                "type": "integer"
+              },
+              "n_probe_spacing": {
+                "type": "integer"
+              },
+              "n_probes": {
+                "type": "integer"
+              },
+              "mode": {
+                "type": "string",
+                "minLength": 1
+              },
+              "eps_r_sub": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              }
             }
           }
         },
@@ -309,27 +517,86 @@
               "mode_profile"
             ],
             "properties": {
-              "name": { "type": "string", "minLength": 1 },
-              "x_position": { "type": "number" },
-              "y_range": { "$ref": "#/$defs/vec2_or_null" },
-              "z_range": { "$ref": "#/$defs/vec2_or_null" },
-              "x_range": { "$ref": "#/$defs/vec2_or_null" },
-              "mode": { "$ref": "#/$defs/ivec2" },
-              "mode_type": { "type": "string", "minLength": 1 },
-              "direction": { "type": "string", "minLength": 1 },
-              "freqs": { "$ref": "#/$defs/array_or_null" },
-              "n_freqs": { "type": "integer" },
-              "f0": { "type": ["number", "null"] },
-              "bandwidth": { "type": "number" },
-              "amplitude": { "type": "number" },
-              "probe_offset": { "type": "integer" },
-              "ref_offset": { "type": "integer" },
-              "calibration_preset": { "type": ["string", "null"] },
-              "reference_plane": { "type": ["number", "null"] },
-              "probe_plane": { "type": ["number", "null"] },
-              "n_modes": { "type": "integer" },
-              "waveform": { "type": "string", "minLength": 1 },
-              "mode_profile": { "type": "string", "minLength": 1 }
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "x_position": {
+                "type": "number"
+              },
+              "y_range": {
+                "$ref": "#/$defs/vec2_or_null"
+              },
+              "z_range": {
+                "$ref": "#/$defs/vec2_or_null"
+              },
+              "x_range": {
+                "$ref": "#/$defs/vec2_or_null"
+              },
+              "mode": {
+                "$ref": "#/$defs/ivec2"
+              },
+              "mode_type": {
+                "type": "string",
+                "minLength": 1
+              },
+              "direction": {
+                "type": "string",
+                "minLength": 1
+              },
+              "freqs": {
+                "$ref": "#/$defs/array_or_null"
+              },
+              "n_freqs": {
+                "type": "integer"
+              },
+              "f0": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "bandwidth": {
+                "type": "number"
+              },
+              "amplitude": {
+                "type": "number"
+              },
+              "probe_offset": {
+                "type": "integer"
+              },
+              "ref_offset": {
+                "type": "integer"
+              },
+              "calibration_preset": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "reference_plane": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "probe_plane": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "n_modes": {
+                "type": "integer"
+              },
+              "waveform": {
+                "type": "string",
+                "minLength": 1
+              },
+              "mode_profile": {
+                "type": "string",
+                "minLength": 1
+              }
             }
           }
         },
@@ -348,13 +615,28 @@
               "excitation"
             ],
             "properties": {
-              "position": { "$ref": "#/$defs/vec3" },
-              "face": { "type": "string", "minLength": 1 },
-              "pin_length": { "type": "number" },
-              "pin_radius": { "type": "number" },
-              "outer_radius": { "type": "number" },
-              "impedance": { "type": "number" },
-              "excitation": { "$ref": "#/$defs/waveform_or_null" }
+              "position": {
+                "$ref": "#/$defs/vec3"
+              },
+              "face": {
+                "type": "string",
+                "minLength": 1
+              },
+              "pin_length": {
+                "type": "number"
+              },
+              "pin_radius": {
+                "type": "number"
+              },
+              "outer_radius": {
+                "type": "number"
+              },
+              "impedance": {
+                "type": "number"
+              },
+              "excitation": {
+                "$ref": "#/$defs/waveform_or_null"
+              }
             }
           }
         },
@@ -364,11 +646,22 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["port_index", "target_impedance", "axial_offset_cells"],
+            "required": [
+              "port_index",
+              "target_impedance",
+              "axial_offset_cells"
+            ],
             "properties": {
-              "port_index": { "type": "integer", "minimum": 0 },
-              "target_impedance": { "type": "number" },
-              "axial_offset_cells": { "type": "integer" }
+              "port_index": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "target_impedance": {
+                "type": "number"
+              },
+              "axial_offset_cells": {
+                "type": "integer"
+              }
             }
           }
         },
@@ -377,10 +670,18 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["port_index", "pin_retract_cells"],
+            "required": [
+              "port_index",
+              "pin_retract_cells"
+            ],
             "properties": {
-              "port_index": { "type": "integer", "minimum": 0 },
-              "pin_retract_cells": { "type": "integer" }
+              "port_index": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "pin_retract_cells": {
+                "type": "integer"
+              }
             }
           }
         },
@@ -389,10 +690,18 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["port_index", "axial_offset_cells"],
+            "required": [
+              "port_index",
+              "axial_offset_cells"
+            ],
             "properties": {
-              "port_index": { "type": "integer", "minimum": 0 },
-              "axial_offset_cells": { "type": "integer" }
+              "port_index": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "axial_offset_cells": {
+                "type": "integer"
+              }
             }
           }
         },
@@ -417,23 +726,56 @@
               "amplitude"
             ],
             "properties": {
-              "name": { "type": "string", "minLength": 1 },
-              "position": { "type": "number" },
-              "axis": { "type": "string", "minLength": 1 },
-              "scan_theta": { "type": "number" },
-              "scan_phi": { "type": "number" },
-              "polarization": { "type": "string", "minLength": 1 },
-              "n_modes": { "type": "integer" },
-              "freqs": { "$ref": "#/$defs/array_or_null" },
-              "n_freqs": { "type": "integer" },
-              "f0": { "type": ["number", "null"] },
-              "bandwidth": { "type": "number" },
-              "amplitude": { "type": "number" }
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "position": {
+                "type": "number"
+              },
+              "axis": {
+                "type": "string",
+                "minLength": 1
+              },
+              "scan_theta": {
+                "type": "number"
+              },
+              "scan_phi": {
+                "type": "number"
+              },
+              "polarization": {
+                "type": "string",
+                "minLength": 1
+              },
+              "n_modes": {
+                "type": "integer"
+              },
+              "freqs": {
+                "$ref": "#/$defs/array_or_null"
+              },
+              "n_freqs": {
+                "type": "integer"
+              },
+              "f0": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "bandwidth": {
+                "type": "number"
+              },
+              "amplitude": {
+                "type": "number"
+              }
             }
           }
         },
         "tfsf": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "description": "Total-field/scattered-field plane wave. Projecting this onto a commercial solver's plane-wave source is an approximation with a different absorber story, not a translation. `margin` is in cells, and `waveform` is a pulse-shape NAME resolved by the 1-D auxiliary grid.",
           "additionalProperties": false,
           "required": [
@@ -447,14 +789,36 @@
             "waveform"
           ],
           "properties": {
-            "f0": { "type": ["number", "null"] },
-            "bandwidth": { "type": "number" },
-            "amplitude": { "type": "number" },
-            "margin": { "type": "integer" },
-            "polarization": { "type": "string", "minLength": 1 },
-            "direction": { "type": "string", "minLength": 1 },
-            "angle_deg": { "type": "number" },
-            "waveform": { "type": "string", "minLength": 1 }
+            "f0": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "bandwidth": {
+              "type": "number"
+            },
+            "amplitude": {
+              "type": "number"
+            },
+            "margin": {
+              "type": "integer"
+            },
+            "polarization": {
+              "type": "string",
+              "minLength": 1
+            },
+            "direction": {
+              "type": "string",
+              "minLength": 1
+            },
+            "angle_deg": {
+              "type": "number"
+            },
+            "waveform": {
+              "type": "string",
+              "minLength": 1
+            }
           }
         },
         "lumped_rlc": {
@@ -462,14 +826,38 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["R", "L", "C", "topology", "position", "component"],
+            "required": [
+              "R",
+              "L",
+              "C",
+              "topology",
+              "position",
+              "component"
+            ],
             "properties": {
-              "R": { "type": "number", "minimum": 0 },
-              "L": { "type": "number", "minimum": 0 },
-              "C": { "type": "number", "minimum": 0 },
-              "topology": { "type": "string", "minLength": 1 },
-              "position": { "$ref": "#/$defs/vec3" },
-              "component": { "type": "string", "minLength": 1 }
+              "R": {
+                "type": "number",
+                "minimum": 0
+              },
+              "L": {
+                "type": "number",
+                "minimum": 0
+              },
+              "C": {
+                "type": "number",
+                "minimum": 0
+              },
+              "topology": {
+                "type": "string",
+                "minLength": 1
+              },
+              "position": {
+                "$ref": "#/$defs/vec3"
+              },
+              "component": {
+                "type": "string",
+                "minLength": 1
+              }
             }
           }
         }
@@ -478,7 +866,12 @@
     "observables": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["probes", "dft_planes", "flux_monitors", "ntff"],
+      "required": [
+        "probes",
+        "dft_planes",
+        "flux_monitors",
+        "ntff"
+      ],
       "properties": {
         "probes": {
           "type": "array",
@@ -486,10 +879,18 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["position", "component"],
+            "required": [
+              "position",
+              "component"
+            ],
             "properties": {
-              "position": { "$ref": "#/$defs/vec3" },
-              "component": { "type": "string", "minLength": 1 }
+              "position": {
+                "$ref": "#/$defs/vec3"
+              },
+              "component": {
+                "type": "string",
+                "minLength": 1
+              }
             }
           }
         },
@@ -499,14 +900,36 @@
           "items": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["name", "axis", "coordinate", "component", "freqs", "n_freqs"],
+            "required": [
+              "name",
+              "axis",
+              "coordinate",
+              "component",
+              "freqs",
+              "n_freqs"
+            ],
             "properties": {
-              "name": { "type": "string", "minLength": 1 },
-              "axis": { "type": "string", "minLength": 1 },
-              "coordinate": { "type": "number" },
-              "component": { "type": "string", "minLength": 1 },
-              "freqs": { "$ref": "#/$defs/array_or_null" },
-              "n_freqs": { "type": "integer" }
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "axis": {
+                "type": "string",
+                "minLength": 1
+              },
+              "coordinate": {
+                "type": "number"
+              },
+              "component": {
+                "type": "string",
+                "minLength": 1
+              },
+              "freqs": {
+                "$ref": "#/$defs/array_or_null"
+              },
+              "n_freqs": {
+                "type": "integer"
+              }
             }
           }
         },
@@ -527,55 +950,125 @@
               "dft_window_alpha"
             ],
             "properties": {
-              "name": { "type": "string", "minLength": 1 },
-              "axis": { "type": "string", "minLength": 1 },
-              "coordinate": { "type": "number" },
-              "freqs": { "$ref": "#/$defs/array_or_null" },
-              "n_freqs": { "type": "integer" },
-              "size": { "$ref": "#/$defs/vec2_or_null" },
-              "center": { "$ref": "#/$defs/vec2_or_null" },
-              "dft_window": { "type": "string", "minLength": 1 },
-              "dft_window_alpha": { "type": "number" }
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "axis": {
+                "type": "string",
+                "minLength": 1
+              },
+              "coordinate": {
+                "type": "number"
+              },
+              "freqs": {
+                "$ref": "#/$defs/array_or_null"
+              },
+              "n_freqs": {
+                "type": "integer"
+              },
+              "size": {
+                "$ref": "#/$defs/vec2_or_null"
+              },
+              "center": {
+                "$ref": "#/$defs/vec2_or_null"
+              },
+              "dft_window": {
+                "type": "string",
+                "minLength": 1
+              },
+              "dft_window_alpha": {
+                "type": "number"
+              }
             }
           }
         },
         "ntff": {
-          "type": ["object", "null"],
+          "type": [
+            "object",
+            "null"
+          ],
           "description": "freqs is emitted as an explicit array because n_freqs is defaulted at registration and is not recoverable from the stored tuple. It is therefore never null here, unlike the deferred (null, n_freqs) pairs the DFT-plane and flux families allow.",
           "additionalProperties": false,
-          "required": ["corner_lo", "corner_hi", "freqs"],
+          "required": [
+            "corner_lo",
+            "corner_hi",
+            "freqs"
+          ],
           "properties": {
-            "corner_lo": { "$ref": "#/$defs/vec3" },
-            "corner_hi": { "$ref": "#/$defs/vec3" },
-            "freqs": { "$ref": "#/$defs/array_payload" }
+            "corner_lo": {
+              "$ref": "#/$defs/vec3"
+            },
+            "corner_hi": {
+              "$ref": "#/$defs/vec3"
+            },
+            "freqs": {
+              "$ref": "#/$defs/array_payload"
+            }
           }
         }
       }
     },
     "refinement": {
-      "type": ["object", "null"],
+      "type": [
+        "object",
+        "null"
+      ],
       "description": "SBP-SAT subgrid directives. Experimental and falsified in 3D (PR #90): round-trip inside rfx, never project outward.",
       "additionalProperties": false,
-      "required": ["z_range", "ratio", "xy_margin", "tau", "validation", "topology"],
+      "required": [
+        "z_range",
+        "ratio",
+        "xy_margin",
+        "tau",
+        "validation",
+        "topology"
+      ],
       "properties": {
-        "z_range": { "$ref": "#/$defs/vec2" },
-        "ratio": { "type": "integer" },
-        "xy_margin": { "type": ["number", "null"] },
-        "tau": { "type": "number" },
-        "validation": { "type": "string", "minLength": 1 },
-        "topology": { "type": "string", "minLength": 1 }
+        "z_range": {
+          "$ref": "#/$defs/vec2"
+        },
+        "ratio": {
+          "type": "integer"
+        },
+        "xy_margin": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "tau": {
+          "type": "number"
+        },
+        "validation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "topology": {
+          "type": "string",
+          "minLength": 1
+        }
       }
     },
     "non_portable": {
       "type": "array",
-      "description": "DERIVED annotation, not independent state: the paths in this document whose meaning does not survive a translation, each with the reason. An external emitter must consult this and refuse or record an explicit approximation; it must not ship these silently. Nothing is applied from it on import, but it IS verified — the importer re-exports and compares, so the list cannot be edited away to make rfx-only state look portable. Sorted by path.",
+      "description": "DERIVED annotation, not independent state: the paths in this document whose meaning does not survive a translation, each with the reason. An external emitter must consult this and refuse or record an explicit approximation; it must not ship these silently. Nothing is applied from it on import, but it IS verified \u2014 the importer re-exports and compares, so the list cannot be edited away to make rfx-only state look portable. Sorted by path.",
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["path", "reason"],
+        "required": [
+          "path",
+          "reason"
+        ],
         "properties": {
-          "path": { "type": "string", "minLength": 1 },
-          "reason": { "type": "string", "minLength": 1 }
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1
+          }
         }
       }
     }
@@ -585,68 +1078,158 @@
       "type": "array",
       "minItems": 2,
       "maxItems": 2,
-      "items": { "type": "number" }
+      "items": {
+        "type": "number"
+      }
     },
     "vec2_or_null": {
-      "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/vec2" }]
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/vec2"
+        }
+      ]
     },
     "vec3": {
       "type": "array",
       "minItems": 3,
       "maxItems": 3,
-      "items": { "type": "number" }
+      "items": {
+        "type": "number"
+      }
     },
     "ivec2": {
       "type": "array",
       "minItems": 2,
       "maxItems": 2,
-      "items": { "type": "integer" }
+      "items": {
+        "type": "integer"
+      }
     },
     "array_payload": {
       "type": "object",
-      "description": "A 1-D numeric array recorded value by value, never summarised. The container and dtype are part of the record because Simulation.__init__ synthesises the domain extent from float(np.sum(profile)): a float32 profile reloaded as float64 shifts the extent in the last ULPs and breaks the repo's bit-identity gates. dtype is REQUIRED for the numpy and jax containers and FORBIDDEN for list and tuple, which carry no dtype. Contrast rfx.artifacts._profile_summary, which emits {present, shape, min, max, sum} — a summary that cannot be rebuilt.",
+      "description": "A 1-D numeric array recorded value by value, never summarised. The container and dtype are part of the record because Simulation.__init__ synthesises the domain extent from float(np.sum(profile)): a float32 profile reloaded as float64 shifts the extent in the last ULPs and breaks the repo's bit-identity gates. dtype is REQUIRED for the numpy and jax containers and FORBIDDEN for list and tuple, which carry no dtype. Contrast rfx.artifacts._profile_summary, which emits {present, shape, min, max, sum} \u2014 a summary that cannot be rebuilt.",
       "additionalProperties": false,
-      "required": ["container", "values"],
+      "required": [
+        "container",
+        "values"
+      ],
       "properties": {
-        "container": { "enum": ["list", "tuple", "numpy", "jax"] },
-        "dtype": { "type": "string", "minLength": 1 },
-        "values": { "type": "array", "items": { "type": "number" } }
+        "container": {
+          "enum": [
+            "list",
+            "tuple",
+            "numpy",
+            "jax"
+          ]
+        },
+        "dtype": {
+          "type": "string",
+          "minLength": 1
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          }
+        }
       },
       "if": {
-        "properties": { "container": { "enum": ["numpy", "jax"] } },
-        "required": ["container"]
+        "properties": {
+          "container": {
+            "enum": [
+              "numpy",
+              "jax"
+            ]
+          }
+        },
+        "required": [
+          "container"
+        ]
       },
-      "then": { "required": ["container", "dtype", "values"] },
-      "else": { "not": { "required": ["dtype"] } }
+      "then": {
+        "required": [
+          "container",
+          "dtype",
+          "values"
+        ]
+      },
+      "else": {
+        "not": {
+          "required": [
+            "dtype"
+          ]
+        }
+      }
     },
     "array_or_null": {
-      "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/array_payload" }]
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/array_payload"
+        }
+      ]
     },
     "boundary_axis": {
       "type": "object",
       "description": "Boundary.to_dict() for one axis. lo_thickness / hi_thickness appear only when set, and only absorbing faces may carry them; conformal appears only when true, and only on a symmetric PEC axis.",
       "additionalProperties": false,
-      "required": ["lo", "hi"],
+      "required": [
+        "lo",
+        "hi"
+      ],
       "properties": {
-        "lo": { "$ref": "#/$defs/boundary_token" },
-        "hi": { "$ref": "#/$defs/boundary_token" },
-        "lo_thickness": { "type": "integer", "minimum": 0 },
-        "hi_thickness": { "type": "integer", "minimum": 0 },
-        "conformal": { "const": true }
+        "lo": {
+          "$ref": "#/$defs/boundary_token"
+        },
+        "hi": {
+          "$ref": "#/$defs/boundary_token"
+        },
+        "lo_thickness": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "hi_thickness": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "conformal": {
+          "const": true
+        }
       }
     },
     "boundary_token": {
-      "enum": ["cpml", "upml", "pec", "pmc", "periodic"],
+      "enum": [
+        "cpml",
+        "upml",
+        "pec",
+        "pmc",
+        "periodic"
+      ],
       "description": "rfx.boundaries.spec.BOUNDARY_TOKENS. pmc and the per-axis conformal flag are rfx-only."
     },
     "shape": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["kind", "params"],
-      "description": "A geometry primitive recorded by its CONSTRUCTOR PARAMETERS. The kind vocabulary is snake_case, matching the two document layers that already name shapes (rfx/config/_shapes.py uses shape: \"box\", rfx/experiments/canonical.py uses kind: \"box\"). Recording parameters rather than a bounding box is the whole point: every other rfx serialisation layer keeps only a class name plus bounds, which cannot distinguish a cylinder from a box occupying the same box. MeshShape (CAD import, #358) is deliberately absent — a triangle mesh is not parameter-describable, so it is refused rather than degraded to bounds.",
+      "required": [
+        "kind",
+        "params"
+      ],
+      "description": "A geometry primitive recorded by its CONSTRUCTOR PARAMETERS. The kind vocabulary is snake_case, matching the two document layers that already name shapes (rfx/config/_shapes.py uses shape: \"box\", rfx/experiments/canonical.py uses kind: \"box\"). Recording parameters rather than a bounding box is the whole point: every other rfx serialisation layer keeps only a class name plus bounds, which cannot distinguish a cylinder from a box occupying the same box. MeshShape (CAD import, #358) is deliberately absent \u2014 a triangle mesh is not parameter-describable, so it is refused rather than degraded to bounds.",
       "properties": {
         "kind": {
-          "enum": ["box", "curved_patch", "cylinder", "polyline_wire", "sphere", "via"]
+          "enum": [
+            "box",
+            "curved_patch",
+            "cylinder",
+            "polyline_wire",
+            "sphere",
+            "via"
+          ]
         },
         "params": {
           "type": "object",
@@ -655,79 +1238,183 @@
       },
       "allOf": [
         {
-          "if": { "properties": { "kind": { "const": "box" } }, "required": ["kind"] },
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "box"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
           "then": {
             "properties": {
               "params": {
                 "additionalProperties": false,
-                "required": ["corner_lo", "corner_hi"],
+                "required": [
+                  "corner_lo",
+                  "corner_hi"
+                ],
                 "properties": {
-                  "corner_lo": { "$ref": "#/$defs/vec3" },
-                  "corner_hi": { "$ref": "#/$defs/vec3" }
+                  "corner_lo": {
+                    "$ref": "#/$defs/vec3"
+                  },
+                  "corner_hi": {
+                    "$ref": "#/$defs/vec3"
+                  }
                 }
               }
             }
           }
         },
         {
-          "if": { "properties": { "kind": { "const": "cylinder" } }, "required": ["kind"] },
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "cylinder"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
           "then": {
             "properties": {
               "params": {
                 "additionalProperties": false,
-                "required": ["center", "radius", "height", "axis"],
+                "required": [
+                  "center",
+                  "radius",
+                  "height",
+                  "axis"
+                ],
                 "properties": {
-                  "center": { "$ref": "#/$defs/vec3" },
-                  "radius": { "type": "number" },
-                  "height": { "type": "number" },
-                  "axis": { "type": "string", "minLength": 1 }
+                  "center": {
+                    "$ref": "#/$defs/vec3"
+                  },
+                  "radius": {
+                    "type": "number"
+                  },
+                  "height": {
+                    "type": "number"
+                  },
+                  "axis": {
+                    "type": "string",
+                    "minLength": 1
+                  }
                 }
               }
             }
           }
         },
         {
-          "if": { "properties": { "kind": { "const": "sphere" } }, "required": ["kind"] },
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "sphere"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
           "then": {
             "properties": {
               "params": {
                 "additionalProperties": false,
-                "required": ["center", "radius"],
+                "required": [
+                  "center",
+                  "radius"
+                ],
                 "properties": {
-                  "center": { "$ref": "#/$defs/vec3" },
-                  "radius": { "type": "number" }
+                  "center": {
+                    "$ref": "#/$defs/vec3"
+                  },
+                  "radius": {
+                    "type": "number"
+                  }
                 }
               }
             }
           }
         },
         {
-          "if": { "properties": { "kind": { "const": "polyline_wire" } }, "required": ["kind"] },
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "polyline_wire"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
           "then": {
             "properties": {
               "params": {
                 "additionalProperties": false,
-                "required": ["points", "radius"],
+                "required": [
+                  "points",
+                  "radius"
+                ],
                 "properties": {
-                  "points": { "type": "array", "items": { "$ref": "#/$defs/vec3" } },
-                  "radius": { "type": "number" }
+                  "points": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/$defs/vec3"
+                    },
+                    "minItems": 1,
+                    "description": "At least one element. The codec refuses an empty sequence: an empty point list or layer stack does not describe a structure, and accepting one is how a consumed one-shot iterator turned into a silently absent conductor in a schema-valid document."
+                  },
+                  "radius": {
+                    "type": "number"
+                  }
                 }
               }
             }
           }
         },
         {
-          "if": { "properties": { "kind": { "const": "via" } }, "required": ["kind"] },
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "via"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
           "then": {
             "properties": {
               "params": {
                 "additionalProperties": false,
-                "required": ["center", "drill_radius", "pad_radius", "layers", "material"],
+                "required": [
+                  "center",
+                  "drill_radius",
+                  "pad_radius",
+                  "layers",
+                  "material"
+                ],
                 "properties": {
-                  "center": { "$ref": "#/$defs/vec2" },
-                  "drill_radius": { "type": "number" },
-                  "pad_radius": { "type": "number" },
-                  "layers": { "type": "array", "items": { "$ref": "#/$defs/vec2" } },
+                  "center": {
+                    "$ref": "#/$defs/vec2"
+                  },
+                  "drill_radius": {
+                    "type": "number"
+                  },
+                  "pad_radius": {
+                    "type": "number"
+                  },
+                  "layers": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/$defs/vec2"
+                    },
+                    "minItems": 1,
+                    "description": "At least one element. The codec refuses an empty sequence: an empty point list or layer stack does not describe a structure, and accepting one is how a consumed one-shot iterator turned into a silently absent conductor in a schema-valid document."
+                  },
                   "material": {
                     "type": "string",
                     "description": "Via carries its OWN material in addition to the material= handed to Simulation.add(). Both are recorded; resolving the two is the caller's decision, not something the codec may silently pick."
@@ -738,18 +1425,44 @@
           }
         },
         {
-          "if": { "properties": { "kind": { "const": "curved_patch" } }, "required": ["kind"] },
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "curved_patch"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
           "then": {
             "properties": {
               "params": {
                 "additionalProperties": false,
-                "required": ["center", "length", "width", "radius", "axis"],
+                "required": [
+                  "center",
+                  "length",
+                  "width",
+                  "radius",
+                  "axis"
+                ],
                 "properties": {
-                  "center": { "$ref": "#/$defs/vec3" },
-                  "length": { "type": "number" },
-                  "width": { "type": "number" },
-                  "radius": { "type": "number" },
-                  "axis": { "type": "string", "minLength": 1 }
+                  "center": {
+                    "$ref": "#/$defs/vec3"
+                  },
+                  "length": {
+                    "type": "number"
+                  },
+                  "width": {
+                    "type": "number"
+                  },
+                  "radius": {
+                    "type": "number"
+                  },
+                  "axis": {
+                    "type": "string",
+                    "minLength": 1
+                  }
                 }
               }
             }
@@ -760,35 +1473,92 @@
     "waveform": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["kind", "params"],
-      "description": "An excitation waveform recorded as its dataclass parameters. CustomWaveform is deliberately absent: it wraps a Python callable, which has no serialisable form — and because add_polarized_source builds a CustomWaveform closure for a complex Jones vector, that also refuses a circularly polarised source (already unrecoverable from _ports inside rfx itself). Note the waveguide-port and TFSF families do NOT use this payload: they store a waveform NAME as a plain string.",
+      "required": [
+        "kind",
+        "params"
+      ],
+      "description": "An excitation waveform recorded as its dataclass parameters. CustomWaveform is deliberately absent: it wraps a Python callable, which has no serialisable form \u2014 and because add_polarized_source builds a CustomWaveform closure for a complex Jones vector, that also refuses a circularly polarised source (already unrecoverable from _ports inside rfx itself). Note the waveguide-port and TFSF families do NOT use this payload: they store a waveform NAME as a plain string.",
       "properties": {
-        "kind": { "enum": ["cw_source", "gaussian_pulse", "modulated_gaussian"] },
-        "params": { "type": "object" }
+        "kind": {
+          "enum": [
+            "cw_source",
+            "gaussian_pulse",
+            "modulated_gaussian"
+          ]
+        },
+        "params": {
+          "type": "object"
+        }
       },
       "allOf": [
         {
-          "if": { "properties": { "kind": { "const": "gaussian_pulse" } }, "required": ["kind"] },
-          "then": { "properties": { "params": { "$ref": "#/$defs/gaussian_params" } } }
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "gaussian_pulse"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
+          "then": {
+            "properties": {
+              "params": {
+                "$ref": "#/$defs/gaussian_params"
+              }
+            }
+          }
         },
         {
           "if": {
-            "properties": { "kind": { "const": "modulated_gaussian" } },
-            "required": ["kind"]
+            "properties": {
+              "kind": {
+                "const": "modulated_gaussian"
+              }
+            },
+            "required": [
+              "kind"
+            ]
           },
-          "then": { "properties": { "params": { "$ref": "#/$defs/gaussian_params" } } }
+          "then": {
+            "properties": {
+              "params": {
+                "$ref": "#/$defs/gaussian_params"
+              }
+            }
+          }
         },
         {
-          "if": { "properties": { "kind": { "const": "cw_source" } }, "required": ["kind"] },
+          "if": {
+            "properties": {
+              "kind": {
+                "const": "cw_source"
+              }
+            },
+            "required": [
+              "kind"
+            ]
+          },
           "then": {
             "properties": {
               "params": {
                 "additionalProperties": false,
-                "required": ["f0", "amplitude", "ramp_steps"],
+                "required": [
+                  "f0",
+                  "amplitude",
+                  "ramp_steps"
+                ],
                 "properties": {
-                  "f0": { "type": "number" },
-                  "amplitude": { "type": "number" },
-                  "ramp_steps": { "type": "integer" }
+                  "f0": {
+                    "type": "number"
+                  },
+                  "amplitude": {
+                    "type": "number"
+                  },
+                  "ramp_steps": {
+                    "type": "integer"
+                  }
                 }
               }
             }
@@ -799,11 +1569,22 @@
     "gaussian_params": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["f0", "bandwidth", "amplitude", "cutoff"],
+      "required": [
+        "f0",
+        "bandwidth",
+        "amplitude",
+        "cutoff"
+      ],
       "properties": {
-        "f0": { "type": "number" },
-        "bandwidth": { "type": "number" },
-        "amplitude": { "type": "number" },
+        "f0": {
+          "type": "number"
+        },
+        "bandwidth": {
+          "type": "number"
+        },
+        "amplitude": {
+          "type": "number"
+        },
         "cutoff": {
           "type": "number",
           "description": "Number of tau between t=0 and the pulse peak. Load-bearing, not cosmetic: the deposited-DC integral scales as e^(-cutoff^2) (issue #388), so dropping it would silently change the static source remnant."
@@ -811,7 +1592,14 @@
       }
     },
     "waveform_or_null": {
-      "oneOf": [{ "type": "null" }, { "$ref": "#/$defs/waveform" }]
+      "oneOf": [
+        {
+          "type": "null"
+        },
+        {
+          "$ref": "#/$defs/waveform"
+        }
+      ]
     }
   }
 }

--- a/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
+++ b/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://remilab.ai/rfx/schemas/rfx-design-ir-v1.schema.json",
+  "title": "rfx design IR v1",
+  "description": "Round-trip-complete description of an rfx Simulation's DESIGN state, emitted by rfx.interop.design_to_dict and consumed by rfx.interop.simulation_from_design. This is the rfx-to-rfx profile: its gate is structural equality after a round trip. An external-solver projection is a SEPARATE, explicitly lossy artifact and is not described by this schema. Derived state (Grid, dt, axis_pads), preflight verdicts, results, and run-time controls (n_steps, until_decay, compute_s_params, eps_override, ...) are deliberately absent: a design description that carries them invites a reader to trust them. Anything that cannot be represented exactly is refused at export time with UnsupportedDesignFeature rather than approximated.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "rfx_version",
+    "domain",
+    "mesh",
+    "boundary",
+    "solver",
+    "materials",
+    "material_library",
+    "geometry",
+    "thin_conductors",
+    "excitations",
+    "observables",
+    "refinement",
+    "non_portable"
+  ],
+  "properties": {
+    "schema": {
+      "const": "rfx-design-ir/v1",
+      "description": "Schema identifier. A closed world: an unknown top-level key is an error on read, not a forward-compatible extension point."
+    },
+    "rfx_version": {
+      "type": "string",
+      "description": "Provenance only. It records which rfx wrote the document; it is not a compatibility contract."
+    },
+    "domain": {
+      "type": "object",
+      "description": "Physical extent and reduction mode. The extent is the USER domain: rfx adds CPML cells OUTSIDE it (measured: domain 10 mm at dx 1 mm gives grid 11 cells at cpml_layers=0 and 11+2N otherwise), so an external emitter must span domain + 2*cpml_layers*dx per absorbing axis."
+    },
+    "mesh": {
+      "type": "object",
+      "description": "Cell size and optional per-axis graded profiles. Profiles are emitted value-by-value with their dtype and array namespace, never summarised: rfx synthesises the domain extent from float(np.sum(profile)), so a truncated profile silently changes the domain. A profile that is a JAX tracer is refused, because a traced profile is a differentiable design variable with no concrete value to record."
+    },
+    "boundary": {
+      "type": "object",
+      "description": "Authoritative per-face BoundarySpec plus the derived legacy scalar view. _boundary, _pec_faces and _periodic_axes are derived from the spec, except that _periodic_axes is also mutated as a side effect by add_floquet_port, so it is emitted explicitly rather than re-derived on import."
+    },
+    "solver": {
+      "type": "object",
+      "description": "rfx-only solver controls (precision, solver, adi_cfl_factor, stencil_order). These round-trip in rfx and have no counterpart in openEMS/Meep/CST/HFSS; they appear in non_portable."
+    },
+    "materials": {
+      "type": "object",
+      "description": "Name to material payload. Each payload carries every MaterialSpec field including chi3 and the full Debye/Lorentz pole parameters. Contrast rfx.artifacts._material_summary, which reduces pole lists to {present, count} and would rebuild a dispersive material as a non-dispersive one with the same static eps_r. None and [] are kept distinct: no dispersion declared and dispersion declared empty are different design states.",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["eps_r", "sigma", "mu_r", "chi3", "debye_poles", "lorentz_poles"],
+        "properties": {
+          "eps_r": { "type": "number" },
+          "sigma": { "type": "number" },
+          "mu_r": { "type": "number" },
+          "chi3": { "type": "number" },
+          "debye_poles": {
+            "type": ["array", "null"],
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["delta_eps", "tau"],
+              "properties": {
+                "delta_eps": { "type": "number" },
+                "tau": { "type": "number" }
+              }
+            }
+          },
+          "lorentz_poles": {
+            "type": ["array", "null"],
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["omega_0", "delta", "kappa"],
+              "properties": {
+                "omega_0": { "type": "number" },
+                "delta": { "type": "number" },
+                "kappa": { "type": "number" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "material_library": {
+      "type": "object",
+      "description": "Library entries the design referenced, recorded so a document does not depend on the writer's library version."
+    },
+    "geometry": {
+      "type": "array",
+      "description": "ORDERED paint list. Simulation.add appends and rasterisation applies entries in order with later shapes overwriting earlier ones (rfx/geometry/csg.py:321), so the array order is semantic state, not presentation. rfx has no boolean CSG tree on the simulation path: union/difference/intersection exist in rfx/geometry/csg.py but have no call sites in rfx/api or rfx/core. An emitter targeting a boolean solid modeller cannot translate overlapping paint mechanically.",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["shape", "material_name"],
+        "properties": {
+          "shape": { "$ref": "#/$defs/shape" },
+          "material_name": { "type": "string" }
+        }
+      }
+    },
+    "thin_conductors": {
+      "type": "array",
+      "description": "Thin-conductor sheet entries (shape plus sigma_bulk / thickness / eps_r). Routed to a PEC mask when the effective conductivity is high enough."
+    },
+    "excitations": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Sources and ports, split by family. Note that rfx stores soft sources and lumped ports in ONE list (_ports) discriminated only by impedance == 0; the document splits them into named sections so the distinction is explicit rather than sentinel-encoded.",
+      "required": [
+        "soft_sources",
+        "lumped_ports",
+        "msl_ports",
+        "waveguide_ports",
+        "coaxial_ports",
+        "coaxial_matched_loads",
+        "coaxial_open_terminations",
+        "coaxial_pec_end_caps",
+        "floquet_ports",
+        "tfsf",
+        "lumped_rlc"
+      ],
+      "properties": {
+        "soft_sources": { "type": "array" },
+        "lumped_ports": { "type": "array" },
+        "msl_ports": {
+          "type": "array",
+          "description": "n_probe_offset and n_probe_spacing are CELL COUNTS derived from dx at registration time, not physical lengths; they appear in non_portable."
+        },
+        "waveguide_ports": { "type": "array" },
+        "coaxial_ports": { "type": "array" },
+        "coaxial_matched_loads": {
+          "type": "array",
+          "description": "Offsets are cell-relative, not physical coordinates; see non_portable."
+        },
+        "coaxial_open_terminations": { "type": "array" },
+        "coaxial_pec_end_caps": { "type": "array" },
+        "floquet_ports": {
+          "type": "array",
+          "description": "Import goes through add_floquet_port, so the builder's fences still fire: a document tampered to n_modes > 1 raises the builder's own NotImplementedError rather than widening the fence."
+        },
+        "tfsf": {
+          "type": ["object", "null"],
+          "description": "Total-field/scattered-field plane wave. Projecting this onto a commercial solver's plane-wave source is an approximation with a different absorber story, not a translation."
+        },
+        "lumped_rlc": { "type": "array" }
+      }
+    },
+    "observables": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["probes", "dft_planes", "flux_monitors", "ntff"],
+      "properties": {
+        "probes": {
+          "type": "array",
+          "description": "add_vector_probe expands to six flat entries inside rfx itself, so the vector grouping is already lost upstream; only the flat entries round-trip."
+        },
+        "dft_planes": { "type": "array" },
+        "flux_monitors": { "type": "array" },
+        "ntff": {
+          "type": ["object", "null"],
+          "description": "freqs is emitted as an explicit array because n_freqs is defaulted at registration and is not recoverable from the stored tuple."
+        }
+      }
+    },
+    "refinement": {
+      "type": ["object", "null"],
+      "description": "SBP-SAT subgrid directives. Experimental and falsified in 3D (PR #90): round-trip inside rfx, never project outward."
+    },
+    "non_portable": {
+      "type": "array",
+      "description": "DERIVED annotation, not independent state: the paths in this document whose meaning does not survive a translation, each with the reason. An external emitter must consult this and refuse or record an explicit approximation; it must not ship these silently.",
+      "items": {
+        "type": "object",
+        "required": ["path", "reason"],
+        "properties": {
+          "path": { "type": "string" },
+          "reason": { "type": "string" }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "shape": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "params"],
+      "description": "A geometry primitive recorded by its CONSTRUCTOR PARAMETERS. The kind vocabulary is snake_case, matching the two document layers that already name shapes (rfx/config/_shapes.py uses shape: \"box\", rfx/experiments/canonical.py uses kind: \"box\"). Recording parameters rather than a bounding box is the whole point: every other rfx serialisation layer keeps only a class name plus bounds, which cannot distinguish a cylinder from a box occupying the same box. MeshShape (CAD import, #358) is deliberately absent — a triangle mesh is not parameter-describable, so it is refused rather than degraded to bounds.",
+      "properties": {
+        "kind": {
+          "enum": ["box", "curved_patch", "cylinder", "polyline_wire", "sphere", "via"]
+        },
+        "params": {
+          "type": "object",
+          "description": "Constructor arguments for the named kind. Vectors are JSON arrays of finite numbers; the importer restores the tuple types the primitives declare so a round-tripped frozen dataclass compares equal. NaN, infinity and JAX tracers are refused at the codec layer, where the parameter name is still known."
+        }
+      }
+    }
+  }
+}

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -288,7 +288,7 @@ class Simulation(
     boundary : "pec", "cpml", or "upml"
         Boundary condition. Default "cpml".
     cpml_layers : int
-        Number of CPML layers per face. Default 12 (ignored for "pec").
+        Number of CPML layers per face. Default 16 (ignored for "pec").
     dx : float or None
         Cell size override (metres). Auto-computed if None.
     mode : str

--- a/rfx/interop/__init__.py
+++ b/rfx/interop/__init__.py
@@ -24,6 +24,11 @@ from rfx.interop._design import (
     simulation_from_design,
 )
 from rfx.interop._errors import UnsupportedDesignFeature
+from rfx.interop.emitters.openems import (
+    OPENEMS_EMITTER_VERSION,
+    emit_openems_script,
+    plan_openems_projection,
+)
 from rfx.interop._materials import (
     material_from_dict,
     material_to_dict,
@@ -40,15 +45,18 @@ from rfx.interop._shapes import (
 
 __all__ = [
     "DESIGN_SCHEMA_VERSION",
+    "OPENEMS_EMITTER_VERSION",
     "SUPPORTED_SHAPE_KINDS",
     "SUPPORTED_WAVEFORM_KINDS",
     "UnsupportedDesignFeature",
     "design_to_dict",
     "design_to_json",
+    "emit_openems_script",
     "material_from_dict",
     "material_to_dict",
     "materials_from_dict",
     "materials_to_dict",
+    "plan_openems_projection",
     "shape_field_names",
     "shape_from_dict",
     "shape_kind_of",

--- a/rfx/interop/__init__.py
+++ b/rfx/interop/__init__.py
@@ -16,6 +16,13 @@ description and external-solver emitters are under construction.
 
 from __future__ import annotations
 
+from rfx.interop._design import (
+    DESIGN_SCHEMA_VERSION,
+    SUPPORTED_WAVEFORM_KINDS,
+    design_to_dict,
+    design_to_json,
+    simulation_from_design,
+)
 from rfx.interop._errors import UnsupportedDesignFeature
 from rfx.interop._materials import (
     material_from_dict,
@@ -32,8 +39,12 @@ from rfx.interop._shapes import (
 )
 
 __all__ = [
+    "DESIGN_SCHEMA_VERSION",
     "SUPPORTED_SHAPE_KINDS",
+    "SUPPORTED_WAVEFORM_KINDS",
     "UnsupportedDesignFeature",
+    "design_to_dict",
+    "design_to_json",
     "material_from_dict",
     "material_to_dict",
     "materials_from_dict",
@@ -42,4 +53,5 @@ __all__ = [
     "shape_from_dict",
     "shape_kind_of",
     "shape_to_dict",
+    "simulation_from_design",
 ]

--- a/rfx/interop/__init__.py
+++ b/rfx/interop/__init__.py
@@ -17,6 +17,12 @@ description and external-solver emitters are under construction.
 from __future__ import annotations
 
 from rfx.interop._errors import UnsupportedDesignFeature
+from rfx.interop._materials import (
+    material_from_dict,
+    material_to_dict,
+    materials_from_dict,
+    materials_to_dict,
+)
 from rfx.interop._shapes import (
     SUPPORTED_SHAPE_TYPES,
     shape_field_names,
@@ -27,6 +33,10 @@ from rfx.interop._shapes import (
 __all__ = [
     "SUPPORTED_SHAPE_TYPES",
     "UnsupportedDesignFeature",
+    "material_from_dict",
+    "material_to_dict",
+    "materials_from_dict",
+    "materials_to_dict",
     "shape_field_names",
     "shape_from_dict",
     "shape_to_dict",

--- a/rfx/interop/__init__.py
+++ b/rfx/interop/__init__.py
@@ -1,0 +1,33 @@
+"""Design-description interop for rfx.
+
+This package carries the round-trip-complete description of a simulation
+*setup* (geometry parameters, materials, excitations, observables, mesh
+directives) as distinct from:
+
+- ``rfx.artifacts.build_scene_artifact`` — a review/provenance **summary** of
+  runtime state, explicitly "not a CAD export";
+- ``rfx.io.export_geometry_json`` — the older lightweight geometry dump;
+- ``rfx.surrogate.export_geometry_sdf`` — a signed-distance encoding for
+  machine-learning consumers.
+
+Status: **provisional**. The shape codec is round-trip tested; the wider design
+description and external-solver emitters are under construction.
+"""
+
+from __future__ import annotations
+
+from rfx.interop._errors import UnsupportedDesignFeature
+from rfx.interop._shapes import (
+    SUPPORTED_SHAPE_TYPES,
+    shape_field_names,
+    shape_from_dict,
+    shape_to_dict,
+)
+
+__all__ = [
+    "SUPPORTED_SHAPE_TYPES",
+    "UnsupportedDesignFeature",
+    "shape_field_names",
+    "shape_from_dict",
+    "shape_to_dict",
+]

--- a/rfx/interop/__init__.py
+++ b/rfx/interop/__init__.py
@@ -24,14 +24,15 @@ from rfx.interop._materials import (
     materials_to_dict,
 )
 from rfx.interop._shapes import (
-    SUPPORTED_SHAPE_TYPES,
+    SUPPORTED_SHAPE_KINDS,
     shape_field_names,
     shape_from_dict,
+    shape_kind_of,
     shape_to_dict,
 )
 
 __all__ = [
-    "SUPPORTED_SHAPE_TYPES",
+    "SUPPORTED_SHAPE_KINDS",
     "UnsupportedDesignFeature",
     "material_from_dict",
     "material_to_dict",
@@ -39,5 +40,6 @@ __all__ = [
     "materials_to_dict",
     "shape_field_names",
     "shape_from_dict",
+    "shape_kind_of",
     "shape_to_dict",
 ]

--- a/rfx/interop/_design.py
+++ b/rfx/interop/_design.py
@@ -171,6 +171,16 @@ def _num(value: Any, *, what: str) -> float:
         )
     if isinstance(value, bool):
         raise _refuse(f"{what} must be a number, got a bool ({value!r})")
+    if isinstance(value, (str, bytes)):
+        # float("1.2e10") succeeds, so a quoted numeric in a hand-written
+        # document would be coerced silently. The round-trip self-check does
+        # catch it, but only with a message showing two identical-looking
+        # numbers, which sends the reader hunting the wrong thing.
+        raise _refuse(
+            f"{what} is the string {value!r}, not a number. A design document "
+            f"with quoted numerics is accepted silently by float() and would "
+            f"record a value nobody wrote"
+        )
     try:
         out = float(value)
     except (TypeError, ValueError) as exc:
@@ -188,6 +198,11 @@ def _integer(value: Any, *, what: str) -> int:
         raise _refuse(f"{what} must be an integer, got a bool ({value!r})")
     if is_tracer(value):
         raise _refuse(f"{what} is a JAX tracer; expected a concrete integer")
+    if isinstance(value, (str, bytes)):
+        raise _refuse(
+            f"{what} is the string {value!r}, not an integer; int() would have "
+            f"accepted it silently"
+        )
     try:
         out = int(value)
     except (TypeError, ValueError) as exc:

--- a/rfx/interop/_design.py
+++ b/rfx/interop/_design.py
@@ -138,6 +138,7 @@ from rfx.interop._materials import (
     materials_to_dict,
 )
 from rfx.interop._shapes import shape_from_dict, shape_to_dict
+from rfx.interop._validate import check_number, check_text, check_vector
 from rfx.lumped import LumpedRLCSpec
 from rfx.materials.thin_conductor import ThinConductor
 from rfx.sources.coaxial_port import CoaxialPort
@@ -162,38 +163,23 @@ def _refuse(message: str) -> "UnsupportedDesignFeature":
     return UnsupportedDesignFeature(message)
 
 
-def _num(value: Any, *, what: str) -> float:
-    """Coerce to a finite Python float or refuse."""
-    if is_tracer(value):
-        raise _refuse(
-            f"{what} is a JAX tracer; a traced value has no concrete number "
-            f"to record. Export outside jit/grad, or pass a concrete value."
-        )
-    if isinstance(value, bool):
-        raise _refuse(f"{what} must be a number, got a bool ({value!r})")
-    if isinstance(value, (str, bytes)):
-        # float("1.2e10") succeeds, so a quoted numeric in a hand-written
-        # document would be coerced silently. The round-trip self-check does
-        # catch it, but only with a message showing two identical-looking
-        # numbers, which sends the reader hunting the wrong thing.
-        raise _refuse(
-            f"{what} is the string {value!r}, not a number. A design document "
-            f"with quoted numerics is accepted silently by float() and would "
-            f"record a value nobody wrote"
-        )
-    try:
-        out = float(value)
-    except (TypeError, ValueError) as exc:
-        raise _refuse(f"{what} must be a number, got {value!r}") from exc
-    if not math.isfinite(out):
-        raise _refuse(
-            f"{what} is {out!r}; the design document refuses non-finite "
-            f"numbers (JSON cannot represent them portably)"
-        )
-    return out
+# ``check_number`` / ``check_text`` / ``check_vector`` come from
+# ``rfx/interop/_validate.py`` — the shared leaf the shape and material codecs
+# also sit on. They refuse JAX tracers, ``bool`` (an int in Python, so
+# ``float(True)`` would silently record 1.0), ``str``/``bytes`` (a quoted
+# numeric in a hand-written document), one-shot iterators (consumed by the act
+# of exporting, so a second export would emit an empty sequence with no error)
+# and non-finite floats. The two coercions below are the ones the leaf does not
+# provide; they build on it rather than re-deriving its rules.
 
 
 def _integer(value: Any, *, what: str) -> int:
+    """Require an exact integer.
+
+    Not a wrapper around ``check_number``: cell counts, mode indices and
+    ``n_freqs`` must not silently accept 3.5 or come back as a float, and the
+    document distinguishes JSON integers from JSON numbers.
+    """
     if isinstance(value, bool):
         raise _refuse(f"{what} must be an integer, got a bool ({value!r})")
     if is_tracer(value):
@@ -212,26 +198,15 @@ def _integer(value: Any, *, what: str) -> int:
     return out
 
 
-def _text(value: Any, *, what: str) -> str:
-    if not isinstance(value, str):
-        raise _refuse(f"{what} must be a string, got {type(value).__name__}")
-    return value
-
-
 def _flag(value: Any, *, what: str) -> bool:
+    """Require an actual bool.
+
+    ``excite`` decides whether a port carries a source at all, so accepting a
+    truthy int here would turn a JSON ``1`` into an active excitation.
+    """
     if not isinstance(value, bool):
         raise _refuse(f"{what} must be a bool, got {type(value).__name__}")
     return value
-
-
-def _vector(value: Any, n: int, *, what: str) -> tuple[float, ...]:
-    if isinstance(value, (str, bytes)) or not hasattr(value, "__len__"):
-        raise _refuse(f"{what} must be a sequence of {n} numbers, got {value!r}")
-    if len(value) != n:
-        raise _refuse(
-            f"{what} must have exactly {n} components, got {len(value)}: {value!r}"
-        )
-    return tuple(_num(v, what=f"{what}[{i}]") for i, v in enumerate(value))
 
 
 def _integer_vector(value: Any, n: int, *, what: str) -> tuple[int, ...]:
@@ -289,7 +264,7 @@ def _array_to_dict(value: Any, *, what: str) -> dict[str, Any]:
             )
         payload["dtype"] = str(value.dtype)
     payload["values"] = [
-        _num(v, what=f"{what}[{i}]") for i, v in enumerate(np.asarray(value).tolist())
+        check_number(v, what=f"{what}[{i}]") for i, v in enumerate(np.asarray(value).tolist())
     ]
     return payload
 
@@ -309,14 +284,14 @@ def _array_from_dict(payload: Any, *, what: str) -> Any:
     raw = payload["values"]
     if not isinstance(raw, list):
         raise _refuse(f"{what}.values must be a list, got {type(raw).__name__}")
-    values = [_num(v, what=f"{what}.values[{i}]") for i, v in enumerate(raw)]
+    values = [check_number(v, what=f"{what}.values[{i}]") for i, v in enumerate(raw)]
 
     if container == "list":
         return values
     if container == "tuple":
         return tuple(values)
 
-    dtype = _text(payload["dtype"], what=f"{what}.dtype")
+    dtype = check_text(payload["dtype"], what=f"{what}.dtype")
     try:
         arr = np.asarray(values, dtype=np.dtype(dtype))
     except TypeError as exc:
@@ -391,7 +366,7 @@ def _waveform_to_dict(waveform: Any, *, what: str) -> dict[str, Any] | None:
         name: (
             _integer(getattr(waveform, name), what=f"{what}.{name}")
             if name in _WAVEFORM_INT_FIELDS
-            else _num(getattr(waveform, name), what=f"{what}.{name}")
+            else check_number(getattr(waveform, name), what=f"{what}.{name}")
         )
         for name in codec.fields
     }
@@ -404,7 +379,7 @@ def _waveform_from_dict(payload: Any, *, what: str) -> Any:
     if not isinstance(payload, dict):
         raise _refuse(f"{what} must be a mapping or null, got {type(payload).__name__}")
     _require_exact_keys(payload, {"kind", "params"}, what=what)
-    kind = _text(payload["kind"], what=f"{what}.kind")
+    kind = check_text(payload["kind"], what=f"{what}.kind")
     if kind not in _WAVEFORM_CODECS:
         raise _refuse(
             f"{what}.kind {kind!r} is not supported; supported kinds are "
@@ -419,7 +394,7 @@ def _waveform_from_dict(payload: Any, *, what: str) -> Any:
         name: (
             _integer(params[name], what=f"{what}.params.{name}")
             if name in _WAVEFORM_INT_FIELDS
-            else _num(params[name], what=f"{what}.params.{name}")
+            else check_number(params[name], what=f"{what}.params.{name}")
         )
         for name in codec.fields
     }
@@ -477,9 +452,9 @@ def _opt(field: _F) -> _F:
     )
 
 
-_NUM = _F(dump=lambda v, w: _num(v, what=w), load=lambda v, w: _num(v, what=w))
+_NUM = _F(dump=lambda v, w: check_number(v, what=w), load=lambda v, w: check_number(v, what=w))
 _INT = _F(dump=lambda v, w: _integer(v, what=w), load=lambda v, w: _integer(v, what=w))
-_STR = _F(dump=lambda v, w: _text(v, what=w), load=lambda v, w: _text(v, what=w))
+_STR = _F(dump=lambda v, w: check_text(v, what=w), load=lambda v, w: check_text(v, what=w))
 _BOOL = _F(dump=lambda v, w: _flag(v, what=w), load=lambda v, w: _flag(v, what=w))
 _SHAPE = _F(dump=lambda v, w: shape_to_dict(v), load=lambda v, w: shape_from_dict(v))
 _WAVEFORM = _F(
@@ -494,8 +469,8 @@ _ARRAY = _F(
 
 def _vec(n: int) -> _F:
     return _F(
-        dump=lambda v, w: list(_vector(v, n, what=w)),
-        load=lambda v, w: _vector(v, n, what=w),
+        dump=lambda v, w: list(check_vector(v, n, what=w)),
+        load=lambda v, w: check_vector(v, n, what=w),
     )
 
 
@@ -838,11 +813,11 @@ def _dump_boundary(sim: Any) -> dict[str, Any]:
         # scalar + set_periodic_axes() path, and _periodic_axes is also
         # mutated as a side effect by add_floquet_port.
         "legacy": {
-            "boundary": _text(sim._boundary, what="_boundary"),
+            "boundary": check_text(sim._boundary, what="_boundary"),
             "cpml_layers": _integer(sim._cpml_layers, what="_cpml_layers"),
-            "cpml_kappa_max": _num(sim._cpml_kappa_max, what="_cpml_kappa_max"),
-            "pec_faces": sorted(_text(f, what="_pec_faces entry") for f in sim._pec_faces),
-            "periodic_axes": _text(sim._periodic_axes, what="_periodic_axes"),
+            "cpml_kappa_max": check_number(sim._cpml_kappa_max, what="_cpml_kappa_max"),
+            "pec_faces": sorted(check_text(f, what="_pec_faces entry") for f in sim._pec_faces),
+            "periodic_axes": check_text(sim._periodic_axes, what="_periodic_axes"),
         },
     }
 
@@ -888,9 +863,9 @@ def _plan_boundary(payload: dict, *, has_floquet: bool) -> _BoundaryPlan:
         {"boundary", "cpml_layers", "cpml_kappa_max", "pec_faces", "periodic_axes"},
         what="boundary.legacy",
     )
-    scalar = _text(legacy["boundary"], what="boundary.legacy.boundary")
+    scalar = check_text(legacy["boundary"], what="boundary.legacy.boundary")
     cpml_layers = _integer(legacy["cpml_layers"], what="boundary.legacy.cpml_layers")
-    kappa = _num(legacy["cpml_kappa_max"], what="boundary.legacy.cpml_kappa_max")
+    kappa = check_number(legacy["cpml_kappa_max"], what="boundary.legacy.cpml_kappa_max")
     raw_faces = legacy["pec_faces"]
     if not isinstance(raw_faces, list):
         raise _refuse(
@@ -898,10 +873,10 @@ def _plan_boundary(payload: dict, *, has_floquet: bool) -> _BoundaryPlan:
             f"{type(raw_faces).__name__}"
         )
     pec_faces = {
-        _text(face, what=f"boundary.legacy.pec_faces[{i}]")
+        check_text(face, what=f"boundary.legacy.pec_faces[{i}]")
         for i, face in enumerate(raw_faces)
     }
-    periodic = _text(legacy["periodic_axes"], what="boundary.legacy.periodic_axes")
+    periodic = check_text(legacy["periodic_axes"], what="boundary.legacy.periodic_axes")
 
     common = {"cpml_kappa_max": kappa}
 
@@ -987,7 +962,7 @@ def _dump_ports(sim: Any) -> tuple[list[dict], list[dict]]:
             raise _refuse(
                 f"{what} is a {type(entry).__name__}, expected _PortEntry"
             )
-        if _num(entry.impedance, what=f"{what}.impedance") == 0.0:
+        if check_number(entry.impedance, what=f"{what}.impedance") == 0.0:
             for name, expected in _SOFT_SOURCE_PINNED_DEFAULTS.items():
                 actual = getattr(entry, name)
                 if actual != expected:
@@ -1027,7 +1002,7 @@ def _dump_coaxial_matched_loads(sim: Any) -> list[dict[str, Any]]:
         out.append(
             {
                 "port_index": _integer(port_index, what=f"{what}.port_index"),
-                "target_impedance": _num(impedance, what=f"{what}.target_impedance"),
+                "target_impedance": check_number(impedance, what=f"{what}.target_impedance"),
                 "axial_offset_cells": _integer(
                     offset, what=f"{what}.axial_offset_cells"
                 ),
@@ -1272,14 +1247,14 @@ def design_to_dict(sim: Any) -> dict[str, Any]:
         "schema": DESIGN_SCHEMA_VERSION,
         "rfx_version": _rfx_version(),
         "domain": {
-            "freq_max": _num(sim._freq_max, what="_freq_max"),
-            "extent": list(_vector(sim._domain, 3, what="_domain")),
-            "mode": _text(sim._mode, what="_mode"),
+            "freq_max": check_number(sim._freq_max, what="_freq_max"),
+            "extent": list(check_vector(sim._domain, 3, what="_domain")),
+            "mode": check_text(sim._mode, what="_mode"),
         },
         "mesh": {
             # dx is None on the auto-mesh path: "let rfx choose" is itself the
             # design decision, and it round-trips as null.
-            "dx": None if sim._dx is None else _num(sim._dx, what="_dx"),
+            "dx": None if sim._dx is None else check_number(sim._dx, what="_dx"),
             "dx_profile": (
                 None
                 if sim._dx_profile is None
@@ -1298,9 +1273,9 @@ def design_to_dict(sim: Any) -> dict[str, Any]:
         },
         "boundary": _dump_boundary(sim),
         "solver": {
-            "precision": _text(sim._precision, what="_precision"),
-            "solver": _text(sim._solver, what="_solver"),
-            "adi_cfl_factor": _num(sim._adi_cfl_factor, what="_adi_cfl_factor"),
+            "precision": check_text(sim._precision, what="_precision"),
+            "solver": check_text(sim._solver, what="_solver"),
+            "adi_cfl_factor": check_number(sim._adi_cfl_factor, what="_adi_cfl_factor"),
             "stencil_order": _integer(sim._stencil_order, what="_stencil_order"),
         },
         "materials": _dump_materials(sim),
@@ -1496,13 +1471,13 @@ def simulation_from_design(document: Any) -> Any:
         )
     _require_exact_keys(document, _TOP_LEVEL_KEYS, what="design document")
 
-    schema = _text(document["schema"], what="schema")
+    schema = check_text(document["schema"], what="schema")
     if schema != DESIGN_SCHEMA_VERSION:
         raise _refuse(
             f"schema {schema!r} is not {DESIGN_SCHEMA_VERSION!r}; this reader "
             f"does not translate between schema versions"
         )
-    _text(document["rfx_version"], what="rfx_version")
+    check_text(document["rfx_version"], what="rfx_version")
     if not isinstance(document["non_portable"], list):
         raise _refuse(
             f"non_portable must be a list, got "
@@ -1542,10 +1517,10 @@ def simulation_from_design(document: Any) -> Any:
     )
 
     sim = Simulation(
-        freq_max=_num(domain["freq_max"], what="domain.freq_max"),
-        domain=_vector(domain["extent"], 3, what="domain.extent"),
-        dx=None if mesh["dx"] is None else _num(mesh["dx"], what="mesh.dx"),
-        mode=_text(domain["mode"], what="domain.mode"),
+        freq_max=check_number(domain["freq_max"], what="domain.freq_max"),
+        domain=check_vector(domain["extent"], 3, what="domain.extent"),
+        dx=None if mesh["dx"] is None else check_number(mesh["dx"], what="mesh.dx"),
+        mode=check_text(domain["mode"], what="domain.mode"),
         dx_profile=(
             None
             if mesh["dx_profile"] is None
@@ -1561,9 +1536,9 @@ def simulation_from_design(document: Any) -> Any:
             if mesh["dz_profile"] is None
             else _array_from_dict(mesh["dz_profile"], what="mesh.dz_profile")
         ),
-        precision=_text(solver["precision"], what="solver.precision"),
-        solver=_text(solver["solver"], what="solver.solver"),
-        adi_cfl_factor=_num(solver["adi_cfl_factor"], what="solver.adi_cfl_factor"),
+        precision=check_text(solver["precision"], what="solver.precision"),
+        solver=check_text(solver["solver"], what="solver.solver"),
+        adi_cfl_factor=check_number(solver["adi_cfl_factor"], what="solver.adi_cfl_factor"),
         stencil_order=_integer(solver["stencil_order"], what="solver.stencil_order"),
         **plan.kwargs,
     )
@@ -1636,7 +1611,7 @@ def simulation_from_design(document: Any) -> Any:
         )
         sim.add_coaxial_matched_load(
             _integer(payload["port_index"], what=f"{what}.port_index"),
-            target_impedance=_num(
+            target_impedance=check_number(
                 payload["target_impedance"], what=f"{what}.target_impedance"
             ),
             axial_offset_cells=_integer(

--- a/rfx/interop/_design.py
+++ b/rfx/interop/_design.py
@@ -1054,13 +1054,38 @@ def _non_portable(document: dict[str, Any]) -> list[dict[str, str]]:
             "all, so a profile must be re-meshed, never averaged to a scalar "
             "resolution",
         )
-    if document["boundary"]["legacy"]["cpml_layers"] > 0:
+    # The scalar is only one of two ways to define an absorber: a per-face
+    # BoundarySpec can carry cpml/upml tokens with their own lo/hi thickness
+    # while the legacy scalar stays 0. Gating on the scalar alone annotated a
+    # real 12-cell-per-face CPML as fully portable.
+    boundary_spec = document["boundary"]["spec"]
+    absorbing_faces = sorted(
+        f"{axis}_{side}"
+        for axis, faces in boundary_spec.items()
+        for side in ("lo", "hi")
+        if faces.get(side) in ("cpml", "upml")
+    )
+    if absorbing_faces or document["boundary"]["legacy"]["cpml_layers"] > 0:
         note(
-            "boundary.legacy.cpml_layers",
-            "absorber depth as a cell count; the remaining CPML knobs "
-            "(sigma_max, alpha_max, grading order) are hard-coded in "
-            "rfx/boundaries/cpml.py, so two solvers given the same layer "
-            "count build different absorbers",
+            "boundary",
+            "absorber depth is a cell count (legacy.cpml_layers and/or the "
+            "per-face lo_thickness/hi_thickness on "
+            f"{', '.join(absorbing_faces) or 'the absorbing faces'}); the "
+            "remaining CPML knobs (sigma_max, alpha_max, grading order) are "
+            "hard-coded in rfx/boundaries/cpml.py, so two solvers given the "
+            "same layer count build different absorbers",
+        )
+    conformal_axes = sorted(
+        axis for axis, faces in boundary_spec.items() if faces.get("conformal")
+    )
+    if conformal_axes:
+        note(
+            "boundary.spec." + "/".join(conformal_axes) + ".conformal",
+            "conformal PEC on a boundary face is rfx-only: openEMS has no "
+            "conformal PEC (this branch's own emitter refuses it rather than "
+            "emitting a staircased face, which would compare a different "
+            "structure), and rfx's own conformal treatment does not propagate "
+            "to the nonuniform or subgrid paths",
         )
 
     solver = document["solver"]

--- a/rfx/interop/_design.py
+++ b/rfx/interop/_design.py
@@ -1,0 +1,1828 @@
+"""Round-trip-complete design description of an rfx ``Simulation``.
+
+``design_to_dict(sim)`` serialises the complete *design state* of a
+:class:`~rfx.api.Simulation` — the state a user established with the
+constructor and the ``add_*`` builder methods — and
+``simulation_from_design(document)`` rebuilds it.  The gate is field-by-field
+equality of the builder state, not visual similarity of the JSON.
+
+Contract
+--------
+1. **Refuse, never approximate.**  Any state that cannot be represented
+   exactly raises :class:`~rfx.interop._errors.UnsupportedDesignFeature`,
+   naming the entry family and its index.  There is no ``warnings.warn``-and-
+   drop path and no bounding-box fallback: a design description that quietly
+   loses a shape parameter, a dispersion pole or a mesh profile is worse than
+   no description at all, because the resulting comparison looks valid while
+   describing a different structure.
+2. **Full arrays.**  Mesh profiles and frequency lists are emitted value by
+   value, with their dtype and array namespace, never summarised.  Numbers are
+   plain Python floats, so ``json.dump(..., allow_nan=False)`` with no
+   ``default=str`` round-trips them exactly.  Non-finite values are refused.
+3. **Closed world.**  An unknown key — at the top level or in any nested
+   section — is refused on import.  This mirrors ``rfx/config/loader.py``.
+4. **Design state only.**  No derived or transient state: no ``Grid`` /
+   ``NonUniformGrid``, no ``dt``, no grid shape, no preflight scratch, no
+   results.  No run-time control either (``n_steps``, ``until_decay``,
+   ``compute_s_params``, ``eps_override``, ...): those change the answer but
+   are arguments to ``run()`` / ``forward()``, not properties of the design.
+5. **Fences are mirrored, never widened.**  The importer drives the public
+   ``add_*`` builders, so every builder fence (for example the Floquet
+   ``n_modes > 1`` / ``polarization='tm'`` ``NotImplementedError``) applies to
+   an imported design exactly as it applies to hand-written code.  After the
+   rebuild the importer re-exports the result and refuses if it differs from
+   the input document, so an inexact reconstruction fails loudly instead of
+   returning a plausible-looking ``Simulation``.
+
+When NOT to call the exporter
+-----------------------------
+**Do not export from inside an S-parameter driver.**  ``rfx/api/_sparams.py``
+temporarily *rewrites* builder state — ``_dz_profile``, ``_msl_ports``,
+``_ports``, ``_dft_planes``, ``_waveguide_ports`` — and restores it in a
+``finally`` block (see ``_sparams.py`` around lines 1489, 1528-1531,
+1877-1880, 2691, 2727, 2765, 2958-2959).  A document captured from a callback
+that runs inside one of those drivers describes the driver's synthetic
+per-run configuration, not the user's design, and there is currently **no
+sentinel on ``Simulation`` to detect it** — the substitutions are
+value-level (a uniform ``_dz_profile``, a one-port ``_msl_ports``) and are
+indistinguishable from a legitimate design.  Export from user-level code,
+before or after the driver call.
+
+A second time dependence: with ``dx=None`` the auto-mesh runs inside ``run()``
+and writes back ``_dx``, ``_dz_profile`` and ``_domain``.  Exporting before a
+run therefore yields ``"dx": null`` and no ``dz_profile``, and exporting after
+the same run yields the resolved mesh.  Both are faithful; they describe
+different design states of the same script.
+
+Relationship to the other rfx setup serialisers
+-----------------------------------------------
+rfx already has four setup serialisers and every one of them is box-level:
+
+- ``rfx/io.py::export_geometry_json`` — class name plus bounding box;
+- ``rfx/artifacts.py::build_scene_artifact`` (``rfx-scene-artifact-v1``) — a
+  provenance/report summary that self-declares it is "not a CAD export";
+- ``rfx/config/_shapes.py`` — the YAML config CLI, ``_SUPPORTED_SHAPES =
+  ("box",)``;
+- ``rfx/experiments/canonical.py`` (``rfx-experiment/v1``) — "P0 supports box
+  geometry", geometry carried as ``bounds_m``.
+
+This module is deliberately **not** a fifth independent vocabulary.  The
+``geometry`` and ``materials`` sections are shaped so they can be folded into
+a future ``rfx-experiment/v2`` mechanically: shapes use the ``{"kind":
+"<snake_case>", "params": {...}}`` discriminated union of
+``rfx/interop/_shapes.py`` — the same ``kind`` spelling the config layer and
+``canonical.py`` already use for a box — and materials use the
+``rfx/interop/_materials.py`` payload verbatim.  A consumer that wants
+box-only geometry can filter on ``kind == "box"``; it does not need a second
+shape decoder.
+
+External-solver portability
+---------------------------
+This schema is rfx→rfx.  Some design state round-trips perfectly here yet has
+no meaning in another solver, and the document says so explicitly in its
+``non_portable`` list rather than leaving a later external emitter to
+rediscover it:
+
+- ``_coaxial_terminations`` / ``_coaxial_open_terminations`` /
+  ``_coaxial_pec_end_caps`` carry **cell-relative** axial offsets;
+- ``_MSLPortEntry.n_probe_offset`` / ``n_probe_spacing`` are **cell counts**
+  derived from ``_dx`` at registration time;
+- ``_WaveguidePortEntry.probe_offset`` / ``ref_offset`` and
+  ``_PortEntry.reference_plane_cells`` are likewise cell counts;
+- ``_refinement`` is the rfx SBP-SAT subgrid prototype — experimental, and
+  falsified in 3D (PR #90);
+- ``cpml_layers`` is a cell count against an absorber whose remaining knobs
+  are hard-coded in ``rfx/boundaries/cpml.py``;
+- non-uniform mesh profiles have no counterpart in a solver with a scalar
+  resolution.
+
+``non_portable`` is an annotation derived from the document's own content.  It
+is not applied on import and carries no numbers.
+
+Status: **provisional**.  Round-trip fidelity is gated by
+``tests/test_interop_design_document.py``; no external emitter exists yet.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import math
+from typing import Any, Callable, NamedTuple
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from rfx.api._spec import (
+    MATERIAL_LIBRARY,
+    _DFTPlaneEntry,
+    _FloquetPortEntry,
+    _FluxMonitorEntry,
+    _GeometryEntry,
+    _MSLPortEntry,
+    _PortEntry,
+    _ProbeEntry,
+    _TFSFEntry,
+    _WaveguidePortEntry,
+)
+from rfx.boundaries.spec import BoundarySpec
+from rfx.core.jax_utils import is_tracer
+from rfx.interop._errors import UnsupportedDesignFeature
+from rfx.interop._materials import (
+    material_to_dict,
+    materials_from_dict,
+    materials_to_dict,
+)
+from rfx.interop._shapes import shape_from_dict, shape_to_dict
+from rfx.lumped import LumpedRLCSpec
+from rfx.materials.thin_conductor import ThinConductor
+from rfx.sources.coaxial_port import CoaxialPort
+from rfx.sources.sources import CWSource, GaussianPulse, ModulatedGaussian
+
+__all__ = [
+    "DESIGN_SCHEMA_VERSION",
+    "SUPPORTED_WAVEFORM_KINDS",
+    "design_to_dict",
+    "design_to_json",
+    "simulation_from_design",
+]
+
+DESIGN_SCHEMA_VERSION = "rfx-design-ir/v1"
+
+
+# ---------------------------------------------------------------------------
+# Scalar coercions
+# ---------------------------------------------------------------------------
+
+def _refuse(message: str) -> "UnsupportedDesignFeature":
+    return UnsupportedDesignFeature(message)
+
+
+def _num(value: Any, *, what: str) -> float:
+    """Coerce to a finite Python float or refuse."""
+    if is_tracer(value):
+        raise _refuse(
+            f"{what} is a JAX tracer; a traced value has no concrete number "
+            f"to record. Export outside jit/grad, or pass a concrete value."
+        )
+    if isinstance(value, bool):
+        raise _refuse(f"{what} must be a number, got a bool ({value!r})")
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise _refuse(f"{what} must be a number, got {value!r}") from exc
+    if not math.isfinite(out):
+        raise _refuse(
+            f"{what} is {out!r}; the design document refuses non-finite "
+            f"numbers (JSON cannot represent them portably)"
+        )
+    return out
+
+
+def _integer(value: Any, *, what: str) -> int:
+    if isinstance(value, bool):
+        raise _refuse(f"{what} must be an integer, got a bool ({value!r})")
+    if is_tracer(value):
+        raise _refuse(f"{what} is a JAX tracer; expected a concrete integer")
+    try:
+        out = int(value)
+    except (TypeError, ValueError) as exc:
+        raise _refuse(f"{what} must be an integer, got {value!r}") from exc
+    if out != value:
+        raise _refuse(f"{what} must be an exact integer, got {value!r}")
+    return out
+
+
+def _text(value: Any, *, what: str) -> str:
+    if not isinstance(value, str):
+        raise _refuse(f"{what} must be a string, got {type(value).__name__}")
+    return value
+
+
+def _flag(value: Any, *, what: str) -> bool:
+    if not isinstance(value, bool):
+        raise _refuse(f"{what} must be a bool, got {type(value).__name__}")
+    return value
+
+
+def _vector(value: Any, n: int, *, what: str) -> tuple[float, ...]:
+    if isinstance(value, (str, bytes)) or not hasattr(value, "__len__"):
+        raise _refuse(f"{what} must be a sequence of {n} numbers, got {value!r}")
+    if len(value) != n:
+        raise _refuse(
+            f"{what} must have exactly {n} components, got {len(value)}: {value!r}"
+        )
+    return tuple(_num(v, what=f"{what}[{i}]") for i, v in enumerate(value))
+
+
+def _integer_vector(value: Any, n: int, *, what: str) -> tuple[int, ...]:
+    if isinstance(value, (str, bytes)) or not hasattr(value, "__len__"):
+        raise _refuse(f"{what} must be a sequence of {n} integers, got {value!r}")
+    if len(value) != n:
+        raise _refuse(
+            f"{what} must have exactly {n} components, got {len(value)}: {value!r}"
+        )
+    return tuple(_integer(v, what=f"{what}[{i}]") for i, v in enumerate(value))
+
+
+# ---------------------------------------------------------------------------
+# Array codec — full values, dtype and namespace preserved
+# ---------------------------------------------------------------------------
+#
+# Mesh profiles and frequency lists reach the builder as Python lists, numpy
+# arrays or jax arrays, and the container matters: ``Simulation.__init__``
+# synthesises ``domain`` from ``float(np.sum(profile))``, so a float32 profile
+# reloaded as float64 shifts the domain extent in the last ULPs and breaks the
+# bit-identity gates the repo relies on.  The dtype and the array namespace are
+# therefore part of the record.
+
+_ARRAY_CONTAINERS = ("list", "tuple", "numpy", "jax")
+
+
+def _array_to_dict(value: Any, *, what: str) -> dict[str, Any]:
+    """Record a 1-D numeric array value-by-value with its container identity."""
+    if is_tracer(value):
+        raise _refuse(
+            f"{what} is a JAX tracer (differentiable-mesh / traced path). A "
+            f"tracer has no concrete values, so exporting it would record a "
+            f"placeholder rather than a mesh. Export the design outside "
+            f"jit/grad with concrete profile values."
+        )
+    if isinstance(value, np.ndarray):
+        container = "numpy"
+    elif isinstance(value, jax.Array):
+        container = "jax"
+    elif isinstance(value, list):
+        container = "list"
+    elif isinstance(value, tuple):
+        container = "tuple"
+    else:
+        raise _refuse(
+            f"{what} is a {type(value).__name__}; the design document records "
+            f"lists, tuples, numpy arrays and jax arrays only"
+        )
+
+    payload: dict[str, Any] = {"container": container}
+    if container in ("numpy", "jax"):
+        if value.ndim != 1:
+            raise _refuse(
+                f"{what} must be 1-D, got shape {tuple(value.shape)}"
+            )
+        payload["dtype"] = str(value.dtype)
+    payload["values"] = [
+        _num(v, what=f"{what}[{i}]") for i, v in enumerate(np.asarray(value).tolist())
+    ]
+    return payload
+
+
+def _array_from_dict(payload: Any, *, what: str) -> Any:
+    if not isinstance(payload, dict):
+        raise _refuse(f"{what} must be a mapping, got {type(payload).__name__}")
+    container = payload.get("container")
+    if container not in _ARRAY_CONTAINERS:
+        raise _refuse(
+            f"{what}.container must be one of {_ARRAY_CONTAINERS}, got "
+            f"{container!r}"
+        )
+    expected = {"container", "values"} | ({"dtype"} if container in ("numpy", "jax") else set())
+    _require_exact_keys(payload, expected, what=what)
+
+    raw = payload["values"]
+    if not isinstance(raw, list):
+        raise _refuse(f"{what}.values must be a list, got {type(raw).__name__}")
+    values = [_num(v, what=f"{what}.values[{i}]") for i, v in enumerate(raw)]
+
+    if container == "list":
+        return values
+    if container == "tuple":
+        return tuple(values)
+
+    dtype = _text(payload["dtype"], what=f"{what}.dtype")
+    try:
+        arr = np.asarray(values, dtype=np.dtype(dtype))
+    except TypeError as exc:
+        raise _refuse(f"{what}.dtype {dtype!r} is not a numpy dtype") from exc
+    if container == "numpy":
+        return arr
+    out = jnp.asarray(arr)
+    if str(out.dtype) != dtype:
+        raise _refuse(
+            f"{what} was exported as a jax array of dtype {dtype!r} but this "
+            f"process rebuilds it as {str(out.dtype)!r} — the JAX x64 setting "
+            f"differs from the exporting process. Rebuilding would change the "
+            f"numbers, so the import is refused (see JAX_ENABLE_X64)."
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Waveform codec
+# ---------------------------------------------------------------------------
+#
+# ``CustomWaveform`` wraps a user callable and is unrepresentable by
+# construction.  Note that ``add_polarized_source`` builds a
+# ``CustomWaveform`` closure for a complex Jones vector, so a circularly
+# polarised source is refused here — it is already unrecoverable from
+# ``_ports`` inside rfx itself.
+
+class _WaveformCodec(NamedTuple):
+    cls: type
+    fields: tuple[str, ...]
+
+
+_WAVEFORM_CODECS: dict[str, _WaveformCodec] = {
+    "gaussian_pulse": _WaveformCodec(
+        GaussianPulse, ("f0", "bandwidth", "amplitude", "cutoff")
+    ),
+    "modulated_gaussian": _WaveformCodec(
+        ModulatedGaussian, ("f0", "bandwidth", "amplitude", "cutoff")
+    ),
+    "cw_source": _WaveformCodec(CWSource, ("f0", "amplitude", "ramp_steps")),
+}
+
+SUPPORTED_WAVEFORM_KINDS: tuple[str, ...] = tuple(sorted(_WAVEFORM_CODECS))
+
+_WAVEFORM_KIND_BY_CLASS = {c.cls: k for k, c in _WAVEFORM_CODECS.items()}
+
+_WAVEFORM_INT_FIELDS = frozenset({"ramp_steps"})
+
+
+def _waveform_to_dict(waveform: Any, *, what: str) -> dict[str, Any] | None:
+    if waveform is None:
+        return None
+    try:
+        kind = _WAVEFORM_KIND_BY_CLASS[type(waveform)]
+    except KeyError:
+        raise _refuse(
+            f"{what} is a {type(waveform).__name__}; the design document "
+            f"records {', '.join(SUPPORTED_WAVEFORM_KINDS)} only. A "
+            f"CustomWaveform (including the closure add_polarized_source "
+            f"builds for a complex Jones vector) wraps a Python callable and "
+            f"has no serialisable form."
+        ) from None
+    codec = _WAVEFORM_CODECS[kind]
+    live = tuple(f.name for f in dataclasses.fields(codec.cls))
+    if live != codec.fields:
+        raise _refuse(
+            f"{codec.cls.__name__} now declares fields {live} but the design "
+            f"document records {codec.fields}. Update rfx/interop/_design.py "
+            f"rather than exporting a partial waveform"
+        )
+    params = {
+        name: (
+            _integer(getattr(waveform, name), what=f"{what}.{name}")
+            if name in _WAVEFORM_INT_FIELDS
+            else _num(getattr(waveform, name), what=f"{what}.{name}")
+        )
+        for name in codec.fields
+    }
+    return {"kind": kind, "params": params}
+
+
+def _waveform_from_dict(payload: Any, *, what: str) -> Any:
+    if payload is None:
+        return None
+    if not isinstance(payload, dict):
+        raise _refuse(f"{what} must be a mapping or null, got {type(payload).__name__}")
+    _require_exact_keys(payload, {"kind", "params"}, what=what)
+    kind = _text(payload["kind"], what=f"{what}.kind")
+    if kind not in _WAVEFORM_CODECS:
+        raise _refuse(
+            f"{what}.kind {kind!r} is not supported; supported kinds are "
+            f"{', '.join(SUPPORTED_WAVEFORM_KINDS)}"
+        )
+    codec = _WAVEFORM_CODECS[kind]
+    params = payload["params"]
+    if not isinstance(params, dict):
+        raise _refuse(f"{what}.params must be a mapping, got {type(params).__name__}")
+    _require_exact_keys(params, set(codec.fields), what=f"{what}.params")
+    kwargs = {
+        name: (
+            _integer(params[name], what=f"{what}.params.{name}")
+            if name in _WAVEFORM_INT_FIELDS
+            else _num(params[name], what=f"{what}.params.{name}")
+        )
+        for name in codec.fields
+    }
+    return codec.cls(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Closed-world key checking
+# ---------------------------------------------------------------------------
+
+def _require_exact_keys(payload: dict, expected: set[str], *, what: str) -> None:
+    present = set(payload)
+    unknown = present - expected
+    missing = expected - present
+    if unknown or missing:
+        raise _refuse(
+            f"{what} key mismatch: missing={sorted(missing)}, "
+            f"unknown={sorted(unknown)}"
+        )
+
+
+def _section(payload: Any, key: str, *, what: str) -> dict:
+    value = payload[key]
+    if not isinstance(value, dict):
+        raise _refuse(
+            f"{what}.{key} must be a mapping, got {type(value).__name__}"
+        )
+    return value
+
+
+def _entry_list(payload: Any, key: str, *, what: str) -> list:
+    value = payload[key]
+    if not isinstance(value, list):
+        raise _refuse(f"{what}.{key} must be a list, got {type(value).__name__}")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Per-entry field registry
+# ---------------------------------------------------------------------------
+#
+# Every builder-owned record type has one entry here.  ``_dump_entry`` asserts
+# the live class declares exactly these fields, so a field added upstream reds
+# the interop contract test instead of vanishing from exported designs.
+
+class _F(NamedTuple):
+    dump: Callable[[Any, str], Any]
+    load: Callable[[Any, str], Any]
+
+
+def _opt(field: _F) -> _F:
+    return _F(
+        dump=lambda v, w: None if v is None else field.dump(v, w),
+        load=lambda v, w: None if v is None else field.load(v, w),
+    )
+
+
+_NUM = _F(dump=lambda v, w: _num(v, what=w), load=lambda v, w: _num(v, what=w))
+_INT = _F(dump=lambda v, w: _integer(v, what=w), load=lambda v, w: _integer(v, what=w))
+_STR = _F(dump=lambda v, w: _text(v, what=w), load=lambda v, w: _text(v, what=w))
+_BOOL = _F(dump=lambda v, w: _flag(v, what=w), load=lambda v, w: _flag(v, what=w))
+_SHAPE = _F(dump=lambda v, w: shape_to_dict(v), load=lambda v, w: shape_from_dict(v))
+_WAVEFORM = _F(
+    dump=lambda v, w: _waveform_to_dict(v, what=w),
+    load=lambda v, w: _waveform_from_dict(v, what=w),
+)
+_ARRAY = _F(
+    dump=lambda v, w: _array_to_dict(v, what=w),
+    load=lambda v, w: _array_from_dict(v, what=w),
+)
+
+
+def _vec(n: int) -> _F:
+    return _F(
+        dump=lambda v, w: list(_vector(v, n, what=w)),
+        load=lambda v, w: _vector(v, n, what=w),
+    )
+
+
+def _ivec(n: int) -> _F:
+    return _F(
+        dump=lambda v, w: list(_integer_vector(v, n, what=w)),
+        load=lambda v, w: _integer_vector(v, n, what=w),
+    )
+
+
+_GEOMETRY_FIELDS: dict[str, _F] = {
+    "shape": _SHAPE,
+    "material_name": _STR,
+}
+
+# ``_PortEntry`` holds two physically different objects, discriminated only by
+# the ``impedance == 0`` sentinel that ``add_source`` stamps.  The document
+# splits them into ``soft_sources`` and ``lumped_ports``; a soft source records
+# only the three fields ``add_source`` can set.
+_SOFT_SOURCE_FIELDS: dict[str, _F] = {
+    "position": _vec(3),
+    "component": _STR,
+    "waveform": _WAVEFORM,
+}
+
+_LUMPED_PORT_FIELDS: dict[str, _F] = {
+    "position": _vec(3),
+    "component": _STR,
+    "impedance": _NUM,
+    "waveform": _opt(_WAVEFORM),
+    "extent": _opt(_NUM),
+    "excite": _BOOL,
+    "direction": _opt(_STR),
+    "reference_plane_cells": _opt(_INT),
+}
+
+_PROBE_FIELDS: dict[str, _F] = {
+    "position": _vec(3),
+    "component": _STR,
+}
+
+_THIN_CONDUCTOR_FIELDS: dict[str, _F] = {
+    "shape": _SHAPE,
+    "sigma_bulk": _NUM,
+    "thickness": _NUM,
+    "eps_r": _NUM,
+}
+
+_COAXIAL_PORT_FIELDS: dict[str, _F] = {
+    "position": _vec(3),
+    "face": _STR,
+    "pin_length": _NUM,
+    "pin_radius": _NUM,
+    "outer_radius": _NUM,
+    "impedance": _NUM,
+    "excitation": _WAVEFORM,
+}
+
+_TFSF_FIELDS: dict[str, _F] = {
+    "f0": _opt(_NUM),
+    "bandwidth": _NUM,
+    "amplitude": _NUM,
+    "margin": _INT,
+    "polarization": _STR,
+    "direction": _STR,
+    "angle_deg": _NUM,
+    "waveform": _STR,
+}
+
+_DFT_PLANE_FIELDS: dict[str, _F] = {
+    "name": _STR,
+    "axis": _STR,
+    "coordinate": _NUM,
+    "component": _STR,
+    "freqs": _opt(_ARRAY),
+    "n_freqs": _INT,
+}
+
+_FLUX_MONITOR_FIELDS: dict[str, _F] = {
+    "name": _STR,
+    "axis": _STR,
+    "coordinate": _NUM,
+    "freqs": _opt(_ARRAY),
+    "n_freqs": _INT,
+    "size": _opt(_vec(2)),
+    "center": _opt(_vec(2)),
+    "dft_window": _STR,
+    "dft_window_alpha": _NUM,
+}
+
+_WAVEGUIDE_PORT_FIELDS: dict[str, _F] = {
+    "name": _STR,
+    "x_position": _NUM,
+    "y_range": _opt(_vec(2)),
+    "z_range": _opt(_vec(2)),
+    "x_range": _opt(_vec(2)),
+    "mode": _ivec(2),
+    "mode_type": _STR,
+    "direction": _STR,
+    "freqs": _opt(_ARRAY),
+    "n_freqs": _INT,
+    "f0": _opt(_NUM),
+    "bandwidth": _NUM,
+    "amplitude": _NUM,
+    "probe_offset": _INT,
+    "ref_offset": _INT,
+    "calibration_preset": _opt(_STR),
+    "reference_plane": _opt(_NUM),
+    "probe_plane": _opt(_NUM),
+    "n_modes": _INT,
+    "waveform": _STR,
+    "mode_profile": _STR,
+}
+
+_FLOQUET_PORT_FIELDS: dict[str, _F] = {
+    "name": _STR,
+    "position": _NUM,
+    "axis": _STR,
+    "scan_theta": _NUM,
+    "scan_phi": _NUM,
+    "polarization": _STR,
+    "n_modes": _INT,
+    "freqs": _opt(_ARRAY),
+    "n_freqs": _INT,
+    "f0": _opt(_NUM),
+    "bandwidth": _NUM,
+    "amplitude": _NUM,
+}
+
+_MSL_PORT_FIELDS: dict[str, _F] = {
+    "name": _STR,
+    "position": _vec(3),
+    "width": _NUM,
+    "height": _NUM,
+    "direction": _STR,
+    "impedance": _NUM,
+    "waveform": _opt(_WAVEFORM),
+    "excite": _BOOL,
+    "n_probe_offset": _INT,
+    "n_probe_spacing": _INT,
+    "n_probes": _INT,
+    "mode": _STR,
+    "eps_r_sub": _opt(_NUM),
+}
+
+_LUMPED_RLC_FIELDS: dict[str, _F] = {
+    "R": _NUM,
+    "L": _NUM,
+    "C": _NUM,
+    "topology": _STR,
+    "position": _vec(3),
+    "component": _STR,
+}
+
+_REFINEMENT_FIELDS: dict[str, _F] = {
+    "z_range": _vec(2),
+    "ratio": _INT,
+    "xy_margin": _opt(_NUM),
+    "tau": _NUM,
+    "validation": _STR,
+    "topology": _STR,
+}
+
+_NTFF_FIELDS: dict[str, _F] = {
+    "corner_lo": _vec(3),
+    "corner_hi": _vec(3),
+    "freqs": _ARRAY,
+}
+
+# Record classes pinned against their field registry.  ``_PortEntry`` is
+# absent because it is split across two document sections and checked
+# separately in ``_dump_ports``.
+_PINNED_RECORDS: tuple[tuple[type, dict[str, _F]], ...] = (
+    (_GeometryEntry, _GEOMETRY_FIELDS),
+    (_ProbeEntry, _PROBE_FIELDS),
+    (ThinConductor, _THIN_CONDUCTOR_FIELDS),
+    (CoaxialPort, _COAXIAL_PORT_FIELDS),
+    (_TFSFEntry, _TFSF_FIELDS),
+    (_DFTPlaneEntry, _DFT_PLANE_FIELDS),
+    (_FluxMonitorEntry, _FLUX_MONITOR_FIELDS),
+    (_WaveguidePortEntry, _WAVEGUIDE_PORT_FIELDS),
+    (_FloquetPortEntry, _FLOQUET_PORT_FIELDS),
+    (_MSLPortEntry, _MSL_PORT_FIELDS),
+    (LumpedRLCSpec, _LUMPED_RLC_FIELDS),
+)
+
+
+def live_field_names(cls: type) -> tuple[str, ...]:
+    """Declared field names of a dataclass or NamedTuple record class.
+
+    Used by the interop contract test to pin the registries above against the
+    live builder record classes.
+    """
+    if dataclasses.is_dataclass(cls):
+        return tuple(f.name for f in dataclasses.fields(cls))
+    fields = getattr(cls, "_fields", None)
+    if fields is not None:
+        return tuple(fields)
+    raise TypeError(f"{cls.__name__} is neither a dataclass nor a NamedTuple")
+
+
+def _dump_entry(
+    entry: Any, fields: dict[str, _F], cls: type, *, what: str
+) -> dict[str, Any]:
+    if type(entry) is not cls:
+        raise _refuse(
+            f"{what} is a {type(entry).__name__}, expected {cls.__name__}; the "
+            f"design document does not infer fields of unknown record types"
+        )
+    live = set(live_field_names(cls))
+    unrecorded = live - set(fields)
+    if unrecorded:
+        raise _refuse(
+            f"{cls.__name__} carries fields the design document does not "
+            f"record: {sorted(unrecorded)}. Update rfx/interop/_design.py "
+            f"rather than exporting a partial entry"
+        )
+    return {
+        name: field.dump(getattr(entry, name), f"{what}.{name}")
+        for name, field in fields.items()
+    }
+
+
+def _load_entry(
+    payload: Any, fields: dict[str, _F], *, what: str
+) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise _refuse(f"{what} must be a mapping, got {type(payload).__name__}")
+    _require_exact_keys(payload, set(fields), what=what)
+    return {
+        name: field.load(payload[name], f"{what}.{name}")
+        for name, field in fields.items()
+    }
+
+
+def _dump_list(
+    entries: Any, fields: dict[str, _F], cls: type, *, what: str
+) -> list[dict[str, Any]]:
+    return [
+        _dump_entry(entry, fields, cls, what=f"{what}[{index}]")
+        for index, entry in enumerate(entries)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Exported / excluded attribute inventory
+# ---------------------------------------------------------------------------
+#
+# Anti-drift ledger.  ``tests/test_interop_design_document.py`` asserts that
+# every ``self._*`` attribute a fresh ``Simulation`` carries appears in exactly
+# one of these two tuples, so a new builder field cannot slip into rfx without
+# a decision being recorded here.
+
+EXPORTED_SIMULATION_ATTRS: tuple[str, ...] = (
+    "_adi_cfl_factor",
+    "_boundary",
+    "_boundary_spec",
+    "_coaxial_open_terminations",
+    "_coaxial_pec_end_caps",
+    "_coaxial_ports",
+    "_coaxial_terminations",
+    "_cpml_kappa_max",
+    "_cpml_layers",
+    "_dft_planes",
+    "_domain",
+    "_dx",
+    "_dx_profile",
+    "_dy_profile",
+    "_dz_profile",
+    "_floquet_ports",
+    "_flux_monitors",
+    "_freq_max",
+    "_geometry",
+    "_lumped_rlc",
+    "_materials",
+    "_mode",
+    "_msl_ports",
+    "_ntff",
+    "_pec_faces",
+    "_periodic_axes",
+    "_ports",
+    "_precision",
+    "_probes",
+    "_refinement",
+    "_solver",
+    "_stencil_order",
+    "_tfsf",
+    "_thin_conductors",
+    "_waveguide_ports",
+)
+
+#: Attributes deliberately absent from the document.  These are derived,
+#: transient, or run-time state — see the module docstring, rule 4.  A
+#: ``Simulation`` does not carry them at construction; they appear only after a
+#: preflight/run pass, which is exactly why they are not design state.
+EXCLUDED_SIMULATION_ATTRS: tuple[str, ...] = (
+    "_ntff_min_steps_hint",
+)
+
+
+# ---------------------------------------------------------------------------
+# Boundary section
+# ---------------------------------------------------------------------------
+
+def _predict_legacy_spec(
+    boundary: str, pec_faces: set[str], periodic_axes: str
+) -> BoundarySpec:
+    """Pure mirror of ``Simulation._build_spec_from_legacy``.
+
+    Used to decide which construction path reproduces a recorded boundary
+    state; kept as a separate function so the choice is made before any
+    ``Simulation`` is built (and so the mirror is testable on its own).
+    """
+    from rfx.boundaries.spec import Boundary
+
+    axes = {}
+    for axis in "xyz":
+        if axis in periodic_axes:
+            axes[axis] = Boundary(lo="periodic", hi="periodic")
+        else:
+            lo = "pec" if f"{axis}_lo" in pec_faces else boundary
+            hi = "pec" if f"{axis}_hi" in pec_faces else boundary
+            axes[axis] = Boundary(lo=lo, hi=hi)
+    return BoundarySpec(x=axes["x"], y=axes["y"], z=axes["z"])
+
+
+def _dump_boundary(sim: Any) -> dict[str, Any]:
+    spec = sim._boundary_spec
+    if not isinstance(spec, BoundarySpec):
+        raise _refuse(
+            f"_boundary_spec is a {type(spec).__name__}, expected BoundarySpec; "
+            f"the design document treats the spec as authoritative"
+        )
+    return {
+        # BoundarySpec.to_dict / from_dict are reused verbatim — the boundary
+        # vocabulary lives in rfx/boundaries/spec.py, not here.
+        "spec": spec.to_dict(),
+        # Derived views, emitted explicitly rather than re-derived: _boundary
+        # and _cpml_layers can disagree with the spec on the legacy
+        # scalar + set_periodic_axes() path, and _periodic_axes is also
+        # mutated as a side effect by add_floquet_port.
+        "legacy": {
+            "boundary": _text(sim._boundary, what="_boundary"),
+            "cpml_layers": _integer(sim._cpml_layers, what="_cpml_layers"),
+            "cpml_kappa_max": _num(sim._cpml_kappa_max, what="_cpml_kappa_max"),
+            "pec_faces": sorted(_text(f, what="_pec_faces entry") for f in sim._pec_faces),
+            "periodic_axes": _text(sim._periodic_axes, what="_periodic_axes"),
+        },
+    }
+
+
+class _BoundaryPlan(NamedTuple):
+    """Constructor kwargs plus an optional deprecated periodic-axes call."""
+
+    kwargs: dict[str, Any]
+    set_periodic_axes: str | None
+
+
+def _plan_boundary(payload: dict, *, has_floquet: bool) -> _BoundaryPlan:
+    """Choose the construction path that reproduces a recorded boundary state.
+
+    ``Simulation`` accepts either a ``BoundarySpec`` (authoritative; the
+    legacy views are then derived from it) or the legacy
+    ``boundary=<scalar> + pec_faces`` triad.  The two paths do **not** produce
+    the same attributes for the same physics: a legacy ``boundary="pec"`` cavity
+    keeps ``_pec_faces == set()`` while the equivalent all-PEC ``BoundarySpec``
+    derives ``_pec_faces`` = all six faces.  Reproducing the recorded state
+    therefore means reproducing the path, which is decided from the document
+    rather than guessed.
+    """
+    _require_exact_keys(payload, {"spec", "legacy"}, what="boundary")
+    spec_payload = payload["spec"]
+    if not isinstance(spec_payload, dict):
+        raise _refuse(
+            f"boundary.spec must be a mapping, got {type(spec_payload).__name__}"
+        )
+    _require_exact_keys(spec_payload, {"x", "y", "z"}, what="boundary.spec")
+    try:
+        spec = BoundarySpec.from_dict(spec_payload)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise _refuse(f"boundary.spec is not a valid BoundarySpec: {exc}") from exc
+
+    legacy = payload["legacy"]
+    if not isinstance(legacy, dict):
+        raise _refuse(
+            f"boundary.legacy must be a mapping, got {type(legacy).__name__}"
+        )
+    _require_exact_keys(
+        legacy,
+        {"boundary", "cpml_layers", "cpml_kappa_max", "pec_faces", "periodic_axes"},
+        what="boundary.legacy",
+    )
+    scalar = _text(legacy["boundary"], what="boundary.legacy.boundary")
+    cpml_layers = _integer(legacy["cpml_layers"], what="boundary.legacy.cpml_layers")
+    kappa = _num(legacy["cpml_kappa_max"], what="boundary.legacy.cpml_kappa_max")
+    raw_faces = legacy["pec_faces"]
+    if not isinstance(raw_faces, list):
+        raise _refuse(
+            f"boundary.legacy.pec_faces must be a list, got "
+            f"{type(raw_faces).__name__}"
+        )
+    pec_faces = {
+        _text(face, what=f"boundary.legacy.pec_faces[{i}]")
+        for i, face in enumerate(raw_faces)
+    }
+    periodic = _text(legacy["periodic_axes"], what="boundary.legacy.periodic_axes")
+
+    common = {"cpml_kappa_max": kappa}
+
+    # Preferred path: hand the spec to the constructor and let it derive the
+    # legacy views. Accept it only when the derivation reproduces every
+    # recorded legacy value. ``_periodic_axes`` is allowed to be empty in the
+    # spec when Floquet ports are present, because add_floquet_port fills it in
+    # as a documented side effect.
+    derived_scalar = spec.absorber_type or "pec"
+    derived_layers = cpml_layers if derived_scalar in ("cpml", "upml") else 0
+    spec_periodic = spec.periodic_axes()
+    periodic_ok = spec_periodic == periodic or (has_floquet and spec_periodic == "")
+    if (
+        derived_scalar == scalar
+        and derived_layers == cpml_layers
+        and spec.pec_faces() == pec_faces
+        and periodic_ok
+    ):
+        return _BoundaryPlan(
+            kwargs={"boundary": spec, "cpml_layers": cpml_layers, **common},
+            set_periodic_axes=None,
+        )
+
+    # Fallback: reproduce the legacy triad. ``_build_spec_from_legacy`` folds
+    # ``_periodic_axes`` into the spec, so try both the empty value (Floquet
+    # side effect, applied later by the builder) and the recorded value
+    # (an explicit deprecated set_periodic_axes call).
+    if not (scalar == "pec" and pec_faces):
+        for axes in ("", periodic):
+            if _predict_legacy_spec(scalar, pec_faces, axes) == spec:
+                return _BoundaryPlan(
+                    kwargs={
+                        "boundary": scalar,
+                        "cpml_layers": cpml_layers,
+                        "pec_faces": set(pec_faces) or None,
+                        **common,
+                    },
+                    set_periodic_axes=axes or None,
+                )
+
+    raise _refuse(
+        "boundary.spec and boundary.legacy cannot both be reproduced by any "
+        f"Simulation construction path: spec={spec.to_dict()!r}, "
+        f"legacy boundary={scalar!r}, cpml_layers={cpml_layers}, "
+        f"pec_faces={sorted(pec_faces)}, periodic_axes={periodic!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Port / source split
+# ---------------------------------------------------------------------------
+
+_SOFT_SOURCE_PINNED_DEFAULTS: dict[str, Any] = {
+    "extent": None,
+    "excite": True,
+    "direction": None,
+    "reference_plane_cells": None,
+}
+
+
+def _dump_ports(sim: Any) -> tuple[list[dict], list[dict]]:
+    """Split ``_ports`` into soft sources and lumped/wire ports.
+
+    The two families share ``_PortEntry`` and are discriminated only by the
+    ``impedance == 0`` sentinel ``add_source`` stamps (``add_port`` rejects a
+    non-positive impedance).  The document names them separately so a consumer
+    never has to re-derive the intent from a sentinel.
+    """
+    live = set(live_field_names(_PortEntry))
+    unrecorded = live - set(_LUMPED_PORT_FIELDS)
+    if unrecorded:
+        raise _refuse(
+            f"_PortEntry carries fields the design document does not record: "
+            f"{sorted(unrecorded)}. Update rfx/interop/_design.py rather than "
+            f"exporting a partial port"
+        )
+
+    soft: list[dict] = []
+    lumped: list[dict] = []
+    for index, entry in enumerate(sim._ports):
+        what = f"_ports[{index}]"
+        if type(entry) is not _PortEntry:
+            raise _refuse(
+                f"{what} is a {type(entry).__name__}, expected _PortEntry"
+            )
+        if _num(entry.impedance, what=f"{what}.impedance") == 0.0:
+            for name, expected in _SOFT_SOURCE_PINNED_DEFAULTS.items():
+                actual = getattr(entry, name)
+                if actual != expected:
+                    raise _refuse(
+                        f"{what} is a soft source (impedance == 0) but carries "
+                        f"{name}={actual!r}; add_source() cannot set that "
+                        f"field, so the entry was not built through the public "
+                        f"API and cannot be rebuilt through it"
+                    )
+            soft.append(
+                {
+                    name: field.dump(getattr(entry, name), f"{what}.{name}")
+                    for name, field in _SOFT_SOURCE_FIELDS.items()
+                }
+            )
+        else:
+            lumped.append(
+                {
+                    name: field.dump(getattr(entry, name), f"{what}.{name}")
+                    for name, field in _LUMPED_PORT_FIELDS.items()
+                }
+            )
+    return soft, lumped
+
+
+# ---------------------------------------------------------------------------
+# Coaxial termination tuples (cell-relative)
+# ---------------------------------------------------------------------------
+
+def _dump_coaxial_matched_loads(sim: Any) -> list[dict[str, Any]]:
+    out = []
+    for index, item in enumerate(sim._coaxial_terminations):
+        what = f"_coaxial_terminations[{index}]"
+        if len(item) != 3:
+            raise _refuse(f"{what} must be a 3-tuple, got {item!r}")
+        port_index, impedance, offset = item
+        out.append(
+            {
+                "port_index": _integer(port_index, what=f"{what}.port_index"),
+                "target_impedance": _num(impedance, what=f"{what}.target_impedance"),
+                "axial_offset_cells": _integer(
+                    offset, what=f"{what}.axial_offset_cells"
+                ),
+            }
+        )
+    return out
+
+
+def _dump_coaxial_pairs(
+    items: Any, second_key: str, *, what: str
+) -> list[dict[str, Any]]:
+    out = []
+    for index, item in enumerate(items):
+        label = f"{what}[{index}]"
+        if len(item) != 2:
+            raise _refuse(f"{label} must be a 2-tuple, got {item!r}")
+        port_index, value = item
+        out.append(
+            {
+                "port_index": _integer(port_index, what=f"{label}.port_index"),
+                second_key: _integer(value, what=f"{label}.{second_key}"),
+            }
+        )
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Non-portability annotation
+# ---------------------------------------------------------------------------
+
+def _non_portable(document: dict[str, Any]) -> list[dict[str, str]]:
+    """Annotate the sections of *document* whose semantics are rfx-only.
+
+    Derived purely from the document's own content, so it is deterministic and
+    byte-stable.  It is an annotation: the importer validates its shape and
+    ignores its content.
+    """
+    notes: list[dict[str, str]] = []
+
+    def note(path: str, reason: str) -> None:
+        notes.append({"path": path, "reason": reason})
+
+    mesh = document["mesh"]
+    if any(mesh[k] is not None for k in ("dx_profile", "dy_profile", "dz_profile")):
+        note(
+            "mesh",
+            "per-axis cell-size profiles describe a graded rfx mesh; openEMS "
+            "needs explicit mesh lines and Meep has no non-uniform mesh at "
+            "all, so a profile must be re-meshed, never averaged to a scalar "
+            "resolution",
+        )
+    if document["boundary"]["legacy"]["cpml_layers"] > 0:
+        note(
+            "boundary.legacy.cpml_layers",
+            "absorber depth as a cell count; the remaining CPML knobs "
+            "(sigma_max, alpha_max, grading order) are hard-coded in "
+            "rfx/boundaries/cpml.py, so two solvers given the same layer "
+            "count build different absorbers",
+        )
+
+    solver = document["solver"]
+    if (
+        solver["solver"] != "yee"
+        or solver["precision"] != "float32"
+        or solver["stencil_order"] != 2
+    ):
+        note(
+            "solver",
+            "ADI, mixed precision and the (2,4) stencil are rfx-specific "
+            "solver settings with no counterpart in openEMS or Meep",
+        )
+
+    excitations = document["excitations"]
+    if excitations["msl_ports"]:
+        note(
+            "excitations.msl_ports",
+            "n_probe_offset and n_probe_spacing are cell counts derived from "
+            "dx when the port was registered; they carry no physical length "
+            "and are meaningless on another mesh",
+        )
+    if any(p["reference_plane_cells"] is not None for p in excitations["lumped_ports"]):
+        note(
+            "excitations.lumped_ports",
+            "reference_plane_cells is a cell count, not a physical "
+            "measurement-plane distance",
+        )
+    if excitations["waveguide_ports"]:
+        note(
+            "excitations.waveguide_ports",
+            "probe_offset and ref_offset are cell counts from the source "
+            "plane, not physical distances",
+        )
+    for key, field in (
+        ("coaxial_matched_loads", "axial_offset_cells"),
+        ("coaxial_open_terminations", "pin_retract_cells"),
+        ("coaxial_pec_end_caps", "axial_offset_cells"),
+    ):
+        if excitations[key]:
+            note(
+                f"excitations.{key}",
+                f"{field} is a cell-relative offset; the termination moves "
+                f"physically if dx changes",
+            )
+    if excitations["tfsf"] is not None:
+        note(
+            "excitations.tfsf",
+            "the rfx TFSF injector is a narrow-scope 1-D auxiliary-grid source "
+            "(x-normal, ez/ey, CPML only) and margin is in cells; Meep has no "
+            "TFSF primitive",
+        )
+    if document["refinement"] is not None:
+        note(
+            "refinement",
+            "SBP-SAT subgridding is an rfx research prototype, falsified in 3D "
+            "(PR #90) and outside the public support scope; it must not be "
+            "exported to another solver, where its presence would read as a "
+            "validated capability",
+        )
+
+    notes.sort(key=lambda item: item["path"])
+    return notes
+
+
+# ---------------------------------------------------------------------------
+# Exporter
+# ---------------------------------------------------------------------------
+
+def _rfx_version() -> str:
+    import rfx
+
+    return str(rfx.__version__)
+
+
+def _dump_materials(sim: Any) -> dict[str, Any]:
+    materials = sim._materials
+    if not isinstance(materials, dict):
+        raise _refuse(
+            f"_materials must be a dict, got {type(materials).__name__}"
+        )
+    return materials_to_dict(materials)
+
+
+def _dump_material_library(sim: Any) -> dict[str, Any]:
+    """Snapshot the library materials this design references but never registered.
+
+    A geometry entry may name ``"pec"`` or ``"fr4"`` without ever touching
+    ``_materials``; ``Simulation._resolve_material`` falls through to
+    ``MATERIAL_LIBRARY``.  Those values are version-dependent (the Rogers
+    conductivities are computed from Df at a fixed frequency), so the document
+    records the resolved numbers and the importer verifies them against the
+    live library.  The section is provenance, not applied state: importing does
+    not register these materials, exactly as the original design did not.
+    """
+    referenced = {
+        entry.material_name
+        for entry in sim._geometry
+        if isinstance(entry, _GeometryEntry)
+    }
+    out: dict[str, Any] = {}
+    for name in sorted(referenced):
+        if name in sim._materials:
+            continue
+        if name not in MATERIAL_LIBRARY:
+            raise _refuse(
+                f"geometry references material {name!r}, which is neither "
+                f"registered with add_material() nor a library name "
+                f"({sorted(MATERIAL_LIBRARY)})"
+            )
+        out[name] = material_to_dict(sim._resolve_material(name))
+    return out
+
+
+def design_to_dict(sim: Any) -> dict[str, Any]:
+    """Serialise the complete design state of *sim* to a JSON-ready mapping.
+
+    Parameters
+    ----------
+    sim : Simulation
+        A simulation whose design has been established through the
+        constructor and the ``add_*`` builders.
+
+    Returns
+    -------
+    dict
+        A ``rfx-design-ir/v1`` document.  Every value is a JSON scalar, list
+        or mapping; ``json.dump(document, allow_nan=False)`` succeeds without
+        ``default=``.
+
+    Raises
+    ------
+    UnsupportedDesignFeature
+        If any design state cannot be represented exactly — an unregistered
+        shape class (``MeshShape``, a user-defined ``Shape``), a
+        ``CustomWaveform``, a JAX-traced mesh profile, a non-finite number, or
+        a record class that has grown a field this module does not record.
+
+    Notes
+    -----
+    Do **not** call this from inside an S-parameter driver: those drivers
+    temporarily rewrite ``_dz_profile`` / ``_msl_ports`` / ``_ports`` /
+    ``_dft_planes`` / ``_waveguide_ports`` and restore them afterwards, so a
+    document captured mid-driver describes the driver's synthetic
+    configuration.  There is no sentinel on ``Simulation`` that lets this
+    function detect the situation, so the responsibility is the caller's.  See
+    the module docstring.
+    """
+    soft_sources, lumped_ports = _dump_ports(sim)
+
+    ntff = None
+    if sim._ntff is not None:
+        if len(sim._ntff) != 3:
+            raise _refuse(
+                f"_ntff must be a (corner_lo, corner_hi, freqs) triple, got "
+                f"{sim._ntff!r}"
+            )
+        corner_lo, corner_hi, freqs = sim._ntff
+        ntff = {
+            "corner_lo": _NTFF_FIELDS["corner_lo"].dump(corner_lo, "_ntff.corner_lo"),
+            "corner_hi": _NTFF_FIELDS["corner_hi"].dump(corner_hi, "_ntff.corner_hi"),
+            "freqs": _NTFF_FIELDS["freqs"].dump(freqs, "_ntff.freqs"),
+        }
+
+    refinement = None
+    if sim._refinement is not None:
+        if not isinstance(sim._refinement, dict):
+            raise _refuse(
+                f"_refinement must be a dict, got {type(sim._refinement).__name__}"
+            )
+        _require_exact_keys(
+            sim._refinement, set(_REFINEMENT_FIELDS), what="_refinement"
+        )
+        refinement = {
+            name: field.dump(sim._refinement[name], f"_refinement.{name}")
+            for name, field in _REFINEMENT_FIELDS.items()
+        }
+
+    tfsf = None
+    if sim._tfsf is not None:
+        tfsf = _dump_entry(sim._tfsf, _TFSF_FIELDS, _TFSFEntry, what="_tfsf")
+
+    document: dict[str, Any] = {
+        "schema": DESIGN_SCHEMA_VERSION,
+        "rfx_version": _rfx_version(),
+        "domain": {
+            "freq_max": _num(sim._freq_max, what="_freq_max"),
+            "extent": list(_vector(sim._domain, 3, what="_domain")),
+            "mode": _text(sim._mode, what="_mode"),
+        },
+        "mesh": {
+            # dx is None on the auto-mesh path: "let rfx choose" is itself the
+            # design decision, and it round-trips as null.
+            "dx": None if sim._dx is None else _num(sim._dx, what="_dx"),
+            "dx_profile": (
+                None
+                if sim._dx_profile is None
+                else _array_to_dict(sim._dx_profile, what="_dx_profile")
+            ),
+            "dy_profile": (
+                None
+                if sim._dy_profile is None
+                else _array_to_dict(sim._dy_profile, what="_dy_profile")
+            ),
+            "dz_profile": (
+                None
+                if sim._dz_profile is None
+                else _array_to_dict(sim._dz_profile, what="_dz_profile")
+            ),
+        },
+        "boundary": _dump_boundary(sim),
+        "solver": {
+            "precision": _text(sim._precision, what="_precision"),
+            "solver": _text(sim._solver, what="_solver"),
+            "adi_cfl_factor": _num(sim._adi_cfl_factor, what="_adi_cfl_factor"),
+            "stencil_order": _integer(sim._stencil_order, what="_stencil_order"),
+        },
+        "materials": _dump_materials(sim),
+        "material_library": _dump_material_library(sim),
+        "geometry": _dump_list(
+            sim._geometry, _GEOMETRY_FIELDS, _GeometryEntry, what="_geometry"
+        ),
+        "thin_conductors": _dump_list(
+            sim._thin_conductors,
+            _THIN_CONDUCTOR_FIELDS,
+            ThinConductor,
+            what="_thin_conductors",
+        ),
+        "excitations": {
+            "soft_sources": soft_sources,
+            "lumped_ports": lumped_ports,
+            "msl_ports": _dump_list(
+                sim._msl_ports, _MSL_PORT_FIELDS, _MSLPortEntry, what="_msl_ports"
+            ),
+            "waveguide_ports": _dump_list(
+                sim._waveguide_ports,
+                _WAVEGUIDE_PORT_FIELDS,
+                _WaveguidePortEntry,
+                what="_waveguide_ports",
+            ),
+            "coaxial_ports": _dump_list(
+                sim._coaxial_ports,
+                _COAXIAL_PORT_FIELDS,
+                CoaxialPort,
+                what="_coaxial_ports",
+            ),
+            "coaxial_matched_loads": _dump_coaxial_matched_loads(sim),
+            "coaxial_open_terminations": _dump_coaxial_pairs(
+                sim._coaxial_open_terminations,
+                "pin_retract_cells",
+                what="_coaxial_open_terminations",
+            ),
+            "coaxial_pec_end_caps": _dump_coaxial_pairs(
+                sim._coaxial_pec_end_caps,
+                "axial_offset_cells",
+                what="_coaxial_pec_end_caps",
+            ),
+            "floquet_ports": _dump_list(
+                sim._floquet_ports,
+                _FLOQUET_PORT_FIELDS,
+                _FloquetPortEntry,
+                what="_floquet_ports",
+            ),
+            "tfsf": tfsf,
+            "lumped_rlc": _dump_list(
+                sim._lumped_rlc, _LUMPED_RLC_FIELDS, LumpedRLCSpec, what="_lumped_rlc"
+            ),
+        },
+        "observables": {
+            "probes": _dump_list(
+                sim._probes, _PROBE_FIELDS, _ProbeEntry, what="_probes"
+            ),
+            "dft_planes": _dump_list(
+                sim._dft_planes, _DFT_PLANE_FIELDS, _DFTPlaneEntry, what="_dft_planes"
+            ),
+            "flux_monitors": _dump_list(
+                sim._flux_monitors,
+                _FLUX_MONITOR_FIELDS,
+                _FluxMonitorEntry,
+                what="_flux_monitors",
+            ),
+            "ntff": ntff,
+        },
+        "refinement": refinement,
+    }
+    document["non_portable"] = _non_portable(document)
+    return document
+
+
+def design_to_json(sim: Any, *, indent: int | None = 2) -> str:
+    """Canonical JSON text for :func:`design_to_dict`.
+
+    Keys are sorted and NaN/Infinity are rejected, so two exports of the same
+    design produce byte-identical text.  Numbers use Python's shortest
+    round-trip repr, which reproduces float64 exactly.
+    """
+    return json.dumps(
+        design_to_dict(sim), sort_keys=True, indent=indent, allow_nan=False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Importer
+# ---------------------------------------------------------------------------
+
+_TOP_LEVEL_KEYS = {
+    "schema",
+    "rfx_version",
+    "domain",
+    "mesh",
+    "boundary",
+    "solver",
+    "materials",
+    "material_library",
+    "geometry",
+    "thin_conductors",
+    "excitations",
+    "observables",
+    "refinement",
+    "non_portable",
+}
+
+_EXCITATION_KEYS = {
+    "soft_sources",
+    "lumped_ports",
+    "msl_ports",
+    "waveguide_ports",
+    "coaxial_ports",
+    "coaxial_matched_loads",
+    "coaxial_open_terminations",
+    "coaxial_pec_end_caps",
+    "floquet_ports",
+    "tfsf",
+    "lumped_rlc",
+}
+
+_OBSERVABLE_KEYS = {"probes", "dft_planes", "flux_monitors", "ntff"}
+
+
+def _resolve_library_material(name: str):
+    """Resolve a ``MATERIAL_LIBRARY`` row exactly as ``_resolve_material`` does."""
+    from rfx.api._spec import MaterialSpec
+
+    row = MATERIAL_LIBRARY[name]
+    return MaterialSpec(
+        eps_r=row.get("eps_r", 1.0),
+        sigma=row.get("sigma", 0.0),
+        mu_r=row.get("mu_r", 1.0),
+        debye_poles=row.get("debye_poles"),
+        lorentz_poles=row.get("lorentz_poles"),
+    )
+
+
+def _verify_material_library(payload: Any, materials: dict) -> None:
+    if not isinstance(payload, dict):
+        raise _refuse(
+            f"material_library must be a mapping, got {type(payload).__name__}"
+        )
+    for name, recorded in payload.items():
+        if name in materials:
+            raise _refuse(
+                f"material_library[{name!r}] shadows a material registered in "
+                f"the materials section; a name resolves to one or the other, "
+                f"never both"
+            )
+        if name not in MATERIAL_LIBRARY:
+            raise _refuse(
+                f"material_library[{name!r}] is not a name in this rfx "
+                f"version's MATERIAL_LIBRARY ({sorted(MATERIAL_LIBRARY)})"
+            )
+        live = material_to_dict(_resolve_library_material(name))
+        if not _equal(live, recorded):
+            raise _refuse(
+                f"material_library[{name!r}] does not match this rfx version's "
+                f"library: recorded={recorded!r}, live={live!r}. The library "
+                f"values are version-dependent, so importing would silently "
+                f"change the design's material."
+            )
+
+
+def simulation_from_design(document: Any) -> Any:
+    """Rebuild a :class:`~rfx.api.Simulation` from a ``rfx-design-ir/v1`` document.
+
+    The rebuild goes through the public ``add_*`` builders, so every builder
+    fence applies unchanged — an imported design is not a way around a
+    ``NotImplementedError`` in the API.  Warnings the builders emit for the
+    recorded configuration (a deprecated ``pec_faces=``, a PEC-routed thin
+    conductor, a single-component series RLC) are re-emitted, because the
+    imported design really does have that configuration.
+
+    After the rebuild the design is re-exported and compared with *document*;
+    a mismatch raises :class:`UnsupportedDesignFeature` naming the first
+    differing path, so an inexact reconstruction fails loudly instead of
+    returning a plausible-looking ``Simulation``.
+
+    Raises
+    ------
+    UnsupportedDesignFeature
+        On an unknown or missing key, an unsupported shape/waveform kind, a
+        schema mismatch, a drifted material-library value, or a design that no
+        ``Simulation`` construction path reproduces exactly.
+    """
+    from rfx.api import Simulation
+
+    if not isinstance(document, dict):
+        raise _refuse(
+            f"design document must be a mapping, got {type(document).__name__}"
+        )
+    _require_exact_keys(document, _TOP_LEVEL_KEYS, what="design document")
+
+    schema = _text(document["schema"], what="schema")
+    if schema != DESIGN_SCHEMA_VERSION:
+        raise _refuse(
+            f"schema {schema!r} is not {DESIGN_SCHEMA_VERSION!r}; this reader "
+            f"does not translate between schema versions"
+        )
+    _text(document["rfx_version"], what="rfx_version")
+    if not isinstance(document["non_portable"], list):
+        raise _refuse(
+            f"non_portable must be a list, got "
+            f"{type(document['non_portable']).__name__}"
+        )
+
+    domain = _section(document, "domain", what="design document")
+    _require_exact_keys(domain, {"freq_max", "extent", "mode"}, what="domain")
+
+    mesh = _section(document, "mesh", what="design document")
+    _require_exact_keys(
+        mesh, {"dx", "dx_profile", "dy_profile", "dz_profile"}, what="mesh"
+    )
+
+    solver = _section(document, "solver", what="design document")
+    _require_exact_keys(
+        solver,
+        {"precision", "solver", "adi_cfl_factor", "stencil_order"},
+        what="solver",
+    )
+
+    excitations = _section(document, "excitations", what="design document")
+    _require_exact_keys(excitations, _EXCITATION_KEYS, what="excitations")
+
+    observables = _section(document, "observables", what="design document")
+    _require_exact_keys(observables, _OBSERVABLE_KEYS, what="observables")
+
+    materials = materials_from_dict(
+        _section(document, "materials", what="design document")
+    )
+    _verify_material_library(document["material_library"], materials)
+
+    floquet_payloads = _entry_list(excitations, "floquet_ports", what="excitations")
+    plan = _plan_boundary(
+        _section(document, "boundary", what="design document"),
+        has_floquet=bool(floquet_payloads),
+    )
+
+    sim = Simulation(
+        freq_max=_num(domain["freq_max"], what="domain.freq_max"),
+        domain=_vector(domain["extent"], 3, what="domain.extent"),
+        dx=None if mesh["dx"] is None else _num(mesh["dx"], what="mesh.dx"),
+        mode=_text(domain["mode"], what="domain.mode"),
+        dx_profile=(
+            None
+            if mesh["dx_profile"] is None
+            else _array_from_dict(mesh["dx_profile"], what="mesh.dx_profile")
+        ),
+        dy_profile=(
+            None
+            if mesh["dy_profile"] is None
+            else _array_from_dict(mesh["dy_profile"], what="mesh.dy_profile")
+        ),
+        dz_profile=(
+            None
+            if mesh["dz_profile"] is None
+            else _array_from_dict(mesh["dz_profile"], what="mesh.dz_profile")
+        ),
+        precision=_text(solver["precision"], what="solver.precision"),
+        solver=_text(solver["solver"], what="solver.solver"),
+        adi_cfl_factor=_num(solver["adi_cfl_factor"], what="solver.adi_cfl_factor"),
+        stencil_order=_integer(solver["stencil_order"], what="solver.stencil_order"),
+        **plan.kwargs,
+    )
+    if plan.set_periodic_axes is not None:
+        sim.set_periodic_axes(plan.set_periodic_axes)
+
+    for name, spec in materials.items():
+        sim.add_material(
+            name,
+            eps_r=spec.eps_r,
+            sigma=spec.sigma,
+            mu_r=spec.mu_r,
+            debye_poles=spec.debye_poles,
+            lorentz_poles=spec.lorentz_poles,
+            chi3=spec.chi3,
+        )
+
+    refinement = document["refinement"]
+    if refinement is not None:
+        values = _load_entry(refinement, _REFINEMENT_FIELDS, what="refinement")
+        sim.add_refinement(
+            values.pop("z_range"),
+            **values,
+        )
+
+    for index, payload in enumerate(
+        _entry_list(document, "geometry", what="design document")
+    ):
+        values = _load_entry(
+            payload, _GEOMETRY_FIELDS, what=f"geometry[{index}]"
+        )
+        sim.add(values["shape"], material=values["material_name"])
+
+    for index, payload in enumerate(
+        _entry_list(document, "thin_conductors", what="design document")
+    ):
+        values = _load_entry(
+            payload, _THIN_CONDUCTOR_FIELDS, what=f"thin_conductors[{index}]"
+        )
+        sim.add_thin_conductor(values.pop("shape"), **values)
+
+    for index, payload in enumerate(
+        _entry_list(excitations, "coaxial_ports", what="excitations")
+    ):
+        values = _load_entry(
+            payload,
+            _COAXIAL_PORT_FIELDS,
+            what=f"excitations.coaxial_ports[{index}]",
+        )
+        sim.add_coaxial_port(
+            values["position"],
+            values["face"],
+            pin_length=values["pin_length"],
+            pin_radius=values["pin_radius"],
+            outer_radius=values["outer_radius"],
+            impedance=values["impedance"],
+            waveform=values["excitation"],
+        )
+
+    for index, payload in enumerate(
+        _entry_list(excitations, "coaxial_matched_loads", what="excitations")
+    ):
+        what = f"excitations.coaxial_matched_loads[{index}]"
+        if not isinstance(payload, dict):
+            raise _refuse(f"{what} must be a mapping, got {type(payload).__name__}")
+        _require_exact_keys(
+            payload,
+            {"port_index", "target_impedance", "axial_offset_cells"},
+            what=what,
+        )
+        sim.add_coaxial_matched_load(
+            _integer(payload["port_index"], what=f"{what}.port_index"),
+            target_impedance=_num(
+                payload["target_impedance"], what=f"{what}.target_impedance"
+            ),
+            axial_offset_cells=_integer(
+                payload["axial_offset_cells"], what=f"{what}.axial_offset_cells"
+            ),
+        )
+
+    for index, payload in enumerate(
+        _entry_list(excitations, "coaxial_open_terminations", what="excitations")
+    ):
+        what = f"excitations.coaxial_open_terminations[{index}]"
+        if not isinstance(payload, dict):
+            raise _refuse(f"{what} must be a mapping, got {type(payload).__name__}")
+        _require_exact_keys(payload, {"port_index", "pin_retract_cells"}, what=what)
+        sim.add_coaxial_open_termination(
+            _integer(payload["port_index"], what=f"{what}.port_index"),
+            pin_retract_cells=_integer(
+                payload["pin_retract_cells"], what=f"{what}.pin_retract_cells"
+            ),
+        )
+
+    for index, payload in enumerate(
+        _entry_list(excitations, "coaxial_pec_end_caps", what="excitations")
+    ):
+        what = f"excitations.coaxial_pec_end_caps[{index}]"
+        if not isinstance(payload, dict):
+            raise _refuse(f"{what} must be a mapping, got {type(payload).__name__}")
+        _require_exact_keys(payload, {"port_index", "axial_offset_cells"}, what=what)
+        sim.add_coaxial_pec_end_cap(
+            _integer(payload["port_index"], what=f"{what}.port_index"),
+            axial_offset_cells=_integer(
+                payload["axial_offset_cells"], what=f"{what}.axial_offset_cells"
+            ),
+        )
+
+    for index, payload in enumerate(
+        _entry_list(excitations, "soft_sources", what="excitations")
+    ):
+        values = _load_entry(
+            payload,
+            _SOFT_SOURCE_FIELDS,
+            what=f"excitations.soft_sources[{index}]",
+        )
+        sim.add_source(
+            values["position"], values["component"], waveform=values["waveform"]
+        )
+
+    for index, payload in enumerate(
+        _entry_list(excitations, "lumped_ports", what="excitations")
+    ):
+        values = _load_entry(
+            payload,
+            _LUMPED_PORT_FIELDS,
+            what=f"excitations.lumped_ports[{index}]",
+        )
+        sim.add_port(
+            values.pop("position"),
+            values.pop("component"),
+            **values,
+        )
+
+    for index, payload in enumerate(
+        _entry_list(excitations, "msl_ports", what="excitations")
+    ):
+        values = _load_entry(
+            payload, _MSL_PORT_FIELDS, what=f"excitations.msl_ports[{index}]"
+        )
+        sim.add_msl_port(values.pop("position"), **values)
+
+    for index, payload in enumerate(
+        _entry_list(excitations, "lumped_rlc", what="excitations")
+    ):
+        values = _load_entry(
+            payload, _LUMPED_RLC_FIELDS, what=f"excitations.lumped_rlc[{index}]"
+        )
+        sim.add_lumped_rlc(
+            values.pop("position"),
+            values.pop("component"),
+            **values,
+        )
+
+    tfsf = excitations["tfsf"]
+    if tfsf is not None:
+        sim.add_tfsf_source(
+            **_load_entry(tfsf, _TFSF_FIELDS, what="excitations.tfsf")
+        )
+
+    for index, payload in enumerate(
+        _entry_list(excitations, "waveguide_ports", what="excitations")
+    ):
+        values = _load_entry(
+            payload,
+            _WAVEGUIDE_PORT_FIELDS,
+            what=f"excitations.waveguide_ports[{index}]",
+        )
+        sim.add_waveguide_port(values.pop("x_position"), **values)
+
+    for index, payload in enumerate(floquet_payloads):
+        values = _load_entry(
+            payload,
+            _FLOQUET_PORT_FIELDS,
+            what=f"excitations.floquet_ports[{index}]",
+        )
+        sim.add_floquet_port(values.pop("position"), **values)
+
+    for index, payload in enumerate(
+        _entry_list(observables, "probes", what="observables")
+    ):
+        values = _load_entry(
+            payload, _PROBE_FIELDS, what=f"observables.probes[{index}]"
+        )
+        sim.add_probe(values["position"], values["component"])
+
+    for index, payload in enumerate(
+        _entry_list(observables, "dft_planes", what="observables")
+    ):
+        values = _load_entry(
+            payload, _DFT_PLANE_FIELDS, what=f"observables.dft_planes[{index}]"
+        )
+        sim.add_dft_plane_probe(**values)
+
+    for index, payload in enumerate(
+        _entry_list(observables, "flux_monitors", what="observables")
+    ):
+        values = _load_entry(
+            payload,
+            _FLUX_MONITOR_FIELDS,
+            what=f"observables.flux_monitors[{index}]",
+        )
+        sim.add_flux_monitor(**values)
+
+    ntff = observables["ntff"]
+    if ntff is not None:
+        values = _load_entry(ntff, _NTFF_FIELDS, what="observables.ntff")
+        sim.add_ntff_box(
+            values["corner_lo"], values["corner_hi"], values["freqs"]
+        )
+
+    _assert_round_trip(sim, document)
+    return sim
+
+
+# ---------------------------------------------------------------------------
+# Round-trip self-check
+# ---------------------------------------------------------------------------
+
+def _equal(left: Any, right: Any) -> bool:
+    """Structural equality that treats list and tuple alike.
+
+    Numbers compare with ``==``, so an ``int`` in a hand-written document
+    matches the ``float`` the exporter emits for the same value.
+    """
+    if isinstance(left, dict) or isinstance(right, dict):
+        if not (isinstance(left, dict) and isinstance(right, dict)):
+            return False
+        if set(left) != set(right):
+            return False
+        return all(_equal(left[k], right[k]) for k in left)
+    if isinstance(left, (list, tuple)) or isinstance(right, (list, tuple)):
+        if not (
+            isinstance(left, (list, tuple)) and isinstance(right, (list, tuple))
+        ):
+            return False
+        if len(left) != len(right):
+            return False
+        return all(_equal(a, b) for a, b in zip(left, right))
+    if isinstance(left, bool) or isinstance(right, bool):
+        return left is right
+    return left == right
+
+
+def _first_difference(left: Any, right: Any, path: str = "") -> str | None:
+    """Path of the first structural difference, or None when equal."""
+    if isinstance(left, dict) and isinstance(right, dict):
+        for key in sorted(set(left) | set(right)):
+            here = f"{path}.{key}" if path else key
+            if key not in left:
+                return f"{here} (missing from the rebuilt design)"
+            if key not in right:
+                return f"{here} (missing from the document)"
+            found = _first_difference(left[key], right[key], here)
+            if found is not None:
+                return found
+        return None
+    if isinstance(left, (list, tuple)) and isinstance(right, (list, tuple)):
+        if len(left) != len(right):
+            return f"{path} (length {len(left)} rebuilt vs {len(right)} in document)"
+        for index, (a, b) in enumerate(zip(left, right)):
+            found = _first_difference(a, b, f"{path}[{index}]")
+            if found is not None:
+                return found
+        return None
+    if _equal(left, right):
+        return None
+    return f"{path} (rebuilt {left!r} vs document {right!r})"
+
+
+def _assert_round_trip(sim: Any, document: dict) -> None:
+    rebuilt = design_to_dict(sim)
+    if _equal(rebuilt, document):
+        return
+    where = _first_difference(rebuilt, document) or "<unknown>"
+    raise _refuse(
+        f"the design could not be rebuilt exactly: {where}. The document "
+        f"describes state no public builder call reproduces, so the import is "
+        f"refused rather than returning an approximate Simulation."
+    )

--- a/rfx/interop/_design.py
+++ b/rfx/interop/_design.py
@@ -96,8 +96,11 @@ rediscover it:
 - non-uniform mesh profiles have no counterpart in a solver with a scalar
   resolution.
 
-``non_portable`` is an annotation derived from the document's own content.  It
-is not applied on import and carries no numbers.
+``non_portable`` is an annotation derived from the document's own content, so
+it carries no numbers and nothing is applied from it on import.  It is,
+however, **verified**: because the importer re-exports and compares, a document
+whose ``non_portable`` list has been edited is refused.  A downstream tool
+cannot strip the annotation to make rfx-only state look portable.
 
 Status: **provisional**.  Round-trip fidelity is gated by
 ``tests/test_interop_design_document.py``; no external emitter exists yet.

--- a/rfx/interop/_errors.py
+++ b/rfx/interop/_errors.py
@@ -1,0 +1,16 @@
+"""Errors raised by the design-interop layer."""
+
+from __future__ import annotations
+
+
+class UnsupportedDesignFeature(ValueError):
+    """Raised when a design cannot be represented without silent loss.
+
+    The interop layer refuses rather than approximating: a design description
+    that quietly drops a shape parameter, a dispersion pole, or a mesh profile
+    is worse than no description at all, because the resulting comparison looks
+    valid while comparing a different structure.
+    """
+
+
+__all__ = ["UnsupportedDesignFeature"]

--- a/rfx/interop/_materials.py
+++ b/rfx/interop/_materials.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from rfx.api._spec import MaterialSpec
 from rfx.interop._errors import UnsupportedDesignFeature
+from rfx.interop._shapes import _checked_scalar
 from rfx.materials.debye import DebyePole
 from rfx.materials.lorentz import LorentzPole
 
@@ -54,7 +55,11 @@ def _dump_poles(kind: str, poles: Any) -> list[dict[str, float]] | None:
                 f"{pole_cls.__name__}; the interop layer will not guess its "
                 f"parameter meaning"
             )
-        dumped.append({name: float(getattr(pole, name)) for name in names})
+        dumped.append({
+            name: _checked_scalar(
+                getattr(pole, name), what=f"{kind}[{index}].{name}")
+            for name in names
+        })
     return dumped
 
 
@@ -80,7 +85,11 @@ def _load_poles(kind: str, payload: Any) -> list[Any] | None:
                 f"{pole_cls.__name__}: missing={sorted(missing)}, "
                 f"unknown={sorted(unknown)}"
             )
-        poles.append(pole_cls(**{name: float(item[name]) for name in names}))
+        poles.append(pole_cls(**{
+            name: _checked_scalar(
+                item[name], what=f"{kind}[{index}].{name}")
+            for name in names
+        }))
     return poles
 
 
@@ -110,7 +119,8 @@ def material_to_dict(material: Any) -> dict[str, Any]:
         )
 
     out: dict[str, Any] = {
-        name: float(getattr(material, name)) for name in _SCALAR_FIELDS
+        name: _checked_scalar(getattr(material, name), what=f"material.{name}")
+        for name in _SCALAR_FIELDS
     }
     for kind in _POLE_FIELDS:
         out[kind] = _dump_poles(kind, getattr(material, kind))
@@ -134,7 +144,7 @@ def material_from_dict(payload: dict[str, Any]) -> MaterialSpec:
         )
 
     kwargs: dict[str, Any] = {
-        name: float(payload[name]) for name in _SCALAR_FIELDS
+        name: _checked_scalar(payload[name], what=f"material.{name}") for name in _SCALAR_FIELDS
     }
     for kind in _POLE_FIELDS:
         kwargs[kind] = _load_poles(kind, payload[kind])

--- a/rfx/interop/_materials.py
+++ b/rfx/interop/_materials.py
@@ -1,0 +1,155 @@
+"""Lossless serialisation of rfx material definitions.
+
+``rfx.artifacts._material_summary`` reduces ``debye_poles`` / ``lorentz_poles``
+to ``{"present": bool, "count": int}``, which is enough to review a run but
+discards the pole parameters that define the dispersion.  A design description
+rebuilt from that summary would silently become a non-dispersive material with
+the same static ``eps_r`` — a different structure wearing the same name.
+
+This module records every ``MaterialSpec`` field, including each pole's
+parameters, and refuses anything it cannot represent exactly.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from rfx.api._spec import MaterialSpec
+from rfx.interop._errors import UnsupportedDesignFeature
+from rfx.materials.debye import DebyePole
+from rfx.materials.lorentz import LorentzPole
+
+__all__ = [
+    "material_from_dict",
+    "material_to_dict",
+    "materials_from_dict",
+    "materials_to_dict",
+]
+
+# Pole parameter names are pinned here and asserted against the live NamedTuple
+# definitions by the interop contract test, so adding a pole parameter upstream
+# fails a test instead of vanishing from exported designs.
+_POLE_FIELDS: dict[str, tuple[type, tuple[str, ...]]] = {
+    "debye_poles": (DebyePole, ("delta_eps", "tau")),
+    "lorentz_poles": (LorentzPole, ("omega_0", "delta", "kappa")),
+}
+
+_SCALAR_FIELDS: tuple[str, ...] = ("eps_r", "sigma", "mu_r", "chi3")
+
+
+def _material_spec_field_names() -> tuple[str, ...]:
+    return tuple(f.name for f in dataclasses.fields(MaterialSpec))
+
+
+def _dump_poles(kind: str, poles: Any) -> list[dict[str, float]] | None:
+    if poles is None:
+        return None
+    pole_cls, names = _POLE_FIELDS[kind]
+    dumped: list[dict[str, float]] = []
+    for index, pole in enumerate(poles):
+        if not isinstance(pole, pole_cls):
+            raise UnsupportedDesignFeature(
+                f"{kind}[{index}] is {type(pole).__name__}, expected "
+                f"{pole_cls.__name__}; the interop layer will not guess its "
+                f"parameter meaning"
+            )
+        dumped.append({name: float(getattr(pole, name)) for name in names})
+    return dumped
+
+
+def _load_poles(kind: str, payload: Any) -> list[Any] | None:
+    if payload is None:
+        return None
+    pole_cls, names = _POLE_FIELDS[kind]
+    if not isinstance(payload, list):
+        raise UnsupportedDesignFeature(
+            f"{kind} must be a list or null, got {type(payload).__name__}"
+        )
+    poles: list[Any] = []
+    for index, item in enumerate(payload):
+        if not isinstance(item, dict):
+            raise UnsupportedDesignFeature(
+                f"{kind}[{index}] must be a mapping, got {type(item).__name__}"
+            )
+        missing = set(names) - set(item)
+        unknown = set(item) - set(names)
+        if missing or unknown:
+            raise UnsupportedDesignFeature(
+                f"{kind}[{index}] parameter mismatch for "
+                f"{pole_cls.__name__}: missing={sorted(missing)}, "
+                f"unknown={sorted(unknown)}"
+            )
+        poles.append(pole_cls(**{name: float(item[name]) for name in names}))
+    return poles
+
+
+def material_to_dict(material: Any) -> dict[str, Any]:
+    """Serialise a :class:`MaterialSpec` losslessly.
+
+    Raises
+    ------
+    UnsupportedDesignFeature
+        If ``material`` is not a ``MaterialSpec``, or if ``MaterialSpec`` has
+        gained a field this module does not record.
+    """
+    if type(material) is not MaterialSpec:
+        raise UnsupportedDesignFeature(
+            f"expected MaterialSpec, got {type(material).__name__}; the "
+            f"interop layer does not infer fields of unknown material types"
+        )
+
+    recorded = set(_SCALAR_FIELDS) | set(_POLE_FIELDS)
+    live = set(_material_spec_field_names())
+    unrecorded = live - recorded
+    if unrecorded:
+        raise UnsupportedDesignFeature(
+            f"MaterialSpec carries fields the design-interop layer does not "
+            f"record: {sorted(unrecorded)}. Update rfx/interop/_materials.py "
+            f"rather than exporting a partial material"
+        )
+
+    out: dict[str, Any] = {
+        name: float(getattr(material, name)) for name in _SCALAR_FIELDS
+    }
+    for kind in _POLE_FIELDS:
+        out[kind] = _dump_poles(kind, getattr(material, kind))
+    return out
+
+
+def material_from_dict(payload: dict[str, Any]) -> MaterialSpec:
+    """Rebuild a :class:`MaterialSpec` from :func:`material_to_dict` output."""
+    if not isinstance(payload, dict):
+        raise UnsupportedDesignFeature(
+            f"material payload must be a mapping, got {type(payload).__name__}"
+        )
+
+    expected = set(_SCALAR_FIELDS) | set(_POLE_FIELDS)
+    unknown = set(payload) - expected
+    missing = expected - set(payload)
+    if unknown or missing:
+        raise UnsupportedDesignFeature(
+            f"material payload field mismatch: missing={sorted(missing)}, "
+            f"unknown={sorted(unknown)}"
+        )
+
+    kwargs: dict[str, Any] = {
+        name: float(payload[name]) for name in _SCALAR_FIELDS
+    }
+    for kind in _POLE_FIELDS:
+        kwargs[kind] = _load_poles(kind, payload[kind])
+    return MaterialSpec(**kwargs)
+
+
+def materials_to_dict(materials: dict[str, Any]) -> dict[str, Any]:
+    """Serialise a name → :class:`MaterialSpec` mapping."""
+    return {str(name): material_to_dict(spec) for name, spec in materials.items()}
+
+
+def materials_from_dict(payload: dict[str, Any]) -> dict[str, MaterialSpec]:
+    """Rebuild a name → :class:`MaterialSpec` mapping."""
+    if not isinstance(payload, dict):
+        raise UnsupportedDesignFeature(
+            f"materials payload must be a mapping, got {type(payload).__name__}"
+        )
+    return {str(name): material_from_dict(spec) for name, spec in payload.items()}

--- a/rfx/interop/_materials.py
+++ b/rfx/interop/_materials.py
@@ -170,4 +170,10 @@ def materials_from_dict(payload: dict[str, Any]) -> dict[str, MaterialSpec]:
         raise UnsupportedDesignFeature(
             f"materials payload must be a mapping, got {type(payload).__name__}"
         )
-    return {str(name): material_from_dict(spec) for name, spec in payload.items()}
+    # Symmetric with materials_to_dict: a non-string key is refused rather than
+    # coerced, so a JSON object with numeric-looking keys cannot quietly become a
+    # material named "5".
+    return {
+        check_text(name, what="material name"): material_from_dict(spec)
+        for name, spec in payload.items()
+    }

--- a/rfx/interop/_materials.py
+++ b/rfx/interop/_materials.py
@@ -17,7 +17,7 @@ from typing import Any
 
 from rfx.api._spec import MaterialSpec
 from rfx.interop._errors import UnsupportedDesignFeature
-from rfx.interop._shapes import _checked_scalar
+from rfx.interop._validate import check_number, check_text
 from rfx.materials.debye import DebyePole
 from rfx.materials.lorentz import LorentzPole
 
@@ -56,7 +56,7 @@ def _dump_poles(kind: str, poles: Any) -> list[dict[str, float]] | None:
                 f"parameter meaning"
             )
         dumped.append({
-            name: _checked_scalar(
+            name: check_number(
                 getattr(pole, name), what=f"{kind}[{index}].{name}")
             for name in names
         })
@@ -86,7 +86,7 @@ def _load_poles(kind: str, payload: Any) -> list[Any] | None:
                 f"unknown={sorted(unknown)}"
             )
         poles.append(pole_cls(**{
-            name: _checked_scalar(
+            name: check_number(
                 item[name], what=f"{kind}[{index}].{name}")
             for name in names
         }))
@@ -119,7 +119,7 @@ def material_to_dict(material: Any) -> dict[str, Any]:
         )
 
     out: dict[str, Any] = {
-        name: _checked_scalar(getattr(material, name), what=f"material.{name}")
+        name: check_number(getattr(material, name), what=f"material.{name}")
         for name in _SCALAR_FIELDS
     }
     for kind in _POLE_FIELDS:
@@ -144,7 +144,7 @@ def material_from_dict(payload: dict[str, Any]) -> MaterialSpec:
         )
 
     kwargs: dict[str, Any] = {
-        name: _checked_scalar(payload[name], what=f"material.{name}") for name in _SCALAR_FIELDS
+        name: check_number(payload[name], what=f"material.{name}") for name in _SCALAR_FIELDS
     }
     for kind in _POLE_FIELDS:
         kwargs[kind] = _load_poles(kind, payload[kind])
@@ -153,7 +153,15 @@ def material_from_dict(payload: dict[str, Any]) -> MaterialSpec:
 
 def materials_to_dict(materials: dict[str, Any]) -> dict[str, Any]:
     """Serialise a name → :class:`MaterialSpec` mapping."""
-    return {str(name): material_to_dict(spec) for name, spec in materials.items()}
+    if not isinstance(materials, dict):
+        raise UnsupportedDesignFeature(
+            f"materials must be a mapping of name to MaterialSpec, got "
+            f"{type(materials).__name__}"
+        )
+    return {
+        check_text(name, what="material name"): material_to_dict(spec)
+        for name, spec in materials.items()
+    }
 
 
 def materials_from_dict(payload: dict[str, Any]) -> dict[str, MaterialSpec]:

--- a/rfx/interop/_shapes.py
+++ b/rfx/interop/_shapes.py
@@ -296,6 +296,13 @@ def shape_from_dict(payload: dict[str, Any]) -> Any:
         raise UnsupportedDesignFeature(
             f"shape payload must be a mapping, got {type(payload).__name__}"
         )
+    stray = set(payload) - {"kind", "params"}
+    if stray:
+        raise UnsupportedDesignFeature(
+            f"shape payload carries unknown top-level keys {sorted(stray)}; "
+            f"a shape payload is exactly {{'kind', 'params'}} and dropping the "
+            f"rest would silently discard whatever a writer meant by them"
+        )
     try:
         kind = payload["kind"]
     except KeyError:

--- a/rfx/interop/_shapes.py
+++ b/rfx/interop/_shapes.py
@@ -1,0 +1,234 @@
+"""Lossless serialisation of rfx geometry primitives.
+
+``rfx.artifacts.build_scene_artifact`` records a shape as its class name plus a
+bounding box (``artifacts.py`` pops the ``shape`` field and keeps ``_bbox``).
+That is adequate for a review summary but cannot distinguish a ``Cylinder``
+from a ``Box`` occupying the same bounding box, so it cannot rebuild its own
+input and cannot drive an external solver.
+
+This module records the *constructor parameters* instead.  Every supported
+primitive survives a JSON round trip exactly; anything not in the registry is
+refused loudly (:class:`~rfx.interop._errors.UnsupportedDesignFeature`) rather
+than degraded to a bounding box.
+
+JSON canonical form uses lists for vectors; the Python canonical form restores
+the tuples the primitives declare, so a round-tripped frozen dataclass compares
+equal to the original.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+from typing import Any, Callable, NamedTuple
+
+from rfx.geometry.csg import Box, Cylinder, PolylineWire, Sphere
+from rfx.geometry.curved import CurvedPatch
+from rfx.geometry.via import Via
+from rfx.interop._errors import UnsupportedDesignFeature
+
+__all__ = [
+    "SUPPORTED_SHAPE_TYPES",
+    "shape_from_dict",
+    "shape_to_dict",
+    "shape_field_names",
+]
+
+
+class _Field(NamedTuple):
+    """A pair of coercions: to JSON-canonical form, and back to Python."""
+
+    dump: Callable[[Any], Any]
+    load: Callable[[Any], Any]
+
+
+def _checked_vec(value: Any, n: int, *, what: str) -> tuple[float, ...]:
+    try:
+        seq = tuple(float(v) for v in value)
+    except (TypeError, ValueError) as exc:
+        raise UnsupportedDesignFeature(
+            f"{what} must be a sequence of {n} numbers, got {value!r}"
+        ) from exc
+    if len(seq) != n:
+        raise UnsupportedDesignFeature(
+            f"{what} must have exactly {n} components, got {len(seq)}: {value!r}"
+        )
+    return seq
+
+
+def _vec(n: int, *, what: str) -> _Field:
+    return _Field(
+        dump=lambda v: list(_checked_vec(v, n, what=what)),
+        load=lambda v: _checked_vec(v, n, what=what),
+    )
+
+
+def _vec_seq(n: int, *, what: str, container: Callable[[Any], Any]) -> _Field:
+    return _Field(
+        dump=lambda v: [list(_checked_vec(p, n, what=what)) for p in v],
+        load=lambda v: container(_checked_vec(p, n, what=what) for p in v),
+    )
+
+
+_FLOAT = _Field(dump=lambda v: float(v), load=lambda v: float(v))
+_STR = _Field(dump=lambda v: str(v), load=lambda v: str(v))
+
+
+class _ShapeCodec(NamedTuple):
+    cls: type
+    fields: dict[str, _Field]
+
+
+_CODECS: dict[str, _ShapeCodec] = {
+    "Box": _ShapeCodec(Box, {
+        "corner_lo": _vec(3, what="Box.corner_lo"),
+        "corner_hi": _vec(3, what="Box.corner_hi"),
+    }),
+    "Cylinder": _ShapeCodec(Cylinder, {
+        "center": _vec(3, what="Cylinder.center"),
+        "radius": _FLOAT,
+        "height": _FLOAT,
+        "axis": _STR,
+    }),
+    "Sphere": _ShapeCodec(Sphere, {
+        "center": _vec(3, what="Sphere.center"),
+        "radius": _FLOAT,
+    }),
+    "PolylineWire": _ShapeCodec(PolylineWire, {
+        "points": _vec_seq(3, what="PolylineWire.points", container=tuple),
+        "radius": _FLOAT,
+    }),
+    # ``Via`` carries its own ``material`` in addition to the ``material=``
+    # handed to ``Simulation.add()``.  Both are recorded; resolving the two is
+    # the caller's decision, not something this codec may silently pick.
+    "Via": _ShapeCodec(Via, {
+        "center": _vec(2, what="Via.center"),
+        "drill_radius": _FLOAT,
+        "pad_radius": _FLOAT,
+        "layers": _vec_seq(2, what="Via.layers", container=list),
+        "material": _STR,
+    }),
+    "CurvedPatch": _ShapeCodec(CurvedPatch, {
+        "center": _vec(3, what="CurvedPatch.center"),
+        "length": _FLOAT,
+        "width": _FLOAT,
+        "radius": _FLOAT,
+        "axis": _STR,
+    }),
+}
+
+SUPPORTED_SHAPE_TYPES: tuple[str, ...] = tuple(sorted(_CODECS))
+
+
+def shape_field_names(shape_type: str) -> tuple[str, ...]:
+    """Return the recorded parameter names for ``shape_type``."""
+    codec = _codec_for_type(shape_type)
+    return tuple(codec.fields)
+
+
+def constructor_parameter_names(cls: type) -> tuple[str, ...]:
+    """Return the constructor parameters of a primitive class.
+
+    Used by the contract test that pins the registry against the live classes,
+    so that adding a parameter upstream fails a test instead of silently
+    vanishing from exported designs.
+    """
+    if dataclasses.is_dataclass(cls):
+        return tuple(f.name for f in dataclasses.fields(cls))
+    params = inspect.signature(cls.__init__).parameters
+    return tuple(name for name in params if name != "self")
+
+
+def _codec_for_type(shape_type: str) -> _ShapeCodec:
+    try:
+        return _CODECS[shape_type]
+    except KeyError:
+        raise UnsupportedDesignFeature(
+            f"shape type {shape_type!r} is not supported by the design-interop "
+            f"layer; supported types are {', '.join(SUPPORTED_SHAPE_TYPES)}"
+        ) from None
+
+
+def _instance_field_names(shape: Any) -> tuple[str, ...]:
+    if dataclasses.is_dataclass(shape):
+        return tuple(f.name for f in dataclasses.fields(shape))
+    return tuple(vars(shape))
+
+
+def shape_to_dict(shape: Any) -> dict[str, Any]:
+    """Serialise a geometry primitive to its JSON-canonical parameters.
+
+    Raises
+    ------
+    UnsupportedDesignFeature
+        If the shape's class is not registered, or if the live class carries
+        state the registry does not know about (which would otherwise be
+        dropped silently).
+    """
+    shape_type = type(shape).__name__
+    codec = _codec_for_type(shape_type)
+    if type(shape) is not codec.cls:
+        raise UnsupportedDesignFeature(
+            f"{shape_type!r} resolves to {type(shape)!r}, which is not the "
+            f"registered {codec.cls!r}; subclasses may carry state the "
+            f"interop layer cannot see"
+        )
+
+    recorded = set(codec.fields)
+    present = set(_instance_field_names(shape))
+    missing = present - recorded
+    if missing:
+        raise UnsupportedDesignFeature(
+            f"{shape_type} carries state the design-interop registry does not "
+            f"record: {sorted(missing)}. Update rfx/interop/_shapes.py rather "
+            f"than exporting a partial shape"
+        )
+
+    params: dict[str, Any] = {}
+    for name, field in codec.fields.items():
+        try:
+            value = getattr(shape, name)
+        except AttributeError as exc:
+            raise UnsupportedDesignFeature(
+                f"{shape_type} is missing the recorded parameter {name!r}"
+            ) from exc
+        params[name] = field.dump(value)
+    return {"type": shape_type, "params": params}
+
+
+def shape_from_dict(payload: dict[str, Any]) -> Any:
+    """Rebuild a geometry primitive from :func:`shape_to_dict` output."""
+    if not isinstance(payload, dict):
+        raise UnsupportedDesignFeature(
+            f"shape payload must be a mapping, got {type(payload).__name__}"
+        )
+    try:
+        shape_type = payload["type"]
+    except KeyError:
+        raise UnsupportedDesignFeature(
+            "shape payload is missing the 'type' key"
+        ) from None
+
+    codec = _codec_for_type(shape_type)
+    params = payload.get("params", {})
+    if not isinstance(params, dict):
+        raise UnsupportedDesignFeature(
+            f"{shape_type} params must be a mapping, got {type(params).__name__}"
+        )
+
+    unknown = set(params) - set(codec.fields)
+    if unknown:
+        raise UnsupportedDesignFeature(
+            f"{shape_type} payload carries unknown parameters {sorted(unknown)}"
+        )
+    absent = set(codec.fields) - set(params)
+    if absent:
+        raise UnsupportedDesignFeature(
+            f"{shape_type} payload is missing parameters {sorted(absent)}"
+        )
+
+    kwargs = {
+        name: field.load(params[name])
+        for name, field in codec.fields.items()
+    }
+    return codec.cls(**kwargs)

--- a/rfx/interop/_shapes.py
+++ b/rfx/interop/_shapes.py
@@ -28,8 +28,10 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
+import math
 from typing import Any, Callable, NamedTuple
 
+from rfx.core.jax_utils import is_tracer
 from rfx.geometry.csg import Box, Cylinder, PolylineWire, Sphere
 from rfx.geometry.curved import CurvedPatch
 from rfx.geometry.via import Via
@@ -51,18 +53,58 @@ class _Field(NamedTuple):
     load: Callable[[Any], Any]
 
 
-def _checked_vec(value: Any, n: int, *, what: str) -> tuple[float, ...]:
+def _checked_scalar(value: Any, *, what: str) -> float:
+    """Coerce to a finite Python float, refusing tracers and NaN/inf.
+
+    A tracer means the parameter is a differentiable design variable with no
+    concrete value to record; NaN/inf would be written by ``json.dump`` only as
+    non-standard tokens (and ``allow_nan=False`` raises a bare ``ValueError``
+    far from the offending field), so both are refused here where the field name
+    is still known.
+    """
+    if is_tracer(value):
+        raise UnsupportedDesignFeature(
+            f"{what} is a JAX tracer, so it is a differentiable design variable "
+            f"with no concrete value to record. Export the design outside the "
+            f"traced/jax.grad context, or record the concrete design you want "
+            f"to hand to another tool"
+        )
     try:
-        seq = tuple(float(v) for v in value)
+        out = float(value)
     except (TypeError, ValueError) as exc:
+        raise UnsupportedDesignFeature(
+            f"{what} must be a number, got {value!r}"
+        ) from exc
+    if not math.isfinite(out):
+        raise UnsupportedDesignFeature(
+            f"{what} is {out}, which is not a finite number; a design "
+            f"description with NaN/inf geometry does not describe a structure"
+        )
+    return out
+
+
+def _checked_vec(value: Any, n: int, *, what: str) -> tuple[float, ...]:
+    if is_tracer(value):
+        raise UnsupportedDesignFeature(
+            f"{what} is a JAX tracer, so it is a differentiable design variable "
+            f"with no concrete value to record. Export the design outside the "
+            f"traced/jax.grad context"
+        )
+    try:
+        components = tuple(value)
+    except TypeError as exc:
         raise UnsupportedDesignFeature(
             f"{what} must be a sequence of {n} numbers, got {value!r}"
         ) from exc
-    if len(seq) != n:
+    if len(components) != n:
         raise UnsupportedDesignFeature(
-            f"{what} must have exactly {n} components, got {len(seq)}: {value!r}"
+            f"{what} must have exactly {n} components, got {len(components)}: "
+            f"{value!r}"
         )
-    return seq
+    return tuple(
+        _checked_scalar(v, what=f"{what}[{i}]")
+        for i, v in enumerate(components)
+    )
 
 
 def _vec(n: int, *, what: str) -> _Field:
@@ -79,7 +121,13 @@ def _vec_seq(n: int, *, what: str, container: Callable[[Any], Any]) -> _Field:
     )
 
 
-_FLOAT = _Field(dump=lambda v: float(v), load=lambda v: float(v))
+def _flt(*, what: str) -> _Field:
+    return _Field(
+        dump=lambda v: _checked_scalar(v, what=what),
+        load=lambda v: _checked_scalar(v, what=what),
+    )
+
+
 _STR = _Field(dump=lambda v: str(v), load=lambda v: str(v))
 
 
@@ -95,33 +143,33 @@ _CODECS: dict[str, _ShapeCodec] = {
     }),
     "cylinder": _ShapeCodec(Cylinder, {
         "center": _vec(3, what="cylinder.center"),
-        "radius": _FLOAT,
-        "height": _FLOAT,
+        "radius": _flt(what="cylinder.radius"),
+        "height": _flt(what="cylinder.height"),
         "axis": _STR,
     }),
     "sphere": _ShapeCodec(Sphere, {
         "center": _vec(3, what="sphere.center"),
-        "radius": _FLOAT,
+        "radius": _flt(what="sphere.radius"),
     }),
     "polyline_wire": _ShapeCodec(PolylineWire, {
         "points": _vec_seq(3, what="polyline_wire.points", container=tuple),
-        "radius": _FLOAT,
+        "radius": _flt(what="polyline_wire.radius"),
     }),
     # ``Via`` carries its own ``material`` in addition to the ``material=``
     # handed to ``Simulation.add()``.  Both are recorded; resolving the two is
     # the caller's decision, not something this codec may silently pick.
     "via": _ShapeCodec(Via, {
         "center": _vec(2, what="via.center"),
-        "drill_radius": _FLOAT,
-        "pad_radius": _FLOAT,
+        "drill_radius": _flt(what="via.drill_radius"),
+        "pad_radius": _flt(what="via.pad_radius"),
         "layers": _vec_seq(2, what="via.layers", container=list),
         "material": _STR,
     }),
     "curved_patch": _ShapeCodec(CurvedPatch, {
         "center": _vec(3, what="curved_patch.center"),
-        "length": _FLOAT,
-        "width": _FLOAT,
-        "radius": _FLOAT,
+        "length": _flt(what="curved_patch.length"),
+        "width": _flt(what="curved_patch.width"),
+        "radius": _flt(what="curved_patch.radius"),
         "axis": _STR,
     }),
 }

--- a/rfx/interop/_shapes.py
+++ b/rfx/interop/_shapes.py
@@ -6,14 +6,20 @@ That is adequate for a review summary but cannot distinguish a ``Cylinder``
 from a ``Box`` occupying the same bounding box, so it cannot rebuild its own
 input and cannot drive an external solver.
 
-This module records the *constructor parameters* instead.  Every supported
-primitive survives a JSON round trip exactly; anything not in the registry is
-refused loudly (:class:`~rfx.interop._errors.UnsupportedDesignFeature`) rather
-than degraded to a bounding box.
+This module records the *constructor parameters* instead.  An unregistered shape
+class, and any value the layer cannot represent exactly, are refused loudly
+(:class:`~rfx.interop._errors.UnsupportedDesignFeature`) rather than degraded to
+a bounding box.
 
 JSON canonical form uses lists for vectors; the Python canonical form restores
-the tuples the primitives declare, so a round-tripped frozen dataclass compares
-equal to the original.
+the tuples the primitives declare.  Round-tripping is therefore **normalising,
+not identity**: a shape constructed with canonical containers (the tuples the
+classes declare, which is what every construction path in this repo uses)
+compares equal after a round trip, but one built with lists — ``Box(corner_lo=[0,
+0, 0], ...)`` is legal, since the primitives do not coerce in ``__init__`` —
+comes back with tuples and compares unequal while describing identical geometry.
+``Via.layers`` normalises to a ``list`` of tuples and ``PolylineWire.points`` to
+a ``tuple`` of tuples, matching what those classes declare.
 
 Vocabulary: the discriminator is ``kind`` with snake_case names, matching the
 two document layers that already name shapes — ``rfx/config/_shapes.py``
@@ -28,14 +34,18 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
-import math
 from typing import Any, Callable, NamedTuple
 
-from rfx.core.jax_utils import is_tracer
 from rfx.geometry.csg import Box, Cylinder, PolylineWire, Sphere
 from rfx.geometry.curved import CurvedPatch
 from rfx.geometry.via import Via
 from rfx.interop._errors import UnsupportedDesignFeature
+from rfx.interop._validate import (
+    check_number,
+    check_sequence,
+    check_text,
+    check_vector,
+)
 
 __all__ = [
     "SUPPORTED_SHAPE_KINDS",
@@ -53,82 +63,54 @@ class _Field(NamedTuple):
     load: Callable[[Any], Any]
 
 
-def _checked_scalar(value: Any, *, what: str) -> float:
-    """Coerce to a finite Python float, refusing tracers and NaN/inf.
-
-    A tracer means the parameter is a differentiable design variable with no
-    concrete value to record; NaN/inf would be written by ``json.dump`` only as
-    non-standard tokens (and ``allow_nan=False`` raises a bare ``ValueError``
-    far from the offending field), so both are refused here where the field name
-    is still known.
-    """
-    if is_tracer(value):
-        raise UnsupportedDesignFeature(
-            f"{what} is a JAX tracer, so it is a differentiable design variable "
-            f"with no concrete value to record. Export the design outside the "
-            f"traced/jax.grad context, or record the concrete design you want "
-            f"to hand to another tool"
-        )
-    try:
-        out = float(value)
-    except (TypeError, ValueError) as exc:
-        raise UnsupportedDesignFeature(
-            f"{what} must be a number, got {value!r}"
-        ) from exc
-    if not math.isfinite(out):
-        raise UnsupportedDesignFeature(
-            f"{what} is {out}, which is not a finite number; a design "
-            f"description with NaN/inf geometry does not describe a structure"
-        )
-    return out
-
-
-def _checked_vec(value: Any, n: int, *, what: str) -> tuple[float, ...]:
-    if is_tracer(value):
-        raise UnsupportedDesignFeature(
-            f"{what} is a JAX tracer, so it is a differentiable design variable "
-            f"with no concrete value to record. Export the design outside the "
-            f"traced/jax.grad context"
-        )
-    try:
-        components = tuple(value)
-    except TypeError as exc:
-        raise UnsupportedDesignFeature(
-            f"{what} must be a sequence of {n} numbers, got {value!r}"
-        ) from exc
-    if len(components) != n:
-        raise UnsupportedDesignFeature(
-            f"{what} must have exactly {n} components, got {len(components)}: "
-            f"{value!r}"
-        )
-    return tuple(
-        _checked_scalar(v, what=f"{what}[{i}]")
-        for i, v in enumerate(components)
-    )
-
-
 def _vec(n: int, *, what: str) -> _Field:
     return _Field(
-        dump=lambda v: list(_checked_vec(v, n, what=what)),
-        load=lambda v: _checked_vec(v, n, what=what),
+        dump=lambda v: list(check_vector(v, n, what=what)),
+        load=lambda v: check_vector(v, n, what=what),
     )
 
 
-def _vec_seq(n: int, *, what: str, container: Callable[[Any], Any]) -> _Field:
+def _vec_seq(
+    n: int,
+    *,
+    what: str,
+    container: Callable[[Any], Any],
+    min_length: int = 1,
+) -> _Field:
+    """A sequence of fixed-width vectors.
+
+    ``min_length`` defaults to 1: an empty point list or layer stack does not
+    describe a structure, and accepting one is how a consumed iterator used to
+    turn into a silently absent conductor.
+    """
+
+    def _items(value: Any) -> tuple:
+        return check_sequence(value, what=what, min_length=min_length)
+
     return _Field(
-        dump=lambda v: [list(_checked_vec(p, n, what=what)) for p in v],
-        load=lambda v: container(_checked_vec(p, n, what=what) for p in v),
+        dump=lambda v: [
+            list(check_vector(p, n, what=f"{what}[{i}]"))
+            for i, p in enumerate(_items(v))
+        ],
+        load=lambda v: container(
+            check_vector(p, n, what=f"{what}[{i}]")
+            for i, p in enumerate(_items(v))
+        ),
     )
 
 
 def _flt(*, what: str) -> _Field:
     return _Field(
-        dump=lambda v: _checked_scalar(v, what=what),
-        load=lambda v: _checked_scalar(v, what=what),
+        dump=lambda v: check_number(v, what=what),
+        load=lambda v: check_number(v, what=what),
     )
 
 
-_STR = _Field(dump=lambda v: str(v), load=lambda v: str(v))
+def _txt(*, what: str) -> _Field:
+    return _Field(
+        dump=lambda v: check_text(v, what=what),
+        load=lambda v: check_text(v, what=what),
+    )
 
 
 class _ShapeCodec(NamedTuple):
@@ -145,7 +127,7 @@ _CODECS: dict[str, _ShapeCodec] = {
         "center": _vec(3, what="cylinder.center"),
         "radius": _flt(what="cylinder.radius"),
         "height": _flt(what="cylinder.height"),
-        "axis": _STR,
+        "axis": _txt(what="cylinder.axis"),
     }),
     "sphere": _ShapeCodec(Sphere, {
         "center": _vec(3, what="sphere.center"),
@@ -163,14 +145,14 @@ _CODECS: dict[str, _ShapeCodec] = {
         "drill_radius": _flt(what="via.drill_radius"),
         "pad_radius": _flt(what="via.pad_radius"),
         "layers": _vec_seq(2, what="via.layers", container=list),
-        "material": _STR,
+        "material": _txt(what="via.material"),
     }),
     "curved_patch": _ShapeCodec(CurvedPatch, {
         "center": _vec(3, what="curved_patch.center"),
         "length": _flt(what="curved_patch.length"),
         "width": _flt(what="curved_patch.width"),
         "radius": _flt(what="curved_patch.radius"),
-        "axis": _STR,
+        "axis": _txt(what="curved_patch.axis"),
     }),
 }
 
@@ -212,11 +194,27 @@ def constructor_parameter_names(cls: type) -> tuple[str, ...]:
     Used by the contract test that pins the registry against the live classes,
     so that adding a parameter upstream fails a test instead of silently
     vanishing from exported designs.
+
+    Reads ``inspect.signature(cls.__init__)`` even for dataclasses, because
+    ``dataclasses.fields`` has blind spots in both directions: it **excludes**
+    ``InitVar`` (so an upstream ``units: InitVar[str] = "mm"`` consumed in
+    ``__post_init__`` would not show up, and every export would silently carry
+    values under an undeclared unit convention) and it **includes**
+    ``field(init=False)`` derived attributes, which are not constructor
+    parameters at all and must not be passed back on import.
     """
-    if dataclasses.is_dataclass(cls):
-        return tuple(f.name for f in dataclasses.fields(cls))
-    params = inspect.signature(cls.__init__).parameters
-    return tuple(name for name in params if name != "self")
+    signature_names = tuple(
+        name
+        for name in inspect.signature(cls.__init__).parameters
+        if name != "self"
+    )
+    if not dataclasses.is_dataclass(cls):
+        return signature_names
+    # Union both views, preserving signature order, so an InitVar shows up and a
+    # non-init field does not masquerade as a constructor parameter.
+    init_fields = tuple(f.name for f in dataclasses.fields(cls) if f.init)
+    extra = tuple(n for n in init_fields if n not in signature_names)
+    return signature_names + extra
 
 
 def _codec_for_kind(kind: str) -> _ShapeCodec:
@@ -229,10 +227,33 @@ def _codec_for_kind(kind: str) -> _ShapeCodec:
         ) from None
 
 
-def _instance_field_names(shape: Any) -> tuple[str, ...]:
+def _instance_state_names(shape: Any) -> tuple[str, ...]:
+    """Public instance state, for the "did this class grow a field?" check.
+
+    Leading-underscore names are excluded because they are caches and memos, not
+    design state — ``MeshShape.__init__`` already stamps ``self._mask_cache``
+    (``rfx/geometry/mesh_import.py:66``), and without this exclusion a shape
+    would become unexportable the moment it grew one, *after* having exported
+    fine a moment earlier.
+
+    Handles ``__slots__`` / NamedTuple classes, which have no ``__dict__``;
+    unreachable today because :func:`shape_kind_of` refuses unregistered classes
+    first, but ``rfx/geometry/thin_wire.py`` already defines a NamedTuple shape,
+    so this is a live trap for whoever registers one.
+    """
     if dataclasses.is_dataclass(shape):
-        return tuple(f.name for f in dataclasses.fields(shape))
-    return tuple(vars(shape))
+        names: tuple[str, ...] = tuple(f.name for f in dataclasses.fields(shape))
+    elif hasattr(shape, "_fields"):  # NamedTuple
+        names = tuple(shape._fields)
+    elif hasattr(shape, "__dict__"):
+        names = tuple(vars(shape))
+    else:  # __slots__ without __dict__
+        names = tuple(
+            slot
+            for klass in type(shape).__mro__
+            for slot in getattr(klass, "__slots__", ())
+        )
+    return tuple(name for name in names if not name.startswith("_"))
 
 
 def shape_to_dict(shape: Any) -> dict[str, Any]:
@@ -249,13 +270,12 @@ def shape_to_dict(shape: Any) -> dict[str, Any]:
     codec = _codec_for_kind(kind)
 
     recorded = set(codec.fields)
-    present = set(_instance_field_names(shape))
-    missing = present - recorded
-    if missing:
+    unrecorded = set(_instance_state_names(shape)) - recorded
+    if unrecorded:
         raise UnsupportedDesignFeature(
             f"{kind} carries state the design-interop registry does not "
-            f"record: {sorted(missing)}. Update rfx/interop/_shapes.py rather "
-            f"than exporting a partial shape"
+            f"record: {sorted(unrecorded)}. Update rfx/interop/_shapes.py "
+            f"rather than exporting a partial shape"
         )
 
     params: dict[str, Any] = {}
@@ -305,4 +325,16 @@ def shape_from_dict(payload: dict[str, Any]) -> Any:
         name: field.load(params[name])
         for name, field in codec.fields.items()
     }
-    return codec.cls(**kwargs)
+    try:
+        return codec.cls(**kwargs)
+    except UnsupportedDesignFeature:
+        raise
+    except (ValueError, TypeError) as exc:
+        # The primitive's own invariants (e.g. Via requires pad_radius >=
+        # drill_radius, rfx/geometry/via.py:49) would otherwise escape as a bare
+        # ValueError naming neither the kind nor the document. Note
+        # UnsupportedDesignFeature IS a ValueError, so a caller writing
+        # `except UnsupportedDesignFeature` would have missed those.
+        raise UnsupportedDesignFeature(
+            f"{kind} payload violates the primitive's own invariants: {exc}"
+        ) from exc

--- a/rfx/interop/_shapes.py
+++ b/rfx/interop/_shapes.py
@@ -14,6 +14,14 @@ than degraded to a bounding box.
 JSON canonical form uses lists for vectors; the Python canonical form restores
 the tuples the primitives declare, so a round-tripped frozen dataclass compares
 equal to the original.
+
+Vocabulary: the discriminator is ``kind`` with snake_case names, matching the
+two document layers that already name shapes — ``rfx/config/_shapes.py``
+(``shape: "box"``) and ``rfx/experiments/canonical.py`` (``kind: "box"``) — so
+the repo does not grow a third name for the same primitive.  Parameter names
+are the *constructor* names, which is what makes the registry pinnable against
+each live class signature; per-layer spellings of a box (``bounds``,
+``bounds_m``) stay an adapter concern for those layers.
 """
 
 from __future__ import annotations
@@ -28,8 +36,9 @@ from rfx.geometry.via import Via
 from rfx.interop._errors import UnsupportedDesignFeature
 
 __all__ = [
-    "SUPPORTED_SHAPE_TYPES",
+    "SUPPORTED_SHAPE_KINDS",
     "shape_from_dict",
+    "shape_kind_of",
     "shape_to_dict",
     "shape_field_names",
 ]
@@ -80,36 +89,36 @@ class _ShapeCodec(NamedTuple):
 
 
 _CODECS: dict[str, _ShapeCodec] = {
-    "Box": _ShapeCodec(Box, {
-        "corner_lo": _vec(3, what="Box.corner_lo"),
-        "corner_hi": _vec(3, what="Box.corner_hi"),
+    "box": _ShapeCodec(Box, {
+        "corner_lo": _vec(3, what="box.corner_lo"),
+        "corner_hi": _vec(3, what="box.corner_hi"),
     }),
-    "Cylinder": _ShapeCodec(Cylinder, {
-        "center": _vec(3, what="Cylinder.center"),
+    "cylinder": _ShapeCodec(Cylinder, {
+        "center": _vec(3, what="cylinder.center"),
         "radius": _FLOAT,
         "height": _FLOAT,
         "axis": _STR,
     }),
-    "Sphere": _ShapeCodec(Sphere, {
-        "center": _vec(3, what="Sphere.center"),
+    "sphere": _ShapeCodec(Sphere, {
+        "center": _vec(3, what="sphere.center"),
         "radius": _FLOAT,
     }),
-    "PolylineWire": _ShapeCodec(PolylineWire, {
-        "points": _vec_seq(3, what="PolylineWire.points", container=tuple),
+    "polyline_wire": _ShapeCodec(PolylineWire, {
+        "points": _vec_seq(3, what="polyline_wire.points", container=tuple),
         "radius": _FLOAT,
     }),
     # ``Via`` carries its own ``material`` in addition to the ``material=``
     # handed to ``Simulation.add()``.  Both are recorded; resolving the two is
     # the caller's decision, not something this codec may silently pick.
-    "Via": _ShapeCodec(Via, {
-        "center": _vec(2, what="Via.center"),
+    "via": _ShapeCodec(Via, {
+        "center": _vec(2, what="via.center"),
         "drill_radius": _FLOAT,
         "pad_radius": _FLOAT,
-        "layers": _vec_seq(2, what="Via.layers", container=list),
+        "layers": _vec_seq(2, what="via.layers", container=list),
         "material": _STR,
     }),
-    "CurvedPatch": _ShapeCodec(CurvedPatch, {
-        "center": _vec(3, what="CurvedPatch.center"),
+    "curved_patch": _ShapeCodec(CurvedPatch, {
+        "center": _vec(3, what="curved_patch.center"),
         "length": _FLOAT,
         "width": _FLOAT,
         "radius": _FLOAT,
@@ -117,13 +126,36 @@ _CODECS: dict[str, _ShapeCodec] = {
     }),
 }
 
-SUPPORTED_SHAPE_TYPES: tuple[str, ...] = tuple(sorted(_CODECS))
+SUPPORTED_SHAPE_KINDS: tuple[str, ...] = tuple(sorted(_CODECS))
+
+_KIND_BY_CLASS: dict[type, str] = {
+    codec.cls: kind for kind, codec in _CODECS.items()
+}
 
 
-def shape_field_names(shape_type: str) -> tuple[str, ...]:
-    """Return the recorded parameter names for ``shape_type``."""
-    codec = _codec_for_type(shape_type)
+def shape_field_names(kind: str) -> tuple[str, ...]:
+    """Return the recorded parameter names for a shape ``kind``."""
+    codec = _codec_for_kind(kind)
     return tuple(codec.fields)
+
+
+def shape_kind_of(shape: Any) -> str:
+    """Return the IR ``kind`` for a shape instance.
+
+    Raises
+    ------
+    UnsupportedDesignFeature
+        If the shape's exact class is not registered.  Subclasses are refused
+        because they may carry state the registry cannot see.
+    """
+    try:
+        return _KIND_BY_CLASS[type(shape)]
+    except KeyError:
+        raise UnsupportedDesignFeature(
+            f"shape class {type(shape).__name__!r} is not supported by the "
+            f"design-interop layer; supported kinds are "
+            f"{', '.join(SUPPORTED_SHAPE_KINDS)}"
+        ) from None
 
 
 def constructor_parameter_names(cls: type) -> tuple[str, ...]:
@@ -139,13 +171,13 @@ def constructor_parameter_names(cls: type) -> tuple[str, ...]:
     return tuple(name for name in params if name != "self")
 
 
-def _codec_for_type(shape_type: str) -> _ShapeCodec:
+def _codec_for_kind(kind: str) -> _ShapeCodec:
     try:
-        return _CODECS[shape_type]
-    except KeyError:
+        return _CODECS[kind]
+    except (KeyError, TypeError):
         raise UnsupportedDesignFeature(
-            f"shape type {shape_type!r} is not supported by the design-interop "
-            f"layer; supported types are {', '.join(SUPPORTED_SHAPE_TYPES)}"
+            f"shape kind {kind!r} is not supported by the design-interop "
+            f"layer; supported kinds are {', '.join(SUPPORTED_SHAPE_KINDS)}"
         ) from None
 
 
@@ -165,21 +197,15 @@ def shape_to_dict(shape: Any) -> dict[str, Any]:
         state the registry does not know about (which would otherwise be
         dropped silently).
     """
-    shape_type = type(shape).__name__
-    codec = _codec_for_type(shape_type)
-    if type(shape) is not codec.cls:
-        raise UnsupportedDesignFeature(
-            f"{shape_type!r} resolves to {type(shape)!r}, which is not the "
-            f"registered {codec.cls!r}; subclasses may carry state the "
-            f"interop layer cannot see"
-        )
+    kind = shape_kind_of(shape)
+    codec = _codec_for_kind(kind)
 
     recorded = set(codec.fields)
     present = set(_instance_field_names(shape))
     missing = present - recorded
     if missing:
         raise UnsupportedDesignFeature(
-            f"{shape_type} carries state the design-interop registry does not "
+            f"{kind} carries state the design-interop registry does not "
             f"record: {sorted(missing)}. Update rfx/interop/_shapes.py rather "
             f"than exporting a partial shape"
         )
@@ -190,10 +216,10 @@ def shape_to_dict(shape: Any) -> dict[str, Any]:
             value = getattr(shape, name)
         except AttributeError as exc:
             raise UnsupportedDesignFeature(
-                f"{shape_type} is missing the recorded parameter {name!r}"
+                f"{kind} is missing the recorded parameter {name!r}"
             ) from exc
         params[name] = field.dump(value)
-    return {"type": shape_type, "params": params}
+    return {"kind": kind, "params": params}
 
 
 def shape_from_dict(payload: dict[str, Any]) -> Any:
@@ -203,28 +229,28 @@ def shape_from_dict(payload: dict[str, Any]) -> Any:
             f"shape payload must be a mapping, got {type(payload).__name__}"
         )
     try:
-        shape_type = payload["type"]
+        kind = payload["kind"]
     except KeyError:
         raise UnsupportedDesignFeature(
-            "shape payload is missing the 'type' key"
+            "shape payload is missing the 'kind' key"
         ) from None
 
-    codec = _codec_for_type(shape_type)
+    codec = _codec_for_kind(kind)
     params = payload.get("params", {})
     if not isinstance(params, dict):
         raise UnsupportedDesignFeature(
-            f"{shape_type} params must be a mapping, got {type(params).__name__}"
+            f"{kind} params must be a mapping, got {type(params).__name__}"
         )
 
     unknown = set(params) - set(codec.fields)
     if unknown:
         raise UnsupportedDesignFeature(
-            f"{shape_type} payload carries unknown parameters {sorted(unknown)}"
+            f"{kind} payload carries unknown parameters {sorted(unknown)}"
         )
     absent = set(codec.fields) - set(params)
     if absent:
         raise UnsupportedDesignFeature(
-            f"{shape_type} payload is missing parameters {sorted(absent)}"
+            f"{kind} payload is missing parameters {sorted(absent)}"
         )
 
     kwargs = {

--- a/rfx/interop/_validate.py
+++ b/rfx/interop/_validate.py
@@ -1,0 +1,145 @@
+"""Value coercions shared by the design-interop codecs.
+
+A leaf module on purpose: ``_materials`` needed these and was importing them
+from ``_shapes``, which made materials depend on geometry (and dragged
+``rfx.geometry.*`` plus ``jax`` into any import of the material codec). Nothing
+here imports another interop module except the error type.
+
+Every coercion refuses rather than repairs, and names the field it is refusing,
+because the alternative failure modes are all silent or late:
+
+- a **JAX tracer** means the value is a differentiable design variable with no
+  concrete number to record;
+- **NaN/inf** would surface only at ``json.dump`` time as a bare
+  ``ValueError: Out of range float values are not JSON compliant`` that names no
+  field;
+- a **``bool``** is an ``int`` in Python, so ``float(True)`` silently yields
+  ``1.0`` — a JSON ``true`` would become a length;
+- a **``str``** of digits is iterable and float-able per character, so
+  ``"123"`` would silently become the vector ``(1.0, 2.0, 3.0)``;
+- a **one-shot iterator** is consumed by the act of exporting it, so a second
+  export of the same object emits an empty sequence with no error.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Iterable
+
+from rfx.interop._errors import UnsupportedDesignFeature
+
+__all__ = [
+    "check_number",
+    "check_sequence",
+    "check_text",
+    "check_vector",
+]
+
+
+def _is_tracer(value: Any) -> bool:
+    # Imported lazily: this leaf must stay importable without paying for jax.
+    from rfx.core.jax_utils import is_tracer
+
+    return bool(is_tracer(value))
+
+
+def check_number(value: Any, *, what: str) -> float:
+    """Coerce to a finite, non-boolean Python float."""
+    if _is_tracer(value):
+        raise UnsupportedDesignFeature(
+            f"{what} is a JAX tracer, so it is a differentiable design variable "
+            f"with no concrete value to record. Export the design outside the "
+            f"traced/jax.grad context, or record the concrete design you want "
+            f"to hand to another tool"
+        )
+    if isinstance(value, bool):
+        raise UnsupportedDesignFeature(
+            f"{what} is the boolean {value!r}; a boolean is an int in Python, "
+            f"so accepting it would silently record {float(value)!r}"
+        )
+    if isinstance(value, (str, bytes)):
+        raise UnsupportedDesignFeature(
+            f"{what} is the string {value!r}, not a number. A design document "
+            f"with quoted numerics is accepted silently by float() and would "
+            f"record a value nobody wrote"
+        )
+    try:
+        out = float(value)
+    except (TypeError, ValueError) as exc:
+        raise UnsupportedDesignFeature(
+            f"{what} must be a number, got {value!r}"
+        ) from exc
+    if not math.isfinite(out):
+        raise UnsupportedDesignFeature(
+            f"{what} is {out}, which is not a finite number; a design "
+            f"description with NaN/inf geometry does not describe a structure"
+        )
+    return out
+
+
+def check_text(value: Any, *, what: str) -> str:
+    """Require an actual string.
+
+    ``str(value)`` cannot fail, so an unguarded string field will happily record
+    ``None``, a whole ``MaterialSpec`` repr, or a multi-line tracer repr as if it
+    were a name.
+    """
+    if not isinstance(value, str):
+        raise UnsupportedDesignFeature(
+            f"{what} must be a string, got {type(value).__name__} "
+            f"({value!r:.80}); str() would have recorded its repr as a name"
+        )
+    return value
+
+
+def check_sequence(value: Any, *, what: str, min_length: int = 0) -> tuple:
+    """Materialise a sized, non-string sequence.
+
+    Requires ``__len__`` so a generator or other one-shot iterator is refused
+    instead of being consumed: consuming it makes export non-idempotent, and a
+    second export emits an empty sequence with no error at all.
+    """
+    if isinstance(value, (str, bytes)):
+        raise UnsupportedDesignFeature(
+            f"{what} must be a sequence, got the string {value!r:.60}"
+        )
+    if not isinstance(value, Iterable):
+        raise UnsupportedDesignFeature(
+            f"{what} must be a sequence, got {type(value).__name__} "
+            f"({value!r:.60})"
+        )
+    if not hasattr(value, "__len__"):
+        # Iterable but unsized: a generator or other one-shot iterator.
+        raise UnsupportedDesignFeature(
+            f"{what} is a {type(value).__name__}, which has no length. A "
+            f"one-shot iterator is consumed by exporting it, so a second export "
+            f"of the same object would silently emit an empty sequence. Store a "
+            f"tuple or list instead"
+        )
+    items = tuple(value)
+    if len(items) < min_length:
+        raise UnsupportedDesignFeature(
+            f"{what} needs at least {min_length} element(s), got {len(items)}; "
+            f"an empty sequence does not describe a structure"
+        )
+    return items
+
+
+def check_vector(value: Any, n: int, *, what: str) -> tuple[float, ...]:
+    """Coerce to exactly ``n`` finite floats."""
+    if _is_tracer(value):
+        raise UnsupportedDesignFeature(
+            f"{what} is a JAX tracer, so it is a differentiable design variable "
+            f"with no concrete value to record. Export the design outside the "
+            f"traced/jax.grad context"
+        )
+    components = check_sequence(value, what=what)
+    if len(components) != n:
+        raise UnsupportedDesignFeature(
+            f"{what} must have exactly {n} components, got "
+            f"{len(components)}: {value!r:.80}"
+        )
+    return tuple(
+        check_number(v, what=f"{what}[{i}]")
+        for i, v in enumerate(components)
+    )

--- a/rfx/interop/emitters/__init__.py
+++ b/rfx/interop/emitters/__init__.py
@@ -1,0 +1,36 @@
+"""External-solver emitters — the *projection* profile of the design interop.
+
+``rfx/interop/_design.py`` carries the round-trip-complete rfx→rfx document.
+This subpackage carries the other profile named by decision **D3** of
+``docs/design_notes/geometry_setup_interop.md``: a projection onto a foreign
+solver's input language, **explicitly lossy**, shipping its own itemised list
+of approximations.  The two are deliberately separate artifacts, because a
+reader of a single "portable-ish" schema cannot tell which fields survived.
+
+An emitter is text in, text out: it consumes a ``rfx-design-ir/v1`` document
+and returns a plain-text script.  Generation requires no licence and no
+solver — that is what makes a CST/HFSS emitter possible at all, and it is why
+generation is testable in CI while *execution* is target-dependent.
+
+openEMS is the first target because it is the only one whose generated script
+can also be executed in this environment (``/usr/bin/openEMS``, v0.0.35), so
+emitter output can be checked rather than reviewed.
+
+Status: **provisional**.  See ``openems.py`` for the supported/refused fence.
+"""
+
+from __future__ import annotations
+
+from rfx.interop.emitters.openems import (
+    OPENEMS_EMITTER_VERSION,
+    OpenEMSPlan,
+    emit_openems_script,
+    plan_openems_projection,
+)
+
+__all__ = [
+    "OPENEMS_EMITTER_VERSION",
+    "OpenEMSPlan",
+    "emit_openems_script",
+    "plan_openems_projection",
+]

--- a/rfx/interop/emitters/openems.py
+++ b/rfx/interop/emitters/openems.py
@@ -9,9 +9,10 @@ Scope of v1 — read this before reading the code
 -----------------------------------------------
 The supported fence is **S-parameters from lumped / wire / MSL ports on a
 uniform mesh**.  That is not an accident of effort: it is the intersection of
-what this repository has actually exercised against openEMS (see the mapping
-census in the branch's emitter notes — 10 scripts call the openEMS API, and
-the port families they cover are lumped, wire and MSL) with what can be
+what this repository has actually exercised against openEMS (10 committed
+scripts call the openEMS API, and the port families they cover are lumped,
+wire and MSL; the durable mapping decisions live in
+docs/design_notes/geometry_setup_interop.md) with what can be
 translated without inventing a convention.  Everything else refuses.
 
 Generable
@@ -53,8 +54,9 @@ reference, quoted with its preflight context — a separate exercise.
 
 Divergences honoured
 --------------------
-Each is cited in the code at the point it is applied, using the numbering of
-the branch's rfx→openEMS mapping report:
+Each is cited in the code at the point it is applied, numbered ``D1``..``D16``
+and defined inline below (the durable rationale is also recorded in
+docs/design_notes/geometry_setup_interop.md):
 
 ``D1``  CPML padding direction — rfx adds absorber cells **outside** the user
         domain (``rfx/grid.py``: ``nx = ceil(Lx/dx) + 1 + pad_lo + pad_hi``,

--- a/rfx/interop/emitters/openems.py
+++ b/rfx/interop/emitters/openems.py
@@ -79,10 +79,26 @@ the branch's rfx→openEMS mapping report:
 ``D6``  ``priority`` has no rfx counterpart and is synthesised from paint
         order — see ``_plan_geometry`` for the derivation, which is stronger
         than the scripts' de-facto ladder.
-``D7``  Port-model span mismatch: rfx lumped ports are single-cell and rfx
-        wire ports are a point-feed column, while openEMS lumped ports average
-        over the span and ``MSLPort`` occupies a span along the propagation
-        axis.  ``msl_port_w_cells`` has no rfx counterpart.
+``D7``  Port-model span mismatch, and the direction convention.  rfx lumped
+        ports are single-cell and rfx wire ports are a **point** feed column,
+        while openEMS lumped ports average over the span and ``MSLPort``
+        occupies a span along the propagation axis.  ``msl_port_w_cells`` has
+        no rfx counterpart, so it is an explicit emitter parameter and appears
+        in the generated header as an assumption the reader accepts.  **The
+        measured size of this gap is ≈0.20 in |S|** — the deliberate tolerance
+        of ``build_wire_openems_broad_envelope.py:12-16``, set "because the
+        wire-port mid-cell convention has known mismatch with openEMS's
+        lumped-port multi-cell averaging".  That is the floor on any agreement
+        claim for an emitted lumped/wire setup, looser than the cv06b mean gate
+        (0.13) and comparable to its max gate (0.25).
+        The two rfx port builders use **opposite** ``direction=`` conventions,
+        so the emitter resolves the sense per builder from the implementation:
+        ``add_port``'s ``direction`` is the outward normal (so a wire port
+        needs the negation openEMS's ``sign(stop-start)`` implies), while
+        ``add_msl_port``'s is the propagation direction (so the MSL span
+        extends *along* it, with no negation).  Both readings are cited at
+        their code sites and pinned by tests.  ``add_port``'s ``direction`` has
+        no openEMS counterpart at all and is itemised as not carried.
 ``D8``  Reference planes differ; only magnitudes are comparable without an
         explicit de-embedding contract, which no script in this repo has.
 ``D9``  Units — openEMS geometry is in mm via ``SetDeltaUnit(1e-3)``.
@@ -772,6 +788,7 @@ def _plan_ports(
     required_lines: list[tuple[str, float]] = []
     plans: list[_PortPlan] = []
     snap_shifts: list[str] = []
+    direction_drops: list[str] = []
 
     def snap(value_m: float, label: str) -> float:
         cells = int(round(value_m / dx_m))
@@ -800,6 +817,7 @@ def _plan_ports(
         extent = _get(payload, "extent", what)
         impedance = float(_get(payload, "impedance", what))
         excite = bool(_get(payload, "excite", what))
+        rfx_direction = _get(payload, "direction", what)
         reference_plane_cells = _get(payload, "reference_plane_cells", what)
         if reference_plane_cells is not None:
             raise _refuse(
@@ -841,6 +859,12 @@ def _plan_ports(
                 )
             f0, fc, wf_notes = _gauss_from_waveform(waveform, what)
             notes.extend(wf_notes)
+
+        if rfx_direction is not None:
+            # NOT a refusal: the port's geometry is fully determined without
+            # it. But it is not carried either, and a silent drop is exactly
+            # what this emitter must not do.
+            direction_drops.append(f"{what}.direction={rfx_direction!r}")
 
         number = len(plans) + 1
         for axis_name, coordinate in zip(_AXES, start):
@@ -892,13 +916,32 @@ def _plan_ports(
                 "seed for the port; openEMS MSLPort launches its own line mode "
                 "and has no equivalent knob, so the launched profiles differ."
             )
-        # D7: MSLPort occupies a SPAN along the propagation axis; port_w_cells
-        # (6, inherited from upstream MSL_NotchFilter.py) has no rfx
-        # counterpart at all. rfx's add_msl_port documents `direction` as the
-        # direction the launched wave propagates, so the span extends that way
-        # — note this is the *opposite* reading from add_port()'s `direction`,
-        # which names the outward normal. Nothing in this repository pins the
-        # MSL case against a measurement, which is why it is itemised.
+        # D7 — the span, and its SENSE. Two separate facts:
+        #
+        # (a) MSLPort occupies a SPAN along the propagation axis, and
+        #     msl_port_w_cells has no rfx counterpart at all (rfx uses a feed
+        #     plane plus downstream probes). It is an emitter parameter, and it
+        #     is itemised in the generated header as an accepted assumption.
+        #
+        # (b) The span extends ALONG rfx's direction=, with NO negation. rfx's
+        #     two port builders disagree with each other here, so this is
+        #     resolved per builder from the implementation, not by analogy:
+        #       * add_port():     direction= is the OUTWARD normal
+        #                         (api/__init__.py:1116-1117), confirmed by
+        #                         refplane.py:196-198 / outboard_sign = -1 for
+        #                         '+'. A wire port DOES need the negation.
+        #       * add_msl_port(): direction= is 'the direction the launched
+        #                         wave propagates away from the feed plane'
+        #                         (msl_port.py:50-51), confirmed twice in the
+        #                         implementation — probes go to
+        #                         i_feed + sign*offset with sign=+1 for '+x',
+        #                         i.e. downstream into the line (:865, :894),
+        #                         and the TFSF auxiliary H plane sits BEHIND
+        #                         the feed at i-1 for '+x', the pattern that
+        #                         launches a +x wave (:733).
+        #     Negating here would launch both ports away from the shared trace
+        #     and give a plausible-looking S21 with the wrong reference sense.
+        #     test_msl_span_extends_along_the_rfx_propagation_direction pins it.
         sign = 1.0 if direction == "+x" else -1.0
         span_m = msl_port_w_cells * dx_m
         x_feed = snap(float(position[0]), f"{what}.position[0]")
@@ -958,18 +1001,38 @@ def _plan_ports(
     if any(p.family == "msl" for p in plans):
         notes.append(
             f"[D7] MSL ports: msl_port_w_cells={msl_port_w_cells} sets the "
-            "MSLPort span along the propagation axis. That span has NO rfx "
-            "counterpart — rfx extracts through an N-probe spatial fit "
-            "downstream of a feed plane, while MSLPort launches and de-embeds "
-            "inside its own span — so the two measure at different planes and "
-            "no committed comparison in this repository pins the choice. The "
-            "span direction follows add_msl_port's documented meaning of "
-            "direction= (the direction the launched wave propagates), which is "
-            "the OPPOSITE reading from add_port's direction= (the outward "
-            "normal); if that reading is wrong the two ports swap ends. "
-            "openEMS may additionally log 'Unused primitive ... msl_feed_N' "
-            "when the design's own trace already covers the port span — benign, "
-            "and distinct from the port-dropped failure mode."
+            "MSLPort span along the propagation axis. YOU ARE ACCEPTING THIS "
+            "AS AN ASSUMPTION: the span has NO rfx counterpart at all. rfx's "
+            "port is a feed plane plus an N-probe spatial fit downstream of "
+            "it, while MSLPort launches and de-embeds INSIDE its own span, so "
+            "the two measure at different planes; 6 cells is inherited from "
+            "upstream's MSL_NotchFilter.py and no committed comparison in this "
+            "repository pins it. openEMS may also log 'Unused primitive ... "
+            "msl_feed_N' when the design's own trace already covers the port "
+            "span — benign (both are PEC), and distinct from the port-dropped "
+            "failure mode that the uf_inc guard catches."
+        )
+        notes.append(
+            "[D7] MSL span SENSE: rfx's two port builders use OPPOSITE "
+            "direction= conventions and this emitter follows the one that is "
+            "verified for the builder in hand. add_port() documents direction= "
+            "as the OUTWARD normal 'from the port cell into the external "
+            "world' (rfx/api/__init__.py:1116-1117), and rfx/probes/refplane.py "
+            ":196-198 confirms it — 'The reference planes go the OPPOSITE way "
+            "(into the DUT)', implemented as outboard_sign = -1 for '+'. "
+            "add_msl_port() is the reverse: direction= is 'the direction the "
+            "launched wave propagates away from the feed plane' "
+            "(rfx/sources/msl_port.py:50-51), and TWO independent "
+            "implementation sites agree — probe placement puts the "
+            "de-embedding probes at i_feed + sign*offset with sign=+1 for "
+            "'+x', i.e. downstream INTO the line (msl_port.py:865, 894), and "
+            "the TFSF injector places the auxiliary H plane BEHIND the feed "
+            "(i-1) for '+x', the pattern that launches a +x wave "
+            "(msl_port.py:733). So for an MSL port the span extends ALONG "
+            "rfx's direction=, with NO negation. Negating it here (correct for "
+            "a wire port, wrong for this one) would launch both ports away "
+            "from the shared trace and yield a plausible-looking S21 with the "
+            "wrong reference sense — see the test that pins this sign."
         )
 
     if not any(p.excite for p in plans):
@@ -979,6 +1042,21 @@ def _plan_ports(
             "no S-parameter column exists",
         )
 
+    if direction_drops:
+        notes.append(
+            "[D7] rfx port direction= is NOT carried into openEMS: "
+            + ", ".join(direction_drops)
+            + ". For add_port() it is the OUTWARD normal 'from the port cell "
+            "into the external world' (rfx/api/__init__.py:1116-1117) and rfx "
+            "uses it only to orient its own V/I → (incoming, outgoing) wave "
+            "decomposition. openEMS's AddLumpedPort has no such knob: it "
+            "derives its own sense from sign(stop - start) along the "
+            "EXCITATION axis (the vertical feed), not along the line, and "
+            "decomposes with its own convention. The port geometry is "
+            "therefore fully determined without direction=, but the reference "
+            "SENSE of the off-diagonal terms is openEMS's, not rfx's — do not "
+            "compare S21 phase or sign across the two on this basis."
+        )
     if snap_shifts:
         notes.append(
             "port coordinates were snapped to the mesh the way "
@@ -1222,12 +1300,23 @@ def plan_openems_projection(
         "the faithful ordering — not a flat priority=index."
     )
     notes.append(
-        "[D7/D8] port models and reference planes differ. rfx's lumped port is "
-        "single-cell and its wire port is a point-feed column, while openEMS "
-        "averages over the port span; the repository's own wire-port envelope "
-        "measures that convention gap at about 0.20 in |S|. Compare magnitudes "
-        "only: phase, group delay and Z0 need a de-embedding contract that no "
-        "script in this repository has."
+        "[D7/D8] PORT MODELS ARE KNOWN TO DIFFER BY ABOUT 0.20 IN |S| BEFORE "
+        "ANY PHYSICS IS IN QUESTION. rfx's lumped port is single-cell and its "
+        "wire port is a POINT feed (a single vertical cell column from ground "
+        "to trace, the extent=), while openEMS's lumped port averages over its "
+        "span and MSLPort occupies a span along the propagation axis. "
+        "scripts/diagnostics/build_wire_openems_broad_envelope.py:12-16 sets "
+        "its per-case tolerance to max_mag_abs_diff <= 0.20 deliberately "
+        "'because the wire-port mid-cell convention has known mismatch with "
+        "openEMS's lumped-port multi-cell averaging', and states that broad "
+        "calibrated E5 still requires resolving the wire-port absolute "
+        "calibration convention. 0.20 is therefore the FLOOR on any agreement "
+        "claim for an emitted lumped/wire setup — looser than the cv06b mean "
+        "gate (0.13) and comparable to its max gate (0.25), so a passing "
+        "comparison at this tolerance is NOT evidence that the port models "
+        "agree. Reference planes differ too: compare magnitudes only, because "
+        "phase, group delay and Z0 need a de-embedding contract that no script "
+        "in this repository has."
     )
     notes.append(
         "[D9] all geometry coordinates in this script are millimetres "

--- a/rfx/interop/emitters/openems.py
+++ b/rfx/interop/emitters/openems.py
@@ -1,0 +1,1755 @@
+"""Project a ``rfx-design-ir/v1`` design document onto a runnable openEMS script.
+
+``emit_openems_script(document)`` is text in, text out: it needs no solver, no
+licence and no ``Simulation``.  The returned string is a self-contained Python
+script that builds the structure with CSXCAD, runs openEMS once per driven
+port, and writes the S-matrix to JSON.
+
+Scope of v1 — read this before reading the code
+-----------------------------------------------
+The supported fence is **S-parameters from lumped / wire / MSL ports on a
+uniform mesh**.  That is not an accident of effort: it is the intersection of
+what this repository has actually exercised against openEMS (see the mapping
+census in the branch's emitter notes — 10 scripts call the openEMS API, and
+the port families they cover are lumped, wire and MSL) with what can be
+translated without inventing a convention.  Everything else refuses.
+
+Generable
+    uniform ``dx`` mesh; ``pec`` / ``pmc`` / ``cpml`` / ``upml`` faces;
+    ``add_material(eps_r=, sigma=)``; PEC-by-sigma materials; ``Box`` and
+    ``Cylinder`` geometry in paint order; ``add_port`` (single-cell lumped and
+    ``extent=`` wire); ``add_msl_port``; ``GaussianPulse`` excitation.
+
+Refused, with the reason attached to each raise
+    coaxial ports (no ``AddCoaxialPort`` exists — verified absent on the local
+    v0.0.35 install — and the radial-``AddLumpedPort`` workaround is recorded
+    as failed across three runs); every cell-relative coaxial termination;
+    Floquet ports and ``periodic`` faces (``PBC`` raises "Unknown boundary
+    condition"); ``add_waveguide_port`` (``AddRectWaveGuidePort`` exists but has
+    zero in-repo precedent, and its rfx side carries cell-count extraction
+    planes); ``add_tfsf_source``; ``add_lumped_rlc``; ``add_thin_conductor``;
+    non-uniform mesh profiles; ``refinement``; rfx-only solver controls
+    (``solver != "yee"``, ``precision != "float32"``, ``stencil_order != 2``);
+    conformal PEC faces; ``mode != "3d"``; probes, DFT-plane probes, flux
+    monitors and NTFF boxes; soft (impedance-0) sources; ``Sphere`` /
+    ``PolylineWire`` / ``Via`` / ``CurvedPatch``; non-Gaussian waveforms;
+    dispersive or magnetic dielectrics.
+
+Several of those are refusals *for now* rather than verdicts — the reason
+string says which.  The ones that are verdicts are the ones where a
+translation would have to pick a convention the reader could not see.
+
+What a generated script does NOT prove
+--------------------------------------
+**Structural equivalence of a generated setup is not evidence of physics
+agreement.**  A generated script that runs and returns passive S-parameters
+shows that the projection is executable and self-consistent.  It does not show
+that openEMS and rfx agree, and it does not show that the projection is
+faithful to the rfx design: the absorber formulations differ, the port models
+differ (the repo's own wire-port envelope measures the lumped/wire port-
+convention gap at ``≈0.20`` in ``|S|``), and the reference planes differ.  A
+physics-agreement claim needs a matched-resolution run against a committed
+reference, quoted with its preflight context — a separate exercise.
+
+Divergences honoured
+--------------------
+Each is cited in the code at the point it is applied, using the numbering of
+the branch's rfx→openEMS mapping report:
+
+``D1``  CPML padding direction — rfx adds absorber cells **outside** the user
+        domain (``rfx/grid.py``: ``nx = ceil(Lx/dx) + 1 + pad_lo + pad_hi``,
+        and ``(idx - axis_pads[ax]) * dx`` recovers user coordinates), while
+        openEMS ``PML_<N>`` consumes ``N`` cells **inside** the mesh extent it
+        is handed.  The emitted mesh therefore spans the user domain *plus*
+        the per-face pads, and ``PML_<N>`` eats exactly the added margin.
+        Getting this wrong silently compares a different structure; the repo's
+        own hand-written scripts get it wrong.
+``D2``  ``ceil`` vs ``round`` on the cell count — rfx uses ``ceil``; the
+        emitter follows rfx, so the emitted extent is ``n_cells * dx`` and may
+        exceed ``domain``.
+``D3``  ``PML_<N>`` is parameterised from ``cpml_layers``; the scripts'
+        hard-coded ``PML_8`` is stale against the current rfx default of 16.
+``D4``  ``MUR`` is never emitted (measured 8 % resonance error on a patch, and
+        exponential blow-up on a dielectric).
+``D5``  Off-grid ports are silently dropped by openEMS ("Unused primitive",
+        ``uf_inc == 0``, all-NaN S).  Port coordinates are snapped exactly the
+        way ``Grid.position_to_index`` snaps them (``round(pos/dx)``), so they
+        land on mesh lines by construction; the emitter then *verifies* it and
+        the generated script carries the runtime excitation guard.
+``D6``  ``priority`` has no rfx counterpart and is synthesised from paint
+        order — see ``_plan_geometry`` for the derivation, which is stronger
+        than the scripts' de-facto ladder.
+``D7``  Port-model span mismatch: rfx lumped ports are single-cell and rfx
+        wire ports are a point-feed column, while openEMS lumped ports average
+        over the span and ``MSLPort`` occupies a span along the propagation
+        axis.  ``msl_port_w_cells`` has no rfx counterpart.
+``D8``  Reference planes differ; only magnitudes are comparable without an
+        explicit de-embedding contract, which no script in this repo has.
+``D9``  Units — openEMS geometry is in mm via ``SetDeltaUnit(1e-3)``.
+``D12`` ``EndCriteria`` vs a step count: a step count does not transfer
+        between solvers because their timesteps differ, and ``EndCriteria``
+        can fire early on a resonator.  Run control is an emitter parameter and
+        is itemised in the header.
+``D13`` ``CalcPort`` is called without a scalar ``ref_impedance`` (upstream bug
+        when ``Z_ref`` is array-valued).
+``D14`` ``FDTD.Run()`` needs an absolute path and leaves the process CWD inside
+        the sim directory; the generated script passes an absolute path and
+        restores the CWD in a ``finally``.
+``D15`` The numpy-2.x alias shim must precede the openEMS import — the local
+        numpy is 2.x and ``openEMS.ports.MSLPort`` itself uses ``np.int``.
+``D16`` Metal thickness is taken verbatim from the rfx shape; the emitter does
+        not choose between a sheet and a one-cell box.
+
+Status: **provisional**.
+"""
+
+from __future__ import annotations
+
+import math
+import textwrap
+from dataclasses import dataclass, field
+from typing import Any, Sequence
+
+from rfx.interop._errors import UnsupportedDesignFeature
+
+__all__ = [
+    "OPENEMS_EMITTER_VERSION",
+    "OpenEMSPlan",
+    "emit_openems_script",
+    "plan_openems_projection",
+]
+
+#: Emitter contract version.  Bump when the generated script's structure or the
+#: supported fence changes in a way a reader of an old artifact would notice.
+OPENEMS_EMITTER_VERSION = "rfx-openems-emitter/v1"
+
+#: ``SetDeltaUnit`` value used by every openEMS script in this repository, and
+#: therefore by the emitter: geometry coordinates are millimetres (D9).
+UNIT_M = 1.0e-3
+
+#: rfx treats a material with ``sigma >= 1e6`` S/m as a PEC mask rather than a
+#: lossy dielectric (``rfx/api/_compile.py``: ``_PEC_SIGMA_THRESHOLD``, applied
+#: in the geometry assembly loop).  The openEMS counterpart of that branch is
+#: ``AddMetal``, not ``AddMaterial(kappa=...)``.
+PEC_SIGMA_THRESHOLD = 1.0e6
+
+#: Absorbing boundary tokens on the rfx side.
+_ABSORBING = ("cpml", "upml")
+
+#: Tolerance for "this coordinate is already a mesh line", relative to ``dx``.
+#: Snapped coordinates are ``round(pos/dx) * dx``, so the residual is float
+#: noise (~1e-16 relative); anything larger means a genuine off-grid feature.
+_LINE_TOL_REL = 1.0e-9
+
+_AXES = ("x", "y", "z")
+_COMPONENT_AXIS = {"ex": 0, "ey": 1, "ez": 2}
+_SUPPORTED_SHAPE_KINDS = ("box", "cylinder")
+
+
+# ---------------------------------------------------------------------------
+# Refusal
+# ---------------------------------------------------------------------------
+
+def _refuse(construct: str, reason: str) -> UnsupportedDesignFeature:
+    """Refusal naming the construct first, then why it cannot be projected.
+
+    Per decision D4 of the design note the emitter refuses rather than
+    approximating, and per the task's refusal contract the message must name
+    the construct so a reader knows what to remove or which target to use.
+    """
+    return UnsupportedDesignFeature(
+        f"openEMS emitter cannot project {construct}: {reason}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plan — the reviewable intermediate
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class _MaterialPlan:
+    name: str
+    ident: str
+    is_metal: bool
+    epsilon: float
+    kappa: float
+
+
+@dataclass(frozen=True)
+class _GeometryPlan:
+    index: int
+    kind: str
+    material_ident: str
+    is_metal: bool
+    priority: int
+    start_mm: tuple[float, float, float]
+    stop_mm: tuple[float, float, float]
+    radius_mm: float | None = None
+
+
+@dataclass(frozen=True)
+class _PortPlan:
+    number: int
+    family: str  # "lumped" | "wire" | "msl"
+    label: str
+    impedance: float
+    start_mm: tuple[float, float, float]
+    stop_mm: tuple[float, float, float]
+    excite: bool
+    priority: int
+    exc_dir: int
+    prop_dir: int | None = None  # msl only
+    f0_hz: float | None = None
+    fc_hz: float | None = None
+
+
+@dataclass(frozen=True)
+class OpenEMSPlan:
+    """Reviewable projection of a design document onto openEMS constructs.
+
+    Exposed so tests (and humans) can check the arithmetic that matters —
+    above all the CPML span (D1) — without parsing generated source text.
+    All coordinates are millimetres, matching ``SetDeltaUnit(UNIT_M)``.
+    """
+
+    rfx_version: str
+    schema: str
+    dx_m: float
+    n_cells: tuple[int, int, int]
+    pad_lo: tuple[int, int, int]
+    pad_hi: tuple[int, int, int]
+    mesh_lines_mm: dict[str, tuple[float, ...]]
+    boundary: tuple[str, str, str, str, str, str]
+    materials: tuple[_MaterialPlan, ...]
+    geometry: tuple[_GeometryPlan, ...]
+    ports: tuple[_PortPlan, ...]
+    driven_port_numbers: tuple[int, ...]
+    freqs_hz: tuple[float, ...]
+    n_timesteps: int
+    end_criteria: float
+    msl_port_w_cells: int
+    approximations: tuple[str, ...] = field(default=())
+
+    @property
+    def grid_shape(self) -> tuple[int, int, int]:
+        """Mesh-line counts per axis — must equal the rfx ``Grid.shape`` (D1)."""
+        return tuple(len(self.mesh_lines_mm[ax]) for ax in _AXES)  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Document accessors (fail loudly rather than defaulting)
+# ---------------------------------------------------------------------------
+
+def _require_mapping(value: Any, what: str) -> dict:
+    if not isinstance(value, dict):
+        raise _refuse(
+            what, f"expected a mapping in the design document, got {type(value).__name__}"
+        )
+    return value
+
+
+def _require_list(value: Any, what: str) -> list:
+    if not isinstance(value, list):
+        raise _refuse(
+            what, f"expected a list in the design document, got {type(value).__name__}"
+        )
+    return value
+
+
+def _get(payload: dict, key: str, what: str) -> Any:
+    if key not in payload:
+        raise _refuse(
+            f"{what}.{key}",
+            "the key is absent from the design document; the document was not "
+            "produced by rfx.interop.design_to_dict at this schema version",
+        )
+    return payload[key]
+
+
+def _mm(value_m: float) -> float:
+    return float(value_m) / UNIT_M
+
+
+def _mm3(values_m: Sequence[float]) -> tuple[float, float, float]:
+    return (_mm(values_m[0]), _mm(values_m[1]), _mm(values_m[2]))
+
+
+def _ident(prefix: str, name: str, used: set[str]) -> str:
+    """A CSXCAD property name that is unique and safe in generated source."""
+    base = "".join(ch if (ch.isalnum() or ch == "_") else "_" for ch in str(name))
+    if not base:
+        base = "unnamed"
+    candidate = f"{prefix}_{base}"
+    suffix = 1
+    while candidate in used:
+        suffix += 1
+        candidate = f"{prefix}_{base}_{suffix}"
+    used.add(candidate)
+    return candidate
+
+
+# ---------------------------------------------------------------------------
+# Mesh (D1, D2, D5, D9)
+# ---------------------------------------------------------------------------
+
+def _face_plan(
+    boundary_spec: dict, cpml_layers: int, periodic_axes: str
+) -> tuple[dict[str, int], dict[str, str]]:
+    """Per-face absorber pad (cells) and openEMS boundary string.
+
+    Mirrors ``Grid.__init__``'s ``_face_pad``: a ``pec`` / ``pmc`` / ``periodic``
+    face gets ``pad = 0`` even when the axis participates in CPML, and an
+    absorbing face gets its per-face thickness (``lo_thickness`` /
+    ``hi_thickness``) or the scalar ``cpml_layers``.  Note the comment in
+    ``rfx/grid.py`` calls that per-face allocation "the Meep / OpenEMS / Tidy3D
+    convention" — so the pad side of the translation is already aligned; only
+    the *direction* of the absorber differs (D1).
+    """
+    pads: dict[str, int] = {}
+    strings: dict[str, str] = {}
+    for axis in _AXES:
+        axis_payload = _require_mapping(
+            _get(boundary_spec, axis, "boundary.spec"), f"boundary.spec.{axis}"
+        )
+        if axis_payload.get("conformal", False):
+            raise _refuse(
+                f"boundary.spec.{axis}.conformal",
+                "conformal=True selects rfx's Dey-Mittra PEC face-shift, which "
+                "changes how the boundary face rasterises; openEMS has no "
+                "conformal PEC, so emitting a staircased face would compare a "
+                "different structure",
+            )
+        for side in ("lo", "hi"):
+            face = f"{axis}_{side}"
+            token = _get(axis_payload, side, f"boundary.spec.{axis}")
+            if not isinstance(token, str):
+                raise _refuse(f"boundary.spec.{face}", f"expected a token string, got {token!r}")
+            if token == "periodic":
+                raise _refuse(
+                    f"periodic boundary on face {face}",
+                    "the openEMS v0.0.35 Python bindings expose no periodic "
+                    "boundary through SetBoundaryCond — 'PBC' raises 'Unknown "
+                    "boundary condition', and PEC/PMC each kill a field "
+                    "component of a normally incident plane wave. Documented "
+                    "workarounds (an oversized waveguide, or driving the solver "
+                    "from hand-written XML) are not translations",
+                )
+            if token == "pec":
+                pads[face] = 0
+                strings[face] = "PEC"
+            elif token == "pmc":
+                pads[face] = 0
+                strings[face] = "PMC"
+            elif token in _ABSORBING:
+                thickness = axis_payload.get(f"{side}_thickness")
+                layers = int(cpml_layers if thickness is None else thickness)
+                if layers <= 0:
+                    raise _refuse(
+                        f"absorbing face {face} with {layers} layers",
+                        "an absorbing face with zero thickness has no openEMS "
+                        "counterpart: 'PML_0' is not a boundary condition and "
+                        "dropping to PEC would close an open domain",
+                    )
+                if axis in periodic_axes:
+                    # Grid._face_pad zeroes the pad when the axis is not a CPML
+                    # axis, and _build_grid strips periodic axes from
+                    # cpml_axes.  A design in that state is already refused
+                    # above by the periodic token, so reaching here means the
+                    # legacy periodic_axes view disagrees with the spec.
+                    raise _refuse(
+                        f"absorbing face {face} on periodic axis {axis!r}",
+                        "boundary.legacy.periodic_axes marks this axis periodic "
+                        "while boundary.spec marks the face absorbing; rfx "
+                        "strips CPML from periodic axes, so the two views "
+                        "describe different absorbers",
+                    )
+                pads[face] = layers
+                # D3: parameterised from the design, not the scripts' PML_8.
+                # D4: MUR is never emitted.
+                strings[face] = f"PML_{layers}"
+            else:
+                raise _refuse(f"boundary token {token!r} on face {face}", "unknown token")
+    return pads, strings
+
+
+def _axis_lines_mm(
+    n_cells: int, pad_lo: int, pad_hi: int, dx_m: float
+) -> tuple[float, ...]:
+    """Mesh lines for one axis, in mm, spanning the pads as well as the domain.
+
+    **D1 — the highest-severity divergence.**  rfx's grid is
+    ``ceil(L/dx) + 1 + pad_lo + pad_hi`` nodes and user coordinates are
+    ``(idx - pad_lo) * dx``, i.e. index 0 lies *outside* the user domain.
+    openEMS's ``PML_<N>`` instead consumes ``N`` cells of whatever mesh it is
+    given.  So the emitted mesh runs from ``-pad_lo * dx`` to
+    ``(n_cells + pad_hi) * dx`` and the declared ``PML_<N>`` eats exactly the
+    added margin, leaving ``[0, n_cells*dx]`` as the clear region — the same
+    clear volume rfx simulates.  Meshing only ``[0, L]`` (what the repo's
+    hand-written comparators do) buries ``pad * dx`` of the structure in the
+    absorber at each absorbing face.
+    """
+    return tuple(
+        _mm(index * dx_m) for index in range(-pad_lo, n_cells + pad_hi + 1)
+    )
+
+
+def _pin(
+    lines_mm: tuple[float, ...], required_mm: float, dx_m: float
+) -> tuple[tuple[float, ...], bool]:
+    """Guarantee *required_mm* is exactly a mesh line (D5).
+
+    openEMS drops an excitation whose edges fall between mesh lines — it logs
+    "Unused primitive", ``uf_inc`` stays 0 and every S value comes back NaN.
+    One committed fixture records a whole wasted solver run to that cause.
+    Port coordinates are snapped the way ``Grid.position_to_index`` snaps them
+    so this is normally a no-op assertion; the return flag says whether a line
+    actually had to be inserted, which would mean the mesh is no longer the
+    uniform mesh rfx used.
+    """
+    tol = _LINE_TOL_REL * _mm(dx_m)
+    best = min(range(len(lines_mm)), key=lambda i: abs(lines_mm[i] - required_mm))
+    if abs(lines_mm[best] - required_mm) <= tol:
+        if lines_mm[best] != required_mm:
+            patched = list(lines_mm)
+            patched[best] = required_mm
+            return tuple(patched), False
+        return lines_mm, False
+    merged = tuple(sorted(set(lines_mm) | {required_mm}))
+    return merged, True
+
+
+# ---------------------------------------------------------------------------
+# Materials
+# ---------------------------------------------------------------------------
+
+def _plan_materials(document: dict) -> dict[str, _MaterialPlan]:
+    registered = _require_mapping(_get(document, "materials", "document"), "materials")
+    library = _require_mapping(
+        _get(document, "material_library", "document"), "material_library"
+    )
+    overlap = set(registered) & set(library)
+    if overlap:
+        raise _refuse(
+            f"materials {sorted(overlap)}",
+            "the same name appears in both 'materials' and 'material_library'; "
+            "the document should record a registered material in exactly one "
+            "of them, so which value applies is ambiguous",
+        )
+
+    used: set[str] = set()
+    plans: dict[str, _MaterialPlan] = {}
+    for name in sorted({**registered, **library}):
+        payload = _require_mapping(
+            registered.get(name, library.get(name)), f"materials.{name}"
+        )
+        sigma = float(_get(payload, "sigma", f"materials.{name}"))
+        eps_r = float(_get(payload, "eps_r", f"materials.{name}"))
+        mu_r = float(_get(payload, "mu_r", f"materials.{name}"))
+        chi3 = float(_get(payload, "chi3", f"materials.{name}"))
+        debye = _get(payload, "debye_poles", f"materials.{name}")
+        lorentz = _get(payload, "lorentz_poles", f"materials.{name}")
+
+        # rfx's own assembly loop branches on this threshold and, for a PEC
+        # material, ignores eps_r / mu_r / chi3 / poles entirely — so those
+        # fields are checked only on the dielectric branch.
+        is_metal = sigma >= PEC_SIGMA_THRESHOLD
+        if not is_metal:
+            if debye:
+                raise _refuse(
+                    f"material {name!r} with Debye poles",
+                    "openEMS has no Debye/Lorentz dispersion primitive reachable "
+                    "through the path this emitter targets, and no script in "
+                    "this repository has ever exercised one; flattening the "
+                    "poles to a single eps_r would silently change the material",
+                )
+            if lorentz:
+                raise _refuse(
+                    f"material {name!r} with Lorentz poles",
+                    "same as Debye: no reachable openEMS counterpart, and "
+                    "flattening to a single eps_r would change the material",
+                )
+            if chi3 != 0.0:
+                raise _refuse(
+                    f"material {name!r} with chi3={chi3!r}",
+                    "the Kerr nonlinearity has no openEMS counterpart on this "
+                    "path; dropping it would turn a nonlinear design into a "
+                    "linear one under the same name",
+                )
+            if mu_r != 1.0:
+                raise _refuse(
+                    f"material {name!r} with mu_r={mu_r!r}",
+                    "openEMS exposes SetMaterialProperty(mue=...), but no script "
+                    "in this repository has ever exercised it, so the mapping is "
+                    "unverified. An unproven primitive translation is exactly "
+                    "the comparator-divergence failure class this project treats "
+                    "as dominant — prove it with a reproduce-gated script first",
+                )
+        plans[name] = _MaterialPlan(
+            name=name,
+            ident=_ident("metal" if is_metal else "mat", name, used),
+            is_metal=is_metal,
+            epsilon=eps_r,
+            kappa=sigma,
+        )
+    return plans
+
+
+# ---------------------------------------------------------------------------
+# Geometry (D6, D16)
+# ---------------------------------------------------------------------------
+
+def _plan_geometry(
+    document: dict, materials: dict[str, _MaterialPlan]
+) -> tuple[tuple[_GeometryPlan, ...], int, int]:
+    """Translate the paint list, synthesising openEMS ``priority`` (D6).
+
+    rfx geometry is an ordered last-write-wins paint list
+    (``rfx/geometry/csg.py``: "Applied in order; later shapes overwrite earlier
+    ones") — decision D4a.  openEMS resolves overlap by ``priority``, higher
+    wins, and there is no rfx field to copy.
+
+    The synthesis is not just "priority = paint index".  rfx's assembly loop
+    (``rfx/api/_compile.py``) treats the two material classes differently:
+    dielectrics are painted in order (``eps_r = where(mask, ...)``), while every
+    PEC material accumulates into a **union mask** that is applied on top
+    regardless of position in the paint list.  So in rfx a dielectric painted
+    after a PEC box does *not* overwrite the PEC.  The faithful projection is
+    therefore two bands — all metals above all dielectrics, paint order within
+    each band — which happens to reproduce the de-facto ladder the repo's coax
+    script arrived at by hand (dielectric low, metal high) but now with a
+    derivation instead of a precedent.
+
+    Ports sit between the bands: a dielectric must not bury a port (rfx folds
+    the port conductance in on top of the material), while PEC must win over a
+    port (rfx marks port cells inside PEC as *dead* and applies no port sigma
+    there — issue #318).  Returns the two port/metal band bases.
+    """
+    entries = _require_list(_get(document, "geometry", "document"), "geometry")
+    n = len(entries)
+    port_priority = 1 + n
+    metal_base = 2 + n
+
+    plans: list[_GeometryPlan] = []
+    for index, entry in enumerate(entries):
+        payload = _require_mapping(entry, f"geometry[{index}]")
+        material_name = str(_get(payload, "material_name", f"geometry[{index}]"))
+        shape = _require_mapping(
+            _get(payload, "shape", f"geometry[{index}]"), f"geometry[{index}].shape"
+        )
+        kind = str(_get(shape, "kind", f"geometry[{index}].shape"))
+        params = _require_mapping(
+            _get(shape, "params", f"geometry[{index}].shape"),
+            f"geometry[{index}].shape.params",
+        )
+        if kind not in _SUPPORTED_SHAPE_KINDS:
+            raise _refuse(
+                f"geometry[{index}] shape kind {kind!r}",
+                "openEMS has AddSphere / AddPolygon / AddLinPoly / "
+                "AddCylindricalShell / AddCurve, but not one of them is called "
+                "by any script in this repository, so no translation of this "
+                "primitive has ever been checked against a known-good result. "
+                f"Supported here: {', '.join(_SUPPORTED_SHAPE_KINDS)}",
+            )
+        if material_name not in materials:
+            raise _refuse(
+                f"geometry[{index}] material {material_name!r}",
+                "the material is neither in 'materials' nor in "
+                "'material_library'; the document is internally inconsistent",
+            )
+        material = materials[material_name]
+        priority = (metal_base + index) if material.is_metal else (1 + index)
+
+        if kind == "box":
+            # D16: thickness verbatim from the rfx Box. A zero-thickness rfx
+            # Box stays a zero-thickness openEMS sheet; the emitter does not
+            # promote it to a one-cell slab or vice versa.
+            start = _mm3(_get(params, "corner_lo", f"geometry[{index}].shape.params"))
+            stop = _mm3(_get(params, "corner_hi", f"geometry[{index}].shape.params"))
+            plans.append(
+                _GeometryPlan(
+                    index=index,
+                    kind="box",
+                    material_ident=material.ident,
+                    is_metal=material.is_metal,
+                    priority=priority,
+                    start_mm=start,
+                    stop_mm=stop,
+                )
+            )
+            continue
+
+        # Cylinder: rfx records the *centre* plus a height, openEMS wants the
+        # two axis endpoints and a separate radius.
+        centre = list(_get(params, "center", f"geometry[{index}].shape.params"))
+        radius = float(_get(params, "radius", f"geometry[{index}].shape.params"))
+        height = float(_get(params, "height", f"geometry[{index}].shape.params"))
+        axis = str(_get(params, "axis", f"geometry[{index}].shape.params"))
+        if axis not in _AXES:
+            raise _refuse(
+                f"geometry[{index}] cylinder axis {axis!r}",
+                "openEMS AddCylinder takes free axis endpoints, but an rfx "
+                "cylinder axis outside 'xyz' is not a state this emitter knows "
+                "how to read",
+            )
+        ax = _AXES.index(axis)
+        lo = list(centre)
+        hi = list(centre)
+        lo[ax] = centre[ax] - height / 2.0
+        hi[ax] = centre[ax] + height / 2.0
+        plans.append(
+            _GeometryPlan(
+                index=index,
+                kind="cylinder",
+                material_ident=material.ident,
+                is_metal=material.is_metal,
+                priority=priority,
+                start_mm=_mm3(lo),
+                stop_mm=_mm3(hi),
+                radius_mm=_mm(radius),
+            )
+        )
+    return tuple(plans), port_priority, metal_base
+
+
+# ---------------------------------------------------------------------------
+# Excitations
+# ---------------------------------------------------------------------------
+
+def _gauss_from_waveform(payload: Any, what: str) -> tuple[float, float, list[str]]:
+    """``GaussianPulse`` → ``SetGaussExcite(f0, fc)`` with ``fc = bandwidth*f0``."""
+    mapping = _require_mapping(payload, what)
+    kind = str(_get(mapping, "kind", what))
+    if kind != "gaussian_pulse":
+        raise _refuse(
+            f"{what} waveform kind {kind!r}",
+            "openEMS's SetGaussExcite is the only excitation shape any script "
+            "in this repository has driven a port with. SetSinusExcite exists "
+            "for a CW source but is unexercised here, and a modulated Gaussian "
+            "has no direct counterpart — approximating either by a Gaussian "
+            "would change the spectrum the S-parameters are read from",
+        )
+    params = _require_mapping(_get(mapping, "params", what), f"{what}.params")
+    f0 = float(_get(params, "f0", f"{what}.params"))
+    bandwidth = float(_get(params, "bandwidth", f"{what}.params"))
+    amplitude = float(_get(params, "amplitude", f"{what}.params"))
+    cutoff = float(_get(params, "cutoff", f"{what}.params"))
+    if not (f0 > 0.0 and bandwidth > 0.0):
+        raise _refuse(
+            f"{what} waveform",
+            f"SetGaussExcite needs f0 > 0 and a positive fractional bandwidth; "
+            f"got f0={f0!r}, bandwidth={bandwidth!r}",
+        )
+    notes: list[str] = []
+    if amplitude != 1.0:
+        notes.append(
+            f"{what}: GaussianPulse amplitude={amplitude!r} is dropped — "
+            "SetGaussExcite is amplitude-normalised. S-parameters are ratios so "
+            "this does not affect them, but any absolute field or power number "
+            "read out of this run is on openEMS's normalisation, not rfx's."
+        )
+    if cutoff != 3.0:
+        notes.append(
+            f"{what}: GaussianPulse cutoff={cutoff!r} (Gaussian truncation in "
+            "sigma) has no SetGaussExcite counterpart; openEMS truncates on its "
+            "own rule, so the two pulses differ in their far tails."
+        )
+    return f0, bandwidth * f0, notes
+
+
+def _plan_ports(
+    document: dict,
+    *,
+    dx_m: float,
+    port_priority: int,
+    msl_port_w_cells: int,
+) -> tuple[tuple[_PortPlan, ...], list[str], list[tuple[str, float]]]:
+    """Lumped / wire / MSL ports; everything else in ``excitations`` refuses.
+
+    Returns the port plans, the approximation notes they generated, and the
+    ``(axis, coordinate_m)`` pairs that must land on mesh lines (D5).
+    """
+    excitations = _require_mapping(
+        _get(document, "excitations", "document"), "excitations"
+    )
+
+    for key, construct, reason in (
+        (
+            "coaxial_ports",
+            "add_coaxial_port(...)",
+            "openEMS v0.0.35 has no AddCoaxialPort — verified absent on the "
+            "local install — and the documented radial-AddLumpedPort workaround "
+            "failed three separate runs (mesh misalignment, MUR-on-PTFE "
+            "instability, then uf_inc ~ 6e-14 with no usable coupling). There is "
+            "no translation to emit, only a known-bad one",
+        ),
+        (
+            "coaxial_matched_loads",
+            "add_coaxial_matched_load(...)",
+            "the axial offset is recorded in *cells*, not metres, so it has no "
+            "meaning on another solver's mesh — it would move physically if dx "
+            "changed. It is listed in the document's own non_portable annotation",
+        ),
+        (
+            "coaxial_open_terminations",
+            "add_coaxial_open_termination(...)",
+            "pin_retract_cells is a cell-relative offset (non_portable), so the "
+            "termination plane cannot be placed from this document",
+        ),
+        (
+            "coaxial_pec_end_caps",
+            "add_coaxial_pec_end_cap(...)",
+            "axial_offset_cells is a cell-relative offset (non_portable), so the "
+            "cap plane cannot be placed from this document",
+        ),
+        (
+            "floquet_ports",
+            "add_floquet_port(...)",
+            "a Floquet port needs periodic boundaries, and the openEMS v0.0.35 "
+            "Python bindings expose none — 'PBC' raises 'Unknown boundary "
+            "condition'",
+        ),
+        (
+            "waveguide_ports",
+            "add_waveguide_port(...)",
+            "AddRectWaveGuidePort exists in the local bindings but is called by "
+            "zero scripts in this repository, so its port-plane and mode-"
+            "normalisation conventions have never been checked against rfx's; "
+            "the rfx side additionally carries probe_offset / ref_offset as cell "
+            "counts (non_portable). This is the largest known gap — it needs a "
+            "reproduce-gated openEMS waveguide script before it can be emitted",
+        ),
+        (
+            "lumped_rlc",
+            "add_lumped_rlc(...)",
+            "openEMS AddLumpedElement is called by no script in this repository, "
+            "and rfx's R/L/C is an ADE sub-cell model whose series/parallel "
+            "topology mapping is unverified",
+        ),
+    ):
+        if _require_list(_get(excitations, key, "excitations"), f"excitations.{key}"):
+            raise _refuse(construct, reason)
+
+    if _get(excitations, "tfsf", "excitations") is not None:
+        raise _refuse(
+            "add_tfsf_source(...)",
+            "the only openEMS plane-wave precedent in this repository is a soft-E "
+            "one-cell slab in a script that is DEFERRED and not wired up, with no "
+            "absorber story; the design note calls a plane-wave projection 'an "
+            "approximation ... not a translation'",
+        )
+    if _require_list(
+        _get(excitations, "soft_sources", "excitations"), "excitations.soft_sources"
+    ):
+        raise _refuse(
+            "add_source(...) (soft, impedance-0 source)",
+            "a soft field source maps to AddExcitation, which no script in this "
+            "repository uses for a port-driven S-parameter run; it has no "
+            "reference impedance, so no S-parameter can be read from it. Use "
+            "add_port() for a projected setup",
+        )
+
+    lumped = _require_list(
+        _get(excitations, "lumped_ports", "excitations"), "excitations.lumped_ports"
+    )
+    msl = _require_list(
+        _get(excitations, "msl_ports", "excitations"), "excitations.msl_ports"
+    )
+    if not lumped and not msl:
+        raise _refuse(
+            "a design with no lumped, wire or MSL port",
+            "this emitter projects port-driven S-parameter runs; with no such "
+            "port there is nothing to excite and nothing to extract",
+        )
+    if lumped and msl:
+        raise _refuse(
+            "a mixed lumped/wire + MSL port set",
+            "rfx's own S-parameter driver refuses mixed port families (the "
+            "wave-decomposition conventions differ), and openEMS would compose "
+            "two different port models into one S-matrix",
+        )
+
+    notes: list[str] = []
+    required_lines: list[tuple[str, float]] = []
+    plans: list[_PortPlan] = []
+    snap_shifts: list[str] = []
+
+    def snap(value_m: float, label: str) -> float:
+        cells = int(round(value_m / dx_m))
+        snapped = cells * dx_m
+        # Grid.position_to_index uses round(pos/dx); reporting the shift makes
+        # the rasterisation visible rather than silent.
+        if abs(snapped - value_m) > _LINE_TOL_REL * dx_m:
+            snap_shifts.append(
+                f"{label}: {value_m!r} m → {snapped!r} m "
+                f"({(snapped - value_m) / dx_m:+.3f} cells)"
+            )
+        return snapped
+
+    for index, entry in enumerate(lumped):
+        payload = _require_mapping(entry, f"excitations.lumped_ports[{index}]")
+        what = f"excitations.lumped_ports[{index}]"
+        component = str(_get(payload, "component", what))
+        if component not in _COMPONENT_AXIS:
+            raise _refuse(
+                f"{what} component {component!r}",
+                "openEMS AddLumpedPort takes an excitation direction of x, y or "
+                "z; an rfx port component outside ex/ey/ez has no counterpart",
+            )
+        axis_index = _COMPONENT_AXIS[component]
+        position = list(_get(payload, "position", what))
+        extent = _get(payload, "extent", what)
+        impedance = float(_get(payload, "impedance", what))
+        excite = bool(_get(payload, "excite", what))
+        reference_plane_cells = _get(payload, "reference_plane_cells", what)
+        if reference_plane_cells is not None:
+            raise _refuse(
+                f"{what} reference_plane_cells={reference_plane_cells!r}",
+                "the de-embedding plane is recorded as a cell count "
+                "(non_portable), and openEMS's lumped port measures at its own "
+                "plane with no equivalent knob; emitting the port without the "
+                "plane would compare two different measurement planes",
+            )
+
+        start = [snap(float(v), f"{what}.position[{i}]") for i, v in enumerate(position)]
+        stop = list(start)
+        if extent is None:
+            # D7: rfx's single-cell lumped port; openEMS spans one cell and
+            # averages over it. The repo's own wire envelope measures the size
+            # of this convention gap at ~0.20 in |S|.
+            stop[axis_index] = start[axis_index] + dx_m
+            family = "lumped"
+        else:
+            end_m = float(position[axis_index]) + float(extent)
+            stop[axis_index] = snap(end_m, f"{what}.position+extent")
+            family = "wire"
+            if stop[axis_index] == start[axis_index]:
+                raise _refuse(
+                    f"{what} extent={extent!r}",
+                    "the wire port rasterises to zero cells at this dx, and "
+                    "openEMS asserts start != stop in the excitation direction",
+                )
+        f0 = fc = None
+        if excite:
+            waveform = _get(payload, "waveform", what)
+            if waveform is None:
+                raise _refuse(
+                    f"{what} with excite=True and no waveform",
+                    "rfx defaults an absent waveform inside run(), which is "
+                    "run-time state the design document deliberately does not "
+                    "carry; there is no pulse to project. Pass an explicit "
+                    "waveform= to the port",
+                )
+            f0, fc, wf_notes = _gauss_from_waveform(waveform, what)
+            notes.extend(wf_notes)
+
+        number = len(plans) + 1
+        for axis_name, coordinate in zip(_AXES, start):
+            required_lines.append((axis_name, coordinate))
+        for axis_name, coordinate in zip(_AXES, stop):
+            required_lines.append((axis_name, coordinate))
+        plans.append(
+            _PortPlan(
+                number=number,
+                family=family,
+                label=f"{family}_port_{number}",
+                impedance=impedance,
+                start_mm=_mm3(start),
+                stop_mm=_mm3(stop),
+                excite=excite,
+                priority=port_priority,
+                exc_dir=axis_index,
+                f0_hz=f0,
+                fc_hz=fc,
+            )
+        )
+
+    for index, entry in enumerate(msl):
+        payload = _require_mapping(entry, f"excitations.msl_ports[{index}]")
+        what = f"excitations.msl_ports[{index}]"
+        name = str(_get(payload, "name", what))
+        position = list(_get(payload, "position", what))
+        width = float(_get(payload, "width", what))
+        height = float(_get(payload, "height", what))
+        direction = str(_get(payload, "direction", what))
+        impedance = float(_get(payload, "impedance", what))
+        excite = bool(_get(payload, "excite", what))
+        mode = str(_get(payload, "mode", what))
+        if direction not in ("+x", "-x"):
+            raise _refuse(
+                f"{what} direction {direction!r}",
+                "rfx's MSL port is x-propagating only, and this emitter does not "
+                "guess a rotation of the MSLPort axes",
+            )
+        if not (width > 0.0 and height > 0.0):
+            raise _refuse(
+                f"{what} width={width!r}, height={height!r}",
+                "openEMS MSLPort asserts start != stop in every component, so a "
+                "degenerate cross-section cannot be built",
+            )
+        if mode != "laplace":
+            notes.append(
+                f"{what}: rfx mode={mode!r} selects rfx's own transverse-field "
+                "seed for the port; openEMS MSLPort launches its own line mode "
+                "and has no equivalent knob, so the launched profiles differ."
+            )
+        # D7: MSLPort occupies a SPAN along the propagation axis; port_w_cells
+        # (6, inherited from upstream MSL_NotchFilter.py) has no rfx
+        # counterpart at all. rfx's add_msl_port documents `direction` as the
+        # direction the launched wave propagates, so the span extends that way
+        # — note this is the *opposite* reading from add_port()'s `direction`,
+        # which names the outward normal. Nothing in this repository pins the
+        # MSL case against a measurement, which is why it is itemised.
+        sign = 1.0 if direction == "+x" else -1.0
+        span_m = msl_port_w_cells * dx_m
+        x_feed = snap(float(position[0]), f"{what}.position[0]")
+        y_centre = float(position[1])
+        z_lo = snap(float(position[2]), f"{what}.position[2]")
+        y_lo = snap(y_centre - width / 2.0, f"{what}.trace_y_lo")
+        y_hi = snap(y_centre + width / 2.0, f"{what}.trace_y_hi")
+        z_hi = snap(z_lo + height, f"{what}.trace_plane")
+        x_end = x_feed + sign * span_m
+        if y_hi == y_lo or z_hi == z_lo:
+            raise _refuse(
+                f"{what} cross-section",
+                "the trace width or substrate height rasterises to zero cells at "
+                "this dx, so MSLPort's start != stop assertion cannot hold",
+            )
+
+        f0 = fc = None
+        if excite:
+            waveform = _get(payload, "waveform", what)
+            if waveform is None:
+                raise _refuse(
+                    f"{what} with excite=True and no waveform",
+                    "rfx defaults the MSL pulse inside run() from freq_max, which "
+                    "is run-time state the design document does not carry. Pass "
+                    "an explicit waveform= to the port",
+                )
+            f0, fc, wf_notes = _gauss_from_waveform(waveform, what)
+            notes.extend(wf_notes)
+
+        number = len(plans) + 1
+        for coordinate in (x_feed, x_end):
+            required_lines.append(("x", coordinate))
+        for coordinate in (y_lo, y_hi):
+            required_lines.append(("y", coordinate))
+        for coordinate in (z_lo, z_hi):
+            required_lines.append(("z", coordinate))
+        plans.append(
+            _PortPlan(
+                number=number,
+                family="msl",
+                label=f"msl_port_{number}_{name}",
+                impedance=impedance,
+                # start at the trace plane, stop at ground: exc_dir=2 (Ez) then
+                # points from trace down to ground, matching the repo's MSL
+                # referee exactly.
+                start_mm=(_mm(x_feed), _mm(y_lo), _mm(z_hi)),
+                stop_mm=(_mm(x_end), _mm(y_hi), _mm(z_lo)),
+                excite=excite,
+                priority=port_priority,
+                exc_dir=2,
+                prop_dir=0,
+                f0_hz=f0,
+                fc_hz=fc,
+            )
+        )
+
+    if not any(p.excite for p in plans):
+        raise _refuse(
+            "a design whose every port has excite=False",
+            "every port is a passive matched load, so no run can be driven and "
+            "no S-parameter column exists",
+        )
+
+    if snap_shifts:
+        notes.append(
+            "port coordinates were snapped to the mesh the way "
+            "Grid.position_to_index snaps them (round(pos/dx)), so the emitted "
+            "port sits where rfx rasterises it, not at the metres the user "
+            "typed: " + "; ".join(snap_shifts)
+        )
+    return tuple(plans), notes, required_lines
+
+
+# ---------------------------------------------------------------------------
+# Run control (D12) and frequencies
+# ---------------------------------------------------------------------------
+
+def _courant_dt(dx_m: float) -> float:
+    """rfx's ``Grid.courant_dt`` for 3D — a pure function of ``dx``."""
+    return dx_m / (299792458.0 * math.sqrt(3.0)) * 0.99
+
+
+def _default_freqs(ports: Sequence[_PortPlan]) -> tuple[float, ...]:
+    driven = [p for p in ports if p.excite and p.f0_hz and p.fc_hz]
+    f0 = min(p.f0_hz for p in driven)  # type: ignore[misc]
+    fc = max(p.fc_hz for p in driven)  # type: ignore[misc]
+    lo = max(f0 - fc, 0.02 * f0)
+    hi = f0 + fc
+    n = 21
+    return tuple(lo + (hi - lo) * i / (n - 1) for i in range(n))
+
+
+# ---------------------------------------------------------------------------
+# Planner
+# ---------------------------------------------------------------------------
+
+def plan_openems_projection(
+    document: dict,
+    *,
+    freqs_hz: Sequence[float] | None = None,
+    n_timesteps: int | None = None,
+    num_periods: float | None = None,
+    end_criteria: float | None = None,
+    msl_port_w_cells: int = 6,
+) -> OpenEMSPlan:
+    """Reviewable projection plan for *document* — the emitter's real work.
+
+    Separated from text generation so the arithmetic that matters (above all
+    the D1 absorber span) is assertable directly.
+    """
+    document = _require_mapping(document, "document")
+    schema = str(_get(document, "schema", "document"))
+    if schema != "rfx-design-ir/v1":
+        raise _refuse(
+            f"design document schema {schema!r}",
+            "this emitter reads rfx-design-ir/v1 only; a different schema may "
+            "spell fields differently and silently mis-project them",
+        )
+    rfx_version = str(_get(document, "rfx_version", "document"))
+
+    if _get(document, "refinement", "document") is not None:
+        raise _refuse(
+            "add_refinement(...) (SBP-SAT subgrid)",
+            "the subgrid path is an rfx research prototype, falsified in 3D "
+            "(PR #90) and outside the public support scope. The design note is "
+            "explicit: round-trip it for rfx, never project it outward, because "
+            "its presence in a foreign setup would read as a validated capability",
+        )
+
+    solver = _require_mapping(_get(document, "solver", "document"), "solver")
+    if str(_get(solver, "solver", "solver")) != "yee":
+        raise _refuse(
+            f"solver={_get(solver, 'solver', 'solver')!r}",
+            "rfx's ADI solver has no openEMS counterpart (openEMS is explicit "
+            "Yee only); emitting the same structure under a different time "
+            "integrator would compare two different numerical schemes",
+        )
+    if int(_get(solver, "stencil_order", "solver")) != 2:
+        raise _refuse(
+            f"stencil_order={_get(solver, 'stencil_order', 'solver')!r}",
+            "the (2,4) spatial stencil is rfx-specific; openEMS is second order, "
+            "so the emitted run would have a different dispersion relation",
+        )
+    precision = str(_get(solver, "precision", "solver"))
+    if precision != "float32":
+        raise _refuse(
+            f"precision={precision!r}",
+            "openEMS's engine precision is fixed and not selectable from the "
+            "Python bindings, so an rfx design that asks for a different working "
+            "precision cannot be reproduced",
+        )
+
+    domain = _require_mapping(_get(document, "domain", "document"), "domain")
+    mode = str(_get(domain, "mode", "domain"))
+    if mode != "3d":
+        raise _refuse(
+            f"mode={mode!r}",
+            "rfx's 2-D mode is a single-cell-thick z slab with periodic z; "
+            "openEMS has no 2-D mode, and emitting a one-cell 3-D slab would be "
+            "a different problem",
+        )
+    extent = list(_get(domain, "extent", "domain"))
+
+    mesh = _require_mapping(_get(document, "mesh", "document"), "mesh")
+    dx = _get(mesh, "dx", "mesh")
+    if dx is None:
+        raise _refuse(
+            "a design with dx=None (auto-mesh)",
+            "the auto-mesh resolves inside run() and writes _dx back, so a "
+            "document exported before the run carries no mesh at all. Export "
+            "after a run, or pass dx= explicitly",
+        )
+    dx_m = float(dx)
+    if dx_m <= 0.0:
+        raise _refuse(f"dx={dx_m!r}", "the mesh step must be positive")
+    for profile in ("dx_profile", "dy_profile", "dz_profile"):
+        if _get(mesh, profile, "mesh") is not None:
+            raise _refuse(
+                f"non-uniform mesh profile {profile}",
+                "openEMS takes explicit mesh lines, so a graded profile is "
+                "expressible in principle — but rfx's absorber padding on a "
+                "non-uniform axis, and the transition cells smooth_grading "
+                "inserts, decide where the material stack actually rasterises "
+                "(the #325 class of defect). Emitting a cumulative-sum guess "
+                "would compare a differently-graded structure. v1 refuses; the "
+                "fix is a pinned NonUniformGrid coordinate comparison, not a "
+                "wider emitter",
+            )
+
+    boundary = _require_mapping(_get(document, "boundary", "document"), "boundary")
+    spec = _require_mapping(_get(boundary, "spec", "boundary"), "boundary.spec")
+    legacy = _require_mapping(_get(boundary, "legacy", "boundary"), "boundary.legacy")
+    cpml_layers = int(_get(legacy, "cpml_layers", "boundary.legacy"))
+    periodic_axes = str(_get(legacy, "periodic_axes", "boundary.legacy"))
+    pads, strings = _face_plan(spec, cpml_layers, periodic_axes)
+
+    if _require_list(
+        _get(document, "thin_conductors", "document"), "thin_conductors"
+    ):
+        raise _refuse(
+            "add_thin_conductor(...)",
+            "openEMS's conducting-sheet property is called by no script in this "
+            "repository, and rfx's sub-cell sheet model would otherwise have to "
+            "be flattened to either a zero-thickness sheet or a one-cell slab — "
+            "two different physical models (D16), neither of them the rfx one",
+        )
+
+    observables = _require_mapping(
+        _get(document, "observables", "document"), "observables"
+    )
+    for key, construct, reason in (
+        (
+            "probes",
+            "add_probe(...)",
+            "openEMS's AddProbe is called by no script in this repository, so "
+            "the field-component and weighting conventions of a translated point "
+            "probe are unchecked. Dropping the probe instead would silently "
+            "produce a script that does not measure what was asked for",
+        ),
+        (
+            "dft_planes",
+            "add_dft_plane_probe(...)",
+            "the openEMS counterpart is AddDump plus an HDF5 read-back whose "
+            "DumpType/FileType and post-processing are the emitter's choice, not "
+            "the design's; no committed comparison pins that choice",
+        ),
+        (
+            "flux_monitors",
+            "add_flux_monitor(...)",
+            "no script in this repository extracts a flux spectrum from openEMS, "
+            "so the surface-integration and normalisation conventions are "
+            "unverified",
+        ),
+    ):
+        if _require_list(_get(observables, key, "observables"), f"observables.{key}"):
+            raise _refuse(construct, reason)
+    if _get(observables, "ntff", "observables") is not None:
+        raise _refuse(
+            "add_ntff_box(...)",
+            "openEMS's CreateNF2FFBox is auto-sized and takes no corners, so the "
+            "rfx box corners would be discarded — an approximation, not a "
+            "translation. The far-field would then be computed on a different "
+            "surface than the design specifies",
+        )
+
+    materials = _plan_materials(document)
+    geometry, port_priority, _metal_base = _plan_geometry(document, materials)
+    ports, port_notes, required_lines = _plan_ports(
+        document,
+        dx_m=dx_m,
+        port_priority=port_priority,
+        msl_port_w_cells=msl_port_w_cells,
+    )
+
+    # --- mesh lines (D1, D2) ------------------------------------------------
+    n_cells = tuple(int(math.ceil(float(extent[i]) / dx_m)) for i in range(3))
+    pad_lo = tuple(pads[f"{ax}_lo"] for ax in _AXES)
+    pad_hi = tuple(pads[f"{ax}_hi"] for ax in _AXES)
+    lines: dict[str, tuple[float, ...]] = {
+        ax: _axis_lines_mm(n_cells[i], pad_lo[i], pad_hi[i], dx_m)
+        for i, ax in enumerate(_AXES)
+    }
+
+    inserted: list[str] = []
+    for axis_name, coordinate_m in required_lines:
+        lines[axis_name], did_insert = _pin(
+            lines[axis_name], _mm(coordinate_m), dx_m
+        )
+        if did_insert:
+            inserted.append(f"{axis_name}={_mm(coordinate_m)!r} mm")
+
+    notes: list[str] = []
+    notes.append(
+        "[D1] absorber span: the emitted mesh is the user domain PLUS the rfx "
+        "absorber pads, because rfx adds CPML cells outside the domain while "
+        "openEMS PML_<N> consumes cells inside the mesh it is given. Per axis "
+        "(pad_lo, n_cells, pad_hi) = "
+        + ", ".join(
+            f"{ax}:({pad_lo[i]}, {n_cells[i]}, {pad_hi[i]})"
+            for i, ax in enumerate(_AXES)
+        )
+        + f"; mesh-line counts {tuple(len(lines[ax]) for ax in _AXES)} match the "
+        "rfx Grid.shape. rfx CPML and openEMS PML are different absorber "
+        "formulations, so the same layer count does not mean the same absorber."
+    )
+    notes.append(
+        f"[D2] cell counts use rfx's ceil(domain/dx), not the round() the "
+        f"repository's hand-written openEMS scripts use, so the emitted clear "
+        f"extent is {tuple(n_cells[i] * dx_m for i in range(3))} m and may exceed "
+        f"the requested domain {tuple(float(v) for v in extent)} m."
+    )
+    notes.append(
+        "[D3/D4] absorbing faces are emitted as PML_<cpml_layers> taken from the "
+        "design (not the scripts' hard-coded PML_8), and MUR is never emitted: "
+        "MUR on a dielectric is unstable and cost one patch run an 8 % resonance "
+        "error."
+    )
+    notes.append(
+        "[D6] openEMS priority is synthesised from the rfx paint order, in two "
+        "bands: dielectrics 1..N in paint order, ports at "
+        f"{port_priority}, PEC metals above that. rfx applies PEC as a union "
+        "mask on top of the painted dielectrics regardless of paint position, "
+        "and marks port cells inside PEC as dead, so metal>port>dielectric is "
+        "the faithful ordering — not a flat priority=index."
+    )
+    notes.append(
+        "[D7/D8] port models and reference planes differ. rfx's lumped port is "
+        "single-cell and its wire port is a point-feed column, while openEMS "
+        "averages over the port span; the repository's own wire-port envelope "
+        "measures that convention gap at about 0.20 in |S|. Compare magnitudes "
+        "only: phase, group delay and Z0 need a de-embedding contract that no "
+        "script in this repository has."
+    )
+    notes.append(
+        "[D9] all geometry coordinates in this script are millimetres "
+        f"(SetDeltaUnit({UNIT_M!r}))."
+    )
+    notes.append(
+        "[D5] port edge coordinates are snapped with round(pos/dx), the same "
+        "rule Grid.position_to_index uses, so every port edge coincides with a "
+        "mesh line — an off-grid port is silently dropped by openEMS ('Unused "
+        "primitive', uf_inc=0, all-NaN S). Geometry faces are deliberately NOT "
+        "pinned: rfx rasterises them against the uniform grid, so inserting "
+        "lines at conductor edges would mesh a different problem than rfx solved."
+    )
+    if inserted:
+        notes.append(
+            "[D5] WARNING — mesh lines had to be INSERTED at "
+            + ", ".join(inserted)
+            + ". The mesh is therefore no longer the uniform mesh rfx used, and "
+            "this run is not comparable to the rfx design cell-for-cell."
+        )
+    notes.extend(port_notes)
+
+    # --- frequencies (not design state) ------------------------------------
+    if freqs_hz is None:
+        chosen = _default_freqs(ports)
+        notes.append(
+            "the S-parameter frequency list is NOT design state — in rfx it is "
+            "an argument to run()/compute_*_s_matrix, which the design document "
+            "deliberately excludes. The emitter chose "
+            f"{len(chosen)} points from {chosen[0]:.6e} to {chosen[-1]:.6e} Hz "
+            "spanning the excitation band. Pass freqs_hz= to pin it to the "
+            "frequencies an rfx result was actually taken at."
+        )
+    else:
+        chosen = tuple(float(f) for f in freqs_hz)
+        if not chosen:
+            raise _refuse("an empty freqs_hz list", "there is nothing to extract")
+        if any(f <= 0.0 or not math.isfinite(f) for f in chosen):
+            raise _refuse(
+                "a non-positive or non-finite frequency in freqs_hz",
+                "openEMS's port DFT needs finite positive frequencies",
+            )
+
+    # --- run control (D12) --------------------------------------------------
+    absorbing = any(s.startswith("PML_") for s in strings.values())
+    dt_rfx = _courant_dt(dx_m)
+    freq_max = float(_get(domain, "freq_max", "domain"))
+    if n_timesteps is not None and num_periods is not None:
+        raise _refuse(
+            "both n_timesteps= and num_periods=",
+            "they are two spellings of the same run length; pass one",
+        )
+    if n_timesteps is not None:
+        steps = int(n_timesteps)
+        source = f"n_timesteps={steps} passed to the emitter"
+    elif num_periods is not None:
+        steps = int(math.ceil(float(num_periods) / freq_max / dt_rfx))
+        source = (
+            f"num_periods={num_periods!r} at freq_max={freq_max:.6e} Hz, "
+            f"converted with rfx's Courant dt={dt_rfx:.6e} s"
+        )
+    elif absorbing:
+        steps = 500_000
+        source = (
+            "the emitter default for an open domain: a 500000-step ceiling that "
+            "EndCriteria is expected to cut short (the repository's MSL referee "
+            "uses exactly this pair)"
+        )
+    else:
+        periods = 60.0
+        steps = int(math.ceil(periods / freq_max / dt_rfx))
+        source = (
+            f"the emitter default for a closed (non-absorbing) domain: "
+            f"num_periods={periods} at freq_max={freq_max:.6e} Hz via rfx's "
+            f"Courant dt={dt_rfx:.6e} s, because a closed lossless domain never "
+            f"decays and EndCriteria would never fire"
+        )
+    if steps <= 0:
+        raise _refuse(f"a run length of {steps} timesteps", "must be positive")
+
+    if end_criteria is not None:
+        criteria = float(end_criteria)
+        criteria_source = f"end_criteria={criteria!r} passed to the emitter"
+    elif absorbing:
+        criteria = 1.0e-4
+        criteria_source = (
+            "the emitter default 1e-4 (-40 dB residual energy) for an open domain"
+        )
+    else:
+        criteria = 0.0
+        criteria_source = (
+            "0 (disabled) because the domain has no absorbing face: energy is "
+            "conserved, so any decay criterion is meaningless"
+        )
+    notes.append(
+        "[D12] run control is NOT design state (n_steps / until_decay are "
+        f"run() arguments). NrTS={steps} from {source}; EndCriteria={criteria!r} "
+        f"from {criteria_source}. A step count does not transfer between "
+        "solvers — openEMS computes its own Courant timestep from its own mesh, "
+        "so an identical NrTS is a different physical duration. EndCriteria can "
+        "also fire early on a high-Q resonator, cutting the signal before the "
+        "DFT resolves the peak."
+    )
+    notes.append(
+        "[D16] conductor thickness is taken verbatim from the rfx shape: a "
+        "zero-thickness rfx Box stays a zero-thickness openEMS sheet and a "
+        "one-cell Box stays a one-cell slab. The emitter does not convert "
+        "between the two, because they are different physical models."
+    )
+
+    if msl_port_w_cells < 5 and any(p.family == "msl" for p in ports):
+        raise _refuse(
+            f"msl_port_w_cells={msl_port_w_cells}",
+            "openEMS MSLPort asserts at least 5 mesh lines along the "
+            "propagation direction of its span",
+        )
+
+    return OpenEMSPlan(
+        rfx_version=rfx_version,
+        schema=schema,
+        dx_m=dx_m,
+        n_cells=n_cells,  # type: ignore[arg-type]
+        pad_lo=pad_lo,  # type: ignore[arg-type]
+        pad_hi=pad_hi,  # type: ignore[arg-type]
+        mesh_lines_mm=lines,
+        boundary=(
+            strings["x_lo"],
+            strings["x_hi"],
+            strings["y_lo"],
+            strings["y_hi"],
+            strings["z_lo"],
+            strings["z_hi"],
+        ),
+        materials=tuple(materials[name] for name in sorted(materials)),
+        geometry=geometry,
+        ports=ports,
+        driven_port_numbers=tuple(p.number for p in ports if p.excite),
+        freqs_hz=chosen,
+        n_timesteps=steps,
+        end_criteria=criteria,
+        msl_port_w_cells=msl_port_w_cells,
+        approximations=tuple(notes),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Renderer
+# ---------------------------------------------------------------------------
+
+def _floats(values: Sequence[float]) -> str:
+    return ", ".join(repr(float(v)) for v in values)
+
+
+def _wrap(text: str, prefix: str, width: int = 78) -> list[str]:
+    """Wrap *text* into comment/docstring lines, each starting with *prefix*."""
+    return textwrap.wrap(
+        " ".join(text.split()),
+        width=width,
+        initial_indent=prefix,
+        subsequent_indent=prefix,
+    ) or [prefix.rstrip()]
+
+
+def _header(plan: OpenEMSPlan) -> str:
+    lines = [
+        '"""GENERATED BY rfx — DO NOT EDIT BY HAND.',
+        "",
+        f"emitter          : {OPENEMS_EMITTER_VERSION}",
+        f"source rfx       : {plan.rfx_version}",
+        f"design IR schema : {plan.schema}",
+        "target           : openEMS v0.0.35 Python bindings + CSXCAD",
+        "profile          : external projection (design-note decision D3) —",
+        "                   explicitly lossy, NOT the rfx round-trip document",
+        "",
+        "WHAT THIS SCRIPT DOES NOT PROVE",
+    ]
+    lines.extend(
+        _wrap(
+            "Structural equivalence of this generated setup to the rfx design is "
+            "not evidence of physics agreement. If this script runs and returns "
+            "passive S-parameters, that shows the projection is executable and "
+            "self-consistent — nothing more. The absorber formulations differ, "
+            "the port models differ, and the reference planes differ. A "
+            "physics-agreement claim needs a matched-resolution comparison "
+            "against a committed reference, quoted together with the rfx "
+            "preflight output.",
+            "  ",
+        )
+    )
+    lines.extend(["", "APPROXIMATIONS APPLIED (itemised, per decision D3)"])
+    for index, note in enumerate(plan.approximations, start=1):
+        body = _wrap(note, "       ")
+        first = body[0].lstrip()
+        lines.append(f"  [{index:2d}] {first}")
+        lines.extend(body[1:])
+    lines.append('"""')
+    return "\n".join(lines)
+
+
+def _render_build(plan: OpenEMSPlan) -> list[str]:
+    out: list[str] = []
+    out.append("def _build(driven_number):")
+    out.append('    """Assemble the structure with exactly one port driven."""')
+    out.append("    f0, fc = _EXCITATION[driven_number]")
+    out.append("    fdtd = openEMS(NrTS=NRTS, EndCriteria=END_CRITERIA)")
+    out.append("    fdtd.SetGaussExcite(f0, fc)")
+    out.append("    fdtd.SetBoundaryCond(list(BOUNDARY))")
+    out.append("    csx = ContinuousStructure()")
+    out.append("    fdtd.SetCSX(csx)")
+    out.append("")
+    out.append("    # Mesh first: openEMS MSLPort reads the grid lines in its")
+    out.append("    # constructor, so properties and ports must come after this.")
+    out.append("    mesh = csx.GetGrid()")
+    out.append(f"    mesh.SetDeltaUnit({UNIT_M!r})")
+    for axis in _AXES:
+        out.append(f"    mesh.SetLines({axis!r}, {axis.upper()}_LINES_MM)")
+    out.append("")
+    if plan.materials:
+        out.append("    # Materials. rfx treats sigma >= 1e6 S/m as a PEC mask")
+        out.append("    # rather than a lossy dielectric, so those become AddMetal.")
+        for material in plan.materials:
+            if material.is_metal:
+                out.append(
+                    f"    {material.ident} = csx.AddMetal({material.ident!r})"
+                    f"  # rfx {material.name!r}, sigma={material.kappa!r} S/m"
+                )
+            else:
+                out.append(
+                    f"    {material.ident} = csx.AddMaterial({material.ident!r}, "
+                    f"epsilon={material.epsilon!r}, kappa={material.kappa!r})"
+                    f"  # rfx {material.name!r}"
+                )
+        out.append("")
+    if plan.geometry:
+        out.append("    # Geometry in rfx paint order; priority synthesised per [D6].")
+        for geo in plan.geometry:
+            if geo.kind == "box":
+                out.append(
+                    f"    {geo.material_ident}.AddBox([{_floats(geo.start_mm)}], "
+                    f"[{_floats(geo.stop_mm)}], priority={geo.priority})"
+                    f"  # geometry[{geo.index}]"
+                )
+            else:
+                out.append(
+                    f"    {geo.material_ident}.AddCylinder([{_floats(geo.start_mm)}], "
+                    f"[{_floats(geo.stop_mm)}], radius={geo.radius_mm!r}, "
+                    f"priority={geo.priority})  # geometry[{geo.index}]"
+                )
+        out.append("")
+    out.append("    ports = []")
+    for port in plan.ports:
+        out.append(f"    # {port.label}: rfx {port.family} port")
+        excite_expr = f"(1.0 if driven_number == {port.number} else 0.0)"
+        if port.family == "msl":
+            out.append(
+                f"    _metal_{port.number} = csx.AddMetal('msl_feed_{port.number}')"
+            )
+            out.append("    ports.append(MSLPort(")
+            out.append(f"        csx, port_nr={port.number},")
+            out.append(f"        metal_prop=_metal_{port.number},")
+            out.append(f"        start=[{_floats(port.start_mm)}],")
+            out.append(f"        stop=[{_floats(port.stop_mm)}],")
+            out.append(f"        prop_dir={port.prop_dir}, exc_dir={port.exc_dir},")
+            out.append(f"        excite={excite_expr},")
+            out.append(f"        Feed_R={port.impedance!r},")
+            out.append(f"        priority={port.priority},")
+            out.append("    ))")
+        else:
+            out.append("    ports.append(fdtd.AddLumpedPort(")
+            out.append(f"        {port.number}, {port.impedance!r},")
+            out.append(f"        [{_floats(port.start_mm)}],")
+            out.append(f"        [{_floats(port.stop_mm)}],")
+            out.append(f"        {_AXES[port.exc_dir]!r},")
+            out.append(f"        excite={excite_expr},")
+            out.append(f"        priority={port.priority},")
+            out.append("    ))")
+    out.append("    return fdtd, csx, ports")
+    return out
+
+
+_RUNNER = '''
+def _run_one(driven_number, sim_root, threads):
+    sim_dir = os.path.abspath(os.path.join(sim_root, "drive_%d" % driven_number))
+    if os.path.isdir(sim_dir):
+        shutil.rmtree(sim_dir)
+    os.makedirs(sim_dir, exist_ok=True)
+
+    fdtd, csx, ports = _build(driven_number)
+    csx.Write2XML(os.path.join(sim_dir, "geometry.xml"))
+
+    # [D14] Run() asserts on a relative path (bare AssertionError from
+    # openEMS.pyx) and leaves the process CWD inside the sim directory.
+    original_cwd = os.getcwd()
+    try:
+        if threads:
+            fdtd.Run(sim_dir, verbose=0, cleanup=True, numThreads=threads)
+        else:
+            fdtd.Run(sim_dir, verbose=0, cleanup=True)
+    finally:
+        try:
+            os.chdir(original_cwd)
+        except OSError:
+            os.chdir("/tmp")
+
+    # [D13] Never pass ref_impedance as a scalar float: that trips an upstream
+    # bug in Port.CalcPort when Z_ref is array-valued.
+    for port in ports:
+        port.CalcPort(sim_dir, FREQS_HZ)
+
+    driven = [p for p in ports if p.number == driven_number][0]
+    incident = np.asarray(driven.uf_inc, dtype=complex)
+
+    # [D5] Excitation guard, the hand-ported stand-in for rfx preflight (an
+    # external script gets none). An off-grid port makes openEMS log "Unused
+    # primitive", leaves uf_inc at exactly zero and turns every S value into
+    # NaN. No absolute floor is used on purpose: a verified-good small run on
+    # this install peaked at |uf_inc| ~ 3e-14, so the 1e-9 floor some
+    # hand-written comparators use would false-fire here.
+    peak = float(np.max(np.abs(incident))) if incident.size else 0.0
+    if not np.isfinite(peak) or peak == 0.0:
+        raise RuntimeError(
+            "port %d injected no incident wave (peak |uf_inc| = %r). openEMS "
+            "silently drops an excitation whose edges miss the mesh lines; "
+            "check %s for 'Unused primitive'." % (driven_number, peak, sim_dir)
+        )
+    trace = os.path.join(sim_dir, "port_ut_%d" % driven_number)
+    trace_peak = None
+    if os.path.exists(trace):
+        raw = np.loadtxt(trace, comments="%")
+        if raw.size:
+            trace_peak = float(np.max(np.abs(np.atleast_2d(raw)[:, 1])))
+            if trace_peak == 0.0:
+                raise RuntimeError(
+                    "port %d time trace is identically zero: the excitation "
+                    "never entered the grid." % driven_number
+                )
+
+    column = {}
+    for port in ports:
+        received = np.asarray(port.uf_ref, dtype=complex)
+        column[port.number] = received / incident
+    z_ref = np.asarray(driven.Z_ref, dtype=complex)
+    return column, peak, trace_peak, z_ref
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--sim-dir", default="openems_run",
+                        help="scratch directory for the solver runs")
+    parser.add_argument("--output", default="openems_sparams.json",
+                        help="where to write the S-parameter JSON")
+    parser.add_argument("--threads", type=int, default=0,
+                        help="numThreads for FDTD.Run (0 = openEMS default)")
+    args = parser.parse_args(argv)
+
+    sim_root = os.path.abspath(args.sim_dir)
+    columns = {}
+    diagnostics = {}
+    for driven in DRIVEN_PORTS:
+        column, peak, trace_peak, z_ref = _run_one(driven, sim_root, args.threads)
+        columns[driven] = column
+        diagnostics[str(driven)] = {
+            "incident_peak_abs": peak,
+            "port_ut_peak_abs": trace_peak,
+            "z_ref_real_ohm": [float(v.real) for v in z_ref],
+            "z_ref_imag_ohm": [float(v.imag) for v in z_ref],
+        }
+
+    s_matrix = {}
+    max_abs = 0.0
+    for driven, column in columns.items():
+        for received, values in column.items():
+            key = "S%d%d" % (received, driven)
+            s_matrix[key] = [[float(v.real), float(v.imag)] for v in values]
+            finite = np.abs(values)[np.isfinite(np.abs(values))]
+            if finite.size:
+                max_abs = max(max_abs, float(np.max(finite)))
+
+    payload = {
+        "schema": "rfx-openems-emitted-sparams/v1",
+        "emitter": EMITTER,
+        "source_rfx_version": SOURCE_RFX_VERSION,
+        "design_ir_schema": DESIGN_IR_SCHEMA,
+        "approximations": APPROXIMATIONS,
+        "grid": {
+            "delta_unit_m": UNIT,
+            "line_counts": [len(X_LINES_MM), len(Y_LINES_MM), len(Z_LINES_MM)],
+            "boundary": list(BOUNDARY),
+            "nrts": NRTS,
+            "end_criteria": END_CRITERIA,
+        },
+        "freqs_hz": [float(f) for f in FREQS_HZ],
+        "driven_ports": list(DRIVEN_PORTS),
+        "s_matrix": s_matrix,
+        "port_diagnostics": diagnostics,
+        "passivity": {
+            "max_abs_s": max_abs,
+            "documented_envelope": 1.05,
+            "within_envelope": bool(max_abs <= 1.05),
+        },
+    }
+
+    # Passivity witness, not a gate: |S| above the documented 1.05 single-run
+    # envelope on a passive structure is unphysical and must be reported with
+    # the run, never quoted as physics. Above 2.0 it is a broken setup.
+    if max_abs > 2.0:
+        raise RuntimeError(
+            "max |S| = %r on a passive structure: the setup is broken "
+            "(check the excitation guard and the port geometry), not physics."
+            % max_abs
+        )
+    if max_abs > 1.05:
+        sys.stderr.write(
+            "WARNING: max |S| = %r exceeds the documented 1.05 passivity "
+            "envelope. Suspect the extraction/normalisation path first, then "
+            "confirm with an energy witness before attributing anything to "
+            "physics.\\n" % max_abs
+        )
+
+    output = os.path.abspath(args.output)
+    with open(output, "w") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True, allow_nan=False)
+    sys.stdout.write("wrote %s (max |S| = %r)\\n" % (output, max_abs))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+def emit_openems_script(
+    document: dict,
+    *,
+    freqs_hz: Sequence[float] | None = None,
+    n_timesteps: int | None = None,
+    num_periods: float | None = None,
+    end_criteria: float | None = None,
+    msl_port_w_cells: int = 6,
+) -> str:
+    """Project a ``rfx-design-ir/v1`` document onto a runnable openEMS script.
+
+    Parameters
+    ----------
+    document
+        A document from :func:`rfx.interop.design_to_dict`.
+    freqs_hz
+        Frequencies for the port DFT.  **Not design state** — in rfx this is an
+        argument to ``run()`` / ``compute_*_s_matrix``, which the design
+        document deliberately excludes.  When omitted the emitter spans the
+        excitation band and says so in the generated header.
+    n_timesteps, num_periods, end_criteria
+        Run control, also not design state (D12).  Pass at most one of
+        ``n_timesteps`` / ``num_periods``.  Both defaults are itemised in the
+        generated header, along with the fact that a step count does not
+        transfer between solvers whose timesteps differ.
+    msl_port_w_cells
+        Span of an ``MSLPort`` along the propagation axis, in cells.  This has
+        **no rfx counterpart** (D7); 6 is the value inherited from upstream's
+        ``MSL_NotchFilter.py`` and used by this repository's MSL referee.
+
+    Returns
+    -------
+    str
+        A self-contained Python script.  Generating it needs no solver and no
+        licence; running it needs openEMS.
+
+    Raises
+    ------
+    UnsupportedDesignFeature
+        For every construct outside the fence documented in this module.  The
+        message names the construct and why it is refused.
+    """
+    plan = plan_openems_projection(
+        document,
+        freqs_hz=freqs_hz,
+        n_timesteps=n_timesteps,
+        num_periods=num_periods,
+        end_criteria=end_criteria,
+        msl_port_w_cells=msl_port_w_cells,
+    )
+
+    body: list[str] = ["#!/usr/bin/env python3", _header(plan), ""]
+    body.append("import argparse")
+    body.append("import json")
+    body.append("import os")
+    body.append("import shutil")
+    body.append("import sys")
+    body.append("")
+    body.append("import numpy as np")
+    body.append("")
+    body.append("# [D15] numpy 2.x removed np.float / np.int / np.complex / np.mat,")
+    body.append("# and openEMS.ports.MSLPort still uses np.int. The shim MUST run")
+    body.append("# before the openEMS import.")
+    body.append("for _name, _value in (('float', float), ('int', int),")
+    body.append("                      ('complex', complex), ('bool', bool),")
+    body.append("                      ('object', object), ('str', str)):")
+    body.append("    if not hasattr(np, _name):")
+    body.append("        setattr(np, _name, _value)")
+    body.append("if not hasattr(np, 'mat'):")
+    body.append("    np.mat = np.asmatrix")
+    body.append("")
+    body.append("from CSXCAD.CSXCAD import ContinuousStructure  # noqa: E402")
+    body.append("from openEMS.openEMS import openEMS  # noqa: E402")
+    if any(p.family == "msl" for p in plan.ports):
+        body.append("from openEMS.ports import MSLPort  # noqa: E402")
+    body.append("")
+    body.append(f"EMITTER = {OPENEMS_EMITTER_VERSION!r}")
+    body.append(f"SOURCE_RFX_VERSION = {plan.rfx_version!r}")
+    body.append(f"DESIGN_IR_SCHEMA = {plan.schema!r}")
+    body.append(f"UNIT = {UNIT_M!r}")
+    body.append(f"BOUNDARY = {list(plan.boundary)!r}")
+    body.append(f"NRTS = {plan.n_timesteps!r}")
+    body.append(f"END_CRITERIA = {plan.end_criteria!r}")
+    body.append(f"DRIVEN_PORTS = {list(plan.driven_port_numbers)!r}")
+    body.append("")
+    for axis in _AXES:
+        body.append(
+            f"{axis.upper()}_LINES_MM = np.array([{_floats(plan.mesh_lines_mm[axis])}])"
+        )
+    body.append("")
+    body.append(f"FREQS_HZ = np.array([{_floats(plan.freqs_hz)}])")
+    body.append("")
+    body.append("# Per-driven-port Gaussian excitation: SetGaussExcite(f0, fc) with")
+    body.append("# fc = bandwidth * f0, the mapping every openEMS script here uses.")
+    body.append("_EXCITATION = {")
+    for port in plan.ports:
+        if port.excite:
+            body.append(f"    {port.number}: ({port.f0_hz!r}, {port.fc_hz!r}),")
+    body.append("}")
+    body.append("")
+    body.append("APPROXIMATIONS = [")
+    for note in plan.approximations:
+        body.append(f"    {note!r},")
+    body.append("]")
+    body.append("")
+    body.append("")
+    body.extend(_render_build(plan))
+    body.append("")
+    body.append(_RUNNER.strip("\n"))
+    body.append("")
+    return "\n".join(body)

--- a/rfx/interop/emitters/openems.py
+++ b/rfx/interop/emitters/openems.py
@@ -310,8 +310,8 @@ def _ident(prefix: str, name: str, used: set[str]) -> str:
 
 def _face_plan(
     boundary_spec: dict, cpml_layers: int, periodic_axes: str
-) -> tuple[dict[str, int], dict[str, str]]:
-    """Per-face absorber pad (cells) and openEMS boundary string.
+) -> tuple[dict[str, int], dict[str, str], list[str]]:
+    """Per-face absorber pad (cells), openEMS boundary string, and UPML faces.
 
     Mirrors ``Grid.__init__``'s ``_face_pad``: a ``pec`` / ``pmc`` / ``periodic``
     face gets ``pad = 0`` even when the axis participates in CPML, and an
@@ -323,6 +323,7 @@ def _face_plan(
     """
     pads: dict[str, int] = {}
     strings: dict[str, str] = {}
+    upml_faces: list[str] = []
     for axis in _AXES:
         axis_payload = _require_mapping(
             _get(boundary_spec, axis, "boundary.spec"), f"boundary.spec.{axis}"
@@ -383,9 +384,13 @@ def _face_plan(
                 # D3: parameterised from the design, not the scripts' PML_8.
                 # D4: MUR is never emitted.
                 strings[face] = f"PML_{layers}"
+                if token == "upml":
+                    # openEMS has one absorber. Collapsing rfx's two onto it is
+                    # a translation the reader must be told about, not a detail.
+                    upml_faces.append(face)
             else:
                 raise _refuse(f"boundary token {token!r} on face {face}", "unknown token")
-    return pads, strings
+    return pads, strings, upml_faces
 
 
 def _axis_lines_mm(
@@ -1188,7 +1193,7 @@ def plan_openems_projection(
     legacy = _require_mapping(_get(boundary, "legacy", "boundary"), "boundary.legacy")
     cpml_layers = int(_get(legacy, "cpml_layers", "boundary.legacy"))
     periodic_axes = str(_get(legacy, "periodic_axes", "boundary.legacy"))
-    pads, strings = _face_plan(spec, cpml_layers, periodic_axes)
+    pads, strings, upml_faces = _face_plan(spec, cpml_layers, periodic_axes)
 
     if _require_list(
         _get(document, "thin_conductors", "document"), "thin_conductors"
@@ -1285,6 +1290,22 @@ def plan_openems_projection(
         f"extent is {tuple(n_cells[i] * dx_m for i in range(3))} m and may exceed "
         f"the requested domain {tuple(float(v) for v in extent)} m."
     )
+    if upml_faces:
+        notes.append(
+            "[D3] rfx UPML faces (" + ", ".join(upml_faces) + ") are emitted as "
+            "PML_<N>, the same string a cpml face gets: openEMS has exactly one "
+            "absorber, so rfx's two distinct formulations collapse onto it. The "
+            "layer count survives; the absorber does not. Do not read a UPML-vs-"
+            "PML comparison as testing rfx's UPML implementation."
+        )
+    if len({s for s in strings.values() if s.startswith("PML_")}) > 1:
+        notes.append(
+            "[D3] per-face PML depths differ across faces "
+            f"({', '.join(f'{f}={strings[f]}' for f in sorted(strings) if strings[f].startswith('PML_'))}). "
+            "The PML_<N> string format is verified on this install, but only "
+            "uniform depths have been measured here; per-face independence is "
+            "assumed from the API shape (six independent strings), not observed."
+        )
     notes.append(
         "[D3/D4] absorbing faces are emitted as PML_<cpml_layers> taken from the "
         "design (not the scripts' hard-coded PML_8), and MUR is never emitted: "

--- a/rfx/interop/emitters/openems.py
+++ b/rfx/interop/emitters/openems.py
@@ -955,6 +955,23 @@ def _plan_ports(
             )
         )
 
+    if any(p.family == "msl" for p in plans):
+        notes.append(
+            f"[D7] MSL ports: msl_port_w_cells={msl_port_w_cells} sets the "
+            "MSLPort span along the propagation axis. That span has NO rfx "
+            "counterpart — rfx extracts through an N-probe spatial fit "
+            "downstream of a feed plane, while MSLPort launches and de-embeds "
+            "inside its own span — so the two measure at different planes and "
+            "no committed comparison in this repository pins the choice. The "
+            "span direction follows add_msl_port's documented meaning of "
+            "direction= (the direction the launched wave propagates), which is "
+            "the OPPOSITE reading from add_port's direction= (the outward "
+            "normal); if that reading is wrong the two ports swap ends. "
+            "openEMS may additionally log 'Unused primitive ... msl_feed_N' "
+            "when the design's own trace already covers the port span — benign, "
+            "and distinct from the port-dropped failure mode."
+        )
+
     if not any(p.excite for p in plans):
         raise _refuse(
             "a design whose every port has excite=False",
@@ -1466,6 +1483,24 @@ def _render_build(plan: OpenEMSPlan) -> list[str]:
         excite_expr = f"(1.0 if driven_number == {port.number} else 0.0)"
         if port.family == "msl":
             out.append(
+                "    # MSLPort builds its own launch-conductor sheet from this"
+            )
+            out.append(
+                "    # property. When the design's own trace already covers the"
+            )
+            out.append(
+                "    # port span with metal, that sheet is fully overridden and"
+            )
+            out.append(
+                "    # openEMS logs 'Unused primitive ... msl_feed_N'. That is"
+            )
+            out.append(
+                "    # benign (both are PEC) and is NOT the port-dropped failure"
+            )
+            out.append(
+                "    # mode -- the uf_inc guard below is what discriminates."
+            )
+            out.append(
                 f"    _metal_{port.number} = csx.AddMetal('msl_feed_{port.number}')"
             )
             out.append("    ports.append(MSLPort(")
@@ -1536,23 +1571,33 @@ def _run_one(driven_number, sim_root, threads):
             "silently drops an excitation whose edges miss the mesh lines; "
             "check %s for 'Unused primitive'." % (driven_number, peak, sim_dir)
         )
-    trace = os.path.join(sim_dir, "port_ut_%d" % driven_number)
+    # Independent witness on the time domain. The voltage-probe filenames come
+    # from the port object itself because they differ per family: a lumped port
+    # writes "port_ut_<n>", an MSLPort writes "port_ut_<n>A/B/C".
     trace_peak = None
-    if os.path.exists(trace):
+    for name in list(getattr(driven, "U_filenames", []) or []):
+        trace = os.path.join(sim_dir, name)
+        if not os.path.exists(trace):
+            continue
         raw = np.loadtxt(trace, comments="%")
-        if raw.size:
-            trace_peak = float(np.max(np.abs(np.atleast_2d(raw)[:, 1])))
-            if trace_peak == 0.0:
-                raise RuntimeError(
-                    "port %d time trace is identically zero: the excitation "
-                    "never entered the grid." % driven_number
-                )
+        if not raw.size:
+            continue
+        peak_here = float(np.max(np.abs(np.atleast_2d(raw)[:, 1])))
+        trace_peak = peak_here if trace_peak is None else max(trace_peak, peak_here)
+    if trace_peak == 0.0:
+        raise RuntimeError(
+            "port %d time trace is identically zero: the excitation never "
+            "entered the grid." % driven_number
+        )
 
     column = {}
     for port in ports:
         received = np.asarray(port.uf_ref, dtype=complex)
         column[port.number] = received / incident
-    z_ref = np.asarray(driven.Z_ref, dtype=complex)
+    # A lumped port's Z_ref is the scalar feed resistance; MSLPort's is an
+    # array over frequency. Normalise so the artifact shape does not depend on
+    # the port family.
+    z_ref = np.atleast_1d(np.asarray(driven.Z_ref, dtype=complex))
     return column, peak, trace_peak, z_ref
 
 

--- a/rfx/io.py
+++ b/rfx/io.py
@@ -867,10 +867,19 @@ def export_radiation_pattern(path, ff_result, freq_idx=0):
 # =========================================================================
 
 def export_geometry_json(path, sim):
-    """Export simulation geometry as JSON for cross-validation or dataset indexing.
+    """Export a lightweight geometry *index* as JSON (bounding boxes only).
 
-    Captures materials, geometry entries, sources, probes, and grid config
-    in a tool-agnostic format.
+    Intended for dataset indexing and eyeball review. Each geometry entry is
+    recorded as its shape class name plus a bounding box, so a ``Cylinder`` and
+    a ``Box`` with the same bounds are indistinguishable here, and materials are
+    reduced to scalar ``eps_r``/``sigma``/``mu_r`` (dispersion poles are
+    dropped). Sources are recorded as position + component only.
+
+    This output therefore **cannot round-trip** and is not a design description:
+    do not drive an external solver from it. For a round-trip-complete design
+    document use :func:`rfx.interop.design_to_dict` /
+    :func:`rfx.interop.design_to_json`, which record constructor parameters and
+    refuse rather than degrade what they cannot represent.
 
     Parameters
     ----------

--- a/tests/test_interop_design_document.py
+++ b/tests/test_interop_design_document.py
@@ -1,0 +1,1172 @@
+"""Contract tests for the ``rfx-design-ir/v1`` design document.
+
+These tests are pure: they build ``Simulation`` objects with the real public
+API, serialise them, rebuild them, and compare builder state.  No FDTD runs.
+
+The load-bearing test is :func:`test_round_trip_is_structurally_identical`,
+which compares the rebuilt simulation to the original **attribute by
+attribute** rather than comparing JSON text — a document can round-trip
+through itself while describing a different simulation, which is exactly the
+failure mode this feature exists to prevent.  ``_canonical`` records array
+dtype and namespace, set membership, and every dataclass / NamedTuple field it
+can reach, with one deliberate lenience: a coordinate ``list`` and the
+equivalent ``tuple`` compare equal, because the builders accept either and the
+choice is not part of the design.
+
+:func:`test_every_simulation_attribute_is_classified` is the anti-drift gate: a
+new ``Simulation`` builder field reds it until someone decides whether the
+field is design state or not.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import math
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import rfx
+from rfx import Simulation
+from rfx.api._spec import MATERIAL_LIBRARY, _GeometryEntry, _PortEntry
+from rfx.boundaries.spec import Boundary, BoundarySpec
+from rfx.geometry.csg import Box, Cylinder, PolylineWire, Sphere
+from rfx.interop import (
+    DESIGN_SCHEMA_VERSION,
+    SUPPORTED_WAVEFORM_KINDS,
+    UnsupportedDesignFeature,
+    design_to_dict,
+    design_to_json,
+    simulation_from_design,
+)
+from rfx.interop._design import (
+    EXCLUDED_SIMULATION_ATTRS,
+    EXPORTED_SIMULATION_ATTRS,
+    _PINNED_RECORDS,
+    _WAVEFORM_CODECS,
+    _predict_legacy_spec,
+    live_field_names,
+)
+from rfx.materials.debye import DebyePole
+from rfx.materials.lorentz import LorentzPole
+from rfx.sources.sources import (
+    CustomWaveform,
+    CWSource,
+    GaussianPulse,
+    ModulatedGaussian,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — progressively richer designs, all built through the public API
+# ---------------------------------------------------------------------------
+
+def _graded_microstrip() -> Simulation:
+    """Graded z-mesh microstrip with a cylindrical via and a probe."""
+    dz = rfx.smooth_grading(
+        np.concatenate(
+            [np.full(8, 5e-4), np.full(6, 1.5e-4), np.full(16, 5e-4)]
+        )
+    )
+    sim = Simulation(
+        freq_max=20e9,
+        domain=(0.020, 0.012, 0.0),
+        dx=5e-4,
+        boundary="cpml",
+        cpml_layers=8,
+        dz_profile=dz,
+    )
+    sim.add_material("fr4", eps_r=4.3, sigma=0.01)
+    sim.add(Box(corner_lo=(0.0, 0.0, 0.0), corner_hi=(0.020, 0.012, 0.0015)), material="fr4")
+    sim.add(
+        Cylinder(center=(0.010, 0.006, 0.0008), radius=3e-4, height=0.0015, axis="z"),
+        material="pec",
+    )
+    sim.add_source((0.004, 0.006, 0.002), "ez")
+    sim.add_probe((0.014, 0.006, 0.002), "ez")
+    return sim
+
+
+def _waveguide_with_dispersive_slab() -> Simulation:
+    """Two-port WR-90-like guide loaded with Debye and Lorentz materials."""
+    sim = Simulation(
+        freq_max=12e9,
+        domain=(0.10, 0.02286, 0.01016),
+        dx=1e-3,
+        boundary="cpml",
+        cpml_layers=4,
+        cpml_kappa_max=2.0,
+    )
+    sim.add_material(
+        "water_like",
+        eps_r=4.9,
+        debye_poles=[DebyePole(delta_eps=75.0, tau=9.4e-12)],
+    )
+    sim.add_material(
+        "kerr_lorentz",
+        eps_r=2.0,
+        lorentz_poles=[LorentzPole(omega_0=1e11, delta=2.0, kappa=1e9)],
+        chi3=1e-20,
+    )
+    sim.add(
+        Box(corner_lo=(0.040, 0.0, 0.0), corner_hi=(0.050, 0.02286, 0.01016)),
+        material="water_like",
+    )
+    sim.add(
+        Box(corner_lo=(0.050, 0.0, 0.0), corner_hi=(0.055, 0.02286, 0.01016)),
+        material="kerr_lorentz",
+    )
+    sim.add_waveguide_port(
+        x_position=0.010,
+        y_range=(0.0, 0.02286),
+        z_range=(0.0, 0.01016),
+        direction="+x",
+        f0=10e9,
+        name="p1",
+        probe_offset=12,
+        ref_offset=4,
+        freqs=jnp.linspace(8e9, 12e9, 11),
+        waveform="modulated_gaussian",
+    )
+    sim.add_waveguide_port(
+        x_position=0.090,
+        y_range=(0.0, 0.02286),
+        z_range=(0.0, 0.01016),
+        direction="-x",
+        f0=10e9,
+        name="p2",
+        calibration_preset="source_to_probe",
+        mode=(2, 0),
+        n_modes=2,
+    )
+    sim.add_flux_monitor(
+        axis="x",
+        coordinate=0.060,
+        n_freqs=7,
+        size=(0.020, 0.010),
+        center=(0.011, 0.005),
+        dft_window="tukey",
+        dft_window_alpha=0.3,
+    )
+    sim.add_dft_plane_probe(axis="z", coordinate=0.005, component="ey", freqs=[9e9, 10e9])
+    sim.add_ntff_box((0.005, 0.001, 0.001), (0.095, 0.021, 0.009), n_freqs=5)
+    return sim
+
+
+def _coax_cavity_with_terminations() -> Simulation:
+    """PEC cavity, coaxial port with all three cell-relative terminations."""
+    sim = Simulation(freq_max=6e9, domain=(0.040, 0.040, 0.020), dx=5e-4, boundary="pec")
+    sim.add_coaxial_port(
+        (0.020, 0.020, 0.020),
+        "top",
+        pin_length=4e-3,
+        pin_radius=0.6e-3,
+        outer_radius=2.0e-3,
+        impedance=50.0,
+        waveform=ModulatedGaussian(f0=3e9, bandwidth=0.6, amplitude=2.0, cutoff=4.0),
+    )
+    sim.add_coaxial_matched_load(0, target_impedance=50.0, axial_offset_cells=2)
+    sim.add_coaxial_open_termination(0, pin_retract_cells=2)
+    sim.add_coaxial_pec_end_cap(0, axial_offset_cells=1)
+    sim.add_lumped_rlc((0.010, 0.010, 0.010), "ez", R=50.0, L=1e-9, C=1e-12, topology="series")
+    sim.add_thin_conductor(
+        Box(corner_lo=(0.005, 0.005, 0.005), corner_hi=(0.015, 0.015, 0.005)),
+        sigma_bulk=5.8e4,
+        thickness=35e-6,
+        eps_r=1.2,
+    )
+    sim.add_vector_probe((0.020, 0.020, 0.010))
+    return sim
+
+
+def _msl_pair_with_wire_port() -> Simulation:
+    """MSL ports with explicit cell-counted probe placement plus a wire port."""
+    sim = Simulation(freq_max=10e9, domain=(0.020, 0.006, 0.002), dx=0.5e-3, boundary="pec")
+    sim.add_material("sub", eps_r=4.3)
+    sim.add(Box(corner_lo=(0.0, 0.0, 0.0), corner_hi=(0.020, 0.006, 0.0005)), material="sub")
+    sim.add_msl_port(
+        (0.004, 0.003, 0.0),
+        width=0.5e-3,
+        height=0.5e-3,
+        direction="+x",
+        n_probe_offset=7,
+        n_probe_spacing=3,
+        n_probes=4,
+        mode="laplace",
+        eps_r_sub=4.3,
+        name="in",
+    )
+    sim.add_msl_port(
+        (0.016, 0.003, 0.0),
+        width=0.5e-3,
+        height=0.5e-3,
+        direction="-x",
+        excite=False,
+        name="out",
+    )
+    sim.add_port(
+        (0.010, 0.003, 0.0),
+        "ez",
+        impedance=75.0,
+        extent=0.0005,
+        direction="+x",
+        reference_plane_cells=3,
+        waveform=CWSource(f0=5e9, amplitude=0.5, ramp_steps=20),
+    )
+    return sim
+
+
+def _floquet_unit_cell() -> Simulation:
+    """Periodic unit cell driven by a Floquet port at a scan angle."""
+    spec = BoundarySpec(x="periodic", y="periodic", z="cpml")
+    sim = Simulation(
+        freq_max=10e9, domain=(0.015, 0.015, 0.030), dx=1e-3, boundary=spec, cpml_layers=8
+    )
+    sim.add(Sphere(center=(0.0075, 0.0075, 0.015), radius=0.003), material="copper")
+    sim.add_floquet_port(0.005, axis="z", scan_theta=20.0, scan_phi=30.0, n_freqs=9, f0=6e9)
+    return sim
+
+
+def _tfsf_scatterer() -> Simulation:
+    """Oblique TFSF plane wave on a PEC sphere."""
+    sim = Simulation(
+        freq_max=10e9, domain=(0.020, 0.020, 0.020), dx=1e-3, boundary="cpml", cpml_layers=6
+    )
+    sim.add(Sphere(center=(0.010, 0.010, 0.010), radius=0.003), material="pec")
+    sim.add_tfsf_source(
+        f0=5e9,
+        bandwidth=0.7,
+        amplitude=2.0,
+        margin=4,
+        polarization="ey",
+        direction="-x",
+        angle_deg=15.0,
+        waveform="modulated_gaussian",
+    )
+    return sim
+
+
+def _subgrid_research_design() -> Simulation:
+    """rfx-only SBP-SAT refinement plus a polyline wire."""
+    sim = Simulation(freq_max=10e9, domain=(0.020, 0.020, 0.020), dx=1e-3, boundary="pec")
+    sim.add_refinement(
+        (0.008, 0.012),
+        ratio=2,
+        xy_margin=0.002,
+        tau=0.4,
+        validation="research",
+        topology="overlap_z_slab",
+    )
+    sim.add(
+        PolylineWire(
+            points=((0.005, 0.005, 0.005), (0.015, 0.005, 0.005), (0.015, 0.015, 0.010)),
+            radius=3e-4,
+        ),
+        material="copper",
+    )
+    return sim
+
+
+def _mixed_face_boundaries() -> Simulation:
+    """PMC face, conformal PEC axis, per-face CPML thickness."""
+    spec = BoundarySpec(
+        x=Boundary(lo="pec", hi="pec", conformal=True),
+        y="pmc",
+        z=Boundary(lo="cpml", hi="cpml", lo_thickness=12, hi_thickness=20),
+    )
+    return Simulation(
+        freq_max=10e9, domain=(0.020, 0.020, 0.020), dx=1e-3, boundary=spec, cpml_layers=8
+    )
+
+
+def _legacy_pec_faces() -> Simulation:
+    """Deprecated ``pec_faces=`` kwarg on the legacy scalar-boundary path."""
+    with pytest.warns(DeprecationWarning):
+        return Simulation(
+            freq_max=10e9,
+            domain=(0.020, 0.020, 0.020),
+            dx=1e-3,
+            boundary="cpml",
+            cpml_layers=6,
+            pec_faces={"z_lo"},
+        )
+
+
+def _legacy_periodic_axes() -> Simulation:
+    """Deprecated ``set_periodic_axes()``: _boundary disagrees with the spec."""
+    sim = Simulation(
+        freq_max=10e9, domain=(0.020, 0.020, 0.020), dx=1e-3, boundary="cpml", cpml_layers=6
+    )
+    with pytest.warns(DeprecationWarning):
+        sim.set_periodic_axes("xy")
+    return sim
+
+
+def _auto_mesh_design() -> Simulation:
+    """``dx=None``: the mesh choice is deferred to auto_configure at run time."""
+    sim = Simulation(freq_max=10e9, domain=(0.020, 0.020, 0.020), boundary="cpml")
+    sim.add_source(
+        (0.010, 0.010, 0.010),
+        "ez",
+        waveform=GaussianPulse(f0=4e9, bandwidth=1.1, amplitude=0.7, cutoff=4.5),
+    )
+    return sim
+
+
+def _nonuniform_xy_design() -> Simulation:
+    """Explicit per-axis x/y profiles; the constructor synthesises the extent."""
+    return Simulation(
+        freq_max=10e9,
+        domain=(0.030, 0.020, 0.020),
+        dx=1e-3,
+        boundary="cpml",
+        cpml_layers=6,
+        dx_profile=np.full(30, 1e-3),
+        dy_profile=np.full(20, 1e-3),
+    )
+
+
+def _adi_mixed_precision() -> Simulation:
+    return Simulation(
+        freq_max=10e9,
+        domain=(0.020, 0.020, 0.020),
+        dx=1e-3,
+        boundary="pec",
+        solver="adi",
+        adi_cfl_factor=2.0,
+        precision="mixed",
+    )
+
+
+def _fourth_order_2d() -> Simulation:
+    return Simulation(
+        freq_max=10e9,
+        domain=(0.020, 0.020, 0.020),
+        dx=1e-3,
+        boundary="pec",
+        mode="2d_tmz",
+        stencil_order=4,
+    )
+
+
+DESIGN_BUILDERS = {
+    "graded_microstrip": _graded_microstrip,
+    "waveguide_dispersive": _waveguide_with_dispersive_slab,
+    "coax_cavity": _coax_cavity_with_terminations,
+    "msl_pair_wire_port": _msl_pair_with_wire_port,
+    "floquet_unit_cell": _floquet_unit_cell,
+    "tfsf_scatterer": _tfsf_scatterer,
+    "subgrid_research": _subgrid_research_design,
+    "mixed_face_boundaries": _mixed_face_boundaries,
+    "legacy_pec_faces": _legacy_pec_faces,
+    "legacy_periodic_axes": _legacy_periodic_axes,
+    "auto_mesh": _auto_mesh_design,
+    "nonuniform_xy": _nonuniform_xy_design,
+    "adi_mixed_precision": _adi_mixed_precision,
+    "fourth_order_2d": _fourth_order_2d,
+}
+
+
+# ---------------------------------------------------------------------------
+# Structural comparison
+# ---------------------------------------------------------------------------
+
+def _canonical(value):
+    """Reduce builder state to a comparable structure.
+
+    Arrays carry their namespace and dtype, sets compare by membership, and
+    every dataclass / NamedTuple / plain-attribute record is walked field by
+    field.  ``list`` and ``tuple`` are deliberately conflated: the builders
+    accept either for a coordinate and the choice is not design state.
+    """
+    if value is None or isinstance(value, (bool, str)):
+        return value
+    if isinstance(value, np.generic):
+        return ("scalar", value.item())
+    if isinstance(value, (int, float)):
+        return ("scalar", value)
+    if isinstance(value, (set, frozenset)):
+        return ("set", sorted(repr(_canonical(v)) for v in value))
+    if isinstance(value, np.ndarray):
+        return ("array", "numpy", str(value.dtype), np.asarray(value).tolist())
+    if isinstance(value, jax.Array):
+        return ("array", "jax", str(value.dtype), np.asarray(value).tolist())
+    if hasattr(value, "_fields"):  # NamedTuple — check before the tuple branch
+        return (
+            "record",
+            type(value).__name__,
+            {name: _canonical(getattr(value, name)) for name in value._fields},
+        )
+    if isinstance(value, (list, tuple)):
+        return ("seq", [_canonical(v) for v in value])
+    if isinstance(value, dict):
+        return ("map", {k: _canonical(v) for k, v in sorted(value.items())})
+    if dataclasses.is_dataclass(value):
+        return (
+            "record",
+            type(value).__name__,
+            {f.name: _canonical(getattr(value, f.name)) for f in dataclasses.fields(value)},
+        )
+    if hasattr(value, "__dict__"):
+        return (
+            "object",
+            type(value).__name__,
+            {k: _canonical(v) for k, v in sorted(vars(value).items())},
+        )
+    return ("repr", repr(value))
+
+
+def assert_designs_equivalent(original: Simulation, rebuilt: Simulation) -> None:
+    """Diff two simulations attribute by attribute over the census inventory."""
+    assert set(vars(original)) == set(vars(rebuilt)), (
+        "the rebuilt simulation carries a different attribute set: "
+        f"only in original={sorted(set(vars(original)) - set(vars(rebuilt)))}, "
+        f"only in rebuilt={sorted(set(vars(rebuilt)) - set(vars(original)))}"
+    )
+    mismatched = {}
+    for name in sorted(vars(original)):
+        left = _canonical(getattr(original, name))
+        right = _canonical(getattr(rebuilt, name))
+        if left != right:
+            mismatched[name] = (left, right)
+    assert not mismatched, "design attributes differ after round trip: " + "; ".join(
+        f"{name}: original={left!r} rebuilt={right!r}"
+        for name, (left, right) in mismatched.items()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anti-drift ledgers
+# ---------------------------------------------------------------------------
+
+def test_every_simulation_attribute_is_classified():
+    """Every builder attribute is either exported or explicitly excluded.
+
+    A new ``self._*`` field in ``Simulation.__init__`` reds this test until a
+    decision is recorded in ``rfx/interop/_design.py``.
+    """
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="cpml")
+    live = set(vars(sim))
+    classified = set(EXPORTED_SIMULATION_ATTRS) | set(EXCLUDED_SIMULATION_ATTRS)
+
+    assert not live - classified, (
+        f"Simulation carries unclassified design state {sorted(live - classified)}; "
+        f"add each name to EXPORTED_SIMULATION_ATTRS or "
+        f"EXCLUDED_SIMULATION_ATTRS in rfx/interop/_design.py"
+    )
+    assert set(EXPORTED_SIMULATION_ATTRS) == live, (
+        "EXPORTED_SIMULATION_ATTRS has drifted from the live constructor: "
+        f"stale={sorted(set(EXPORTED_SIMULATION_ATTRS) - live)}, "
+        f"missing={sorted(live - set(EXPORTED_SIMULATION_ATTRS))}"
+    )
+    assert not set(EXCLUDED_SIMULATION_ATTRS) & live, (
+        "an attribute listed as excluded is set by the constructor: "
+        f"{sorted(set(EXCLUDED_SIMULATION_ATTRS) & live)}"
+    )
+
+
+def test_every_builder_method_is_covered_by_the_document():
+    """Each public ``add_*`` builder writes into a section the document records."""
+    builders = {
+        name
+        for name in dir(Simulation)
+        if name == "add" or name.startswith("add_")
+    }
+    # Every builder either appends to one of the exported lists or is a
+    # documented desugaring of another builder.
+    desugaring = {
+        # expands to 1-2 add_source calls at registration time
+        "add_polarized_source",
+        # expands to 6 _ProbeEntry rows at registration time
+        "add_vector_probe",
+    }
+    expected = {
+        "add",
+        "add_coaxial_matched_load",
+        "add_coaxial_open_termination",
+        "add_coaxial_pec_end_cap",
+        "add_coaxial_port",
+        "add_dft_plane_probe",
+        "add_floquet_port",
+        "add_flux_monitor",
+        "add_lumped_rlc",
+        "add_material",
+        "add_msl_port",
+        "add_ntff_box",
+        "add_port",
+        "add_probe",
+        "add_refinement",
+        "add_source",
+        "add_thin_conductor",
+        "add_tfsf_source",
+        "add_waveguide_port",
+    } | desugaring
+    assert builders == expected, (
+        "the Simulation builder surface has changed; confirm the new method's "
+        "state reaches the design document and update this list: "
+        f"new={sorted(builders - expected)}, gone={sorted(expected - builders)}"
+    )
+
+
+@pytest.mark.parametrize("cls,fields", _PINNED_RECORDS, ids=lambda v: getattr(v, "__name__", ""))
+def test_record_field_registry_is_pinned(cls, fields):
+    """The per-entry field registry matches the live record class exactly."""
+    assert set(live_field_names(cls)) == set(fields), (
+        f"{cls.__name__} fields drifted from rfx/interop/_design.py: "
+        f"live={sorted(live_field_names(cls))}, recorded={sorted(fields)}"
+    )
+
+
+def test_port_entry_registry_is_pinned():
+    """``_PortEntry`` splits across two sections, so it is pinned separately."""
+    from rfx.interop._design import _LUMPED_PORT_FIELDS, _SOFT_SOURCE_FIELDS
+
+    assert set(live_field_names(_PortEntry)) == set(_LUMPED_PORT_FIELDS)
+    assert set(_SOFT_SOURCE_FIELDS) <= set(_LUMPED_PORT_FIELDS)
+
+
+def test_waveform_registry_is_pinned():
+    for kind, codec in _WAVEFORM_CODECS.items():
+        live = tuple(f.name for f in dataclasses.fields(codec.cls))
+        assert live == codec.fields, (
+            f"{codec.cls.__name__} (kind {kind!r}) fields drifted: live={live}, "
+            f"recorded={codec.fields}"
+        )
+    assert SUPPORTED_WAVEFORM_KINDS == tuple(sorted(_WAVEFORM_CODECS))
+    assert CustomWaveform not in {c.cls for c in _WAVEFORM_CODECS.values()}
+
+
+def test_legacy_spec_mirror_matches_the_builder():
+    """``_predict_legacy_spec`` mirrors ``Simulation._build_spec_from_legacy``."""
+    cases = [
+        ("cpml", set(), ""),
+        ("pec", set(), ""),
+        ("upml", set(), ""),
+        ("cpml", {"z_lo"}, ""),
+        ("cpml", {"x_lo", "y_hi"}, ""),
+        ("cpml", set(), "xy"),
+        ("pec", set(), "xyz"),
+        ("cpml", {"z_lo"}, "x"),
+    ]
+    for boundary, pec_faces, periodic in cases:
+        sim = Simulation(
+            freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="cpml"
+        )
+        sim._boundary = boundary
+        sim._pec_faces = set(pec_faces)
+        sim._periodic_axes = periodic
+        assert sim._build_spec_from_legacy() == _predict_legacy_spec(
+            boundary, pec_faces, periodic
+        ), f"mirror diverged for {(boundary, sorted(pec_faces), periodic)}"
+
+
+# ---------------------------------------------------------------------------
+# Round-trip equivalence witness
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("name", sorted(DESIGN_BUILDERS))
+def test_round_trip_is_structurally_identical(name):
+    original = DESIGN_BUILDERS[name]()
+    document = design_to_dict(original)
+    rebuilt = simulation_from_design(document)
+    assert_designs_equivalent(original, rebuilt)
+
+
+def _mutate_waveform_cutoff(sim):
+    entry = sim._ports[0]
+    sim._ports[0] = dataclasses.replace(
+        entry, waveform=dataclasses.replace(entry.waveform, cutoff=4.5)
+    )
+
+
+def _mutate_profile_dtype(sim):
+    sim._dz_profile = np.asarray(sim._dz_profile, dtype=np.float32)
+
+
+def _mutate_profile_values(sim):
+    profile = np.array(sim._dz_profile, copy=True)
+    profile[0] *= 1.0000001
+    sim._dz_profile = profile
+
+
+def _mutate_shape_parameter(sim):
+    entry = sim._geometry[1]
+    sim._geometry[1] = dataclasses.replace(
+        entry, shape=dataclasses.replace(entry.shape, radius=4e-4)
+    )
+
+
+def _mutate_pec_faces(sim):
+    sim._pec_faces = {"z_lo"}
+
+
+def _mutate_dispersion_pole(sim):
+    sim.add_material("fr4", eps_r=4.3, sigma=0.01, debye_poles=[DebyePole(delta_eps=1.0, tau=1e-12)])
+
+
+def _mutate_probe_component(sim):
+    sim._probes[0] = dataclasses.replace(sim._probes[0], component="hx")
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        _mutate_waveform_cutoff,
+        _mutate_profile_dtype,
+        _mutate_profile_values,
+        _mutate_shape_parameter,
+        _mutate_pec_faces,
+        _mutate_dispersion_pole,
+        _mutate_probe_component,
+    ],
+    ids=lambda fn: fn.__name__,
+)
+def test_the_equivalence_witness_detects_a_difference(mutate):
+    """The attribute diff is not vacuous.
+
+    Each mutation is a difference the JSON text would also show, but the point
+    is that ``assert_designs_equivalent`` — the helper every round-trip test
+    relies on — actually fails when the two simulations differ, including in a
+    dtype, a single profile cell, a nested shape parameter and a dispersion
+    pole.
+    """
+    original = _graded_microstrip()
+    other = _graded_microstrip()
+    mutate(other)
+
+    with pytest.raises(AssertionError, match="design attributes differ"):
+        assert_designs_equivalent(original, other)
+
+
+@pytest.mark.parametrize("name", sorted(DESIGN_BUILDERS))
+def test_round_trip_document_is_a_fixed_point(name):
+    """Export → import → export reproduces the document byte for byte."""
+    original = DESIGN_BUILDERS[name]()
+    first = design_to_json(original)
+    rebuilt = simulation_from_design(json.loads(first))
+    assert design_to_json(rebuilt) == first
+
+
+@pytest.mark.parametrize("name", sorted(DESIGN_BUILDERS))
+def test_design_to_dict_is_byte_stable(name):
+    """Two exports of the same simulation produce identical canonical JSON."""
+    sim = DESIGN_BUILDERS[name]()
+    assert design_to_json(sim) == design_to_json(sim)
+
+
+@pytest.mark.parametrize("name", sorted(DESIGN_BUILDERS))
+def test_document_is_strict_json(name):
+    """No NaN/Infinity, and no object needed a ``default=`` fallback."""
+    document = design_to_dict(DESIGN_BUILDERS[name]())
+    text = json.dumps(document, sort_keys=True, allow_nan=False)
+    assert "Traced" not in text, (
+        "a traced value leaked into the document as a string — the "
+        "export_geometry_json default=str failure mode"
+    )
+    assert document["schema"] == DESIGN_SCHEMA_VERSION
+    assert document["rfx_version"] == rfx.__version__
+
+
+def test_mesh_profile_is_emitted_value_by_value():
+    """A graded profile appears in full, with its dtype, not as a summary."""
+    sim = _graded_microstrip()
+    document = design_to_dict(sim)
+    profile = document["mesh"]["dz_profile"]
+
+    assert profile["container"] == "numpy"
+    assert profile["dtype"] == str(sim._dz_profile.dtype)
+    assert profile["values"] == list(np.asarray(sim._dz_profile).tolist())
+    assert len(profile["values"]) == len(sim._dz_profile)
+    # The census's measured failure mode: artifacts.py emits
+    # {"present": true, "shape": [...], "min": ..., "max": ..., "sum": ...}.
+    assert not {"min", "max", "sum", "present", "shape"} & set(profile)
+
+
+def test_ntff_frequencies_are_emitted_in_full():
+    """``n_freqs`` is unrecoverable from ``_ntff``, so the array is authoritative."""
+    sim = _waveguide_with_dispersive_slab()
+    document = design_to_dict(sim)
+    freqs = document["observables"]["ntff"]["freqs"]
+
+    assert freqs["container"] == "jax"
+    assert freqs["values"] == list(np.asarray(sim._ntff[2]).tolist())
+    assert len(freqs["values"]) == 5
+
+
+def test_source_and_lumped_port_are_separate_sections():
+    """``_ports`` holds two objects; the document never asks a reader to guess."""
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
+    sim.add_source((0.005, 0.010, 0.010), "ez")
+    sim.add_port((0.015, 0.010, 0.010), "ez", impedance=50.0)
+
+    excitations = design_to_dict(sim)["excitations"]
+
+    assert len(excitations["soft_sources"]) == 1
+    assert len(excitations["lumped_ports"]) == 1
+    # No impedance sentinel on the soft source: the intent is in the section name.
+    assert "impedance" not in excitations["soft_sources"][0]
+    assert excitations["lumped_ports"][0]["impedance"] == 50.0
+
+
+# ---------------------------------------------------------------------------
+# Exclusion proof
+# ---------------------------------------------------------------------------
+
+_FORBIDDEN_KEYS = frozenset(
+    {
+        # derived grid / timestep state
+        "dt",
+        "grid",
+        "grid_shape",
+        "axis_pads",
+        "face_layers",
+        "inv_dx",
+        "inv_dy",
+        "inv_dz",
+        "nx",
+        "ny",
+        "nz",
+        # results
+        "results",
+        "result",
+        "s_params",
+        "time_series",
+        "fields",
+        "energy",
+        # preflight scratch
+        "preflight",
+        "ntff_min_steps_hint",
+        "_ntff_min_steps_hint",
+        # run-time control (run()/forward() kwargs, not design state)
+        "n_steps",
+        "num_periods",
+        "until_decay",
+        "decay_by",
+        "compute_s_params",
+        "s_param_freqs",
+        "s_param_n_steps",
+        "snapshot",
+        "checkpoint",
+        "devices",
+        "exchange_interval",
+        "skip_preflight",
+        "subpixel_smoothing",
+        "conformal_pec",
+        "conformal_min_weight",
+        "radiated_flux_box",
+        "flux_env_checks",
+        "eps_override",
+        "sigma_override",
+        "pec_mask_override",
+        "design_mask",
+        "rlc_values_override",
+        "execution",
+    }
+)
+
+
+def _all_keys(value, out=None):
+    out = set() if out is None else out
+    if isinstance(value, dict):
+        out |= set(value)
+        for item in value.values():
+            _all_keys(item, out)
+    elif isinstance(value, list):
+        for item in value:
+            _all_keys(item, out)
+    return out
+
+
+@pytest.mark.parametrize("name", sorted(DESIGN_BUILDERS))
+def test_document_carries_no_derived_or_run_control_state(name):
+    keys = _all_keys(design_to_dict(DESIGN_BUILDERS[name]()))
+    leaked = keys & _FORBIDDEN_KEYS
+    assert not leaked, (
+        f"derived/transient/run-control keys leaked into the design document: "
+        f"{sorted(leaked)}"
+    )
+
+
+def test_running_a_design_does_not_add_state_the_document_records():
+    """Preflight scratch stays out of the document."""
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=2e-3, boundary="pec")
+    sim.add_source((0.010, 0.010, 0.010), "ez")
+    before = design_to_json(sim)
+    sim.preflight()
+    assert design_to_json(sim) == before
+
+
+# ---------------------------------------------------------------------------
+# Refusals — export side
+# ---------------------------------------------------------------------------
+
+def test_refuses_traced_mesh_profile():
+    """A JAX tracer has no concrete mesh; exporting it would record a placeholder."""
+
+    def export_under_trace(scale):
+        profile = jnp.full(20, 1e-3) * scale
+        sim = Simulation(
+            freq_max=10e9,
+            domain=(0.020, 0.020, 0.020),
+            dx=1e-3,
+            boundary="cpml",
+            cpml_layers=4,
+            dz_profile=profile,
+        )
+        return design_to_dict(sim)
+
+    with pytest.raises(UnsupportedDesignFeature, match="tracer"):
+        jax.jit(export_under_trace)(1.0)
+
+
+def test_refuses_mesh_shape_geometry():
+    """CAD meshes discard path/scale/translate, so they cannot be described."""
+    trimesh = pytest.importorskip("trimesh")
+    from rfx.geometry.mesh_import import MeshShape
+
+    mesh = trimesh.creation.box(extents=(0.002, 0.002, 0.002))
+    mesh.apply_translation((0.010, 0.010, 0.010))
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
+    sim.add(MeshShape(mesh), material="pec")
+
+    with pytest.raises(UnsupportedDesignFeature, match="MeshShape"):
+        design_to_dict(sim)
+
+
+def test_refuses_user_defined_shape():
+    """``Shape`` is a Protocol, so an arbitrary class is a legal geometry entry."""
+
+    class WedgeShape:
+        def bounding_box(self):
+            return ((0.0, 0.0, 0.0), (0.01, 0.01, 0.01))
+
+        def mask(self, grid):  # pragma: no cover - never reached
+            raise NotImplementedError
+
+        def mask_on_coords(self, *args, **kwargs):  # pragma: no cover
+            raise NotImplementedError
+
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
+    sim.add(WedgeShape(), material="pec")
+
+    with pytest.raises(UnsupportedDesignFeature, match="WedgeShape"):
+        design_to_dict(sim)
+
+
+def test_refuses_custom_waveform():
+    """A closure has no serialisable form (add_polarized_source builds these)."""
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
+    sim.add_source((0.010, 0.010, 0.010), "ez", waveform=CustomWaveform(func=lambda t: 0.0))
+
+    with pytest.raises(UnsupportedDesignFeature, match="CustomWaveform"):
+        design_to_dict(sim)
+
+
+def test_refuses_circularly_polarized_source():
+    """The complex-Jones desugaring stores a CustomWaveform closure."""
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
+    sim.add_polarized_source((0.010, 0.010, 0.010), polarization=(1.0, 1.0j))
+
+    with pytest.raises(UnsupportedDesignFeature, match="CustomWaveform"):
+        design_to_dict(sim)
+
+
+def test_refuses_non_finite_number():
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
+    sim.add_probe((math.inf, 0.010, 0.010), "ez")
+
+    with pytest.raises(UnsupportedDesignFeature, match="non-finite"):
+        design_to_dict(sim)
+
+
+def test_refuses_soft_source_that_no_builder_could_have_created():
+    """``impedance == 0`` with a wire extent is not reachable through add_source."""
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
+    sim._ports.append(
+        _PortEntry(
+            position=(0.010, 0.010, 0.010),
+            component="ez",
+            impedance=0.0,
+            waveform=GaussianPulse(f0=5e9),
+            extent=0.002,
+        )
+    )
+
+    with pytest.raises(UnsupportedDesignFeature, match="soft source"):
+        design_to_dict(sim)
+
+
+def test_refuses_geometry_referencing_an_unknown_material():
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
+    sim._geometry.append(
+        _GeometryEntry(
+            shape=Box(corner_lo=(0.0, 0.0, 0.0), corner_hi=(0.01, 0.01, 0.01)),
+            material_name="unobtainium",
+        )
+    )
+
+    with pytest.raises(UnsupportedDesignFeature, match="unobtainium"):
+        design_to_dict(sim)
+
+
+def test_refuses_a_record_class_that_grew_a_field(monkeypatch):
+    """A field added upstream must red the export, not vanish from the document."""
+    from rfx.interop import _design
+
+    # Stand in for "the record class gained a field the registry lacks" by
+    # dropping one from the registry: the exporter must refuse rather than
+    # write a probe without its component.
+    monkeypatch.setattr(
+        _design, "_PROBE_FIELDS", {"position": _design._PROBE_FIELDS["position"]}
+    )
+
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
+    sim.add_probe((0.010, 0.010, 0.010), "ez")
+
+    with pytest.raises(UnsupportedDesignFeature, match="does not record"):
+        design_to_dict(sim)
+
+
+# ---------------------------------------------------------------------------
+# Refusals — import side
+# ---------------------------------------------------------------------------
+
+def test_refuses_unknown_top_level_key():
+    document = design_to_dict(_graded_microstrip())
+    document["execution"] = {"n_steps": 100}
+
+    with pytest.raises(UnsupportedDesignFeature, match="unknown=\\['execution'\\]"):
+        simulation_from_design(document)
+
+
+def test_refuses_missing_top_level_key():
+    document = design_to_dict(_graded_microstrip())
+    del document["observables"]
+
+    with pytest.raises(UnsupportedDesignFeature, match="missing=\\['observables'\\]"):
+        simulation_from_design(document)
+
+
+def test_refuses_unknown_nested_key():
+    document = design_to_dict(_graded_microstrip())
+    document["mesh"]["resolution"] = 20
+
+    with pytest.raises(UnsupportedDesignFeature, match="mesh key mismatch"):
+        simulation_from_design(document)
+
+
+def test_refuses_unknown_shape_kind():
+    document = design_to_dict(_graded_microstrip())
+    document["geometry"][0]["shape"]["kind"] = "torus"
+
+    with pytest.raises(UnsupportedDesignFeature, match="torus"):
+        simulation_from_design(document)
+
+
+def test_refuses_foreign_schema():
+    document = design_to_dict(_graded_microstrip())
+    document["schema"] = "rfx-scene-artifact-v1"
+
+    with pytest.raises(UnsupportedDesignFeature, match="does not translate"):
+        simulation_from_design(document)
+
+
+def test_refuses_drifted_material_library_value():
+    """Library values are version-dependent; a silent substitution is refused."""
+    document = design_to_dict(_graded_microstrip())
+    assert "pec" in document["material_library"]
+    document["material_library"]["pec"]["sigma"] *= 2.0
+
+    with pytest.raises(UnsupportedDesignFeature, match="does not match this rfx version"):
+        simulation_from_design(document)
+
+
+def test_refuses_material_library_name_that_shadows_a_registered_material():
+    document = design_to_dict(_graded_microstrip())
+    document["material_library"]["fr4"] = document["material_library"]["pec"]
+
+    with pytest.raises(UnsupportedDesignFeature, match="shadows"):
+        simulation_from_design(document)
+
+
+def test_refuses_a_document_the_builders_cannot_reproduce():
+    """A recorded extent the constructor overrides is refused, not corrected.
+
+    ``Simulation.__init__`` synthesises ``domain[2]`` from ``sum(dz_profile)``
+    when the given extent is non-positive.  A document that records a different
+    extent alongside the profile therefore cannot be rebuilt exactly, and the
+    importer says so instead of handing back a silently adjusted simulation.
+    """
+    document = design_to_dict(_graded_microstrip())
+    document["domain"]["extent"][2] = 0.0
+
+    with pytest.raises(UnsupportedDesignFeature, match="could not be rebuilt exactly"):
+        simulation_from_design(document)
+
+
+def test_refuses_inconsistent_boundary_sections():
+    document = design_to_dict(_graded_microstrip())
+    document["boundary"]["legacy"]["boundary"] = "upml"
+
+    with pytest.raises(UnsupportedDesignFeature, match="cannot both be reproduced"):
+        simulation_from_design(document)
+
+
+def test_refuses_a_non_mapping_document():
+    with pytest.raises(UnsupportedDesignFeature, match="must be a mapping"):
+        simulation_from_design([1, 2, 3])
+
+
+def test_refuses_summarised_array_payload():
+    """The artifacts.py array summary is not a valid mesh profile."""
+    document = design_to_dict(_graded_microstrip())
+    document["mesh"]["dz_profile"] = {
+        "present": True,
+        "shape": [30],
+        "min": 1.5e-4,
+        "max": 5e-4,
+        "sum": 0.0159,
+    }
+
+    with pytest.raises(UnsupportedDesignFeature, match="container"):
+        simulation_from_design(document)
+
+
+# ---------------------------------------------------------------------------
+# Fences are mirrored, not widened
+# ---------------------------------------------------------------------------
+
+def test_import_does_not_widen_the_floquet_mode_fence():
+    document = design_to_dict(_floquet_unit_cell())
+    document["excitations"]["floquet_ports"][0]["n_modes"] = 2
+
+    with pytest.raises(NotImplementedError, match="specular"):
+        simulation_from_design(document)
+
+
+def test_import_does_not_widen_the_floquet_polarization_fence():
+    document = design_to_dict(_floquet_unit_cell())
+    document["excitations"]["floquet_ports"][0]["polarization"] = "tm"
+
+    with pytest.raises(NotImplementedError, match="TM Floquet"):
+        simulation_from_design(document)
+
+
+def test_import_does_not_widen_the_reference_plane_fence():
+    """``reference_plane_cells`` needs a wire port; a lumped port is rejected."""
+    document = design_to_dict(_msl_pair_with_wire_port())
+    document["excitations"]["lumped_ports"][0]["extent"] = None
+
+    with pytest.raises(NotImplementedError, match="wire ports"):
+        simulation_from_design(document)
+
+
+def test_import_does_not_widen_the_tfsf_boundary_fence():
+    document = design_to_dict(_tfsf_scatterer())
+    document["boundary"]["spec"] = BoundarySpec.uniform("pec").to_dict()
+    document["boundary"]["legacy"]["boundary"] = "pec"
+    document["boundary"]["legacy"]["cpml_layers"] = 0
+
+    with pytest.raises(ValueError, match="requires boundary='cpml'"):
+        simulation_from_design(document)
+
+
+# ---------------------------------------------------------------------------
+# Non-portability annotation
+# ---------------------------------------------------------------------------
+
+def test_non_portable_annotation_flags_cell_relative_state():
+    paths = {
+        note["path"] for note in design_to_dict(_coax_cavity_with_terminations())["non_portable"]
+    }
+    assert {
+        "excitations.coaxial_matched_loads",
+        "excitations.coaxial_open_terminations",
+        "excitations.coaxial_pec_end_caps",
+    } <= paths
+
+
+def test_non_portable_annotation_flags_msl_probe_cell_counts():
+    paths = {note["path"] for note in design_to_dict(_msl_pair_with_wire_port())["non_portable"]}
+    assert "excitations.msl_ports" in paths
+    assert "excitations.lumped_ports" in paths
+
+
+def test_non_portable_annotation_flags_subgridding():
+    notes = design_to_dict(_subgrid_research_design())["non_portable"]
+    refinement = [note for note in notes if note["path"] == "refinement"]
+    assert refinement, f"refinement not annotated: {notes}"
+    assert "#90" in refinement[0]["reason"]
+
+
+def test_non_portable_annotation_flags_graded_mesh_and_absorber():
+    paths = {note["path"] for note in design_to_dict(_graded_microstrip())["non_portable"]}
+    assert "mesh" in paths
+    assert "boundary.legacy.cpml_layers" in paths
+
+
+def test_non_portable_annotation_is_empty_for_a_plain_pec_design():
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
+    sim.add(Box(corner_lo=(0.0, 0.0, 0.0), corner_hi=(0.01, 0.01, 0.01)), material="fr4")
+    sim.add_material("fr4", eps_r=4.3)
+    assert design_to_dict(sim)["non_portable"] == []
+
+
+def test_non_portable_annotation_is_sorted():
+    document = design_to_dict(_coax_cavity_with_terminations())
+    paths = [note["path"] for note in document["non_portable"]]
+    assert paths == sorted(paths)
+
+
+def test_non_portable_annotation_cannot_be_stripped():
+    """Editing the annotation away is refused, not silently accepted.
+
+    Nothing is *applied* from ``non_portable`` on import, but because the
+    importer re-exports and compares, a downstream tool cannot delete the
+    annotation to make rfx-only state look portable.
+    """
+    document = design_to_dict(_coax_cavity_with_terminations())
+    assert document["non_portable"]
+    document["non_portable"] = []
+
+    with pytest.raises(UnsupportedDesignFeature, match="non_portable"):
+        simulation_from_design(document)
+
+
+# ---------------------------------------------------------------------------
+# Governance
+# ---------------------------------------------------------------------------
+
+def test_design_helpers_are_not_added_to_the_pinned_rfx_surface():
+    """``rfx.interop`` is the import path; ``rfx.__all__`` stays unchanged."""
+    for name in ("design_to_dict", "design_to_json", "simulation_from_design"):
+        assert name not in getattr(rfx, "__all__", ()), (
+            f"{name} was added to rfx.__all__, which trips the pinned API "
+            f"inventory in scripts/check_api_reference.py"
+        )
+        assert not hasattr(rfx, name)
+
+
+def test_geometry_and_material_sections_share_the_existing_vocabulary():
+    """Shapes and materials use the vocabulary the other layers already use.
+
+    A future ``rfx-experiment/v2`` should be able to fold these sections in
+    mechanically rather than growing a fifth shape decoder.
+    """
+    from rfx.config._shapes import _SUPPORTED_SHAPES
+    from rfx.interop import SUPPORTED_SHAPE_KINDS, material_from_dict
+
+    document = design_to_dict(_graded_microstrip())
+    kinds = {entry["shape"]["kind"] for entry in document["geometry"]}
+    assert kinds <= set(SUPPORTED_SHAPE_KINDS)
+    # The config CLI's box spelling is the same token, so a box-only consumer
+    # can filter on it without translation.
+    assert set(_SUPPORTED_SHAPES) <= set(SUPPORTED_SHAPE_KINDS)
+    assert "box" in kinds
+
+    for payload in document["materials"].values():
+        assert material_from_dict(payload) is not None
+    assert set(document["material_library"]) <= set(MATERIAL_LIBRARY)

--- a/tests/test_interop_design_document.py
+++ b/tests/test_interop_design_document.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import dataclasses
 import json
 import math
+from pathlib import Path
 
 import jax
 import jax.numpy as jnp
@@ -1192,6 +1193,285 @@ def test_non_portable_annotation_cannot_be_stripped():
 # ---------------------------------------------------------------------------
 # Governance
 # ---------------------------------------------------------------------------
+
+SCHEMA_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "docs/design_notes/schemas/rfx-design-ir-v1.schema.json"
+)
+
+
+@pytest.fixture(scope="module")
+def published_schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+def _schema_at(schema: dict, path: str) -> dict:
+    """Resolve a dotted document path to its schema node, stepping into arrays."""
+    node = schema
+    for part in path.split("."):
+        node = node["properties"][part]
+        if node.get("type") == "array":
+            node = node["items"]
+    return node
+
+
+#: Document path -> the emitter's field registry for one entry at that path.
+#: This is the drift guard that key-set checks cannot give: it pins every
+#: recorded field of every entry family, so a field added to a builder record
+#: reds the schema test as well as the exporter test.
+_SCHEMA_ENTRY_REGISTRIES = [
+    ("geometry", "_GEOMETRY_FIELDS"),
+    ("thin_conductors", "_THIN_CONDUCTOR_FIELDS"),
+    ("excitations.soft_sources", "_SOFT_SOURCE_FIELDS"),
+    ("excitations.lumped_ports", "_LUMPED_PORT_FIELDS"),
+    ("excitations.msl_ports", "_MSL_PORT_FIELDS"),
+    ("excitations.waveguide_ports", "_WAVEGUIDE_PORT_FIELDS"),
+    ("excitations.coaxial_ports", "_COAXIAL_PORT_FIELDS"),
+    ("excitations.floquet_ports", "_FLOQUET_PORT_FIELDS"),
+    ("excitations.lumped_rlc", "_LUMPED_RLC_FIELDS"),
+    ("excitations.tfsf", "_TFSF_FIELDS"),
+    ("observables.probes", "_PROBE_FIELDS"),
+    ("observables.dft_planes", "_DFT_PLANE_FIELDS"),
+    ("observables.flux_monitors", "_FLUX_MONITOR_FIELDS"),
+    ("observables.ntff", "_NTFF_FIELDS"),
+    ("refinement", "_REFINEMENT_FIELDS"),
+]
+
+
+@pytest.mark.parametrize("path,registry_name", _SCHEMA_ENTRY_REGISTRIES)
+def test_schema_entry_fields_match_the_emitter_registry(
+    published_schema, path, registry_name
+):
+    """Every entry family's field set is pinned, not just the section names.
+
+    Runs without ``jsonschema``: it compares the schema document's own
+    ``required`` / ``properties`` against the exporter's field registries.
+    """
+    from rfx.interop import _design
+
+    registry = getattr(_design, registry_name)
+    node = _schema_at(published_schema, path)
+
+    assert set(node["required"]) == set(registry), (
+        f"{path}: schema required={sorted(node['required'])} but the emitter "
+        f"records {sorted(registry)}"
+    )
+    assert set(node["properties"]) == set(registry), (
+        f"{path}: schema properties={sorted(node['properties'])} but the "
+        f"emitter records {sorted(registry)}"
+    )
+    assert node["additionalProperties"] is False, (
+        f"{path}: the document is a closed world; the schema must say so"
+    )
+
+
+def test_schema_vocabularies_are_pinned_to_the_implementation(published_schema):
+    """The three closed vocabularies the codecs enforce.
+
+    If one of these grows upstream, this fails rather than the schema silently
+    rejecting a document the emitter legitimately produces.
+    """
+    from rfx.boundaries.spec import BOUNDARY_TOKENS
+    from rfx.interop import SUPPORTED_SHAPE_KINDS
+    from rfx.interop._design import _ARRAY_CONTAINERS
+
+    defs = published_schema["$defs"]
+    assert sorted(defs["shape"]["properties"]["kind"]["enum"]) == sorted(
+        SUPPORTED_SHAPE_KINDS
+    )
+    assert sorted(defs["waveform"]["properties"]["kind"]["enum"]) == sorted(
+        SUPPORTED_WAVEFORM_KINDS
+    )
+    assert sorted(defs["boundary_token"]["enum"]) == sorted(BOUNDARY_TOKENS)
+    assert sorted(defs["array_payload"]["properties"]["container"]["enum"]) == sorted(
+        _ARRAY_CONTAINERS
+    )
+
+
+@pytest.mark.parametrize("kind", sorted(_WAVEFORM_CODECS))
+def test_schema_waveform_params_match_the_codec(published_schema, kind):
+    branches = published_schema["$defs"]["waveform"]["allOf"]
+    branch = next(
+        b for b in branches if b["if"]["properties"]["kind"]["const"] == kind
+    )
+    node = branch["then"]["properties"]["params"]
+    if "$ref" in node:
+        ref = node["$ref"].removeprefix("#/$defs/")
+        node = published_schema["$defs"][ref]
+    assert set(node["required"]) == set(_WAVEFORM_CODECS[kind].fields)
+    assert node["additionalProperties"] is False
+
+
+def test_schema_shape_params_match_the_shape_codec(published_schema):
+    from rfx.interop import SUPPORTED_SHAPE_KINDS
+    from rfx.interop._shapes import shape_field_names
+
+    branches = published_schema["$defs"]["shape"]["allOf"]
+    by_kind = {b["if"]["properties"]["kind"]["const"]: b for b in branches}
+    assert set(by_kind) == set(SUPPORTED_SHAPE_KINDS), (
+        "the schema pins parameters for a different set of shape kinds than the "
+        f"codec supports: schema={sorted(by_kind)}, "
+        f"codec={sorted(SUPPORTED_SHAPE_KINDS)}"
+    )
+    for kind, branch in by_kind.items():
+        node = branch["then"]["properties"]["params"]
+        assert set(node["required"]) == set(shape_field_names(kind)), (
+            f"shape {kind!r}: schema required={sorted(node['required'])} but the "
+            f"codec records {sorted(shape_field_names(kind))}"
+        )
+        assert node["additionalProperties"] is False
+
+
+@pytest.mark.parametrize("name", sorted(DESIGN_BUILDERS))
+def test_emitted_document_validates_against_the_published_schema(
+    published_schema, name
+):
+    jsonschema = pytest.importorskip("jsonschema")
+    jsonschema.validate(
+        instance=design_to_dict(DESIGN_BUILDERS[name]()), schema=published_schema
+    )
+
+
+def test_schema_is_not_vacuous(published_schema):
+    """Tamper a valid document; the schema must reject each case.
+
+    A schema whose sections are bare ``{"type": "array"}`` validates anything
+    and cannot catch emitter drift, so the strictness itself is worth pinning.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+
+    def rejects(mutate, label):
+        document = design_to_dict(_waveguide_with_dispersive_slab())
+        mutate(document)
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=document, schema=published_schema)
+
+    def unknown_nested_key(d):
+        d["mesh"]["resolution"] = 20
+
+    def unknown_entry_field(d):
+        d["observables"]["probes"].append(
+            {"position": [0.0, 0.0, 0.0], "component": "ez", "gain": 1.0}
+        )
+
+    def summarised_profile(d):
+        # The rfx.artifacts._profile_summary shape, which cannot be rebuilt.
+        d["mesh"]["dz_profile"] = {
+            "present": True,
+            "shape": [75],
+            "min": 0.000381,
+            "max": 0.002,
+            "sum": 0.1278,
+        }
+
+    def dtype_free_numpy_array(d):
+        d["observables"]["ntff"]["freqs"] = {
+            "container": "numpy",
+            "values": [1e9, 2e9],
+        }
+
+    def dtype_on_a_plain_list(d):
+        d["observables"]["ntff"]["freqs"] = {
+            "container": "list",
+            "dtype": "float64",
+            "values": [1e9, 2e9],
+        }
+
+    def wrong_vector_width(d):
+        d["geometry"][0]["shape"]["params"]["corner_lo"] = [0.0, 0.0]
+
+    def unknown_shape_param(d):
+        d["geometry"][0]["shape"]["params"]["thickness"] = 1e-3
+
+    def unknown_waveform_kind(d):
+        d["excitations"]["soft_sources"] = [
+            {
+                "position": [0.0, 0.0, 0.0],
+                "component": "ez",
+                "waveform": {"kind": "custom_waveform", "params": {}},
+            }
+        ]
+
+    def stringified_number(d):
+        d["domain"]["freq_max"] = "1.2e10"
+
+    for mutate in (
+        unknown_nested_key,
+        unknown_entry_field,
+        summarised_profile,
+        dtype_free_numpy_array,
+        dtype_on_a_plain_list,
+        wrong_vector_width,
+        unknown_shape_param,
+        unknown_waveform_kind,
+        stringified_number,
+    ):
+        rejects(mutate, mutate.__name__)
+
+
+def test_schema_polyline_cardinality_matches_the_codec(published_schema):
+    """Whether an empty point list is legal is the codec's call, not the schema's.
+
+    Pinned as a property rather than a constant so the two cannot drift: the
+    codec is the authority, and the schema must agree with whatever it does.
+    """
+    from rfx.interop import shape_from_dict
+
+    payload = {"kind": "polyline_wire", "params": {"points": [], "radius": 1e-4}}
+    try:
+        shape_from_dict(payload)
+        codec_accepts_empty = True
+    except UnsupportedDesignFeature:
+        codec_accepts_empty = False
+
+    branch = next(
+        b
+        for b in published_schema["$defs"]["shape"]["allOf"]
+        if b["if"]["properties"]["kind"]["const"] == "polyline_wire"
+    )
+    declared_min = (
+        branch["then"]["properties"]["params"]["properties"]["points"].get("minItems", 0)
+    )
+    assert (declared_min == 0) is codec_accepts_empty, (
+        f"schema minItems={declared_min} but the codec "
+        f"{'accepts' if codec_accepts_empty else 'refuses'} an empty point list"
+    )
+
+
+def test_geometry_order_is_semantic_state():
+    """Entry order is a last-write-wins paint order, not presentation.
+
+    ``rfx/geometry/csg.py`` applies geometry in order with later shapes
+    overwriting earlier ones, so a document that reorders ``geometry``
+    describes a different structure. Canonical JSON sorts object keys but must
+    never sort this array.
+    """
+    sub = Box(corner_lo=(0.0, 0.0, 0.0), corner_hi=(0.010, 0.010, 0.002))
+    trace = Box(corner_lo=(0.002, 0.002, 0.001), corner_hi=(0.008, 0.008, 0.002))
+
+    first = Simulation(freq_max=10e9, domain=(0.01, 0.01, 0.01), dx=5e-4, boundary="pec")
+    first.add_material("fr4", eps_r=4.3)
+    first.add(sub, material="fr4")
+    first.add(trace, material="pec")
+
+    second = Simulation(freq_max=10e9, domain=(0.01, 0.01, 0.01), dx=5e-4, boundary="pec")
+    second.add_material("fr4", eps_r=4.3)
+    second.add(trace, material="pec")
+    second.add(sub, material="fr4")
+
+    doc_first = design_to_dict(first)
+    doc_second = design_to_dict(second)
+    assert [e["material_name"] for e in doc_first["geometry"]] == ["fr4", "pec"]
+    assert [e["material_name"] for e in doc_second["geometry"]] == ["pec", "fr4"]
+    assert design_to_json(first) != design_to_json(second), (
+        "the two paint orders produced the same document; geometry order was lost"
+    )
+
+    for original in (first, second):
+        assert_designs_equivalent(
+            original, simulation_from_design(design_to_dict(original))
+        )
+
 
 def test_design_helpers_are_not_added_to_the_pinned_rfx_surface():
     """``rfx.interop`` is the import path; ``rfx.__all__`` stays unchanged."""

--- a/tests/test_interop_design_document.py
+++ b/tests/test_interop_design_document.py
@@ -932,8 +932,43 @@ def test_refuses_non_finite_number():
     sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
     sim.add_probe((math.inf, 0.010, 0.010), "ez")
 
-    with pytest.raises(UnsupportedDesignFeature, match="non-finite"):
+    with pytest.raises(UnsupportedDesignFeature, match="not a finite number"):
         design_to_dict(sim)
+
+
+def test_refuses_a_one_shot_iterator_shape_parameter():
+    """A generator in a shape parameter must not silently vanish on re-export.
+
+    The failure this pins is a whole document, not a message: the first export
+    consumed the iterator, so the SECOND export emitted ``points: []`` and
+    produced a complete, schema-valid ``rfx-design-ir/v1`` document with the
+    wire simply absent — which then survived re-import. ``_SHAPE`` delegates to
+    the shape codec and does not re-validate, so the document inherited the
+    hole; it is closed in ``rfx/interop/_validate.check_sequence``. This test
+    lives at the document level because that is where the consequence was.
+    """
+    wire = PolylineWire(
+        points=(p for p in ((0.0, 0.0, 1e-3), (5e-3, 0.0, 1e-3))), radius=1e-4
+    )
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
+    sim.add(wire, material="pec")
+
+    with pytest.raises(UnsupportedDesignFeature, match="no length|one-shot"):
+        design_to_dict(sim)
+
+
+def test_a_second_export_never_loses_geometry():
+    """Export idempotence over every fixture, as a property.
+
+    A shape parameter that is consumed, cached, or lazily evaluated shows up
+    here as a document that shrinks on the second read.
+    """
+    for name, build in sorted(DESIGN_BUILDERS.items()):
+        sim = build()
+        first = design_to_dict(sim)
+        second = design_to_dict(sim)
+        assert len(second["geometry"]) == len(first["geometry"]), name
+        assert first == second, name
 
 
 def test_refuses_soft_source_that_no_builder_could_have_created():

--- a/tests/test_interop_design_document.py
+++ b/tests/test_interop_design_document.py
@@ -1069,6 +1069,32 @@ def test_refuses_inconsistent_boundary_sections():
         simulation_from_design(document)
 
 
+@pytest.mark.parametrize(
+    "path,value",
+    [
+        (("domain", "freq_max"), "20000000000.0"),
+        (("mesh", "dx"), "0.0005"),
+        (("boundary", "legacy", "cpml_layers"), "8"),
+        (("solver", "stencil_order"), "2"),
+    ],
+)
+def test_refuses_a_quoted_numeric(path, value):
+    """``float("1.2e10")`` succeeds, so a quoted numeric must be refused by name.
+
+    The round-trip self-check does catch these, but only with a message showing
+    two identical-looking numbers ('rebuilt 2e10 vs document "2e10"'), which
+    points the reader at the wrong thing. The coercion names the real cause.
+    """
+    document = design_to_dict(_graded_microstrip())
+    node = document
+    for key in path[:-1]:
+        node = node[key]
+    node[path[-1]] = value
+
+    with pytest.raises(UnsupportedDesignFeature, match="not a numb|not an integer"):
+        simulation_from_design(document)
+
+
 def test_refuses_a_non_mapping_document():
     with pytest.raises(UnsupportedDesignFeature, match="must be a mapping"):
         simulation_from_design([1, 2, 3])

--- a/tests/test_interop_design_document.py
+++ b/tests/test_interop_design_document.py
@@ -1220,7 +1220,47 @@ def test_non_portable_annotation_flags_subgridding():
 def test_non_portable_annotation_flags_graded_mesh_and_absorber():
     paths = {note["path"] for note in design_to_dict(_graded_microstrip())["non_portable"]}
     assert "mesh" in paths
-    assert "boundary.legacy.cpml_layers" in paths
+    # The absorber note is keyed on "boundary", not on the legacy scalar, because
+    # an absorber can be defined EITHER by legacy.cpml_layers OR by per-face
+    # lo_thickness/hi_thickness on a BoundarySpec. Keying it on the scalar meant a
+    # real 12-cell-per-face CPML with cpml_layers == 0 was annotated as fully
+    # portable; see test_non_portable_annotation_flags_a_per_face_absorber.
+    assert "boundary" in paths
+
+
+def test_non_portable_annotation_flags_a_per_face_absorber():
+    """An absorber defined only by per-face thickness must still be annotated."""
+    sim = Simulation(
+        freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, cpml_layers=0,
+        boundary=BoundarySpec(
+            x="pec", y="pec",
+            z=Boundary(lo="cpml", hi="cpml", lo_thickness=12, hi_thickness=12)),
+    )
+    sim.add(Box(corner_lo=(0.005, 0.005, 0.005),
+                corner_hi=(0.015, 0.015, 0.015)), material="pec")
+
+    document = design_to_dict(sim)
+    assert document["boundary"]["legacy"]["cpml_layers"] == 0, (
+        "fixture premise: the legacy scalar must be 0 so only the per-face "
+        "thickness defines the absorber"
+    )
+    notes = {note["path"]: note["reason"] for note in document["non_portable"]}
+    assert "boundary" in notes
+    assert "z_lo" in notes["boundary"] and "z_hi" in notes["boundary"]
+
+
+def test_non_portable_annotation_flags_conformal_pec_faces():
+    """rfx-only state the branch's own openEMS emitter refuses outright."""
+    sim = Simulation(
+        freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3,
+        boundary=BoundarySpec(
+            x=Boundary(lo="pec", hi="pec", conformal=True), y="pmc", z="pmc"),
+    )
+    sim.add(Box(corner_lo=(0.005, 0.005, 0.005),
+                corner_hi=(0.015, 0.015, 0.015)), material="pec")
+
+    paths = {note["path"] for note in design_to_dict(sim)["non_portable"]}
+    assert "boundary.spec.x.conformal" in paths
 
 
 def test_non_portable_annotation_is_empty_for_a_plain_pec_design():

--- a/tests/test_interop_design_document.py
+++ b/tests/test_interop_design_document.py
@@ -305,6 +305,23 @@ def _legacy_periodic_axes() -> Simulation:
     return sim
 
 
+def _legacy_all_periodic() -> Simulation:
+    """The one design where the spec path cannot reproduce the legacy views.
+
+    ``set_periodic_axes("xyz")`` leaves ``_boundary == "cpml"`` and
+    ``_cpml_layers == 16``, but the all-periodic spec has no absorbing face, so
+    rebuilding through ``boundary=BoundarySpec(...)`` would derive
+    ``_boundary == "pec"`` and ``_cpml_layers == 0``.  The importer has to
+    reproduce the legacy construction path, not just the spec.
+    """
+    sim = Simulation(
+        freq_max=10e9, domain=(0.020, 0.020, 0.020), dx=1e-3, boundary="cpml", cpml_layers=16
+    )
+    with pytest.warns(DeprecationWarning):
+        sim.set_periodic_axes("xyz")
+    return sim
+
+
 def _auto_mesh_design() -> Simulation:
     """``dx=None``: the mesh choice is deferred to auto_configure at run time."""
     sim = Simulation(freq_max=10e9, domain=(0.020, 0.020, 0.020), boundary="cpml")
@@ -363,6 +380,7 @@ DESIGN_BUILDERS = {
     "mixed_face_boundaries": _mixed_face_boundaries,
     "legacy_pec_faces": _legacy_pec_faces,
     "legacy_periodic_axes": _legacy_periodic_axes,
+    "legacy_all_periodic": _legacy_all_periodic,
     "auto_mesh": _auto_mesh_design,
     "nonuniform_xy": _nonuniform_xy_design,
     "adi_mixed_precision": _adi_mixed_precision,
@@ -537,6 +555,41 @@ def test_waveform_registry_is_pinned():
         )
     assert SUPPORTED_WAVEFORM_KINDS == tuple(sorted(_WAVEFORM_CODECS))
     assert CustomWaveform not in {c.cls for c in _WAVEFORM_CODECS.values()}
+
+
+def test_both_boundary_construction_paths_are_reproduced():
+    """The same ``BoundarySpec`` reached two ways is not the same builder state.
+
+    ``boundary="pec"`` and ``BoundarySpec.uniform("pec")`` produce an identical
+    ``_boundary_spec`` but different ``_pec_faces`` (empty vs all six faces), so
+    an importer that always hands the spec to the constructor would silently
+    change every legacy PEC cavity.  Both paths must round-trip.
+    """
+    legacy = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
+    spec = Simulation(
+        freq_max=10e9,
+        domain=(0.02, 0.02, 0.02),
+        dx=1e-3,
+        boundary=BoundarySpec.uniform("pec"),
+    )
+
+    assert legacy._boundary_spec == spec._boundary_spec
+    assert legacy._pec_faces == set()
+    assert spec._pec_faces == {"x_lo", "x_hi", "y_lo", "y_hi", "z_lo", "z_hi"}
+
+    for original in (legacy, spec):
+        assert_designs_equivalent(original, simulation_from_design(design_to_dict(original)))
+
+
+def test_all_periodic_legacy_design_keeps_its_absorber_fields():
+    """The legacy fallback branch: the spec alone would derive pec/0 layers."""
+    original = _legacy_all_periodic()
+    assert (original._boundary, original._cpml_layers) == ("cpml", 16)
+    assert original._boundary_spec.absorber_type is None
+
+    with pytest.warns(DeprecationWarning):
+        rebuilt = simulation_from_design(design_to_dict(original))
+    assert_designs_equivalent(original, rebuilt)
 
 
 def test_legacy_spec_mirror_matches_the_builder():

--- a/tests/test_interop_design_schema_contract.py
+++ b/tests/test_interop_design_schema_contract.py
@@ -1,0 +1,166 @@
+"""Contract tests pinning the published design-IR schema against the emitter.
+
+A schema that disagrees with the code it documents is worse than no schema: a
+reader validates against it, passes, and believes something false. These tests
+fail if either side drifts.
+
+Pure structural checks — no FDTD.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from rfx import Simulation
+from rfx.api._spec import MaterialSpec
+from rfx.geometry.csg import Box, Cylinder
+from rfx.interop import design_to_dict, design_to_json
+from rfx.interop._design import (
+    DESIGN_SCHEMA_VERSION,
+    _EXCITATION_KEYS,
+    _OBSERVABLE_KEYS,
+    _TOP_LEVEL_KEYS,
+)
+from rfx.interop._shapes import SUPPORTED_SHAPE_KINDS
+from rfx.materials.debye import DebyePole
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_PATH = _REPO_ROOT / "docs/design_notes/schemas/rfx-design-ir-v1.schema.json"
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict:
+    return json.loads(SCHEMA_PATH.read_text())
+
+
+@pytest.fixture(scope="module")
+def documents() -> list[dict]:
+    """A few progressively richer designs, exported."""
+    docs = []
+
+    plain = Simulation(freq_max=10e9, domain=(0.02, 0.012, 0.004), dx=2e-4,
+                       boundary="cpml")
+    plain.add_material("fr4", eps_r=4.3, sigma=0.0)
+    plain.add(Box(corner_lo=(0.0, 0.0, 0.0),
+                  corner_hi=(0.02, 0.012, 0.0015)), material="fr4")
+    plain.add(Cylinder(center=(0.010, 0.006, 0.0008), radius=3e-4,
+                       height=1.5e-3, axis="z"), material="pec")
+    plain.add_probe(position=(0.010, 0.006, 0.0016), component="ez")
+    docs.append(design_to_dict(plain))
+
+    # smooth_grading is what rfx itself recommends for an abrupt profile, and it
+    # inserts transition cells — so the profile is also a harder serialisation
+    # case (uneven values, not three flat blocks).
+    from rfx import smooth_grading
+    dz = np.asarray(smooth_grading(
+        np.concatenate([np.full(20, 2e-4), np.full(30, 5e-5), np.full(20, 2e-4)])))
+    graded = Simulation(freq_max=12e9, domain=(0.02, 0.012, float(dz.sum())),
+                        dx=2e-4, boundary="cpml", cpml_layers=12, dz_profile=dz)
+    graded.add_material(
+        "lossy", eps_r=3.5, sigma=0.02,
+        debye_poles=[DebyePole(delta_eps=1.1, tau=1.7e-12)])
+    graded.add(Box(corner_lo=(0.0, 0.0, 0.0),
+                   corner_hi=(0.02, 0.012, 0.001)), material="lossy")
+    docs.append(design_to_dict(graded))
+
+    pec = Simulation(freq_max=8e9, domain=(0.03, 0.02, 0.01), dx=5e-4,
+                     boundary="pec")
+    pec.add(Box(corner_lo=(0.001, 0.001, 0.001),
+                corner_hi=(0.004, 0.004, 0.004)), material="pec")
+    docs.append(design_to_dict(pec))
+
+    return docs
+
+
+def test_schema_file_exists_and_declares_the_right_identity(schema):
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["$id"].endswith("rfx-design-ir-v1.schema.json")
+    assert schema["properties"]["schema"]["const"] == DESIGN_SCHEMA_VERSION
+
+
+def test_schema_top_level_keys_match_the_emitter(schema):
+    """If the emitter gains or loses a section, this fails rather than the
+    schema silently documenting a stale shape."""
+    assert set(schema["required"]) == _TOP_LEVEL_KEYS
+    assert set(schema["properties"]) == _TOP_LEVEL_KEYS
+    assert schema["additionalProperties"] is False, (
+        "the document is a closed world; the schema must say so"
+    )
+
+
+def test_schema_excitation_keys_match_the_emitter(schema):
+    section = schema["properties"]["excitations"]
+    assert set(section["required"]) == _EXCITATION_KEYS
+    assert set(section["properties"]) == _EXCITATION_KEYS
+    assert section["additionalProperties"] is False
+
+
+def test_schema_observable_keys_match_the_emitter(schema):
+    section = schema["properties"]["observables"]
+    assert set(section["required"]) == _OBSERVABLE_KEYS
+    assert set(section["properties"]) == _OBSERVABLE_KEYS
+    assert section["additionalProperties"] is False
+
+
+def test_schema_shape_kinds_match_the_codec(schema):
+    declared = schema["$defs"]["shape"]["properties"]["kind"]["enum"]
+    assert sorted(declared) == sorted(SUPPORTED_SHAPE_KINDS)
+
+
+def test_schema_shape_kinds_exclude_mesh_shape(schema):
+    """MeshShape is refused, not degraded — the schema must not imply support."""
+    declared = schema["$defs"]["shape"]["properties"]["kind"]["enum"]
+    assert not any("mesh" in kind for kind in declared)
+
+
+@pytest.mark.parametrize("index", [0, 1, 2])
+def test_emitted_documents_validate_against_the_published_schema(
+        schema, documents, index):
+    jsonschema = pytest.importorskip("jsonschema")
+    jsonschema.validate(instance=documents[index], schema=schema)
+
+
+def test_documents_carry_no_derived_or_run_control_state(documents):
+    """The schema forbids extra keys; this pins the specific things that must
+    never appear, since those are the ones a reader would wrongly trust."""
+    forbidden = ("dt", "grid_shape", "axis_pads", "n_steps", "until_decay",
+                 "compute_s_params", "eps_override", "preflight", "result")
+    for document in documents:
+        text = json.dumps(document)
+        for key in forbidden:
+            assert f'"{key}"' not in text, f"{key} must not appear in a design document"
+
+
+def test_json_output_rejects_non_standard_float_tokens(documents):
+    """json.dumps would happily write NaN/Infinity, which no strict reader
+    accepts; the emitter must not rely on that."""
+    plain = Simulation(freq_max=10e9, domain=(0.02, 0.012, 0.004), dx=2e-4,
+                       boundary="cpml")
+    plain.add(Box(corner_lo=(0.0, 0.0, 0.0),
+                  corner_hi=(0.02, 0.012, 0.0015)), material="pec")
+    text = design_to_json(plain)
+    assert "NaN" not in text and "Infinity" not in text
+    json.loads(text)  # strict parse
+
+
+def test_material_payload_shape_is_pinned(schema):
+    """The material payload is the part most likely to drift silently, because
+    artifacts.py already reduces poles to {present, count}."""
+    payload = schema["properties"]["materials"]["additionalProperties"]
+    assert set(payload["required"]) == {
+        "eps_r", "sigma", "mu_r", "chi3", "debye_poles", "lorentz_poles"}
+
+    live = {f.name for f in __import__("dataclasses").fields(MaterialSpec)}
+    assert set(payload["required"]) == live, (
+        "MaterialSpec and the published schema disagree"
+    )
+
+    debye = payload["properties"]["debye_poles"]["items"]
+    lorentz = payload["properties"]["lorentz_poles"]["items"]
+    assert set(debye["required"]) == set(DebyePole._fields)
+    from rfx.materials.lorentz import LorentzPole
+    assert set(lorentz["required"]) == set(LorentzPole._fields)

--- a/tests/test_interop_design_schema_contract.py
+++ b/tests/test_interop_design_schema_contract.py
@@ -1,8 +1,14 @@
 """Contract tests pinning the published design-IR schema against the emitter.
 
 A schema that disagrees with the code it documents is worse than no schema: a
-reader validates against it, passes, and believes something false. These tests
-fail if either side drifts.
+reader validates against it, passes, and believes something false.
+
+Scope of what these tests actually pin: the top-level, excitation and observable
+key sets; the shape-kind vocabulary; the material payload including pole
+parameters; and validation of every design fixture in
+``tests/test_interop_design_document.py`` against the published schema. Entry
+field sets are pinned only insofar as a fixture populates that family — the
+coverage guard below names any family no fixture exercises.
 
 Pure structural checks — no FDTD.
 """
@@ -10,6 +16,7 @@ Pure structural checks — no FDTD.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -29,6 +36,11 @@ from rfx.interop._shapes import SUPPORTED_SHAPE_KINDS
 from rfx.materials.debye import DebyePole
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# The design fixtures live in the sibling test module; reuse them rather than
+# maintaining a second, thinner set that would silently stop covering families.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from test_interop_design_document import DESIGN_BUILDERS  # noqa: E402
 SCHEMA_PATH = _REPO_ROOT / "docs/design_notes/schemas/rfx-design-ir-v1.schema.json"
 
 
@@ -122,6 +134,63 @@ def test_emitted_documents_validate_against_the_published_schema(
         schema, documents, index):
     jsonschema = pytest.importorskip("jsonschema")
     jsonschema.validate(instance=documents[index], schema=schema)
+
+
+@pytest.mark.parametrize("name", sorted(DESIGN_BUILDERS))
+def test_every_design_fixture_validates_against_the_published_schema(
+        schema, name):
+    """Validate the FULL fixture set, not three ad-hoc documents.
+
+    The three documents above carry no entries at all for most sections
+    (ports of every family, the coax termination lists, tfsf, lumped_rlc,
+    dft_planes, flux_monitors, ntff, thin_conductors, refinement), so they
+    exercised only the top level. The schema pins each entry family with
+    ``additionalProperties: false``, which means adding a field to a record
+    registry without updating the schema would leave every real document of
+    that family invalid while every unit test still passed. Driving the whole
+    builder set is what makes the schema's entry level load-bearing.
+    """
+    jsonschema = pytest.importorskip("jsonschema")
+    document = design_to_dict(DESIGN_BUILDERS[name]())
+    jsonschema.validate(instance=document, schema=schema)
+
+
+def test_the_fixture_set_actually_covers_the_entry_families(schema):
+    """Guard against the above becoming vacuous again.
+
+    If a section is never populated by any fixture, its schema branch is
+    unexercised and this test names it rather than letting the coverage quietly
+    rot.
+    """
+    populated: set[str] = set()
+    for build in DESIGN_BUILDERS.values():
+        document = design_to_dict(build())
+        for section in ("geometry", "thin_conductors"):
+            if document[section]:
+                populated.add(section)
+        for key, value in document["excitations"].items():
+            if value:
+                populated.add(f"excitations.{key}")
+        for key, value in document["observables"].items():
+            if value:
+                populated.add(f"observables.{key}")
+        if document["refinement"]:
+            populated.add("refinement")
+
+    expected = {
+        "geometry", "thin_conductors", "refinement",
+        "excitations.soft_sources", "excitations.lumped_ports",
+        "excitations.msl_ports", "excitations.waveguide_ports",
+        "excitations.coaxial_ports", "excitations.floquet_ports",
+        "excitations.tfsf", "excitations.lumped_rlc",
+        "observables.probes", "observables.dft_planes",
+        "observables.flux_monitors", "observables.ntff",
+    }
+    missing = sorted(expected - populated)
+    assert not missing, (
+        f"no design fixture populates {missing}, so the published schema's "
+        f"branch for each is validated by nothing"
+    )
 
 
 def test_documents_carry_no_derived_or_run_control_state(documents):

--- a/tests/test_interop_material_codec.py
+++ b/tests/test_interop_material_codec.py
@@ -127,6 +127,30 @@ def test_missing_field_in_payload_is_refused():
         material_from_dict(payload)
 
 
+@pytest.mark.parametrize("field", ["eps_r", "sigma", "mu_r", "chi3"])
+def test_non_finite_scalar_is_refused(field):
+    spec = MaterialSpec(**{field: float("nan")})
+    with pytest.raises(UnsupportedDesignFeature, match="not a finite number"):
+        material_to_dict(spec)
+
+
+def test_non_finite_pole_parameter_is_refused_naming_the_pole():
+    spec = MaterialSpec(
+        eps_r=1.0,
+        debye_poles=[DebyePole(delta_eps=1.0, tau=float("inf"))],
+    )
+    with pytest.raises(UnsupportedDesignFeature,
+                       match=r"debye_poles\[0\]\.tau is inf"):
+        material_to_dict(spec)
+
+
+def test_non_finite_is_refused_on_import_too():
+    payload = material_to_dict(_dispersive())
+    payload["lorentz_poles"][0]["kappa"] = float("nan")
+    with pytest.raises(UnsupportedDesignFeature, match="not a finite number"):
+        material_from_dict(payload)
+
+
 def test_unknown_field_in_payload_is_refused():
     payload = material_to_dict(_fr4())
     payload["tan_delta"] = 0.02

--- a/tests/test_interop_material_codec.py
+++ b/tests/test_interop_material_codec.py
@@ -1,0 +1,134 @@
+"""Contract tests for the design-interop material codec.
+
+Pure structural checks — no FDTD.  The existing scene artifact reduces
+dispersion pole lists to ``{"present", "count"}``, so a material rebuilt from
+it would silently lose its dispersion; these tests pin the lossless path.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+from rfx.api._spec import MaterialSpec
+from rfx.interop import UnsupportedDesignFeature
+from rfx.interop._materials import (
+    _POLE_FIELDS,
+    _SCALAR_FIELDS,
+    material_from_dict,
+    material_to_dict,
+    materials_from_dict,
+    materials_to_dict,
+)
+from rfx.materials.debye import DebyePole
+from rfx.materials.lorentz import LorentzPole
+
+
+def _fr4() -> MaterialSpec:
+    return MaterialSpec(eps_r=4.3, sigma=0.0, mu_r=1.0)
+
+
+def _dispersive() -> MaterialSpec:
+    return MaterialSpec(
+        eps_r=2.1,
+        sigma=1e-3,
+        mu_r=1.2,
+        chi3=3.5e-22,
+        debye_poles=[DebyePole(delta_eps=1.4, tau=2.3e-12)],
+        lorentz_poles=[
+            LorentzPole(omega_0=2 * 3.141592653589793 * 6e9, delta=1e8, kappa=0.7),
+            LorentzPole(omega_0=2 * 3.141592653589793 * 9e9, delta=2e8, kappa=0.3),
+        ],
+    )
+
+
+def test_registry_pins_live_material_spec_fields():
+    """A new MaterialSpec field must fail here, not vanish from exports."""
+    live = {f.name for f in dataclasses.fields(MaterialSpec)}
+    recorded = set(_SCALAR_FIELDS) | set(_POLE_FIELDS)
+    assert live == recorded, (
+        "MaterialSpec and the interop registry disagree; update "
+        "rfx/interop/_materials.py"
+    )
+
+
+@pytest.mark.parametrize("kind", sorted(_POLE_FIELDS))
+def test_registry_pins_live_pole_parameters(kind):
+    pole_cls, names = _POLE_FIELDS[kind]
+    assert tuple(pole_cls._fields) == names, (
+        f"{pole_cls.__name__} parameters changed; update "
+        f"rfx/interop/_materials.py"
+    )
+
+
+@pytest.mark.parametrize("factory", [_fr4, _dispersive])
+def test_round_trip_through_json_text(factory):
+    original = factory()
+    rebuilt = material_from_dict(json.loads(json.dumps(material_to_dict(original))))
+    assert rebuilt == original
+
+
+def test_dispersion_poles_survive_with_parameters():
+    """The gap this codec exists to close (rfx/artifacts.py:245)."""
+    payload = material_to_dict(_dispersive())
+    assert payload["debye_poles"] == [{"delta_eps": 1.4, "tau": 2.3e-12}]
+    assert len(payload["lorentz_poles"]) == 2
+    assert payload["lorentz_poles"][0]["kappa"] == pytest.approx(0.7)
+    assert payload["chi3"] == pytest.approx(3.5e-22)
+
+
+def test_absent_poles_stay_none_not_empty_list():
+    """None and [] are different states; the codec must not conflate them."""
+    payload = material_to_dict(_fr4())
+    assert payload["debye_poles"] is None
+    assert payload["lorentz_poles"] is None
+
+    empty = MaterialSpec(eps_r=1.0, debye_poles=[])
+    assert material_to_dict(empty)["debye_poles"] == []
+    assert material_from_dict(material_to_dict(empty)).debye_poles == []
+
+
+def test_mapping_round_trip():
+    materials = {"fr4": _fr4(), "resin": _dispersive()}
+    rebuilt = materials_from_dict(
+        json.loads(json.dumps(materials_to_dict(materials))))
+    assert rebuilt == materials
+
+
+def test_non_material_spec_is_refused():
+    class FakeMaterial:
+        eps_r = 4.3
+        sigma = 0.0
+        mu_r = 1.0
+
+    with pytest.raises(UnsupportedDesignFeature, match="expected MaterialSpec"):
+        material_to_dict(FakeMaterial())
+
+
+def test_foreign_pole_type_is_refused():
+    bogus = MaterialSpec(eps_r=1.0, debye_poles=[(1.4, 2.3e-12)])
+    with pytest.raises(UnsupportedDesignFeature, match="expected DebyePole"):
+        material_to_dict(bogus)
+
+
+def test_pole_parameter_mismatch_is_refused():
+    payload = material_to_dict(_dispersive())
+    del payload["debye_poles"][0]["tau"]
+    with pytest.raises(UnsupportedDesignFeature, match="parameter mismatch"):
+        material_from_dict(payload)
+
+
+def test_missing_field_in_payload_is_refused():
+    payload = material_to_dict(_fr4())
+    del payload["mu_r"]
+    with pytest.raises(UnsupportedDesignFeature, match="missing="):
+        material_from_dict(payload)
+
+
+def test_unknown_field_in_payload_is_refused():
+    payload = material_to_dict(_fr4())
+    payload["tan_delta"] = 0.02
+    with pytest.raises(UnsupportedDesignFeature, match="unknown="):
+        material_from_dict(payload)

--- a/tests/test_interop_openems_emitter.py
+++ b/tests/test_interop_openems_emitter.py
@@ -485,8 +485,13 @@ def test_msl_port_span_and_direction():
     assert p0.stop_mm[2] == pytest.approx(0.0)
     assert p0.exc_dir == 2 and p0.prop_dir == 0
     assert plan.driven_port_numbers == (1,)
-    assert any("no rfx counterpart" in note or "msl" in note.lower()
-               for note in plan.approximations)
+    # The span, and the direction convention it depends on, must be itemised:
+    # nothing in this repository pins add_msl_port's direction against an
+    # openEMS measurement, so a silent choice here would be unreviewable.
+    msl_notes = [n for n in plan.approximations if "msl_port_w_cells" in n]
+    assert len(msl_notes) == 1
+    assert "NO rfx counterpart" in msl_notes[0]
+    assert "OPPOSITE reading" in msl_notes[0]
 
 
 def test_msl_port_w_cells_below_the_openems_assert_is_refused():

--- a/tests/test_interop_openems_emitter.py
+++ b/tests/test_interop_openems_emitter.py
@@ -928,3 +928,49 @@ def test_generated_script_runs_under_openems_and_is_finite_and_passive():
     # not, which is the failure mode this cheap case exists to catch.
     s11 = np.array([complex(re, im) for re, im in payload["s_matrix"]["S11"]])
     assert np.all(np.abs(s11) > 0.9)
+
+
+def test_upml_collapse_onto_pml_is_itemised():
+    """rfx has two absorber formulations; openEMS has one. Say so.
+
+    rfx refuses to mix CPML and UPML across faces (``rfx/boundaries/spec.py:182``
+    — "the update stencils differ"), so a design is all-one or all-the-other.
+    Both map to the same ``PML_<N>`` string, which is exactly why the collapse
+    has to be stated rather than inferred from the boundary list.
+    """
+    sim = Simulation(
+        freq_max=10e9, domain=(0.010, 0.010, 0.010), dx=1.0e-3,
+        boundary="upml", cpml_layers=8,
+    )
+    sim.add_port(position=(0.005, 0.005, 0.005), component="ez",
+                 impedance=50.0, waveform=_PULSE)
+    plan = plan_openems_projection(design_to_dict(sim))
+
+    assert plan.boundary == ("PML_8",) * 6
+    notes = [n for n in plan.approximations if "UPML faces" in n]
+    assert len(notes) == 1
+    assert "x_lo, x_hi, y_lo, y_hi, z_lo, z_hi" in notes[0]
+    assert "The layer count survives; the absorber does not" in notes[0]
+
+    # A pure-cpml design must not carry it.
+    quiet = plan_openems_projection(design_to_dict(_thru()))
+    assert not [n for n in quiet.approximations if "UPML faces" in n]
+
+
+def test_differing_per_face_pml_depth_is_flagged_as_assumed_not_measured():
+    sim = Simulation(
+        freq_max=10e9, domain=(0.010, 0.010, 0.010), dx=1.0e-3,
+        boundary=BoundarySpec(x=Boundary(lo="cpml", hi="cpml", lo_thickness=5),
+                              y="cpml", z="cpml"),
+        cpml_layers=12,
+    )
+    sim.add_port(position=(0.005, 0.005, 0.005), component="ez",
+                 impedance=50.0, waveform=_PULSE)
+    plan = plan_openems_projection(design_to_dict(sim))
+    notes = [n for n in plan.approximations if "per-face PML depths differ" in n]
+    assert len(notes) == 1
+    assert "not observed" in notes[0]
+
+    uniform = plan_openems_projection(design_to_dict(_thru()))
+    assert not [n for n in uniform.approximations
+                if "per-face PML depths differ" in n]

--- a/tests/test_interop_openems_emitter.py
+++ b/tests/test_interop_openems_emitter.py
@@ -485,13 +485,117 @@ def test_msl_port_span_and_direction():
     assert p0.stop_mm[2] == pytest.approx(0.0)
     assert p0.exc_dir == 2 and p0.prop_dir == 0
     assert plan.driven_port_numbers == (1,)
-    # The span, and the direction convention it depends on, must be itemised:
-    # nothing in this repository pins add_msl_port's direction against an
-    # openEMS measurement, so a silent choice here would be unreviewable.
+    # msl_port_w_cells has no rfx counterpart, so it must surface in the header
+    # as an assumption the reader is accepting — never buried as a literal.
     msl_notes = [n for n in plan.approximations if "msl_port_w_cells" in n]
     assert len(msl_notes) == 1
     assert "NO rfx counterpart" in msl_notes[0]
-    assert "OPPOSITE reading" in msl_notes[0]
+    assert "ACCEPTING THIS" in msl_notes[0]
+    assert "MSL_NotchFilter.py" in msl_notes[0]
+
+
+def test_msl_span_extends_along_the_rfx_propagation_direction():
+    """The MSL span sense, pinned against the rfx implementation.
+
+    rfx's two port builders use **opposite** ``direction=`` conventions, and
+    this test exists because getting the sense wrong yields a plausible-looking
+    S21 with the wrong reference sense rather than an obvious failure.
+
+    ``add_port``: outward normal — ``rfx/api/__init__.py:1116-1117`` ("from the
+    port cell into the external world"), confirmed by
+    ``rfx/probes/refplane.py:196-198`` ("The reference planes go the OPPOSITE
+    way (into the DUT)", ``outboard_sign = -1`` for ``'+'``).
+
+    ``add_msl_port``: propagation direction — ``rfx/sources/msl_port.py:50-51``
+    ("the direction the launched wave propagates away from the feed plane"),
+    confirmed twice in the implementation: probe placement at
+    ``i_feed + sign*offset`` with ``sign = +1`` for ``'+x'``, i.e. downstream
+    into the line (``:865``, ``:894``), and the TFSF auxiliary H plane behind
+    the feed at ``i-1`` for ``'+x'``, the pattern that launches a ``+x`` wave
+    (``:733``).
+
+    So for an MSL port the span extends ALONG ``direction=``, with no negation.
+    The asserted consequence is physical, not cosmetic: both ports' spans must
+    point INTO the shared trace, i.e. toward each other.
+    """
+    y_mid = _THRU_DOMAIN[1] / 2
+    sim = Simulation(
+        freq_max=10e9, domain=_THRU_DOMAIN, dx=_THRU_DX,
+        boundary=BoundarySpec(x="cpml", y="cpml",
+                              z=Boundary(lo="pec", hi="cpml")),
+        cpml_layers=8,
+    )
+    sim.add(Box((_THRU_X1, y_mid - _THRU_W / 2, _THRU_H),
+                (_THRU_X2, y_mid + _THRU_W / 2, _THRU_H + _THRU_DX)),
+            material="pec")
+    pulse = GaussianPulse(f0=5e9, bandwidth=0.8)
+    # Left port launches +x (rightwards, into the line); right port launches
+    # -x (leftwards, into the line).
+    sim.add_msl_port((_THRU_X1, y_mid, 0.0), width=_THRU_W, height=_THRU_H,
+                     direction="+x", waveform=pulse)
+    sim.add_msl_port((_THRU_X2, y_mid, 0.0), width=_THRU_W, height=_THRU_H,
+                     direction="-x", excite=False)
+
+    plan = plan_openems_projection(design_to_dict(sim), msl_port_w_cells=6)
+    left, right = plan.ports
+    span = 6 * _THRU_DX / UNIT_M
+
+    # openEMS derives propagation from sign(stop - start) on the prop axis.
+    assert left.stop_mm[0] - left.start_mm[0] == pytest.approx(+span)
+    assert right.stop_mm[0] - right.start_mm[0] == pytest.approx(-span)
+
+    # The physical statement: both spans point into the trace, so each span's
+    # far end is strictly inside the port-to-port interval.
+    x_lo, x_hi = _THRU_X1 / UNIT_M, _THRU_X2 / UNIT_M
+    assert x_lo < left.stop_mm[0] < x_hi
+    assert x_lo < right.stop_mm[0] < x_hi
+    # ... and they approach each other rather than diverging.
+    assert left.stop_mm[0] < right.stop_mm[0]
+
+    sense = [n for n in plan.approximations if "MSL span SENSE" in n]
+    assert len(sense) == 1
+    assert "NO negation" in sense[0]
+    assert "msl_port_w_cells" not in sense[0], "the two facts stay separable"
+
+
+def test_wire_port_direction_is_reported_as_not_carried():
+    """``add_port``'s ``direction`` has no openEMS knob, so it must be itemised.
+
+    rfx uses it only to orient its own V/I → (incoming, outgoing) decomposition;
+    openEMS's lumped port derives its sense from ``sign(stop - start)`` along
+    the *excitation* axis and decomposes with its own convention.  The geometry
+    is fully determined without it, so this is not a refusal — but it is also
+    not something that may vanish silently.
+    """
+    plan = plan_openems_projection(design_to_dict(_thru()))
+    notes = [n for n in plan.approximations if "direction= is NOT carried" in n]
+    assert len(notes) == 1
+    assert "excitations.lumped_ports[0].direction='-x'" in notes[0]
+    assert "excitations.lumped_ports[1].direction='+x'" in notes[0]
+    assert "OUTWARD normal" in notes[0]
+
+    # A design that never set direction must not carry the note.
+    quiet = plan_openems_projection(_cavity_doc())
+    assert not [n for n in quiet.approximations if "direction= is NOT carried" in n]
+
+
+def test_header_states_the_measured_port_convention_gap():
+    """≈0.20 in |S| is the floor on any lumped/wire agreement claim."""
+    plan = plan_openems_projection(design_to_dict(_thru()))
+    gap = [n for n in plan.approximations if "0.20" in n]
+    assert len(gap) == 1
+    note = gap[0]
+    assert "build_wire_openems_broad_envelope.py:12-16" in note
+    assert "FLOOR on any agreement claim" in note
+    # Explicitly relate it to the cv06b gates so nobody reads a pass at this
+    # tolerance as evidence that the port models agree.
+    assert "0.13" in note and "0.25" in note
+    assert "NOT evidence that the port models" in note
+
+    # And it must reach the generated artifact, not just the plan.
+    script = emit_openems_script(design_to_dict(_thru()))
+    flat = " ".join(script.split())
+    assert "0.20 is therefore the FLOOR" in flat
 
 
 def test_msl_port_w_cells_below_the_openems_assert_is_refused():

--- a/tests/test_interop_openems_emitter.py
+++ b/tests/test_interop_openems_emitter.py
@@ -1,0 +1,821 @@
+"""Contract tests for the rfx → openEMS script emitter.
+
+Two kinds of test live here and they prove different things:
+
+*Fast, solver-free tests* pin the **projection arithmetic**: the absorber span
+(the highest-severity translation hazard), the boundary-string spelling, the
+synthesised paint-order priority, the port-edge mesh-line coincidence, the
+itemised approximation header, and every refusal path.  These need no openEMS.
+
+*One executed test* (marked ``slow``) generates a script for a small PEC cavity,
+runs it under the real openEMS, and asserts the artifact is finite and passive.
+It proves the generated script is **runnable and self-consistent**.  It does
+**not** prove physics agreement with rfx — the absorber formulations, port
+models and reference planes all differ, and the generated header says so.
+"""
+
+from __future__ import annotations
+
+import ast
+import copy
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import numpy as np
+import pytest
+
+from rfx.api import Simulation
+from rfx.boundaries.spec import Boundary, BoundarySpec
+from rfx.geometry import Box, Cylinder, Sphere
+from rfx.interop import UnsupportedDesignFeature, design_to_dict
+from rfx.interop.emitters import (
+    OPENEMS_EMITTER_VERSION,
+    emit_openems_script,
+    plan_openems_projection,
+)
+from rfx.interop.emitters.openems import PEC_SIGMA_THRESHOLD, UNIT_M
+from rfx.sources.sources import GaussianPulse
+
+# ---------------------------------------------------------------------------
+# Fixtures — designs, not documents, so the exporter stays in the loop
+# ---------------------------------------------------------------------------
+
+_PULSE = GaussianPulse(f0=1.0e9, bandwidth=0.8, amplitude=1.0)
+
+# Matches scripts/diagnostics/build_lumped_openems_sparameter_comparison.py's
+# DEFAULT_CASE: a coarse two-port PEC box that exercises only constructs with a
+# 1:1 openEMS counterpart, so it is the cheapest thing that can actually run.
+_CAVITY_DOMAIN = (0.030, 0.020, 0.015)
+_CAVITY_DX = 5.0e-3
+_CAVITY_FREQS = (0.8e9, 1.0e9, 1.2e9, 1.5e9, 1.8e9)
+
+# Matches the committed thru fixture in tests/test_refplane_port_waves.py.
+_THRU_DX = 0.5e-3
+_THRU_DOMAIN = (0.032, 0.020, 0.010)
+_THRU_H = 1.0e-3
+_THRU_W = 5.0e-3
+_THRU_X1, _THRU_X2 = 0.008, 0.024
+
+
+def _cavity() -> Simulation:
+    sim = Simulation(
+        freq_max=2.0e9, domain=_CAVITY_DOMAIN, dx=_CAVITY_DX,
+        boundary="pec", cpml_layers=0,
+    )
+    sim.add_port(position=(0.010, 0.010, 0.005), component="ez",
+                 impedance=50.0, waveform=_PULSE)
+    sim.add_port(position=(0.020, 0.010, 0.005), component="ez",
+                 impedance=50.0, excite=False)
+    return sim
+
+
+def _thru(*, msl: bool = False) -> Simulation:
+    y_mid = _THRU_DOMAIN[1] / 2
+    sim = Simulation(
+        freq_max=10e9, domain=_THRU_DOMAIN, dx=_THRU_DX,
+        boundary=BoundarySpec(x="cpml", y="cpml",
+                              z=Boundary(lo="pec", hi="cpml")),
+        cpml_layers=8,
+    )
+    sim.add(
+        Box((_THRU_X1, y_mid - _THRU_W / 2, _THRU_H),
+            (_THRU_X2, y_mid + _THRU_W / 2, _THRU_H + _THRU_DX)),
+        material="pec",
+    )
+    pulse = GaussianPulse(f0=5e9, bandwidth=0.8)
+    if msl:
+        sim.add_msl_port((_THRU_X1, y_mid, 0.0), width=_THRU_W, height=_THRU_H,
+                         direction="+x", waveform=pulse)
+        sim.add_msl_port((_THRU_X2, y_mid, 0.0), width=_THRU_W, height=_THRU_H,
+                         direction="-x", excite=False)
+    else:
+        sim.add_port(position=(_THRU_X1, y_mid, 0.0), component="ez",
+                     impedance=50.0, extent=_THRU_H, waveform=pulse,
+                     direction="-x")
+        sim.add_port(position=(_THRU_X2, y_mid, 0.0), component="ez",
+                     impedance=50.0, extent=_THRU_H, waveform=pulse,
+                     direction="+x")
+    return sim
+
+
+def _cavity_doc() -> dict:
+    return design_to_dict(_cavity())
+
+
+def _refuses(match: str):
+    return pytest.raises(UnsupportedDesignFeature, match=match)
+
+
+# ===========================================================================
+# D1 — the absorber span, the highest-severity translation hazard
+# ===========================================================================
+
+@pytest.mark.parametrize(
+    "cpml_layers, boundary",
+    [
+        (0, "pec"),
+        (8, "cpml"),
+        (16, "cpml"),
+        (16, BoundarySpec(x="cpml", y="cpml", z=Boundary(lo="pec", hi="cpml"))),
+        (12, BoundarySpec(x=Boundary(lo="cpml", hi="cpml"),
+                          y=Boundary(lo="pmc", hi="cpml"),
+                          z=Boundary(lo="pec", hi="pec"))),
+        (20, BoundarySpec(x=Boundary(lo="cpml", hi="cpml", lo_thickness=6),
+                          y="cpml", z="cpml")),
+    ],
+)
+def test_mesh_span_reproduces_rfx_grid_shape(cpml_layers, boundary):
+    """The emitted mesh must have exactly the rfx grid's line count per axis.
+
+    rfx adds absorber cells *outside* the user domain
+    (``nx = ceil(Lx/dx) + 1 + pad_lo + pad_hi``, and ``(idx - axis_pads[ax])*dx``
+    recovers user coordinates); openEMS ``PML_<N>`` consumes ``N`` cells
+    *inside* the mesh it is handed.  Matching the rfx ``Grid.shape`` line count
+    is therefore the direct statement that the clear region survived the
+    projection.  ``Grid`` itself is the oracle — not a number copied into the
+    test — so this test tracks rfx if the padding rule ever changes.
+    """
+    sim = Simulation(
+        freq_max=10e9, domain=(0.021, 0.013, 0.007), dx=1.0e-3,
+        boundary=boundary, cpml_layers=cpml_layers,
+    )
+    sim.add_port(position=(0.010, 0.006, 0.003), component="ez",
+                 impedance=50.0, waveform=_PULSE)
+
+    plan = plan_openems_projection(design_to_dict(sim))
+    assert plan.grid_shape == sim._build_grid().shape
+
+
+def test_mesh_extends_outside_the_user_domain_by_the_pads():
+    """The added margin is on the outside, and ``PML_<N>`` eats exactly it."""
+    sim = Simulation(
+        freq_max=10e9, domain=(0.010, 0.010, 0.010), dx=1.0e-3,
+        boundary="cpml", cpml_layers=8,
+    )
+    sim.add_port(position=(0.005, 0.005, 0.005), component="ez",
+                 impedance=50.0, waveform=_PULSE)
+    plan = plan_openems_projection(design_to_dict(sim))
+
+    assert plan.n_cells == (10, 10, 10)
+    assert plan.pad_lo == (8, 8, 8)
+    assert plan.pad_hi == (8, 8, 8)
+    # 11 domain lines + 8 outside each face = 27, the measured rfx shape.
+    assert plan.grid_shape == (27, 27, 27)
+
+    dx_mm = plan.dx_m / UNIT_M
+    for axis in ("x", "y", "z"):
+        lines = plan.mesh_lines_mm[axis]
+        assert lines[0] == pytest.approx(-8 * dx_mm)
+        assert lines[-1] == pytest.approx((10 + 8) * dx_mm)
+        # The user domain starts at exactly 0.0 — the coordinate frame the rfx
+        # design is written in must survive.
+        assert 0.0 in lines
+        assert pytest.approx(10 * dx_mm) in lines
+
+
+def test_pec_face_gets_no_pad_even_on_a_cpml_axis():
+    """Mirrors ``Grid._face_pad``: a PEC face pads zero, so no margin is added."""
+    plan = plan_openems_projection(design_to_dict(_thru()))
+    assert plan.pad_lo == (8, 8, 0)
+    assert plan.pad_hi == (8, 8, 8)
+    assert plan.mesh_lines_mm["z"][0] == 0.0
+
+
+# ===========================================================================
+# Boundary strings
+# ===========================================================================
+
+def test_pml_string_uses_underscore_and_the_design_layer_count():
+    """``'PML_<N>'``; the hyphen form raises "Unknown boundary condition"."""
+    for layers in (4, 8, 16, 20):
+        sim = Simulation(
+            freq_max=10e9, domain=(0.010, 0.010, 0.010), dx=1.0e-3,
+            boundary="cpml", cpml_layers=layers,
+        )
+        sim.add_port(position=(0.005, 0.005, 0.005), component="ez",
+                     impedance=50.0, waveform=_PULSE)
+        plan = plan_openems_projection(design_to_dict(sim))
+        assert plan.boundary == (f"PML_{layers}",) * 6
+        assert "PML-" not in "".join(plan.boundary)
+
+
+def test_boundary_order_is_xmin_xmax_ymin_ymax_zmin_zmax():
+    sim = Simulation(
+        freq_max=10e9, domain=(0.010, 0.010, 0.010), dx=1.0e-3,
+        boundary=BoundarySpec(x=Boundary(lo="pec", hi="cpml"),
+                              y=Boundary(lo="pmc", hi="pmc"),
+                              z=Boundary(lo="cpml", hi="pec")),
+        cpml_layers=6,
+    )
+    sim.add_port(position=(0.005, 0.005, 0.005), component="ez",
+                 impedance=50.0, waveform=_PULSE)
+    plan = plan_openems_projection(design_to_dict(sim))
+    assert plan.boundary == ("PEC", "PML_6", "PMC", "PMC", "PML_6", "PEC")
+
+
+def test_per_face_thickness_is_carried_into_the_string():
+    sim = Simulation(
+        freq_max=10e9, domain=(0.010, 0.010, 0.010), dx=1.0e-3,
+        boundary=BoundarySpec(x=Boundary(lo="cpml", hi="cpml", lo_thickness=5),
+                              y="cpml", z="cpml"),
+        cpml_layers=12,
+    )
+    sim.add_port(position=(0.005, 0.005, 0.005), component="ez",
+                 impedance=50.0, waveform=_PULSE)
+    plan = plan_openems_projection(design_to_dict(sim))
+    assert plan.boundary[0] == "PML_5"
+    assert plan.boundary[1] == "PML_12"
+    assert plan.pad_lo[0] == 5 and plan.pad_hi[0] == 12
+
+
+def test_mur_is_never_emitted():
+    """MUR is a documented trap: 8 % resonance error, and unstable on a dielectric."""
+    plan = plan_openems_projection(design_to_dict(_thru()))
+    assert "MUR" not in "".join(plan.boundary)
+    script = emit_openems_script(design_to_dict(_thru()))
+    assert "'MUR'" not in script and '"MUR"' not in script
+
+
+# ===========================================================================
+# D6 — paint order → priority
+# ===========================================================================
+
+def test_paint_order_maps_to_monotonic_priority_within_a_material_class():
+    """Later paint must win, which in openEMS means a strictly higher priority."""
+    sim = Simulation(
+        freq_max=10e9, domain=(0.010, 0.010, 0.010), dx=1.0e-3,
+        boundary="pec", cpml_layers=0,
+    )
+    sim.add_material("low", eps_r=2.0)
+    sim.add_material("high", eps_r=9.0)
+    for index in range(4):
+        name = "low" if index % 2 == 0 else "high"
+        z = 0.001 * index
+        sim.add(Box((0.001, 0.001, z), (0.009, 0.009, z + 0.001)), material=name)
+    sim.add_port(position=(0.005, 0.005, 0.005), component="ez",
+                 impedance=50.0, waveform=_PULSE)
+
+    plan = plan_openems_projection(design_to_dict(sim))
+    priorities = [g.priority for g in plan.geometry]
+    assert priorities == sorted(priorities)
+    assert len(set(priorities)) == len(priorities)
+    assert [g.index for g in plan.geometry] == [0, 1, 2, 3]
+
+
+def test_metal_outranks_ports_which_outrank_dielectrics():
+    """rfx applies PEC as a union mask *on top of* the painted dielectrics.
+
+    ``rfx/api/_compile.py`` accumulates every ``sigma >= 1e6`` material into a
+    single PEC mask applied regardless of paint position, and marks port cells
+    inside PEC as dead (issue #318).  So the faithful openEMS ordering is
+    metal > port > dielectric, not a flat ``priority = paint index``.
+    """
+    sim = Simulation(
+        freq_max=10e9, domain=(0.010, 0.010, 0.010), dx=1.0e-3,
+        boundary="pec", cpml_layers=0,
+    )
+    sim.add_material("sub", eps_r=4.4)
+    # PEC painted FIRST, dielectric SECOND: in rfx the PEC still wins.
+    sim.add(Box((0.002, 0.002, 0.002), (0.008, 0.008, 0.003)), material="pec")
+    sim.add(Box((0.001, 0.001, 0.001), (0.009, 0.009, 0.004)), material="sub")
+    sim.add_port(position=(0.005, 0.005, 0.006), component="ez",
+                 impedance=50.0, waveform=_PULSE)
+
+    plan = plan_openems_projection(design_to_dict(sim))
+    metal = [g for g in plan.geometry if g.is_metal]
+    dielectric = [g for g in plan.geometry if not g.is_metal]
+    port_priority = {p.priority for p in plan.ports}
+    assert len(metal) == 1 and len(dielectric) == 1
+    assert len(port_priority) == 1
+    port = port_priority.pop()
+    assert dielectric[0].priority < port < metal[0].priority
+
+
+def test_pec_by_sigma_becomes_addmetal_not_addmaterial():
+    sim = Simulation(
+        freq_max=10e9, domain=(0.010, 0.010, 0.010), dx=1.0e-3,
+        boundary="pec", cpml_layers=0,
+    )
+    sim.add_material("copperish", eps_r=1.0, sigma=PEC_SIGMA_THRESHOLD * 10)
+    sim.add_material("lossy", eps_r=4.4, sigma=0.01)
+    sim.add(Box((0.001, 0.001, 0.001), (0.009, 0.009, 0.002)),
+            material="copperish")
+    sim.add(Box((0.001, 0.001, 0.003), (0.009, 0.009, 0.004)), material="lossy")
+    sim.add_port(position=(0.005, 0.005, 0.006), component="ez",
+                 impedance=50.0, waveform=_PULSE)
+
+    script = emit_openems_script(design_to_dict(sim))
+    assert "csx.AddMetal('metal_copperish')" in script
+    assert "csx.AddMaterial('mat_lossy', epsilon=4.4, kappa=0.01)" in script
+
+
+def test_cylinder_becomes_axis_endpoints_plus_radius():
+    sim = Simulation(
+        freq_max=10e9, domain=(0.010, 0.010, 0.010), dx=1.0e-3,
+        boundary="pec", cpml_layers=0,
+    )
+    sim.add(Cylinder(center=(0.005, 0.005, 0.004), radius=6.0e-4,
+                     height=2.0e-3, axis="z"), material="pec")
+    sim.add_port(position=(0.005, 0.005, 0.008), component="ez",
+                 impedance=50.0, waveform=_PULSE)
+
+    plan = plan_openems_projection(design_to_dict(sim))
+    cylinder = plan.geometry[0]
+    assert cylinder.kind == "cylinder"
+    # centre 4 mm, height 2 mm -> endpoints 3 mm and 5 mm, radius 0.6 mm.
+    assert cylinder.start_mm == pytest.approx((5.0, 5.0, 3.0))
+    assert cylinder.stop_mm == pytest.approx((5.0, 5.0, 5.0))
+    assert cylinder.radius_mm == pytest.approx(0.6)
+
+
+# ===========================================================================
+# D5 — port edges must coincide with mesh lines
+# ===========================================================================
+
+@pytest.mark.parametrize("build", [_cavity, lambda: _thru(), lambda: _thru(msl=True)])
+def test_every_port_edge_lands_exactly_on_a_mesh_line(build):
+    """openEMS silently drops an off-grid port ("Unused primitive", NaN S).
+
+    Coordinates are snapped with ``round(pos/dx)`` — the same rule
+    ``Grid.position_to_index`` uses — so the port sits where rfx rasterises it
+    *and* on a mesh line.  Exact membership is asserted, not approximate: the
+    generated source carries literal floats, and openEMS compares them as
+    written.
+    """
+    plan = plan_openems_projection(design_to_dict(build()))
+    assert plan.ports
+    for port in plan.ports:
+        for axis, lo, hi in zip("xyz", port.start_mm, port.stop_mm):
+            lines = plan.mesh_lines_mm[axis]
+            assert lo in lines, f"{port.label} {axis}-start {lo} off-grid"
+            assert hi in lines, f"{port.label} {axis}-stop {hi} off-grid"
+
+
+def test_off_grid_port_position_is_snapped_and_reported():
+    """A position between lines is moved onto the grid, and the shift is itemised."""
+    sim = Simulation(
+        freq_max=10e9, domain=(0.010, 0.010, 0.010), dx=1.0e-3,
+        boundary="pec", cpml_layers=0,
+    )
+    sim.add_port(position=(0.0053, 0.005, 0.005), component="ez",
+                 impedance=50.0, waveform=_PULSE)
+    plan = plan_openems_projection(design_to_dict(sim))
+
+    assert plan.ports[0].start_mm[0] == pytest.approx(5.0)
+    assert plan.ports[0].start_mm[0] in plan.mesh_lines_mm["x"]
+    assert any("snapped" in note for note in plan.approximations)
+    assert any("-0.300 cells" in note for note in plan.approximations)
+
+
+def test_geometry_faces_are_not_pinned():
+    """Conductor edges must NOT add mesh lines — that would re-mesh the problem.
+
+    rfx rasterises geometry against the uniform grid, so inserting a line at a
+    conductor face would give openEMS a mesh rfx never used.  Only *port* edges
+    need pinning, because openEMS drops an off-grid excitation entirely.
+    """
+    sim = Simulation(
+        freq_max=10e9, domain=(0.010, 0.010, 0.010), dx=1.0e-3,
+        boundary="pec", cpml_layers=0,
+    )
+    # Deliberately off-grid box faces (0.35 mm, 9.15 mm).
+    sim.add(Box((0.00035, 0.00035, 0.00035), (0.00915, 0.00915, 0.00915)),
+            material="pec")
+    sim.add_port(position=(0.005, 0.005, 0.005), component="ez",
+                 impedance=50.0, waveform=_PULSE)
+    plan = plan_openems_projection(design_to_dict(sim))
+
+    assert plan.grid_shape == sim._build_grid().shape
+    for axis in "xyz":
+        lines = plan.mesh_lines_mm[axis]
+        assert 0.35 not in lines
+        assert 9.15 not in lines
+
+
+# ===========================================================================
+# The generated artifact
+# ===========================================================================
+
+def test_generated_script_is_valid_python_and_self_contained():
+    script = emit_openems_script(_cavity_doc(), freqs_hz=_CAVITY_FREQS)
+    ast.parse(script)  # raises SyntaxError on a malformed emission
+    assert script.startswith("#!/usr/bin/env python3")
+    # The numpy alias shim must precede the openEMS import: numpy 2.x dropped
+    # np.int, and openEMS.ports.MSLPort still uses it.
+    assert script.index("setattr(np, _name, _value)") < script.index(
+        "from openEMS.openEMS import openEMS"
+    )
+
+
+def test_header_itemises_provenance_and_every_approximation():
+    plan = plan_openems_projection(_cavity_doc(), freqs_hz=_CAVITY_FREQS)
+    script = emit_openems_script(_cavity_doc(), freqs_hz=_CAVITY_FREQS)
+    header = script.split('"""')[1]
+
+    import rfx
+
+    assert f"source rfx       : {rfx.__version__}" in header
+    assert "design IR schema : rfx-design-ir/v1" in header
+    assert f"emitter          : {OPENEMS_EMITTER_VERSION}" in header
+    assert "APPROXIMATIONS APPLIED" in header
+    assert "WHAT THIS SCRIPT DOES NOT PROVE" in header
+    flat = " ".join(header.split())
+    assert "not evidence of physics agreement" in flat
+
+    # Every itemised approximation must be numbered in the header, and the
+    # same list must be machine-readable in the emitted artifact.
+    assert len(plan.approximations) >= 8
+    for index in range(1, len(plan.approximations) + 1):
+        assert f"[{index:2d}]" in header
+    for tag in ("[D1]", "[D2]", "[D5]", "[D6]", "[D7/D8]", "[D9]", "[D12]", "[D16]"):
+        assert any(tag in note for note in plan.approximations), tag
+    assert "APPROXIMATIONS = [" in script
+
+
+def test_divergences_are_cited_in_the_generated_runner():
+    script = emit_openems_script(_cavity_doc(), freqs_hz=_CAVITY_FREQS)
+    # D13: no scalar ref_impedance (upstream bug when Z_ref is array-valued).
+    assert "port.CalcPort(sim_dir, FREQS_HZ)" in script
+    assert "ref_impedance=" not in script
+    # D14: absolute path, and the CWD is restored in a finally.
+    assert "os.path.abspath" in script
+    assert "os.chdir(original_cwd)" in script
+    # D5: the runtime excitation guard that stands in for rfx preflight.
+    assert "injected no incident wave" in script
+    # Passivity witness against the repo's documented envelope.
+    assert "1.05" in script
+
+
+def test_frequency_list_default_is_flagged_as_not_design_state():
+    plan = plan_openems_projection(_cavity_doc())
+    assert len(plan.freqs_hz) == 21
+    assert any("NOT design state" in note for note in plan.approximations)
+
+
+def test_run_control_default_differs_for_open_and_closed_domains():
+    closed = plan_openems_projection(_cavity_doc())
+    assert closed.end_criteria == 0.0, "a lossless closed cavity never decays"
+    assert closed.n_timesteps > 0
+
+    open_domain = plan_openems_projection(design_to_dict(_thru()))
+    assert open_domain.end_criteria == pytest.approx(1.0e-4)
+    assert open_domain.n_timesteps == 500_000
+
+
+def test_num_periods_and_n_timesteps_are_mutually_exclusive():
+    with _refuses("both n_timesteps"):
+        emit_openems_script(_cavity_doc(), n_timesteps=100, num_periods=10.0)
+
+
+def test_msl_port_span_and_direction():
+    plan = plan_openems_projection(design_to_dict(_thru(msl=True)),
+                                   msl_port_w_cells=6)
+    p0, p1 = plan.ports
+    span = 6 * _THRU_DX / UNIT_M
+    # rfx add_msl_port documents `direction` as the propagation direction, so
+    # the MSLPort span extends that way. start is the trace plane, stop the
+    # ground plane, giving exc_dir=2 pointing trace -> ground.
+    assert p0.stop_mm[0] - p0.start_mm[0] == pytest.approx(+span)
+    assert p1.stop_mm[0] - p1.start_mm[0] == pytest.approx(-span)
+    assert p0.start_mm[2] == pytest.approx(_THRU_H / UNIT_M)
+    assert p0.stop_mm[2] == pytest.approx(0.0)
+    assert p0.exc_dir == 2 and p0.prop_dir == 0
+    assert plan.driven_port_numbers == (1,)
+    assert any("no rfx counterpart" in note or "msl" in note.lower()
+               for note in plan.approximations)
+
+
+def test_msl_port_w_cells_below_the_openems_assert_is_refused():
+    with _refuses("msl_port_w_cells=4"):
+        emit_openems_script(design_to_dict(_thru(msl=True)), msl_port_w_cells=4)
+
+
+# ===========================================================================
+# Refusals — one test per path, each asserting the construct is NAMED
+# ===========================================================================
+
+def test_refuses_coaxial_port():
+    sim = Simulation(
+        freq_max=10e9, domain=(0.010, 0.010, 0.020), dx=2.5e-4,
+        boundary=BoundarySpec(x="pec", y="pec", z="cpml"), cpml_layers=8,
+    )
+    sim.add_coaxial_port((0.005, 0.005, 0.0), face="bottom",
+                         pin_length=0.005, pin_radius=6.35e-4,
+                         outer_radius=2.055e-3, impedance=50.0,
+                         waveform=GaussianPulse(f0=5e9, bandwidth=0.8))
+    with _refuses("add_coaxial_port"):
+        emit_openems_script(design_to_dict(sim))
+
+
+def test_refuses_cell_relative_coaxial_termination():
+    doc = _cavity_doc()
+    doc["excitations"]["coaxial_matched_loads"] = [
+        {"port_index": 0, "target_impedance": 50.0, "axial_offset_cells": 1}
+    ]
+    with _refuses("add_coaxial_matched_load"):
+        emit_openems_script(doc)
+
+    doc = _cavity_doc()
+    doc["excitations"]["coaxial_open_terminations"] = [
+        {"port_index": 0, "pin_retract_cells": 2}
+    ]
+    with _refuses("add_coaxial_open_termination"):
+        emit_openems_script(doc)
+
+    doc = _cavity_doc()
+    doc["excitations"]["coaxial_pec_end_caps"] = [
+        {"port_index": 0, "axial_offset_cells": 0}
+    ]
+    with _refuses("add_coaxial_pec_end_cap"):
+        emit_openems_script(doc)
+
+
+def test_refuses_floquet_port_and_periodic_boundaries():
+    doc = _cavity_doc()
+    doc["excitations"]["floquet_ports"] = [{"name": "floquet_0"}]
+    with _refuses("add_floquet_port"):
+        emit_openems_script(doc)
+
+    doc = _cavity_doc()
+    doc["boundary"]["spec"]["x"] = {"lo": "periodic", "hi": "periodic"}
+    with _refuses("periodic boundary on face x_lo"):
+        emit_openems_script(doc)
+
+
+def test_refuses_waveguide_port():
+    doc = _cavity_doc()
+    doc["excitations"]["waveguide_ports"] = [{"name": "wg_0"}]
+    with _refuses("add_waveguide_port"):
+        emit_openems_script(doc)
+
+
+def test_refuses_tfsf_and_lumped_rlc_and_soft_source():
+    doc = _cavity_doc()
+    doc["excitations"]["tfsf"] = {"f0": 1e9}
+    with _refuses("add_tfsf_source"):
+        emit_openems_script(doc)
+
+    doc = _cavity_doc()
+    doc["excitations"]["lumped_rlc"] = [{"R": 50.0}]
+    with _refuses("add_lumped_rlc"):
+        emit_openems_script(doc)
+
+    sim = _cavity()
+    sim.add_source(position=(0.015, 0.010, 0.005), component="ez",
+                   waveform=_PULSE)
+    with _refuses("add_source"):
+        emit_openems_script(design_to_dict(sim))
+
+
+def test_refuses_refinement():
+    doc = _cavity_doc()
+    doc["refinement"] = {"z_range": [0.0, 0.001], "ratio": 2, "xy_margin": None,
+                         "tau": 1.0, "validation": "off", "topology": "slab"}
+    with _refuses("add_refinement"):
+        emit_openems_script(doc)
+
+
+def test_refuses_rfx_only_solver_controls():
+    for key, value, pattern in (
+        ("solver", "adi", "solver='adi'"),
+        ("stencil_order", 4, "stencil_order=4"),
+        ("precision", "float64", "precision='float64'"),
+    ):
+        doc = _cavity_doc()
+        doc["solver"][key] = value
+        with _refuses(pattern):
+            emit_openems_script(doc)
+
+
+def test_refuses_non_uniform_mesh_profile():
+    for key in ("dx_profile", "dy_profile", "dz_profile"):
+        doc = _cavity_doc()
+        doc["mesh"][key] = {"container": "list", "values": [1e-3, 2e-3]}
+        with _refuses(f"non-uniform mesh profile {key}"):
+            emit_openems_script(doc)
+
+
+def test_refuses_auto_mesh_document():
+    doc = _cavity_doc()
+    doc["mesh"]["dx"] = None
+    with _refuses("dx=None"):
+        emit_openems_script(doc)
+
+
+def test_refuses_2d_mode():
+    doc = _cavity_doc()
+    doc["domain"]["mode"] = "2d"
+    with _refuses("mode='2d'"):
+        emit_openems_script(doc)
+
+
+def test_refuses_conformal_pec_faces():
+    doc = _cavity_doc()
+    doc["boundary"]["spec"]["z"]["conformal"] = True
+    with _refuses("conformal"):
+        emit_openems_script(doc)
+
+
+def test_refuses_unproven_geometry_primitives():
+    sim = Simulation(
+        freq_max=10e9, domain=(0.010, 0.010, 0.010), dx=1.0e-3,
+        boundary="pec", cpml_layers=0,
+    )
+    sim.add(Sphere(center=(0.005, 0.005, 0.005), radius=0.002), material="pec")
+    sim.add_port(position=(0.005, 0.005, 0.008), component="ez",
+                 impedance=50.0, waveform=_PULSE)
+    with _refuses("shape kind 'sphere'"):
+        emit_openems_script(design_to_dict(sim))
+
+
+def test_refuses_thin_conductor_and_observables():
+    doc = _cavity_doc()
+    doc["thin_conductors"] = [{"shape": {"kind": "box", "params": {}}}]
+    with _refuses("add_thin_conductor"):
+        emit_openems_script(doc)
+
+    for key, pattern in (
+        ("probes", "add_probe"),
+        ("dft_planes", "add_dft_plane_probe"),
+        ("flux_monitors", "add_flux_monitor"),
+    ):
+        doc = _cavity_doc()
+        doc["observables"][key] = [{"name": "x"}]
+        with _refuses(pattern):
+            emit_openems_script(doc)
+
+    doc = _cavity_doc()
+    doc["observables"]["ntff"] = {"corner_lo": [0, 0, 0], "corner_hi": [1, 1, 1],
+                                  "freqs": {"container": "list", "values": [1e9]}}
+    with _refuses("add_ntff_box"):
+        emit_openems_script(doc)
+
+
+def test_refuses_dispersive_and_magnetic_materials():
+    for key, value, pattern in (
+        ("debye_poles", [{"delta_eps": 1.0, "tau": 1e-12}], "Debye poles"),
+        ("lorentz_poles", [{"delta_eps": 1.0, "f0": 1e9, "delta": 1e8}],
+         "Lorentz poles"),
+        ("chi3", 1e-20, "chi3="),
+        ("mu_r", 2.0, "mu_r="),
+    ):
+        doc = _cavity_doc()
+        doc["materials"]["mystery"] = {
+            "eps_r": 4.0, "sigma": 0.0, "mu_r": 1.0, "chi3": 0.0,
+            "debye_poles": None, "lorentz_poles": None,
+        }
+        doc["materials"]["mystery"][key] = value
+        with _refuses(pattern):
+            emit_openems_script(doc)
+
+
+def test_pec_material_is_not_refused_for_its_unused_fields():
+    """rfx ignores eps_r / mu_r / poles on a PEC material, so the emitter must too."""
+    doc = _cavity_doc()
+    doc["materials"]["weird_pec"] = {
+        "eps_r": 4.0, "sigma": 1e10, "mu_r": 7.0, "chi3": 1e-20,
+        "debye_poles": None, "lorentz_poles": None,
+    }
+    emit_openems_script(doc)  # must not raise
+
+
+def test_refuses_non_gaussian_waveform():
+    doc = _cavity_doc()
+    doc["excitations"]["lumped_ports"][0]["waveform"] = {
+        "kind": "cw_source", "params": {"f0": 1e9, "amplitude": 1.0,
+                                        "ramp_steps": 100},
+    }
+    with _refuses("waveform kind 'cw_source'"):
+        emit_openems_script(doc)
+
+
+def test_refuses_reference_plane_cells():
+    doc = _cavity_doc()
+    doc["excitations"]["lumped_ports"][0]["reference_plane_cells"] = 4
+    with _refuses("reference_plane_cells=4"):
+        emit_openems_script(doc)
+
+
+def test_refuses_mixed_port_families_and_undriveable_designs():
+    doc = _cavity_doc()
+    msl_doc = design_to_dict(_thru(msl=True))
+    doc["excitations"]["msl_ports"] = msl_doc["excitations"]["msl_ports"]
+    with _refuses("mixed lumped/wire \\+ MSL port set"):
+        emit_openems_script(doc)
+
+    doc = _cavity_doc()
+    for port in doc["excitations"]["lumped_ports"]:
+        port["excite"] = False
+    with _refuses("every port has excite=False"):
+        emit_openems_script(doc)
+
+    doc = _cavity_doc()
+    doc["excitations"]["lumped_ports"] = []
+    with _refuses("no lumped, wire or MSL port"):
+        emit_openems_script(doc)
+
+
+def test_refuses_a_foreign_schema():
+    doc = _cavity_doc()
+    doc["schema"] = "rfx-design-ir/v2"
+    with _refuses("schema 'rfx-design-ir/v2'"):
+        emit_openems_script(doc)
+
+
+def test_refusals_do_not_mutate_the_document():
+    doc = _cavity_doc()
+    before = copy.deepcopy(doc)
+    doc["observables"]["probes"] = [{"name": "p"}]
+    with _refuses("add_probe"):
+        emit_openems_script(doc)
+    doc["observables"]["probes"] = []
+    assert doc == before
+
+
+# ===========================================================================
+# Executed end-to-end — needs the real solver
+# ===========================================================================
+
+def _openems_available() -> bool:
+    if shutil.which("openEMS") is None:
+        return False
+    try:
+        import numpy as _np
+
+        for _name, _value in (("float", float), ("int", int),
+                              ("complex", complex)):
+            if not hasattr(_np, _name):
+                setattr(_np, _name, _value)
+        import CSXCAD  # noqa: F401
+        import openEMS  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(not _openems_available(),
+                    reason="openEMS binary and Python bindings are required")
+def test_generated_script_runs_under_openems_and_is_finite_and_passive():
+    """Emit → execute → assert the artifact is finite and passive.
+
+    This is an *emitter executability* test, not a physics test.  The case is
+    the coarse two-port PEC cavity (140 cells, ~1 s of solve), which exercises
+    only constructs with a 1:1 openEMS counterpart, so a failure localises to
+    the emitter rather than to a convention choice.
+
+    What passing means: the generated script imports, meshes, builds the ports
+    on-grid (the excitation guard fires otherwise), runs, and produces an
+    S-matrix inside the repository's documented 1.05 passivity envelope.  What
+    passing does **not** mean: that openEMS and rfx agree on this structure.
+    """
+    script = emit_openems_script(_cavity_doc(), freqs_hz=_CAVITY_FREQS,
+                                 num_periods=60.0)
+    with tempfile.TemporaryDirectory() as tmp:
+        path = os.path.join(tmp, "cavity_openems.py")
+        with open(path, "w") as handle:
+            handle.write(script)
+        output = os.path.join(tmp, "sparams.json")
+        completed = subprocess.run(
+            [sys.executable, path,
+             "--sim-dir", os.path.join(tmp, "run"),
+             "--output", output],
+            capture_output=True, text=True, timeout=600, cwd=tmp,
+        )
+        assert completed.returncode == 0, (
+            f"generated script failed\n--- stdout ---\n{completed.stdout}\n"
+            f"--- stderr ---\n{completed.stderr}"
+        )
+        with open(output) as handle:
+            payload = json.load(handle)
+
+    assert payload["schema"] == "rfx-openems-emitted-sparams/v1"
+    assert payload["source_rfx_version"]
+    assert payload["approximations"], "the artifact must carry its own caveats"
+    assert payload["freqs_hz"] == [float(f) for f in _CAVITY_FREQS]
+    assert payload["driven_ports"] == [1]
+    assert payload["grid"]["boundary"] == ["PEC"] * 6
+
+    # The excitation actually entered the grid (D5 guard's positive form).
+    diagnostics = payload["port_diagnostics"]["1"]
+    assert diagnostics["incident_peak_abs"] > 0.0
+    assert diagnostics["port_ut_peak_abs"] > 0.0
+
+    assert set(payload["s_matrix"]) == {"S11", "S21"}
+    for key, values in payload["s_matrix"].items():
+        s = np.array([complex(re, im) for re, im in values])
+        assert s.shape == (len(_CAVITY_FREQS),)
+        assert np.all(np.isfinite(s.real)) and np.all(np.isfinite(s.imag)), key
+        assert np.all(np.abs(s) <= 1.05), f"{key} violates passivity: {np.abs(s)}"
+
+    assert payload["passivity"]["within_envelope"] is True
+    assert payload["passivity"]["max_abs_s"] <= 1.05
+    # A lossless closed PEC cavity reflects essentially everything; a much
+    # smaller |S11| would mean the port is coupling into something it should
+    # not, which is the failure mode this cheap case exists to catch.
+    s11 = np.array([complex(re, im) for re, im in payload["s_matrix"]["S11"]])
+    assert np.all(np.abs(s11) > 0.9)

--- a/tests/test_interop_shape_codec.py
+++ b/tests/test_interop_shape_codec.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import dataclasses
 import json
+from pathlib import Path
 
 import pytest
 
@@ -54,15 +55,34 @@ def test_every_supported_kind_has_a_fixture():
 
 
 def test_kind_vocabulary_is_snake_case():
-    """The repo already names shapes in snake_case; do not grow a third name.
-
-    ``rfx/config/_shapes.py`` uses ``shape: "box"`` and
-    ``rfx/experiments/canonical.py`` uses ``kind: "box"``.
-    """
     for kind in SUPPORTED_SHAPE_KINDS:
         assert kind == kind.lower()
         assert " " not in kind and "-" not in kind
-    assert "box" in SUPPORTED_SHAPE_KINDS
+
+
+def test_kind_vocabulary_agrees_with_the_layers_it_claims_to_follow():
+    """Bind the vocabulary claim to the other layers instead of asserting a
+    literal written in this file.
+
+    ``rfx/config/_shapes.py`` names shapes under the key ``shape`` and
+    ``rfx/experiments/canonical.py`` under the key ``kind``; both spell the box
+    ``"box"``. The codec follows those *values*, so its own name for a box must
+    be importable-equal to theirs, not merely lowercase.
+    """
+    from rfx.config._shapes import _SUPPORTED_SHAPES
+
+    assert set(_SUPPORTED_SHAPES).issubset(set(SUPPORTED_SHAPE_KINDS)), (
+        "the config layer names a shape the codec cannot express"
+    )
+    assert "box" in _SUPPORTED_SHAPES and "box" in SUPPORTED_SHAPE_KINDS
+
+    # The canonical experiment layer rejects any geometry kind other than box;
+    # read its refusal rather than trusting a comment about it.
+    repo_root = Path(__file__).resolve().parents[1]
+    canonical = (repo_root / "rfx/experiments/canonical.py").read_text()
+    assert 'P0 supports box geometry' in canonical, (
+        "canonical.py's box-only fence moved; re-check the shared vocabulary"
+    )
 
 
 @pytest.mark.parametrize("kind", sorted(SHAPES))

--- a/tests/test_interop_shape_codec.py
+++ b/tests/test_interop_shape_codec.py
@@ -216,6 +216,46 @@ def test_wrong_vector_length_is_refused():
         shape_from_dict(payload)
 
 
+def test_long_point_sequences_are_never_truncated():
+    """artifacts.py degrades any array over 16 elements to metadata
+    (``_jsonable(max_array_values=16)``). The codec must emit every value.
+    """
+    points = tuple((i * 1e-4, (i % 3) * 1e-4, 1e-3) for i in range(64))
+    payload = shape_to_dict(PolylineWire(points=points, radius=5e-5))
+    assert len(payload["params"]["points"]) == 64
+
+    rebuilt = shape_from_dict(json.loads(json.dumps(payload)))
+    assert rebuilt.points == points
+
+
+def test_long_via_layer_stacks_are_never_truncated():
+    layers = [(i * 1e-4, (i + 1) * 1e-4) for i in range(40)]
+    payload = shape_to_dict(Via(center=(1e-3, 1e-3), drill_radius=5e-5,
+                                pad_radius=1e-4, layers=layers, material="pec"))
+    assert len(payload["params"]["layers"]) == 40
+
+    rebuilt = shape_from_dict(json.loads(json.dumps(payload)))
+    assert [tuple(v) for v in rebuilt.layers] == [tuple(v) for v in layers]
+
+
+def test_scene_artifact_really_does_lose_what_the_codec_keeps():
+    """Pins the motivating contrast, so the claim cannot rot silently."""
+    from rfx.artifacts import build_scene_artifact
+    from rfx import Simulation
+
+    points = tuple((i * 1e-4, 0.0, 1e-3) for i in range(64))
+    wire = PolylineWire(points=points, radius=5e-5)
+
+    sim = Simulation(freq_max=10e9, domain=(0.01, 0.01, 0.004), dx=1e-4,
+                     boundary="cpml")
+    sim.add(wire, material="pec")
+    entry = build_scene_artifact(sim)["geometry"][0]
+
+    assert "bounding_box" in entry
+    assert "points" not in entry and "params" not in entry
+    assert len(shape_to_dict(wire)["params"]["points"]) == 64
+
+
 @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
 def test_non_finite_scalar_is_refused_at_the_codec(bad):
     """Not at json.dump time: allow_nan=False raises a bare ValueError with no

--- a/tests/test_interop_shape_codec.py
+++ b/tests/test_interop_shape_codec.py
@@ -216,6 +216,79 @@ def test_wrong_vector_length_is_refused():
         shape_from_dict(payload)
 
 
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_scalar_is_refused_at_the_codec(bad):
+    """Not at json.dump time: allow_nan=False raises a bare ValueError with no
+    field name, so the refusal must name the parameter instead."""
+    with pytest.raises(UnsupportedDesignFeature, match="not a finite number"):
+        shape_to_dict(Sphere(center=(0.0, 0.0, 0.0), radius=bad))
+
+
+def test_non_finite_vector_component_is_refused_with_its_index():
+    with pytest.raises(UnsupportedDesignFeature, match=r"corner_hi\[0\] is nan"):
+        shape_to_dict(Box(corner_lo=(0.0, 0.0, 0.0),
+                          corner_hi=(float("nan"), 1.0, 1.0)))
+
+
+def test_non_finite_is_refused_on_import_too():
+    payload = shape_to_dict(SHAPES["sphere"])
+    payload["params"]["radius"] = float("inf")
+    with pytest.raises(UnsupportedDesignFeature, match="not a finite number"):
+        shape_from_dict(payload)
+
+
+def test_traced_scalar_parameter_is_refused_naming_the_tracer():
+    """A traced parameter means the geometry is a differentiable DoF, so there
+    is no concrete value to record. The message must say so rather than blame
+    the component count."""
+    jax = pytest.importorskip("jax")
+    captured = {}
+
+    def export_inside_trace(t):
+        shape = Sphere(center=(0.0, 0.0, 0.0), radius=t)
+        try:
+            shape_to_dict(shape)
+            captured["error"] = None
+        except UnsupportedDesignFeature as exc:
+            captured["error"] = str(exc)
+        return t * 2.0
+
+    jax.grad(export_inside_trace)(1e-3)
+
+    assert captured["error"] is not None, "a traced radius must be refused"
+    assert "JAX tracer" in captured["error"]
+    assert "components" not in captured["error"], (
+        "the refusal must not misattribute a tracer to a bad component count"
+    )
+
+
+def test_traced_vector_parameter_is_refused():
+    jax = pytest.importorskip("jax")
+    jnp = pytest.importorskip("jax.numpy")
+    captured = {}
+
+    def export_inside_trace(t):
+        corner = jnp.stack([t, t, t])
+        try:
+            shape_to_dict(Box(corner_lo=(0.0, 0.0, 0.0), corner_hi=corner))
+            captured["error"] = None
+        except UnsupportedDesignFeature as exc:
+            captured["error"] = str(exc)
+        return t * 2.0
+
+    jax.grad(export_inside_trace)(1e-3)
+    assert captured["error"] is not None
+    assert "JAX tracer" in captured["error"]
+
+
+def test_numpy_array_parameters_are_still_accepted():
+    """The tracer guard must not tighten into rejecting numpy input."""
+    np = pytest.importorskip("numpy")
+    payload = shape_to_dict(Box(corner_lo=np.array([0.0, 0.0, 0.0]),
+                                corner_hi=np.array([0.02, 0.012, 0.0015])))
+    assert payload["params"]["corner_hi"] == [0.02, 0.012, 0.0015]
+
+
 def test_payload_shape_is_json_serialisable_scalars_only():
     for shape in SHAPES.values():
         payload = shape_to_dict(shape)

--- a/tests/test_interop_shape_codec.py
+++ b/tests/test_interop_shape_codec.py
@@ -1,9 +1,15 @@
 """Contract tests for the design-interop shape codec.
 
 These are pure structural checks — they do not run FDTD.  The point of the
-codec is that a shape survives a JSON round trip *exactly*, because the
-existing scene artifact records only a class name plus a bounding box and so
-cannot tell a Cylinder from a Box with the same bounds.
+codec is that a shape survives a JSON round trip *exactly*, because every
+existing setup-serialisation layer in rfx is bbox-or-box-level:
+
+- ``rfx.artifacts.build_scene_artifact`` keeps ``shape_type`` + bounding box;
+- ``rfx.io.export_geometry_json`` keeps the class name + bounding box;
+- ``rfx.config._shapes`` supports ``("box",)`` only;
+- ``rfx.experiments.canonical`` fails any geometry ``kind`` other than ``box``.
+
+So none of them can tell a cylinder from a box with the same bounds.
 """
 
 from __future__ import annotations
@@ -17,48 +23,67 @@ from rfx.geometry.csg import Box, Cylinder, PolylineWire, Sphere
 from rfx.geometry.curved import CurvedPatch
 from rfx.geometry.via import Via
 from rfx.interop import (
-    SUPPORTED_SHAPE_TYPES,
+    SUPPORTED_SHAPE_KINDS,
     UnsupportedDesignFeature,
     shape_from_dict,
+    shape_kind_of,
     shape_to_dict,
 )
 from rfx.interop._shapes import _CODECS, constructor_parameter_names
 
 
 SHAPES = {
-    "Box": Box(corner_lo=(0.0, 0.0, 0.0), corner_hi=(0.02, 0.012, 0.0015)),
-    "Cylinder": Cylinder(
+    "box": Box(corner_lo=(0.0, 0.0, 0.0), corner_hi=(0.02, 0.012, 0.0015)),
+    "cylinder": Cylinder(
         center=(0.010, 0.006, 0.0008), radius=3e-4, height=1.5e-3, axis="z"),
-    "Sphere": Sphere(center=(1e-3, 2e-3, 3e-3), radius=5e-4),
-    "PolylineWire": PolylineWire(
+    "sphere": Sphere(center=(1e-3, 2e-3, 3e-3), radius=5e-4),
+    "polyline_wire": PolylineWire(
         points=((0.0, 0.0, 1e-3), (5e-3, 0.0, 1e-3), (5e-3, 4e-3, 1e-3)),
         radius=1e-4),
-    "Via": Via(
+    "via": Via(
         center=(2e-3, 3e-3), drill_radius=1.5e-4, pad_radius=3e-4,
         layers=[(0.0, 8e-4), (8e-4, 1.6e-3)], material="pec"),
-    "CurvedPatch": CurvedPatch(
+    "curved_patch": CurvedPatch(
         center=(0.0, 0.0, 1e-3), length=8e-3, width=4e-3, radius=0.05,
         axis="x"),
 }
 
 
-def test_every_supported_type_has_a_fixture():
-    assert set(SHAPES) == set(SUPPORTED_SHAPE_TYPES)
+def test_every_supported_kind_has_a_fixture():
+    assert set(SHAPES) == set(SUPPORTED_SHAPE_KINDS)
 
 
-@pytest.mark.parametrize("shape_type", sorted(SHAPES))
-def test_registry_pins_live_constructor_parameters(shape_type):
+def test_kind_vocabulary_is_snake_case():
+    """The repo already names shapes in snake_case; do not grow a third name.
+
+    ``rfx/config/_shapes.py`` uses ``shape: "box"`` and
+    ``rfx/experiments/canonical.py`` uses ``kind: "box"``.
+    """
+    for kind in SUPPORTED_SHAPE_KINDS:
+        assert kind == kind.lower()
+        assert " " not in kind and "-" not in kind
+    assert "box" in SUPPORTED_SHAPE_KINDS
+
+
+@pytest.mark.parametrize("kind", sorted(SHAPES))
+def test_registry_pins_live_constructor_parameters(kind):
     """Adding a parameter upstream must fail here, not vanish from exports."""
-    codec = _CODECS[shape_type]
+    codec = _CODECS[kind]
     assert set(codec.fields) == set(constructor_parameter_names(codec.cls)), (
-        f"{shape_type} constructor and interop registry disagree; update "
+        f"{kind} constructor and interop registry disagree; update "
         f"rfx/interop/_shapes.py"
     )
 
 
-@pytest.mark.parametrize("shape_type", sorted(SHAPES))
-def test_round_trip_through_json_text(shape_type):
-    original = SHAPES[shape_type]
+@pytest.mark.parametrize("kind", sorted(SHAPES))
+def test_shape_kind_of_matches_registry(kind):
+    assert shape_kind_of(SHAPES[kind]) == kind
+    assert shape_to_dict(SHAPES[kind])["kind"] == kind
+
+
+@pytest.mark.parametrize("kind", sorted(SHAPES))
+def test_round_trip_through_json_text(kind):
+    original = SHAPES[kind]
     payload = shape_to_dict(original)
     # Must survive real JSON, not just dict copying.
     rebuilt = shape_from_dict(json.loads(json.dumps(payload)))
@@ -71,10 +96,10 @@ def test_round_trip_through_json_text(shape_type):
             assert getattr(rebuilt, name) == getattr(original, name), name
 
 
-@pytest.mark.parametrize("shape_type", sorted(SHAPES))
-def test_round_trip_preserves_bounding_box(shape_type):
+@pytest.mark.parametrize("kind", sorted(SHAPES))
+def test_round_trip_preserves_bounding_box(kind):
     """Numeric witness: the rebuilt shape occupies the same space."""
-    original = SHAPES[shape_type]
+    original = SHAPES[kind]
     rebuilt = shape_from_dict(json.loads(json.dumps(shape_to_dict(original))))
 
     lo_a, hi_a = original.bounding_box()
@@ -83,18 +108,29 @@ def test_round_trip_preserves_bounding_box(shape_type):
     assert tuple(map(float, hi_a)) == pytest.approx(tuple(map(float, hi_b)))
 
 
-def test_cylinder_records_what_the_scene_artifact_drops():
+def test_cylinder_records_what_the_other_layers_drop():
     """The gap this codec exists to close (see rfx/artifacts.py:274)."""
-    payload = shape_to_dict(SHAPES["Cylinder"])
-    assert payload["type"] == "Cylinder"
+    payload = shape_to_dict(SHAPES["cylinder"])
+    assert payload["kind"] == "cylinder"
     assert payload["params"]["radius"] == pytest.approx(3e-4)
     assert payload["params"]["height"] == pytest.approx(1.5e-3)
     assert payload["params"]["axis"] == "z"
 
 
+def test_cylinder_is_distinguishable_from_a_box_with_the_same_bounds():
+    """The concrete failure the bbox-level layers cannot avoid."""
+    cylinder = SHAPES["cylinder"]
+    lo, hi = cylinder.bounding_box()
+    look_alike = Box(corner_lo=tuple(map(float, lo)), corner_hi=tuple(map(float, hi)))
+
+    assert look_alike.bounding_box() == cylinder.bounding_box()
+    assert shape_to_dict(look_alike) != shape_to_dict(cylinder)
+    assert shape_to_dict(look_alike)["kind"] == "box"
+
+
 def test_via_material_is_recorded_alongside_geometry():
     """Via owns a material; the codec must not drop or resolve it silently."""
-    payload = shape_to_dict(SHAPES["Via"])
+    payload = shape_to_dict(SHAPES["via"])
     assert payload["params"]["material"] == "pec"
     assert payload["params"]["layers"] == [[0.0, 8e-4], [8e-4, 1.6e-3]]
 
@@ -108,6 +144,21 @@ def test_unknown_shape_class_is_refused_loudly():
         shape_to_dict(Torus())
 
 
+def test_mesh_shape_is_refused_until_explicitly_supported():
+    """CAD-sourced geometry (#358) is a real shape class with no IR mapping yet.
+
+    ``MeshShape`` wraps a triangle mesh and rasterises host-side, so it is not
+    parameter-describable the way the CSG primitives are.  It must refuse, not
+    degrade to a bounding box.
+    """
+    trimesh = pytest.importorskip("trimesh")
+    from rfx.geometry.mesh_import import MeshShape
+
+    mesh = trimesh.creation.box(extents=(1e-3, 1e-3, 1e-3))
+    with pytest.raises(UnsupportedDesignFeature, match="MeshShape"):
+        shape_to_dict(MeshShape(mesh))
+
+
 def test_subclass_of_supported_shape_is_refused():
     """A subclass may add state, so it is not silently treated as its base."""
     class TaggedSphere(Sphere):
@@ -118,37 +169,48 @@ def test_subclass_of_supported_shape_is_refused():
 
 
 def test_same_named_impostor_class_is_refused():
-    """Name lookup alone is not trusted: identity against the registry wins."""
+    """Registry lookup is by class identity, not by name."""
     @dataclasses.dataclass(frozen=True)
     class Sphere:  # noqa: N801 - deliberately shadows the real primitive
         center: tuple[float, float, float]
         radius: float
 
-    with pytest.raises(UnsupportedDesignFeature, match="registered"):
+    with pytest.raises(UnsupportedDesignFeature, match="Sphere"):
         shape_to_dict(Sphere(center=(0.0, 0.0, 0.0), radius=1e-3))
 
 
-def test_unknown_type_in_payload_is_refused():
+def test_unknown_kind_in_payload_is_refused():
     with pytest.raises(UnsupportedDesignFeature, match="not supported"):
-        shape_from_dict({"type": "Torus", "params": {}})
+        shape_from_dict({"kind": "torus", "params": {}})
+
+
+def test_class_name_as_kind_is_refused():
+    """Guards the vocabulary: 'Cylinder' is not a kind, 'cylinder' is."""
+    with pytest.raises(UnsupportedDesignFeature, match="not supported"):
+        shape_from_dict({"kind": "Cylinder", "params": {}})
+
+
+def test_missing_kind_key_is_refused():
+    with pytest.raises(UnsupportedDesignFeature, match="missing the 'kind' key"):
+        shape_from_dict({"params": {}})
 
 
 def test_missing_parameter_in_payload_is_refused():
-    payload = shape_to_dict(SHAPES["Cylinder"])
+    payload = shape_to_dict(SHAPES["cylinder"])
     del payload["params"]["axis"]
     with pytest.raises(UnsupportedDesignFeature, match="missing parameters"):
         shape_from_dict(payload)
 
 
 def test_extra_parameter_in_payload_is_refused():
-    payload = shape_to_dict(SHAPES["Sphere"])
+    payload = shape_to_dict(SHAPES["sphere"])
     payload["params"]["thickness"] = 1e-4
     with pytest.raises(UnsupportedDesignFeature, match="unknown parameters"):
         shape_from_dict(payload)
 
 
 def test_wrong_vector_length_is_refused():
-    payload = shape_to_dict(SHAPES["Box"])
+    payload = shape_to_dict(SHAPES["box"])
     payload["params"]["corner_hi"] = [1.0, 2.0]
     with pytest.raises(UnsupportedDesignFeature, match="exactly 3 components"):
         shape_from_dict(payload)

--- a/tests/test_interop_shape_codec.py
+++ b/tests/test_interop_shape_codec.py
@@ -1,0 +1,163 @@
+"""Contract tests for the design-interop shape codec.
+
+These are pure structural checks — they do not run FDTD.  The point of the
+codec is that a shape survives a JSON round trip *exactly*, because the
+existing scene artifact records only a class name plus a bounding box and so
+cannot tell a Cylinder from a Box with the same bounds.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+from rfx.geometry.csg import Box, Cylinder, PolylineWire, Sphere
+from rfx.geometry.curved import CurvedPatch
+from rfx.geometry.via import Via
+from rfx.interop import (
+    SUPPORTED_SHAPE_TYPES,
+    UnsupportedDesignFeature,
+    shape_from_dict,
+    shape_to_dict,
+)
+from rfx.interop._shapes import _CODECS, constructor_parameter_names
+
+
+SHAPES = {
+    "Box": Box(corner_lo=(0.0, 0.0, 0.0), corner_hi=(0.02, 0.012, 0.0015)),
+    "Cylinder": Cylinder(
+        center=(0.010, 0.006, 0.0008), radius=3e-4, height=1.5e-3, axis="z"),
+    "Sphere": Sphere(center=(1e-3, 2e-3, 3e-3), radius=5e-4),
+    "PolylineWire": PolylineWire(
+        points=((0.0, 0.0, 1e-3), (5e-3, 0.0, 1e-3), (5e-3, 4e-3, 1e-3)),
+        radius=1e-4),
+    "Via": Via(
+        center=(2e-3, 3e-3), drill_radius=1.5e-4, pad_radius=3e-4,
+        layers=[(0.0, 8e-4), (8e-4, 1.6e-3)], material="pec"),
+    "CurvedPatch": CurvedPatch(
+        center=(0.0, 0.0, 1e-3), length=8e-3, width=4e-3, radius=0.05,
+        axis="x"),
+}
+
+
+def test_every_supported_type_has_a_fixture():
+    assert set(SHAPES) == set(SUPPORTED_SHAPE_TYPES)
+
+
+@pytest.mark.parametrize("shape_type", sorted(SHAPES))
+def test_registry_pins_live_constructor_parameters(shape_type):
+    """Adding a parameter upstream must fail here, not vanish from exports."""
+    codec = _CODECS[shape_type]
+    assert set(codec.fields) == set(constructor_parameter_names(codec.cls)), (
+        f"{shape_type} constructor and interop registry disagree; update "
+        f"rfx/interop/_shapes.py"
+    )
+
+
+@pytest.mark.parametrize("shape_type", sorted(SHAPES))
+def test_round_trip_through_json_text(shape_type):
+    original = SHAPES[shape_type]
+    payload = shape_to_dict(original)
+    # Must survive real JSON, not just dict copying.
+    rebuilt = shape_from_dict(json.loads(json.dumps(payload)))
+
+    assert type(rebuilt) is type(original)
+    if dataclasses.is_dataclass(original):
+        assert rebuilt == original
+    else:
+        for name in constructor_parameter_names(type(original)):
+            assert getattr(rebuilt, name) == getattr(original, name), name
+
+
+@pytest.mark.parametrize("shape_type", sorted(SHAPES))
+def test_round_trip_preserves_bounding_box(shape_type):
+    """Numeric witness: the rebuilt shape occupies the same space."""
+    original = SHAPES[shape_type]
+    rebuilt = shape_from_dict(json.loads(json.dumps(shape_to_dict(original))))
+
+    lo_a, hi_a = original.bounding_box()
+    lo_b, hi_b = rebuilt.bounding_box()
+    assert tuple(map(float, lo_a)) == pytest.approx(tuple(map(float, lo_b)))
+    assert tuple(map(float, hi_a)) == pytest.approx(tuple(map(float, hi_b)))
+
+
+def test_cylinder_records_what_the_scene_artifact_drops():
+    """The gap this codec exists to close (see rfx/artifacts.py:274)."""
+    payload = shape_to_dict(SHAPES["Cylinder"])
+    assert payload["type"] == "Cylinder"
+    assert payload["params"]["radius"] == pytest.approx(3e-4)
+    assert payload["params"]["height"] == pytest.approx(1.5e-3)
+    assert payload["params"]["axis"] == "z"
+
+
+def test_via_material_is_recorded_alongside_geometry():
+    """Via owns a material; the codec must not drop or resolve it silently."""
+    payload = shape_to_dict(SHAPES["Via"])
+    assert payload["params"]["material"] == "pec"
+    assert payload["params"]["layers"] == [[0.0, 8e-4], [8e-4, 1.6e-3]]
+
+
+def test_unknown_shape_class_is_refused_loudly():
+    class Torus:
+        def __init__(self):
+            self.major_radius = 1.0
+
+    with pytest.raises(UnsupportedDesignFeature, match="Torus"):
+        shape_to_dict(Torus())
+
+
+def test_subclass_of_supported_shape_is_refused():
+    """A subclass may add state, so it is not silently treated as its base."""
+    class TaggedSphere(Sphere):
+        pass
+
+    with pytest.raises(UnsupportedDesignFeature, match="TaggedSphere"):
+        shape_to_dict(TaggedSphere(center=(0.0, 0.0, 0.0), radius=1e-3))
+
+
+def test_same_named_impostor_class_is_refused():
+    """Name lookup alone is not trusted: identity against the registry wins."""
+    @dataclasses.dataclass(frozen=True)
+    class Sphere:  # noqa: N801 - deliberately shadows the real primitive
+        center: tuple[float, float, float]
+        radius: float
+
+    with pytest.raises(UnsupportedDesignFeature, match="registered"):
+        shape_to_dict(Sphere(center=(0.0, 0.0, 0.0), radius=1e-3))
+
+
+def test_unknown_type_in_payload_is_refused():
+    with pytest.raises(UnsupportedDesignFeature, match="not supported"):
+        shape_from_dict({"type": "Torus", "params": {}})
+
+
+def test_missing_parameter_in_payload_is_refused():
+    payload = shape_to_dict(SHAPES["Cylinder"])
+    del payload["params"]["axis"]
+    with pytest.raises(UnsupportedDesignFeature, match="missing parameters"):
+        shape_from_dict(payload)
+
+
+def test_extra_parameter_in_payload_is_refused():
+    payload = shape_to_dict(SHAPES["Sphere"])
+    payload["params"]["thickness"] = 1e-4
+    with pytest.raises(UnsupportedDesignFeature, match="unknown parameters"):
+        shape_from_dict(payload)
+
+
+def test_wrong_vector_length_is_refused():
+    payload = shape_to_dict(SHAPES["Box"])
+    payload["params"]["corner_hi"] = [1.0, 2.0]
+    with pytest.raises(UnsupportedDesignFeature, match="exactly 3 components"):
+        shape_from_dict(payload)
+
+
+def test_payload_shape_is_json_serialisable_scalars_only():
+    for shape in SHAPES.values():
+        payload = shape_to_dict(shape)
+        # json.dumps would accept tuples too; assert the canonical list form so
+        # emitted files stay byte-stable across writers.
+        text = json.dumps(payload, sort_keys=True)
+        assert "(" not in text

--- a/tests/test_interop_value_validation.py
+++ b/tests/test_interop_value_validation.py
@@ -1,0 +1,248 @@
+"""Regression tests for the design-interop value guards.
+
+Every case here was a real hole found by an independent review of the codec
+layer, most of them silent. Pure structural checks — no FDTD.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from rfx.api._spec import MaterialSpec
+from rfx.geometry.csg import Box, Cylinder, PolylineWire, Sphere
+from rfx.geometry.via import Via
+from rfx.interop import (
+    UnsupportedDesignFeature,
+    materials_to_dict,
+    shape_from_dict,
+    shape_to_dict,
+)
+
+
+def _points(n: int = 5) -> list[tuple[float, float, float]]:
+    return [(i * 1e-4, 0.0, 1e-3) for i in range(n)]
+
+
+# --------------------------------------------------------------------------
+# The one that mattered: a one-shot iterator was consumed by exporting it, so
+# the SECOND export emitted an empty sequence with no error, producing a
+# schema-valid design document in which the conductor simply was not there.
+# --------------------------------------------------------------------------
+
+def test_generator_valued_sequence_field_is_refused_not_consumed():
+    wire = PolylineWire(points=(p for p in _points()), radius=5e-5)
+    with pytest.raises(UnsupportedDesignFeature, match="no length"):
+        shape_to_dict(wire)
+
+
+def test_export_is_idempotent_for_sequence_fields():
+    """Export must not mutate what it exports."""
+    wire = PolylineWire(points=tuple(_points()), radius=5e-5)
+    first = shape_to_dict(wire)
+    second = shape_to_dict(wire)
+    assert first == second
+    assert len(second["params"]["points"]) == 5
+
+
+@pytest.mark.parametrize("empty", [[], ()])
+def test_empty_point_sequence_is_refused_on_export(empty):
+    with pytest.raises(UnsupportedDesignFeature, match="at least 1 element"):
+        shape_to_dict(PolylineWire(points=empty, radius=5e-5))
+
+
+def test_empty_point_sequence_is_refused_on_import():
+    with pytest.raises(UnsupportedDesignFeature, match="at least 1 element"):
+        shape_from_dict({"kind": "polyline_wire",
+                         "params": {"points": [], "radius": 5e-5}})
+
+
+def test_empty_via_layer_stack_is_refused_on_import():
+    with pytest.raises(UnsupportedDesignFeature, match="at least 1 element"):
+        shape_from_dict({"kind": "via", "params": {
+            "center": [0.0, 0.0], "drill_radius": 1e-4, "pad_radius": 2e-4,
+            "layers": [], "material": "pec"}})
+
+
+def test_null_sequence_is_refused_before_iteration():
+    with pytest.raises(UnsupportedDesignFeature, match="must be a sequence"):
+        shape_from_dict({"kind": "polyline_wire",
+                         "params": {"points": None, "radius": 5e-5}})
+
+
+# --------------------------------------------------------------------------
+# String fields: str(v) cannot fail, so an unguarded field records a repr.
+# --------------------------------------------------------------------------
+
+def test_none_axis_is_refused_rather_than_stringified():
+    with pytest.raises(UnsupportedDesignFeature, match="must be a string"):
+        shape_to_dict(Cylinder(center=(0.0, 0.0, 0.0), radius=1e-4,
+                               height=1e-3, axis=None))
+
+
+def test_material_spec_in_a_name_slot_is_refused():
+    """Simulation.add(material=...) takes a NAME, so passing a spec to Via is a
+    plausible confusion; it must not be recorded as a repr."""
+    via = Via(center=(0.0, 0.0), drill_radius=1e-4, pad_radius=2e-4,
+              layers=[(0.0, 1e-3)], material=MaterialSpec(eps_r=4.3))
+    with pytest.raises(UnsupportedDesignFeature, match="must be a string"):
+        shape_to_dict(via)
+
+
+def test_traced_string_field_is_refused():
+    jax = pytest.importorskip("jax")
+    captured = {}
+
+    def export_inside_trace(t):
+        try:
+            shape_to_dict(Cylinder(center=(0.0, 0.0, 0.0), radius=1e-4,
+                                   height=1e-3, axis=t))
+            captured["error"] = None
+        except UnsupportedDesignFeature as exc:
+            captured["error"] = str(exc)
+        return t * 2.0
+
+    jax.grad(export_inside_trace)(1.0)
+    assert captured["error"] is not None, (
+        "a traced value in a string slot must not be stringified into the JSON"
+    )
+
+
+# --------------------------------------------------------------------------
+# JSON type discipline: a hand-edited or foreign-generated document.
+# --------------------------------------------------------------------------
+
+def test_digit_string_is_not_silently_read_as_a_vector():
+    """'123' is iterable and each character floats, so an unguarded loader turns
+    it into (1.0, 2.0, 3.0) — silent wrong geometry."""
+    with pytest.raises(UnsupportedDesignFeature, match="got the string"):
+        shape_from_dict({"kind": "box", "params": {
+            "corner_lo": "123", "corner_hi": [1.0, 2.0, 3.0]}})
+
+
+def test_quoted_numeric_is_refused():
+    with pytest.raises(UnsupportedDesignFeature, match="not a number"):
+        shape_from_dict({"kind": "sphere", "params": {
+            "center": [0.0, 0.0, 0.0], "radius": "5e-4"}})
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_json_boolean_is_not_silently_read_as_a_number(value):
+    """A bool is an int in Python, so float(True) == 1.0 would become a length."""
+    with pytest.raises(UnsupportedDesignFeature, match="boolean"):
+        shape_from_dict({"kind": "sphere", "params": {
+            "center": [0.0, 0.0, 0.0], "radius": value}})
+
+
+def test_primitive_invariant_violation_names_the_kind():
+    """Via's own check would otherwise escape as a bare ValueError. Note
+    UnsupportedDesignFeature IS a ValueError, so a caller catching the interop
+    error specifically would have missed it."""
+    with pytest.raises(UnsupportedDesignFeature,
+                       match="via payload violates the primitive's own"):
+        shape_from_dict({"kind": "via", "params": {
+            "center": [0.0, 0.0], "drill_radius": 3e-4, "pad_radius": 1e-4,
+            "layers": [[0.0, 1e-3]], "material": "pec"}})
+
+
+def test_materials_to_dict_refuses_a_non_mapping():
+    with pytest.raises(UnsupportedDesignFeature, match="must be a mapping"):
+        materials_to_dict([MaterialSpec(eps_r=1.0)])
+
+
+# --------------------------------------------------------------------------
+# The pin test's blind spots.
+# --------------------------------------------------------------------------
+
+def test_constructor_parameter_names_sees_init_var():
+    """dataclasses.fields excludes InitVar, so a units InitVar consumed in
+    __post_init__ would be invisible to the pin test and every export would
+    silently carry values under an undeclared convention."""
+    import dataclasses
+    from rfx.interop._shapes import constructor_parameter_names
+
+    @dataclasses.dataclass(frozen=True)
+    class BoxV2:
+        corner_lo: tuple[float, float, float]
+        corner_hi: tuple[float, float, float]
+        units: dataclasses.InitVar[str] = "m"
+
+        def __post_init__(self, units):
+            pass
+
+    assert "units" in constructor_parameter_names(BoxV2)
+
+
+def test_constructor_parameter_names_excludes_non_init_fields():
+    """The inverse trap: a derived field(init=False) is not a constructor
+    parameter and must not be handed back on import."""
+    import dataclasses
+    from rfx.interop._shapes import constructor_parameter_names
+
+    @dataclasses.dataclass(frozen=True)
+    class BoxV3:
+        corner_lo: tuple[float, float, float]
+        corner_hi: tuple[float, float, float]
+        volume: float = dataclasses.field(init=False, default=0.0)
+
+    assert "volume" not in constructor_parameter_names(BoxV3)
+
+
+def test_private_cache_attributes_do_not_break_export():
+    """MeshShape already stamps self._mask_cache; the extra-state guard must not
+    make a shape unexportable the moment it grows a memo."""
+    via = Via(center=(0.0, 0.0), drill_radius=1e-4, pad_radius=2e-4,
+              layers=[(0.0, 1e-3)], material="pec")
+    before = shape_to_dict(via)
+    via._memo = {"cached": 1}
+    assert shape_to_dict(via) == before
+
+
+def test_public_extra_state_is_still_refused():
+    """The guard must keep catching a genuinely new public field."""
+    via = Via(center=(0.0, 0.0), drill_radius=1e-4, pad_radius=2e-4,
+              layers=[(0.0, 1e-3)], material="pec")
+    via.plating_thickness = 1e-5
+    with pytest.raises(UnsupportedDesignFeature, match="plating_thickness"):
+        shape_to_dict(via)
+
+
+def test_named_tuple_shape_state_is_readable():
+    """vars() raises on a NamedTuple; rfx/geometry/thin_wire.py already defines
+    one, so this must not TypeError if such a class is ever registered."""
+    import inspect
+
+    from rfx.geometry.thin_wire import ThinWire
+    from rfx.interop._shapes import _instance_state_names
+
+    # Build from the class's own signature rather than guessing physics values.
+    kwargs = {
+        name: (0.0 if param.default is inspect.Parameter.empty else param.default)
+        for name, param in inspect.signature(ThinWire).parameters.items()
+    }
+    assert _instance_state_names(ThinWire(**kwargs)) == tuple(ThinWire._fields)
+
+
+# --------------------------------------------------------------------------
+# Canonical input must keep working — the guards must not over-tighten.
+# --------------------------------------------------------------------------
+
+def test_canonical_shapes_still_round_trip():
+    shapes = [
+        Box(corner_lo=(0.0, 0.0, 0.0), corner_hi=(1e-3, 1e-3, 1e-3)),
+        Sphere(center=(0.0, 0.0, 0.0), radius=1e-4),
+        PolylineWire(points=tuple(_points()), radius=5e-5),
+        Via(center=(0.0, 0.0), drill_radius=1e-4, pad_radius=2e-4,
+            layers=[(0.0, 1e-3)], material="pec"),
+    ]
+    for shape in shapes:
+        rebuilt = shape_from_dict(json.loads(json.dumps(shape_to_dict(shape))))
+        assert type(rebuilt) is type(shape)
+
+
+def test_numpy_scalars_and_arrays_still_accepted():
+    np = pytest.importorskip("numpy")
+    payload = shape_to_dict(Sphere(center=np.array([0.0, 0.0, 0.0]),
+                                   radius=np.float64(5e-4)))
+    assert payload["params"] == {"center": [0.0, 0.0, 0.0], "radius": 5e-4}

--- a/tests/test_interop_value_validation.py
+++ b/tests/test_interop_value_validation.py
@@ -151,6 +151,28 @@ def test_materials_to_dict_refuses_a_non_mapping():
         materials_to_dict([MaterialSpec(eps_r=1.0)])
 
 
+def test_stray_top_level_key_in_a_shape_payload_is_refused():
+    """The unknown-key check covered `params` but not the payload itself, so a
+    stray sibling key was dropped without a word."""
+    payload = shape_to_dict(Box(corner_lo=(0.0, 0.0, 0.0),
+                                corner_hi=(1e-3, 1e-3, 1e-3)))
+    payload["note"] = "written by some other tool"
+    with pytest.raises(UnsupportedDesignFeature,
+                       match="unknown top-level keys"):
+        shape_from_dict(payload)
+
+
+def test_non_string_material_name_is_refused_on_import():
+    """Symmetric with the export side, which uses check_text: a numeric JSON key
+    must not quietly become a material named "5"."""
+    from rfx.interop import materials_from_dict, materials_to_dict as _dump
+
+    payload = _dump({"fr4": MaterialSpec(eps_r=4.3)})
+    payload[5] = payload.pop("fr4")
+    with pytest.raises(UnsupportedDesignFeature, match="must be a string"):
+        materials_from_dict(payload)
+
+
 # --------------------------------------------------------------------------
 # The pin test's blind spots.
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The cross-solver validation campaign's cost centre is building each structure **twice** — once in rfx, once by hand in openEMS/Meep/Palace — and keeping the two identical. `scripts/diagnostics/build_sheen_lpf_palace_referee.py` and its Palace mesh builder are exactly that hand-porting. `CLAUDE.md`'s comparator-first rule and `.claude/rules/rfx-feature-discovery.md`'s "never hand-roll an external-solver crossval setup" both identify comparator/fixture divergence — **not solver physics** — as the dominant historical failure class. A generated, single-source setup attacks that class directly.

## Two premise corrections found up front

Both were briefly acted on in the wrong form, so they are recorded in the design note.

1. **rfx already has CAD import.** `rfx/geometry/mesh_import.py`'s `MeshShape` reads STL/OBJ/PLY natively and STEP/STP via `cascadio` (#453/#456, issue #358 closed). The real asymmetry is **import exists, export does not**.
2. **There were already four setup serialisers, and every one is box-or-bbox-level**, so none can rebuild its own input:

| layer | geometry fidelity |
|---|---|
| `io.py:869` `export_geometry_json` | class name + bbox |
| `artifacts.py:274,311` `build_scene_artifact` | pops `shape`, keeps `shape_type` + bbox |
| `config/_shapes.py:15` | `_SUPPORTED_SHAPES = ("box",)` |
| `experiments/canonical.py:752` | `"P0 supports box geometry"` |

Measured: `build_scene_artifact` records a `Cylinder(radius=3e-4, height=1.5e-3, axis="z")` as `shape_type` + bounding box only — indistinguishable from a `Box` with the same bounds.

## What this adds

`rfx/interop/` — a leaf codec layer plus `rfx-design-ir/v1`:

- **`_shapes.py`** — all six CSG primitives recorded by **constructor parameters**, registry pinned against each live class signature (`inspect.signature`, so an upstream `InitVar` is visible and a `field(init=False)` is not mistaken for a parameter).
- **`_materials.py`** — every `MaterialSpec` field including Debye/Lorentz pole parameters, which `artifacts.py:245` reduces to `{present, count}`. `None` and `[]` stay distinct.
- **`_validate.py`** — shared value coercions; refuses tracers, `bool`, quoted numerics, non-finite values, unsized iterators.
- **`_design.py`** — `design_to_dict` / `simulation_from_design` over all 35 `Simulation.__init__` attributes. The importer drives the **public `add_*` builders**, so every builder fence still fires.
- **`emitters/openems.py`** — `emit_openems_script(document)` returns a plain-text runnable script. **Generation needs no licence and no solver.**
- **`docs/design_notes/schemas/rfx-design-ir-v1.schema.json`** — published schema, pinned to the code by tests rather than maintained by hand.

## Honest scope — what is and is not established

**The openEMS emitter is proven *executable*, not *agreeing*.** Every generated script carries a `WHAT THIS SCRIPT DOES NOT PROVE` block and an itemised approximation list; the emitted JSON carries the same list as an `approximations` array.

- Gate: an emitted script is written to disk, run as a subprocess under openEMS, and the artifact asserted finite, passive (≤ 1.05), with a non-empty approximation list, a non-zero incident peak (openEMS silently **drops** an off-grid excitation), and `|S11| > 0.9` as a lossless closed cavity must.
- **No physics-agreement claim is made.** A cv06b comparison at dx = 50 µm (~1.6 M cells × 600 k steps) was deliberately not attempted; a coarse stand-in would not be evidence.
- **Ceiling on any future claim:** port models differ structurally — rfx's wire port is a point feed, openEMS's `MSLPort` spans several cells, and `port_w_cells` has no rfx counterpart. `build_wire_openems_broad_envelope.py:12-16` pins the gap at **≈0.20 in |S|**, which is *looser* than cv06b's mean gate (0.13). A passing comparison at that tolerance is not evidence the port models agree.
- Shapes are limited to `box`/`cylinder`. The other four **refuse**, and the message says why: openEMS *has* `AddSphere`/`AddPolygon`/`AddLinPoly`/`AddCylindricalShell`/`AddCurve`, but **none has a single call site in this repo**, so no translation of them has ever been checked against a known-good result. That is "unproven", not "impossible".

## Measured facts that drove the design

- **CPML padding direction (highest-severity translation hazard).** rfx adds CPML *outside* the user domain; openEMS `PML_<N>` consumes cells *inside* the mesh. Measured: `domain=(0.01,0.01,0.01)`, `dx=1e-3` → grid 11³/27³/43³ at `cpml_layers` 0/8/16 (= 11+2N). The emitter spans `domain + 2·N·dx`, and a test asserts the emitted line count equals the live `sim._build_grid().shape` over six configurations.
- **`'PML_<N>'`, not `'PML-<N>'`** — the hyphen form raises "Unknown boundary condition". Confirmed by running it.
- **PEC composition is a union, not last-write-wins.** `_compile.py:166-174`: PEC does `pec_mask |= mask` and **skips** the dielectric paint. Dielectric paint *is* last-write-wins. An emitter assuming uniform last-write-wins would mistranslate every PEC-over-dielectric overlap — most PCB stackups. The previously cited `csg.py:321` is `rasterize()`'s docstring, a function the simulation path never calls.
- **The two port builders use opposite direction conventions.** `add_port`'s direction is the outward normal (`api/__init__.py:1116`); `add_msl_port`'s is the propagation direction (`sources/msl_port.py:51`).

## Round-trip evidence

- `assert_designs_equivalent` diffs **every** attribute in `set(vars(sim))` — not a hand-listed set — after asserting the attribute sets match.
- Non-vacuity of that comparison is itself proven by **7 mutation tests** (dtype-only, a single profile cell × 1.0000001, a nested shape parameter, a dispersion pole, `pec_faces`, probe component, waveform cutoff).
- 16 design fixtures, from graded microstrip to Floquet unit cell to legacy all-periodic.
- Completeness ledgers: a new `Simulation.__init__` attribute or `add_*` method **reds a test** until a decision is recorded.
- Builder fences are not bypassable: a document tampered to Floquet `n_modes=2` raises the builder's own `NotImplementedError`.

## Defects found and fixed by two independent review passes

Author/reviewer separation per the repo methodology. Both reviews found real defects.

**HIGH (silent data loss).** A one-shot iterator in a sequence field was *consumed by exporting it*, and there was no length floor — so the **second** export of the same object emitted `[]` with no error, producing a complete, schema-valid `rfx-design-ir/v1` document in which the wire simply was not there, which then survived re-import. Export also mutated the object it was exporting.

**MEDIUM-HIGH.** `non_portable` gated the absorber note on the legacy *scalar*, so an absorber defined only by per-face `BoundarySpec` thickness (`cpml_layers=0`, `lo_thickness=12`) was annotated as fully portable — the document asserting something false about a real design. `conformal=True` was likewise unannotated, contradicting this branch's own emitter, which refuses it.

Also fixed: unguarded string fields recorded a `MaterialSpec` repr and a multi-line JVP tracer repr as names; a JSON `true` became `1.0`; `"123"` became the vector `(1.0, 2.0, 3.0)`; and the schema's entry level was validated only by documents carrying zero entries for 16 of 19 sections.

## Verification

- `pytest -k interop` → **377 passed, 1 skipped**
- `ruff check rfx/ tests/` (repo flags) → clean
- `python scripts/check_api_reference.py` → `api reference surface: OK` (pinned 274/41 surface untouched; nothing added to `rfx/__init__.py`)
- wheel ships `rfx/interop/*` via the existing `include = ["rfx*"]`
- the executed openEMS case passes (openEMS v0.0.35 binary present in this environment)

**Full-suite note, reported plainly:** the unsharded full run **crashes** in this environment. That is documented existing behaviour — `pr-tests.yml` shards into 4 groups to avoid "the XLA-cache OOM that killed the unsharded full run". Sharded (`-n 8 --dist loadfile`): **2577 passed, 5 failed**. One failure was a stale pre-fix snapshot (now green). The other **4 are `tests/test_tutorial_examples.py` and fail identically on clean `origin/main`** — verified in a separate worktree, so they are pre-existing and unrelated to this branch. Filed separately.

## Not in scope

CST VBA / PyAEDT / Meep emitters (CST needs VBA emission; neither CST nor HFSS can be verified without a licence), the import direction (researched only), and consolidating the four existing serialisers. `CanonicalExperimentSpec` (`rfx-experiment/v2`) is the likely long-term container, but widening its governed geometry beyond `box` deserves an explicit decision rather than a side effect of this branch (design-note D5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
