### PR TITLE
docs(test): MSL-FD-TIGHT ownership + measured f32 comparator envelope (closes #477)

### DIFF
--- a/tests/test_msl_ad_fd_converged.py
+++ b/tests/test_msl_ad_fd_converged.py
@@ -131,6 +131,22 @@ def test_msl_ad_fd_converged_tight():
 
     If rel_err stays >10% this test will fail (deliberately — do NOT loosen
     the gate to force a pass; report as a gradient accuracy finding instead).
+
+    OWNERSHIP + measured comparator envelope (issue #477 root-cause,
+    2026-07-28 — all numbers measured, main @ 98c5e33):
+    This is a GPU-lane gate (gpu marker; VESSL harness). Do NOT treat a CPU
+    execution as a main-health signal: the FD comparator carries an f32
+    evaluation-noise envelope that straddles the 0.10 gate across platforms
+    while the AD side is platform-stable to 5 digits
+    (g_ad CPU −2.1104e-01 vs GPU −2.1105e-01; g_fd CPU −2.3746e-01 vs GPU
+    −2.3079e-01 at the same h=1e-3 → rel_err CPU 0.1113 / GPU 0.0855).
+    A CPU h-sweep (h ∈ [3e-4, 1e-2]) shows a 27% NON-monotone FD scatter —
+    evaluation noise, not h² truncation — so rel_err here compares AD
+    against a ±3–5%-noisy reference. Whether AD carries a genuine ~10%
+    systematic vs the true derivative is INDETERMINATE at f32; the f64
+    referee is blocked by the hardcoded complex64 DFT scan carries (x64
+    flip fails the scan dtype contract — measured). Full record with the
+    h-sweep table and both platform logs: issue #477.
     """
     t_start = time.perf_counter()
 


### PR DESCRIPTION
Docstring-only change closing the #477 root-cause investigation. **Gate value untouched** — this is comparator attribution, not a tolerance change.

**Verdict** (full measured record in the [#477 comment](https://github.com/bk-squared/rfx/issues/477)): the "red on main" was a CPU execution of a GPU-owned gate whose FD comparator carries an f32 evaluation-noise envelope straddling 0.10 across platforms. AD is platform-stable to 5 digits; the CPU↔GPU difference lives entirely in the FD side (2.9% at identical h). CPU h-sweep: 27% non-monotone FD scatter (noise, not truncation). Owner platform (GPU, VESSL 369367249574 at today's main): rel_err 0.0855, PASS. f64 referee blocked by hardcoded complex64 DFT scan carries — named residual.

The docstring now records ownership, the measured envelope, and the residual so a future session doesn't re-file this.

Verification: syntax OK, test collectable, ruff clean (docstring-only; no runtime change — `git diff` is entirely inside the string).

R3: memory=feedback_root_cause_before_gate_change + comparator-first | R2-attempts=0 | falsifier=pre-declared E1/E2/E3 tree (outcomes in the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)