### PR TITLE
fix(rcs): absolute oblique sigma calibrated via measured aux spectrum + 4-plane vacuum guard (#471 F7/F5/F8)

### DIFF
--- a/docs/public/guide/sources-ports.mdx
+++ b/docs/public/guide/sources-ports.mdx
@@ -342,7 +342,8 @@ transverse boundary-value problem: `"bloch"` is the laterally periodic
 (unit-cell / infinite-array) path, `"methodB"` is the open-domain 2.5-D path
 for a compact isolated scatterer (`polarization="ez"`, uniform grid, and
 `direction="+x"` only — `"-x"` raises `NotImplementedError` under
-`"methodB"`; mirror the geometry instead).
+`"methodB"` at `run()` time, since the Simulation API defers TFSF
+construction to the run; mirror the geometry instead).
 
 !!! warning
     `add_tfsf_source` cannot be combined with lumped ports or waveguide ports.

--- a/docs/public/guide/sources-ports.mdx
+++ b/docs/public/guide/sources-ports.mdx
@@ -332,8 +332,17 @@ sim.add_tfsf_source(
     polarization="ez",
     direction="+x",    # propagation direction (+x or -x)
     angle_deg=0.0,     # oblique incidence angle (|angle_deg| < 90, degrees from normal)
+    method="bloch",    # oblique path: "bloch" (periodic unit cell) or
+                       # "methodB" (open-domain compact scatterer)
 )
 ```
+
+For oblique incidence (`angle_deg != 0`) the `method` argument selects the
+transverse boundary-value problem: `"bloch"` is the laterally periodic
+(unit-cell / infinite-array) path, `"methodB"` is the open-domain 2.5-D path
+for a compact isolated scatterer (`polarization="ez"`, uniform grid, and
+`direction="+x"` only — `"-x"` raises `NotImplementedError` under
+`"methodB"`; mirror the geometry instead).
 
 !!! warning
     `add_tfsf_source` cannot be combined with lumped ports or waveguide ports.

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -302,12 +302,24 @@ class _PreflightMixin:
 
     @staticmethod
     def _validate_tfsf_vacuum_boundary(materials: MaterialArrays, tfsf_cfg) -> None:
-        """Ensure the TFSF x-boundary planes remain vacuum.
+        """Ensure the TFSF boundary planes remain vacuum.
 
-        The current TFSF correction assumes vacuum on and immediately
-        adjacent to the TFSF x boundaries. Fail loudly instead of
-        allowing silently wrong scattered fields.
+        The TFSF correction assumes vacuum on and immediately adjacent to
+        the TFSF boundaries. Fail loudly instead of allowing silently wrong
+        scattered fields. For the 4-edge Method-B box this means the y planes
+        as well as the x planes (issue #471 F5: the x-only check let a PEC
+        strip on the y_lo plane pass silently); the check for that path lives
+        with the source in ``tfsf_oblique_open.validate_vacuum_boundary`` so
+        ``compute_rcs`` can run the identical check.
         """
+        from rfx.sources.tfsf import is_tfsf_methodB
+
+        if is_tfsf_methodB(tfsf_cfg):
+            from rfx.sources.tfsf_oblique_open import validate_vacuum_boundary
+
+            validate_vacuum_boundary(materials, tfsf_cfg)
+            return
+
         boundary_slices = (
             ("x_lo-1", slice(tfsf_cfg.x_lo - 1, tfsf_cfg.x_lo)),
             ("x_lo", slice(tfsf_cfg.x_lo, tfsf_cfg.x_lo + 1)),

--- a/rfx/rcs.py
+++ b/rfx/rcs.py
@@ -205,10 +205,26 @@ def compute_rcs(
         measured on the PRE-fix exclusive kernels; not re-measured in-tree
         on the inclusive kernels) —
         i.e. the argmax azimuth of the broad specular lobe is NOT converged to
-        ~1 deg. See ``tests/test_oblique_rcs_specular.py``. The absolute
-        oblique sigma is NOT validated. Requires ``polarization='ez'`` and a
-        uniform grid; other combos raise ``NotImplementedError`` (issue #404
-        arc).
+        ~1 deg. See ``tests/test_oblique_rcs_specular.py``.
+
+        ABSOLUTE oblique sigma (issue #471 F7, all numbers measured): the
+        normalization is the MEASURED 1D-aux incident spectrum (see
+        ``tfsf_oblique_open.measure_incident_spectrum``), which removed a
+        +6.58/+4.51 dB (theta 20/40 deg) inflation the analytic normal-path
+        spectrum caused. Against a PO uniform-aperture oracle on the gate
+        grid (dx=2 mm = lambda/30): specular-peak Delta +0.86/+0.85 dB
+        (theta 20/40), lobe-flat over +/-12 deg. The returned sigma is that
+        of an aperture of height ``h_eff = (k_hi - k_lo)*dx`` of the NTFF
+        z-box (span-doubling ratio 4.000 measured — sigma scales as
+        h_eff^2); the oblique path's hardcoded 2-cell midplane box means
+        h_eff = 2*dx, so scale by ``(L_z/h_eff)^2`` for a physical strip
+        height ``L_z``. CAVEAT (measured, pinned-geometry): halving dx to
+        lambda/60 moves Delta to -1.55 dB — a 2.4 dB resolution
+        sensitivity, so treat absolute oblique sigma as a +/-2 dB-class
+        number at lambda/30-lambda/60, NOT sub-dB (the committed test gates
+        |Delta| <= 1.5 dB at the fixed gate grid as a regression lock, not
+        an accuracy claim). Requires ``polarization='ez'`` and a uniform
+        grid; other combos raise ``NotImplementedError`` (issue #404 arc).
     phi_inc : float
         Incident azimuth in degrees (reserved for future oblique support).
     polarization : str
@@ -326,12 +342,16 @@ def compute_rcs(
     # 2.2-lambda plate's ~30 deg physical-optics 3 dB specular lobe at
     # theta_inc=40 (0.886*lambda/(W*cos(theta))) — argmax on a 1 deg grid
     # inside a broad lobe, an envelope pin, not a loose bound.
-    # SCOPE LIMIT: only the far-field PATTERN / specular DIRECTION is validated.
-    # The ABSOLUTE oblique sigma is NOT validated — the 2.5-D strip's 3-D RCS
-    # scales with the (arbitrary) NTFF z-box height because the two z-faces cancel
-    # for x-y-plane observation, and the incident-spectrum normalization below
-    # assumes the normal-path waveform. Kept fenced for combos Method B does not
-    # support: non-ez polarization and non-uniform / distributed grids.
+    # ABSOLUTE sigma (issue #471 F7): normalized by the MEASURED 1D-aux
+    # incident spectrum (measure_incident_spectrum below), validated vs a PO
+    # uniform-aperture oracle at the gate grid to +0.86/+0.85 dB (theta 20/40)
+    # with a measured 2.4 dB resolution sensitivity lambda/30 -> lambda/60 —
+    # a +/-2 dB-class calibration, envelope-pinned by
+    # tests/test_oblique_rcs_absolute_sigma.py. sigma corresponds to an
+    # aperture height h_eff = (k_hi-k_lo)*dx = 2*dx (z-faces cancel for
+    # x-y-plane observation; span-doubling ratio 4.000 measured). Kept fenced
+    # for combos Method B does not support: non-ez polarization and
+    # non-uniform / distributed grids.
     _oblique = abs(float(theta_inc)) > 1e-6
     if _oblique:
         if polarization != "ez":
@@ -385,6 +405,15 @@ def compute_rcs(
         nz=grid.nz,
         method="methodB" if _oblique else "bloch",
     )
+
+    if _oblique:
+        # #471 F5: compute_rcs never ran the preflight vacuum validator. Run
+        # the identical all-four-planes check here so a target crossing a
+        # TFSF boundary plane fails loud instead of corrupting the scattered
+        # field (the runner-side validator covers the Simulation API lane).
+        from rfx.sources.tfsf_oblique_open import validate_vacuum_boundary
+
+        validate_vacuum_boundary(materials, tfsf_cfg)
 
     # --- 2. Set up NTFF box just outside TFSF box ---
     # NTFF box must be in scattered-field region (outside TFSF box).
@@ -482,9 +511,22 @@ def compute_rcs(
         )
 
     # --- 5. Compute incident field spectrum for normalization ---
-    E_inc_spectrum = _incident_spectrum_amplitude(
-        f0, bandwidth, freqs_arr, dt, n_steps,
-    )
+    if _oblique:
+        # Method B hardcodes its own waveform (t0=40·dt, tau=12·dt modulated
+        # Gaussian) and its source->aux launch response is theta-dependent, so
+        # the analytic normal-path spectrum is the wrong denominator (issue
+        # #471 F7: sigma inflated +6.58 dB at theta=20 deg, +4.51 dB at 40 deg
+        # on the gate grid). Normalize by the MEASURED 1D-aux spectrum instead
+        # — a standalone replay of the same aux the box injects from.
+        from rfx.sources.tfsf_oblique_open import measure_incident_spectrum
+
+        E_inc_spectrum = measure_incident_spectrum(
+            tfsf_cfg, tfsf_st, n_steps, freqs_arr, dx,
+        )
+    else:
+        E_inc_spectrum = _incident_spectrum_amplitude(
+            f0, bandwidth, freqs_arr, dt, n_steps,
+        )
 
     # --- 6. Compute RCS ---
     # RCS = 4*pi * |E_far|^2 / |E_inc|^2

--- a/rfx/sources/tfsf_oblique_open.py
+++ b/rfx/sources/tfsf_oblique_open.py
@@ -188,7 +188,12 @@ def init_tfsf_methodB(
     the dispersion-matched 1D cell size along k̂ at ``ω = 2π f0``.
 
     Source timing reproduces the prototype exactly: ``t0 = 40·dt``,
-    ``tau = 12·dt``, modulated Gaussian at carrier ``f0``.
+    ``tau = 12·dt``, modulated Gaussian at carrier ``f0``.  NOTE the injected
+    SOURCE spectrum is therefore resolution-dependent (``tau ∝ dt``) and its
+    launch response is angle-dependent (``d_aux`` is dispersion-matched per
+    theta); ``compute_rcs`` normalizes absolute sigma by the MEASURED aux
+    spectrum (:func:`measure_incident_spectrum`), which tracks both per run
+    (issue #471 F7).
     """
     if polarization != "ez":
         raise NotImplementedError(
@@ -424,3 +429,119 @@ def apply_methodB_e(state, cfg: MethodBConfig, st: MethodBState, dx: float, dt: 
     ez = ez.at[cfg.x_lo:cfg.x_hi + 1, cfg.y_hi + 1, :].add((ce * sn * inc)[:, None])
 
     return state._replace(ez=ez)
+
+
+# ---------------------------------------------------------------------------
+# Boundary-plane vacuum validation (issue #471 F5)
+# ---------------------------------------------------------------------------
+
+def validate_vacuum_boundary(materials, cfg: MethodBConfig) -> None:
+    """Fail loud if any Method-B TFSF boundary plane is not vacuum.
+
+    The 4-edge box assumes vacuum on and immediately adjacent to ALL FOUR
+    transverse boundary planes — x AND y. The pre-#471 preflight check
+    validated only the x planes (it predates the 4-edge box), so a PEC strip
+    lying on the ``y_lo`` plane passed silently and corrupted the scattered
+    field (issue #471 F5). Called from both the uniform-runner preflight
+    validator and ``compute_rcs`` (which never ran the validator at all).
+    """
+    planes = (
+        ("x_lo-1", (slice(cfg.x_lo - 1, cfg.x_lo), slice(None))),
+        ("x_lo",   (slice(cfg.x_lo, cfg.x_lo + 1), slice(None))),
+        ("x_hi",   (slice(cfg.x_hi, cfg.x_hi + 1), slice(None))),
+        ("x_hi+1", (slice(cfg.x_hi + 1, cfg.x_hi + 2), slice(None))),
+        ("y_lo-1", (slice(None), slice(cfg.y_lo - 1, cfg.y_lo))),
+        ("y_lo",   (slice(None), slice(cfg.y_lo, cfg.y_lo + 1))),
+        ("y_hi",   (slice(None), slice(cfg.y_hi, cfg.y_hi + 1))),
+        ("y_hi+1", (slice(None), slice(cfg.y_hi + 1, cfg.y_hi + 2))),
+    )
+    for plane_name, (xs, ys) in planes:
+        eps = np.asarray(materials.eps_r[xs, ys, :])
+        sigma = np.asarray(materials.sigma[xs, ys, :])
+        mu = np.asarray(materials.mu_r[xs, ys, :])
+        if not (
+            np.allclose(eps, 1.0)
+            and np.allclose(sigma, 0.0)
+            and np.allclose(mu, 1.0)
+        ):
+            raise ValueError(
+                "Method-B oblique TFSF requires vacuum on and adjacent to all "
+                "four transverse TFSF boundary planes; non-vacuum material "
+                f"found at {plane_name} (max eps_r {float(np.max(eps)):.3g}, "
+                f"max sigma {float(np.max(sigma)):.3g}, "
+                f"max mu_r {float(np.max(mu)):.3g}). Shrink the target or "
+                "enlarge tfsf_margin."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Measured incident spectrum — the absolute-sigma normalization (issue #471 F7)
+# ---------------------------------------------------------------------------
+
+def measure_incident_spectrum(
+    cfg: MethodBConfig,
+    state: MethodBState,
+    n_steps: int,
+    freqs,
+    dx: float,
+) -> np.ndarray:
+    """DFT of the ACTUAL 1D-aux incident field at the TFSF-box-centre projection.
+
+    Replays the Method-B 1D auxiliary FDTD standalone (a fresh zero state — the
+    caller's ``state`` is only a shape template and is never mutated) for
+    ``n_steps`` and DFTs the recorded ``e1d`` at the aux index onto which the
+    box centre projects.  This is the incident spectral amplitude the 4-edge
+    box actually injects, so using it as the RCS normalization captures what an
+    analytic waveform DFT cannot (all MEASURED, issue #471 F7 audit, gate grid
+    f0=5 GHz, dx=2 mm):
+
+    * the hardcoded ``t0=40·dt, tau=12·dt`` modulated Gaussian instead of the
+      normal path's assumed differentiated Gaussian (+8.83 dB at f0 — the
+      review's number, reproduced exactly), AND
+    * the source->aux launch/absorption response the review neglected
+      (-2.25 dB at theta=20 deg), which is THETA-DEPENDENT (-4.32 dB at 40 deg)
+      because ``d_aux`` is dispersion-matched per angle, so the pulse's spatial
+      extent vs the lo-CPML clearance changes with the angle.
+
+    Net assumed-vs-actual mismatch: +6.58 dB (20 deg) / +4.51 dB (40 deg) —
+    the pre-fix absolute-sigma inflation.  Cost: ``n_steps`` scans of the
+    ~O(500)-cell 1D aux (well under a second; runs once per compute_rcs call).
+
+    The DFT window equals the 3D run window (same ``n_steps``), so truncation
+    semantics match the NTFF far-field DFT it normalizes.
+    """
+    from jax import lax
+
+    zero = state._replace(
+        e1d=jnp.zeros_like(state.e1d),
+        h1d=jnp.zeros_like(state.h1d),
+        psi_e_lo=jnp.zeros_like(state.psi_e_lo),
+        psi_e_hi=jnp.zeros_like(state.psi_e_hi),
+        psi_h_lo=jnp.zeros_like(state.psi_h_lo),
+        psi_h_hi=jnp.zeros_like(state.psi_h_hi),
+        step=jnp.array(0, dtype=jnp.int32),
+    )
+    # Box-centre projection onto the aux line (same mapping as the gather
+    # tables: idx_E = (x*cos + y*sin)*dx/d_aux + src_idx). The plane-wave
+    # magnitude is position-independent, so the exact interior index is not
+    # critical; the centre is the semantically-right target location.
+    cx = 0.5 * (cfg.x_lo + cfg.x_hi)
+    cy = 0.5 * (cfg.y_lo + cfg.y_hi)
+    ref = int(round(((cx * cfg.cos_theta + cy * cfg.sin_theta) * dx)
+                    / cfg.d_aux + cfg.src_idx))
+
+    ts = jnp.arange(n_steps, dtype=jnp.float32) * cfg.dt
+
+    def _step(st, t):
+        st = update_tfsf_1d_h(cfg, st, cfg.dx_1d, cfg.dt)
+        st = update_tfsf_1d_e(cfg, st, cfg.dx_1d, cfg.dt, t)
+        return st, st.e1d[ref]
+
+    _, rec = lax.scan(_step, zero, ts)
+    rec = np.asarray(rec, dtype=np.float64)
+    times = np.arange(n_steps) * cfg.dt
+    freqs = np.asarray(freqs, dtype=np.float64)
+    out = np.empty(len(freqs), dtype=np.complex128)
+    for i, f in enumerate(freqs):
+        out[i] = np.sum(rec * np.exp(-1j * 2.0 * np.pi * f * times)) * cfg.dt
+    return out

--- a/tests/test_oblique_rcs_absolute_sigma.py
+++ b/tests/test_oblique_rcs_absolute_sigma.py
@@ -1,0 +1,301 @@
+"""Absolute oblique sigma calibration + Method-B boundary guards (issue #471).
+
+F7 — the absolute-sigma normalization is the MEASURED 1D-aux incident spectrum
+(``measure_incident_spectrum``), not the analytic normal-path pulse. Audit
+record (2026-07-27 session, scratchpad ``f7_falsifier_declaration.md`` +
+``f7_audit{1,2,3}.py`` outputs, quoted in PR):
+
+* pre-fix inflation +6.58 dB (theta=20 deg) / +4.51 dB (40 deg) on the gate
+  grid = waveform mismatch +8.83 dB (the #471 review's analytic numbers,
+  reproduced exactly) + a theta-dependent source->aux launch/absorption
+  response (-2.25 / -4.32 dB) the review neglected;
+* post-fix specular-peak Delta vs the PO uniform-aperture oracle:
+  +0.86 dB (20 deg) / +0.85 dB (40 deg), lobe-flat over +/-12 deg,
+  settling witness -60.7 / -50.1 dB (R5);
+* aperture-height convention: sigma(span4)/sigma(span2) = 4.000 measured
+  -> h_eff = (k_hi - k_lo)*dx exactly (no off-by-one node);
+* RESOLUTION SENSITIVITY (corrected-G4, pinned thickness 2 mm + aperture
+  4 mm): Delta moves +0.86 -> -1.55 dB from dx=2 mm to dx=1 mm — a 2.4 dB
+  shift, FAILING the pre-declared 1.0 dB invariance bound. Absolute oblique
+  sigma is therefore a +/-2 dB-CLASS number at lambda/30..lambda/60. The
+  slow gate below pins |Delta| <= 1.5 dB AT THE FIXED GATE GRID as a
+  regression lock, not an accuracy claim.
+
+F5 — the 4-edge Method-B box requires vacuum on ALL FOUR transverse boundary
+planes; the pre-#471 validator checked only x planes and ``compute_rcs`` ran
+no check at all. Fire/clear pairs below cover both lanes.
+
+F8 — the non-uniform-grid oblique fence gets its own test (both prior fence
+tests asserted only the ey path).
+"""
+import numpy as np
+import jax.numpy as jnp
+import pytest
+
+from rfx.grid import Grid, C0
+from rfx.core.yee import MaterialArrays, init_materials
+from rfx.geometry.csg import Box, rasterize
+from rfx.farfield import NTFFBox
+from rfx.simulation import run
+from rfx.rcs import compute_rcs, compute_rcs_jax, _incident_spectrum_amplitude
+from rfx.sources.tfsf_oblique_open import (
+    init_tfsf_methodB,
+    measure_incident_spectrum,
+    validate_vacuum_boundary,
+)
+
+F0 = 5e9
+LAM = C0 / F0
+DX = 0.002
+CPML = 10
+MARGIN = 10
+PLATE_W = 2.2 * LAM
+N_STEPS = 700
+PEC_SIGMA = 1e7
+DOMAIN = (0.11, 0.218, 0.006)
+PHI = np.linspace(0.0, 2 * np.pi, 361)
+TH_OBS = np.array([np.pi / 2])
+
+
+def _po_sigma(phi_obs, theta_i_deg, W, h, lam):
+    """PO / uniform-aperture bistatic sigma(phi) at theta_obs=pi/2 for a PEC
+    plate in the y-z plane (normal-x lit face), ez polarization. Numeric
+    aperture integral; the closed form below is its independent check."""
+    k = 2 * np.pi / lam
+    t = np.radians(theta_i_deg)
+    y = np.linspace(-W / 2, W / 2, 1201)
+    out = np.zeros_like(phi_obs, dtype=np.float64)
+    for i, p in enumerate(phi_obs):
+        iy = np.trapz(np.exp(1j * k * (np.sin(p) - np.sin(t)) * y), y)
+        out[i] = 4 * np.pi * ((k / (4 * np.pi)) * 2 * np.cos(t) * np.abs(iy) * h) ** 2
+    return out
+
+
+def _gate_grid_and_plate():
+    grid = Grid(freq_max=F0 * 3, domain=DOMAIN, dx=DX, cpml_layers=CPML)
+    nx, ny, nz = grid.shape
+    xc = (nx // 2) * DX
+    yc = (ny // 2) * DX
+    plate = Box(corner_lo=(xc - 0.5 * DX, yc - PLATE_W / 2, -1.0),
+                corner_hi=(xc + 0.5 * DX, yc + PLATE_W / 2, +1.0))
+    eps_r, sigma = rasterize(grid, [(plate, 1.0, PEC_SIGMA)])
+    n_w = int(np.max(np.sum(np.asarray(sigma) > 0, axis=1)))
+    mats = MaterialArrays(eps_r=eps_r, sigma=sigma,
+                          mu_r=jnp.ones(grid.shape, dtype=jnp.float32))
+    return grid, mats, n_w
+
+
+# ---------------------------------------------------------------------------
+# Oracle self-check (comparator-first: PO must reproduce its closed form
+# before it referees any rfx number)
+# ---------------------------------------------------------------------------
+
+def test_po_oracle_matches_closed_form():
+    """The numeric aperture integral must reproduce
+    sigma = 4*pi*(W*h*cos(theta_i)/lambda)^2 at the specular direction to
+    <0.1 dB at theta_i in {0, 20, 40} deg (independent algebra: integral vs
+    closed form)."""
+    W, h = 2.2 * LAM, 2 * DX
+    for t_i in (0.0, 20.0, 40.0):
+        spec = np.radians(180.0 - t_i)
+        num = _po_sigma(np.array([spec]), t_i, W, h, LAM)[0]
+        closed = 4 * np.pi * (W * h * np.cos(np.radians(t_i)) / LAM) ** 2
+        assert abs(10 * np.log10(num / closed)) < 0.1, (t_i, num, closed)
+
+
+# ---------------------------------------------------------------------------
+# F7 fast: the measured normalization captures what the analytic one cannot
+# ---------------------------------------------------------------------------
+
+def test_measured_incident_spectrum_captures_mismatch_and_launch():
+    """Envelope pins around the measured facts (gate grid, f0):
+
+    * assumed-vs-measured mismatch 6.58 dB at theta=20 (pinned 4..9) and
+      4.51 dB at theta=40 (pinned 2.5..7) — nonzero mismatch IS the F7 bug
+      class; a normalization that just re-DFTs the assumed pulse fails the
+      lower bound (falsifier);
+    * measured vs the analytic ACTUAL waveform (launch response) is a mild
+    attenuation, -2.25 dB at theta=20 (pinned -4..+0.5) — the term the
+      #471 review neglected.
+    """
+    grid = Grid(freq_max=F0 * 3, domain=DOMAIN, dx=DX, cpml_layers=CPML)
+    nx, ny, nz = grid.shape
+    dt = grid.dt
+    freqs = np.array([F0])
+    bands = {20.0: (4.0, 9.0), 40.0: (2.5, 7.0)}
+    for theta, (lo, hi) in bands.items():
+        cfg, st = init_tfsf_methodB(nx, ny, DX, dt, nz=nz, cpml_layers=CPML,
+                                    tfsf_margin=MARGIN, f0=F0,
+                                    polarization="ez", direction="+x",
+                                    theta_deg=theta)
+        S_meas = measure_incident_spectrum(cfg, st, N_STEPS, freqs, DX)
+        S_ass = _incident_spectrum_amplitude(F0, 0.5, freqs, dt, N_STEPS)
+        mismatch_db = 20 * np.log10(np.abs(S_meas[0]) / np.abs(S_ass[0]))
+        assert lo <= mismatch_db <= hi, (theta, mismatch_db)
+        if theta == 20.0:
+            times = np.arange(N_STEPS) * dt
+            arg = (times - cfg.src_t0) / cfg.src_tau
+            s_act = np.cos(2 * np.pi * F0 * (times - cfg.src_t0)) * np.exp(-arg ** 2)
+            S_act = np.sum(s_act * np.exp(-1j * 2 * np.pi * F0 * times)) * dt
+            launch_db = 20 * np.log10(np.abs(S_meas[0]) / np.abs(S_act))
+            assert -4.0 <= launch_db <= 0.5, launch_db
+
+
+# ---------------------------------------------------------------------------
+# F5: vacuum-boundary guard — fire / clear pairs on both lanes
+# ---------------------------------------------------------------------------
+
+def _small_oblique_setup(strip_iy):
+    grid = Grid(freq_max=F0 * 3, domain=(0.06, 0.08, 0.006), dx=DX,
+                cpml_layers=6)
+    nx, ny, nz = grid.shape
+    eps = jnp.ones(grid.shape, dtype=jnp.float32)
+    sig = jnp.zeros(grid.shape, dtype=jnp.float32)
+    off = 6 + 6  # cpml + margin -> box y_lo/x_lo
+    if strip_iy is not None:
+        sig = sig.at[off + 3:nx - off - 3, strip_iy, :].set(PEC_SIGMA)
+    mats = MaterialArrays(eps_r=eps, sigma=sig,
+                          mu_r=jnp.ones(grid.shape, dtype=jnp.float32))
+    return grid, mats, off
+
+
+def test_compute_rcs_vacuum_guard_fires_on_y_plane():
+    """A PEC strip lying exactly on the TFSF y_lo plane must fail loud in
+    compute_rcs (issue #471 F5: it previously passed silently — compute_rcs
+    ran no vacuum check and the preflight validator checked x planes only)."""
+    grid, mats, off = _small_oblique_setup(strip_iy=12)  # iy == y_lo plane
+    with pytest.raises(ValueError, match="y_lo"):
+        compute_rcs(grid, mats, n_steps=8, f0=F0, bandwidth=0.5,
+                    theta_inc=20.0, polarization="ez", theta_obs=TH_OBS,
+                    phi_obs=np.array([np.pi]), freqs=np.array([F0]),
+                    cpml_layers=6, tfsf_margin=6)
+
+
+def test_compute_rcs_vacuum_guard_clears_interior_target():
+    """Control: the same strip moved to the box interior passes the guard
+    (compute_rcs completes a short run without the validator firing)."""
+    grid, mats, off = _small_oblique_setup(strip_iy=20)  # interior
+    res = compute_rcs(grid, mats, n_steps=8, f0=F0, bandwidth=0.5,
+                      theta_inc=20.0, polarization="ez", theta_obs=TH_OBS,
+                      phi_obs=np.array([np.pi]), freqs=np.array([F0]),
+                      cpml_layers=6, tfsf_margin=6)
+    assert np.all(np.isfinite(np.asarray(res.rcs_linear)))
+
+
+def test_validator_covers_x_planes_too():
+    """The unified Method-B validator still rejects the x-plane violation the
+    old check caught (no coverage regression from the F5 extension)."""
+    grid, mats, off = _small_oblique_setup(strip_iy=None)
+    nx, ny, nz = grid.shape
+    cfg, _ = init_tfsf_methodB(nx, ny, DX, grid.dt, nz=nz, cpml_layers=6,
+                               tfsf_margin=6, f0=F0, polarization="ez",
+                               direction="+x", theta_deg=20.0)
+    sig = mats.sigma.at[cfg.x_lo, 20:24, :].set(PEC_SIGMA)
+    bad = MaterialArrays(eps_r=mats.eps_r, sigma=sig, mu_r=mats.mu_r)
+    with pytest.raises(ValueError, match="x_lo"):
+        validate_vacuum_boundary(bad, cfg)
+
+
+def test_simulation_lane_vacuum_guard_fires_on_y_plane():
+    """Simulation API lane (the runner-level validator): a dielectric box
+    crossing the Method-B y_lo TFSF plane must raise. This is the exact
+    verified silent failure of issue #471 F5. skip_preflight targets the
+    runner-level validator, which runs regardless."""
+    from rfx.api import Simulation
+
+    sim = Simulation(freq_max=10e9, domain=(0.08, 0.10, 0.006), dx=DX,
+                     boundary="cpml", cpml_layers=10, mode="3d")
+    sim.add_tfsf_source(f0=F0, polarization="ez", direction="+x",
+                        angle_deg=20.0, method="methodB", margin=3)
+    sim.add_material("diel", eps_r=4.0)
+    # Simulation Box coords are relative to the PHYSICAL domain origin (CPML
+    # pads excluded), so the y_lo plane (padded index cpml+margin) sits at
+    # physical y = margin * dx.
+    y_plane = 3 * DX
+    sim.add(Box((0.036, y_plane - DX, 0.0), (0.05, y_plane + DX, 0.006)),
+            material="diel")
+    with pytest.raises(ValueError, match="y_lo|vacuum"):
+        sim.run(n_steps=2, skip_preflight=True)
+
+
+# ---------------------------------------------------------------------------
+# F8: the non-uniform-grid oblique fence, tested on the ez path
+# ---------------------------------------------------------------------------
+
+def test_oblique_nu_grid_fence_fails_loud_on_ez():
+    """compute_rcs(theta_inc != 0) on a NonUniformGrid must raise the
+    non-uniform NotImplementedError even for the SUPPORTED ez polarization
+    (both prior fence tests asserted only the ey rejection, which fires
+    earlier and never reaches the grid check)."""
+    from rfx.nonuniform import make_nonuniform_grid
+
+    grid = make_nonuniform_grid((0.04, 0.04), np.full(6, DX), DX,
+                                cpml_layers=4)
+    mats = init_materials(grid.shape)
+    with pytest.raises(NotImplementedError, match="non-uniform"):
+        compute_rcs(grid, mats, n_steps=8, f0=F0, bandwidth=0.5,
+                    theta_inc=20.0, polarization="ez", theta_obs=TH_OBS,
+                    phi_obs=np.array([np.pi]), freqs=np.array([F0]))
+
+
+# ---------------------------------------------------------------------------
+# F7 slow: the absolute-sigma gates (regression locks at the gate grid)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.slow
+@pytest.mark.parametrize("theta_inc", [20.0, 40.0])
+def test_absolute_sigma_matches_po_at_gate_grid(theta_inc):
+    """PUBLIC-path lock: compute_rcs specular-peak sigma vs the PO
+    uniform-aperture oracle (W = rasterized plate width, h = 2*dx) within
+    1.5 dB at the FIXED gate grid. Measured 2026-07-27: +0.86 dB (20 deg),
+    +0.85 dB (40 deg); settling witness -60.7/-50.1 dB (sibling direct-
+    pipeline test measures it on this exact config). This pins the fixed-
+    discretization envelope — the measured lambda/30->lambda/60 resolution
+    sensitivity is 2.4 dB (module docstring), so this is a regression lock,
+    not an accuracy claim."""
+    grid, mats, n_w = _gate_grid_and_plate()
+    res = compute_rcs(grid, mats, N_STEPS, f0=F0, bandwidth=0.5,
+                      theta_inc=theta_inc, polarization="ez",
+                      theta_obs=TH_OBS, phi_obs=PHI, freqs=np.array([F0]),
+                      cpml_layers=CPML, tfsf_margin=MARGIN, ntff_offset=3)
+    sb = int(round(180.0 - theta_inc))
+    sigma_peak = float(np.asarray(res.rcs_linear)[0, 0, sb])
+    po = _po_sigma(np.array([np.radians(180.0 - theta_inc)]), theta_inc,
+                   n_w * DX, 2 * DX, LAM)[0]
+    delta_db = 10 * np.log10(sigma_peak / po)
+    assert abs(delta_db) <= 1.5, (
+        f"absolute sigma vs PO drifted: {delta_db:+.2f} dB at "
+        f"theta_inc={theta_inc} (measured +0.86/+0.85 when locked)"
+    )
+
+
+@pytest.mark.slow
+def test_sigma_scales_as_aperture_height_squared():
+    """z-span convention pin: doubling the NTFF k-span doubles h_eff, so
+    sigma must scale by 4.000 (measured exactly at both dx=2 mm and 1 mm).
+    Guards the h_eff=(k_hi-k_lo)*dx statement in the compute_rcs docstring
+    against a future off-by-one in the box quadrature."""
+    grid, mats, _ = _gate_grid_and_plate()
+    nx, ny, nz = grid.shape
+    dt = grid.dt
+    sigs = {}
+    for k_half in (1, 2):
+        cfg, st = init_tfsf_methodB(nx, ny, DX, dt, nz=nz, cpml_layers=CPML,
+                                    tfsf_margin=MARGIN, f0=F0,
+                                    polarization="ez", direction="+x",
+                                    theta_deg=20.0)
+        kz = nz // 2
+        box = NTFFBox.from_grid(
+            grid, i_lo=cfg.x_lo - 3, i_hi=cfg.x_hi + 3,
+            j_lo=cfg.y_lo - 3, j_hi=cfg.y_hi + 3,
+            k_lo=kz - k_half, k_hi=kz + k_half,
+            freqs=jnp.asarray([F0], jnp.float32))
+        res = run(grid, mats, N_STEPS, boundary="cpml", cpml_axes="xy",
+                  periodic=(False, False, True), pec_axes="",
+                  tfsf=(cfg, st), ntff=box)
+        S = measure_incident_spectrum(cfg, st, N_STEPS, np.array([F0]), DX)
+        sig = np.asarray(compute_rcs_jax(res.ntff_data, box, grid, TH_OBS,
+                                         PHI, S))[0, 0, :]
+        sigs[k_half] = sig[int(round(180.0 - 20.0))]
+    ratio = sigs[2] / sigs[1]
+    assert 3.8 <= ratio <= 4.2, ratio


### PR DESCRIPTION
Track A of the 2026-07-27 delegated-tracks handover (`docs/research_notes/20260727_handover_delegated_tracks.md`): issue #471 F7 (absolute oblique sigma calibration, the main task) + F5 (y-face vacuum guard) + F8 (test/docs hygiene). One-attempt physics session with a pre-declared falsifier ladder (G1-G5); the full declaration + every outcome (including one FAIL, reported verbatim) is in the review comment below.

## F7 — absolute oblique sigma: measured-spectrum normalization

**Diagnosis re-verified before any code change** (comparator-first). The #471 review's analytic numbers reproduce EXACTLY (|S_assumed(f0)|=1.653e-11, |S_actual_analytic|=4.569e-11 → +8.83 dB waveform mismatch), but the review's headline (+8.8 dB) is INCOMPLETE: the measured 1D-aux field is another −2.25 dB below the analytic waveform — a source→aux launch/absorption response the review neglected. Net measured inflation: **+6.58 dB (θ=20°) / +4.51 dB (θ=40°)**. The launch term is θ-dependent (d_aux is dispersion-matched per angle) and resolution-dependent (the τ=12·dt pulse spans ~46 aux cells vs the 40-cell lo-CPML clearance at dx=2 mm; at dx=1 mm it spans 23 cells and the launch response vanishes — mechanism internally consistent).

**Fix**: `measure_incident_spectrum()` (new, `tfsf_oblique_open.py`) replays the 1D aux standalone (lax.scan, fresh zero state) and DFTs the recorded field at the box-centre projection; `compute_rcs`'s oblique branch normalizes by that instead of the analytic normal-path pulse. This captures waveform + launch + discrete dispersion per run — the only variant that can (an analytic-waveform fix would leave the θ- and dx-dependent launch term in). **θ=0 normal path untouched.**

**Validation** (PO uniform-aperture oracle, itself self-checked against the closed form `4π(W·h·cosθ/λ)²` to <1e-4 dB at three angles, BEFORE it refereed anything):
- specular-peak Δ vs PO at the gate grid: **+0.86 dB (20°) / +0.85 dB (40°)**, lobe-flat over ±12° (full per-φ trace in the comment)
- settling witnesses **−60.7 / −50.1 dB** (R5)
- aperture-height convention pinned by measurement: σ(span4)/σ(span2) = **4.000** → `h_eff = (k_hi−k_lo)·dx` exactly, no off-by-one; documented in the docstring with the `(L_z/h_eff)²` scaling rule
- public-API path reproduces the audit prediction to 0.083/0.203 dB

**HONEST LIMIT — the invariance witness FAILED and is documented, not hidden.** With thickness (2 mm) and aperture (4 mm) pinned physically, halving dx (λ/30→λ/60) moves Δ **+0.86 → −1.55 dB** — a 2.41 dB shift against a pre-declared 1.0 dB bound. Absolute oblique σ is therefore a **±2 dB-class number** in this regime. The docstrings say exactly that (replacing "NOT validated" with the measured envelope + caveat), and the committed slow gate (|Δ| ≤ 1.5 dB at the fixed gate grid) is labeled a **regression lock, not an accuracy claim**. The residual mechanism (plate-edge staircase / NTFF quadrature / cell-counted offsets) stays a named open item on #471 — F7 should NOT be closed as "sub-dB validated".

## F5 — 4-plane vacuum guard
`validate_vacuum_boundary()` (single source, `tfsf_oblique_open.py`) checks all four transverse boundary planes; called from the runner-side preflight validator (Simulation lane — previously x-planes only, the verified silent-PEC-on-y_lo failure) AND from `compute_rcs` (previously no check at all). Fire/clear test pairs on both lanes + an x-plane coverage-regression check.

## F8 — hygiene
NU-grid oblique fence now tested on the **ez** path (both prior fence tests asserted only ey, which raises earlier and never reached the grid check); `docs/public/guide/sources-ports.mdx` documents `method=` and the methodB `'-x'` rejection.

## Verification (local, isolated worktree, `rfx.__file__` checked)
- new battery `tests/test_oblique_rcs_absolute_sigma.py`: fast 7/7, slow 3/3
- regressions: oblique/TFSF/RCS fast 17 passed; slow specular set 8 passed; api vacuum/tfsf 6 passed
- full fast suite (sharded `-n 8 --dist loadfile`): see checklist comment
- `api reference surface: OK`; ruff clean (gated scope)

R3: memory=feedback_gate_can_bind_artifact + project_issue404_oblique_tfsf_r2stop + feedback_metric_first_skepticism (mandate executed; none contradicted) | R2-attempts=1 fix + 1 declared harness-correction (corrected-G4 FAIL reported verbatim, not retried) | falsifier=pre-declared G1-G5 ladder, outcomes in the comment

Independent review before merge per the handover process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
