### PR TITLE
fix(msl): probe-offset interval solve + internal-witness-probe isolation (#469, #470)

### DIFF
--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -535,6 +535,19 @@ class Simulation(
         self._flux_monitors: list[_FluxMonitorEntry] = []
         self._waveguide_ports: list[_WaveguidePortEntry] = []
         self._msl_ports: list[_MSLPortEntry] = []
+        # Issue #469/#470 runtime bookkeeping. Deliberately NOT entry
+        # fields: _MSLPortEntry's and _ProbeEntry's field sets are pinned
+        # by the interop design-IR contract (rfx/interop/_design.py
+        # _PINNED_RECORDS), and neither of these is design state.
+        #   _msl_auto_offset_min: port name -> the upstream-only lower
+        #     edge stored when n_probe_offset was auto-resolved; the #469
+        #     interval solve in compute_msl_s_matrix starts from it.
+        #   _internal_probe_indices: indices into self._probes of
+        #     library-registered diagnostic probes (MSL settling
+        #     witnesses); probe-placement preflight advisories and the
+        #     #332 tail advisory skip them (issue #470 self-noise).
+        self._msl_auto_offset_min: dict[str, int] = {}
+        self._internal_probe_indices: set[int] = set()
         self._periodic_axes: str = ""
         self._refinement: dict | None = None
         self._lumped_rlc: list[LumpedRLCSpec] = []
@@ -1290,8 +1303,17 @@ class Simulation(
             dominates: clearing only (a) leaves probe 0 inside the fringing
             transient and corrupts the V·I-split S11 of a high-Q resonant
             load (issue #80 patch: |S11|=8.94/1.11 → passive ~0.99 once
-            cleared). Pass an explicit value to override; ``< 5*h_sub/dx``
-            triggers a preflight near-field warning.
+            cleared). These two terms are only the UPSTREAM (lower) edge:
+            at ``compute_msl_s_matrix`` time the auto default additionally
+            solves the DOWNSTREAM constraint (issue #469) — the deepest
+            probe must stay ≥ λ_g/4 (at ``freq_max``) clear of the nearest
+            reflector — picking the midpoint of the compliant interval
+            when a reflector bounds it, keeping the upstream edge when
+            none does, and warning loudly when the interval is empty (the
+            feed line is too short for a clean N-probe measurement).
+            Pass an explicit value to override (explicit values are never
+            adjusted); ``< 5*h_sub/dx`` triggers a preflight near-field
+            warning.
         n_probe_spacing : int, optional
             Distance (cells) between consecutive probe planes. When ``None``,
             bound so the total N-probe array span stays ~``lam_min_eff/8``
@@ -1377,7 +1399,18 @@ class Simulation(
         #      ``height`` is the port cross-section height = substrate h_sub.
         _lam_cells = int(round(0.5 * lam_min_eff / (2.0 * math.pi) / _dx))
         _hsub_cells = int(round(5.0 * height / _dx))
+        _offset_is_auto = n_probe_offset is None
         if n_probe_offset is None:
+            # This is the UPSTREAM-only lower edge (offset_min). It has no
+            # notion of what sits downstream, and geometry registered after
+            # this call is invisible here — so the downstream (reflector
+            # λ_g/4) term of issue #469 is solved at compute_msl_s_matrix
+            # time, where the full geometry exists: auto ports get the
+            # midpoint of [offset_min, offset_max] when a downstream
+            # reflector bounds the interval, keep offset_min when none
+            # does (byte-identical to the pre-#469 default), and warn
+            # loudly when the interval is empty (feed too short for a
+            # clean measurement). Explicit offsets are never touched.
             n_probe_offset = max(3, _lam_cells, _hsub_cells)
         if n_probe_spacing is None:
             # Bind the default so the TOTAL N-probe array span stays
@@ -1411,6 +1444,14 @@ class Simulation(
 
         if name is None:
             name = f"msl_{len(self._msl_ports)}"
+
+        if _offset_is_auto:
+            # Runtime bookkeeping only (NOT an entry field — _MSLPortEntry's
+            # field set is pinned by the interop design-IR contract): the
+            # #469 interval solve in compute_msl_s_matrix re-derives the
+            # effective offset from THIS stored lower edge every call, so
+            # repeated calls do not drift.
+            self._msl_auto_offset_min[name] = int(n_probe_offset)
 
         self._msl_ports.append(_MSLPortEntry(
             name=name,

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -247,6 +247,18 @@ class _ExecuteMixin:
 
         time_series = getattr(result, "time_series", None)
         series = None if time_series is None else np.asarray(time_series)
+        # Issue #470: exclude library-internal witness probes (the MSL
+        # settling witnesses) — their record is judged by the MSL driver's
+        # own settling_db witness, so #332/#336 here speak for USER probes
+        # only and the two differently-defined witnesses never double-fire
+        # on the same columns. With only internal probes present this
+        # behaves as if no probe series was recorded (the pre-#468 state).
+        # Time-series columns are in probe registration order (the same
+        # convention the MSL driver's witness slice relies on).
+        _internal = getattr(self, "_internal_probe_indices", None)
+        if series is not None and series.ndim == 2 and _internal:
+            _keep = [i for i in range(series.shape[1]) if i not in _internal]
+            series = series[:, _keep] if _keep else None
         has_probe_series = series is not None and series.size > 0
 
         if has_probe_series:

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -297,6 +297,111 @@ class PreflightReport(list):
         return json.dumps(self.to_dict(), **options)
 
 
+# --------------------------------------------------------------------------
+# MSL probe-clearance geometry (module-level so compute_msl_s_matrix can
+# reuse the identical arithmetic for the issue-#469 interval solve).
+# --------------------------------------------------------------------------
+
+# Conservative ε_eff proxy → upper bound on β → lower bound on λ_g → most
+# stringent (smallest) recommended clearance. For air-only lines this is
+# overly conservative, but the cost of a false-positive advisory is low.
+MSL_EPS_EFF_PROXY = 5.0
+
+
+def msl_min_probe_clearance(freq_max: float) -> float:
+    """Minimum probe-to-reflector clearance: λ_g/4 at ``freq_max``.
+
+    At lower frequencies λ_g is larger and the same physical clearance
+    represents fewer cells of standing-wave-free zone — f_max is the
+    worst case.
+    """
+    c0 = 2.998e8
+    lambda_g_min = c0 / (float(freq_max) * (MSL_EPS_EFF_PROXY ** 0.5))
+    return 0.25 * lambda_g_min
+
+
+def msl_nearest_downstream_reflector(
+    geometry,
+    *,
+    x_probe: float,
+    x_feed: float,
+    y_feed: float,
+    w_trace: float,
+    dx: float,
+    domain_y: float,
+    direction: str,
+):
+    """Distance from ``x_probe`` to the nearest downstream PEC discontinuity.
+
+    Walks registered PEC ``Box`` shapes and returns ``(distance_m, label)``
+    for the nearest box edge at or beyond ``x_probe`` along the propagation
+    direction, or ``(inf, None)`` when nothing qualifies.
+
+    Exclusions (both are #469-arc corrections to the pre-existing
+    heuristic):
+
+    * **the line being measured** — any trace-width box
+      (|y-extent − w_trace| ≤ dx, y-range containing the feed centreline)
+      whose x-range contains the FEED plane. This covers the through-line
+      AND a port's own feed trace; the old rule (x-extent ≥ 80 % of an
+      inter-port-extent estimate) missed the latter for '-x' ports —
+      measured d=0 false positive against the port's OWN output feed
+      (validation/crossval/07_sheen_lpf.py known-residual note) — and its
+      '+x' extent estimate evaluated to the CPML thickness instead of the
+      far-wall coordinate (latent arithmetic bug, now moot: the estimate
+      is gone). A same-width series element that does NOT contain the
+      feed plane is a genuine discontinuity and is still counted.
+    * **ground-plane-like boxes** (y-extent ≥ 80 % of the domain y).
+    """
+    from rfx.geometry.csg import Box as _Box
+
+    sign = 1.0 if direction == "+x" else -1.0
+    nearest_d = float("inf")
+    nearest_label = None
+    for ge in geometry:
+        shape = getattr(ge, "shape", None)
+        mat = getattr(ge, "material_name", "")
+        if not isinstance(shape, _Box) or str(mat).lower() != "pec":
+            continue
+        lo, hi = shape.corner_lo, shape.corner_hi
+        box_x_lo, box_x_hi = float(lo[0]), float(hi[0])
+        box_y_lo, box_y_hi = float(lo[1]), float(hi[1])
+        box_y_extent = box_y_hi - box_y_lo
+        # Skip the line being measured (see docstring).
+        if (
+            abs(box_y_extent - w_trace) <= dx
+            and box_y_lo - dx <= y_feed <= box_y_hi + dx
+            and box_x_lo - dx <= x_feed <= box_x_hi + dx
+        ):
+            continue
+        # Skip ground-plane-like boxes.
+        if box_y_extent >= 0.8 * domain_y:
+            continue
+        # Distance from x_probe to the nearest edge of this box,
+        # measured ALONG the propagation direction.
+        if sign > 0:
+            if box_x_lo > x_probe:
+                d = box_x_lo - x_probe
+            elif box_x_hi < x_probe:
+                continue  # behind the probe
+            else:
+                d = 0.0
+        else:
+            if box_x_hi < x_probe:
+                d = x_probe - box_x_hi
+            elif box_x_lo > x_probe:
+                continue
+            else:
+                d = 0.0
+        if d < nearest_d:
+            nearest_d = d
+            nearest_label = (
+                f"PEC Box at x∈[{box_x_lo*1e3:.2f},{box_x_hi*1e3:.2f}]mm "
+                f"y∈[{box_y_lo*1e3:.2f},{box_y_hi*1e3:.2f}]mm"
+            )
+    return nearest_d, nearest_label
+
+
 class _PreflightMixin:
     """Preflight / validation methods mixed into :class:`Simulation`."""
 
@@ -2195,7 +2300,17 @@ class _PreflightMixin:
     ) -> None:
         """P1.2/P1.3: Probe or source inside absorber region."""
         if cpml_thickness > 0:
-            for pe in self._probes:
+            _internal = getattr(self, "_internal_probe_indices", frozenset())
+            for _pi, pe in enumerate(self._probes):
+                if _pi in _internal:
+                    # Library-registered diagnostic probes (e.g. the MSL
+                    # settling-witness probes, issue #470): the library
+                    # placed them deliberately and must not warn about
+                    # itself — that self-noise buried the genuine MSL
+                    # port-clearance advisories. User probes are
+                    # unaffected (precedent: passive DFT probes are
+                    # excluded from the geometry-extent check, #303).
+                    continue
                 pos = pe.position
                 for ax, coord in enumerate(pos):
                     domain_extent = self._domain[ax] if ax < len(self._domain) else self._domain[-1]
@@ -2603,7 +2718,12 @@ class _PreflightMixin:
                     stacklevel=3,
                 )
 
-        for pe in list(self._ports) + list(self._probes):
+        _internal = getattr(self, "_internal_probe_indices", frozenset())
+        _probe_entries = [
+            pe for _pi, pe in enumerate(self._probes) if _pi not in _internal
+        ]  # skip library-internal witness probes (issue #470; see
+        #    _validate_cfg_absorber_placement for the rationale)
+        for pe in list(self._ports) + _probe_entries:
             pos = pe.position
             component = (getattr(pe, "component", "") or "").lower()
             is_h_component = component in ("hx", "hy", "hz")
@@ -3206,8 +3326,8 @@ class _PreflightMixin:
                 )
 
             # ---- 4. Probe-to-reflector distance — standing-wave bias ----
-            # The 3-probe Z0 extractor in compute_msl_s_matrix assumes a
-            # CLEAN travelling-wave regime at the V1/V2/V3 probe locations.
+            # The N-probe Z0 extractor in compute_msl_s_matrix assumes a
+            # CLEAN travelling-wave regime at the probe locations.
             # When a strong reflector (PEC stub, open termination, mismatch)
             # sits within ≲ λ_g/4 of the probes, V_i contains substantial
             # standing-wave content and the recovered (α, γ, Z0) get
@@ -3215,94 +3335,62 @@ class _PreflightMixin:
             # demands full reflection.  Catches the cv06b-vs-Y2-demo
             # divergence (cv06b's L_LINE=30mm passes; Y2's L_LINE=5mm
             # fails by ~7 dB on |S11|@notch).
-            #
-            # Conservative ε_eff_proxy = 5.0 → upper bound on β → lower
-            # bound on λ_g → most stringent (smallest) recommended
-            # clearance.  For air-only lines this is overly conservative,
-            # but the cost of a false-positive warning is low.
-            EPS_EFF_PROXY = 5.0
-            f_max = float(self._freq_max)
-            c0 = 2.998e8
-            lambda_g_min = c0 / (f_max * (EPS_EFF_PROXY ** 0.5))
-            # Recommended: probe-to-reflector ≥ λ_g/4 at f_max.  At lower
-            # frequencies λ_g is larger and the same physical clearance
-            # represents fewer cells of standing-wave-free zone — but
-            # f_max is the worst case.
-            min_probe_clear = 0.25 * lambda_g_min
+            min_probe_clear = msl_min_probe_clearance(float(self._freq_max))
 
-            # Last 3-probe x-position (V₃, deepest into the line)
+            # Deepest probe position. Pre-#469 this used the legacy
+            # 3-probe V₃ convention (offset + 2·spacing) which UNDERCOUNTS
+            # the span for the default n_probes=5 (deepest probe sits at
+            # offset + (n_probes-1)·spacing, rfx/sources/msl_port.py) —
+            # the check now uses the true deepest probe (stricter/correct).
             n_off = pe.n_probe_offset if pe.n_probe_offset is not None else 5
             n_sp = pe.n_probe_spacing if pe.n_probe_spacing is not None else 3
+            n_pr = getattr(pe, "n_probes", 5) or 5
             sign = 1.0 if pe.direction == "+x" else -1.0
-            x_v3 = x_feed + sign * (n_off + 2 * n_sp) * dx
+            x_deep = x_feed + sign * (n_off + (n_pr - 1) * n_sp) * dx
 
-            # Walk geometry: find PEC Box reflectors between this port's
-            # V3 and the FAR end of the line.  Exclude the through-line
-            # trace itself — heuristic: the trace is a Box whose
-            # x-extent ≥ 80 % of the inter-port distance and whose
-            # y-extent equals the trace width.
-            x_far = (float(domain[0]) - x_abs_hi) if pe.direction == "+x" else x_abs_lo
-            inter_port_extent = abs(x_far - x_feed)
-            from rfx.geometry.csg import Box as _Box
-            nearest_d = float("inf")
-            nearest_label = None
-            for ge in getattr(self, "_geometry", []):
-                shape = getattr(ge, "shape", None)
-                mat = getattr(ge, "material_name", "")
-                if not isinstance(shape, _Box) or str(mat).lower() != "pec":
-                    continue
-                lo, hi = shape.corner_lo, shape.corner_hi
-                box_x_lo, box_x_hi = float(lo[0]), float(hi[0])
-                box_y_lo, box_y_hi = float(lo[1]), float(hi[1])
-                # Skip the through-line trace itself
-                box_x_extent = box_x_hi - box_x_lo
-                box_y_extent = box_y_hi - box_y_lo
-                if (box_x_extent >= 0.8 * inter_port_extent
-                        and abs(box_y_extent - w_trace) <= dx):
-                    continue
-                # Skip ground plane boxes (the box that spans both
-                # transversally AND below the substrate; identify by
-                # a thin z-extent below the substrate top)
-                if box_y_extent >= 0.8 * float(domain[1]):
-                    continue
-                # Distance from V3 to the nearest edge of this box,
-                # measured ALONG the propagation direction
-                if sign > 0:
-                    if box_x_lo > x_v3:
-                        d = box_x_lo - x_v3
-                    elif box_x_hi < x_v3:
-                        continue   # behind the probe
-                    else:
-                        d = 0.0
-                else:
-                    if box_x_hi < x_v3:
-                        d = x_v3 - box_x_hi
-                    elif box_x_lo > x_v3:
-                        continue
-                    else:
-                        d = 0.0
-                if d < nearest_d:
-                    nearest_d = d
-                    nearest_label = (
-                        f"PEC Box at x∈[{box_x_lo*1e3:.2f},{box_x_hi*1e3:.2f}]mm "
-                        f"y∈[{box_y_lo*1e3:.2f},{box_y_hi*1e3:.2f}]mm"
-                    )
+            nearest_d, nearest_label = msl_nearest_downstream_reflector(
+                getattr(self, "_geometry", []),
+                x_probe=x_deep,
+                x_feed=x_feed,
+                y_feed=y_centre,
+                w_trace=w_trace,
+                dx=dx,
+                domain_y=float(domain[1]),
+                direction=pe.direction,
+            )
 
             if nearest_d < min_probe_clear and nearest_label is not None:
+                # Interval framing (issue #469): the compliant window is
+                # offset ∈ [offset_min, offset_max]. INCREASING the offset
+                # moves the probes TOWARD the reflector, so the pre-#469
+                # "bump n_probe_offset" mitigation pointed the wrong way
+                # on short feeds.
+                d_feed_to_refl = nearest_d + (n_off + (n_pr - 1) * n_sp) * dx
+                off_max = int((d_feed_to_refl - min_probe_clear) / dx) - (n_pr - 1) * n_sp
+                _hsub_cells = int(round(5.0 * h_sub / dx))
+                interval_txt = (
+                    f"compliant n_probe_offset interval ≈ "
+                    f"[{max(3, _hsub_cells)}, {off_max}] cells"
+                    if off_max >= max(3, _hsub_cells)
+                    else "no compliant n_probe_offset exists on this feed "
+                    "length (interval empty)"
+                )
                 _w.warn(
                     PreflightWarning(
                         f"MSL port '{pe.name}' (direction={pe.direction!r}): "
-                        f"3-probe V₃ at x={x_v3*1e3:.2f}mm sits {nearest_d*1e6:.0f}µm "
+                        f"deepest probe at x={x_deep*1e3:.2f}mm sits "
+                        f"{nearest_d*1e6:.0f}µm "
                         f"from a strong reflector ({nearest_label}); recommended "
                         f"≥ {min_probe_clear*1e6:.0f}µm "
-                        f"(= λ_g/4 at f_max with ε_eff_proxy={EPS_EFF_PROXY:.1f}). "
+                        f"(= λ_g/4 at f_max with ε_eff_proxy={MSL_EPS_EFF_PROXY:.1f}). "
                         f"Standing-wave content at the probes will bias "
                         f"`compute_msl_s_matrix`'s Z₀ extraction and |S11|@notch — "
                         f"physical |S11|→1 at a quarter-wave open stub may read "
                         f"as -5 to -10 dB instead of 0 dB.  Mitigation: "
                         f"extend L_LINE so the line between port and reflector "
-                        f"is ≥ λ_g/2, OR bump n_probe_offset on add_msl_port to "
-                        f"push V₃ further into a clean travelling-wave region.",
+                        f"is ≥ λ_g/2, OR set n_probe_offset inside the "
+                        f"{interval_txt} (do NOT simply increase it — that "
+                        f"moves the probes closer to the reflector).",
                         code="msl_port_geometry",
                         source="_check_msl_port_geometry",
                     ),

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -176,6 +176,90 @@ def _warn_if_ringdown_truncated(
     )
 
 
+def _resolve_msl_auto_offsets(sim, entries, grid):
+    """Issue #469: solve the probe-offset interval for AUTO-offset ports.
+
+    ``add_msl_port``'s auto-default is the UPSTREAM-only lower edge
+    (``offset_min = max(3, λ/(4π·dx), 5·h_sub/dx)``); the downstream
+    constraint — the deepest probe ≥ λ_g/4 (at f_max) clear of the nearest
+    reflector — needs the full registered geometry, which only exists at
+    driver time. Per auto port on a uniform grid:
+
+    * no downstream reflector  -> keep ``offset_min`` (byte-identical to
+      the pre-#469 default);
+    * finite reflector, interval ``[offset_min, offset_max]`` non-empty ->
+      midpoint (on the #469 Sheen measurement the old default sat at the
+      contaminated near edge and the old advisory pushed PAST the far
+      edge; the midpoint lands inside the measured-clean window);
+    * interval EMPTY -> warn loudly (the feed line is too short for a
+      clean N-probe measurement) and keep ``offset_min`` (upstream
+      priority — the fringing transient is the historically dominant
+      corruption, issue #80).
+
+    Explicit offsets are never touched; NU grids keep the stored value
+    (cell-counted intervals are ill-defined under graded dx). The solve
+    always starts from the STORED lower edge
+    (``sim._msl_auto_offset_min``), so repeated calls are idempotent.
+    Returns a new entries list; ``sim`` is not mutated.
+    """
+    if not sim._msl_auto_offset_min or getattr(grid, "dz", None) is not None:
+        return entries
+
+    import dataclasses
+    import warnings
+
+    from rfx.api._preflight import (
+        msl_min_probe_clearance,
+        msl_nearest_downstream_reflector,
+    )
+
+    dx_u = float(grid.dx)
+    clear = msl_min_probe_clearance(float(sim._freq_max))
+    resolved: list = []
+    for pe in entries:
+        off_min = sim._msl_auto_offset_min.get(pe.name)
+        if off_min is None:
+            resolved.append(pe)
+            continue
+        span = (int(pe.n_probes) - 1) * int(pe.n_probe_spacing)
+        d_refl, _ = msl_nearest_downstream_reflector(
+            getattr(sim, "_geometry", []),
+            x_probe=float(pe.position[0]),
+            x_feed=float(pe.position[0]),
+            y_feed=float(pe.position[1]),
+            w_trace=float(pe.width),
+            dx=dx_u,
+            domain_y=float(sim._domain[1]),
+            direction=pe.direction,
+        )
+        if not np.isfinite(d_refl):
+            resolved.append(pe)
+            continue
+        off_max = int((d_refl - clear) / dx_u) - span
+        if off_max >= off_min:
+            resolved.append(dataclasses.replace(
+                pe, n_probe_offset=(off_min + off_max) // 2,
+            ))
+        else:
+            warnings.warn(
+                f"MSL port {pe.name!r}: the upstream and downstream "
+                f"probe clearances are mutually unsatisfiable on this "
+                f"feed (upstream needs n_probe_offset >= {off_min} "
+                f"cells = max(λ/4π, 5·h_sub)/dx; downstream needs "
+                f"<= {off_max} cells to keep the deepest of "
+                f"{int(pe.n_probes)} probes ≥ "
+                f"{clear*1e6:.0f}µm (λ_g/4 at f_max) clear of the "
+                f"reflector {d_refl*1e3:.2f}mm from the feed). "
+                f"The feed line is too short for a clean N-probe "
+                f"measurement — keeping the upstream-priority offset "
+                f"{off_min}; expect standing-wave bias at the deep "
+                f"probes. Extend the feed line to fix (issue #469).",
+                stacklevel=3,
+            )
+            resolved.append(pe)
+    return resolved
+
+
 def _project_passive(S):
     """Project S(f) onto the passive set by singular-value clipping.
 
@@ -1481,6 +1565,11 @@ class _SparamMixin:
             freqs_arr = np.asarray(freqs)
         n_freqs_used = int(freqs_arr.shape[0])
 
+        # Issue #469: solve the probe-offset interval for AUTO ports (the
+        # downstream reflector term is only computable here, with the full
+        # geometry registered — see _resolve_msl_auto_offsets).
+        entries = _resolve_msl_auto_offsets(self, entries, grid)
+
         # Build MSLPort descriptors and probe x-coords once (geometry shared).
         msl_ports: list[MSLPort] = []
         for pe in entries:
@@ -1618,6 +1707,7 @@ class _SparamMixin:
         saved_msl = list(self._msl_ports)
         saved_ports = list(self._ports)
         saved_probes = list(self._probes)
+        saved_internal_probes = set(self._internal_probe_indices)
         try:
             # Mutate self._dz_profile to the (possibly synthesised) grid dz only
             # now — inside the try — so the finally always restores it and the
@@ -1663,6 +1753,14 @@ class _SparamMixin:
                     )
                 _witness_counts.append(len(pxs_w))
             _witness_total = sum(_witness_counts)
+            # Mark the witness probes as library-internal so probe-placement
+            # preflight advisories and the #332 tail advisory skip them
+            # (issue #470: 10 self-inflicted advisories per driven run on
+            # the 2-port thru buried the genuine MSL port-clearance
+            # advisories, and #332 double-fired next to settling_db).
+            self._internal_probe_indices.update(
+                range(_witness_base, _witness_base + _witness_total)
+            )
             settling_db_runs = np.full(n_ports, np.nan)
 
             for driven in range(n_ports):
@@ -2100,6 +2198,7 @@ class _SparamMixin:
             self._msl_ports = saved_msl
             self._ports = saved_ports
             self._probes = saved_probes
+            self._internal_probe_indices = saved_internal_probes
             self._dz_profile = _dz_profile_saved
 
     def compute_coaxial_s_matrix(

--- a/rfx/interop/_design.py
+++ b/rfx/interop/_design.py
@@ -769,15 +769,52 @@ EXPORTED_SIMULATION_ATTRS: tuple[str, ...] = (
     "_tfsf",
     "_thin_conductors",
     "_waveguide_ports",
+    # Issue #469: auto-offset lower edges. Accounted for by the dump via
+    # _msl_ports_with_resolved_offsets — the document records each auto
+    # port's RESOLVED n_probe_offset (frozen concrete value), so a rebuilt
+    # design reproduces the original's probe placement exactly; the
+    # bookkeeping itself is therefore not a document section.
+    "_msl_auto_offset_min",
+    # Issue #470: indices of library-internal witness probes. Populated and
+    # restored strictly inside compute_msl_s_matrix — ALWAYS empty at
+    # construction and at dump time, so it contributes nothing to the
+    # document by construction.
+    "_internal_probe_indices",
 )
 
 #: Attributes deliberately absent from the document.  These are derived,
 #: transient, or run-time state — see the module docstring, rule 4.  A
-#: ``Simulation`` does not carry them at construction; they appear only after a
-#: preflight/run pass, which is exactly why they are not design state.
+#: ``Simulation`` does not carry them at construction (or carries them only
+#: as empty run-time bookkeeping); they matter only inside a
+#: preflight/driver pass, which is exactly why they are not design state.
 EXCLUDED_SIMULATION_ATTRS: tuple[str, ...] = (
     "_ntff_min_steps_hint",
 )
+
+
+def _msl_ports_with_resolved_offsets(sim: Any) -> list[Any]:
+    """MSL port entries with auto ``n_probe_offset`` resolved for export.
+
+    Auto offsets are solved at ``compute_msl_s_matrix`` time against the
+    registered geometry (issue #469 interval solve). The design document
+    must record the CONCRETE value that solve would use — recording the
+    stored lower edge would make a rebuilt design place its probes
+    differently from the original (silent structural divergence, the
+    exact class this layer refuses elsewhere). Resolving at dump time
+    freezes the same number the original would measure with, and the
+    solve is idempotent from the stored lower edge, so re-exporting a
+    rebuilt design is stable.
+    """
+    if not getattr(sim, "_msl_auto_offset_min", None):
+        return list(sim._msl_ports)
+    if getattr(sim, "_dz_profile", None) is not None:
+        # NU lane: the solve is defined for uniform grids only (the driver
+        # keeps the stored value there too) — dump the stored entries.
+        return list(sim._msl_ports)
+    from rfx.api._sparams import _resolve_msl_auto_offsets
+
+    grid = sim._build_grid()
+    return list(_resolve_msl_auto_offsets(sim, list(sim._msl_ports), grid))
 
 
 # ---------------------------------------------------------------------------
@@ -1327,7 +1364,10 @@ def design_to_dict(sim: Any) -> dict[str, Any]:
             "soft_sources": soft_sources,
             "lumped_ports": lumped_ports,
             "msl_ports": _dump_list(
-                sim._msl_ports, _MSL_PORT_FIELDS, _MSLPortEntry, what="_msl_ports"
+                _msl_ports_with_resolved_offsets(sim),
+                _MSL_PORT_FIELDS,
+                _MSLPortEntry,
+                what="_msl_ports",
             ),
             "waveguide_ports": _dump_list(
                 sim._waveguide_ports,

--- a/rfx/interop/_design.py
+++ b/rfx/interop/_design.py
@@ -778,7 +778,11 @@ EXPORTED_SIMULATION_ATTRS: tuple[str, ...] = (
     # Issue #470: indices of library-internal witness probes. Populated and
     # restored strictly inside compute_msl_s_matrix — ALWAYS empty at
     # construction and at dump time, so it contributes nothing to the
-    # document by construction.
+    # document by construction. (Classification note: EXPORTED vs EXCLUDED
+    # is decided by "present at a fresh __init__", not by "appears in the
+    # document" — both #469/#470 attrs are constructed in __init__, so
+    # EXPORTED is the test-legal bucket even though neither maps to a
+    # document section of its own.)
     "_internal_probe_indices",
 )
 
@@ -807,9 +811,18 @@ def _msl_ports_with_resolved_offsets(sim: Any) -> list[Any]:
     """
     if not getattr(sim, "_msl_auto_offset_min", None):
         return list(sim._msl_ports)
-    if getattr(sim, "_dz_profile", None) is not None:
-        # NU lane: the solve is defined for uniform grids only (the driver
-        # keeps the stored value there too) — dump the stored entries.
+    if any(
+        getattr(sim, name, None) is not None
+        for name in ("_dz_profile", "_dx_profile", "_dy_profile")
+    ):
+        # NU lane — MUST mirror the driver's is_nonuniform predicate (all
+        # THREE profiles, compute_msl_s_matrix): the solve is defined for
+        # uniform grids only and the driver keeps the stored value there,
+        # so the document must freeze the stored value too. A dz-only
+        # check here shipped a real divergence (dx/dy-profile-only MSL
+        # sims dumped a solved offset the driver never uses — PR #478
+        # review MAJOR, regression-locked in
+        # test_auto_offset_dump_matches_driver_on_dx_profile_nu).
         return list(sim._msl_ports)
     from rfx.api._sparams import _resolve_msl_auto_offsets
 

--- a/scripts/diagnostics/msl_thru_mesh_convergence.py
+++ b/scripts/diagnostics/msl_thru_mesh_convergence.py
@@ -62,7 +62,9 @@ def run_one(dx: float) -> dict:
     sim.add_msl_port(position=(PORT_MARGIN + L_LINE, yc, 0.0), width=W_TRACE,
                      height=H_SUB, direction="-x", impedance=50.0)
     t0 = time.time()
-    res = sim.compute_msl_s_matrix(n_freqs=30, num_periods=12)
+    # Diagnostics see the RAW extraction (issue #470 rule).
+    res = sim.compute_msl_s_matrix(n_freqs=30, num_periods=12,
+                                   enforce_passivity=False)
     dt = time.time() - t0
     S = np.asarray(res.S)
     Z0 = np.asarray(res.Z0)

--- a/scripts/diagnostics/msl_thru_meshconv.py
+++ b/scripts/diagnostics/msl_thru_meshconv.py
@@ -136,7 +136,11 @@ def run_one(dx: float, *, kill_port1_sigma: bool = False, num_periods: float = 1
     nx_total = int(round((L_LINE + 2 * PORT_MARGIN) / dx))
     print(f"\n[{label}] dx={dx*1e6:.0f}um  nz_sub={nz_sub}  ny_trace={ny_trace}  nx={nx_total}", flush=True)
     t0 = time.time()
-    res = sim.compute_msl_s_matrix(n_freqs=n_freqs, num_periods=num_periods)
+    # Diagnostics see the RAW extraction (issue #470 rule): clipping
+    # coarse-mesh points would compress the |S|-vs-dx trend this study
+    # exists to quantify.
+    res = sim.compute_msl_s_matrix(n_freqs=n_freqs, num_periods=num_periods,
+                                   enforce_passivity=False)
     dt = time.time() - t0
     s = _gate_stats(res)
     s.update(dx=dx, label=label, nz_sub=nz_sub, ny_trace=ny_trace,

--- a/tests/test_interop_design_document.py
+++ b/tests/test_interop_design_document.py
@@ -446,7 +446,16 @@ def assert_designs_equivalent(original: Simulation, rebuilt: Simulation) -> None
         f"only in rebuilt={sorted(set(vars(rebuilt)) - set(vars(original)))}"
     )
     mismatched = {}
-    for name in sorted(vars(original)):
+    # Issue #469 — deliberate representational asymmetry: the document
+    # records each AUTO port's RESOLVED n_probe_offset as an explicit,
+    # frozen value (reproducibility-first; see
+    # _msl_ports_with_resolved_offsets), so the rebuilt simulation does not
+    # reconstruct the auto bookkeeping. The BEHAVIORAL contract — rebuilt
+    # probe placement equals what the original would measure with — is
+    # pinned positively by
+    # test_auto_msl_offset_is_frozen_resolved_in_the_document.
+    skip_attrs = {"_msl_auto_offset_min"}
+    for name in sorted(set(vars(original)) - skip_attrs):
         left = _canonical(getattr(original, name))
         right = _canonical(getattr(rebuilt, name))
         if left != right:
@@ -1624,3 +1633,42 @@ def test_geometry_and_material_sections_share_the_existing_vocabulary():
     for payload in document["materials"].values():
         assert material_from_dict(payload) is not None
     assert set(document["material_library"]) <= set(MATERIAL_LIBRARY)
+
+
+def test_auto_msl_offset_is_frozen_resolved_in_the_document():
+    """Issue #469 representational contract, pinned positively: the document
+    records an AUTO port's RESOLVED n_probe_offset (the value the original
+    would measure with after the driver-time interval solve), NOT the
+    stored lower edge — so a rebuilt design reproduces the original's probe
+    placement with an explicit frozen value, and re-export is stable. The
+    corresponding census exemption lives in assert_designs_equivalent.
+
+    Geometry = the #469 Sheen-parameter case: stored lower edge 20 cells,
+    compliant interval [20, 33] -> resolved midpoint 26 (hand arithmetic in
+    tests/test_msl_probe_offset_interval.py)."""
+    sim = Simulation(freq_max=20e9, domain=(0.020, 0.02632, 0.0038), dx=2e-4,
+                     boundary="cpml", cpml_layers=8)
+    sim.add_material("sub", eps_r=2.2)
+    sim.add(Box((0, 0, 0), (0.020, 0.02632, 0.000794)), material="sub")
+    sim.add(Box((0.001, 0.01316 - 0.0012065, 0.000794),
+                (0.012466, 0.01316 + 0.0012065, 0.000994)), material="pec")
+    sim.add(Box((0.012466, 0.003, 0.000794),
+                (0.015006, 0.02332, 0.000994)), material="pec")
+    sim.add_msl_port(position=(0.0025, 0.01316, 0.0), width=0.002413,
+                     height=0.000794, direction="+x", impedance=50.0,
+                     eps_r_sub=2.2, name="p1")
+
+    assert sim._msl_ports[0].n_probe_offset == 20      # stored lower edge
+    document = design_to_dict(sim)
+    (port_doc,) = document["excitations"]["msl_ports"]
+    assert port_doc["n_probe_offset"] == 26            # frozen RESOLVED value
+    # the original simulation is not mutated by the export
+    assert sim._msl_ports[0].n_probe_offset == 20
+    assert sim._msl_auto_offset_min == {"p1": 20}
+
+    rebuilt = simulation_from_design(document)
+    assert rebuilt._msl_ports[0].n_probe_offset == 26  # explicit, frozen
+    assert rebuilt._msl_auto_offset_min == {}
+    # re-export is stable (the frozen value is explicit, no re-solve)
+    document2 = design_to_dict(rebuilt)
+    assert document2["excitations"]["msl_ports"][0]["n_probe_offset"] == 26

--- a/tests/test_interop_design_document.py
+++ b/tests/test_interop_design_document.py
@@ -1672,3 +1672,31 @@ def test_auto_msl_offset_is_frozen_resolved_in_the_document():
     # re-export is stable (the frozen value is explicit, no re-solve)
     document2 = design_to_dict(rebuilt)
     assert document2["excitations"]["msl_ports"][0]["n_probe_offset"] == 26
+
+
+def test_auto_offset_dump_matches_driver_on_dx_profile_nu():
+    """PR #478 review MAJOR regression lock: the dump-time NU predicate must
+    mirror the DRIVER's (all three profiles). A dz-only check let a
+    dx_profile-only MSL sim dump a SOLVED offset (26) while the real driver
+    routes that sim through the NU lane and keeps the stored lower edge
+    (20) — a rebuilt design would place its probes where the original never
+    measured. The document must freeze the value the driver actually uses."""
+    DX = 2e-4
+    nx = int(round(0.020 / DX))
+    sim = Simulation(freq_max=20e9, domain=(0.020, 0.02632, 0.0038), dx=DX,
+                     boundary="cpml", cpml_layers=8,
+                     dx_profile=np.full(nx, DX))  # dx-profile-only NU
+    sim.add_material("sub", eps_r=2.2)
+    sim.add(Box((0, 0, 0), (0.020, 0.02632, 0.000794)), material="sub")
+    sim.add(Box((0.001, 0.01316 - 0.0012065, 0.000794),
+                (0.012466, 0.01316 + 0.0012065, 0.000994)), material="pec")
+    sim.add(Box((0.012466, 0.003, 0.000794),
+                (0.015006, 0.02332, 0.000994)), material="pec")
+    sim.add_msl_port(position=(0.0025, 0.01316, 0.0), width=0.002413,
+                     height=0.000794, direction="+x", impedance=50.0,
+                     eps_r_sub=2.2, name="p1")
+
+    document = design_to_dict(sim)
+    (port_doc,) = document["excitations"]["msl_ports"]
+    # driver NU lane keeps the stored lower edge -> so must the document
+    assert port_doc["n_probe_offset"] == 20

--- a/tests/test_msl_internal_probe_advisories.py
+++ b/tests/test_msl_internal_probe_advisories.py
@@ -1,0 +1,85 @@
+"""Issue #470: library-internal witness probes stay out of the user record.
+
+``compute_msl_s_matrix`` registers N point Ez settling-witness probes per
+port (PR #468). Pre-#470 they were indistinguishable from user probes, so
+(1) the internal run's auto-preflight reported ~10 self-inflicted
+"Probe at ... near/inside CPML" advisories per driven run on the 2-port
+thru — burying the genuine MSL port-clearance advisories that must be
+quoted next to every claims-bearing number — and (2) the generic #332
+probe-tail advisory double-fired next to the MSL-specific ``settling_db``
+witness (two differently-defined settling numbers per run).
+
+Containment: ``Simulation._internal_probe_indices`` runtime bookkeeping
+(deliberately NOT an ``_ProbeEntry`` field — the entry field set is pinned
+by the interop design-IR contract). Probe-placement preflight advisories
+and #332/#336 skip internal indices; USER probes keep pre-#470 behavior
+exactly (the #332 fail-safe in test_issue80_patch_s11_regression relies on
+user-probe series still being evaluated during MSL runs).
+"""
+import warnings
+
+import jax.numpy as jnp
+import numpy as np
+
+from rfx import Box, Simulation
+
+FREQS = jnp.linspace(2e9, 18e9, 8)
+
+
+def _thru():
+    sim = Simulation(freq_max=20e9, domain=(0.012, 0.008, 0.0032),
+                     dx=2e-4, boundary="cpml", cpml_layers=8)
+    sim.add_material("sub", eps_r=2.2)
+    sim.add(Box((0, 0, 0), (0.012, 0.008, 0.0008)), material="sub")
+    sim.add(Box((0.0, 0.0034, 0.0008), (0.012, 0.0046, 0.0010)),
+            material="pec")
+    sim.add_msl_port(position=(0.002, 0.004, 0.0), width=0.0012,
+                     height=0.0008, direction="+x", impedance=50.0,
+                     eps_r_sub=2.2, name="p1")
+    sim.add_msl_port(position=(0.010, 0.004, 0.0), width=0.0012,
+                     height=0.0008, direction="-x", impedance=50.0,
+                     eps_r_sub=2.2, name="p2")
+    return sim
+
+
+def test_witness_probes_produce_no_probe_advisories_and_no_332():
+    """A user-probe-free thru run must emit ZERO probe-placement advisories
+    ('Probe at ...') and ZERO #332 tail advisories — pre-#470 it emitted 10
+    'Probe at ... near/inside CPML' self-advisories per driven run and
+    double-fired #332 next to settling_db. The MSL-specific settling
+    witness itself must still fire on this truncated record (the
+    consolidation keeps ONE witness, it does not silence the diagnosis)."""
+    sim = _thru()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        res = sim.compute_msl_s_matrix(freqs=FREQS, num_periods=2.0)
+    msgs = [str(w.message) for w in caught]
+    assert not any("Probe at" in m for m in msgs), msgs
+    assert not any("issue #332" in m for m in msgs), msgs
+    assert any("settling witness" in m for m in msgs), msgs
+    assert res.settling_db is not None
+    # bookkeeping fully restored: no internal probes leak out of the call
+    assert sim._internal_probe_indices == set()
+    assert len(sim._probes) == 0
+
+
+def test_user_probe_advisories_and_332_still_fire():
+    """USER probes keep pre-#470 behavior during the same MSL run: a probe
+    inside the CPML still draws its placement advisory, and an interior
+    user probe's hot tail still fires #332 on the truncated record (the
+    fail-safe test_issue80_patch_s11_regression depends on)."""
+    sim = _thru()
+    # interior probe above the trace: sees real signal -> hot tail at
+    # num_periods=2 -> #332 must fire on the USER column
+    sim.add_probe(position=(0.006, 0.004, 0.0012), component="ez")
+    # probe deep in the x-CPML -> placement advisory must fire
+    sim.add_probe(position=(0.0002, 0.004, 0.0012), component="ez")
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        sim.compute_msl_s_matrix(freqs=FREQS, num_periods=2.0)
+    msgs = [str(w.message) for w in caught]
+    assert any("Probe at" in m for m in msgs), msgs
+    assert any("issue #332" in m for m in msgs), msgs
+    # user probes survive the call
+    assert len(sim._probes) == 2
+    assert sim._internal_probe_indices == set()

--- a/tests/test_msl_probe_offset_interval.py
+++ b/tests/test_msl_probe_offset_interval.py
@@ -1,0 +1,145 @@
+"""Issue #469: the auto n_probe_offset solves BOTH clearances, not one edge.
+
+``add_msl_port``'s auto-default is the upstream-only lower edge
+(``max(3, λ/(4π·dx), 5·h_sub/dx)``); ``compute_msl_s_matrix`` now solves the
+downstream reflector constraint too (``_resolve_msl_auto_offsets``): midpoint
+of the compliant interval when a reflector bounds it, unchanged when none
+does, loud warning + upstream-priority fallback when the interval is empty
+(the honest "this feed line is too short for a clean measurement" case —
+the pre-#469 advisory recommended INCREASING the offset, which moves the
+probes toward the reflector).
+
+Geometry mirrors the #469 measurement (Sheen 1990 LPF rfx leg: dx=200 µm,
+h_sub=0.794 mm, εr=2.2, feed ≈ 10 mm, f_max=20 GHz). Hand arithmetic for
+the pinned expectations (kept independent of the implementation):
+  offset_min = round(5·0.794/0.2) = 20 cells (fringing term dominates)
+  spacing    = round(λ_min_eff/8/4/dx) = 2 cells, span = (5−1)·2 = 8 cells
+  λ_g/4 clearance = 0.25·c/(20 GHz·√5) = 1.676 mm
+  d(feed→patch) = 12.466 − 2.5 = 9.966 mm
+  offset_max = int((9.966 − 1.676)/0.2) − 8 = 41 − 8 = 33
+  midpoint   = (20 + 33)//2 = 26  (inside the measured-clean window;
+               the old default 20 sat at the contaminated near edge)
+"""
+import warnings
+
+import numpy as np
+import pytest
+
+from rfx import Box, Simulation
+from rfx.grid import Grid
+from rfx.api._sparams import _resolve_msl_auto_offsets
+
+DX = 2e-4
+DOMAIN = (0.020, 0.02632, 0.0038)
+Y_C = 0.01316
+W_TRACE = 0.002413
+H_SUB = 0.000794
+
+
+def _sim_with_feed_and_patch(patch_x0=0.012466, patch_x1=0.015006):
+    sim = Simulation(freq_max=20e9, domain=DOMAIN, dx=DX,
+                     boundary="cpml", cpml_layers=8)
+    sim.add_material("sub", eps_r=2.2)
+    sim.add(Box((0, 0, 0), (DOMAIN[0], DOMAIN[1], H_SUB)), material="sub")
+    # the port's own feed trace (contains the feed plane -> excluded)
+    sim.add(Box((0.001, Y_C - W_TRACE / 2, H_SUB),
+                (patch_x0, Y_C + W_TRACE / 2, H_SUB + DX)), material="pec")
+    # the patch = downstream reflector (wide, but < 80 % of domain y)
+    sim.add(Box((patch_x0, 0.003, H_SUB),
+                (patch_x1, 0.02332, H_SUB + DX)), material="pec")
+    sim.add_msl_port(position=(0.0025, Y_C, 0.0), width=W_TRACE, height=H_SUB,
+                     direction="+x", impedance=50.0, eps_r_sub=2.2, name="p1")
+    return sim
+
+
+def _grid():
+    return Grid(freq_max=20e9, domain=DOMAIN, dx=DX, cpml_layers=8)
+
+
+def test_auto_offset_moves_to_interval_midpoint_with_reflector():
+    """Sheen-parameter geometry: auto offset resolves to the midpoint 26 of
+    the compliant interval [20, 33] (hand arithmetic in the module
+    docstring), not the contaminated lower edge 20."""
+    sim = _sim_with_feed_and_patch()
+    (pe,) = sim._msl_ports
+    assert pe.n_probe_offset == 20  # stored lower edge (pre-#469 default)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        (resolved,) = _resolve_msl_auto_offsets(sim, list(sim._msl_ports),
+                                                _grid())
+    assert resolved.n_probe_offset == 26
+    # the stored entry and the auto bookkeeping are untouched (idempotency)
+    assert sim._msl_ports[0].n_probe_offset == 20
+    (again,) = _resolve_msl_auto_offsets(sim, list(sim._msl_ports), _grid())
+    assert again.n_probe_offset == 26
+
+
+def test_explicit_offset_is_never_adjusted():
+    sim = _sim_with_feed_and_patch()
+    sim.add_msl_port(position=(0.0025, Y_C, 0.0), width=W_TRACE, height=H_SUB,
+                     direction="+x", impedance=50.0, eps_r_sub=2.2,
+                     name="pexp", n_probe_offset=30)
+    resolved = _resolve_msl_auto_offsets(sim, list(sim._msl_ports), _grid())
+    by_name = {pe.name: pe for pe in resolved}
+    assert by_name["pexp"].n_probe_offset == 30
+
+
+def test_no_reflector_keeps_the_pre469_default():
+    """Only the port's own trace (and substrate) registered: the solve must
+    return the stored lower edge unchanged — byte-identity with the
+    pre-#469 default on open thru lines."""
+    sim = Simulation(freq_max=20e9, domain=DOMAIN, dx=DX,
+                     boundary="cpml", cpml_layers=8)
+    sim.add_material("sub", eps_r=2.2)
+    sim.add(Box((0, 0, 0), (DOMAIN[0], DOMAIN[1], H_SUB)), material="sub")
+    sim.add(Box((0.001, Y_C - W_TRACE / 2, H_SUB),
+                (0.019, Y_C + W_TRACE / 2, H_SUB + DX)), material="pec")
+    sim.add_msl_port(position=(0.0025, Y_C, 0.0), width=W_TRACE, height=H_SUB,
+                     direction="+x", impedance=50.0, eps_r_sub=2.2, name="p1")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        (resolved,) = _resolve_msl_auto_offsets(sim, list(sim._msl_ports),
+                                                _grid())
+    assert resolved.n_probe_offset == 20
+
+
+def test_empty_interval_warns_and_keeps_upstream_priority():
+    """Patch 5 mm from the feed: offset_max = int((5−1.676)/0.2)−8 = 8 < 20
+    -> the two clearances are mutually unsatisfiable; warn loudly and keep
+    the upstream edge (the pre-#469 behavior was a silent compromise)."""
+    sim = _sim_with_feed_and_patch(patch_x0=0.0075, patch_x1=0.010)
+    with pytest.warns(UserWarning, match="mutually unsatisfiable"):
+        (resolved,) = _resolve_msl_auto_offsets(sim, list(sim._msl_ports),
+                                                _grid())
+    assert resolved.n_probe_offset == 20
+
+
+def test_own_trace_of_minus_x_port_is_not_a_reflector():
+    """'-x' port with only its own output feed trace: the pre-#469
+    heuristic (x-extent >= 80 % of a broken inter-port-extent estimate)
+    read the port's OWN trace as a reflector at 0 µm (the cv07 p2 false
+    positive, validation/crossval/07_sheen_lpf.py known-residual note);
+    the feed-containment exclusion must leave this geometry
+    reflector-free."""
+    sim = Simulation(freq_max=20e9, domain=DOMAIN, dx=DX,
+                     boundary="cpml", cpml_layers=8)
+    sim.add_material("sub", eps_r=2.2)
+    sim.add(Box((0, 0, 0), (DOMAIN[0], DOMAIN[1], H_SUB)), material="sub")
+    sim.add(Box((0.008, Y_C - W_TRACE / 2, H_SUB),
+                (0.018, Y_C + W_TRACE / 2, H_SUB + DX)), material="pec")
+    sim.add_msl_port(position=(0.0175, Y_C, 0.0), width=W_TRACE, height=H_SUB,
+                     direction="-x", impedance=50.0, eps_r_sub=2.2, name="p2")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        (resolved,) = _resolve_msl_auto_offsets(sim, list(sim._msl_ports),
+                                                _grid())
+    assert resolved.n_probe_offset == 20
+
+
+def test_driver_applies_the_solve_end_to_end():
+    """The empty-interval warning must surface through the PUBLIC
+    compute_msl_s_matrix call (n_steps=1: the solve runs before the FDTD,
+    so a minimal-step run proves the wiring)."""
+    sim = _sim_with_feed_and_patch(patch_x0=0.0075, patch_x1=0.010)
+    with pytest.warns(UserWarning, match="mutually unsatisfiable"):
+        sim.compute_msl_s_matrix(freqs=np.array([5e9, 10e9]), n_steps=1)


### PR DESCRIPTION
Track B of the 2026-07-27 delegated-tracks handover (`docs/research_notes/20260727_handover_delegated_tracks.md`). Reconnaissance by a 5-agent read-only workflow whose findings redirected the design twice (details below); every number is measured in this session.

## #469 — the auto `n_probe_offset` now solves BOTH clearances
The auto-default was the upstream-only lower edge, and the reflector advisory said "bump n_probe_offset" — which moves probes **toward** the reflector (the #469 Sheen table: default sat at the contaminated near edge, colpow 8.75; the advisory's direction overshot the far edge).

**Fix** (`_resolve_msl_auto_offsets`, driver-time — geometry registered after `add_msl_port` is invisible at add time):
- no downstream reflector → stored lower edge, **byte-identical** to the pre-#469 default (open thru lines unchanged — verified no-op on the `_thru` fixtures and on `test_msl_ad_fd_converged`'s geometry);
- finite reflector → **midpoint** of `[offset_min, offset_max]`. Sheen parameters: [20, 33] → **26**, pinned in-test against independent hand arithmetic;
- interval empty → **loud warning** ("feed too short for a clean N-probe measurement") + upstream-priority fallback, replacing the silent compromise. Explicit offsets never adjusted; NU keeps stored values.

**Prerequisite comparator fixes** in the reflector walk (recon findings, now shared by preflight check 4 and the solve via `msl_nearest_downstream_reflector`):
- own-trace false positive: a `-x` port's OWN feed trace read as a reflector at 0 µm (cv07 p2 known-residual) — the 80%-extent heuristic is replaced by feed-containment discrimination;
- latent `+x` far-wall arithmetic bug (`x_far` evaluated to the CPML *thickness*) — line removed, moot under the new discrimination;
- check 4 now measures the TRUE deepest probe (`offset+(n_probes−1)·spacing`, was the 3-probe V3 span, 2·spacing short for the default 5 probes). Advisory reworded to interval language — pinned tokens kept, advisory suites 62/62 green with no retuning needed.

## #470 — library witness probes out of the user record
Measured before/after on the 2-port thru: **14 advisories/driven run → 4**, "Probe at …" self-advisories **10 → 0**; the remaining 4 are all genuine (2× MSL port-clearance, lossless dielectric, PEC z-extent). #332 no longer double-fires next to `settling_db`.

Containment = `Simulation._internal_probe_indices` runtime bookkeeping — deliberately **not** an `_ProbeEntry` field: recon showed the entry field set is pinned by the interop design-IR contract (3 test files + `additionalProperties:false` schema), so the issue's suggested flag was not the cheapest containment. Probe-placement advisories and #332/#336 skip internal indices only; **user probes keep pre-#470 behavior exactly** — the `test_issue80_patch_s11_regression` #332 fail-safe (a silent-disarm trap recon flagged) still evaluates user columns, with a fire/clear pair proving it.

**Interop representational contract** (the census test forced an explicit decision): the design document records an AUTO port's **resolved** offset as a frozen explicit value (dump-time solve, idempotent, original never mutated) — a rebuilt design reproduces the original's probe placement exactly. Census exemption documented in `assert_designs_equivalent`; the behavior pinned positively by `test_auto_msl_offset_is_frozen_resolved_in_the_document`.

Also, per the issue's "diagnostics see the raw extraction" rule: `msl_thru_meshconv.py` / `msl_thru_mesh_convergence.py` now pass `enforce_passivity=False`.

## Verification (isolated worktree, `rfx.__file__` checked)
- new batteries: `test_msl_probe_offset_interval.py` (6) + `test_msl_internal_probe_advisories.py` (2), incl. end-to-end wiring and fire/clear pairs
- final fast batch across MSL/preflight/contract surfaces: **116 passed, 1 xfailed**; interop **213 passed**; witness+passivity 12; advisory suites 62
- slow: `test_msl_port_integration` passed; `api reference surface: OK`; ruff clean
- **Sheen committed leg untouched** (explicit offset=30; fixtures NOT regenerated)

## Two disclosures
1. **Pre-existing red on main, not this PR**: `test_msl_ad_fd_converged_tight` fails on clean main with **identical numbers** to this branch (rel_err 0.1113 vs 0.10 gate; g_ad/g_fd match to all printed digits) — A/B proven numerics-neutral, filed as #477.
2. **GPU-lane re-measurement duty**: the gpu+slow patch gates (`test_issue80_patch_s11_regression`, `test_msl_nu_sparam_gate`) use the auto default WITH a reflector (the patch), so their probe offsets move to the interval midpoint — they re-measure on the next per-release GPU run. They gate physics with margin (max|S11| ≤ 1.05, band gates), and the midpoint moves probes into a *cleaner* window by construction, but the honest statement is "re-measured, not yet re-run" — flagged for the release-gate cadence.

R3: memory=feedback_gate_can_bind_artifact + feedback_root_cause_before_gate_change + project_issue80_msl_sparam (upstream term preserved; no gate loosened — #477 filed instead of nudged) | R2-attempts=0 | falsifier=midpoint hand-arithmetic pin (26) + empty-interval fire/clear + advisory count 14→4 measured

Independent review before merge per the handover process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)