### PR TITLE
release: v1.6.7 — oblique RCS, MSL probe discipline, CAD import, Kerr oracle, design-IR, crossval campaign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,94 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+## [1.6.7] - 2026-07-28
+
+### Added — open-domain oblique RCS (Method-B TFSF) with calibrated absolute sigma
+
+- `compute_rcs(theta_inc != 0)` now routes a compact scatterer through the
+  open-domain Method-B oblique TFSF (`ez` polarization, uniform grid;
+  other combos fail loud). The specular direction is validated (reflection
+  law tracked across 0/20/40 deg); absolute sigma is normalized by the
+  MEASURED 1D-aux incident spectrum and validated against a PO
+  uniform-aperture oracle to +0.9 dB at the gate grid — with a measured
+  2.4 dB resolution sensitivity, so treat absolute oblique sigma as a
+  +/-2 dB-class number (docstrings carry the full envelope). A 4-plane
+  vacuum guard now protects all Method-B TFSF boundaries in both the
+  runner validator and `compute_rcs`. (#461, #474, #471)
+
+### Added — differentiable plane-wave design lane extensions
+
+- Oblique plane waves in `run()` via opt-in complex-Bloch TFSF (#414) and
+  the differentiable `forward()`+TFSF uniform lane (#415); complex Fresnel
+  reflection helper `rfx.probes.fresnel_reflection_coefficient` (#418,
+  #419); `compute_rcs_jax` differentiable far-field post-processor (#421);
+  `mu_r_override` as a differentiable DoF on `forward()` (#449); analytic
+  TMM-gated multilayer/magnetic RAM inverse-design batteries (#445, #449).
+
+### Changed — MSL auto `n_probe_offset` solves BOTH clearances (**BEHAVIOUR CHANGE**)
+
+- The auto default previously sat at the upstream (fringing) lower edge and
+  the reflector advisory pushed probes the wrong way on short feeds. At
+  `compute_msl_s_matrix` time the auto offset now solves the compliant
+  interval: unchanged when no downstream reflector exists, midpoint when
+  one bounds it, and a loud "mutually unsatisfiable" warning (upstream-
+  priority fallback) when the feed is too short. Explicit offsets are never
+  adjusted. Library-internal settling-witness probes no longer pollute the
+  preflight record (measured 14 -> 4 advisories/run) and no longer
+  double-fire the #332 tail advisory next to `settling_db`. (#478,
+  #469, #470)
+
+### Added — CAD import (`rfx.MeshShape`) — STL/OBJ/PLY + STEP
+
+- Voxelized mesh import with occupancy caching; STEP via the `cad` extra.
+  Top-level export + docs; NOT differentiable (host-side rasterization —
+  traced coordinates raise). (#453, #456, #473, #358, #467)
+
+### Added — Kerr nonlinearity validated at absolute magnitude
+
+- D-based self-consistent Kerr update (fixes the reactive-operator defect)
+  and a TRUE-CW TFSF waveform enabling an absolute-magnitude SPM oracle:
+  measured phase-shift ratio 0.955 +/- 0.03 vs closed form, independently
+  confirmed against Meep. (#440, #441, #448, #450, #452, #446, #437)
+
+### Added — design-document interop (`rfx.interop`) with an openEMS emitter
+
+- `rfx-design-ir/v1`: dump a Simulation to a validated design document and
+  emit a runnable openEMS script (mesh/boundary/port semantics carried
+  explicitly; refuses non-representable constructs rather than
+  approximating). Auto MSL offsets are recorded as their RESOLVED frozen
+  values. (#463, #472, #478)
+
+### Added — `until_decay` radiated-flux stop criterion
+
+- `run(until_decay=..., radiated_flux_box=...)` stops on radiated energy
+  flux instead of the domain-energy floor (which a static charge pins high)
+  — both uniform and non-uniform lanes; static-floor advisories route to
+  the flux-stop remedy. (#442, #443, #454, #388)
+
+### Fixed — 7 RF-core extractor defects (dual-audit sweep)
+
+- Includes the multimode-flux |S| half-step co-location in
+  `_modal_net_power` (reactive->real leak), a sub-cutoff beta scale factor,
+  reference-plane metadata, and Floquet fail-loud API validation
+  (n_modes>1 / TM rejected explicitly). (#459, #404)
+
+### Added — real-structure cross-validation campaign (governed)
+
+- PEC-sphere and dielectric-sphere Mie ka-sweeps, rectangular PEC cavity
+  vs exact Pozar, Sheen-1990 LPF vs openEMS with a Palace-FEM referee
+  (three-solver doublet finding), and an RT5880 patch — all registered in
+  the crossval manifest with honest roles and fail-closed evidence chains.
+  (#462, #475, #476)
+
+### Changed — MSL-FD-TIGHT gradient gate: ownership + measured comparator envelope
+
+- The converged AD-vs-FD gate is GPU-lane-owned; its FD comparator carries
+  an f32 evaluation-noise envelope (+/-3-5%) that straddles the 0.10 gate
+  across platforms while AD is platform-stable. Docstring records the
+  measured numbers; gate value unchanged. (#479, #477)
+
+
 ### Changed — `compute_msl_s_matrix` returns a passivity-enforced S by default (**BEHAVIOUR CHANGE**)
 
 - The returned `MSLSMatrixResult.S` now satisfies `||S(f)||_2 <= 1` at every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,12 +86,19 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   the crossval manifest with honest roles and fail-closed evidence chains.
   (#462, #475, #476)
 
-### Changed — MSL-FD-TIGHT gradient gate: ownership + measured comparator envelope
+### Changed — MSL-FD-TIGHT gradient gate: ownership, comparator envelope, and an f64-determined AD finding
 
 - The converged AD-vs-FD gate is GPU-lane-owned; its FD comparator carries
   an f32 evaluation-noise envelope (+/-3-5%) that straddles the 0.10 gate
   across platforms while AD is platform-stable. Docstring records the
   measured numbers; gate value unchanged. (#479, #477)
+- An f64 referee (enabled by making the DFT accumulators follow the x64
+  state) subsequently DETERMINED the question the noise left open: the MSL
+  `eps_override` AD gradient reads ~13.7% below the clean f64 finite
+  difference on this objective (true derivative ~ -0.244 by three agreeing
+  estimates). Until issue #483 attributes the mechanism, treat
+  `compute_msl_s_matrix(eps_override=...)` gradients as a +/-14%-class
+  quantity. Forward S-parameters are unaffected. (#483)
 
 
 ### Changed — `compute_msl_s_matrix` returns a passivity-enforced S by default (**BEHAVIOUR CHANGE**)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rfx-fdtd"
-version = "1.6.6"
+version = "1.6.7"
 description = "JAX-native 3D FDTD electromagnetic simulator for RF engineering"
 readme = "README.md"
 license = {text = "MIT"}

--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -1,7 +1,7 @@
 """rfx — JAX-based RF FDTD electromagnetic simulator."""
 # ruff: noqa: F401
 
-__version__ = "1.6.6"
+__version__ = "1.6.7"
 
 from rfx.grid import Grid
 from rfx.simulation import run, run_until_decay, make_source, make_probe, make_port_source, SimResult

--- a/tests/test_durable_worker_lifecycle.py
+++ b/tests/test_durable_worker_lifecycle.py
@@ -70,7 +70,20 @@ def test_v2_revision_linked_worker_survives_service_restart(tmp_path):
     runtime = field_payload["runtime"]
     assert runtime["python_version"]
     assert runtime["platform"]
-    assert runtime["packages"]["rfx-fdtd"] == "1.6.6"
+    # The contract is "the worker records the version resolution IT uses",
+    # not a specific number — a hardcoded literal here turned every version
+    # bump red (caught by the v1.6.7 release PR). Mirror the worker's own
+    # preference chain (installed distribution metadata, falling back to
+    # the source __version__) so the assertion is also robust to a dev box
+    # where an older wheel is installed while the source checkout is newer.
+    import importlib.metadata
+
+    try:
+        _rfx_version = importlib.metadata.version("rfx-fdtd")
+    except importlib.metadata.PackageNotFoundError:
+        from rfx import __version__ as _rfx_version
+
+    assert runtime["packages"]["rfx-fdtd"] == _rfx_version
     assert runtime["source"]["kind"] in {"source-checkout", "wheel"}
     assert runtime["seed"]["value"] is None
     assert "no stochastic operator" in runtime["seed"]["policy"]


### PR DESCRIPTION
Release commit per `reference_rfx_release_process`: bumps the two version strings 1.6.6 → 1.6.7 and promotes CHANGELOG `[Unreleased]` → `[1.6.7] - 2026-07-28`, adding the late-window entries the per-PR discipline missed. **185 commits since v1.6.6.** Mechanical + prose only — no runtime change beyond the version strings.

After merge: annotated tag `v1.6.7` at the merge SHA, then the per-release gates run at that SHA — GPU suite (`vessl_gpu_suite.yaml`) **and** crossval-external (`vessl_crossval_external.yaml`, required this window: cv05/cv11 physics paths changed via #378/#459). Gate results go into the GitHub release notes. **No PyPI publish** (explicit-ask-only per process; not asked).

Two known re-measurement points this GPU run will answer (both disclosed in their PRs):
- patch-geometry gates re-measure at the new #478 auto-offset midpoints (`test_issue80_patch_s11_regression`, `test_msl_nu_sparam_gate`)
- `MSL-FD-TIGHT`'s thin owner-platform margin (0.0855/0.10, #477)

R3: memory=reference_rfx_release_process | R2-attempts=0 | falsifier=CI + the two per-release VESSL gates at the tag SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)