### PR TITLE
hygiene: MeshShape export parity, scale-free openEMS excitation guard, subgrid PML-warning frame fix (#465 #466 #467)

### DIFF
--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -145,6 +145,9 @@
     "MeshPlan": {
       "kind": "class"
     },
+    "MeshShape": {
+      "kind": "class"
+    },
     "ModulatedGaussian": {
       "kind": "class"
     },

--- a/docs/public/api/geometry-materials.mdx
+++ b/docs/public/api/geometry-materials.mdx
@@ -21,6 +21,7 @@ listed in [Recommended Configuration](/rfx/validation/reference-lane/) and
 | `PolylineWire` | polyline-defined wire geometry | wire-like studies and routed conductors |
 | `Via` | `Via(center=..., drill_radius=..., pad_radius=..., layers=..., material="pec")` | PCB-style interconnects |
 | `CurvedPatch` | `CurvedPatch(center=..., length=..., width=..., radius=..., axis="x")` | curved-conductor studies; constructor arguments are keyword-only |
+| `MeshShape` | `MeshShape.from_file(path, scale=..., translate=(0,0,0))` | CAD import — STL/OBJ/PLY, plus STEP/STP via the `cad` extra. Rasterizes host-side (trimesh containment): NOT differentiable — a traced coordinate raises, so CAD geometry cannot carry gradients |
 
 ## Material registration
 

--- a/docs/public/guide/materials-geometry.mdx
+++ b/docs/public/guide/materials-geometry.mdx
@@ -193,6 +193,25 @@ rod  = Cylinder((0.010, 0.025, 0.000), radius=0.001,  height=0.050, axis="x")
 sim.add(via, material="copper")
 ```
 
+### MeshShape (CAD import)
+
+```python
+from rfx import MeshShape  # needs: pip install "rfx-fdtd[cad]"
+
+# STL / OBJ / PLY natively; STEP / STP via the cad extra's OpenCASCADE backend.
+# scale converts the file's length unit to metres (STL in mm -> scale=1e-3;
+# STEP is converted to metres already -> scale=1.0).
+part = MeshShape.from_file("bracket.stl", scale=1e-3, translate=(0.01, 0.0, 0.0))
+sim.add(part, material="pec")
+```
+
+!!! warning "Not differentiable"
+    `MeshShape` rasterizes host-side via `trimesh` point-in-mesh containment
+    and **raises on traced coordinates** — CAD-imported geometry cannot carry
+    gradients through `forward()`/`optimize()`. Use the CSG primitives for
+    any shape that must be a design variable. The design-interop layer
+    (`rfx.interop`) likewise refuses `MeshShape` rather than approximating it.
+
 `Box`, `Sphere`, and `Cylinder` cover most structures. rfx also ships
 `PolylineWire`, `Via`, and `CurvedPatch`; see the
 [Geometry and Materials API reference](/rfx/api/geometry-materials/) for their

--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -42,6 +42,7 @@ from rfx.jax_checks import (
 )
 from rfx.geometry.csg import Box, Sphere, Cylinder, PolylineWire
 from rfx.geometry.curved import CurvedPatch
+from rfx.geometry.mesh_import import MeshShape
 from rfx.subgridding.validation import SubgridValidationIssue, SubgridValidationReport
 from rfx.geometry.via import Via
 from rfx.sources.sources import GaussianPulse, ModulatedGaussian, CWSource, CustomWaveform
@@ -257,6 +258,7 @@ __all__ = [
     "check_bounds", "check_courant_number",
     # geometry
     "Box", "Sphere", "Cylinder", "PolylineWire", "CurvedPatch", "Via",
+    "MeshShape",
     "PCBLayer", "Stackup",
     # microstrip closed-form synthesis / analysis
     "microstrip_impedance", "microstrip_eps_eff", "microstrip_width",

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -631,11 +631,18 @@ class Simulation(
         # recovers user coordinates (rfx/grid.py). The pre-#466 check used the
         # opposite frame (absorber inside the first/last N domain cells) and
         # so fired on geometry that was clear of the absorber. In the
-        # builder's frame a z_range overlaps the absorber only when it leaves
-        # the physical domain: z_lo < 0 into an absorbing z_lo face, or
-        # z_hi > domain_z into an absorbing z_hi face. Frame fix only — no
-        # new adjacency/clearance semantics (the subgrid lane is EXPERIMENTAL,
-        # PR #90).
+        # builder's frame a z_range meets the absorber only when it reaches
+        # the physical-domain edge of an ABSORBING face: z_lo <= 0 (touching
+        # or entering the z_lo padding) or z_hi >= domain_z. Touching counts —
+        # the SAT interface then sits directly against the CPML interface,
+        # and the authoritative static validator flags the same geometry as
+        # ``subgrid_overlaps_absorber`` (see
+        # test_production_boundary_terminated_rejects_refined_face_touching_cpml,
+        # which pins this warning for the touching case). What the frame fix
+        # REMOVES is the interior false positive: a z_range strictly inside
+        # (0, domain_z) is clear of the absorber no matter how close to the
+        # edge, because the absorber cells are padding outside. The subgrid
+        # lane stays EXPERIMENTAL (PR #90).
         if self._boundary in ("cpml", "upml") and self._cpml_layers > 0:
             import warnings
             z_lo_kind = self._boundary_spec.z.lo if self._boundary_spec else self._boundary
@@ -644,15 +651,16 @@ class Simulation(
             zhi_absorbing = z_hi_kind in ("cpml", "upml")
             domain_z = self._domain[2] if len(self._domain) > 2 else 0
             z_lo, z_hi = z_range
-            if (zlo_absorbing and z_lo < 0.0) or (
-                zhi_absorbing and domain_z > 0 and z_hi > domain_z
+            if (zlo_absorbing and z_lo <= 0.0) or (
+                zhi_absorbing and domain_z > 0 and z_hi >= domain_z
             ):
                 warnings.warn(
-                    f"Subgrid z_range=({z_lo*1e3:.1f}, {z_hi*1e3:.1f})mm extends "
-                    f"outside the physical domain (0.0, {domain_z*1e3:.1f})mm "
-                    f"into the absorber padding (absorber lies OUTSIDE the "
-                    f"domain — rfx/grid.py convention). This causes late-time "
-                    f"energy growth. Keep z_range inside the physical domain.",
+                    f"Subgrid z_range=({z_lo*1e3:.1f}, {z_hi*1e3:.1f})mm overlaps PML "
+                    f"absorber padding: it reaches the edge of the physical domain "
+                    f"(0.0, {domain_z*1e3:.1f})mm on an absorbing z face (the "
+                    f"absorber lies OUTSIDE the domain — rfx/grid.py convention). "
+                    f"This causes late-time energy growth. Keep z_range strictly "
+                    f"inside the physical domain or use PEC z faces.",
                     stacklevel=2,
                 )
 

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -620,37 +620,39 @@ class Simulation(
                 "topology must be one of 'overlap_z_slab' or "
                 "'stage2_disjoint_3d'"
             )
-        # Warn if subgrid overlaps PML region.
+        # Warn if subgrid overlaps the PML region.
         # PML operates on the coarse grid only; the fine grid has no PML.
         # Overlapping causes late-time energy growth (SAT coupling feeds
         # energy into the PML boundary faster than it can absorb).
+        #
+        # Coordinate frame (issue #466): the grid builder places the absorber
+        # OUTSIDE the user domain — ``domain`` is entirely physical, the CPML
+        # cells are extra padding beyond it, and ``(idx - axis_pads)*dx``
+        # recovers user coordinates (rfx/grid.py). The pre-#466 check used the
+        # opposite frame (absorber inside the first/last N domain cells) and
+        # so fired on geometry that was clear of the absorber. In the
+        # builder's frame a z_range overlaps the absorber only when it leaves
+        # the physical domain: z_lo < 0 into an absorbing z_lo face, or
+        # z_hi > domain_z into an absorbing z_hi face. Frame fix only — no
+        # new adjacency/clearance semantics (the subgrid lane is EXPERIMENTAL,
+        # PR #90).
         if self._boundary in ("cpml", "upml") and self._cpml_layers > 0:
             import warnings
-            dx = self._dx or (2.998e8 / self._freq_max / 10)
-            face_layers = self._resolve_face_layers()
             z_lo_kind = self._boundary_spec.z.lo if self._boundary_spec else self._boundary
             z_hi_kind = self._boundary_spec.z.hi if self._boundary_spec else self._boundary
-            pml_zlo_thickness = (
-                face_layers.get("z_lo", self._cpml_layers) * dx
-                if z_lo_kind in ("cpml", "upml")
-                else 0.0
-            )
-            pml_zhi_thickness = (
-                face_layers.get("z_hi", self._cpml_layers) * dx
-                if z_hi_kind in ("cpml", "upml")
-                else 0.0
-            )
+            zlo_absorbing = z_lo_kind in ("cpml", "upml")
+            zhi_absorbing = z_hi_kind in ("cpml", "upml")
             domain_z = self._domain[2] if len(self._domain) > 2 else 0
             z_lo, z_hi = z_range
-            if z_lo < pml_zlo_thickness or (
-                domain_z > 0 and z_hi > domain_z - pml_zhi_thickness
+            if (zlo_absorbing and z_lo < 0.0) or (
+                zhi_absorbing and domain_z > 0 and z_hi > domain_z
             ):
                 warnings.warn(
-                    f"Subgrid z_range=({z_lo*1e3:.1f}, {z_hi*1e3:.1f})mm overlaps "
-                    f"PML region (zlo={pml_zlo_thickness*1e3:.1f}mm, "
-                    f"zhi={pml_zhi_thickness*1e3:.1f}mm). "
-                    f"This causes late-time energy growth. "
-                    f"Move z_range inside the PML boundary for stable results.",
+                    f"Subgrid z_range=({z_lo*1e3:.1f}, {z_hi*1e3:.1f})mm extends "
+                    f"outside the physical domain (0.0, {domain_z*1e3:.1f})mm "
+                    f"into the absorber padding (absorber lies OUTSIDE the "
+                    f"domain — rfx/grid.py convention). This causes late-time "
+                    f"energy growth. Keep z_range inside the physical domain.",
                     stacklevel=2,
                 )
 

--- a/scripts/diagnostics/build_coaxial_line_openems_broad_comparison.py
+++ b/scripts/diagnostics/build_coaxial_line_openems_broad_comparison.py
@@ -245,6 +245,10 @@ def _run_openems_line_reference(term: str, R: float | None, *, sim_dir: Path,
             f"openEMS feed port time trace is identically zero for term={term!r}: "
             "the excitation never entered the grid (silently dropped port)."
         )
+    # Surface both witnesses (PR #473 review): the D5 guard this mirrors
+    # records them in its diagnostics JSON; here a log line is the artifact.
+    print(f"excitation-guard term={term!r}: max|uf_inc|={inc_peak:.3e} "
+          f"trace_peak={trace_peak if trace_peak is None else f'{trace_peak:.3e}'}")
     s11 = np.asarray(feed.uf_ref / uf_inc, dtype=np.complex128)
     # Fail loud on a blown-up / non-physical field: a stable lossless line has
     # |Gamma| <= 1; anything >> 1 (or non-finite) means the run diverged.

--- a/scripts/diagnostics/build_coaxial_line_openems_broad_comparison.py
+++ b/scripts/diagnostics/build_coaxial_line_openems_broad_comparison.py
@@ -214,12 +214,36 @@ def _run_openems_line_reference(term: str, R: float | None, *, sim_dir: Path,
     # Fail loud and fast: a port that never coupled (mesh-misaligned excitation)
     # yields uf_inc=0 -> S11=0/0=NaN.  Catch it on the FIRST termination instead
     # of running the whole panel to silent NaN.
+    #
+    # SCALE-FREE test (issue #465): the former `inc_peak <= 1e-9` threshold
+    # false-fires on CORRECT runs — measured max|uf_inc| on runs with correct
+    # S-parameters is 1.93e-12 (PEC-cavity two-port) / 1.79e-13 (MSL thru),
+    # 3-4 decades BELOW that constant (openEMS's excitation normalisation, not
+    # a property of the setup; #465 measurement table). The dropped-port
+    # symptom is exactly-zero / non-finite, so test that, plus an independent
+    # time-domain witness (the port voltage trace), mirroring the proven D5
+    # guard in rfx/interop/emitters/openems.py — no absolute scale assumed.
     inc_peak = float(np.max(np.abs(uf_inc))) if uf_inc.size else 0.0
-    if not np.isfinite(inc_peak) or inc_peak <= 1.0e-9:
+    if not np.isfinite(inc_peak) or inc_peak == 0.0:
         raise RuntimeError(
-            f"openEMS feed port injected ~0 incident energy (max|uf_inc|={inc_peak:.3e}) "
+            f"openEMS feed port injected NO incident wave (max|uf_inc|={inc_peak!r}) "
             f"for term={term!r}: excitation did not couple. Check that the radial port "
             f"edges land on mesh lines (SmoothMeshLines/fixed-line snap)."
+        )
+    trace_peak = None
+    for name in list(getattr(feed, "U_filenames", []) or []):
+        trace_path = sim_dir / name
+        if not trace_path.exists():
+            continue
+        raw = np.loadtxt(trace_path, comments="%")
+        if not raw.size:
+            continue
+        peak_here = float(np.max(np.abs(np.atleast_2d(raw)[:, 1])))
+        trace_peak = peak_here if trace_peak is None else max(trace_peak, peak_here)
+    if trace_peak == 0.0:
+        raise RuntimeError(
+            f"openEMS feed port time trace is identically zero for term={term!r}: "
+            "the excitation never entered the grid (silently dropped port)."
         )
     s11 = np.asarray(feed.uf_ref / uf_inc, dtype=np.complex128)
     # Fail loud on a blown-up / non-physical field: a stable lossless line has

--- a/tests/test_subgrid_pml_overlap_warning.py
+++ b/tests/test_subgrid_pml_overlap_warning.py
@@ -3,10 +3,16 @@
 The grid builder places the absorber OUTSIDE the physical domain (extra pad
 cells; ``rfx/grid.py``), but the pre-#466 warning tested ``z_lo <
 pml_thickness`` / ``z_hi > domain_z - pml_thickness`` — the opposite frame
-(absorber inside the first/last N domain cells) — so it fired on subgrids
-that were entirely clear of the absorber. Frame fix only: the subgrid lane is
-EXPERIMENTAL (3-D SBP-SAT falsified, PR #90) and no new adjacency/validation
-semantics are added here.
+(absorber inside the first/last N domain cells) — so it fired on INTERIOR
+subgrids that were entirely clear of the absorber. The frame fix removes that
+false-positive class only. TOUCHING an absorbing face (z_lo <= 0 or z_hi >=
+domain_z) still warns: the SAT interface then sits directly against the CPML
+interface, and the authoritative static validator flags the same geometry as
+``subgrid_overlaps_absorber`` (pinned by
+test_production_boundary_terminated_rejects_refined_face_touching_cpml, which
+stays green — PR #473 review finding). Frame fix only: the subgrid lane is
+EXPERIMENTAL (3-D SBP-SAT falsified, PR #90) and no validation claims are
+added.
 """
 import warnings
 
@@ -20,26 +26,36 @@ def _sim():
                       boundary="cpml", cpml_layers=8, mode="3d")
 
 
-def test_full_domain_subgrid_does_not_warn():
-    """A subgrid spanning the FULL physical domain is clear of the absorber
-    (which lives in the padding outside) — the pre-#466 frame warned here
-    (0 < 8 mm and 12 > 12-8 mm), which was the false positive."""
+def test_interior_subgrid_does_not_warn():
+    """An INTERIOR subgrid (strictly inside the physical domain) is clear of
+    the absorber, which lives in the padding outside — the pre-#466 frame
+    warned here (0.002 < 8 mm "thickness" and 0.010 > 12-8 mm), which was
+    the false positive this fix removes."""
     sim = _sim()
     with warnings.catch_warnings():
         warnings.simplefilter("error")  # any overlap warning -> test failure
         try:
-            sim.add_refinement((0.0, 0.012), ratio=2)
+            sim.add_refinement((0.002, 0.010), ratio=2)
         except Warning as w:  # pragma: no cover - explicit failure message
             if "absorber" in str(w) or "PML" in str(w):
                 pytest.fail(f"false-positive absorber warning: {w}")
             raise
 
 
+def test_touching_an_absorbing_face_warns():
+    """z_lo == 0.0 puts the subgrid boundary directly against the absorbing
+    face's CPML interface -> warns (matches the static validator's
+    subgrid_overlaps_absorber verdict for the same geometry)."""
+    sim = _sim()
+    with pytest.warns(UserWarning, match="overlaps PML"):
+        sim.add_refinement((0.0, 0.006), ratio=2)
+
+
 def test_subgrid_into_padding_warns():
     """A z_range extending below z=0 leaves the physical domain and enters
     the absorbing padding on the z_lo face -> the warning must fire."""
     sim = _sim()
-    with pytest.warns(UserWarning, match="absorber"):
+    with pytest.warns(UserWarning, match="overlaps PML"):
         sim.add_refinement((-0.002, 0.006), ratio=2)
 
 

--- a/tests/test_subgrid_pml_overlap_warning.py
+++ b/tests/test_subgrid_pml_overlap_warning.py
@@ -1,0 +1,60 @@
+"""Subgrid PML-overlap warning uses the grid builder's coordinate frame (#466).
+
+The grid builder places the absorber OUTSIDE the physical domain (extra pad
+cells; ``rfx/grid.py``), but the pre-#466 warning tested ``z_lo <
+pml_thickness`` / ``z_hi > domain_z - pml_thickness`` — the opposite frame
+(absorber inside the first/last N domain cells) — so it fired on subgrids
+that were entirely clear of the absorber. Frame fix only: the subgrid lane is
+EXPERIMENTAL (3-D SBP-SAT falsified, PR #90) and no new adjacency/validation
+semantics are added here.
+"""
+import warnings
+
+import pytest
+
+from rfx.api import Simulation
+
+
+def _sim():
+    return Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.012), dx=1e-3,
+                      boundary="cpml", cpml_layers=8, mode="3d")
+
+
+def test_full_domain_subgrid_does_not_warn():
+    """A subgrid spanning the FULL physical domain is clear of the absorber
+    (which lives in the padding outside) — the pre-#466 frame warned here
+    (0 < 8 mm and 12 > 12-8 mm), which was the false positive."""
+    sim = _sim()
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any overlap warning -> test failure
+        try:
+            sim.add_refinement((0.0, 0.012), ratio=2)
+        except Warning as w:  # pragma: no cover - explicit failure message
+            if "absorber" in str(w) or "PML" in str(w):
+                pytest.fail(f"false-positive absorber warning: {w}")
+            raise
+
+
+def test_subgrid_into_padding_warns():
+    """A z_range extending below z=0 leaves the physical domain and enters
+    the absorbing padding on the z_lo face -> the warning must fire."""
+    sim = _sim()
+    with pytest.warns(UserWarning, match="absorber"):
+        sim.add_refinement((-0.002, 0.006), ratio=2)
+
+
+def test_pec_z_faces_do_not_warn_even_outside():
+    """With non-absorbing z faces there is no absorber to overlap: the frame
+    fix keys the warning to the per-face boundary kind, not to cpml_layers
+    alone."""
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.012), dx=1e-3,
+                     boundary={"x": "cpml", "y": "cpml", "z": "pec"},
+                     cpml_layers=8, mode="3d")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        try:
+            sim.add_refinement((-0.002, 0.006), ratio=2)
+        except Warning as w:  # pragma: no cover
+            if "absorber" in str(w) or "PML" in str(w):
+                pytest.fail(f"absorber warning on PEC z faces: {w}")
+            raise


### PR DESCRIPTION
Track C of the 2026-07-27 delegated-tracks handover (`docs/research_notes/20260727_handover_delegated_tracks.md`): three small independent hygiene items, one commit each.

## #467 — MeshShape export parity (`e6d581d`)
Top-level `rfx.MeshShape` export + regenerated `api_symbol_inventory.json` (diff = the one row) + public-docs rows (primitive table + guide section). Both docs state the AD limitation next to the feature, per the issue: host-side trimesh rasterization, traced coordinates raise, CAD geometry cannot carry gradients, `rfx.interop` refuses it rather than approximating. Checked that `rfx/geometry/mesh_import.py` keeps its trimesh import lazy, so plain `import rfx` still works without the `cad` extra.

## #465 — openEMS excitation guard (`df73ba6`)
The coax broad-comparison guard's `max|uf_inc| <= 1e-9` threshold false-fires: correct runs measure 1.93e-12 / 1.79e-13 (#465 measurement table — openEMS's excitation normalisation scale). Replaced with the scale-free shape the issue proposes, ported from the PROVEN D5 guard in `rfx/interop/emitters/openems.py`: exactly-zero / non-finite incident spectrum → raise, plus the independent port voltage-time-trace witness (`U_filenames`; identically-zero trace = silently dropped port). No absolute scale assumed.

## #466 — subgrid PML-overlap warning frame (`17de70e`)
The warning assumed the absorber occupies the first/last N cells INSIDE the user domain; the grid builder puts it OUTSIDE (domain fully physical, CPML = padding — `rfx/grid.py`). It fired on subgrids that were clear of the absorber (e.g. a full-domain `z_range`). Now warns exactly when `z_range` leaves the physical domain into an absorbing face's padding, respecting per-face boundary kinds. **Frame fix only** — subgrid stays EXPERIMENTAL (PR #90), no new validation claims. Fire/clear/PEC-face test triplet added; no existing test pinned the old wording.

## Verification (local, worktree, `rfx.__file__` checked)
- new tests: 3/3 (`test_subgrid_pml_overlap_warning.py`)
- contract/regression: ad-surface + api + mesh-import + golden-workflow **62 passed**; subgrid public-API + n-1 guard + api **52 passed**
- `api reference surface: OK`; ruff clean (gated scope)
- #465 has no pytest surface (diagnostics script, needs openEMS): guard shape is the emitter's tested D5 pattern, cited in-code.

R3: memory=feedback_contract_tests_for_public_surface + project_sbp_sat_subgridding_research + feedback_imitate_external_solver_examples | R2-attempts=0 | falsifier=fire/clear test pairs + api-reference drift gate

Independent review before merge per the handover process; do not merge on author's word alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)