### PR TITLE
fix(waveguide): absorber advisory on every uniform two-port path + node-raster convention docs (#493, #494)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,18 +40,26 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 - `Box`'s volume branch is half-open `[lo, hi)` over NODE coordinates, so a box
   whose corners land on node planes occupies nodes `i..k-1`: the realized extent
   is one cell short of the drawn extent, entirely at the `hi` face, which also
-  displaces the object by `dx/2`. For a PEC obstacle those nodes are where
-  tangential `E` is zeroed, so this is an ELECTRICAL dimension error — two
-  facing fins drawn to leave a nominal opening `d` leave `d + dx` **or
-  `d + 2*dx`, and which one is not predictable from the nominal dimensions**:
-  one cell from the convention, a second whenever the far fin's corner misses
-  its node under float32 rounding. Measured on WR-90 at both a/30 and a/60,
-  7.620 mm and 18.288 mm give `d + dx` while 12.192 mm gives `d + 2*dx`; a
-  half-cell offset applied toward the metal gives `d + 2*dx` uniformly. This
-  inflated PR #480's `|S11|` error against an analytic mode-matching oracle by
-  4-6x. Because it scales with `dx` it mimics first-order convergence, and on a
-  resonant structure it shifts the passband instead of widening a magnitude
-  tolerance.
+  displaces a SINGLE box by `dx/2`. For a PEC obstacle those nodes are where
+  tangential `E` is zeroed, so this is an ELECTRICAL dimension error, measured
+  between the innermost zeroed planes as `(n_open + 1) * dx` — the measure that
+  reproduces the guide's own `a = cells * dx` exactly.
+- A facing pair does NOT simply inherit that per-box displacement, because its
+  two interior faces are different corner types: the lo fin's is a `hi` corner,
+  which half-openness always drops (so it always retreats one cell), while the
+  hi fin's is a `lo` corner, which is kept unless float32 rounding puts the node
+  just below it. One retreat gives `d + dx` with the opening **asymmetric**
+  (centre `dx/2` low); two retreats cancel and give `d + 2*dx` **centred**.
+  Which one occurs is **not predictable from the nominal dimensions**: measured
+  on WR-90 at both a/30 and a/60, 7.620 mm and 18.288 mm give `d + dx`
+  off-centre while 12.192 mm gives `d + 2*dx` centred. A half-cell offset toward
+  the metal retreats both faces by construction rather than by luck, giving
+  `d + 2*dx` deterministically at every aperture — the drawing case 18's blocked
+  revision used, and why re-comparing it against `oracle(d + 2*dx)` collapsed
+  every row. This inflated PR #480's `|S11|` error against an analytic
+  mode-matching oracle by 4-6x. Because it scales with `dx` it mimics
+  first-order convergence, and on a resonant structure it shifts the passband
+  instead of widening a magnitude tolerance.
 - The float32 effect is sharper than a single ULP of the corner value: node
   coordinates are themselves double-rounded, `f32(f32(i) * f32(dx))` in
   `_grid_coords`, while a caller's corner is computed in float64 and cast once.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,27 +42,46 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   is one cell short of the drawn extent, entirely at the `hi` face, which also
   displaces the object by `dx/2`. For a PEC obstacle those nodes are where
   tangential `E` is zeroed, so this is an ELECTRICAL dimension error — two
-  facing fins drawn to leave a nominal opening `d` leave `d + dx` (measured at
-  WR-90 a/30 and a/60), and a half-cell offset applied the wrong way gives
-  `d + 2*dx`, which inflated PR #480's `|S11|` error against an analytic
-  mode-matching oracle by 4-6x. Because it scales with `dx` it mimics
-  first-order convergence, and on a resonant structure it shifts the passband
-  instead of widening a magnitude tolerance.
-- The convention, its arithmetic, the float32 knife edge at a node plane (one
-  ULP — ~5e-10 m at `dx` = 0.762 mm — flips the footprint by a whole cell) and
-  the cell-midpoint recipe are now stated in the `Box` / `Shape.mask_on_coords`
-  / `rasterize` docstrings and in the waveguide setup restrictions of
+  facing fins drawn to leave a nominal opening `d` leave `d + dx` **or
+  `d + 2*dx`, and which one is not predictable from the nominal dimensions**:
+  one cell from the convention, a second whenever the far fin's corner misses
+  its node under float32 rounding. Measured on WR-90 at both a/30 and a/60,
+  7.620 mm and 18.288 mm give `d + dx` while 12.192 mm gives `d + 2*dx`; a
+  half-cell offset applied toward the metal gives `d + 2*dx` uniformly. This
+  inflated PR #480's `|S11|` error against an analytic mode-matching oracle by
+  4-6x. Because it scales with `dx` it mimics first-order convergence, and on a
+  resonant structure it shifts the passband instead of widening a magnitude
+  tolerance.
+- The float32 effect is sharper than a single ULP of the corner value: node
+  coordinates are themselves double-rounded, `f32(f32(i) * f32(dx))` in
+  `_grid_coords`, while a caller's corner is computed in float64 and cast once.
+  An f64 reconstruction of the nodes disagrees with production on 30 of 31 WR-90
+  nodes by up to 1.1e-9 m (1e-6 of a cell) — enough to move the footprint by a
+  whole cell, which is precisely what separates 12.192 mm from the other two
+  apertures.
+- The recipe therefore has two conditions: interior corners on **cell
+  midpoints** (rounding-independent) AND the metal depth an exact number of
+  cells, i.e. `(cells - d_cells)` even. Under both, the realized opening equals
+  the nominal one exactly (100% of ~50k even-parity combinations measured). At
+  odd parity a symmetric opening of that width is not representable on the grid
+  and costs one cell however it is drawn — a representability limit, not a
+  rasterization defect.
+- All of the above is now stated in the `Box` / `Shape.mask_on_coords` /
+  `rasterize` docstrings and in the waveguide setup restrictions of
   `docs/guides/sparameter_support_matrix.md`. Characterization tests pin the
-  arithmetic in `tests/test_waveguide_geometry_hygiene.py`.
+  arithmetic in `tests/test_waveguide_geometry_hygiene.py`, deriving node
+  coordinates from a real `Grid` rather than an f64 `arange` — an earlier
+  revision of those tests used f64 coordinates and consequently pinned
+  `d + dx` at every aperture, which is wrong at 12.192 mm.
 - **The rasterization rule itself is unchanged** — it is deliberate and other
   paths depend on it. No advisory was added: the predicate floated in #493
   (fire when the rasterized opening differs from the drawn opening by >= 1 cell)
-  has no discriminating power, because the half-open rule shifts the realized
-  aperture by exactly one cell relative to the drawn faces regardless of where
-  they sit, reading +1 cell for the correct midpoint recipe and both defective
-  drawings alike. The defect is `realized != INTENDED`, and the intended
-  dimension is never communicated to the simulator. Pinned by
-  `test_drawn_vs_realized_gap_cannot_discriminate_a_correct_drawing`.
+  gives an AMBIGUOUS reading. At `d = 7.620 mm` the defective nominal drawing
+  and the correct midpoint recipe both read +1 cell, so +1 cell cannot support a
+  defect conclusion — and +1 cell is the common case. The defect is
+  `realized != INTENDED`, and the intended dimension is never communicated to
+  the simulator, so it is not recoverable from geometry. Pinned by
+  `test_drawn_vs_realized_gap_is_ambiguous_between_correct_and_defective`.
 
 ### Fixed — MSL `eps_override` gradient: 13.7% converged deficit attributed and removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,64 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Added — thin-absorber advisory on every uniform waveguide S-matrix path (#494)
+
+- `compute_waveguide_s_matrix` documents a "Far-port discipline" requiring an
+  absorber `>= ~0.5 * lambda_g`, but nothing checked it on the plain two-port
+  path: the sibling `_warn_junction_cpml_thickness` advisory runs only on the
+  `port_reference_sims` junction path, and the functional entry points run no
+  `sim.preflight()`. A gated revision of crossval case 18 therefore shipped a
+  0.30-`lambda_g` stack in silence and the absorber, not discretization, set
+  the reported accuracy envelope. A new in-method ADVISORY (warning, never
+  raises) now fires whenever the absorber on a port's propagation axis is
+  thinner than `0.5 * lambda_g`, quoting both the configured thickness and the
+  requirement.
+- Evaluated at the **lowest** measured frequency, where `lambda_g` is longest
+  and the `cpml_layers=16` default weakest, because `lambda_g` diverges toward
+  cutoff — the existing junction advisory uses band centre, which is what let
+  the 0.30-`lambda_g` stack pass. The message reports the measured ripple
+  ladder (0.0706 at 0.30 `lambda_g`, 0.0366 at 0.50, 0.0093 at 0.75) so
+  `0.5 * lambda_g` reads as a floor, not a target, and names the `cpml_layers`
+  values for both 0.5 and 0.75.
+- Deliberately a LOWER bound, with three fences: silent when the band starts at
+  or below cutoff (`lambda_g` undefined; the `port_freqs_below_cutoff` preflight
+  owns that), silent when the propagation axis carries no absorbing face, and
+  evaluated on the port's lowest-cutoff mode (shortest `lambda_g`, least
+  demanding). Silent on a non-uniform mesh, where `cpml_layers * dx` is
+  ambiguous under a graded profile. Respects per-face
+  `Boundary.lo_thickness` / `.hi_thickness` overrides. No physics changed and no
+  gate or tolerance was touched. Firing and non-firing gates in
+  `tests/test_waveguide_geometry_hygiene.py`.
+
+### Changed — node-rasterization convention documented where obstacles get drawn (#493)
+
+- `Box`'s volume branch is half-open `[lo, hi)` over NODE coordinates, so a box
+  whose corners land on node planes occupies nodes `i..k-1`: the realized extent
+  is one cell short of the drawn extent, entirely at the `hi` face, which also
+  displaces the object by `dx/2`. For a PEC obstacle those nodes are where
+  tangential `E` is zeroed, so this is an ELECTRICAL dimension error — two
+  facing fins drawn to leave a nominal opening `d` leave `d + dx` (measured at
+  WR-90 a/30 and a/60), and a half-cell offset applied the wrong way gives
+  `d + 2*dx`, which inflated PR #480's `|S11|` error against an analytic
+  mode-matching oracle by 4-6x. Because it scales with `dx` it mimics
+  first-order convergence, and on a resonant structure it shifts the passband
+  instead of widening a magnitude tolerance.
+- The convention, its arithmetic, the float32 knife edge at a node plane (one
+  ULP — ~5e-10 m at `dx` = 0.762 mm — flips the footprint by a whole cell) and
+  the cell-midpoint recipe are now stated in the `Box` / `Shape.mask_on_coords`
+  / `rasterize` docstrings and in the waveguide setup restrictions of
+  `docs/guides/sparameter_support_matrix.md`. Characterization tests pin the
+  arithmetic in `tests/test_waveguide_geometry_hygiene.py`.
+- **The rasterization rule itself is unchanged** — it is deliberate and other
+  paths depend on it. No advisory was added: the predicate floated in #493
+  (fire when the rasterized opening differs from the drawn opening by >= 1 cell)
+  has no discriminating power, because the half-open rule shifts the realized
+  aperture by exactly one cell relative to the drawn faces regardless of where
+  they sit, reading +1 cell for the correct midpoint recipe and both defective
+  drawings alike. The defect is `realized != INTENDED`, and the intended
+  dimension is never communicated to the simulator. Pinned by
+  `test_drawn_vs_realized_gap_cannot_discriminate_a_correct_drawing`.
+
 ### Fixed — MSL `eps_override` gradient: 13.7% converged deficit attributed and removed
 
 - The auto-`eps_r_sub` launch fixture (mode profile / sigma loading / source

--- a/docs/guides/sparameter_support_matrix.md
+++ b/docs/guides/sparameter_support_matrix.md
@@ -218,6 +218,29 @@ implementation nor gradient regression is RF validation.
   otherwise relative error is dominated by the numerical noise floor.
 - Choose `dx` so the slab length is an integer number of cells; staircase
   quantization directly perturbs the round-trip phase.
+- Draw interior PEC obstacles (irises, septa, posts) with their interior faces
+  on **cell midpoints**, not on node planes, and assert the realized footprint.
+  `Box` rasterizes half-open `[lo, hi)` over node coordinates, so a box drawn
+  between two node planes occupies one cell fewer than drawn, asymmetrically at
+  the `hi` face. Two facing fins drawn to leave a nominal opening `d` therefore
+  leave an electrical opening of `d + dx`; offsetting each interior face half a
+  cell the wrong way gives `d + 2*dx`. In the WR-90 single-iris lane the latter
+  inflated the `|S11|` difference against an analytic mode-matching oracle by
+  4-6x (0.0193 to 0.1262 at `d = 7.620 mm`, a/30). Because the error scales
+  with `dx` it mimics first-order convergence, and on a resonant structure it
+  shifts the passband instead of widening a magnitude tolerance. See the `Box`
+  docstring for the arithmetic and `run_point` in
+  `validation/crossval/18_wr90_iris_modematch.py` for the assert pattern.
+- Size the absorber from the guide wavelength at the **lowest** measured
+  frequency, where `lambda_g` is longest and the `cpml_layers=16` default is
+  weakest. `compute_waveguide_s_matrix` documents `>= 0.5 * lambda_g` and now
+  emits an advisory when the configured stack is thinner. That floor is a
+  minimum, not a target: at WR-90 band edge (8.2 GHz, `lambda_g` about 61 mm)
+  a 0.30 `lambda_g` stack left residual `|S11|` ripple 0.0706, 0.50 `lambda_g`
+  left 0.0366, and 0.75 `lambda_g` left 0.0093, so a 0.5 `lambda_g` absorber
+  can still set the accuracy envelope instead of discretization. Case 18
+  derives its depth as `ceil(0.75 * lambda_g(band edge) / dx)`; the validated
+  fixtures use 20-24 cells rather than the default 16.
 - Multimode `normalize=True` is unsupported.
 - Branch, T-junction, and septum calculations require per-port matched straight-
   guide references and far-port placement. Compact arbitrary junctions are not

--- a/docs/guides/sparameter_support_matrix.md
+++ b/docs/guides/sparameter_support_matrix.md
@@ -219,17 +219,25 @@ implementation nor gradient regression is RF validation.
 - Choose `dx` so the slab length is an integer number of cells; staircase
   quantization directly perturbs the round-trip phase.
 - Draw interior PEC obstacles (irises, septa, posts) with their interior faces
-  on **cell midpoints**, not on node planes, and assert the realized footprint.
-  `Box` rasterizes half-open `[lo, hi)` over node coordinates, so a box drawn
-  between two node planes occupies one cell fewer than drawn, asymmetrically at
-  the `hi` face. Two facing fins drawn to leave a nominal opening `d` therefore
-  leave an electrical opening of `d + dx`; offsetting each interior face half a
-  cell the wrong way gives `d + 2*dx`. In the WR-90 single-iris lane the latter
-  inflated the `|S11|` difference against an analytic mode-matching oracle by
-  4-6x (0.0193 to 0.1262 at `d = 7.620 mm`, a/30). Because the error scales
-  with `dx` it mimics first-order convergence, and on a resonant structure it
-  shifts the passband instead of widening a magnitude tolerance. See the `Box`
-  docstring for the arithmetic and `run_point` in
+  on **cell midpoints**, keep the metal depth an exact number of cells, and
+  assert the realized footprint. `Box` rasterizes half-open `[lo, hi)` over node
+  coordinates, so a box drawn between two node planes occupies one cell fewer
+  than drawn, asymmetrically at the `hi` face. Two facing fins drawn to leave a
+  nominal opening `d` therefore leave an electrical opening of `d + dx` **or
+  `d + 2*dx`, and which one is not predictable from the nominal dimensions** —
+  one cell from the convention, a second whenever the far fin's corner misses
+  its node under float32 rounding. Measured on WR-90 at both a/30 and a/60:
+  7.620 mm and 18.288 mm give `d + dx`, 12.192 mm gives `d + 2*dx`. Offsetting
+  each interior face half a cell the wrong way gives `d + 2*dx` uniformly. In
+  the WR-90 single-iris lane this inflated the `|S11|` difference against an
+  analytic mode-matching oracle by 4-6x (0.0193 to 0.1262 at `d = 7.620 mm`,
+  a/30). Because the error scales with `dx` it mimics first-order convergence,
+  and on a resonant structure it shifts the passband instead of widening a
+  magnitude tolerance. Midpoint corners are rounding-independent, and with
+  `(cells - d_cells)` even the realized opening equals the nominal one exactly;
+  at odd parity a symmetric opening of that width is not representable on the
+  grid and costs one cell however it is drawn. See the `Box` docstring for the
+  arithmetic and `run_point` in
   `validation/crossval/18_wr90_iris_modematch.py` for the assert pattern.
 - Size the absorber from the guide wavelength at the **lowest** measured
   frequency, where `lambda_g` is longest and the `cpml_layers=16` default is

--- a/docs/guides/sparameter_support_matrix.md
+++ b/docs/guides/sparameter_support_matrix.md
@@ -224,11 +224,19 @@ implementation nor gradient regression is RF validation.
   coordinates, so a box drawn between two node planes occupies one cell fewer
   than drawn, asymmetrically at the `hi` face. Two facing fins drawn to leave a
   nominal opening `d` therefore leave an electrical opening of `d + dx` **or
-  `d + 2*dx`, and which one is not predictable from the nominal dimensions** —
-  one cell from the convention, a second whenever the far fin's corner misses
-  its node under float32 rounding. Measured on WR-90 at both a/30 and a/60:
-  7.620 mm and 18.288 mm give `d + dx`, 12.192 mm gives `d + 2*dx`. Offsetting
-  each interior face half a cell the wrong way gives `d + 2*dx` uniformly. In
+  `d + 2*dx`, and which one is not predictable from the nominal dimensions**.
+  The pair's two interior faces are different corner types: the lo fin's is a
+  `hi` corner, which half-openness always drops, so it always retreats one
+  cell; the hi fin's is a `lo` corner, which is kept unless float32 rounding
+  puts the node just below it. One retreat gives `d + dx` with the opening
+  **asymmetric** (centre `dx/2` low); two retreats give `d + 2*dx`, **centred**.
+  Measured on WR-90 at both a/30 and a/60: 7.620 mm and 18.288 mm give
+  `d + dx` off-centre, 12.192 mm gives `d + 2*dx` centred. The electrical
+  opening is measured between the innermost zeroed planes, `(n_open + 1) * dx`
+  — the measure that reproduces `a = cells * dx` exactly. Offsetting each
+  interior face half a cell the wrong way retreats both faces by construction
+  rather than by luck, giving `d + 2*dx` deterministically at every aperture;
+  that is the drawing case 18's blocked revision used. In
   the WR-90 single-iris lane this inflated the `|S11|` difference against an
   analytic mode-matching oracle by 4-6x (0.0193 to 0.1262 at `d = 7.620 mm`,
   a/30). Because the error scales with `dx` it mimics first-order convergence,

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -620,6 +620,110 @@ def _warn_junction_cpml_thickness(grid, cfgs, freqs, cpml_layers):
             )
 
 
+def _warn_thin_absorber_vs_guide_wavelength(
+    grid, cfgs, freqs, cpml_layers, boundary_spec,
+):
+    """Advisory: absorber depth vs guide wavelength at the LOWEST measured freq.
+
+    ``compute_waveguide_s_matrix``'s "Far-port discipline" requires an absorber
+    ``>= ~0.5 * lambda_g``, but nothing checked it on the plain two-port path:
+    the ``port_reference_sims`` sibling advisory
+    (:func:`_warn_junction_cpml_thickness`) only runs on the junction path, and
+    the functional entry points run no ``sim.preflight()`` at all. A gated
+    revision of crossval case 18 therefore shipped a 0.30 ``lambda_g`` stack in
+    silence, and the absorber — not discretization — set the reported accuracy
+    envelope (issue #494).
+
+    Evaluated at the **lowest** measured frequency, where ``lambda_g`` is
+    longest and the ``cpml_layers=16`` default is weakest, because
+    ``lambda_g`` diverges as ``f`` approaches cutoff. Three deliberate
+    false-positive fences, each of which makes this a *lower* bound on the
+    real requirement:
+
+    * Skipped when the lowest measured frequency is at or below the mode's
+      own cutoff. ``lambda_g`` is undefined there and the band itself is
+      invalid — ``_check_waveguide_port_evanescent`` (preflight code
+      ``port_freqs_below_cutoff``) owns that failure, and warning about the
+      absorber on top of it would be noise. Note this means a band that
+      starts below cutoff gets **no** absorber advisory.
+    * Skipped when the port's propagation axis carries no absorbing face
+      (a PEC-closed or periodic axis has no absorber to under-drain).
+    * Uses the port's lowest-cutoff mode, whose ``lambda_g`` is the shortest
+      and so the least demanding; higher-order content sitting nearer its own
+      cutoff needs a thicker stack than this check asks for.
+
+    Emits one ``warnings.warn`` per distinct (propagation axis, cutoff);
+    does not raise. Pure NumPy, no FDTD.
+    """
+    import warnings
+
+    if boundary_spec is None:
+        return
+    f_arr = np.asarray(freqs, dtype=float)
+    if f_arr.size == 0:
+        return
+    f_lo = float(f_arr.min())
+    dx = float(grid.dx)
+    seen: set = set()
+    for cfg in cfgs:
+        # A multimode port arrives as a list of per-mode configs; the
+        # lowest-cutoff mode carries the least demanding requirement.
+        modes = cfg if isinstance(cfg, list) else [cfg]
+        if not modes:
+            continue
+        c = min(modes, key=lambda m: float(m.f_cutoff))
+        axis = str(c.normal_axis)
+        fc = float(c.f_cutoff)
+        key = (axis, round(fc, 3))
+        if key in seen:
+            continue
+        seen.add(key)
+
+        if fc <= 0.0 or f_lo <= fc:
+            continue
+        axis_boundary = getattr(boundary_spec, axis, None)
+        if axis_boundary is None:
+            continue
+        faces = []
+        for side in ("lo", "hi"):
+            if getattr(axis_boundary, side, None) not in ("cpml", "upml"):
+                continue
+            override = getattr(axis_boundary, f"{side}_thickness", None)
+            n_cells = int(cpml_layers if override is None else override)
+            if n_cells > 0:
+                faces.append((side, n_cells))
+        if not faces:
+            continue
+
+        lambda_g = (_C0_SPARAMS / f_lo) / np.sqrt(1.0 - (fc / f_lo) ** 2)
+        required_m = 0.5 * lambda_g
+        thin = [(side, n) for side, n in faces if n * dx < required_m]
+        if not thin:
+            continue
+        detail = ", ".join(
+            f"{axis}-{side} {n} cells = {n * dx * 1e3:.1f} mm "
+            f"({n * dx / lambda_g:.2f} lambda_g)"
+            for side, n in thin
+        )
+        warnings.warn(
+            f"compute_waveguide_s_matrix: absorber on the {axis} propagation "
+            f"axis is thinner than the documented 0.5 guide-wavelength "
+            f"far-port discipline at the lowest measured frequency "
+            f"{f_lo / 1e9:.3f} GHz (mode cutoff {fc / 1e9:.3f} GHz, "
+            f"lambda_g = {lambda_g * 1e3:.1f} mm): {detail}, against a "
+            f"required {required_m * 1e3:.1f} mm. A thin absorber reflects "
+            f"guided energy and can set the accuracy envelope instead of "
+            f"discretization: in the WR-90 iris lane (issue #494) residual "
+            f"|S11| ripple was 0.0706 at 0.30 lambda_g, 0.0366 at 0.50, and "
+            f"0.0093 at 0.75, so 0.5 lambda_g is a floor and not a target. "
+            f"Raise cpml_layers to at least "
+            f"{int(np.ceil(required_m / dx))} (0.75 lambda_g needs "
+            f"{int(np.ceil(0.75 * lambda_g / dx))}).",
+            UserWarning,
+            stacklevel=2,
+        )
+
+
 class _SparamMixin:
     """S-parameter extraction methods mixed into :class:`Simulation`."""
 
@@ -739,8 +843,27 @@ class _SparamMixin:
             matched reference fixes |S11| (1.86 → 0.49, physical) but the overall
             matrix stays non-physical (residual max|S|~3.9); the two in-method
             advisories (probe clearance, CPML thickness) warn when the far-port
-            discipline is not met. This enables junction measurements UNDER the
-            documented discipline; it does NOT make arbitrary compact junctions
+            discipline is not met.
+
+            The absorber half of that discipline is checked on **every**
+            uniform path, not just this one: an in-method advisory (issue
+            #494) fires whenever the absorber on a port's propagation axis is
+            thinner than ``0.5 * lambda_g`` at the **lowest** measured
+            frequency, which is where ``lambda_g`` is longest and the
+            ``cpml_layers=16`` default weakest. It is checked in-method
+            because the functional entry points run no ``sim.preflight()``.
+            Treat ``0.5 * lambda_g`` as a floor, not a target: at the WR-90
+            band edge the measured residual ``|S11|`` ripple was 0.0706 at
+            0.30 ``lambda_g``, 0.0366 at 0.50 and 0.0093 at 0.75, so a
+            0.5-``lambda_g`` absorber can still set the accuracy envelope
+            instead of discretization. The advisory is silent on a
+            non-uniform mesh (``cpml_layers * dx`` is ambiguous under a
+            graded profile) and on a band that starts at or below cutoff
+            (``lambda_g`` is undefined there; the ``port_freqs_below_cutoff``
+            preflight owns that case).
+
+            This enables junction measurements UNDER the documented
+            discipline; it does NOT make arbitrary compact junctions
             valid. See the skipped ``test_api.py`` T-junction reciprocity test
             and the companion evidence gate test
             ``tests/test_waveguide_tjunction_e4e5_gates.py``.
@@ -971,6 +1094,15 @@ class _SparamMixin:
                 else [c._replace(src_t0=ref_t0, src_tau=ref_tau) for c in cfg]
                 for cfg in raw_cfgs
             ]
+
+        # Far-port absorber advisory for EVERY uniform two-port path (issue
+        # #494). Emitted here, before the FDTD runs and before the
+        # single-mode / multimode split, because the functional entry points
+        # run no sim.preflight() and the port_reference_sims advisory below
+        # covers only the junction path.
+        _warn_thin_absorber_vs_guide_wavelength(
+            grid, raw_cfgs, freqs, self._cpml_layers, self._boundary_spec,
+        )
 
         # Compute Kottke per-component smoothed permittivity if requested.
         # Shared by both single-mode and multi-mode paths.

--- a/rfx/geometry/csg.py
+++ b/rfx/geometry/csg.py
@@ -84,9 +84,13 @@ class Box:
        land on node planes, ``lo = i*dx`` and ``hi = k*dx``, occupies nodes
        ``i .. k-1``. Its realized extent between the first and last occupied
        node plane is therefore ``(hi - lo) - dx``, one cell short of the
-       drawn extent, and the shortfall is entirely at the ``hi`` face — the
-       footprint is **asymmetric**, so the object is also displaced by
-       ``dx/2`` toward ``lo``.
+       drawn extent, and the shortfall is entirely at the ``hi`` face, so a
+       **single box** is also displaced by ``dx/2`` toward ``lo``. Note the
+       two faces are NOT interchangeable: ``lo`` is inclusive and ``hi`` is
+       exclusive. Whether that per-box displacement survives in a
+       multi-object structure depends on which face of each object is the
+       load-bearing one — see the facing-pair discussion below, where it
+       cancels in one case and not the other.
 
     2. **A corner exactly on a node plane is a knife edge.** Masks are
        evaluated in the default float32 precision, and the node coordinates
@@ -102,30 +106,54 @@ class Box:
 
     For a **PEC obstacle** the occupied nodes are where the tangential ``E``
     is zeroed, so consequence (1) is an *electrical* dimension error, not a
-    sub-cell cosmetic one. Two facing fins drawn to leave a nominal opening
-    ``d`` leave an electrical opening of **``d + dx`` or ``d + 2*dx``, and
-    which one is not predictable from the nominal dimensions** — one cell
-    comes from the convention itself, and a second appears whenever the far
-    fin's corner fails to capture its node under (2). Measured on WR-90 at
-    both a/30 and a/60: ``d`` = 7.620 and 18.288 mm give ``d + dx``, while
-    ``d`` = 12.192 mm gives ``d + 2*dx``. Over ~99k (guide, mesh, aperture)
-    combinations the split is 82% / 9% / 8% across ``d + dx`` / ``d + 2*dx``
-    / ``d`` at even parity, shifting one cell up at odd parity (see the
-    recipe). Shifting each interior face half a cell the *wrong* way (toward
-    the metal) gives ``d + 2*dx`` uniformly. In PR #480's WR-90 single-iris
-    lane this inflated the ``|S11|`` error against an analytic mode-matching
-    oracle by 4-6x, and because it scales with ``dx`` it is easy to misread
-    as first-order convergence. For a **resonant** structure (multi-iris
-    filter, cavity) it shifts the passband rather than widening a magnitude
-    tolerance, so it will not look like a discretization error at all.
+    sub-cell cosmetic one. The electrical opening is measured between the
+    innermost ZEROED node planes, i.e. ``(n_open + 1) * dx`` — the same
+    measure that reproduces the guide's own width, ``a = cells * dx``
+    exactly (counting open nodes alone would call WR-90 22.098 mm instead of
+    22.86 at a/30).
+
+    **A facing pair is not symmetric under this rule, because its two
+    interior faces are different kinds of corner.** For fins drawn from each
+    wall inward, the lo fin's interior face is a ``hi`` corner, which
+    half-openness **always** drops, so that fin always retreats one cell.
+    The hi fin's interior face is a ``lo`` corner, which ``coords >= lo``
+    normally **keeps** — it retreats only when (2) puts the node just below
+    the corner. Hence the realized opening is:
+
+    * ``d + dx`` when only the lo fin retreated. The opening is then
+      **asymmetric**: its centre sits ``dx/2`` below the guide centre.
+    * ``d + 2*dx`` when rounding made the hi fin retreat as well. The two
+      retreats cancel and the opening is **symmetric**.
+
+    Which one you get is **not predictable from the nominal dimensions**.
+    Measured on WR-90 at both a/30 and a/60: ``d`` = 7.620 and 18.288 mm
+    give ``d + dx`` (centre offset -0.5 cell), while ``d`` = 12.192 mm gives
+    ``d + 2*dx`` (centred). Over ~99k (guide, mesh, aperture) combinations
+    the split is 82% / 9% / 8% across ``d + dx`` / ``d + 2*dx`` / ``d`` at
+    even parity, shifting one cell up at odd parity (see the recipe).
+    Shifting each interior face half a cell the *wrong* way (toward the
+    metal) retreats both faces by construction rather than by luck, giving
+    ``d + 2*dx`` deterministically at every aperture — that is the drawing
+    case 18's blocked revision used, and it is why re-comparing that
+    revision against ``oracle(d + 2*dx)`` collapsed every row.
+
+    In PR #480's WR-90 single-iris lane this inflated the ``|S11|`` error
+    against an analytic mode-matching oracle by 4-6x, and because it scales
+    with ``dx`` it is easy to misread as first-order convergence. For a
+    **resonant** structure (multi-iris filter, cavity) it shifts the
+    passband rather than widening a magnitude tolerance, so it will not look
+    like a discretization error at all.
 
     **Recipe**, two conditions, both needed:
 
     * Put interior corners on **cell midpoints**, ``(j + 0.5) * dx``, to make
-      node ``j`` the innermost occupied plane. Any value in
-      ``(j*dx, (j+1)*dx]`` selects the same footprint, and the midpoint is
-      the farthest point from both knife edges, so the footprint becomes
-      rounding-independent.
+      node ``j`` the innermost occupied plane. Every corner value in a
+      one-cell-wide interval selects the same footprint (``(j*dx, (j+1)*dx]``
+      for a ``hi`` corner, ``[j*dx, (j+1)*dx)`` for a ``lo`` corner), and the
+      midpoint is that interval's **centre** — not merely a safe nudge away
+      from the node. That is precisely why it is immune to the float32
+      effects in (2), which only ever perturb a corner by a fraction of a
+      cell.
     * Keep the metal depth an exact number of cells, i.e. for a symmetric
       obstacle keep ``(cells - d_cells)`` **even**. When it is odd,
       ``fin_depth = (cells - d_cells)//2`` truncates and a symmetric opening

--- a/rfx/geometry/csg.py
+++ b/rfx/geometry/csg.py
@@ -89,31 +89,54 @@ class Box:
        ``dx/2`` toward ``lo``.
 
     2. **A corner exactly on a node plane is a knife edge.** Masks are
-       evaluated in the default float32 precision, where one ULP of the
-       corner value is ~5e-10 m at ``dx`` = 0.762 mm (6e-7 of a cell).
-       Perturbing ``hi`` by that single ULP moves the occupied-node count by
-       a whole cell, so a corner computed as ``a - n*dx`` may rasterize
-       differently from the algebraically identical ``m*dx``.
+       evaluated in the default float32 precision, and the node coordinates
+       are themselves double-rounded: :func:`_grid_coords` computes
+       ``f32(f32(i) * f32(dx))`` while a caller's corner is computed in
+       float64 and cast once. Algebraically equal values therefore land on
+       opposite sides of the comparison — on a real WR-90 grid an f64
+       reconstruction of the nodes disagrees with production on 30 of 31
+       nodes by up to 1.1e-9 m (1e-6 of a cell), which is enough to move the
+       occupied-node count by a whole cell. A corner computed as ``a - n*dx``
+       may thus rasterize differently from the algebraically identical
+       ``m*dx``.
 
     For a **PEC obstacle** the occupied nodes are where the tangential ``E``
     is zeroed, so consequence (1) is an *electrical* dimension error, not a
     sub-cell cosmetic one. Two facing fins drawn to leave a nominal opening
-    ``d`` leave an electrical opening of ``d + dx`` (measured, WR-90 iris at
-    a/30 and a/60); shifting each interior face half a cell the *wrong* way
-    — a natural attempt at (2) — gives ``d + 2*dx``. In PR #480's WR-90
-    single-iris lane that inflated the ``|S11|`` error against an analytic
-    mode-matching oracle by 4-6x, and because it scales with ``dx`` it is
-    easy to misread as first-order convergence. For a **resonant** structure
-    (multi-iris filter, cavity) it shifts the passband rather than widening
-    a magnitude tolerance, so it will not look like a discretization error
-    at all.
+    ``d`` leave an electrical opening of **``d + dx`` or ``d + 2*dx``, and
+    which one is not predictable from the nominal dimensions** — one cell
+    comes from the convention itself, and a second appears whenever the far
+    fin's corner fails to capture its node under (2). Measured on WR-90 at
+    both a/30 and a/60: ``d`` = 7.620 and 18.288 mm give ``d + dx``, while
+    ``d`` = 12.192 mm gives ``d + 2*dx``. Over ~99k (guide, mesh, aperture)
+    combinations the split is 82% / 9% / 8% across ``d + dx`` / ``d + 2*dx``
+    / ``d`` at even parity, shifting one cell up at odd parity (see the
+    recipe). Shifting each interior face half a cell the *wrong* way (toward
+    the metal) gives ``d + 2*dx`` uniformly. In PR #480's WR-90 single-iris
+    lane this inflated the ``|S11|`` error against an analytic mode-matching
+    oracle by 4-6x, and because it scales with ``dx`` it is easy to misread
+    as first-order convergence. For a **resonant** structure (multi-iris
+    filter, cavity) it shifts the passband rather than widening a magnitude
+    tolerance, so it will not look like a discretization error at all.
 
-    **Recipe.** To make node ``j`` the innermost occupied plane, put the
-    corner at the cell midpoint ``(j + 0.5) * dx`` rather than on a node
-    plane: any value in ``(j*dx, (j+1)*dx]`` selects the same footprint, and
-    the midpoint is the farthest point from both knife edges. Then assert
-    the realized footprint (count the occupied node planes) against the
-    intended one — see ``run_point`` in
+    **Recipe**, two conditions, both needed:
+
+    * Put interior corners on **cell midpoints**, ``(j + 0.5) * dx``, to make
+      node ``j`` the innermost occupied plane. Any value in
+      ``(j*dx, (j+1)*dx]`` selects the same footprint, and the midpoint is
+      the farthest point from both knife edges, so the footprint becomes
+      rounding-independent.
+    * Keep the metal depth an exact number of cells, i.e. for a symmetric
+      obstacle keep ``(cells - d_cells)`` **even**. When it is odd,
+      ``fin_depth = (cells - d_cells)//2`` truncates and a symmetric opening
+      of that width is simply not representable on the grid: the opening is
+      one cell wide however it is drawn. That is a representability limit,
+      not a rasterization defect.
+
+    Under both conditions the realized opening equals the nominal one
+    exactly (measured, 100% of ~50k even-parity combinations). Then still
+    assert the realized footprint (count the occupied node planes) against
+    the intended one — see ``run_point`` in
     ``validation/crossval/18_wr90_iris_modematch.py`` for the pattern.
 
     A box thinner than one local cell takes a separate **thin-sheet**

--- a/rfx/geometry/csg.py
+++ b/rfx/geometry/csg.py
@@ -31,6 +31,12 @@ class Shape(Protocol):
     ) -> jnp.ndarray:
         """Evaluate shape occupancy on explicit 1D coordinate arrays.
 
+        Coordinates are **node** positions, and each shape defines its own
+        boundary rule; :class:`Box` is half-open ``[lo, hi)``, which makes a
+        drawn extent realize one cell shorter at the ``hi`` face. See the
+        :class:`Box` docstring before drawing a PEC obstacle to a nominal
+        physical dimension.
+
         Parameters
         ----------
         x, y, z : 1D arrays of physical coordinates (metres)
@@ -65,7 +71,55 @@ def _grid_coords(grid: Grid):
 
 @dataclass(frozen=True)
 class Box:
-    """Axis-aligned box defined by two corners (meters)."""
+    """Axis-aligned box defined by two corners (meters).
+
+    **Rasterization convention (read before drawing a PEC obstacle).**
+    On each axis the volume branch is **half-open** ``[lo, hi)`` over
+    **node** coordinates: node ``j`` at ``y_j = j * dx`` belongs to the box
+    iff ``lo <= y_j < hi``. The convention is deliberate and several paths
+    depend on it (see ``_axis_mask`` for the issue history), but it has two
+    consequences that bite when a box is drawn to a nominal physical size:
+
+    1. **The ``hi`` face contributes no cell.** A box whose corners both
+       land on node planes, ``lo = i*dx`` and ``hi = k*dx``, occupies nodes
+       ``i .. k-1``. Its realized extent between the first and last occupied
+       node plane is therefore ``(hi - lo) - dx``, one cell short of the
+       drawn extent, and the shortfall is entirely at the ``hi`` face — the
+       footprint is **asymmetric**, so the object is also displaced by
+       ``dx/2`` toward ``lo``.
+
+    2. **A corner exactly on a node plane is a knife edge.** Masks are
+       evaluated in the default float32 precision, where one ULP of the
+       corner value is ~5e-10 m at ``dx`` = 0.762 mm (6e-7 of a cell).
+       Perturbing ``hi`` by that single ULP moves the occupied-node count by
+       a whole cell, so a corner computed as ``a - n*dx`` may rasterize
+       differently from the algebraically identical ``m*dx``.
+
+    For a **PEC obstacle** the occupied nodes are where the tangential ``E``
+    is zeroed, so consequence (1) is an *electrical* dimension error, not a
+    sub-cell cosmetic one. Two facing fins drawn to leave a nominal opening
+    ``d`` leave an electrical opening of ``d + dx`` (measured, WR-90 iris at
+    a/30 and a/60); shifting each interior face half a cell the *wrong* way
+    — a natural attempt at (2) — gives ``d + 2*dx``. In PR #480's WR-90
+    single-iris lane that inflated the ``|S11|`` error against an analytic
+    mode-matching oracle by 4-6x, and because it scales with ``dx`` it is
+    easy to misread as first-order convergence. For a **resonant** structure
+    (multi-iris filter, cavity) it shifts the passband rather than widening
+    a magnitude tolerance, so it will not look like a discretization error
+    at all.
+
+    **Recipe.** To make node ``j`` the innermost occupied plane, put the
+    corner at the cell midpoint ``(j + 0.5) * dx`` rather than on a node
+    plane: any value in ``(j*dx, (j+1)*dx]`` selects the same footprint, and
+    the midpoint is the farthest point from both knife edges. Then assert
+    the realized footprint (count the occupied node planes) against the
+    intended one — see ``run_point`` in
+    ``validation/crossval/18_wr90_iris_modematch.py`` for the pattern.
+
+    A box thinner than one local cell takes a separate **thin-sheet**
+    branch (single nearest-centre node); the notes above apply to the
+    volume branch only.
+    """
 
     corner_lo: tuple[float, float, float]
     corner_hi: tuple[float, float, float]
@@ -74,6 +128,13 @@ class Box:
         return (self.corner_lo, self.corner_hi)
 
     def mask_on_coords(self, x, y, z):
+        """Occupancy on explicit node coordinates.
+
+        Volume branch is half-open ``[lo, hi)`` per axis, so the ``hi`` face
+        contributes no node and a drawn extent realizes as ``extent - dx``
+        between the outermost occupied planes. See the class docstring for
+        the PEC-obstacle consequences and the half-cell-offset recipe.
+        """
         def _axis_mask(coords, lo, hi):
             # Use LOCAL cell size at the geometry's midpoint — critical for
             # thin objects on a non-uniform axis. Using the first-cell dc
@@ -313,6 +374,16 @@ def rasterize(
     background_eps: float = 1.0,
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Rasterize shapes onto grid, producing (eps_r, sigma) arrays.
+
+    Shapes are sampled on **node** coordinates. :class:`Box` uses a
+    half-open ``[lo, hi)`` volume rule, so a box drawn between two node
+    planes realizes one cell short of its drawn extent, asymmetrically at
+    the ``hi`` face. For a PEC obstacle that is an electrical dimension
+    error — a nominal opening ``d`` between two facing boxes rasterizes to
+    ``d + dx``. Read the :class:`Box` docstring before drawing an obstacle
+    to a nominal physical size, and assert the realized footprint (this
+    function's ``sigma`` output is what the raster asserts in
+    ``validation/crossval/18_wr90_iris_modematch.py`` inspect).
 
     Parameters
     ----------

--- a/rfx/geometry/csg.py
+++ b/rfx/geometry/csg.py
@@ -92,17 +92,24 @@ class Box:
        load-bearing one — see the facing-pair discussion below, where it
        cancels in one case and not the other.
 
-    2. **A corner exactly on a node plane is a knife edge.** Masks are
-       evaluated in the default float32 precision, and the node coordinates
-       are themselves double-rounded: :func:`_grid_coords` computes
-       ``f32(f32(i) * f32(dx))`` while a caller's corner is computed in
-       float64 and cast once. Algebraically equal values therefore land on
-       opposite sides of the comparison — on a real WR-90 grid an f64
-       reconstruction of the nodes disagrees with production on 30 of 31
-       nodes by up to 1.1e-9 m (1e-6 of a cell), which is enough to move the
-       occupied-node count by a whole cell. A corner computed as ``a - n*dx``
-       may thus rasterize differently from the algebraically identical
-       ``m*dx``.
+    2. **A corner exactly on a node plane is a knife edge.** What you can
+       observe: *the same drawing recipe, on the same grid, gives a
+       one-cell-too-wide opening at one aperture and a two-cell-too-wide
+       opening at another* — WR-90 fins drawn to the nominal opening give
+       ``d + dx`` at ``d`` = 7.620 and 18.288 mm but ``d + 2*dx`` at
+       12.192 mm, at both a/30 and a/60. Nothing about the nominal
+       dimensions predicts which.
+
+       Why: masks are evaluated in the default float32 precision, and the
+       node coordinates are themselves double-rounded.
+       :func:`_grid_coords` computes ``f32(f32(i) * f32(dx))`` while a
+       caller's corner is computed in float64 and cast once, so
+       **algebraically equal values land on opposite sides of the
+       comparison**. On a real WR-90 grid an f64 reconstruction of the nodes
+       disagrees with production on 30 of 31 nodes by up to 1.1e-9 m (1e-6
+       of a cell), which is enough to move the occupied-node count by a
+       whole cell. A corner computed as ``a - n*dx`` may thus rasterize
+       differently from the algebraically identical ``m*dx``.
 
     For a **PEC obstacle** the occupied nodes are where the tangential ``E``
     is zeroed, so consequence (1) is an *electrical* dimension error, not a

--- a/tests/test_waveguide_geometry_hygiene.py
+++ b/tests/test_waveguide_geometry_hygiene.py
@@ -186,6 +186,45 @@ def test_fins_drawn_to_nominal_aperture_are_one_or_two_cells_too_wide(
 
 
 @pytest.mark.parametrize("cells,d_mm", sorted(_NOMINAL_EXCESS))
+def test_which_interior_face_retreats_decides_the_symmetry(cells, d_mm):
+    """The two interior faces of a facing pair are different corner types.
+
+    The lo fin's interior face is a ``hi`` corner, which half-openness ALWAYS
+    drops — so that fin always retreats one cell. The hi fin's interior face
+    is a ``lo`` corner, which ``coords >= lo`` KEEPS, unless float32 rounding
+    puts the node just below it. Hence excess 1 cell means only the lo fin
+    retreated and the opening is asymmetric (centre ``dx/2`` low), while
+    excess 2 cells means both retreated, the retreats cancel, and the opening
+    is symmetric.
+
+    Pinned because an unconditional "the obstacle is asymmetric" claim would
+    send the next reader hunting a bug that is not there at the apertures
+    where it is centred (PR #495 review, item 2).
+    """
+    d_phys = d_mm * 1e-3
+    y, dx, d_c, fin_c = _iris(cells, d_phys)
+    lo_metal = _occupied(fin_c * dx, y)
+    hi_fin = Box((-1.0, A_WR90 - fin_c * dx, -1.0), (1.0, 1.0, 1.0))
+    hi_metal = np.nonzero(
+        np.asarray(hi_fin.mask_on_coords(_ZERO, y, _ZERO))[0, :, 0])[0]
+    aperture_cells, free = _fin_pair(fin_c * dx, y, dx)
+    excess = aperture_cells - d_c
+
+    # The lo fin's interior face is a hi corner: it always loses exactly one.
+    assert lo_metal[-1] == fin_c - 1
+    # The hi fin's interior face is a lo corner: it loses one only under (2).
+    hi_retreat = int(hi_metal[0] - (cells - fin_c))
+    assert hi_retreat == excess - 1, (hi_retreat, excess)
+
+    centre_offset = 0.5 * (free[0] + free[-1]) - cells / 2
+    if excess == 1:
+        assert centre_offset == pytest.approx(-0.5), "one retreat => asymmetric"
+    else:
+        assert excess == 2
+        assert centre_offset == pytest.approx(0.0), "two retreats => symmetric"
+
+
+@pytest.mark.parametrize("cells,d_mm", sorted(_NOMINAL_EXCESS))
 def test_midpoint_recipe_is_exact_at_even_parity(cells, d_mm):
     """The documented recipe, and the non-firing control for the test above.
 

--- a/tests/test_waveguide_geometry_hygiene.py
+++ b/tests/test_waveguide_geometry_hygiene.py
@@ -1,0 +1,336 @@
+"""Geometry / absorber hygiene for waveguide S-parameter setups.
+
+Two independent hygiene defects found while reviewing PR #480 (WR-90 single
+inductive iris), both filed as general issues because the iris lane only
+exposed them:
+
+* **#493** — ``Box``'s volume branch is half-open ``[lo, hi)`` over NODE
+  coordinates, so a PEC obstacle drawn to its nominal physical dimension
+  rasterizes one cell short at its ``hi`` face. The tests below pin that
+  arithmetic (including the float32 knife edge at a node plane) so the
+  convention is executable documentation rather than folklore. They are
+  CHARACTERIZATION tests: the convention is deliberate and other paths
+  depend on it, so a change here is a deliberate behaviour change and must
+  be reviewed as one, not silenced.
+
+* **#494** — ``compute_waveguide_s_matrix``'s own docstring requires an
+  absorber ``>= ~0.5 * lambda_g`` but nothing checked it on the plain
+  two-port path, so a 0.30-``lambda_g`` stack shipped in a gated revision
+  and the absorber, not discretization, set the accuracy envelope. Each
+  advisory test comes in a firing / non-firing pair.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import jax.numpy as jnp
+import pytest
+
+from rfx.api import Simulation
+from rfx.api._sparams import _warn_thin_absorber_vs_guide_wavelength
+from rfx.boundaries.spec import Boundary, BoundarySpec
+from rfx.geometry.csg import Box
+
+
+ADVISORY_KEY = "far-port discipline"
+
+
+# --------------------------------------------------------------------------- #
+# #493 — half-open node rasterization of PEC obstacles
+# --------------------------------------------------------------------------- #
+A_WR90 = 22.86e-3
+_ZERO = np.array([0.0])
+
+
+def _occupied(hi_face: float, coords: np.ndarray) -> np.ndarray:
+    """Indices of nodes occupied by a box spanning up to ``hi_face`` in y."""
+    m = Box((-1.0, -1.0, -1.0), (1.0, float(hi_face), 1.0)).mask_on_coords(
+        _ZERO, coords, _ZERO)
+    return np.nonzero(np.asarray(m)[0, :, 0])[0]
+
+
+def _fin_pair_aperture(hi_face: float, coords: np.ndarray, dx: float):
+    """Electrical aperture between two facing fins, in metres.
+
+    Returns ``(aperture_m, free_node_indices)``. The aperture is the span
+    between the innermost OCCUPIED (zeroed-tangential-E) node planes.
+    """
+    lo_fin = Box((-1.0, -1.0, -1.0), (1.0, float(hi_face), 1.0))
+    hi_fin = Box((-1.0, A_WR90 - float(hi_face), -1.0), (1.0, 1.0, 1.0))
+    metal = (np.asarray(lo_fin.mask_on_coords(_ZERO, coords, _ZERO))[0, :, 0]
+             | np.asarray(hi_fin.mask_on_coords(_ZERO, coords, _ZERO))[0, :, 0])
+    free = np.nonzero(~metal)[0]
+    return ((free[-1] + 1) - (free[0] - 1)) * dx, free
+
+
+@pytest.mark.parametrize("cells", [30, 60])
+def test_box_volume_branch_is_half_open_and_asymmetric_over_nodes(cells):
+    """A box between two node planes occupies nodes ``i..k-1``, not ``i..k``.
+
+    The drawn extent realizes as ``extent - dx`` between the outermost
+    occupied planes, and the shortfall is entirely at the ``hi`` face — the
+    footprint is asymmetric, which displaces the object by ``dx/2``.
+    """
+    dx = A_WR90 / cells
+    coords = np.arange(cells + 1) * dx
+    occ = _occupied(8 * dx, coords)
+
+    assert occ[0] == 0
+    assert occ[-1] == 7, "hi face at node 8 must contribute no cell"
+    assert len(occ) == 8
+    realized = (occ[-1] - occ[0]) * dx
+    assert realized == pytest.approx(8 * dx - dx, rel=1e-6), (
+        "realized extent must be one cell short of the drawn extent")
+
+
+@pytest.mark.parametrize("cells", [30, 60])
+@pytest.mark.parametrize("d_phys", [7.620e-3, 12.192e-3, 18.288e-3])
+def test_fins_drawn_to_nominal_aperture_open_one_cell_too_wide(cells, d_phys):
+    """Drawing to the nominal opening yields an ELECTRICAL opening d + dx.
+
+    This is the #493 mechanism. It also displaces the aperture by half a
+    cell, because the shortfall sits only at the lo fin's ``hi`` face.
+    """
+    dx = A_WR90 / cells
+    coords = np.arange(cells + 1) * dx
+    d_c = int(round(d_phys / dx))
+    fin_c = (cells - d_c) // 2
+
+    aperture, free = _fin_pair_aperture(fin_c * dx, coords, dx)
+
+    assert aperture == pytest.approx(d_phys + dx, rel=1e-6), (
+        f"expected d + dx, got d + {(aperture - d_phys) / dx:.2f}*dx")
+    # Asymmetry witness: the free span's centre is half a cell below the
+    # guide centre node.
+    assert 0.5 * (free[0] + free[-1]) == pytest.approx(cells / 2 - 0.5)
+
+
+@pytest.mark.parametrize("cells", [30, 60])
+@pytest.mark.parametrize("d_phys", [7.620e-3, 12.192e-3, 18.288e-3])
+def test_half_cell_outward_offset_restores_nominal_electrical_aperture(
+        cells, d_phys):
+    """The documented recipe: interior faces on cell midpoints.
+
+    Non-firing control for the test above — same geometry, corrected
+    corners, aperture exactly nominal and centred.
+    """
+    dx = A_WR90 / cells
+    coords = np.arange(cells + 1) * dx
+    d_c = int(round(d_phys / dx))
+    fin_c = (cells - d_c) // 2
+
+    aperture, free = _fin_pair_aperture((fin_c + 0.5) * dx, coords, dx)
+
+    assert aperture == pytest.approx(d_phys, rel=1e-6)
+    assert 0.5 * (free[0] + free[-1]) == pytest.approx(cells / 2)
+
+
+def test_half_cell_inward_offset_opens_two_cells_too_wide():
+    """Offsetting interior faces the WRONG way gives d + 2*dx.
+
+    This is the variant that produced #493's headline 4-6x |S11| envelope
+    inflation: a half-cell offset applied to make footprints deterministic,
+    but toward the metal instead of into the opening.
+    """
+    cells, d_phys = 30, 12.192e-3
+    dx = A_WR90 / cells
+    coords = np.arange(cells + 1) * dx
+    fin_c = (cells - int(round(d_phys / dx))) // 2
+
+    aperture, _ = _fin_pair_aperture((fin_c - 0.5) * dx, coords, dx)
+
+    assert aperture == pytest.approx(d_phys + 2 * dx, rel=1e-6)
+
+
+def test_node_plane_corner_is_a_single_float32_ulp_knife_edge():
+    """Why the recipe says "cell midpoint" and not "on the node plane".
+
+    Masks are evaluated at float32 precision (x64 is off by design), so one
+    ULP of the corner value — ~5e-10 m at dx = 0.762 mm, 6e-7 of a cell —
+    moves the footprint by a whole cell. A corner computed as ``a - n*dx``
+    can therefore rasterize differently from an algebraically identical
+    ``m*dx``. Midpoint corners sit half a cell from either edge.
+    """
+    dx = 0.762e-3
+    coords = np.arange(31) * dx
+    node8 = np.float32(8 * dx)
+    ulp = float(np.nextafter(node8, np.float32(1)) - node8)
+    assert ulp < 1e-9 * 1.0, ulp  # sanity: sub-nanometre
+
+    below = _occupied(float(np.nextafter(node8, np.float32(0))), coords)
+    above = _occupied(float(np.nextafter(node8, np.float32(1))), coords)
+
+    assert below[-1] == 7
+    assert above[-1] == 8, "one float32 ULP must flip the footprint by a cell"
+    # And the midpoint recipe is insensitive to that perturbation.
+    mid = 8 * dx + 0.5 * dx
+    assert _occupied(mid, coords)[-1] == _occupied(mid + 8 * ulp, coords)[-1]
+
+
+def test_drawn_vs_realized_gap_cannot_discriminate_a_correct_drawing():
+    """Why #493 ships as documentation and not as a rasterized-vs-drawn check.
+
+    Issue #493 floated an advisory that fires when a PEC volume's rasterized
+    opening differs from its drawn opening by >= 1 cell. That predicate has
+    no discriminating power: the half-open rule shifts the realized aperture
+    up by exactly one cell relative to the gap between the drawn faces
+    REGARDLESS of where those faces sit, so it reads +1 cell for the correct
+    midpoint recipe and for both defective drawings alike. The defect is
+    ``realized != INTENDED``, and the intended dimension is never
+    communicated to the simulator, so it cannot be recovered from geometry.
+    """
+    cells, d_phys = 30, 12.192e-3
+    dx = A_WR90 / cells
+    coords = np.arange(cells + 1) * dx
+    fin_c = (cells - int(round(d_phys / dx))) // 2
+
+    diffs = {}
+    for label, hi_face in (("nominal", fin_c * dx),
+                           ("inward", (fin_c - 0.5) * dx),
+                           ("outward", (fin_c + 0.5) * dx)):
+        realized, _ = _fin_pair_aperture(hi_face, coords, dx)
+        drawn = (A_WR90 - hi_face) - hi_face
+        diffs[label] = (realized - drawn) / dx
+
+    assert diffs["outward"] == pytest.approx(1.0, abs=1e-6)
+    assert diffs["nominal"] == pytest.approx(1.0, abs=1e-6)
+    assert diffs["inward"] == pytest.approx(1.0, abs=1e-6)
+
+
+# --------------------------------------------------------------------------- #
+# #494 — thin-absorber advisory on the plain two-port path
+# --------------------------------------------------------------------------- #
+_FREQS = np.linspace(4.5e9, 8.0e9, 4)
+_F0 = float(_FREQS.mean())
+
+
+def _two_port(cpml_layers, *, boundary="cpml", freqs=_FREQS, dx=0.004):
+    sim = Simulation(
+        freq_max=float(freqs[-1]),
+        domain=(0.12, 0.04, 0.02),
+        dx=dx,
+        boundary=boundary,
+        cpml_layers=cpml_layers,
+    )
+    for x, direction in ((0.02, "+x"), (0.10, "-x")):
+        sim.add_waveguide_port(
+            x, direction=direction, mode=(1, 0), mode_type="TE",
+            freqs=jnp.asarray(freqs), f0=float(np.mean(freqs)), bandwidth=0.6,
+        )
+    return sim
+
+
+def _advisories(sim, freqs=_FREQS):
+    """Run the predicate on real port configs without paying for FDTD."""
+    grid = sim._build_grid()
+    cfgs = [sim._build_waveguide_port_config(e, grid, jnp.asarray(freqs), 2000)
+            for e in sim._waveguide_ports]
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _warn_thin_absorber_vs_guide_wavelength(
+            grid, cfgs, freqs, sim._cpml_layers, sim._boundary_spec)
+    return [str(w.message) for w in caught if ADVISORY_KEY in str(w.message)]
+
+
+def test_thin_absorber_advisory_fires_end_to_end_on_the_two_port_path():
+    """FIRING, end-to-end: the advisory must reach the functional path.
+
+    The functional entry points run no ``sim.preflight()``, which is why the
+    check lives in the method. A predicate unit test alone would not prove
+    it is wired, so this drives the real extraction.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _two_port(10).compute_waveguide_s_matrix(num_periods=6.0)
+    hits = [str(w.message) for w in caught if ADVISORY_KEY in str(w.message)]
+
+    assert len(hits) == 1, [str(w.message) for w in caught]
+    msg = hits[0]
+    # Both numbers must be quoted: what you have and what is required.
+    assert "40.0 mm" in msg, msg          # 10 cells * 4 mm
+    assert "against a required" in msg
+    assert "lowest measured frequency 4.500 GHz" in msg
+    assert "cpml_layers" in msg           # actionable remedy
+
+
+def test_thin_absorber_advisory_silent_end_to_end_when_absorber_is_thick():
+    """NON-FIRING control: same band and geometry, adequate absorber.
+
+    16 cells * 4 mm = 64 mm against a 50.8 mm requirement at 4.5 GHz.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _two_port(16).compute_waveguide_s_matrix(num_periods=6.0)
+
+    assert [str(w.message) for w in caught if ADVISORY_KEY in str(w.message)] == []
+
+
+def test_thin_absorber_advisory_quotes_the_lowest_frequency_not_band_centre():
+    """The requirement is evaluated where lambda_g is longest.
+
+    Band centre would understate it — that is what the sibling junction
+    advisory does, and it is why a 0.30-lambda_g stack passed unnoticed.
+    """
+    hits = _advisories(_two_port(10))
+    assert len(hits) == 1
+    assert "4.500 GHz" in hits[0]
+    assert "6.250 GHz" not in hits[0]     # band centre
+
+
+def test_thin_absorber_advisory_fires_once_per_axis_not_once_per_port():
+    """Both ports share one propagation axis and one absorber."""
+    sim = _two_port(10)
+    assert len(sim._waveguide_ports) == 2
+    assert len(_advisories(sim)) == 1
+
+
+def test_thin_absorber_advisory_silent_on_pec_closed_propagation_axis():
+    """NON-FIRING control: no absorber on the propagation axis to under-drain.
+
+    The absorber must be somewhere (``add_waveguide_port`` requires an
+    absorbing boundary), so this closes the x propagation axis with PEC and
+    leaves the transverse faces absorbing. The advisory is scoped to the
+    propagation axis, so it must stay silent even though the scalar
+    ``cpml_layers`` is far below 0.5 lambda_g.
+    """
+    sim = _two_port(
+        10,
+        boundary=BoundarySpec(x=Boundary(lo="pec", hi="pec"),
+                              y="cpml", z="cpml"),
+    )
+    assert _advisories(sim) == []
+
+
+def test_thin_absorber_advisory_silent_when_band_starts_below_cutoff():
+    """NON-FIRING control: lambda_g is undefined below cutoff.
+
+    A band that starts at or below cutoff has a more fundamental problem,
+    already named by the ``port_freqs_below_cutoff`` preflight check;
+    piling an absorber advisory on top would be noise. Documented
+    consequence: such a band gets no absorber advisory at all.
+    """
+    # TE10 cutoff of the 40 mm guide is ~3.4-3.75 GHz; start well below it.
+    freqs = np.linspace(1.0e9, 8.0e9, 4)
+    assert _advisories(_two_port(10, freqs=freqs), freqs=freqs) == []
+
+
+def test_thin_absorber_advisory_honours_per_face_thickness_overrides():
+    """A per-face override, not the scalar, sets the reported thickness.
+
+    Firing/non-firing in one setup: the thin face is reported and the thick
+    face is not. Note the scalar is the allocation BUDGET — a per-face
+    override may only reduce thickness below it (``rfx/grid.py`` rejects
+    ``face_layers > cpml_layers``), so the budget here is the thick value.
+    """
+    sim = _two_port(
+        40,
+        boundary=BoundarySpec(
+            x=Boundary(lo="cpml", hi="cpml", lo_thickness=4, hi_thickness=40),
+            y="cpml", z="cpml"),
+    )
+    hits = _advisories(sim)
+    assert len(hits) == 1
+    assert "x-lo 4 cells" in hits[0], hits[0]
+    assert "x-hi" not in hits[0], hits[0]

--- a/tests/test_waveguide_geometry_hygiene.py
+++ b/tests/test_waveguide_geometry_hygiene.py
@@ -6,9 +6,12 @@ exposed them:
 
 * **#493** — ``Box``'s volume branch is half-open ``[lo, hi)`` over NODE
   coordinates, so a PEC obstacle drawn to its nominal physical dimension
-  rasterizes one cell short at its ``hi`` face. The tests below pin that
-  arithmetic (including the float32 knife edge at a node plane) so the
-  convention is executable documentation rather than folklore. They are
+  rasterizes short at its ``hi`` face. The tests below pin that arithmetic
+  (including the float32 rounding that decides whether the cost is one cell
+  or two) so the convention is executable documentation rather than
+  folklore. They derive node coordinates from a real ``Grid``, never from an
+  f64 ``arange``, because the two disagree by enough to change the answer.
+  They are
   CHARACTERIZATION tests: the convention is deliberate and other paths
   depend on it, so a change here is a deliberate behaviour change and must
   be reviewed as one, not silenced.
@@ -31,7 +34,7 @@ import pytest
 from rfx.api import Simulation
 from rfx.api._sparams import _warn_thin_absorber_vs_guide_wavelength
 from rfx.boundaries.spec import Boundary, BoundarySpec
-from rfx.geometry.csg import Box
+from rfx.geometry.csg import Box, _grid_coords
 
 
 ADVISORY_KEY = "far-port discipline"
@@ -41,7 +44,36 @@ ADVISORY_KEY = "far-port discipline"
 # #493 — half-open node rasterization of PEC obstacles
 # --------------------------------------------------------------------------- #
 A_WR90 = 22.86e-3
+B_WR90 = 10.16e-3
 _ZERO = np.array([0.0])
+_COORD_CACHE: dict = {}
+
+
+def _real_node_coords(cells: int):
+    """y-node coordinates from a REAL ``Grid`` — the production f32 path.
+
+    Deliberately NOT ``np.arange(ny) * dx``. ``_grid_coords`` computes
+    ``(jnp.arange(ny) - pad) * dx`` in float32, so every node is
+    ``f32(f32(i) * f32(dx))`` — double-rounded — whereas a ``Box`` corner is
+    computed by the caller in float64 and cast once. An f64 construction
+    differs from production on 30 of 31 nodes by up to 1.12e-9 m, which is
+    enough to flip a whole cell of metal: an earlier revision of these tests
+    built coordinates in f64 and consequently pinned ``d + dx`` at every
+    aperture, while production gives ``d + 2*dx`` at ``d`` = 12.192 mm.
+    Deriving coordinates from a real grid is what keeps these tests from
+    drifting away from the code they document.
+    """
+    if cells not in _COORD_CACHE:
+        dx = A_WR90 / cells
+        sim = Simulation(
+            freq_max=14e9, domain=(0.05, A_WR90, B_WR90), dx=dx,
+            boundary=BoundarySpec(x=Boundary(lo="cpml", hi="cpml"),
+                                  y=Boundary(lo="pec", hi="pec"),
+                                  z=Boundary(lo="pec", hi="pec")),
+            cpml_layers=10)
+        y = np.asarray(_grid_coords(sim._build_grid())[1])
+        _COORD_CACHE[cells] = (y, dx)
+    return _COORD_CACHE[cells]
 
 
 def _occupied(hi_face: float, coords: np.ndarray) -> np.ndarray:
@@ -51,152 +83,213 @@ def _occupied(hi_face: float, coords: np.ndarray) -> np.ndarray:
     return np.nonzero(np.asarray(m)[0, :, 0])[0]
 
 
-def _fin_pair_aperture(hi_face: float, coords: np.ndarray, dx: float):
-    """Electrical aperture between two facing fins, in metres.
+def _fin_pair(hi_face: float, coords: np.ndarray, dx: float):
+    """Electrical aperture between two facing fins.
 
-    Returns ``(aperture_m, free_node_indices)``. The aperture is the span
-    between the innermost OCCUPIED (zeroed-tangential-E) node planes.
+    Returns ``(aperture_cells, free_node_indices)``. The aperture is the span
+    between the innermost OCCUPIED node planes, i.e. between the innermost
+    planes where tangential E is zeroed. That is the same convention under
+    which the guide itself measures ``a``: with PEC on the outermost node
+    planes 0 and ``cells``, the width is ``cells * dx`` = 22.86 mm exactly,
+    and the free-node count is ``width/dx - 1``.
     """
     lo_fin = Box((-1.0, -1.0, -1.0), (1.0, float(hi_face), 1.0))
     hi_fin = Box((-1.0, A_WR90 - float(hi_face), -1.0), (1.0, 1.0, 1.0))
     metal = (np.asarray(lo_fin.mask_on_coords(_ZERO, coords, _ZERO))[0, :, 0]
              | np.asarray(hi_fin.mask_on_coords(_ZERO, coords, _ZERO))[0, :, 0])
     free = np.nonzero(~metal)[0]
-    return ((free[-1] + 1) - (free[0] - 1)) * dx, free
+    return int((free[-1] + 1) - (free[0] - 1)), free
 
 
-@pytest.mark.parametrize("cells", [30, 60])
-def test_box_volume_branch_is_half_open_and_asymmetric_over_nodes(cells):
-    """A box between two node planes occupies nodes ``i..k-1``, not ``i..k``.
-
-    The drawn extent realizes as ``extent - dx`` between the outermost
-    occupied planes, and the shortfall is entirely at the ``hi`` face — the
-    footprint is asymmetric, which displaces the object by ``dx/2``.
-    """
-    dx = A_WR90 / cells
-    coords = np.arange(cells + 1) * dx
-    occ = _occupied(8 * dx, coords)
-
-    assert occ[0] == 0
-    assert occ[-1] == 7, "hi face at node 8 must contribute no cell"
-    assert len(occ) == 8
-    realized = (occ[-1] - occ[0]) * dx
-    assert realized == pytest.approx(8 * dx - dx, rel=1e-6), (
-        "realized extent must be one cell short of the drawn extent")
-
-
-@pytest.mark.parametrize("cells", [30, 60])
-@pytest.mark.parametrize("d_phys", [7.620e-3, 12.192e-3, 18.288e-3])
-def test_fins_drawn_to_nominal_aperture_open_one_cell_too_wide(cells, d_phys):
-    """Drawing to the nominal opening yields an ELECTRICAL opening d + dx.
-
-    This is the #493 mechanism. It also displaces the aperture by half a
-    cell, because the shortfall sits only at the lo fin's ``hi`` face.
-    """
-    dx = A_WR90 / cells
-    coords = np.arange(cells + 1) * dx
+def _iris(cells: int, d_phys: float):
+    y, dx = _real_node_coords(cells)
     d_c = int(round(d_phys / dx))
+    return y, dx, d_c, (cells - d_c) // 2
+
+
+@pytest.mark.parametrize("cells", [30, 60])
+def test_guide_width_fixes_the_zeroed_plane_convention(cells):
+    """The convention under which the guide itself measures ``a`` exactly.
+
+    Anchors every aperture number below: distance between the bounding
+    zeroed node planes, NOT the span of open nodes (which would call WR-90
+    22.098 mm at a/30).
+    """
+    y, dx = _real_node_coords(cells)
+    assert len(y) == cells + 1
+    assert cells * dx == pytest.approx(A_WR90, rel=1e-9)
+    assert (cells - 1) == (cells * dx) / dx - 1
+
+
+@pytest.mark.parametrize("cells", [30, 60])
+def test_box_volume_branch_excludes_the_hi_node_plane(cells):
+    """Half-open ``[lo, hi)``: the ``hi`` face contributes no cell.
+
+    ``hi`` is taken from the realized node value so the comparison is an
+    exact equality and the result cannot depend on rounding — the rule
+    itself, isolated from the float32 effects tested separately below.
+    """
+    y, _ = _real_node_coords(cells)
+    for k in (8, 12):
+        occ = _occupied(float(y[k]), y)
+        assert occ[-1] == k - 1, f"node {k} must be excluded"
+        assert len(occ) == k
+
+
+def test_production_node_coords_differ_from_an_f64_construction():
+    """Why these tests must derive coordinates from a real grid.
+
+    Pins the float32 double-rounding finding: production nodes are
+    ``f32(f32(i) * f32(dx))``, an f64 construction is ``f32(i * dx)``, and
+    they disagree on almost every node. The magnitude is ~1e-9 m — 1e-6 of a
+    cell — yet it changes the rasterized footprint (see the nominal-drawing
+    table below, where 12.192 mm lands on a different cell count than the
+    other two apertures).
+    """
+    for cells in (30, 60):
+        y, dx = _real_node_coords(cells)
+        y_f64 = np.arange(len(y)) * dx
+        delta = np.abs(y - y_f64)
+        assert (delta > 0).sum() >= cells, "expected almost every node to differ"
+        assert 0 < delta.max() < 1e-8
+        assert delta.max() / dx < 1e-5
+
+
+# Measured on the production f32 coordinate path. The nominal drawing is NOT
+# predictable from the nominal dimensions: 12.192 mm lands on d + 2*dx while
+# the other two apertures land on d + 1*dx, at BOTH mesh rungs. Pinned as a
+# characterization table so a change in the rounding behaviour is visible.
+_NOMINAL_EXCESS = {
+    (30, 7.620): 1, (30, 12.192): 2, (30, 18.288): 1,
+    (60, 7.620): 1, (60, 12.192): 2, (60, 18.288): 1,
+}
+
+
+@pytest.mark.parametrize("cells,d_mm", sorted(_NOMINAL_EXCESS))
+def test_fins_drawn_to_nominal_aperture_are_one_or_two_cells_too_wide(
+        cells, d_mm):
+    """#493's mechanism, with the measured per-config value.
+
+    Drawing to the nominal opening never yields the nominal ELECTRICAL
+    opening, and how much it overshoots is config-dependent: one cell from
+    the convention itself, plus a second whenever the hi fin's lo corner
+    fails to capture its node under float32 rounding.
+    """
+    d_phys = d_mm * 1e-3
+    y, dx, d_c, fin_c = _iris(cells, d_phys)
+    aperture_cells, _ = _fin_pair(fin_c * dx, y, dx)
+
+    excess = aperture_cells - d_c
+    assert excess == _NOMINAL_EXCESS[(cells, d_mm)]
+    assert excess in (1, 2), "the drawn-to-nominal defect is 1 or 2 cells"
+    assert aperture_cells * dx > d_phys, "must never be the nominal opening"
+
+
+@pytest.mark.parametrize("cells,d_mm", sorted(_NOMINAL_EXCESS))
+def test_midpoint_recipe_is_exact_at_even_parity(cells, d_mm):
+    """The documented recipe, and the non-firing control for the test above.
+
+    Interior faces on cell midpoints sit half a cell from either edge, so the
+    footprint is rounding-independent. Every case-18 configuration has
+    ``(cells - d_c)`` even and lands on the nominal aperture exactly.
+    """
+    d_phys = d_mm * 1e-3
+    y, dx, d_c, fin_c = _iris(cells, d_phys)
+    assert (cells - d_c) % 2 == 0, "case-18 configs are even-parity by design"
+
+    aperture_cells, free = _fin_pair((fin_c + 0.5) * dx, y, dx)
+
+    assert aperture_cells == d_c
+    assert aperture_cells * dx == pytest.approx(d_phys, rel=1e-6)
+    assert len(free) == d_c - 1, "free-node count == aperture/dx - 1"
+    assert 0.5 * (free[0] + free[-1]) == pytest.approx(cells / 2), "centred"
+
+
+@pytest.mark.parametrize("cells", [30, 60])
+def test_midpoint_recipe_costs_a_cell_at_odd_parity(cells):
+    """A representability limit, not a rasterization defect.
+
+    ``fin_c = (cells - d_c)//2`` truncates, so when ``(cells - d_c)`` is odd
+    a SYMMETRIC iris of that aperture cannot be placed on the node grid at
+    all and the opening is one cell wide regardless of how it is drawn. Keep
+    ``(cells - d_c)`` even, i.e. the fin depth an exact number of cells.
+    """
+    y, dx = _real_node_coords(cells)
+    d_c = 3
+    assert (cells - d_c) % 2 == 1
     fin_c = (cells - d_c) // 2
 
-    aperture, free = _fin_pair_aperture(fin_c * dx, coords, dx)
+    aperture_cells, _ = _fin_pair((fin_c + 0.5) * dx, y, dx)
 
-    assert aperture == pytest.approx(d_phys + dx, rel=1e-6), (
-        f"expected d + dx, got d + {(aperture - d_phys) / dx:.2f}*dx")
-    # Asymmetry witness: the free span's centre is half a cell below the
-    # guide centre node.
-    assert 0.5 * (free[0] + free[-1]) == pytest.approx(cells / 2 - 0.5)
+    assert aperture_cells == d_c + 1
 
 
-@pytest.mark.parametrize("cells", [30, 60])
-@pytest.mark.parametrize("d_phys", [7.620e-3, 12.192e-3, 18.288e-3])
-def test_half_cell_outward_offset_restores_nominal_electrical_aperture(
-        cells, d_phys):
-    """The documented recipe: interior faces on cell midpoints.
+@pytest.mark.parametrize("cells,d_mm", sorted(_NOMINAL_EXCESS))
+def test_half_cell_inward_offset_opens_two_cells_too_wide(cells, d_mm):
+    """Offsetting interior faces the WRONG way gives d + 2*dx everywhere.
 
-    Non-firing control for the test above — same geometry, corrected
-    corners, aperture exactly nominal and centred.
+    Unlike the nominal drawing this one is uniform across the table: the
+    corner sits half a cell from either edge, so it is rounding-independent
+    and the two cells are structural.
     """
-    dx = A_WR90 / cells
-    coords = np.arange(cells + 1) * dx
-    d_c = int(round(d_phys / dx))
-    fin_c = (cells - d_c) // 2
+    d_phys = d_mm * 1e-3
+    y, dx, d_c, fin_c = _iris(cells, d_phys)
 
-    aperture, free = _fin_pair_aperture((fin_c + 0.5) * dx, coords, dx)
+    aperture_cells, _ = _fin_pair((fin_c - 0.5) * dx, y, dx)
 
-    assert aperture == pytest.approx(d_phys, rel=1e-6)
-    assert 0.5 * (free[0] + free[-1]) == pytest.approx(cells / 2)
-
-
-def test_half_cell_inward_offset_opens_two_cells_too_wide():
-    """Offsetting interior faces the WRONG way gives d + 2*dx.
-
-    This is the variant that produced #493's headline 4-6x |S11| envelope
-    inflation: a half-cell offset applied to make footprints deterministic,
-    but toward the metal instead of into the opening.
-    """
-    cells, d_phys = 30, 12.192e-3
-    dx = A_WR90 / cells
-    coords = np.arange(cells + 1) * dx
-    fin_c = (cells - int(round(d_phys / dx))) // 2
-
-    aperture, _ = _fin_pair_aperture((fin_c - 0.5) * dx, coords, dx)
-
-    assert aperture == pytest.approx(d_phys + 2 * dx, rel=1e-6)
+    assert aperture_cells == d_c + 2
 
 
 def test_node_plane_corner_is_a_single_float32_ulp_knife_edge():
     """Why the recipe says "cell midpoint" and not "on the node plane".
 
-    Masks are evaluated at float32 precision (x64 is off by design), so one
-    ULP of the corner value — ~5e-10 m at dx = 0.762 mm, 6e-7 of a cell —
-    moves the footprint by a whole cell. A corner computed as ``a - n*dx``
-    can therefore rasterize differently from an algebraically identical
-    ``m*dx``. Midpoint corners sit half a cell from either edge.
+    Masks are evaluated at float32 (x64 is off by design), so one ULP of the
+    corner — ~5e-10 m at dx = 0.762 mm, 6e-7 of a cell — moves the footprint
+    by a whole cell. Combined with the double-rounded node coordinates, this
+    is why a corner computed as ``a - n*dx`` can rasterize differently from
+    an algebraically identical ``m*dx``. Midpoint corners sit half a cell
+    from either edge and are immune.
     """
-    dx = 0.762e-3
-    coords = np.arange(31) * dx
-    node8 = np.float32(8 * dx)
-    ulp = float(np.nextafter(node8, np.float32(1)) - node8)
-    assert ulp < 1e-9 * 1.0, ulp  # sanity: sub-nanometre
+    y, dx = _real_node_coords(30)
+    node = np.float32(y[8])
+    ulp = float(np.nextafter(node, np.float32(1)) - node)
+    assert 0 < ulp < 1e-9
 
-    below = _occupied(float(np.nextafter(node8, np.float32(0))), coords)
-    above = _occupied(float(np.nextafter(node8, np.float32(1))), coords)
+    below = _occupied(float(np.nextafter(node, np.float32(0))), y)
+    above = _occupied(float(np.nextafter(node, np.float32(1))), y)
 
     assert below[-1] == 7
     assert above[-1] == 8, "one float32 ULP must flip the footprint by a cell"
-    # And the midpoint recipe is insensitive to that perturbation.
-    mid = 8 * dx + 0.5 * dx
-    assert _occupied(mid, coords)[-1] == _occupied(mid + 8 * ulp, coords)[-1]
+    mid = float(y[8]) + 0.5 * dx
+    assert _occupied(mid, y)[-1] == _occupied(mid + 8 * ulp, y)[-1]
 
 
-def test_drawn_vs_realized_gap_cannot_discriminate_a_correct_drawing():
+def test_drawn_vs_realized_gap_is_ambiguous_between_correct_and_defective():
     """Why #493 ships as documentation and not as a rasterized-vs-drawn check.
 
     Issue #493 floated an advisory that fires when a PEC volume's rasterized
-    opening differs from its drawn opening by >= 1 cell. That predicate has
-    no discriminating power: the half-open rule shifts the realized aperture
-    up by exactly one cell relative to the gap between the drawn faces
-    REGARDLESS of where those faces sit, so it reads +1 cell for the correct
-    midpoint recipe and for both defective drawings alike. The defect is
+    opening differs from its drawn opening by >= 1 cell. The reading is
+    AMBIGUOUS: at d = 7.620 mm the defective nominal drawing and the correct
+    midpoint recipe both read +1 cell, so +1 cell cannot support a defect
+    conclusion — and +1 cell is the common case. The defect is
     ``realized != INTENDED``, and the intended dimension is never
-    communicated to the simulator, so it cannot be recovered from geometry.
+    communicated to the simulator, so it is not recoverable from geometry.
     """
-    cells, d_phys = 30, 12.192e-3
-    dx = A_WR90 / cells
-    coords = np.arange(cells + 1) * dx
-    fin_c = (cells - int(round(d_phys / dx))) // 2
-
-    diffs = {}
-    for label, hi_face in (("nominal", fin_c * dx),
-                           ("inward", (fin_c - 0.5) * dx),
-                           ("outward", (fin_c + 0.5) * dx)):
-        realized, _ = _fin_pair_aperture(hi_face, coords, dx)
+    def drawn_vs_realized(cells, d_mm, offset):
+        d_phys = d_mm * 1e-3
+        y, dx, d_c, fin_c = _iris(cells, d_phys)
+        hi_face = (fin_c + offset) * dx
+        aperture_cells, _ = _fin_pair(hi_face, y, dx)
         drawn = (A_WR90 - hi_face) - hi_face
-        diffs[label] = (realized - drawn) / dx
+        return (aperture_cells * dx - drawn) / dx
 
-    assert diffs["outward"] == pytest.approx(1.0, abs=1e-6)
-    assert diffs["nominal"] == pytest.approx(1.0, abs=1e-6)
-    assert diffs["inward"] == pytest.approx(1.0, abs=1e-6)
+    # The collision that kills the predicate: same reading, opposite verdicts.
+    assert drawn_vs_realized(30, 7.620, 0.0) == pytest.approx(1.0, abs=1e-6)
+    assert drawn_vs_realized(30, 7.620, 0.5) == pytest.approx(1.0, abs=1e-6)
+    # Elsewhere the readings do differ, so the predicate is not merely
+    # constant — it is unreliable, which is worse for a guard.
+    assert drawn_vs_realized(30, 12.192, 0.0) == pytest.approx(2.0, abs=1e-6)
+    assert drawn_vs_realized(30, 12.192, 0.5) == pytest.approx(1.0, abs=1e-6)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #493. Closes #494.

Both came out of the PR #480 review. Neither changes physics. **No committed gate, tolerance or fixture was touched.** The only behaviour change is one new advisory warning.

## #494 — thin-absorber advisory on the plain two-port path

`compute_waveguide_s_matrix`'s own docstring requires an absorber `>= ~0.5 * lambda_g`, but nothing checked it there: the sibling `_warn_junction_cpml_thickness` runs only on the `port_reference_sims` junction path, and the functional entry points run no `sim.preflight()`. New in-method advisory (`warnings.warn`, never raises) quoting **both** numbers, next to the passivity self-check whose warnings already form part of a result record.

Evaluated at the **lowest** measured frequency, where `lambda_g` is longest and the `cpml_layers=16` default weakest. The junction sibling uses band centre — that is precisely what let a 0.30-`lambda_g` stack pass unnoticed.

Measured, WR-90 two-port (a = 22.86 mm, 8.2-12.4 GHz, dx = 0.762 mm, numerical TE10 cutoff 6.343 GHz, `lambda_g`(8.2 GHz) = 57.7 mm, requirement 28.8 mm):

| `cpml_layers` | thickness | fraction of `lambda_g` | advisory |
|---|---|---|---|
| 16 (default) | 12.2 mm | 0.21 | fires |
| 24 | 18.3 mm | 0.32 | fires |
| 40 | 30.5 mm | 0.53 | silent |

The message reports the measured ripple ladder from the issue (0.0706 at 0.30 `lambda_g`, 0.0366 at 0.50, 0.0093 at 0.75) so `0.5 * lambda_g` reads as a floor rather than a target, and names the `cpml_layers` value for both 0.5 and 0.75.

Deliberately a **lower** bound, with three fences that each make it under-ask rather than over-ask:

- silent when the lowest measured frequency is at or below cutoff — `lambda_g` is undefined there and the band itself is invalid, which the existing `port_freqs_below_cutoff` preflight already names. Consequence to be aware of: a band starting below cutoff gets **no** absorber advisory. This fence is what keeps the default `linspace(freq_max/10, freq_max)` frequency grid from firing spuriously.
- silent when the port's propagation axis carries no absorbing face.
- evaluated on the port's lowest-cutoff mode (shortest `lambda_g`, least demanding).

Silent on a non-uniform mesh, where `cpml_layers * dx` is ambiguous under a graded profile. Honours per-face `Boundary.lo_thickness` / `.hi_thickness`.

## #493 — node-rasterization convention: DOCUMENTATION ONLY

**The rasterization rule is unchanged** — it is deliberate and other paths depend on it.

`Box`'s volume branch is half-open `[lo, hi)` over NODE coordinates, so a box with both corners on node planes occupies nodes `i..k-1`: the realized extent is one cell short of the drawn extent, entirely at the `hi` face, which also displaces the object by `dx/2`. For a PEC obstacle those are the nodes where tangential `E` is zeroed, so it is an *electrical* dimension error.

Measured on a REAL grid (`Simulation._build_grid()` + `_grid_coords`, i.e. the production float32 coordinate path), WR-90 at both case-18 rungs:

| interior faces drawn at | electrical aperture | rounding-dependent? |
|---|---|---|
| the nominal opening (on a node plane) | **`d + dx` or `d + 2*dx`** | yes |
| half a cell toward the metal | `d + 2*dx` uniformly | no |
| half a cell into the opening (cell midpoint) | `d` exactly, at even parity | no |

The nominal drawing is **not predictable from the nominal dimensions**, and the reason is structural: a facing pair's two interior faces are **different corner types**.

- The lo fin's interior face is a `hi` corner, which half-openness **always** drops — that fin always retreats one cell.
- The hi fin's interior face is a `lo` corner, which `coords >= lo` **keeps** — it retreats only when float32 rounding puts the node just below it.

So the excess and the symmetry are one fact seen twice. Measured per aperture, both rungs (lo-fin retreat / hi-fin retreat / aperture-centre offset in cells):

| `d` (mm) | `d_c` | retreats | centre offset | realized |
|---|---|---|---|---|
| 7.620 | 10 / 20 | 1 / 0 | −0.5 cell | `d + dx`, **asymmetric** |
| 12.192 | 16 / 32 | 1 / 1 | 0.0 | **`d + 2*dx`, centred** |
| 18.288 | 24 / 48 | 1 / 0 | −0.5 cell | `d + dx`, **asymmetric** |

At 12.192 mm the open nodes are 7..23, symmetric about node 15 — matching the reviewer's independent measurement exactly. The half-cell-**inward** drawing retreats both faces by construction rather than by luck, hence `d + 2*dx` deterministically at every aperture; that is the drawing case 18's blocked revision used, which is why re-comparing it against `oracle(d + 2*dx)` collapsed *every* row. The fixture's `d + 2*dx` is therefore correct as a statement about **that drawing**, and the docstrings now name the drawing rather than leaving it to read as a general law.

### Two independent methods agree, aperture for aperture

The rasterization arithmetic above (what the rasterizer produces) and an oracle best-fit run by the reviewer (which candidate aperture the mode-matching oracle needs to match rfx's measured `|S11|` over 8.2-12.4 GHz, a/30, cpml=60, flux) agree with no exceptions:

| aperture | nominal drawing (faces on node) | inward drawing (blocked revision) |
|---|---|---|
| 7.620 mm | open 10 (10..19) → `d + dx` (fit 0.025) | open 11 (10..20) → `d + 2*dx` (fit 0.032) |
| 12.192 mm | open 17 (7..23) → `d + 2*dx` (fit 0.041) | open 17 (7..23) → `d + 2*dx` (fit 0.041) |
| 18.288 mm | open 24 (3..26) → `d + dx` (fit 0.012) | open 25 (3..27) → `d + 2*dx` (fit 0.010) |

So the config-dependence of the nominal drawing is confirmed by physics, not only by arithmetic, and the inward drawing is deterministically `d + 2*dx` at every aperture — the drawing case 18's blocked revision used, which is why the PR #480 reviewer's re-comparison against `oracle(d + 2*dx)` collapsed every row. **No fixture correction is needed.**

The 12.192 mm row is also a direct physical observation of the float32 effect: the nominal and inward drawings produce the *identical* footprint there (both 17 open nodes, 7..23), which is only possible if the corner at exactly `7*dx` fell on the metal side of the comparison, while at the other two apertures it fell the other way.

Over ~99k (guide, mesh, aperture) combinations across 8 guide widths and 10-160 cells: at even `(cells - d_c)` the nominal drawing splits 82.4% / 9.5% / 8.1% over `d + dx` / `d + 2*dx` / `d`, shifting one cell up at odd parity. A second, independent effect sets that parity: `fin_depth = (cells - d_c)//2` truncates, so at odd `(cells - d_c)` a symmetric opening of that width is *not representable* on the grid and costs a cell however it is drawn — a representability limit, not a rasterization defect.

The electrical opening throughout is measured between the innermost **zeroed** planes, `(n_open + 1) * dx` — the measure that reproduces the guide's own width `a = cells * dx` exactly (counting open nodes alone would call WR-90 22.098 mm instead of 22.86 at a/30).

The **midpoint recipe is deterministic**: `d` exactly in 100% of ~50k even-parity combinations, `d + dx` in 100% of odd-parity ones. So the guidance is **three requirements**, not one recipe:

1. interior corners on cell midpoints — every corner value in a one-cell-wide interval selects the same footprint (`(j*dx, (j+1)*dx]` for a `hi` corner, `[j*dx, (j+1)*dx)` for a `lo` corner), and the midpoint is that interval's **centre**, not merely a safe nudge, which is why it is immune to float32 perturbations that only move a corner by a fraction of a cell;
2. keep `(cells - d_c)` **even**, the part case 18 gets for free at a/30 and not automatically at a/60;
3. assert the realized footprint.

### The knife edge is float32, and sharper than one ULP of the corner

Node coordinates are themselves **double-rounded**: `_grid_coords` computes `f32(f32(i) * f32(dx))`, while a caller's `Box` corner is computed in float64 and cast once. Algebraically equal values therefore land on opposite sides of the `coords < hi` comparison. On a real WR-90 grid an f64 reconstruction of the nodes disagrees with production on **30 of 31 nodes by up to 1.12e-9 m — 1e-6 of a cell** — and that is enough to move the footprint by a whole cell. Separately, one f32 ULP of the corner value (4.66e-10 m at dx = 0.762 mm, 6e-7 of a cell) flips the occupied-node count on its own. Midpoint corners sit half a cell from either edge and are immune to both.

This is also how I got the arithmetic wrong the first time, and it is worth recording as the reason the tests are built the way they are: my original probe built node coordinates with an f64 `np.arange(ny) * dx`, measured `d + dx` everywhere, and the first revision of these tests pinned that. They passed — against the wrong comparator. The tests now derive coordinates from a real `Grid`, so they cannot drift from production again.

### No advisory added — with evidence

The predicate floated in #493 (fire when a PEC volume's rasterized opening differs from its drawn opening by >= 1 cell) gives an **ambiguous reading**. At `d = 7.620 mm` the defective nominal drawing and the correct midpoint recipe *both* read +1 cell, so +1 cell cannot support a defect conclusion — and +1 cell is the common case. (At 12.192 mm they read +2 and +1 and are distinguishable, so the predicate is not constant; it is unreliable, which is worse for a guard.) The defect is `realized != INTENDED`, and the intended dimension is never communicated to the simulator, so it cannot be recovered from geometry. Pinned by `test_drawn_vs_realized_gap_is_ambiguous_between_correct_and_defective`.

A preflight advisory would also not have caught case 18, which drives the functional entry point and runs no preflight — the same gap #494 is about.

The form that *could* check intent is #493's option (b), an opt-in helper that draws an obstacle to a requested electrical dimension. That is new public API surface, so it is left as a follow-up rather than folded into a hygiene PR.

## Tests

`tests/test_waveguide_geometry_hygiene.py`, 40 passing in 6.3 s. Every advisory has a firing test **and** a non-firing control; the #493 tests are characterization tests that pin the convention arithmetic.

Mutation-checked, so the tests are not vacuous:
- disabling the advisory reds the 4 firing tests, non-firing controls still green;
- changing the volume branch to closed `[lo, hi]` reds 9 convention tests;
- making the `lo` face exclusive as well (symmetric exclusion) reds 5 tests including `test_which_interior_face_retreats_decides_the_symmetry`, so that test binds the lo/hi corner asymmetry rather than restating the excess.

Regression sweep, sharded (never single-process — XLA cache OOM):

| selection | result |
|---|---|
| `test_stage1_tier2_tracer_fixes` + `test_mesh_import` + `test_thin_conductor` | 23 passed |
| `test_subpixel_pec` + `test_waveguide_twoport_contract_v1` | 21 passed |
| `test_sparam` + `test_sparam_passivity_guard` + `test_passivity_guard_wiring` + `test_sparameter_support_contract` | 38 passed |
| `test_waveguide_port_validation_battery` | 9 passed |
| `test_multimode_waveguide` + `test_waveguide_port_reference_sims` | 33 passed |
| `test_wr90_iris_modematch_gates` + `test_waveguide_phase_gate` + `test_waveguide_smatrix_checkpoint` | 23 passed |

147 existing tests, zero failures. Lint clean on the repo flags; `scripts/check_api_reference.py` reports `api reference surface: OK`.

## Two configurations that now warn — reported, not silenced (filed as #496)

Neither is a test failure (there is no warnings-as-errors filter in `pyproject.toml` or CI, and no waveguide test asserts an exact warning count), and I changed neither. Both are filed together as **#496**, which records the measured numbers and states explicitly that whether the contract tests' bindings survive a corrected absorber was NOT determined:

1. **`tests/test_waveguide_twoport_contract_v1.py`** (4 test items): `cpml_layers=10` at dx = 1.87 mm, band from 4.5 GHz, = 18.7 mm = **0.18 `lambda_g`** against a 52.4 mm requirement. Thinner than the 0.30 `lambda_g` that #494 documents as envelope-corrupting. Its own docstring frames these as extraction-algebra tripwires and reciprocity / magnitude-invariance binds rather than absolute-accuracy gates, so what they bind survives — but they also carry passivity violations (max column power 1.211 and 1.534), which is the same symptom case 18 saw from its thin absorber and **retracted** after fixing it. Worth a look independently of this PR.
2. **`validation/crossval/11_waveguide_port_wr90.py`**: `CPML_LAYERS = 20` at dx = 1 mm = 20 mm = **0.35 `lambda_g`** at the 8.2 GHz band edge, against 28.2 mm. cv11 is a diagnostic reporter, not a gate, so this is informational — but the weekly `crossval-external` lane output will gain a line. Corroborating detail: cv11's own comment records that the previous value of 10 gave "guided-mode reflection ~12%", and my predicate reads that rejected value at 0.18 `lambda_g` — so the check tracks an effect they had already measured, and says the replacement is still under the documented floor.

Case 18 as merged derives `ceil(0.75 * lambda_g / dx)` and is **silent**, which is the confirmation that the predicate agrees with the corrected reference setup.

## What I did NOT verify

- **No FDTD accuracy claim of my own.** Every ripple/envelope number quoted in the advisory message, the guide and the changelog is *imported from #493/#494 and PR #480*, not re-measured here. I verified the geometry arithmetic, the ULP behaviour and the advisory predicate; I did not re-run the WR-90 iris lane or reproduce the 0.0706 / 0.0366 / 0.0093 ladder.
- **The non-uniform lane is not covered** by the advisory and has no test asserting silence there; the exclusion is documented in the method docstring but rests on the argument that `cpml_layers * dx` is ambiguous under a graded profile, not on a measurement.
- **`upml` is accepted by the predicate but untested** — I included the token for parity with the boundary spec, but every test uses `cpml`.
- **No GPU run** and no full-suite run; only the shards tabulated above.
- **The 4-6x inflation figure** is quoted from #493's table, not independently reproduced against the analytic oracle.
- **The oracle best-fit is the reviewer's measurement, not mine.** It confirms the rasterization table at all three apertures and both drawings (see above), but I measured what the rasterizer produces, not what the physics needs — the `|S11|` fits are quoted from the reviewer's run.
- **The ~99k-combination sweep used a NumPy replication** of the f32 volume comparison, not the JAX path, for speed. The replication was validated against the real `Box.mask_on_coords` on 603 configurations with zero mismatches, but the sweep percentages themselves are from the replication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
