### PR TITLE
fix(probes): DFT accumulator dtype follows x64 — unblocks the f64 gradient referee (#483)

### DIFF
--- a/rfx/probes/probes.py
+++ b/rfx/probes/probes.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import NamedTuple
 
+import jax
 import jax.numpy as jnp
 
 from rfx.core.dft_utils import dft_window_weight as _dft_window_weight
@@ -59,8 +60,14 @@ def init_dft_probe(
 ) -> DFTProbe:
     """Create a DFT probe at a point for given frequencies."""
     idx = grid.position_to_index(position)
+    # Accumulator dtype follows the x64 state (issue #477 residual): under
+    # x64 the per-step update (field * complex phase) is complex128, and a
+    # hardcoded complex64 accumulator breaks the scan-carry dtype contract.
+    # With x64 off this is complex64 — bit-identical to the previous
+    # behaviour. Same idiom as compute_msl_s_matrix's _complex_dtype.
+    _cdtype = jnp.complex128 if jax.config.x64_enabled else jnp.complex64
     return DFTProbe(
-        accumulator=jnp.zeros(len(freqs), dtype=jnp.complex64),
+        accumulator=jnp.zeros(len(freqs), dtype=_cdtype),
         freqs=freqs,
         index=idx,
         component=component,
@@ -430,7 +437,9 @@ def init_dft_plane_probe(
         plane_shape = (grid_shape[0], grid_shape[1])
 
     nf = len(freqs)
-    acc = jnp.zeros((nf,) + plane_shape, dtype=jnp.complex64)
+    # dtype follows the x64 state — see create_dft_probe (issue #477 residual).
+    _cdtype = jnp.complex128 if jax.config.x64_enabled else jnp.complex64
+    acc = jnp.zeros((nf,) + plane_shape, dtype=_cdtype)
     return DFTPlaneProbe(
         accumulator=acc, freqs=freqs,
         component=component, axis=axis, index=index,

--- a/tests/test_dft_accumulator_dtype.py
+++ b/tests/test_dft_accumulator_dtype.py
@@ -1,0 +1,50 @@
+"""DFT accumulator dtype follows the x64 state (issue #477 residual).
+
+Hardcoded complex64 accumulators broke the scan-carry dtype contract the
+moment x64 was enabled (the per-step update `field * exp(-j w t)` promotes
+to complex128), which blocked any f64 gradient referee. The constructors
+now use the same conditional dtype idiom as compute_msl_s_matrix.
+
+x64 is scoped per-test via a context manager — NEVER flipped at module
+level (process-global; reds every same-process pytest shard).
+"""
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from rfx.grid import Grid
+from rfx.probes.probes import init_dft_probe, init_dft_plane_probe
+
+
+def _grid():
+    return Grid(freq_max=10e9, domain=(0.01, 0.01, 0.01), dx=1e-3,
+                cpml_layers=4)
+
+
+def test_accumulators_are_complex64_by_default():
+    """f32 mode (the default): dtypes unchanged from the pre-#477 behaviour
+    — the production path is BIT-identical (verified against pre-change
+    code on a thru-line S-matrix during the #477 E3 enablement)."""
+    g = _grid()
+    freqs = jnp.asarray([5e9], dtype=jnp.float32)
+    p = init_dft_probe(g, (0.005, 0.005, 0.005), "ez", freqs)
+    pl = init_dft_plane_probe(axis=2, index=5, component="ez", freqs=freqs, grid_shape=g.shape)
+    assert p.accumulator.dtype == jnp.complex64
+    assert pl.accumulator.dtype == jnp.complex64
+
+
+def test_accumulators_follow_x64_when_enabled():
+    """Under scoped x64 the accumulators must be complex128, so the scan
+    carry stays dtype-consistent and an f64 referee can run."""
+    with jax.experimental.enable_x64():
+        g = _grid()
+        freqs = jnp.asarray([5e9])
+        p = init_dft_probe(g, (0.005, 0.005, 0.005), "ez", freqs)
+        pl = init_dft_plane_probe(axis=2, index=5, component="ez", freqs=freqs, grid_shape=g.shape)
+        assert p.accumulator.dtype == jnp.complex128
+        assert pl.accumulator.dtype == jnp.complex128
+    # and back to the default outside the scope
+    g2 = _grid()
+    p2 = init_dft_probe(g2, (0.005, 0.005, 0.005), "ez",
+                        jnp.asarray([5e9], dtype=jnp.float32))
+    assert p2.accumulator.dtype == jnp.complex64

--- a/tests/test_msl_ad_fd_converged.py
+++ b/tests/test_msl_ad_fd_converged.py
@@ -143,10 +143,14 @@ def test_msl_ad_fd_converged_tight():
     A CPU h-sweep (h ∈ [3e-4, 1e-2]) shows a 27% NON-monotone FD scatter —
     evaluation noise, not h² truncation — so rel_err here compares AD
     against a ±3–5%-noisy reference. Whether AD carries a genuine ~10%
-    systematic vs the true derivative is INDETERMINATE at f32; the f64
-    referee is blocked by the hardcoded complex64 DFT scan carries (x64
-    flip fails the scan dtype contract — measured). Full record with the
-    h-sweep table and both platform logs: issue #477.
+    systematic vs the true derivative was initially INDETERMINATE at f32;
+    the f64 referee (unblocked by the accumulator-dtype fix, issue #483)
+    then DETERMINED it: f64 AD −2.1103e-01 vs f64 FD −2.4447e-01 →
+    **a genuine ~13.7% AD systematic** (the true derivative ≈ −0.244 per
+    three agreeing estimates; the GPU pass at 0.0855 was the noisy f32 FD
+    landing closer to AD than the truth). Treat eps_override MSL gradients
+    as ~±14%-class until #483 is attributed. Full record: issues #477 and
+    #483.
     """
     t_start = time.perf_counter()
 


### PR DESCRIPTION
Ships the dtype enabler that resolved #477's named residual and produced the #483 finding.

## Change (2 constructors + tests + docstring)
`init_dft_probe` / `init_dft_plane_probe` accumulators were hardcoded `complex64`, breaking the scan-carry dtype contract under x64 (per-step update promotes to complex128) — no f64 referee could run. Both now use the `_complex_dtype` idiom already established in `compute_msl_s_matrix`.

**Refactor gates:**
- x64 OFF → dtype unchanged, production path **bit-identical** (thru-line S bytes equal pre/post — verified)
- probe/DFT/witness/contract suites **33 passed**; new dtype test pair uses **per-test-scoped x64** (context manager; never module-level per the repo rule)
- `api reference surface: OK`, ruff clean

**Not a re-attempt of the refuted complex128 band-edge fix** (`project_sparam_drift_consolidation`): that record refuted a *physics claim* about precision; this makes none — it restores dtype consistency so a *measurement* can run, f32 path untouched.

## What the unblocked referee measured (→ #483, docstring updated in this PR)
```
f64 AD  = -2.1103e-01   (precision- and platform-stable)
f64 FD  = -2.4447e-01   (clean; agrees with the f32 large-h cluster → true ≈ -0.244)
rel_err = 0.1368        (pre-declared band: >=0.05 → genuine AD systematic)
```
The #477 comparator-noise story was half the picture: underneath it sits a **real ~13.7% AD deficit** on the MSL `eps_override` gradient. This PR ships only the enabler + the honest docstring; attribution (candidate mechanisms + discriminators) is tracked in #483. Gate values untouched.

R3: memory=project_sparam_drift_consolidation (distinguished, not reopened) + feedback_jax_x64_module_level_tests + bit-identity refactor gate | R2-attempts=0 | falsifier=bit-identity bytes + dtype fire/clear pair + pre-declared E3 bands

Independent review before merge per process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)