### PR TITLE
fix(interop): carry the TFSF method field added by #461 in the design IR

### DIFF
--- a/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
+++ b/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
@@ -786,7 +786,8 @@
             "polarization",
             "direction",
             "angle_deg",
-            "waveform"
+            "waveform",
+            "method"
           ],
           "properties": {
             "f0": {
@@ -816,6 +817,10 @@
               "type": "number"
             },
             "waveform": {
+              "type": "string",
+              "minLength": 1
+            },
+            "method": {
               "type": "string",
               "minLength": 1
             }

--- a/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
+++ b/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
@@ -821,8 +821,8 @@
               "minLength": 1
             },
             "method": {
-              "type": "string",
-              "minLength": 1
+              "enum": ["bloch", "methodB"],
+              "description": "Transverse boundary-value-problem lane: 'bloch' = laterally periodic (infinite array), 'methodB' = open transverse boundary (compact isolated scatterer). Required despite the builder default because the failure is asymmetric: defaulting an oblique isolated-scatterer document to 'bloch' would silently import it as an infinite periodic array. The labels are rfx-internal; the translatable semantic for an external emitter is transverse boundary = periodic vs absorbing, not the lane name."
             }
           }
         },

--- a/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
+++ b/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
@@ -821,8 +821,9 @@
               "minLength": 1
             },
             "method": {
-              "enum": ["bloch", "methodB"],
-              "description": "Transverse boundary-value-problem lane: 'bloch' = laterally periodic (infinite array), 'methodB' = open transverse boundary (compact isolated scatterer). Required despite the builder default because the failure is asymmetric: defaulting an oblique isolated-scatterer document to 'bloch' would silently import it as an infinite periodic array. The labels are rfx-internal; the translatable semantic for an external emitter is transverse boundary = periodic vs absorbing, not the lane name."
+              "type": "string",
+              "minLength": 1,
+              "description": "Transverse boundary-value-problem lane ('bloch' = laterally periodic infinite array, 'methodB' = open transverse boundary, compact isolated scatterer); the closed value set is a builder fence enforced on import, like polarization/direction/waveform. Required despite the builder default because the failure is asymmetric: defaulting an oblique isolated-scatterer document to 'bloch' would silently import it as an infinite periodic array."
             }
           }
         },

--- a/rfx/interop/_design.py
+++ b/rfx/interop/_design.py
@@ -538,6 +538,10 @@ _TFSF_FIELDS: dict[str, _F] = {
     "direction": _STR,
     "angle_deg": _NUM,
     "waveform": _STR,
+    # PR #461: injection-algorithm selector ('bloch' periodic 2-D aux vs
+    # 'methodB' open-domain 1-D aux along k-hat). Design state, not run
+    # control — the two lanes assume different transverse boundary physics.
+    "method": _STR,
 }
 
 _DFT_PLANE_FIELDS: dict[str, _F] = {

--- a/rfx/interop/_design.py
+++ b/rfx/interop/_design.py
@@ -538,9 +538,14 @@ _TFSF_FIELDS: dict[str, _F] = {
     "direction": _STR,
     "angle_deg": _NUM,
     "waveform": _STR,
-    # PR #461: injection-algorithm selector ('bloch' periodic 2-D aux vs
-    # 'methodB' open-domain 1-D aux along k-hat). Design state, not run
-    # control — the two lanes assume different transverse boundary physics.
+    # PR #461: transverse boundary-value-problem selector — 'bloch' runs
+    # periodic=(F,T,T)/cpml_axes="x" (laterally periodic: infinite array),
+    # 'methodB' runs periodic=(F,F,T)/cpml_axes="xy" (open transverse
+    # boundary: compact isolated scatterer). Design state, not run control:
+    # the two lanes describe different physical structures. The labels are
+    # rfx-internal; a future TFSF emitter should translate the semantic
+    # (transverse boundary = periodic vs absorbing), not hunt for another
+    # solver's "method B".
     "method": _STR,
 }
 

--- a/tests/test_interop_design_document.py
+++ b/tests/test_interop_design_document.py
@@ -1179,6 +1179,26 @@ def test_import_does_not_widen_the_reference_plane_fence():
         simulation_from_design(document)
 
 
+def test_round_trip_preserves_the_tfsf_method_lane():
+    """The bloch/methodB lane selects the transverse boundary value problem
+    (infinite periodic array vs compact isolated scatterer) — the IR must
+    preserve it through a round trip. Pinned on the NON-default value: a codec
+    that ever defaulted `method` away would still round-trip 'bloch' cleanly
+    while silently importing an oblique isolated-scatterer design as a
+    periodic array (PR #461 x #463 drift, PR #472)."""
+    sim = Simulation(
+        freq_max=10e9, domain=(0.020, 0.020, 0.020), dx=1e-3, boundary="cpml", cpml_layers=6
+    )
+    sim.add(Sphere(center=(0.010, 0.010, 0.010), radius=0.003), material="pec")
+    sim.add_tfsf_source(f0=5e9, polarization="ez", direction="+x", angle_deg=30.0, method="methodB")
+
+    document = design_to_dict(sim)
+    assert document["excitations"]["tfsf"]["method"] == "methodB"
+    restored = simulation_from_design(document)
+    assert restored._tfsf.method == "methodB"
+    assert restored._tfsf.angle_deg == 30.0
+
+
 def test_import_does_not_widen_the_tfsf_boundary_fence():
     document = design_to_dict(_tfsf_scatterer())
     document["boundary"]["spec"] = BoundarySpec.uniform("pec").to_dict()


### PR DESCRIPTION
Post-merge sanity after landing #461 and #463 (each CI-green against a pre-merge main, zero textual merge conflicts) caught the first real drift the interop contract tests were built to catch: #461 added `method: str = "bloch"` to `_TFSFEntry`, and #463's field-registry pin + `rfx-design-ir/v1` schema + `tfsf_scatterer` fixtures predate it → 9 contract-test failures on main.

**Fix (2 files):**
- `rfx/interop/_design.py`: `_TFSF_FIELDS` += `method` (`_STR`), with a comment recording why it is design state rather than run control (bloch vs methodB select different solver physics lanes with different transverse-boundary assumptions — PR #461 review).
- `docs/design_notes/schemas/rfx-design-ir-v1.schema.json`: `method` added to the tfsf entry's `required` + `properties`.

No importer change needed (entries splat into `add_tfsf_source(**...)`, which accepts `method` since #461). No emitter change (openEMS emitter refuses all TFSF designs).

**Evidence (clean clone of main + this fix):**
- failing selection `-k "oblique or tfsf"`: 9 failed / 53 passed → **62 passed, 1 skipped**
- full interop suite: **361 passed**
- ruff, `check_api_reference.py`: green

Follow-up note (not in this PR): a `method="methodB"` round-trip fixture would pin the non-default value end-to-end; the current fixtures exercise the default through the registry pin and round-trip lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)