### PR TITLE
Mixed port families: lumped/wire + MSL S-matrix with a flux-normalized magnitude channel (#488)

### DIFF
--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -148,6 +148,9 @@
     "MeshShape": {
       "kind": "class"
     },
+    "MixedSMatrixResult": {
+      "kind": "class"
+    },
     "ModulatedGaussian": {
       "kind": "class"
     },
@@ -2438,6 +2441,18 @@
       "signal_floor",
       "reference_plane_axial_index_offset",
       "strict_passivity"
+    ],
+    "compute_mixed_s_matrix": [
+      "n_steps",
+      "num_periods",
+      "freqs",
+      "n_freqs",
+      "strict_extractor",
+      "enforce_passivity",
+      "skip_preflight",
+      "return_diagnostics",
+      "magnitude_channel",
+      "reciprocity_tol"
     ],
     "compute_msl_s_matrix": [
       "n_steps",

--- a/docs/guides/sparameter_support_matrix.json
+++ b/docs/guides/sparameter_support_matrix.json
@@ -484,7 +484,7 @@
         "quote the preflight output and settling_db with any number from this lane",
         "a green passivity/column-power result here is structurally uninformative"
       ],
-      "ad_traceable": false,
+      "ad_traceable": "no",
       "ad_evidence": "not wired to the differentiable forward lane (imperative only)"
     }
   ],

--- a/docs/guides/sparameter_support_matrix.json
+++ b/docs/guides/sparameter_support_matrix.json
@@ -457,9 +457,10 @@
         "PEC z_lo ground required for magnitude_channel='flux' (the default)",
         "imperative forward path only (no eps_override AD channel)"
       ],
-      "validation_status": "EXPERIMENTAL. Diagonals come from the per-family validated extractors; off-diagonal MAGNITUDES come from Poynting flux with the incident power normalized as P_net/(1-|S_jj|^2). Internal reciprocity witness measured 9% on the probe-fed MSL fixture (the wave channel measured 55% on the same fixture). NO external-solver referee has been run, so ABSOLUTE magnitude is NOT validated. Off-diagonal PHASE mixes two reference-plane conventions and is provisional. Do not cite this family as validation.",
+      "validation_status": "EXPERIMENTAL. Diagonals come from the per-family extractors but are NOT verified on this lane (both the wire port-cell V*I accounting and the MSL analytic-Z0 anchor are open), and the shipped values are additionally rewritten by the passivity projection when the raw matrix is non-passive. off-diagonal MAGNITUDES come from Poynting flux with the incident power normalized as P_net/(1-|S_jj|^2). Internal reciprocity witness measured 9% on the probe-fed MSL fixture (the wave channel measured 55% on the same fixture). NO external-solver referee has been run, so ABSOLUTE magnitude is NOT validated. Off-diagonal PHASE mixes two reference-plane conventions and is provisional. Do not cite this family as validation.",
       "known_limits": [
         "absolute |S| unvalidated — openEMS referee pending",
+        "with enforce_passivity=True (default) the returned diagonal is a JOINT SVD-projected value, not the raw per-family measurement — measured ~4x its unprojected value on the committed test fixture; read S_raw/passivity_correction for what was measured",
         "off-diagonal phase provisional (cross-family reference-plane mismatch)",
         "per-column power is an ALGEBRAIC IDENTITY on the flux channel and is not a passivity check; reciprocity is the only independent internal witness",
         "residual reciprocity disagreement traced to a driven-port diagonal; which diagonal is open (issue #313 wire port-cell vs the MSL analytic Z0 anchor)",
@@ -475,7 +476,8 @@
         "tests/test_mixed_port_sparam.py"
       ],
       "numeric_metrics": [
-        "reciprocity deviation 9.0% (flux channel) vs 55% (wave channel), probe-fed MSL fixture, dx=63.5um, settling -101/-100 dB"
+        "reciprocity deviation 9.0% (flux channel) vs 55% (wave channel), probe-fed MSL fixture, dx=63.5um, settling -101/-100 dB",
+        "reciprocity witness default tolerance 0.06, set BELOW the 9% reference-fixture residual so that fixture warns rather than passing silently"
       ],
       "validated_scope": "NONE — this family is a diagnostic surface, not a validated result. It is listed so the matrix does not read as 'mixed families are impossible in rfx', which the per-extractor limits elsewhere in this document would otherwise imply. Those per-extractor statements remain accurate: compute_msl_s_matrix, the lumped/wire scan driver, and the coaxial calculators each still reject foreign port families.",
       "caveats": [

--- a/docs/guides/sparameter_support_matrix.json
+++ b/docs/guides/sparameter_support_matrix.json
@@ -447,9 +447,11 @@
     {
       "primitive": "add_port(...) + add_msl_port(...) driven by compute_mixed_s_matrix(...)",
       "family": "mixed_lumped_wire_msl",
-      "is_port": true,
+      "is_port": false,
       "support_status": "experimental_diagnostic_not_in_validated_set",
-      "calculation_api": "Simulation.compute_mixed_s_matrix(...)",
+      "calculation_api": [
+        "Simulation.compute_mixed_s_matrix(...)"
+      ],
       "result_type": "MixedSMatrixResult",
       "supported_configurations": [
         "uniform second-order Yee mesh only",
@@ -479,7 +481,7 @@
         "reciprocity deviation 9.0% (flux channel) vs 55% (wave channel), probe-fed MSL fixture, dx=63.5um, settling -101/-100 dB",
         "reciprocity witness default tolerance 0.06, set BELOW the 9% reference-fixture residual so that fixture warns rather than passing silently"
       ],
-      "validated_scope": "NONE — this family is a diagnostic surface, not a validated result. It is listed so the matrix does not read as 'mixed families are impossible in rfx', which the per-extractor limits elsewhere in this document would otherwise imply. Those per-extractor statements remain accurate: compute_msl_s_matrix, the lumped/wire scan driver, and the coaxial calculators each still reject foreign port families.",
+      "validated_scope": "NONE — this is a diagnostic CALCULATION over the already-registered lumped/wire and microstrip_line port families, not a new port primitive and not a validated result. It is listed so the matrix does not read as 'mixed families are impossible in rfx', which the per-extractor limits elsewhere in this document would otherwise imply. Those per-extractor statements remain accurate: compute_msl_s_matrix, the lumped/wire scan driver, and the coaxial calculators each still reject foreign port families.",
       "caveats": [
         "quote the preflight output and settling_db with any number from this lane",
         "a green passivity/column-power result here is structurally uninformative"

--- a/docs/guides/sparameter_support_matrix.json
+++ b/docs/guides/sparameter_support_matrix.json
@@ -1,6 +1,6 @@
 {
   "version": 3,
-  "updated": "2026-07-28",
+  "updated": "2026-07-29",
   "result_convention": {
     "full_s_matrix_shape": "(n_ports, n_ports, n_freqs)",
     "frequency_shape": "(n_freqs,)",
@@ -443,6 +443,47 @@
         "does not define a port impedance or S-matrix reference"
       ],
       "ad_traceable": "not_applicable"
+    },
+    {
+      "primitive": "add_port(...) + add_msl_port(...) driven by compute_mixed_s_matrix(...)",
+      "family": "mixed_lumped_wire_msl",
+      "is_port": true,
+      "support_status": "experimental_diagnostic_not_in_validated_set",
+      "calculation_api": "Simulation.compute_mixed_s_matrix(...)",
+      "result_type": "MixedSMatrixResult",
+      "supported_configurations": [
+        "uniform second-order Yee mesh only",
+        "one homogeneous lumped OR wire set (component='ez', vertical) plus one or more MSL ports",
+        "PEC z_lo ground required for magnitude_channel='flux' (the default)",
+        "imperative forward path only (no eps_override AD channel)"
+      ],
+      "validation_status": "EXPERIMENTAL. Diagonals come from the per-family validated extractors; off-diagonal MAGNITUDES come from Poynting flux with the incident power normalized as P_net/(1-|S_jj|^2). Internal reciprocity witness measured 9% on the probe-fed MSL fixture (the wave channel measured 55% on the same fixture). NO external-solver referee has been run, so ABSOLUTE magnitude is NOT validated. Off-diagonal PHASE mixes two reference-plane conventions and is provisional. Do not cite this family as validation.",
+      "known_limits": [
+        "absolute |S| unvalidated — openEMS referee pending",
+        "off-diagonal phase provisional (cross-family reference-plane mismatch)",
+        "per-column power is an ALGEBRAIC IDENTITY on the flux channel and is not a passivity check; reciprocity is the only independent internal witness",
+        "residual reciprocity disagreement traced to a driven-port diagonal; which diagonal is open (issue #313 wire port-cell vs the MSL analytic Z0 anchor)",
+        "waveguide, Floquet, coaxial, TFSF, bare sources, 0-ohm ports, mixed lumped+wire sets, reference_plane_cells, non-uniform meshes, SBP-SAT and ADI are all rejected loudly"
+      ],
+      "evidence_level": "experimental/internal-witness-only",
+      "validation_gaps": [
+        "no external-solver cross-check of any mixed-family |S|",
+        "no mesh-convergence study",
+        "single fixture class (vertical probe feed onto a microstrip line)"
+      ],
+      "evidence_artifacts": [
+        "tests/test_mixed_port_sparam.py"
+      ],
+      "numeric_metrics": [
+        "reciprocity deviation 9.0% (flux channel) vs 55% (wave channel), probe-fed MSL fixture, dx=63.5um, settling -101/-100 dB"
+      ],
+      "validated_scope": "NONE — this family is a diagnostic surface, not a validated result. It is listed so the matrix does not read as 'mixed families are impossible in rfx', which the per-extractor limits elsewhere in this document would otherwise imply. Those per-extractor statements remain accurate: compute_msl_s_matrix, the lumped/wire scan driver, and the coaxial calculators each still reject foreign port families.",
+      "caveats": [
+        "quote the preflight output and settling_db with any number from this lane",
+        "a green passivity/column-power result here is structurally uninformative"
+      ],
+      "ad_traceable": false,
+      "ad_evidence": "not wired to the differentiable forward lane (imperative only)"
     }
   ],
   "physics_evidence_rule": "docs/guides/physics_validation_evidence_rule.md",

--- a/docs/guides/sparameter_support_matrix.md
+++ b/docs/guides/sparameter_support_matrix.md
@@ -389,3 +389,16 @@ lumped+wire sets, `reference_plane_cells`, non-uniform meshes, SBP-SAT, and ADI.
 The flux channel additionally requires a PEC `z_lo` ground and vertical
 (`component="ez"`) lumped/wire ports, since the per-port flux box omits its
 bottom face and treats the port extent as a height.
+
+Two further cautions on this lane, both measured rather than anticipated:
+
+- **Neither diagonal is verified.** The wire port-cell V·I accounting was measured
+  undercounting delivered power ~3× against an independent Poynting referee, and on an
+  end-fed fixture the MSL probe plane's local `V/I` was ~591 Ω and strongly reactive
+  while the reported `|S22|` was 0.03. Those cannot both be right, and which one is
+  wrong is open.
+- **The returned diagonal is not always the measured one.** With
+  `enforce_passivity=True` (the default), `_project_passive` is a joint SVD clip: when
+  any entry is non-passive it rewrites others as a side effect. On the committed test
+  fixture the shipped MSL diagonal came out ~4× its unprojected value. Read `S_raw` and
+  `passivity_correction` for what was actually measured.

--- a/docs/guides/sparameter_support_matrix.md
+++ b/docs/guides/sparameter_support_matrix.md
@@ -312,3 +312,41 @@ sim.preflight_sparameters(calculator="waveguide")
 
 The returned issues check API compatibility, not mesh/time convergence or RF
 accuracy. Use `strict=True` when the setup should fail on any reported issue.
+
+## Mixed port families — EXPERIMENTAL, not in the validated set
+
+The per-extractor restrictions above are accurate: `compute_msl_s_matrix`, the
+lumped/wire scan driver, and the coaxial calculators each reject foreign port
+families. They should not be read as "rfx cannot compute across port families
+at all" — a separate, explicitly experimental method exists:
+
+```python
+res = sim.compute_mixed_s_matrix(freqs=freqs)   # lumped/wire + MSL, uniform mesh
+```
+
+`compute_mixed_s_matrix` drives each port in turn, takes its diagonals from the
+per-family validated extractors, and takes off-diagonal **magnitudes** from
+Poynting flux (`magnitude_channel="flux"`, the default), normalizing incident
+power as `P_net / (1 - |S_jj|^2)`. No characteristic-impedance anchor enters the
+magnitude.
+
+What this is and is not:
+
+| aspect | status |
+|---|---|
+| off-diagonal magnitude | experimental; internal reciprocity witness 9% on the probe-fed MSL fixture (55% on the wave channel) |
+| absolute magnitude | **NOT validated** — no external-solver referee has been run |
+| off-diagonal phase | provisional (mixes two reference-plane conventions) |
+| per-column power | an algebraic identity on the flux channel — **not** a passivity check |
+
+Because the flux normalization makes column power identically 1 whenever the
+arriving power equals the net launched power, a green passivity result on this
+lane carries no information. Reciprocity is the only independent internal
+witness, and the method warns when it exceeds `reciprocity_tol`.
+
+Everything outside the first supported pair is rejected loudly: waveguide,
+Floquet, coaxial and TFSF registrations, bare sources and 0-ohm ports, mixed
+lumped+wire sets, `reference_plane_cells`, non-uniform meshes, SBP-SAT, and ADI.
+The flux channel additionally requires a PEC `z_lo` ground and vertical
+(`component="ez"`) lumped/wire ports, since the per-port flux box omits its
+bottom face and treats the port extent as a height.

--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -8,7 +8,7 @@ from rfx.simulation import run, run_until_decay, make_source, make_probe, make_p
 from rfx.adi import ADIState2D, ADIState3D, thomas_solve, adi_step_2d, run_adi_2d, adi_step_3d, run_adi_3d
 from rfx.api import (
     Simulation, Result, WaveguideSParamResult, WaveguideSMatrixResult,
-    MSLSMatrixResult, CoaxialSMatrixResult, MATERIAL_LIBRARY,
+    MSLSMatrixResult, MixedSMatrixResult, CoaxialSMatrixResult, MATERIAL_LIBRARY,
     AD_MemoryEstimate, ADMemoryPlan, ADMemoryComponent,
     ADMemoryActionHint, ADMemoryExplainabilityReport,
     ADMemoryPreflightReport, ADCompiledMemoryCertificate,
@@ -241,7 +241,7 @@ __all__ = [
     "SimResult", "SnapshotSpec",
     # result + S-matrix types
     "Result", "WaveguideSParamResult", "WaveguideSMatrixResult",
-    "MSLSMatrixResult", "CoaxialSMatrixResult",
+    "MSLSMatrixResult", "MixedSMatrixResult", "CoaxialSMatrixResult",
     "AD_MemoryEstimate", "ADMemoryPlan", "ADMemoryComponent",
     "ADMemoryActionHint",
     "ADMemoryExplainabilityReport", "MeshIntelligenceReport",

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -84,6 +84,7 @@ from rfx.api._spec import (  # noqa: E402
     CoaxialLineReflectionResult,
     _MSLPortEntry,
     MSLSMatrixResult,
+    MixedSMatrixResult,
 )
 from rfx.mesh_planner import MeshPlan, plan_simulation_mesh  # noqa: E402,F401
 
@@ -3725,4 +3726,5 @@ __all__ = [
     "CoaxialSMatrixResult",
     "CoaxialLineReflectionResult",
     "MSLSMatrixResult",
+    "MixedSMatrixResult",
 ]

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -1252,10 +1252,20 @@ class _ExecuteMixin:
 
         # Flux monitors — same configs the run() lane builds, so the
         # issue-#488 mixed-family magnitude channel can read Poynting
-        # flux through this low-level lane too (PURE ADD: empty list
-        # when nothing is registered, exactly the prior behavior).
-        from rfx.runners.uniform import build_flux_monitor_cfgs
-        flux_monitor_cfgs = build_flux_monitor_cfgs(self, grid, n_steps)
+        # flux through this low-level lane too.
+        #
+        # GATED to the raw-hook path on purpose. This lane's
+        # ``ForwardResult`` has never carried flux monitors, so an
+        # existing ``forward()``/``optimize()`` caller with
+        # ``add_flux_monitor()`` registered would pay for flux DFT
+        # accumulation inside the differentiable scan (memory on the AD
+        # tape included) and never see the result — a silent cost
+        # regression, not a feature. Only ``_return_raw_port_sparams``
+        # consumers read these back.
+        flux_monitor_cfgs = []
+        if _return_raw_port_sparams and self._flux_monitors:
+            from rfx.runners.uniform import build_flux_monitor_cfgs
+            flux_monitor_cfgs = build_flux_monitor_cfgs(self, grid, n_steps)
 
         # DFT plane probes — mirror runners/uniform.py:340-359 so the
         # JIT scan body actually accumulates plane-resolved DFT, then

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -1250,6 +1250,13 @@ class _ExecuteMixin:
             corner_lo, corner_hi, freqs = self._ntff
             ntff_box = make_ntff_box(grid, corner_lo, corner_hi, freqs)
 
+        # Flux monitors — same configs the run() lane builds, so the
+        # issue-#488 mixed-family magnitude channel can read Poynting
+        # flux through this low-level lane too (PURE ADD: empty list
+        # when nothing is registered, exactly the prior behavior).
+        from rfx.runners.uniform import build_flux_monitor_cfgs
+        flux_monitor_cfgs = build_flux_monitor_cfgs(self, grid, n_steps)
+
         # DFT plane probes — mirror runners/uniform.py:340-359 so the
         # JIT scan body actually accumulates plane-resolved DFT, then
         # carry the result back through ForwardResult.dft_planes for
@@ -1467,6 +1474,7 @@ class _ExecuteMixin:
             lumped_rlc=rlc_metas,
             kerr_chi3=kerr_chi3,
             dft_planes=dft_planes if dft_planes else None,
+            flux_monitors=flux_monitor_cfgs if flux_monitor_cfgs else None,
             return_state=False,
             stencil_order=self._stencil_order,
         )
@@ -1503,6 +1511,18 @@ class _ExecuteMixin:
                     if self._dft_planes else None
                 ),
                 "time_series": getattr(result, "time_series", None),
+                # Flux monitors for the issue-#488 arch-A magnitude channel
+                # (same name-keyed contract the runner uses for run()).
+                "flux_monitors": (
+                    {
+                        entry.name: fmv
+                        for entry, fmv in zip(
+                            self._flux_monitors,
+                            getattr(result, "flux_monitors", None) or (),
+                        )
+                    }
+                    if self._flux_monitors else None
+                ),
             }
 
         s_params_out = getattr(result, "s_params", None)

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -1485,6 +1485,24 @@ class _ExecuteMixin:
                 "wire": result.wire_port_sparams,
                 "wire_refplane": result.wire_refplane_sparams,
                 "freqs": _raw_freqs,
+                # Mixed-family S-matrix hook (issue #488): the DFT plane
+                # probes and probe time series recorded in the SAME run, so
+                # compute_mixed_s_matrix can read MSL port planes + settling
+                # witnesses alongside the lumped/wire accumulators without a
+                # second pass. The name-keyed dict mirrors the run()/forward()
+                # ``ForwardResult.dft_planes`` contract below. PURE ADD — the
+                # lumped/wire scan driver reads only the keys above.
+                "dft_planes": (
+                    {
+                        entry.name: probe
+                        for entry, probe in zip(
+                            self._dft_planes,
+                            getattr(result, "dft_planes", None) or (),
+                        )
+                    }
+                    if self._dft_planes else None
+                ),
+                "time_series": getattr(result, "time_series", None),
             }
 
         s_params_out = getattr(result, "s_params", None)

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -770,6 +770,29 @@ def _assemble_mixed_power_wave_s(
     return S, s21_power
 
 
+def _mixed_reciprocity_deviation(S):
+    """Worst relative |S_ij| vs |S_ji| disagreement (issue #488).
+
+    Magnitude-only by design: cross-family phase mixes two reference-plane
+    conventions on this lane, so a complex comparison would misfire.
+    Returns ``((i, j), max_relative_deviation)`` over all off-diagonal
+    pairs and frequencies, or ``None`` for a 1-port / tracer input.
+    """
+    s = np.abs(np.asarray(jax.lax.stop_gradient(S)))
+    n = int(s.shape[0])
+    if n < 2 or not np.all(np.isfinite(s)):
+        return None
+    worst_pair, worst = None, 0.0
+    for i in range(n):
+        for j in range(i + 1, n):
+            a, b = s[i, j, :], s[j, i, :]
+            denom = np.maximum(np.maximum(a, b), 1e-12)
+            dev = float(np.max(np.abs(a - b) / denom))
+            if dev >= worst:
+                worst, worst_pair = dev, (i, j)
+    return worst_pair, worst
+
+
 def _mixed_flux_magnitude_override(
     S_wave, box_lw, plane_msl, drive_plan, msl_away_signs, n_lw,
     ill_cond_floor=0.05,
@@ -792,17 +815,21 @@ def _mixed_flux_magnitude_override(
     the #313 port-cell V*I accounting and the analytic-vs-measured MSL Z0
     divergence drop out).
 
-    Returns (S_out, ill_cond_cols, neg_pnet_cols): boolean per-column
-    masks marking bins where 1-|S_jj|^2 < ill_cond_floor (normalization
-    unreliable — near-total reflection) and where the raw P_net was
-    negative (sign/accounting defect; clipped to 0).
+    Returns (S_out, ill_cond, neg_power): boolean ``(n_ports, n_freqs)``
+    masks. ``ill_cond[j]`` marks bins where ``1-|S_jj|^2 <
+    ill_cond_floor`` (normalization unreliable — near-total reflection at
+    driven port j). ``neg_power[i]`` marks bins where a raw power at port
+    i came out negative and was clipped to zero — tracked for BOTH the
+    driven port's net launched power and every receive port's arriving
+    power, because either sign defect silently produces a plausible
+    ``|S| = 0`` instead of failing loudly.
     """
     S_wave = jnp.asarray(S_wave)
     n_tot = int(S_wave.shape[0])
     n_freqs = int(S_wave.shape[-1])
     S_out = S_wave
     ill_cond = np.zeros((n_tot, n_freqs), dtype=bool)
-    neg_pnet = np.zeros((n_tot, n_freqs), dtype=bool)
+    neg_power = np.zeros((n_tot, n_freqs), dtype=bool)
     for run_idx, (fam, loc) in enumerate(drive_plan):
         col = loc if fam == "lw" else n_lw + loc
         s_jj = np.asarray(jax.lax.stop_gradient(S_wave[col, col, :]))
@@ -812,7 +839,7 @@ def _mixed_flux_magnitude_override(
             p_net = box_lw[run_idx, loc, :]
         else:
             p_net = msl_away_signs[loc] * plane_msl[run_idx, loc, :]
-        neg_pnet[col, :] = p_net < 0.0
+        neg_power[col, :] |= p_net < 0.0
         p_inc = np.clip(p_net, 0.0, None) / np.clip(one_minus, ill_cond_floor, None)
         safe_pinc = np.where(p_inc > 0.0, p_inc, np.inf)
         for i in range(n_tot):
@@ -822,12 +849,18 @@ def _mixed_flux_magnitude_override(
                 p_arr = -box_lw[run_idx, i, :]          # inward = -outward
             else:
                 p_arr = -msl_away_signs[i - n_lw] * plane_msl[run_idx, i - n_lw, :]
+            # Symmetric with the driven-port tracking above: a negative
+            # ARRIVING power is also a sign/accounting defect, and
+            # clipping it silently yields |S_ij| = 0 — a plausible-looking
+            # number that reads as "no coupling" instead of "broken
+            # measurement".
+            neg_power[i, :] |= p_arr < 0.0
             mag = np.sqrt(np.clip(p_arr, 0.0, None) / safe_pinc)
             ph = jnp.exp(1j * jnp.angle(S_wave[i, col, :]))
             S_out = S_out.at[i, col, :].set(
                 (jnp.asarray(mag) * ph).astype(S_wave.dtype)
             )
-    return S_out, ill_cond, neg_pnet
+    return S_out, ill_cond, neg_power
 
 
 class _SparamMixin:
@@ -2423,6 +2456,7 @@ class _SparamMixin:
         skip_preflight: bool = False,
         return_diagnostics: bool = False,
         magnitude_channel: str = "flux",
+        reciprocity_tol: float = 0.15,
     ) -> "MixedSMatrixResult":
         """Mixed-family S-matrix: lumped/wire ports + MSL ports (issue #488).
 
@@ -2776,6 +2810,39 @@ class _SparamMixin:
                 "compute_mixed_s_matrix: magnitude_channel must be 'flux' "
                 f"(default) or 'wave', got {magnitude_channel!r}."
             )
+        if magnitude_channel == "flux":
+            # The per-port flux box is CLOSED by the z-lo PEC ground: it
+            # has five faces and omits the bottom because flux through a
+            # PEC face is identically zero. It also treats pe.extent as a
+            # VERTICAL height. Both are physical preconditions, so check
+            # them instead of assuming (review finding: a user with an
+            # open z-lo boundary or a horizontal port would otherwise get
+            # a silently wrong P_net on the DEFAULT channel).
+            _pec_faces = (
+                self._boundary_spec.pec_faces()
+                if self._boundary_spec is not None else set()
+            )
+            if "z_lo" not in _pec_faces:
+                raise NotImplementedError(
+                    "compute_mixed_s_matrix(magnitude_channel='flux') "
+                    "requires a PEC z_lo boundary: the per-port flux box "
+                    "omits its bottom face because flux through a PEC "
+                    "ground is identically zero. Your z_lo face is "
+                    f"{sorted(_pec_faces) or 'not PEC'}, so the box would "
+                    "not be closed and P_net would be wrong. Use "
+                    "BoundarySpec(z=Boundary(lo='pec', ...)), or pass "
+                    "magnitude_channel='wave' (which carries the #313 "
+                    "port-cell deflation instead)."
+                )
+            _bad = [pe for pe in lw_entries if pe.component != "ez"]
+            if _bad:
+                raise NotImplementedError(
+                    "compute_mixed_s_matrix(magnitude_channel='flux') "
+                    "supports vertical (component='ez') lumped/wire ports "
+                    "only: the flux box is built assuming the port extent "
+                    "is a z height above the ground plane. Offending "
+                    f"component(s): {sorted({pe.component for pe in _bad})}."
+                )
 
         drive_plan = [("lw", j) for j in range(n_lw)] + \
                      [("msl", d) for d in range(n_msl)]
@@ -3028,20 +3095,34 @@ class _SparamMixin:
             )
             S = jnp.asarray(S, dtype=_complex_dtype)
 
-            # ---- Measured line Zc for the MSL diagonals ----------------
-            # Documented deviation from compute_msl_s_matrix's analytic
-            # z0_hj anchor: on the mixed lane's interface-aligned fixtures
-            # the analytic anchor diverged from the discretized line
-            # (arch-A battery: an understated |S22| broke lossless-
-            # reciprocal consistency |S11| == |S22| and carried the whole
-            # 9% reciprocity residual). The N-probe least-squares fit
-            # measures Zc(f) from the recorded ez ladder; per-bin fallback
-            # to z0_hj where the fit is unreliable.
+            # ---- N-probe line Zc: DIAGNOSTIC ONLY (issue #488) ---------
+            # This lane does NOT substitute a fitted Zc into the MSL
+            # diagonal. An earlier revision did, and it was withdrawn
+            # after review: the fit's sign is not stable here, so the
+            # substitution silently fell back to the analytic anchor and
+            # looked like a confirmed measurement.
+            #
+            # Mechanism (why a sign fix would not be enough): the model
+            # V_n = alpha*exp(-j beta x_n) + gamma*exp(+j beta x_n) is
+            # invariant under (beta -> -beta, alpha <-> gamma), so a beta
+            # scan that lands on the wrong branch SWAPS the two wave
+            # roles and flips the sign of (alpha - gamma) — and therefore
+            # of z0 = (alpha - gamma)/I1. Measured on one fixture: the
+            # fitted sign differs between num_periods=4 and 20. On top of
+            # that, `msl_loop_current`'s docstring (rfx/sources/
+            # msl_port.py, "the returned I is positive for a forward
+            # quasi-TEM wave") and compute_msl_s_matrix's #140 dir_sign
+            # comment ("a -x port's fitted z0 inherits a negative sign")
+            # describe OPPOSITE conventions; that contradiction is
+            # unresolved and is tracked as a follow-up, not papered over
+            # here.
+            #
+            # The fit is still computed and EXPOSED (return_diagnostics)
+            # because it is the only handle on the open 30-vs-48 ohm
+            # question, but it never feeds a shipped number, and its
+            # magnitude is reported without a sign claim.
             from rfx.probes.msl_wave_decomp import extract_msl_nprobe
-            z0_msl_meas = np.tile(
-                np.asarray(z0_hj_per_port, dtype=float)[:, None],
-                (1, n_freqs_used),
-            )
+            z0_msl_fit = np.full((n_msl, n_freqs_used), np.nan)
             for d in range(n_msl):
                 run_d = n_lw + d
                 n_p = len(probe_xs[d])
@@ -3052,49 +3133,27 @@ class _SparamMixin:
                     jnp.asarray(beta0_per_port[d]),
                     z0_hj=z0_hj_per_port[d],
                 )
-                # #140 sign convention: msl_loop_current negates only for
-                # "+x" ports; mirror so the reported Zc is positive-real.
-                dir_sign = 1.0 if entries[d].direction == "+x" else -1.0
-                zc = np.real(np.asarray(
+                z0_msl_fit[d, :] = np.abs(np.asarray(
                     jax.lax.stop_gradient(res_fit["z0"])
-                )) * dir_sign
-                ok = np.isfinite(zc) & (zc > 5.0) & (zc < 500.0)
-                z0_msl_meas[d, :] = np.where(ok, zc, z0_hj_per_port[d])
-                # Soft caveat, mirroring compute_msl_s_matrix's _Z0_TOL
-                # pattern: the [5, 500] ohm guard above is a sanity floor,
-                # NOT a settling check — measured on this lane, the same
-                # fixture fits 47.9 ohm at num_periods=40 but scatters over
-                # 57-82 ohm at num_periods=4. A large deviation from the
-                # analytic anchor therefore usually means the record is
-                # under-settled (check settling_db), not that the line is
-                # exotic. Warn; never clamp the measurement to the
-                # assumption.
+                ).astype(np.complex128))
                 _dev = float(np.max(
-                    np.abs(z0_msl_meas[d, :] - z0_hj_per_port[d])
+                    np.abs(z0_msl_fit[d, :] - z0_hj_per_port[d])
                     / z0_hj_per_port[d]
                 ))
                 if _dev > 0.10:
                     import warnings as _wz
                     _wz.warn(
-                        f"compute_mixed_s_matrix: measured line Zc for MSL "
-                        f"port {entries[d].name!r} deviates up to "
+                        f"compute_mixed_s_matrix: the N-probe |Zc| fit for "
+                        f"MSL port {entries[d].name!r} deviates up to "
                         f"{_dev * 100:.1f}% from analytic Hammerstad-Jensen "
-                        f"{z0_hj_per_port[d]:.2f} ohm. The N-probe fit needs "
-                        "a SETTLED record (same fixture: 47.9 ohm at "
-                        "num_periods=40 vs 57-82 ohm at num_periods=4) — "
-                        "check settling_db before trusting the MSL "
-                        "diagonal, and on coarse meshes expect genuine "
-                        "Yee-staircase Z0 bias on top.",
+                        f"{z0_hj_per_port[d]:.2f} ohm. The MSL diagonal "
+                        "here uses the ANALYTIC anchor, so this does not "
+                        "change the returned S — it is a diagnostic that "
+                        "the record may be under-settled (check "
+                        "settling_db) or the discretized line genuinely "
+                        "differs (Yee staircase on coarse meshes).",
                         stacklevel=2,
                     )
-                v_d = v0_msl[run_d, d, :]
-                i_d = i_msl[run_d, d, :]
-                den = v_d + z0_msl_meas[d, :] * i_d
-                den = np.where(np.abs(den) > 0, den, 1e-30)
-                s_dd = (v_d - z0_msl_meas[d, :] * i_d) / den
-                S = S.at[n_lw + d, n_lw + d, :].set(
-                    jnp.asarray(s_dd).astype(_complex_dtype)
-                )
             s_wave_full = None
 
             if magnitude_channel == "flux":
@@ -3103,7 +3162,7 @@ class _SparamMixin:
                 msl_away = [
                     (+1.0 if pe.direction == "+x" else -1.0) for pe in entries
                 ]
-                S, _ill_cond, _neg_pnet = _mixed_flux_magnitude_override(
+                S, _ill_cond, _neg_power = _mixed_flux_magnitude_override(
                     S, box_lw, plane_msl, drive_plan, msl_away, n_lw,
                 )
                 S = jnp.asarray(S, dtype=_complex_dtype)
@@ -3120,16 +3179,19 @@ class _SparamMixin:
                             "are UNRELIABLE at those bins.",
                             stacklevel=2,
                         )
-                    n_neg = int(_neg_pnet[col].sum())
+                    n_neg = int(_neg_power[col].sum())
                     if n_neg:
                         _wf.warn(
-                            f"compute_mixed_s_matrix: NET flux at driven "
-                            f"port index {col} is NEGATIVE at "
+                            f"compute_mixed_s_matrix: flux power at port "
+                            f"index {col} came out NEGATIVE at "
                             f"{n_neg}/{n_freqs_used} bins — a sign or "
-                            "accounting defect in the flux surfaces (power "
-                            "cannot flow INTO a driven passive-terminated "
-                            "port net). Clipped to zero; treat the column "
-                            "as an extraction failure, not physics.",
+                            "accounting defect in that port's flux "
+                            "surface (net launched power cannot flow INTO "
+                            "a driven port, and arriving power cannot be "
+                            "negative at a receive port). Clipped to zero, "
+                            "which reports |S| = 0 rather than failing: "
+                            "treat those bins as an extraction failure, "
+                            "not as an absence of coupling.",
                             stacklevel=2,
                         )
 
@@ -3201,6 +3263,37 @@ class _SparamMixin:
                 strict=strict_extractor,
                 passivity_tol=0.10,
             )
+            # RECIPROCITY WITNESS — the only independent runtime check on
+            # the flux channel (review finding: the shared passivity audit
+            # above is structurally inert here, because column power is an
+            # identity under the flux normalization; and
+            # validate_port_smatrix's own reciprocity option compares
+            # COMPLEX S, which would misfire on this lane where
+            # cross-family phase is provisional by construction).
+            # S_ij and S_ji come from different drive runs with different
+            # normalizations, so their MAGNITUDE agreement is real
+            # evidence — and it is exactly the check that would have
+            # caught a wrong diagonal feeding the flux normalization.
+            _rec = _mixed_reciprocity_deviation(S)
+            if _rec is not None:
+                _pair, _dev_max = _rec
+                if _dev_max > reciprocity_tol:
+                    import warnings as _wr
+                    _wr.warn(
+                        f"compute_mixed_s_matrix: reciprocity deviation "
+                        f"max {_dev_max * 100:.1f}% between |S[{_pair[0]},"
+                        f"{_pair[1]}]| and |S[{_pair[1]},{_pair[0]}]| "
+                        f"(tolerance {reciprocity_tol * 100:.0f}%). For a "
+                        "reciprocal structure these must agree; a "
+                        "disagreement means one DRIVEN-port diagonal is "
+                        "wrong (the diagonals set the incident-power "
+                        "normalization P_inc = P_net/(1-|S_jj|^2)), or a "
+                        "flux surface is mis-signed. Note the per-column "
+                        "power sum CANNOT detect this — it is an identity "
+                        "on this channel. Inspect the diagonals and "
+                        "settling_db before quoting any |S|.",
+                        stacklevel=2,
+                    )
             if return_diagnostics:
                 # R5 inspection surface: the raw per-run phasors behind
                 # every wave, so a suspicious |S| can be traced to V/I
@@ -3211,7 +3304,10 @@ class _SparamMixin:
                     "v0_msl": v0_msl, "i_msl": i_msl,
                     "drive_plan": drive_plan,
                     "z0_hj_msl": np.asarray(z0_hj_per_port),
-                    "z0_msl_measured": z0_msl_meas,
+                    # |Zc| from the N-probe fit — DIAGNOSTIC ONLY, never
+                    # substituted into S (sign unstable; see the block
+                    # above). Magnitude only: no sign claim is made.
+                    "z0_msl_fit_abs": z0_msl_fit,
                     "box_lw_flux": box_lw,
                     "plane_msl_flux": plane_msl,
                 }

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -2587,7 +2587,7 @@ class _SparamMixin:
         skip_preflight: bool = False,
         return_diagnostics: bool = False,
         magnitude_channel: str = "flux",
-        reciprocity_tol: float = 0.15,
+        reciprocity_tol: float = 0.06,
     ) -> "MixedSMatrixResult":
         """Mixed-family S-matrix: lumped/wire ports + MSL ports (issue #488).
 
@@ -2620,14 +2620,31 @@ class _SparamMixin:
 
             |S_ij|^2 = P_arrive,i / (P_net,j / (1 - |S_jj|^2))
 
-        with the VALIDATED per-family diagonal S_jj (a local ratio at one
-        cell — immune to the #313 magnitude class) supplying the
-        reflection correction; no Z0 anchor enters the magnitude.
-        Off-diagonal PHASE still comes from the wave channel (see below).
+        where ``S_jj`` is the per-family diagonal supplying the reflection
+        correction; no Z0 anchor enters the magnitude. Off-diagonal PHASE
+        still comes from the wave channel (see below).
         ``magnitude_channel="wave"`` keeps the raw power-wave magnitudes
         (diagnostic; carries the #313 deflation at lumped/wire ports).
 
         HONESTY NOTES (read before quoting numbers):
+
+        * **Neither diagonal is verified on this lane, and the returned
+          diagonal is not always the measured one.** Two separate
+          findings: (a) the wire port-cell V*I accounting was measured
+          undercounting delivered power ~3x against an independent
+          Poynting referee (the open issue #313 reaching the diagonal at
+          a near-field-dominated vertical probe), and on an end-fed
+          fixture the MSL probe plane's local ``V/I`` was ~591 ohm and
+          strongly reactive while the reported ``|S22|`` was 0.03 — those
+          cannot both be right. (b) With ``enforce_passivity=True`` (the
+          default), ``_project_passive`` is a JOINT SVD clip: when any
+          entry is non-passive it rewrites others as a side effect.
+          Measured on the committed test fixture, the shipped MSL
+          diagonal came out ~4x its unprojected value. So ``result.S``'s
+          diagonal is a projected quantity, not a raw per-family
+          measurement — read ``S_raw`` and ``passivity_correction`` for
+          what was actually measured, and treat any diagonal-derived
+          conclusion accordingly.
 
         * The flux magnitudes inherit a flux-accounting envelope (box
           leakage + finite DFT; the Phase-0 referee class measured ~1.3%
@@ -2645,7 +2662,10 @@ class _SparamMixin:
           still detects power GAIN, i.e. ``P_arr > P_net``). The
           independent internal check on this channel is RECIPROCITY:
           ``S_ij`` and ``S_ji`` come from different runs with different
-          normalizations, so their agreement is real evidence.
+          normalizations, so their agreement is real evidence. It runs
+          automatically on every extraction (see ``reciprocity_tol``),
+          audits the RAW matrix, and is the check that a wrong diagonal
+          trips.
         * With ``magnitude_channel="wave"``, off-diagonal magnitudes that
           RECEIVE at a lumped/wire port cell inherit the issue-#313
           near-field deflation of the default port-cell waves. The
@@ -2664,7 +2684,21 @@ class _SparamMixin:
         0-ohm ports (they would fire in every drive run), no
         ``reference_plane_cells`` wire ports, no mixed lumped+wire set
         (same fence as the production scan driver), imperative only (no
-        ``eps_override`` AD channel).
+        ``eps_override`` AD channel). The default ``"flux"`` channel adds
+        two more, because the per-port flux box omits its bottom face and
+        treats the port extent as a height: a **PEC ``z_lo`` boundary**
+        and **vertical (``component="ez"``) lumped/wire ports** are
+        required. ``magnitude_channel="wave"`` makes neither assumption.
+
+        Parameters
+        ----------
+        reciprocity_tol : float, default 0.06
+            Relative ``|S_ij|`` vs ``|S_ji|`` disagreement above which the
+            reciprocity witness warns. Deliberately set BELOW the 9%
+            residual measured on this lane's own reference fixture, so
+            that fixture warns rather than passing silently: a tolerance
+            above the known residual would document the check and never
+            fire it.
 
         Returns
         -------
@@ -3405,7 +3439,17 @@ class _SparamMixin:
             # normalizations, so their MAGNITUDE agreement is real
             # evidence — and it is exactly the check that would have
             # caught a wrong diagonal feeding the flux normalization.
-            _rec = _mixed_reciprocity_deviation(S)
+            #
+            # Audited on the RAW (unprojected) matrix for the same reason
+            # the passivity self-check above is: `_project_passive` is a
+            # joint SVD clip, so it moves entries TOWARD each other and
+            # would understate the disagreement actually measured. It
+            # also rewrites diagonals as a side effect (measured on the
+            # test fixture: a shipped MSL diagonal ~4x its raw value),
+            # which is precisely what this witness exists to surface.
+            _rec = _mixed_reciprocity_deviation(
+                S if s_raw is None else s_raw
+            )
             if _rec is not None:
                 _pair, _dev_max = _rec
                 if _dev_max > reciprocity_tol:

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -38,6 +38,7 @@ from rfx.api._spec import (
     CoaxialSMatrixResult,
     CoaxialLineReflectionResult,
     MSLSMatrixResult,
+    MixedSMatrixResult,
     _WaveguidePortEntry,
     _MSLPortEntry,
 )
@@ -618,6 +619,155 @@ def _warn_junction_cpml_thickness(grid, cfgs, freqs, cpml_layers):
                 UserWarning,
                 stacklevel=2,
             )
+
+
+def _assemble_mixed_power_wave_s(
+    v_lw, i_lw, v0_msl, i_msl,
+    z0_lw, n_live_lw, z0_hj_msl,
+    wire_mode, drive_plan,
+):
+    """Assemble the mixed-family power-wave S-matrix (issue #488).
+
+    Pure function of the recorded phasors so the cross-impedance
+    normalization is unit-testable without an FDTD run.
+
+    Wave conventions (each mirrored line-for-line from the validated
+    per-family extractors — do NOT re-derive here):
+
+    * lumped/wire drive wave  ``a = (-V + Z0c*I) / (2*sqrt(Z0c))`` —
+      ``decompose_s_matrix`` probes.py:913 / ``decompose_wire_s_matrix``
+      probes.py:1018, with ``Z0c = Z0/n_live`` (n_live=1 for lumped).
+    * lumped/wire passive receive ``b = (V - Z0c*I) / (2*sqrt(Z0c))`` —
+      the issue-#308 orthogonal receive channel, DC-falsifier-pinned
+      (probes.py:925 / :1014).
+    * lumped drive-port diagonal ``b = (-V - Z0*I) / (2*sqrt(Z0))`` —
+      byte-frozen ``extract_lumped_s11`` algebra (probes.py:920).
+    * wire drive-port diagonal ``S_ii = (Z_in - Z0)/(Z_in + Z0)`` with
+      ``Z_in = -V/I`` and the FULL Z0 (probes.py:1001-1006).
+    * MSL waves ``a = (V0 + Z0_hj*I)/2``, ``b = (V0 - Z0_hj*I)/2`` — the
+      OpenEMS-style V*I split at probe 0 (compute_msl_s_matrix stage S1).
+
+    The per-family extractors report pseudo-wave ``b/a`` ratios; those
+    drop the ``sqrt(Re Z0)`` Kurokawa factor, which cancels only for
+    equal-impedance ports (issue #460). Mixed families have unequal Z0 by
+    construction, so every wave above is divided by ``sqrt(Z0_ref)`` of
+    its own port BEFORE forming ``S[i, j] = b_i / a_j``: reciprocity
+    ``S21 == S12`` of a reciprocal structure then holds and is the
+    committed internal falsifier for this normalization.
+
+    Also returns the extractor-independent |S21| power witness for
+    lumped/wire-driven columns (issue #313 triangulation): the port-cell
+    off-diagonal wave MAGNITUDES are near-field polluted on the default
+    lumped/wire path (measured |S21| 0.52-0.67 vs flux-true 0.97-1.0 on
+    the canonical thru), so ``|a_drive|`` is re-derived from delivered
+    power ``P_del = 0.5*Re(Z_in)*|I|^2`` and ``(1 - |S_jj|^2)`` via the
+    real-Z0 power-wave identity ``P_del = 0.5*|a|^2*(1 - |S11|^2)``.
+
+    Parameters
+    ----------
+    v_lw, i_lw : (n_runs, n_lw, n_freqs) complex
+        FDTD-sign V/I DFT phasors at each lumped/wire port per run.
+    v0_msl, i_msl : (n_runs, n_msl, n_freqs) complex
+        MSL probe-0 line voltage and closed-Ampere-loop current per run.
+    z0_lw : (n_lw,) float — full registered port impedances.
+    n_live_lw : (n_lw,) int — wire live-cell counts (1s for lumped).
+    z0_hj_msl : (n_msl,) float — analytic Hammerstad-Jensen Z0 per port.
+    wire_mode : bool — True when the lumped/wire family is wire ports.
+    drive_plan : list of ("lw"|"msl", local_idx) — run order.
+
+    Returns
+    -------
+    S : (n_tot, n_tot, n_freqs) complex — power-wave S-matrix.
+    s21_power : (n_msl, n_lw, n_freqs) real — |S21| power witness.
+    """
+    v_lw = jnp.asarray(v_lw)
+    i_lw = jnp.asarray(i_lw)
+    v0_msl = jnp.asarray(v0_msl)
+    i_msl = jnp.asarray(i_msl)
+    n_lw = int(v_lw.shape[1])
+    n_msl = int(v0_msl.shape[1])
+    n_tot = n_lw + n_msl
+    n_freqs = int(v_lw.shape[-1])
+    cdt = v_lw.dtype
+    S = jnp.zeros((n_tot, n_tot, n_freqs), dtype=cdt)
+    s21_power = np.zeros((n_msl, n_lw, n_freqs), dtype=np.float64)
+
+    z0c_lw = np.asarray(z0_lw, dtype=np.float64) / np.maximum(
+        np.asarray(n_live_lw, dtype=np.int64), 1
+    )
+    sq_lw = jnp.sqrt(jnp.asarray(z0c_lw))
+    sq_msl = jnp.sqrt(jnp.asarray(np.asarray(z0_hj_msl, dtype=np.float64)))
+
+    def _b_lw_passive(run, i_port):
+        # #308 receive channel, power-wave normalized (probes.py:925/:1014).
+        return (v_lw[run, i_port] - z0c_lw[i_port] * i_lw[run, i_port]) / (
+            2.0 * sq_lw[i_port]
+        )
+
+    def _b_msl(run, p):
+        return (v0_msl[run, p] - z0_hj_msl[p] * i_msl[run, p]) / (
+            2.0 * sq_msl[p]
+        )
+
+    for run, (fam, loc) in enumerate(drive_plan):
+        if fam == "lw":
+            col = loc
+            v_d, i_d = v_lw[run, loc], i_lw[run, loc]
+            # Drive wave — probes.py:913/:1018 (z0_cell for wire).
+            a = (-v_d + z0c_lw[loc] * i_d) / (2.0 * sq_lw[loc])
+            safe_a = jnp.where(jnp.abs(a) > 0, a, jnp.ones_like(a))
+            # Diagonal first (byte-frozen legacy algebra, full Z0).
+            if wire_mode:
+                safe_i = jnp.where(
+                    jnp.abs(i_d) > 0, i_d, jnp.ones_like(i_d) * 1e-30
+                )
+                z_in = -v_d / safe_i
+                s_jj = (z_in - z0_lw[loc]) / (z_in + z0_lw[loc])
+            else:
+                b_diag = (-v_d - z0_lw[loc] * i_d) / (
+                    2.0 * jnp.sqrt(jnp.asarray(z0_lw[loc]))
+                )
+                s_jj = b_diag / safe_a
+            S = S.at[col, col, :].set(s_jj.astype(cdt))
+            for ri in range(n_lw):
+                if ri == loc:
+                    continue
+                S = S.at[ri, col, :].set(
+                    (_b_lw_passive(run, ri) / safe_a).astype(cdt)
+                )
+            # Power witness: |a| from delivered power, not the port-cell
+            # wave magnitude (#313 near-field pollution triangulation).
+            safe_i = jnp.where(
+                jnp.abs(i_d) > 0, i_d, jnp.ones_like(i_d) * 1e-30
+            )
+            z_in = -v_d / safe_i
+            p_del = 0.5 * jnp.real(z_in) * jnp.abs(i_d) ** 2
+            one_minus = jnp.clip(1.0 - jnp.abs(s_jj) ** 2, 1e-9, None)
+            a_recon = jnp.sqrt(jnp.clip(2.0 * p_del, 0.0, None) / one_minus)
+            safe_ar = jnp.where(a_recon > 0, a_recon, jnp.ones_like(a_recon))
+            for p in range(n_msl):
+                b_p = _b_msl(run, p)
+                S = S.at[n_lw + p, col, :].set((b_p / safe_a).astype(cdt))
+                s21_power[p, loc, :] = np.asarray(
+                    jax.lax.stop_gradient(jnp.abs(b_p) / safe_ar),
+                    dtype=np.float64,
+                )
+        else:
+            col = n_lw + loc
+            # MSL drive wave (stage-S1 V*I split), power-wave normalized.
+            a = (v0_msl[run, loc] + z0_hj_msl[loc] * i_msl[run, loc]) / (
+                2.0 * sq_msl[loc]
+            )
+            safe_a = jnp.where(jnp.abs(a) > 0, a, jnp.ones_like(a))
+            for ri in range(n_lw):
+                S = S.at[ri, col, :].set(
+                    (_b_lw_passive(run, ri) / safe_a).astype(cdt)
+                )
+            for p in range(n_msl):
+                S = S.at[n_lw + p, col, :].set(
+                    (_b_msl(run, p) / safe_a).astype(cdt)
+                )
+    return S, s21_power
 
 
 class _SparamMixin:
@@ -2200,6 +2350,573 @@ class _SparamMixin:
             self._probes = saved_probes
             self._internal_probe_indices = saved_internal_probes
             self._dz_profile = _dz_profile_saved
+
+    def compute_mixed_s_matrix(
+        self,
+        *,
+        n_steps: int | None = None,
+        num_periods: float = 40.0,
+        freqs: "jnp.ndarray | None" = None,
+        n_freqs: int = 100,
+        strict_extractor: bool = False,
+        enforce_passivity: bool = True,
+        skip_preflight: bool = False,
+        return_diagnostics: bool = False,
+    ) -> "MixedSMatrixResult":
+        """Mixed-family S-matrix: lumped/wire ports + MSL ports (issue #488).
+
+        End-to-end S-parameters on ONE structure carrying two port
+        families — the first supported pair is a homogeneous lumped OR
+        wire set (``add_port``) together with MSL ports (``add_msl_port``),
+        e.g. a vertical probe feed launching onto a microstrip line.
+
+        Each port is driven in turn (lumped/wire ports first, then MSL
+        ports, registration order within each family); the non-driven
+        lumped/wire ports remain physical matched resistor loads and the
+        non-driven MSL ports are passive probe columns. Extraction reuses
+        the validated per-family wave machinery unchanged and combines the
+        waves in the **Kurokawa power-wave convention** (each wave divided
+        by ``sqrt(Re Z0)`` of its own port) — with unequal reference
+        impedances across families a pseudo-wave ratio would be off by
+        ``sqrt(Z_j/Z_i)`` (issue #460); reciprocity of a reciprocal
+        structure is the committed internal falsifier for this choice.
+
+        HONESTY NOTES (read before quoting numbers):
+
+        * Off-diagonal magnitudes that RECEIVE at a lumped/wire port cell
+          inherit the issue-#313 near-field deflation of the default
+          port-cell waves. The returned ``s21_power_witness`` cross-checks
+          the MSL-receiving direction against an extractor-independent
+          delivered-power normalization; quote it alongside ``|S|``.
+        * Cross-family off-diagonal PHASE mixes two reference-plane
+          conventions (port cell vs de-embedded MSL probe plane) and a
+          component-mixing ±1 (probes.py sign-convention fence);
+          magnitude is the validated observable.
+        * ``settling_db`` is the ring-down witness (above −40 dB =
+          truncation suspect); preflight output is part of the result.
+
+        v1 restrictions (loud ``NotImplementedError``): uniform mesh only,
+        no waveguide/Floquet/coax/TFSF registrations, no bare sources or
+        0-ohm ports (they would fire in every drive run), no
+        ``reference_plane_cells`` wire ports, no mixed lumped+wire set
+        (same fence as the production scan driver), imperative only (no
+        ``eps_override`` AD channel).
+
+        Returns
+        -------
+        MixedSMatrixResult
+        """
+        import dataclasses as _dc
+
+        from rfx.sources.msl_eigenmode import hammerstad_jensen_z0_eps_eff
+        from rfx.sources.msl_port import (
+            MSLPort,
+            _msl_yz_cells,
+            msl_loop_current,
+            msl_probe_x_coords_n,
+        )
+
+        # ---- Registration guards (v1 envelope) --------------------------
+        if not self._msl_ports:
+            raise ValueError(
+                "compute_mixed_s_matrix() needs at least one add_msl_port() "
+                "registration (for a pure lumped/wire multiport use the "
+                "production scan driver / extract_s_matrix)."
+            )
+        lw_entries = [pe for pe in self._ports if pe.impedance != 0.0]
+        if not lw_entries:
+            raise ValueError(
+                "compute_mixed_s_matrix() needs at least one sparam-eligible "
+                "add_port() lumped/wire port (impedance != 0). For a pure "
+                "MSL multiport use compute_msl_s_matrix()."
+            )
+        if any(pe.impedance == 0.0 for pe in self._ports):
+            raise NotImplementedError(
+                "compute_mixed_s_matrix() does not support bare sources / "
+                "0-ohm ports (add_source or add_port(impedance=0)): they "
+                "are not excite-gated and would fire in EVERY drive run, "
+                "contaminating the single-drive S-parameter contract."
+            )
+        if self._waveguide_ports or self._floquet_ports:
+            raise NotImplementedError(
+                "compute_mixed_s_matrix() v1 covers lumped/wire + MSL only; "
+                "waveguide/Floquet ports are not part of the validated "
+                "mixed lane (issue #488)."
+            )
+        if self._coaxial_ports:
+            raise NotImplementedError(
+                "compute_mixed_s_matrix() v1 covers lumped/wire + MSL only; "
+                "coaxial ports need a separate calibration contract."
+            )
+        if self._tfsf is not None:
+            raise NotImplementedError(
+                "compute_mixed_s_matrix() is not supported together with "
+                "TFSF; TFSF is a plane-wave source, not a port."
+            )
+        is_wire = [pe.extent is not None for pe in lw_entries]
+        if any(is_wire) and not all(is_wire):
+            raise NotImplementedError(
+                "compute_mixed_s_matrix(): mixed lumped + wire port sets "
+                "are not supported (the off-diagonal wave-decomposition "
+                "conventions differ — same fence as "
+                "compute_lumped_wire_s_matrix_via_scan)."
+            )
+        wire_mode = all(is_wire)
+        if any(getattr(pe, "reference_plane_cells", None) for pe in lw_entries):
+            raise NotImplementedError(
+                "compute_mixed_s_matrix() v1 does not support "
+                "add_port(reference_plane_cells=...); the mixed lane uses "
+                "the delivered-power witness for magnitude honesty instead."
+            )
+        if (
+            self._dz_profile is not None
+            or self._dx_profile is not None
+            or self._dy_profile is not None
+        ):
+            raise NotImplementedError(
+                "compute_mixed_s_matrix() v1 supports the uniform mesh "
+                "only (issue #488 scope: NU is explicitly out until the "
+                "first pair ships)."
+            )
+        if self._refinement is not None:
+            raise NotImplementedError(
+                "compute_mixed_s_matrix() is not supported with SBP-SAT "
+                "subgridding."
+            )
+        if self._solver == "adi":
+            raise NotImplementedError(
+                "compute_mixed_s_matrix() is not supported with "
+                "solver='adi'; use the uniform Yee solver."
+            )
+
+        n_lw = len(lw_entries)
+        grid = self._build_grid()
+
+        if freqs is None:
+            freqs_arr = np.asarray(
+                jnp.linspace(self._freq_max / 10, self._freq_max, n_freqs)
+            )
+        else:
+            freqs_arr = np.asarray(freqs)
+        n_freqs_used = int(freqs_arr.shape[0])
+        if n_steps is None:
+            n_steps = grid.num_timesteps(num_periods=num_periods)
+
+        # ---- MSL geometry prep (mirrors compute_msl_s_matrix; uniform
+        # lane only, so the NU grid/dz-profile machinery is not needed) ----
+        entries = _resolve_msl_auto_offsets(self, list(self._msl_ports), grid)
+        n_msl = len(entries)
+        msl_ports: list[MSLPort] = []
+        for pe in entries:
+            x_feed, y_centre, z_lo = pe.position
+            msl_ports.append(MSLPort(
+                feed_x=float(x_feed),
+                y_lo=float(y_centre - pe.width / 2),
+                y_hi=float(y_centre + pe.width / 2),
+                z_lo=float(z_lo),
+                z_hi=float(z_lo + pe.height),
+                direction=pe.direction,
+                impedance=pe.impedance,
+                excitation=pe.waveform,
+            ))
+        # Probe-0 x-coordinate per port: the S1 V*I wave split lives at
+        # probe 0 (the de-embedding reference plane); the mixed lane does
+        # not run the N-probe spatial fit, so only probe 0 is recorded.
+        probe_xs = [
+            msl_probe_x_coords_n(
+                grid, mp,
+                n_probes=int(pe.n_probes),
+                n_offset_cells=pe.n_probe_offset,
+                n_spacing_cells=pe.n_probe_spacing,
+            )
+            for mp, pe in zip(msl_ports, entries)
+        ]
+        # Probe-LADDER validation (issue #488 attempt-1 defect D3). The S1
+        # V*I split records probe 0 only, but v1 must not silently accept
+        # a ladder the validated MSL lane rejects: attempt 1 registered a
+        # "+x"-facing port whose default ladder (offset 31 + 4x12 cells)
+        # ran past the declared domain; msl_probe_x_coords_n CLAMPS such
+        # coordinates, and the surviving probe-0 plane sat 1.1 mm from
+        # the trace's open end at the domain edge (a Box is rasterized
+        # only inside the declared domain — the trace does NOT continue
+        # into the CPML padding, so every boundary-touching trace has an
+        # OPEN end there). The plane then measures the open-stub
+        # standing-wave impedance -j*Z0*cot(beta*d) ~ 1/f (~1400 ohm at
+        # 1 GHz vs the 48 ohm line) instead of a travelling wave.
+        # Hard guard: every ladder coordinate strictly inside (0, lx)
+        # and strictly monotonic (clamp shows up as duplicates).
+        # Advisory: probe-0 closer than lambda_g/4 to a domain x-edge.
+        from rfx.api._preflight import msl_min_probe_clearance
+        _lx_dom = float(self._domain[0])
+        _clear = msl_min_probe_clearance(float(self._freq_max))
+        for pe, pxs in zip(entries, probe_xs):
+            xs = [float(x) for x in pxs]
+            mono = all(
+                (xs[q + 1] - xs[q]) * (1 if pe.direction == "+x" else -1)
+                > 0.5 * float(grid.dx)
+                for q in range(len(xs) - 1)
+            )
+            if (not mono) or min(xs) <= 0.0 or max(xs) >= _lx_dom:
+                raise ValueError(
+                    f"compute_mixed_s_matrix: MSL port {pe.name!r} probe "
+                    f"ladder ({', '.join(f'{x * 1e3:.2f}' for x in xs)} mm) "
+                    f"leaves the declared x-domain (0, {_lx_dom * 1e3:.2f}) "
+                    "mm or was clamped at its edge — the equivalent "
+                    "registration is rejected by compute_msl_s_matrix, and "
+                    "a plane near the trace's open end at the domain edge "
+                    "measures the stub standing wave, not the line. Face "
+                    "the port toward the DUT (direction), reduce "
+                    "n_probe_offset/n_probe_spacing, or enlarge the domain."
+                )
+            _edge_d = min(xs[0], _lx_dom - xs[0])
+            if _edge_d < _clear:
+                import warnings as _w488
+                _w488.warn(
+                    f"compute_mixed_s_matrix: MSL port {pe.name!r} probe-0 "
+                    f"plane is {_edge_d * 1e3:.2f} mm from a domain x-edge "
+                    f"(< lambda_g/4 = {_clear * 1e3:.2f} mm at freq_max). "
+                    "A boundary-touching trace has an OPEN end there; "
+                    "standing waves from that discontinuity can bias the "
+                    "V*I split (see the reliable mask).",
+                    stacklevel=2,
+                )
+
+        dy_arr = _msl_cell_profile(grid, "y", grid.ny)
+        dz_arr = _msl_cell_profile(grid, "z", grid.nz)
+        port_idx_meta = []
+        for mp in msl_ports:
+            cells = _msl_yz_cells(grid, mp)
+            j_set = sorted({c[1] for c in cells})
+            k_set = sorted({c[2] for c in cells})
+            j_lo, j_hi = j_set[0], j_set[-1]
+            k_lo, k_hi = k_set[0], k_set[-1]
+            port_idx_meta.append(dict(
+                j_lo=j_lo, j_hi=j_hi, k_lo=k_lo, k_hi=k_hi,
+                j_centre=(j_lo + j_hi) // 2, k_top=k_hi,
+            ))
+
+        # One materials assembly shared by the HJ eps anchor AND every
+        # drive run (materials do not depend on excite flags).
+        materials, debye_spec, lorentz_spec, pec_mask, _, _, _ = \
+            self._assemble_materials(grid)
+        pec_mask_np = None if pec_mask is None else np.asarray(pec_mask)
+
+        # Analytic Hammerstad-Jensen anchor per MSL port (eps precedence
+        # mirrors compute_msl_s_matrix: explicit eps_r_sub > rasterised
+        # eps_r at the trace-centre substrate cell).
+        z0_hj_per_port: list[float] = []
+        for p_idx, pe in enumerate(entries):
+            meta = port_idx_meta[p_idx]
+            if pe.eps_r_sub is not None:
+                eps_r_ref = float(pe.eps_r_sub)
+            else:
+                k_mid = (meta["k_lo"] + meta["k_hi"]) // 2
+                i_feed_p = _msl_yz_cells(grid, msl_ports[p_idx])[0][0]
+                eps_r_ref = float(np.asarray(
+                    materials.eps_r[i_feed_p, meta["j_centre"], k_mid]
+                ))
+            z0_hj, _eps_eff = hammerstad_jensen_z0_eps_eff(
+                pe.width, pe.height, eps_r_ref
+            )
+            z0_hj_per_port.append(float(z0_hj))
+
+        # Trace-conductor z-cell span (closed Ampere loop needs the PEC
+        # trace; mirrors compute_msl_s_matrix issue #80 stage S1).
+        trace_k_per_port: list[tuple[int, int]] = []
+        for p_idx in range(n_msl):
+            meta = port_idx_meta[p_idx]
+            i_feed_p = _msl_yz_cells(grid, msl_ports[p_idx])[0][0]
+            col = (
+                None if pec_mask_np is None
+                else pec_mask_np[i_feed_p, meta["j_centre"], meta["k_top"]:]
+            )
+            k_pec = np.array([], dtype=int) if col is None else np.where(col)[0]
+            if k_pec.size == 0:
+                raise RuntimeError(
+                    "compute_mixed_s_matrix: no PEC trace conductor found "
+                    "above the substrate top for MSL port "
+                    f"{entries[p_idx].name!r}; the closed Ampere-loop "
+                    "current needs the trace PEC. Add the microstrip trace "
+                    "as a Box(material='pec')."
+                )
+            trace_k_per_port.append((
+                int(meta["k_top"] + int(k_pec.min())),
+                int(meta["k_top"] + int(k_pec.max())),
+            ))
+
+        # Wire live-cell counts for the per-cell impedance normalization
+        # (mirrors compute_lumped_wire_s_matrix_via_scan, issue #318).
+        n_live_lw = np.ones(n_lw, dtype=np.int64)
+        if wire_mode:
+            from rfx.sources.sources import WirePort, _wire_port_live_cells
+            axis_map = {"ex": 0, "ey": 1, "ez": 2}
+            for idx, pe in enumerate(lw_entries):
+                end = list(pe.position)
+                end[axis_map[pe.component]] += pe.extent
+                wp = WirePort(
+                    start=pe.position, end=tuple(end),
+                    component=pe.component, impedance=pe.impedance,
+                    excitation=pe.waveform,
+                )
+                n_live_lw[idx] = _wire_port_live_cells(grid, wp, pec_mask)[2]
+
+        if not skip_preflight:
+            # One preflight for the full registration (run() would fire it
+            # per drive run — 2*n_ports repeats of the same advisories).
+            self.preflight()
+
+        drive_plan = [("lw", j) for j in range(n_lw)] + \
+                     [("msl", d) for d in range(n_msl)]
+        n_runs = len(drive_plan)
+        _complex_dtype = (
+            jnp.complex128 if jax.config.x64_enabled else jnp.complex64
+        )
+
+        saved_dft = list(self._dft_planes)
+        saved_msl = list(self._msl_ports)
+        saved_ports = list(self._ports)
+        saved_probes = list(self._probes)
+        saved_internal = set(self._internal_probe_indices)
+        try:
+            # Ring-down settling witness probes at every MSL probe plane,
+            # mid-substrate (worst plane wins — a single plane is
+            # standing-wave-node sensitive; mirrors compute_msl_s_matrix).
+            _witness_base = len(self._probes)
+            _witness_total = 0
+            for pe_w, pxs_w in zip(entries, probe_xs):
+                for _x_w in pxs_w:
+                    self.add_probe(
+                        position=(
+                            float(_x_w),
+                            float(pe_w.position[1]),
+                            float(pe_w.position[2]) + 0.5 * float(pe_w.height),
+                        ),
+                        component="ez",
+                    )
+                    _witness_total += 1
+            self._internal_probe_indices.update(
+                range(_witness_base, _witness_base + _witness_total)
+            )
+            witness_probes = list(self._probes)
+
+            v_lw = np.zeros((n_runs, n_lw, n_freqs_used), dtype=np.complex128)
+            i_lw = np.zeros((n_runs, n_lw, n_freqs_used), dtype=np.complex128)
+            v0_msl = np.zeros((n_runs, n_msl, n_freqs_used), dtype=np.complex128)
+            i_msl = np.zeros((n_runs, n_msl, n_freqs_used), dtype=np.complex128)
+            settling_db_runs = np.full(n_runs, np.nan)
+
+            for run_idx, (fam, loc) in enumerate(drive_plan):
+                # Excite exactly one port; every other port keeps its
+                # physical termination (matched resistor cells for
+                # lumped/wire, passive probe column for MSL). The driven
+                # lumped/wire port's default waveform is synthesised by
+                # the runner (issue #322); the driven MSL port mirrors the
+                # compute_msl_s_matrix default.
+                self._ports = [
+                    _dc.replace(pe, excite=(fam == "lw" and k == loc))
+                    for k, pe in enumerate(saved_ports)
+                ]
+                run_msl = []
+                for k, pe in enumerate(saved_msl):
+                    driven = fam == "msl" and k == loc
+                    wf = (
+                        (pe.waveform if pe.waveform is not None else
+                         GaussianPulse(f0=self._freq_max / 2, bandwidth=0.8))
+                        if driven else None
+                    )
+                    run_msl.append(_dc.replace(pe, excite=driven, waveform=wf))
+                self._msl_ports = run_msl
+                self._probes = list(witness_probes)
+
+                # Per-run named DFT planes: Ez at probe 0 (line voltage),
+                # Hy+Hz at probe 0 (closed Ampere-loop current legs).
+                self._dft_planes = list(saved_dft)
+                names = []
+                for p_idx, pxs in enumerate(probe_xs):
+                    nm = f"_mixed_run{run_idx}_p{p_idx}"
+                    self.add_dft_plane_probe(
+                        axis="x", coordinate=float(pxs[0]), component="ez",
+                        freqs=jnp.asarray(freqs_arr), name=nm + "_ez",
+                    )
+                    self.add_dft_plane_probe(
+                        axis="x", coordinate=float(pxs[0]), component="hy",
+                        freqs=jnp.asarray(freqs_arr), name=nm + "_hy",
+                    )
+                    self.add_dft_plane_probe(
+                        axis="x", coordinate=float(pxs[0]), component="hz",
+                        freqs=jnp.asarray(freqs_arr), name=nm + "_hz",
+                    )
+                    names.append(nm)
+
+                raw = self._forward_from_materials(
+                    grid, materials, debye_spec, lorentz_spec,
+                    n_steps=n_steps, checkpoint=False, pec_mask=pec_mask,
+                    port_s11_freqs=freqs_arr,
+                    _return_raw_port_sparams=True,
+                )
+                accs = raw["wire"] if wire_mode else raw["lumped"]
+                if accs is None or len(accs) != n_lw:
+                    raise RuntimeError(
+                        "compute_mixed_s_matrix: production scan returned "
+                        f"{0 if accs is None else len(accs)} "
+                        f"{'wire' if wire_mode else 'lumped'} accumulators "
+                        f"for run {run_idx}, expected {n_lw}."
+                    )
+                for i_port in range(n_lw):
+                    _spec_i, vi = accs[i_port]
+                    v_lw[run_idx, i_port, :] = np.asarray(vi[0])
+                    i_lw[run_idx, i_port, :] = np.asarray(vi[1])
+
+                planes = raw.get("dft_planes")
+                if not planes:
+                    raise RuntimeError(
+                        "compute_mixed_s_matrix: the production scan "
+                        "returned no DFT planes — the issue-#488 raw hook "
+                        "is out of sync with _forward_from_materials."
+                    )
+
+                # Settling witness from the probe time series (worst
+                # end/peak Ez^2 across the MSL probe planes).
+                _ts = raw.get("time_series")
+                if _ts is not None and not is_tracer(_ts):
+                    _ts_np = np.asarray(
+                        _ts[:, _witness_base:_witness_base + _witness_total],
+                        dtype=float,
+                    )
+                    if (_ts_np.shape[0] >= 10
+                            and _ts_np.shape[1] == _witness_total):
+                        _p = _ts_np ** 2
+                        _tail = max(1, _p.shape[0] // 10)
+                        _end = _p[-_tail:, :].mean(axis=0)
+                        _peak = _p.max(axis=0)
+                        _tiny = np.finfo(float).tiny
+                        settling_db_runs[run_idx] = float(np.max(
+                            10.0 * np.log10((_end + _tiny) / (_peak + _tiny))
+                        ))
+
+                # MSL line V (probe-0 plane) + closed-loop I, with the
+                # leapfrog E/H half-step correction (mirrors
+                # compute_msl_s_matrix line-for-line; see that method for
+                # the full derivation comments).
+                _hs_phase = jnp.exp(
+                    1j * 2.0 * jnp.pi * jnp.asarray(freqs_arr)
+                    * (float(grid.dt) * 0.5)
+                )
+                for p_idx, meta in enumerate(port_idx_meta):
+                    nm = names[p_idx]
+                    ez_plane = jnp.asarray(planes[nm + "_ez"].accumulator)
+                    v_f = jnp.zeros(n_freqs_used, dtype=_complex_dtype)
+                    for k in range(meta["k_lo"], meta["k_hi"] + 1):
+                        v_f = v_f + ez_plane[:, meta["j_centre"], k] \
+                            * float(dz_arr[k])
+                    hy_plane = jnp.asarray(planes[nm + "_hy"].accumulator)
+                    hz_plane = jnp.asarray(planes[nm + "_hz"].accumulator)
+                    hy_plane = hy_plane * _hs_phase[:, None, None].astype(hy_plane.dtype)
+                    hz_plane = hz_plane * _hs_phase[:, None, None].astype(hz_plane.dtype)
+                    k_tr_lo, k_tr_hi = trace_k_per_port[p_idx]
+                    i_f = msl_loop_current(
+                        hy_plane, hz_plane,
+                        j_lo=meta["j_lo"], j_hi=meta["j_hi"],
+                        k_trace_lo=k_tr_lo, k_trace_hi=k_tr_hi,
+                        dy_arr=dy_arr, dz_arr=dz_arr,
+                        direction=msl_ports[p_idx].direction,
+                    )
+                    v0_msl[run_idx, p_idx, :] = np.asarray(v_f)
+                    i_msl[run_idx, p_idx, :] = np.asarray(i_f)
+
+            # ---- Power-wave assembly (pure; unit-tested separately) ----
+            S, s21_power = _assemble_mixed_power_wave_s(
+                v_lw, i_lw, v0_msl, i_msl,
+                np.asarray([pe.impedance for pe in lw_entries]),
+                n_live_lw, np.asarray(z0_hj_per_port),
+                wire_mode, drive_plan,
+            )
+            S = jnp.asarray(S, dtype=_complex_dtype)
+
+            # MSL standing-wave-null reliability from each MSL port's own
+            # driven run (mirrors compute_msl_s_matrix issue #337).
+            reliable = None
+            try:
+                v_port = np.stack([
+                    v0_msl[n_lw + p, p, :] for p in range(n_msl)
+                ])
+                i_port = np.stack([
+                    i_msl[n_lw + p, p, :] for p in range(n_msl)
+                ])
+                reliable = _msl_wave_split_reliability(
+                    v_port, i_port, freqs_arr
+                )
+                _warn_msl_wave_split_unreliable(reliable, freqs_arr)
+            except (ValueError, TypeError):
+                pass
+
+            port_names = tuple(
+                [f"lw{k}" for k in range(n_lw)]
+                + [pe.name for pe in entries]
+            )
+            port_families = tuple(
+                [("wire" if wire_mode else "lumped")] * n_lw
+                + ["msl"] * n_msl
+            )
+            z0_ref = np.asarray(
+                [float(pe.impedance) for pe in lw_entries]
+                + z0_hj_per_port
+            )
+
+            s_raw = None
+            passivity_correction = None
+            if enforce_passivity and not is_tracer(S):
+                s_projected, correction = _project_passive(S)
+                if bool(np.any(np.asarray(correction) > 0.0)):
+                    s_raw = S
+                    passivity_correction = correction
+                    S = s_projected
+
+            result = MixedSMatrixResult(
+                S=S,
+                freqs=np.asarray(freqs_arr),
+                port_names=port_names,
+                port_families=port_families,
+                z0_ref=z0_ref,
+                settling_db=settling_db_runs,
+                s21_power_witness=s21_power,
+                reliable=reliable,
+                S_raw=s_raw,
+                passivity_correction=passivity_correction,
+            )
+            _warn_if_ringdown_truncated(
+                settling_db_runs, port_names, num_periods=num_periods,
+            )
+            if passivity_correction is not None and not is_tracer(passivity_correction):
+                _warn_if_passivity_projected(passivity_correction, freqs_arr)
+            import dataclasses as _dc2
+            audit_result = (
+                result if s_raw is None else _dc2.replace(result, S=s_raw)
+            )
+            _warn_if_nonpassive_smatrix(
+                audit_result,
+                extractor="compute_mixed_s_matrix",
+                strict=strict_extractor,
+                passivity_tol=0.10,
+            )
+            if return_diagnostics:
+                # R5 inspection surface: the raw per-run phasors behind
+                # every wave, so a suspicious |S| can be traced to V/I
+                # health (e.g. a broken Ampere loop shows as v0/i far
+                # from the line Z0) without re-running.
+                return result, {
+                    "v_lw": v_lw, "i_lw": i_lw,
+                    "v0_msl": v0_msl, "i_msl": i_msl,
+                    "drive_plan": drive_plan,
+                    "z0_hj_msl": np.asarray(z0_hj_per_port),
+                }
+            return result
+        finally:
+            self._dft_planes = saved_dft
+            self._msl_ports = saved_msl
+            self._ports = saved_ports
+            self._probes = saved_probes
+            self._internal_probe_indices = saved_internal
 
     def compute_coaxial_s_matrix(
         self,

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -770,6 +770,66 @@ def _assemble_mixed_power_wave_s(
     return S, s21_power
 
 
+def _mixed_flux_magnitude_override(
+    S_wave, box_lw, plane_msl, drive_plan, msl_away_signs, n_lw,
+    ill_cond_floor=0.05,
+):
+    """Replace off-diagonal MAGNITUDES with Poynting-flux ratios (issue #488).
+
+    Pure function (unit-testable without FDTD). Per driven column j:
+
+        P_inc,j  = max(P_net,j, 0) / max(1 - |S_jj|^2, floor)
+        |S_ij|   = sqrt(max(P_arr,i, 0) / P_inc,j)
+        S_out[i,j] = |S_ij| * exp(1j * arg(S_wave[i,j]))   (phase kept)
+
+    with P_net,j the net flux leaving the driven port through its own
+    surface (outward box for lumped/wire; away-signed plane for MSL) and
+    P_arr,i the toward-port flux at receive port i (inward box / toward-
+    signed plane). Diagonals are NOT touched — they stay on the validated
+    per-family channels. The identity P_net = P_inc*(1-|S_jj|^2) holds for
+    the net flow at ANY closed surface / cross-section around the driven
+    port, so no Z0 anchor enters the magnitude (the point of arch A: both
+    the #313 port-cell V*I accounting and the analytic-vs-measured MSL Z0
+    divergence drop out).
+
+    Returns (S_out, ill_cond_cols, neg_pnet_cols): boolean per-column
+    masks marking bins where 1-|S_jj|^2 < ill_cond_floor (normalization
+    unreliable — near-total reflection) and where the raw P_net was
+    negative (sign/accounting defect; clipped to 0).
+    """
+    S_wave = jnp.asarray(S_wave)
+    n_tot = int(S_wave.shape[0])
+    n_freqs = int(S_wave.shape[-1])
+    S_out = S_wave
+    ill_cond = np.zeros((n_tot, n_freqs), dtype=bool)
+    neg_pnet = np.zeros((n_tot, n_freqs), dtype=bool)
+    for run_idx, (fam, loc) in enumerate(drive_plan):
+        col = loc if fam == "lw" else n_lw + loc
+        s_jj = np.asarray(jax.lax.stop_gradient(S_wave[col, col, :]))
+        one_minus = 1.0 - np.abs(s_jj) ** 2
+        ill_cond[col, :] = one_minus < ill_cond_floor
+        if fam == "lw":
+            p_net = box_lw[run_idx, loc, :]
+        else:
+            p_net = msl_away_signs[loc] * plane_msl[run_idx, loc, :]
+        neg_pnet[col, :] = p_net < 0.0
+        p_inc = np.clip(p_net, 0.0, None) / np.clip(one_minus, ill_cond_floor, None)
+        safe_pinc = np.where(p_inc > 0.0, p_inc, np.inf)
+        for i in range(n_tot):
+            if i == col:
+                continue
+            if i < n_lw:
+                p_arr = -box_lw[run_idx, i, :]          # inward = -outward
+            else:
+                p_arr = -msl_away_signs[i - n_lw] * plane_msl[run_idx, i - n_lw, :]
+            mag = np.sqrt(np.clip(p_arr, 0.0, None) / safe_pinc)
+            ph = jnp.exp(1j * jnp.angle(S_wave[i, col, :]))
+            S_out = S_out.at[i, col, :].set(
+                (jnp.asarray(mag) * ph).astype(S_wave.dtype)
+            )
+    return S_out, ill_cond, neg_pnet
+
+
 class _SparamMixin:
     """S-parameter extraction methods mixed into :class:`Simulation`."""
 
@@ -2362,6 +2422,7 @@ class _SparamMixin:
         enforce_passivity: bool = True,
         skip_preflight: bool = False,
         return_diagnostics: bool = False,
+        magnitude_channel: str = "flux",
     ) -> "MixedSMatrixResult":
         """Mixed-family S-matrix: lumped/wire ports + MSL ports (issue #488).
 
@@ -2381,13 +2442,51 @@ class _SparamMixin:
         ``sqrt(Z_j/Z_i)`` (issue #460); reciprocity of a reciprocal
         structure is the committed internal falsifier for this choice.
 
+        MAGNITUDE CHANNEL (``magnitude_channel``, default ``"flux"``):
+        the #488 falsifier battery + an independent Poynting-flux referee
+        measured the port-cell V*I accounting undercounting delivered
+        power ~3x at a wire probe feed (the OPEN issue-#313 class) and
+        the analytic Hammerstad-Jensen Z0 anchor diverging from the
+        measured line ratio on an interface-aligned mesh. Off-diagonal
+        MAGNITUDES are therefore taken from Poynting flux by default:
+        auto-registered surfaces (a closed 5-face box around each
+        lumped/wire port over the z-lo ground; a full cross-section plane
+        at each MSL port's probe-0 x) give per-drive net powers, and
+
+            |S_ij|^2 = P_arrive,i / (P_net,j / (1 - |S_jj|^2))
+
+        with the VALIDATED per-family diagonal S_jj (a local ratio at one
+        cell — immune to the #313 magnitude class) supplying the
+        reflection correction; no Z0 anchor enters the magnitude.
+        Off-diagonal PHASE still comes from the wave channel (see below).
+        ``magnitude_channel="wave"`` keeps the raw power-wave magnitudes
+        (diagnostic; carries the #313 deflation at lumped/wire ports).
+
         HONESTY NOTES (read before quoting numbers):
 
-        * Off-diagonal magnitudes that RECEIVE at a lumped/wire port cell
-          inherit the issue-#313 near-field deflation of the default
-          port-cell waves. The returned ``s21_power_witness`` cross-checks
-          the MSL-receiving direction against an extractor-independent
-          delivered-power normalization; quote it alongside ``|S|``.
+        * The flux magnitudes inherit a flux-accounting envelope (box
+          leakage + finite DFT; the Phase-0 referee class measured ~1.3%
+          on the canonical thru) and an ill-conditioning guard: when
+          ``1 - |S_jj|^2`` is small (near-total reflection at the driven
+          port) the normalization is unreliable and a warning names the
+          column.
+        * **A per-column power sum near 1 is NOT evidence on this
+          channel.** Substituting the definition gives
+          ``sum_i |S_ij|^2 = |S_jj|^2 + (P_arr/P_net)(1 - |S_jj|^2)``,
+          which is identically 1 whenever the arriving power equals the
+          net launched power — for ANY value of the diagonal. The flux
+          normalization makes passivity an identity, not a measurement,
+          so do not quote column power as a passivity check here (it
+          still detects power GAIN, i.e. ``P_arr > P_net``). The
+          independent internal check on this channel is RECIPROCITY:
+          ``S_ij`` and ``S_ji`` come from different runs with different
+          normalizations, so their agreement is real evidence.
+        * With ``magnitude_channel="wave"``, off-diagonal magnitudes that
+          RECEIVE at a lumped/wire port cell inherit the issue-#313
+          near-field deflation of the default port-cell waves. The
+          returned ``s21_power_witness`` cross-checks the MSL-receiving
+          direction against a delivered-power normalization; quote it
+          alongside ``|S|``.
         * Cross-family off-diagonal PHASE mixes two reference-plane
           conventions (port cell vs de-embedded MSL probe plane) and a
           component-mixing ±1 (probes.py sign-convention fence);
@@ -2605,6 +2704,9 @@ class _SparamMixin:
         # mirrors compute_msl_s_matrix: explicit eps_r_sub > rasterised
         # eps_r at the trace-centre substrate cell).
         z0_hj_per_port: list[float] = []
+        beta0_per_port: list[np.ndarray] = []
+        from rfx.core.yee import EPS_0 as _EPS_0, MU_0 as _MU_0
+        _c0_mixed = 1.0 / float(np.sqrt(_MU_0 * _EPS_0))
         for p_idx, pe in enumerate(entries):
             meta = port_idx_meta[p_idx]
             if pe.eps_r_sub is not None:
@@ -2615,10 +2717,14 @@ class _SparamMixin:
                 eps_r_ref = float(np.asarray(
                     materials.eps_r[i_feed_p, meta["j_centre"], k_mid]
                 ))
-            z0_hj, _eps_eff = hammerstad_jensen_z0_eps_eff(
+            z0_hj, eps_eff_hj = hammerstad_jensen_z0_eps_eff(
                 pe.width, pe.height, eps_r_ref
             )
             z0_hj_per_port.append(float(z0_hj))
+            beta0_per_port.append(
+                2.0 * np.pi * freqs_arr * float(np.sqrt(eps_eff_hj))
+                / _c0_mixed
+            )
 
         # Trace-conductor z-cell span (closed Ampere loop needs the PEC
         # trace; mirrors compute_msl_s_matrix issue #80 stage S1).
@@ -2665,6 +2771,12 @@ class _SparamMixin:
             # per drive run — 2*n_ports repeats of the same advisories).
             self.preflight()
 
+        if magnitude_channel not in ("flux", "wave"):
+            raise ValueError(
+                "compute_mixed_s_matrix: magnitude_channel must be 'flux' "
+                f"(default) or 'wave', got {magnitude_channel!r}."
+            )
+
         drive_plan = [("lw", j) for j in range(n_lw)] + \
                      [("msl", d) for d in range(n_msl)]
         n_runs = len(drive_plan)
@@ -2677,6 +2789,7 @@ class _SparamMixin:
         saved_ports = list(self._ports)
         saved_probes = list(self._probes)
         saved_internal = set(self._internal_probe_indices)
+        saved_flux = list(self._flux_monitors)
         try:
             # Ring-down settling witness probes at every MSL probe plane,
             # mid-substrate (worst plane wins — a single plane is
@@ -2699,11 +2812,60 @@ class _SparamMixin:
             )
             witness_probes = list(self._probes)
 
+            # Flux surfaces for the magnitude channel (registered once —
+            # geometry is drive-independent). Lumped/wire port p: a closed
+            # 5-face box over the z-lo ground plane (flux through the PEC
+            # ground face is identically zero); outward-signed face list.
+            # MSL port p: one full-cross-section x-plane at probe 0 (its
+            # de-embedding reference plane).
+            flux_faces_lw: list[list[tuple[str, float]]] = []
+            flux_names_msl: list[str] = []
+            if magnitude_channel == "flux":
+                _m = 3.0 * float(grid.dx)
+                for p, pe in enumerate(lw_entries):
+                    x0_p, y0_p, _z0p = (float(c) for c in pe.position)
+                    z_top = float(pe.extent or grid.dx) + _m
+                    faces = []
+                    for ax, coord, size, center, sgn in (
+                        ("x", x0_p - _m, (2 * _m, z_top), (y0_p, z_top / 2), -1.0),
+                        ("x", x0_p + _m, (2 * _m, z_top), (y0_p, z_top / 2), +1.0),
+                        ("y", y0_p - _m, (2 * _m, z_top), (x0_p, z_top / 2), -1.0),
+                        ("y", y0_p + _m, (2 * _m, z_top), (x0_p, z_top / 2), +1.0),
+                        ("z", z_top, (2 * _m, 2 * _m), (x0_p, y0_p), +1.0),
+                    ):
+                        nm = f"_mixed_flux_lw{p}_{ax}{'+' if sgn > 0 else '-'}{coord:.6g}"
+                        self.add_flux_monitor(
+                            axis=ax, coordinate=float(coord),
+                            freqs=jnp.asarray(freqs_arr),
+                            size=(float(size[0]), float(size[1])),
+                            center=(float(center[0]), float(center[1])),
+                            name=nm,
+                        )
+                        faces.append((nm, sgn))
+                    flux_faces_lw.append(faces)
+                for p, pxs in enumerate(probe_xs):
+                    nm = f"_mixed_flux_msl{p}"
+                    self.add_flux_monitor(
+                        axis="x", coordinate=float(pxs[0]),
+                        freqs=jnp.asarray(freqs_arr), name=nm,
+                    )
+                    flux_names_msl.append(nm)
+
             v_lw = np.zeros((n_runs, n_lw, n_freqs_used), dtype=np.complex128)
             i_lw = np.zeros((n_runs, n_lw, n_freqs_used), dtype=np.complex128)
             v0_msl = np.zeros((n_runs, n_msl, n_freqs_used), dtype=np.complex128)
             i_msl = np.zeros((n_runs, n_msl, n_freqs_used), dtype=np.complex128)
+            _n_probes_max = max(len(pxs) for pxs in probe_xs)
+            v_lad = np.zeros(
+                (n_runs, n_msl, _n_probes_max, n_freqs_used),
+                dtype=np.complex128,
+            )
             settling_db_runs = np.full(n_runs, np.nan)
+            # Signed per-run flux accountings (magnitude_channel="flux"):
+            # box_lw[run, p]  = net OUTWARD box flux at lumped/wire port p
+            # plane_msl[run, p] = raw +x-directed flux at MSL port p's plane
+            box_lw = np.zeros((n_runs, n_lw, n_freqs_used))
+            plane_msl = np.zeros((n_runs, n_msl, n_freqs_used))
 
             for run_idx, (fam, loc) in enumerate(drive_plan):
                 # Excite exactly one port; every other port keeps its
@@ -2734,10 +2896,16 @@ class _SparamMixin:
                 names = []
                 for p_idx, pxs in enumerate(probe_xs):
                     nm = f"_mixed_run{run_idx}_p{p_idx}"
-                    self.add_dft_plane_probe(
-                        axis="x", coordinate=float(pxs[0]), component="ez",
-                        freqs=jnp.asarray(freqs_arr), name=nm + "_ez",
-                    )
+                    # Full ez ladder: probe 0 feeds the V*I wave split;
+                    # the N-probe least-squares fit (measured line Zc for
+                    # the MSL diagonal — see the z0_fit block below) needs
+                    # every plane.
+                    for q_idx, x_c in enumerate(pxs):
+                        self.add_dft_plane_probe(
+                            axis="x", coordinate=float(x_c), component="ez",
+                            freqs=jnp.asarray(freqs_arr),
+                            name=nm + f"_ez{q_idx}",
+                        )
                     self.add_dft_plane_probe(
                         axis="x", coordinate=float(pxs[0]), component="hy",
                         freqs=jnp.asarray(freqs_arr), name=nm + "_hy",
@@ -2775,6 +2943,28 @@ class _SparamMixin:
                         "is out of sync with _forward_from_materials."
                     )
 
+                if magnitude_channel == "flux":
+                    from rfx.probes.probes import flux_spectrum
+                    fmon = raw.get("flux_monitors")
+                    if not fmon:
+                        raise RuntimeError(
+                            "compute_mixed_s_matrix: the production scan "
+                            "returned no flux monitors — the issue-#488 "
+                            "flux hook is out of sync with "
+                            "_forward_from_materials."
+                        )
+                    for p, faces in enumerate(flux_faces_lw):
+                        acc = np.zeros(n_freqs_used)
+                        for nm, sgn in faces:
+                            acc = acc + sgn * np.asarray(
+                                flux_spectrum(fmon[nm]), dtype=np.float64
+                            )
+                        box_lw[run_idx, p, :] = acc
+                    for p, nm in enumerate(flux_names_msl):
+                        plane_msl[run_idx, p, :] = np.asarray(
+                            flux_spectrum(fmon[nm]), dtype=np.float64
+                        )
+
                 # Settling witness from the probe time series (worst
                 # end/peak Ez^2 across the MSL probe planes).
                 _ts = raw.get("time_series")
@@ -2804,11 +2994,16 @@ class _SparamMixin:
                 )
                 for p_idx, meta in enumerate(port_idx_meta):
                     nm = names[p_idx]
-                    ez_plane = jnp.asarray(planes[nm + "_ez"].accumulator)
-                    v_f = jnp.zeros(n_freqs_used, dtype=_complex_dtype)
-                    for k in range(meta["k_lo"], meta["k_hi"] + 1):
-                        v_f = v_f + ez_plane[:, meta["j_centre"], k] \
-                            * float(dz_arr[k])
+                    for q_idx in range(len(probe_xs[p_idx])):
+                        ez_plane = jnp.asarray(
+                            planes[nm + f"_ez{q_idx}"].accumulator
+                        )
+                        v_q = jnp.zeros(n_freqs_used, dtype=_complex_dtype)
+                        for k in range(meta["k_lo"], meta["k_hi"] + 1):
+                            v_q = v_q + ez_plane[:, meta["j_centre"], k] \
+                                * float(dz_arr[k])
+                        v_lad[run_idx, p_idx, q_idx, :] = np.asarray(v_q)
+                    v_f = jnp.asarray(v_lad[run_idx, p_idx, 0, :])
                     hy_plane = jnp.asarray(planes[nm + "_hy"].accumulator)
                     hz_plane = jnp.asarray(planes[nm + "_hz"].accumulator)
                     hy_plane = hy_plane * _hs_phase[:, None, None].astype(hy_plane.dtype)
@@ -2832,6 +3027,111 @@ class _SparamMixin:
                 wire_mode, drive_plan,
             )
             S = jnp.asarray(S, dtype=_complex_dtype)
+
+            # ---- Measured line Zc for the MSL diagonals ----------------
+            # Documented deviation from compute_msl_s_matrix's analytic
+            # z0_hj anchor: on the mixed lane's interface-aligned fixtures
+            # the analytic anchor diverged from the discretized line
+            # (arch-A battery: an understated |S22| broke lossless-
+            # reciprocal consistency |S11| == |S22| and carried the whole
+            # 9% reciprocity residual). The N-probe least-squares fit
+            # measures Zc(f) from the recorded ez ladder; per-bin fallback
+            # to z0_hj where the fit is unreliable.
+            from rfx.probes.msl_wave_decomp import extract_msl_nprobe
+            z0_msl_meas = np.tile(
+                np.asarray(z0_hj_per_port, dtype=float)[:, None],
+                (1, n_freqs_used),
+            )
+            for d in range(n_msl):
+                run_d = n_lw + d
+                n_p = len(probe_xs[d])
+                res_fit = extract_msl_nprobe(
+                    jnp.asarray(v_lad[run_d, d, :n_p, :].T),
+                    jnp.asarray(np.asarray(probe_xs[d], dtype=float)),
+                    jnp.asarray(i_msl[run_d, d, :]),
+                    jnp.asarray(beta0_per_port[d]),
+                    z0_hj=z0_hj_per_port[d],
+                )
+                # #140 sign convention: msl_loop_current negates only for
+                # "+x" ports; mirror so the reported Zc is positive-real.
+                dir_sign = 1.0 if entries[d].direction == "+x" else -1.0
+                zc = np.real(np.asarray(
+                    jax.lax.stop_gradient(res_fit["z0"])
+                )) * dir_sign
+                ok = np.isfinite(zc) & (zc > 5.0) & (zc < 500.0)
+                z0_msl_meas[d, :] = np.where(ok, zc, z0_hj_per_port[d])
+                # Soft caveat, mirroring compute_msl_s_matrix's _Z0_TOL
+                # pattern: the [5, 500] ohm guard above is a sanity floor,
+                # NOT a settling check — measured on this lane, the same
+                # fixture fits 47.9 ohm at num_periods=40 but scatters over
+                # 57-82 ohm at num_periods=4. A large deviation from the
+                # analytic anchor therefore usually means the record is
+                # under-settled (check settling_db), not that the line is
+                # exotic. Warn; never clamp the measurement to the
+                # assumption.
+                _dev = float(np.max(
+                    np.abs(z0_msl_meas[d, :] - z0_hj_per_port[d])
+                    / z0_hj_per_port[d]
+                ))
+                if _dev > 0.10:
+                    import warnings as _wz
+                    _wz.warn(
+                        f"compute_mixed_s_matrix: measured line Zc for MSL "
+                        f"port {entries[d].name!r} deviates up to "
+                        f"{_dev * 100:.1f}% from analytic Hammerstad-Jensen "
+                        f"{z0_hj_per_port[d]:.2f} ohm. The N-probe fit needs "
+                        "a SETTLED record (same fixture: 47.9 ohm at "
+                        "num_periods=40 vs 57-82 ohm at num_periods=4) — "
+                        "check settling_db before trusting the MSL "
+                        "diagonal, and on coarse meshes expect genuine "
+                        "Yee-staircase Z0 bias on top.",
+                        stacklevel=2,
+                    )
+                v_d = v0_msl[run_d, d, :]
+                i_d = i_msl[run_d, d, :]
+                den = v_d + z0_msl_meas[d, :] * i_d
+                den = np.where(np.abs(den) > 0, den, 1e-30)
+                s_dd = (v_d - z0_msl_meas[d, :] * i_d) / den
+                S = S.at[n_lw + d, n_lw + d, :].set(
+                    jnp.asarray(s_dd).astype(_complex_dtype)
+                )
+            s_wave_full = None
+
+            if magnitude_channel == "flux":
+                import warnings as _wf
+                s_wave_full = np.asarray(jax.lax.stop_gradient(S))
+                msl_away = [
+                    (+1.0 if pe.direction == "+x" else -1.0) for pe in entries
+                ]
+                S, _ill_cond, _neg_pnet = _mixed_flux_magnitude_override(
+                    S, box_lw, plane_msl, drive_plan, msl_away, n_lw,
+                )
+                S = jnp.asarray(S, dtype=_complex_dtype)
+                for col in range(n_lw + n_msl):
+                    n_ill = int(_ill_cond[col].sum())
+                    if n_ill:
+                        _wf.warn(
+                            f"compute_mixed_s_matrix: flux magnitude for "
+                            f"driven port index {col} is ill-conditioned at "
+                            f"{n_ill}/{n_freqs_used} bins "
+                            f"(1 - |S_jj|^2 < 0.05 — near-total reflection; "
+                            "the incident-power reconstruction divides by "
+                            "almost nothing). Off-diagonals of that column "
+                            "are UNRELIABLE at those bins.",
+                            stacklevel=2,
+                        )
+                    n_neg = int(_neg_pnet[col].sum())
+                    if n_neg:
+                        _wf.warn(
+                            f"compute_mixed_s_matrix: NET flux at driven "
+                            f"port index {col} is NEGATIVE at "
+                            f"{n_neg}/{n_freqs_used} bins — a sign or "
+                            "accounting defect in the flux surfaces (power "
+                            "cannot flow INTO a driven passive-terminated "
+                            "port net). Clipped to zero; treat the column "
+                            "as an extraction failure, not physics.",
+                            stacklevel=2,
+                        )
 
             # MSL standing-wave-null reliability from each MSL port's own
             # driven run (mirrors compute_msl_s_matrix issue #337).
@@ -2883,6 +3183,8 @@ class _SparamMixin:
                 reliable=reliable,
                 S_raw=s_raw,
                 passivity_correction=passivity_correction,
+                S_wave=s_wave_full,
+                magnitude_channel=magnitude_channel,
             )
             _warn_if_ringdown_truncated(
                 settling_db_runs, port_names, num_periods=num_periods,
@@ -2909,6 +3211,9 @@ class _SparamMixin:
                     "v0_msl": v0_msl, "i_msl": i_msl,
                     "drive_plan": drive_plan,
                     "z0_hj_msl": np.asarray(z0_hj_per_port),
+                    "z0_msl_measured": z0_msl_meas,
+                    "box_lw_flux": box_lw,
+                    "plane_msl_flux": plane_msl,
                 }
             return result
         finally:
@@ -2917,6 +3222,7 @@ class _SparamMixin:
             self._ports = saved_ports
             self._probes = saved_probes
             self._internal_probe_indices = saved_internal
+            self._flux_monitors = saved_flux
 
     def compute_coaxial_s_matrix(
         self,

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -1385,6 +1385,11 @@ class MixedSMatrixResult:
     reliable: np.ndarray | None = None
     S_raw: np.ndarray | None = None
     passivity_correction: np.ndarray | None = None
+    # Arch-A magnitude channel (issue #488): off-diagonal magnitudes come
+    # from Poynting flux by default; ``S_wave`` keeps the raw power-wave
+    # matrix for comparison (None when magnitude_channel="wave").
+    S_wave: np.ndarray | None = None
+    magnitude_channel: str = "wave"
 
 
 __all__ = [

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -1328,6 +1328,65 @@ class MSLSMatrixResult:
     passivity_correction: np.ndarray | None = None
 
 
+@dataclass
+class MixedSMatrixResult:
+    """Mixed-family S-matrix result (issue #488, lumped/wire + MSL v1).
+
+    Unlike the per-family extractors, ``S`` here is in the **Kurokawa
+    power-wave convention** (every wave amplitude divided by
+    ``sqrt(Re(Z0_port))``): with unequal reference impedances across
+    families a pseudo-wave ``b/a`` ratio is off by ``sqrt(Z_j/Z_i)``
+    (issue #460), so the mixed lane normalizes to power waves by
+    construction. Off-diagonal PHASE across families is provisional —
+    the lumped/wire cell and the MSL de-embedded plane are different
+    reference-plane conventions (magnitude is the validated observable).
+
+    Attributes
+    ----------
+    S : (n_ports, n_ports, n_freqs) complex
+        Power-wave S-matrix; ``S[i, j]`` = response at port *i* driving
+        port *j*. Port order: lumped/wire ports (registration order),
+        then MSL ports (registration order).
+    freqs : (n_freqs,) float
+        Frequency grid in Hz.
+    port_names : tuple of str
+        Combined port names (lumped/wire ports are auto-named
+        ``"lw<k>"``; MSL ports keep their registered names).
+    port_families : tuple of str
+        ``"lumped"`` / ``"wire"`` / ``"msl"`` per port, same order.
+    z0_ref : (n_ports,) float
+        Power-wave reference impedance per port: the registered port
+        impedance for lumped/wire, analytic Hammerstad-Jensen Z0 for MSL.
+    settling_db : (n_ports,) float, optional
+        Ring-down settling witness per driven-port run (worst end/peak
+        Ez^2 over the MSL probe planes, dB; above -40 dB = truncation
+        suspect, same convention as :class:`MSLSMatrixResult`).
+    s21_power_witness : np.ndarray | None
+        (n_msl, n_lw, n_freqs) real — extractor-independent |S21|
+        cross-check for lumped/wire-driven columns: the MSL arriving
+        power-wave magnitude over ``|a_drive|`` reconstructed from the
+        delivered power ``P_del = 0.5*Re(Z_in)*|I|^2`` and
+        ``(1 - |S_jj|^2)`` (does not trust the port-cell a-wave
+        magnitude; issue #313 triangulation).
+    reliable : np.ndarray | None
+        (n_msl, n_freqs) bool — MSL standing-wave-null reliability mask
+        from each MSL port's own driven run (False = ill-conditioned bin).
+    S_raw / passivity_correction :
+        As in :class:`MSLSMatrixResult` — set only when the passivity
+        projection touched at least one bin.
+    """
+    S: np.ndarray
+    freqs: np.ndarray
+    port_names: tuple[str, ...]
+    port_families: tuple[str, ...]
+    z0_ref: np.ndarray
+    settling_db: np.ndarray | None = None
+    s21_power_witness: np.ndarray | None = None
+    reliable: np.ndarray | None = None
+    S_raw: np.ndarray | None = None
+    passivity_correction: np.ndarray | None = None
+
+
 __all__ = [
     "MATERIAL_LIBRARY",
     "AD_MemoryEstimate",
@@ -1355,4 +1414,5 @@ __all__ = [
     "CoaxialLineReflectionResult",
     "_MSLPortEntry",
     "MSLSMatrixResult",
+    "MixedSMatrixResult",
 ]

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -59,6 +59,71 @@ def _reconstruct_oblique_physical(sim_result, tfsf_cfg, grid, probes):
     return sim_result._replace(state=new_state, time_series=new_ts)
 
 
+def build_flux_monitor_cfgs(sim, grid, n_steps):
+    """Materialize ``sim._flux_monitors`` entries into scan monitor configs.
+
+    Mechanical extraction of the historical ``run_uniform`` inline block so
+    the low-level forward lane (``_forward_from_materials``, issue-#488
+    mixed-family flux magnitude channel) can register the SAME monitors
+    the run() lane does. Pure function of (sim registrations, grid,
+    n_steps) — keep byte-identical to the pre-extraction block.
+    """
+    axis_to_index = {"x": 0, "y": 1, "z": 2}
+    flux_monitors = []
+    for pe in getattr(sim, '_flux_monitors', []):
+        axis_idx = axis_to_index[pe.axis]
+        plane_pos = [0.0, 0.0, 0.0]
+        plane_pos[axis_idx] = pe.coordinate
+        grid_index = grid.position_to_index(tuple(plane_pos))[axis_idx]
+        freqs_arr = (
+            pe.freqs
+            if pe.freqs is not None
+            else jnp.linspace(sim._freq_max / 10, sim._freq_max, pe.n_freqs)
+        )
+        # Compute tangential index bounds from size (finite flux region)
+        tangential_axes = [a for a in range(3) if a != axis_idx]
+        domain_sizes = [sim._domain[a] for a in tangential_axes]
+        grid_ns = [grid.shape[a] for a in tangential_axes]
+        if pe.size is not None:
+            # User-specified or default center (domain midpoint)
+            user_center = pe.center if hasattr(pe, 'center') and pe.center is not None else None
+            bounds = []
+            for idx_t, (s, dom, n) in enumerate(zip(pe.size, domain_sizes, grid_ns)):
+                c = user_center[idx_t] if user_center is not None else dom / 2.0
+                pad = getattr(
+                    grid,
+                    ['pad_x_lo', 'pad_y_lo', 'pad_z_lo'][tangential_axes[idx_t]],
+                    0,
+                )
+                # Convert physical coordinate to grid index (add CPML padding offset)
+                lo = max(0, int(round(c / grid.dx - s / (2.0 * grid.dx))) + pad)
+                hi = min(n, int(round(c / grid.dx + s / (2.0 * grid.dx))) + pad)
+                bounds.append((lo, hi))
+            lo1, hi1 = bounds[0]
+            lo2, hi2 = bounds[1]
+        else:
+            lo1, hi1 = 0, grid_ns[0]
+            lo2, hi2 = 0, grid_ns[1]
+        flux_monitors.append(
+            init_flux_monitor(
+                axis=axis_idx,
+                index=grid_index,
+                freqs=freqs_arr,
+                grid_shape=grid.shape,
+                # Grid is cubic (single dx) — both tangential cell sizes
+                # equal grid.dx. If Grid ever becomes non-cubic, select
+                # the two tangential sizes by axis_idx here.
+                d1=grid.dx,
+                d2=grid.dx,
+                dft_total_steps=n_steps,
+                dft_window=getattr(pe, 'dft_window', 'rect'),
+                dft_window_alpha=getattr(pe, 'dft_window_alpha', 0.25),
+                lo1=lo1, hi1=hi1, lo2=lo2, hi2=hi2,
+            )
+        )
+    return flux_monitors
+
+
 def run_uniform(
     sim,
     *,
@@ -417,58 +482,7 @@ def run_uniform(
         )
 
     # Flux monitors (Poynting flux through plane)
-    flux_monitors = []
-    for pe in getattr(sim, '_flux_monitors', []):
-        axis_idx = axis_to_index[pe.axis]
-        plane_pos = [0.0, 0.0, 0.0]
-        plane_pos[axis_idx] = pe.coordinate
-        grid_index = grid.position_to_index(tuple(plane_pos))[axis_idx]
-        freqs_arr = (
-            pe.freqs
-            if pe.freqs is not None
-            else jnp.linspace(sim._freq_max / 10, sim._freq_max, pe.n_freqs)
-        )
-        # Compute tangential index bounds from size (finite flux region)
-        tangential_axes = [a for a in range(3) if a != axis_idx]
-        domain_sizes = [sim._domain[a] for a in tangential_axes]
-        grid_ns = [grid.shape[a] for a in tangential_axes]
-        if pe.size is not None:
-            # User-specified or default center (domain midpoint)
-            user_center = pe.center if hasattr(pe, 'center') and pe.center is not None else None
-            bounds = []
-            for idx_t, (s, dom, n) in enumerate(zip(pe.size, domain_sizes, grid_ns)):
-                c = user_center[idx_t] if user_center is not None else dom / 2.0
-                pad = getattr(
-                    grid,
-                    ['pad_x_lo', 'pad_y_lo', 'pad_z_lo'][tangential_axes[idx_t]],
-                    0,
-                )
-                # Convert physical coordinate to grid index (add CPML padding offset)
-                lo = max(0, int(round(c / grid.dx - s / (2.0 * grid.dx))) + pad)
-                hi = min(n, int(round(c / grid.dx + s / (2.0 * grid.dx))) + pad)
-                bounds.append((lo, hi))
-            lo1, hi1 = bounds[0]
-            lo2, hi2 = bounds[1]
-        else:
-            lo1, hi1 = 0, grid_ns[0]
-            lo2, hi2 = 0, grid_ns[1]
-        flux_monitors.append(
-            init_flux_monitor(
-                axis=axis_idx,
-                index=grid_index,
-                freqs=freqs_arr,
-                grid_shape=grid.shape,
-                # Grid is cubic (single dx) — both tangential cell sizes
-                # equal grid.dx. If Grid ever becomes non-cubic, select
-                # the two tangential sizes by axis_idx here.
-                d1=grid.dx,
-                d2=grid.dx,
-                dft_total_steps=n_steps,
-                dft_window=getattr(pe, 'dft_window', 'rect'),
-                dft_window_alpha=getattr(pe, 'dft_window_alpha', 0.25),
-                lo1=lo1, hi1=hi1, lo2=lo2, hi2=hi2,
-            )
-        )
+    flux_monitors = build_flux_monitor_cfgs(sim, grid, n_steps)
 
     if sim._waveguide_ports:
         cpml_axes = grid.cpml_axes

--- a/tests/test_ad_surface_contract.py
+++ b/tests/test_ad_surface_contract.py
@@ -59,6 +59,12 @@ AD_CLASSIFICATION = {
         "tests/test_msl_sparam_ad.py::test_compute_msl_s_matrix_ad_smoke_has_finite_gradient, "
         "tests/test_sparam_ad_end_to_end.py::test_msl_s_matrix_ad_end_to_end",
     ),
+    "Simulation.compute_mixed_s_matrix": (
+        NOT_TRACEABLE,
+        "issue #488 mixed lumped/wire+MSL lane: host-side numpy flux and V/I "
+        "accumulation per drive run, and the flux magnitude override reads "
+        "concrete powers — no eps_override/AD channel is wired",
+    ),
     "Simulation.compute_coaxial_s_matrix": (
         NOT_TRACEABLE,
         "deprecated single-plane V/I path; numpy extraction, no differentiable input",

--- a/tests/test_mixed_port_sparam.py
+++ b/tests/test_mixed_port_sparam.py
@@ -224,6 +224,106 @@ def test_guard_rejects_mixed_lumped_and_wire():
         sim.compute_mixed_s_matrix(skip_preflight=True)
 
 
+def test_flux_magnitude_override_math():
+    """Arch-A unit falsifier: flux ratios replace off-diagonal magnitudes.
+
+    P_net = 0.75 at a drive with |S11| = 0.5 gives P_inc = 1.0; a receive
+    plane carrying 0.36 toward the port must read |S21| = 0.6 with the
+    WAVE phase preserved and the diagonal untouched — regardless of how
+    wrong the wave-channel magnitude was (the #313 class).
+    """
+    from rfx.api._sparams import _mixed_flux_magnitude_override
+    n_freqs = 3
+    S_wave = np.zeros((2, 2, n_freqs), dtype=np.complex64)
+    S_wave[0, 0, :] = 0.5                       # validated diagonal
+    S_wave[1, 0, :] = 1.7j                      # wrong magnitude, known phase
+    S_wave[1, 1, :] = 0.1
+    S_wave[0, 1, :] = -0.2                      # wrong magnitude, phase pi
+    box_lw = np.zeros((2, 1, n_freqs))
+    plane_msl = np.zeros((2, 1, n_freqs))
+    box_lw[0, 0, :] = 0.75                      # run 0: lw driven, net out
+    plane_msl[0, 0, :] = 0.36                   # +x toward the "-x" port
+    plane_msl[1, 0, :] = -0.99                  # run 1: msl driven, away=-x
+    box_lw[1, 0, :] = -0.25                     # inward 0.25 at the lw box
+    S_out, ill, neg = _mixed_flux_magnitude_override(
+        S_wave, box_lw, plane_msl, [("lw", 0), ("msl", 0)],
+        msl_away_signs=[-1.0], n_lw=1,
+    )
+    S_out = np.asarray(S_out)
+    np.testing.assert_allclose(S_out[0, 0, :], 0.5, atol=1e-6)   # untouched
+    np.testing.assert_allclose(np.abs(S_out[1, 0, :]), 0.6, rtol=1e-5)
+    np.testing.assert_allclose(np.angle(S_out[1, 0, :]), np.pi / 2, atol=1e-5)
+    # msl-driven column: P_net = (-1)*(-0.99) = 0.99, |S22|=0.1 ->
+    # P_inc = 1.0; lw receive inward = 0.25 -> |S12| = 0.5, phase pi.
+    np.testing.assert_allclose(np.abs(S_out[0, 1, :]), 0.5, rtol=1e-5)
+    np.testing.assert_allclose(np.abs(np.angle(S_out[0, 1, :])), np.pi, atol=1e-5)
+    assert not ill.any() and not neg.any()
+
+
+def test_flux_column_power_is_an_identity_not_a_passivity_check():
+    """ANTI-GATE LOCK (issue #488): do not gate passivity on this channel.
+
+    With |S_ij|^2 = P_arr,i / (P_net,j / (1 - |S_jj|^2)), the column sum
+    collapses to |S_jj|^2 + (P_arr/P_net)(1 - |S_jj|^2), which is exactly
+    1 whenever the arriving power equals the net launched power — for ANY
+    diagonal. A green column-power check therefore binds an algebraic
+    identity, not physics (feedback: a gate can bind an artifact). The
+    independent internal witness on the flux channel is RECIPROCITY,
+    because S_ij and S_ji come from different runs.
+
+    This test asserts the identity holds across wildly different
+    diagonals so that anyone tempted to promote column power to a
+    passivity gate here sees why it cannot discriminate.
+    """
+    from rfx.api._sparams import _mixed_flux_magnitude_override
+    for s11_mag in (0.03, 0.41, 0.90):
+        S_wave = np.zeros((2, 2, 1), dtype=np.complex64)
+        S_wave[0, 0, :] = s11_mag
+        S_wave[1, 1, :] = 0.5
+        S_wave[1, 0, :] = 0.123          # arbitrary wrong wave magnitude
+        box_lw = np.zeros((2, 1, 1))
+        plane_msl = np.zeros((2, 1, 1))
+        box_lw[0, 0, :] = 0.4            # net launched
+        plane_msl[0, 0, :] = 0.4         # all of it arrives (lossless)
+        S_out, _, _ = _mixed_flux_magnitude_override(
+            S_wave, box_lw, plane_msl, [("lw", 0)],
+            msl_away_signs=[-1.0], n_lw=1,
+        )
+        col_power = float(
+            np.abs(np.asarray(S_out)[0, 0, 0]) ** 2
+            + np.abs(np.asarray(S_out)[1, 0, 0]) ** 2
+        )
+        assert col_power == pytest.approx(1.0, abs=1e-6), (
+            f"identity broken for |S11|={s11_mag}: {col_power}"
+        )
+    # Power GAIN is still detectable — that is all this quantity tests.
+    S_wave = np.zeros((2, 2, 1), dtype=np.complex64)
+    S_wave[0, 0, :] = 0.0
+    box_lw = np.zeros((2, 1, 1))
+    plane_msl = np.zeros((2, 1, 1))
+    box_lw[0, 0, :] = 0.4
+    plane_msl[0, 0, :] = 0.8             # twice as much arrives: gain
+    S_out, _, _ = _mixed_flux_magnitude_override(
+        S_wave, box_lw, plane_msl, [("lw", 0)],
+        msl_away_signs=[-1.0], n_lw=1,
+    )
+    assert float(np.abs(np.asarray(S_out)[1, 0, 0]) ** 2) > 1.5
+
+
+def test_flux_override_masks_ill_conditioned_and_negative():
+    from rfx.api._sparams import _mixed_flux_magnitude_override
+    S_wave = np.zeros((2, 2, 2), dtype=np.complex64)
+    S_wave[0, 0, :] = 0.999                     # near-total reflection
+    box_lw = np.zeros((2, 1, 2))
+    plane_msl = np.zeros((2, 1, 2))
+    box_lw[0, 0, :] = -1e-3                     # negative net at the drive
+    _, ill, neg = _mixed_flux_magnitude_override(
+        S_wave, box_lw, plane_msl, [("lw", 0), ("msl", 0)],
+        msl_away_signs=[-1.0], n_lw=1,
+    )
+    assert ill[0].all() and neg[0].all()
+
+
 def test_guard_rejects_cpml_adjacent_probe_ladder():
     """Regression lock for the #488 attempt-1 defect D3.
 
@@ -275,6 +375,8 @@ def test_mixed_probe_fed_msl_plumbing_smoke():
     assert 20.0 < res.z0_ref[1] < 120.0          # HJ analytic, sane band
     assert res.s21_power_witness.shape == (1, 1, 5)
     assert np.all(np.isfinite(res.s21_power_witness))
+    assert res.magnitude_channel == "flux"
+    assert res.S_wave is not None and res.S_wave.shape == S.shape
     assert res.settling_db is not None and np.all(np.isfinite(res.settling_db))
     # Registration state restored after the drive loop.
     assert len(sim._dft_planes) == 0

--- a/tests/test_mixed_port_sparam.py
+++ b/tests/test_mixed_port_sparam.py
@@ -359,8 +359,23 @@ def test_reciprocity_witness_catches_a_wrong_diagonal():
 
     # Matching diagonals -> reciprocity holds.
     assert run(0.4, 0.4) == pytest.approx(0.0, abs=1e-5)
-    # A wrong diagonal on ONE port breaks it, and by a large margin.
-    assert run(0.4, 0.03) > 0.05
+    # A wrong diagonal on ONE port breaks it. Assert against the SHIPPED
+    # DEFAULT tolerance, not an ad-hoc constant: a review round found the
+    # first version of this test asserting > 0.05 while the runtime
+    # default was 0.15, so the test proved the helper discriminates but
+    # NOT that the warning a user actually gets would ever fire.
+    import inspect
+
+    default_tol = inspect.signature(
+        Simulation.compute_mixed_s_matrix
+    ).parameters["reciprocity_tol"].default
+    assert run(0.4, 0.03) > default_tol, (
+        f"a wrong diagonal deviates by {run(0.4, 0.03):.3f}, which the "
+        f"shipped default tolerance {default_tol} would NOT warn about"
+    )
+    # And the observed real-fixture residual (9%) must also trip it —
+    # the tolerance has to sit below the known residual, not above it.
+    assert default_tol < 0.09
 
 
 def test_guard_requires_pec_ground_for_flux_channel():

--- a/tests/test_mixed_port_sparam.py
+++ b/tests/test_mixed_port_sparam.py
@@ -1,0 +1,283 @@
+"""Mixed-family S-matrix lane (issue #488): guards + power-wave honesty.
+
+Layer 1 (this file, fast suite):
+  * the Kurokawa cross-impedance normalization unit falsifier — a synthetic
+    unit power transfer across UNEQUAL reference impedances must read
+    |S21| = |S12| = 1 (the issue-#460 sqrt(Z_j/Z_i) class caught directly,
+    no FDTD run involved),
+  * the delivered-power witness consistency on the same synthetic,
+  * registration-guard contract (v1 envelope raises loudly),
+  * one end-to-end PLUMBING smoke on a coarse probe-fed MSL line —
+    asserts shapes/finiteness/witness bookkeeping only. It is NOT a
+    physics gate: the claims-bearing fixture battery with the
+    pre-declared falsifiers (passivity, reciprocity, openEMS referee)
+    is the separate slow-lane battery.
+"""
+
+import numpy as np
+import pytest
+
+from rfx import Box, Simulation
+from rfx.api._sparams import _assemble_mixed_power_wave_s
+from rfx.boundaries.spec import Boundary, BoundarySpec
+from rfx.sources.sources import GaussianPulse
+
+_EPS_R = 3.66
+_H_SUB = 254e-6
+_W_TRACE = 600e-6
+_DX = 80e-6
+
+
+# ---------------------------------------------------------------------------
+# Layer 1a — pure power-wave assembly falsifiers (no FDTD)
+# ---------------------------------------------------------------------------
+
+def _synthetic_unit_transfer(z0_lump=50.0, z0_msl=30.0, n_freqs=3):
+    """Phasors for an ideal matched unit POWER transfer lumped <-> MSL.
+
+    Both runs are constructed so the incident wave carries unit power-wave
+    amplitude and the far port receives unit power-wave amplitude:
+
+    * run 0 (lumped driven): FDTD-sign V/I with a = (-V + Z0*I)/(2*sqrt(Z0))
+      = 1 and drive-port diagonal b = 0 (matched);
+      MSL receive with (V0 - Z_msl*I)/2 = sqrt(Z_msl) i.e. b_pw = 1.
+    * run 1 (MSL driven): a_msl = (V0 + Z_msl*I)/2/sqrt(Z_msl) = 1;
+      lumped receive with (V - Z0*I)/(2*sqrt(Z0)) = 1.
+
+    In VOLTAGE pseudo-waves the same data reads b_V/a_V = sqrt(Z_msl/Z0)
+    != 1 — exactly the issue-#460 error a non-power-wave mixed lane
+    would report.
+    """
+    s50, s30 = np.sqrt(z0_lump), np.sqrt(z0_msl)
+    ones = np.ones(n_freqs, dtype=np.complex128)
+    v_lw = np.zeros((2, 1, n_freqs), dtype=np.complex128)
+    i_lw = np.zeros_like(v_lw)
+    v0_msl = np.zeros_like(v_lw)
+    i_msl = np.zeros_like(v_lw)
+    # run 0 — lumped driven: a=1 ((-V+Z0 I)/(2 sqrt(Z0))), diag b=0.
+    v_lw[0, 0] = -s50 * ones
+    i_lw[0, 0] = ones / s50
+    # run 0 — MSL receives unit power wave: (V0 - Zm I)/2 = sqrt(Zm).
+    v0_msl[0, 0] = s30 * ones
+    i_msl[0, 0] = -ones / s30
+    # run 1 — MSL driven: (V0 + Zm I)/2/sqrt(Zm) = 1.
+    v0_msl[1, 0] = s30 * ones
+    i_msl[1, 0] = ones / s30
+    # run 1 — lumped receives unit power wave: (V - Z0 I)/(2 sqrt(Z0)) = 1.
+    v_lw[1, 0] = s50 * ones
+    i_lw[1, 0] = -ones / s50
+    return v_lw, i_lw, v0_msl, i_msl
+
+
+def test_power_wave_normalization_unequal_z0():
+    """|S21| of a unit power transfer is 1 for UNEQUAL Z0 (issue #460).
+
+    The voltage pseudo-wave ratio on the same phasors is
+    sqrt(30/50) = 0.7746 — a mixed lane without the Kurokawa sqrt(Z)
+    factors would report that instead.
+    """
+    z0_lump, z0_msl = 50.0, 30.0
+    v_lw, i_lw, v0_msl, i_msl = _synthetic_unit_transfer(z0_lump, z0_msl)
+    S, s21_power = _assemble_mixed_power_wave_s(
+        v_lw, i_lw, v0_msl, i_msl,
+        np.asarray([z0_lump]), np.asarray([1]), np.asarray([z0_msl]),
+        wire_mode=False, drive_plan=[("lw", 0), ("msl", 0)],
+    )
+    S = np.asarray(S)
+    pseudo_ratio = np.sqrt(z0_msl / z0_lump)  # 0.7746 — the #460 error
+    assert abs(pseudo_ratio - 1.0) > 0.2
+    np.testing.assert_allclose(np.abs(S[1, 0, :]), 1.0, atol=1e-5)
+    np.testing.assert_allclose(np.abs(S[0, 0, :]), 0.0, atol=1e-6)
+
+
+def test_reciprocity_on_synthetic_transfer():
+    """S12 == S21 on the synthetic reciprocal transfer (both = 1)."""
+    v_lw, i_lw, v0_msl, i_msl = _synthetic_unit_transfer()
+    S, _ = _assemble_mixed_power_wave_s(
+        v_lw, i_lw, v0_msl, i_msl,
+        np.asarray([50.0]), np.asarray([1]), np.asarray([30.0]),
+        wire_mode=False, drive_plan=[("lw", 0), ("msl", 0)],
+    )
+    S = np.asarray(S)
+    np.testing.assert_allclose(
+        np.abs(S[0, 1, :]), np.abs(S[1, 0, :]), atol=1e-5
+    )
+
+
+def test_power_witness_matches_synthetic():
+    """Delivered-power |a| reconstruction reproduces the unit transfer.
+
+    P_del = 0.5*Re(Z_in)*|I|^2 = 0.5 at the matched synthetic drive,
+    so |a|_recon = sqrt(2*P_del/(1-|S11|^2)) = 1 and the witness equals
+    |b_msl_pw| = 1 (issue #313 triangulation channel).
+    """
+    v_lw, i_lw, v0_msl, i_msl = _synthetic_unit_transfer()
+    _, s21_power = _assemble_mixed_power_wave_s(
+        v_lw, i_lw, v0_msl, i_msl,
+        np.asarray([50.0]), np.asarray([1]), np.asarray([30.0]),
+        wire_mode=False, drive_plan=[("lw", 0), ("msl", 0)],
+    )
+    np.testing.assert_allclose(s21_power[0, 0, :], 1.0, atol=1e-5)
+
+
+def test_wire_mode_uses_per_cell_impedance():
+    """Wire off-diagonals normalize by Z0/n_live (issue #318 convention).
+
+    Rebuilding the run-0 synthetic with Z0c = 50/5 in the wave formulas
+    must again read |S21| = 1 under wire_mode with n_live = 5; feeding the
+    LUMPED-convention phasors instead mis-normalizes by sqrt(n_live).
+    """
+    n_live, z0_lump, z0_msl = 5, 50.0, 30.0
+    z0c = z0_lump / n_live
+    sqc, s30 = np.sqrt(z0c), np.sqrt(z0_msl)
+    ones = np.ones(3, dtype=np.complex128)
+    v_lw = np.zeros((1, 1, 3), dtype=np.complex128)
+    i_lw = np.zeros_like(v_lw)
+    v0_msl = np.zeros_like(v_lw)
+    i_msl = np.zeros_like(v_lw)
+    v_lw[0, 0] = -sqc * ones          # a = (-V + Z0c I)/(2 sqrt(Z0c)) = 1
+    i_lw[0, 0] = ones / sqc
+    v0_msl[0, 0] = s30 * ones          # b_pw = 1 at the MSL port
+    i_msl[0, 0] = -ones / s30
+    S, _ = _assemble_mixed_power_wave_s(
+        v_lw, i_lw, v0_msl, i_msl,
+        np.asarray([z0_lump]), np.asarray([n_live]), np.asarray([z0_msl]),
+        wire_mode=True, drive_plan=[("lw", 0)],
+    )
+    np.testing.assert_allclose(np.abs(np.asarray(S)[1, 0, :]), 1.0, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1b — registration-guard contract (v1 envelope)
+# ---------------------------------------------------------------------------
+
+def _base_sim(**kw):
+    lx, ly, lz = 8e-3, 3e-3, 754e-6
+    sim = Simulation(
+        freq_max=5e9, domain=(lx, ly, lz), dx=_DX, cpml_layers=8,
+        boundary=BoundarySpec(x="cpml", y="cpml",
+                              z=Boundary(lo="pec", hi="cpml")),
+        **kw,
+    )
+    sim.add_material("sub", eps_r=_EPS_R)
+    sim.add(Box((0.0, 0.0, 0.0), (lx, ly, _H_SUB)), material="sub")
+    y_c = ly / 2.0
+    sim.add(Box((0.0, y_c - _W_TRACE / 2, _H_SUB),
+                (lx, y_c + _W_TRACE / 2, _H_SUB + _DX)), material="pec")
+    return sim, y_c
+
+
+def _add_msl(sim, y_c, x=5.5e-3, direction="-x", **kw):
+    # Default facing is TOWARD the wire feed (issue #488 attempt-1 defect
+    # D1: a port facing away from the DUT measures launch+return mixed
+    # in its a-channel and its probe ladder walks into the CPML).
+    sim.add_msl_port(position=(x, y_c, 0.0), width=_W_TRACE,
+                     height=_H_SUB, direction=direction, impedance=50.0,
+                     waveform=GaussianPulse(f0=2.5e9, bandwidth=0.5), **kw)
+
+
+def _add_feed(sim, y_c, x=2e-3):
+    # Vertical probe feed: ez wire port ground-plane -> trace bottom.
+    sim.add_port(position=(x, y_c, 0.0), component="ez",
+                 impedance=50.0, extent=_H_SUB)
+
+
+def test_guard_requires_msl_port():
+    sim, y_c = _base_sim()
+    _add_feed(sim, y_c)
+    with pytest.raises(ValueError, match="add_msl_port"):
+        sim.compute_mixed_s_matrix(skip_preflight=True)
+
+
+def test_guard_requires_lumped_or_wire_port():
+    sim, y_c = _base_sim()
+    _add_msl(sim, y_c)
+    with pytest.raises(ValueError, match="add_port"):
+        sim.compute_mixed_s_matrix(skip_preflight=True)
+
+
+def test_guard_rejects_bare_source():
+    sim, y_c = _base_sim()
+    _add_feed(sim, y_c)
+    _add_msl(sim, y_c)
+    sim.add_source(position=(1e-3, y_c, 4e-4), component="ez",
+                   waveform=GaussianPulse(f0=2.5e9, bandwidth=0.5))
+    with pytest.raises(NotImplementedError, match="bare sources"):
+        sim.compute_mixed_s_matrix(skip_preflight=True)
+
+
+def test_guard_rejects_nonuniform_mesh():
+    sim, y_c = _base_sim(dz_profile=np.full(10, 75.4e-6))
+    _add_feed(sim, y_c)
+    _add_msl(sim, y_c)
+    with pytest.raises(NotImplementedError, match="uniform mesh"):
+        sim.compute_mixed_s_matrix(skip_preflight=True)
+
+
+def test_guard_rejects_mixed_lumped_and_wire():
+    sim, y_c = _base_sim()
+    _add_feed(sim, y_c)                       # wire (extent set)
+    sim.add_port(position=(1.5e-3, y_c, 4e-4), component="ez",
+                 impedance=50.0)              # lumped (no extent)
+    _add_msl(sim, y_c)
+    with pytest.raises(NotImplementedError, match="lumped \\+ wire"):
+        sim.compute_mixed_s_matrix(skip_preflight=True)
+
+
+def test_guard_rejects_cpml_adjacent_probe_ladder():
+    """Regression lock for the #488 attempt-1 defect D3.
+
+    A "+x"-facing MSL port at 5.5 mm in an 8 mm domain resolves its
+    default probe ladder (offset 31, spacing 12 cells) past the domain
+    edge; msl_probe_x_coords_n CLAMPS the coordinates, and attempt 1
+    silently measured probe 0 next to the trace's OPEN end at the domain
+    edge (a Box is not rasterized into the CPML padding), reading the
+    open-stub standing-wave impedance -j*Z0*cot(beta*d) ~ 1400 ohm at
+    1 GHz instead of the 48 ohm line. The mixed lane must refuse the
+    registration the same way compute_msl_s_matrix does.
+    """
+    sim, y_c = _base_sim()
+    _add_feed(sim, y_c)
+    _add_msl(sim, y_c, direction="+x")
+    with pytest.raises(ValueError, match="declared x-domain"):
+        sim.compute_mixed_s_matrix(skip_preflight=True)
+
+
+# ---------------------------------------------------------------------------
+# Layer 1c — end-to-end plumbing smoke (NOT a physics gate)
+# ---------------------------------------------------------------------------
+
+def test_mixed_probe_fed_msl_plumbing_smoke():
+    """Coarse probe-fed MSL line runs end to end and fills the result.
+
+    num_periods=4 is deliberately truncated — this asserts BOOKKEEPING
+    (shapes, port order, finiteness, witnesses recorded), not physics.
+    The claims-bearing battery with the pre-declared falsifiers is the
+    slow-lane fixture battery (issue #488 arc).
+    """
+    sim, y_c = _base_sim()
+    _add_feed(sim, y_c, x=2e-3)
+    _add_msl(sim, y_c, x=5.5e-3, n_probe_offset=10, n_probe_spacing=4)
+    freqs = np.linspace(1e9, 4e9, 5)
+    with pytest.warns(UserWarning):
+        # The truncated record must surface the ring-down warning — its
+        # absence on a 4-period open-domain record would itself be a bug.
+        res = sim.compute_mixed_s_matrix(
+            freqs=freqs, num_periods=4.0, skip_preflight=True,
+        )
+    S = np.asarray(res.S)
+    assert S.shape == (2, 2, 5)
+    assert np.all(np.isfinite(S))
+    assert res.port_families == ("wire", "msl")
+    assert res.port_names[1] != "lw0" and res.port_names[0] == "lw0"
+    assert res.z0_ref.shape == (2,)
+    assert res.z0_ref[0] == pytest.approx(50.0)
+    assert 20.0 < res.z0_ref[1] < 120.0          # HJ analytic, sane band
+    assert res.s21_power_witness.shape == (1, 1, 5)
+    assert np.all(np.isfinite(res.s21_power_witness))
+    assert res.settling_db is not None and np.all(np.isfinite(res.settling_db))
+    # Registration state restored after the drive loop.
+    assert len(sim._dft_planes) == 0
+    assert len(sim._probes) == 0
+    assert sim._msl_ports[0].excite is True
+    assert sim._ports[0].excite is True

--- a/tests/test_mixed_port_sparam.py
+++ b/tests/test_mixed_port_sparam.py
@@ -324,6 +324,123 @@ def test_flux_override_masks_ill_conditioned_and_negative():
     assert ill[0].all() and neg[0].all()
 
 
+def test_reciprocity_witness_catches_a_wrong_diagonal():
+    """The runtime witness must catch what column power structurally cannot.
+
+    A wrong driven-port diagonal corrupts the incident-power
+    normalization `P_inc = P_net/(1-|S_jj|^2)` on that column only, so
+    |S21| and |S12| stop agreeing. Column power cannot see it (it is an
+    identity — see the anti-gate-lock test); reciprocity can. This is the
+    exact failure class that reached review in the first revision of this
+    lane.
+    """
+    from rfx.api._sparams import (
+        _mixed_flux_magnitude_override,
+        _mixed_reciprocity_deviation,
+    )
+    # Symmetric lossless 2-port: both ports launch 1.0 and receive 1.0.
+    box_lw = np.zeros((2, 1, 1))
+    plane_msl = np.zeros((2, 1, 1))
+    # "-x" MSL port: away_sign = -1, so the code reads net launched power
+    # as -plane and arriving power as +plane.
+    box_lw[0, 0, :] = 1.0            # run 0: lw driven, net outward
+    plane_msl[0, 0, :] = 1.0         # ...arrives at the msl plane
+    plane_msl[1, 0, :] = -1.0        # run 1: msl driven, net away
+    box_lw[1, 0, :] = -1.0           # ...arrives back at lw (inward)
+    plan = [("lw", 0), ("msl", 0)]
+
+    def run(s11, s22):
+        S = np.zeros((2, 2, 1), dtype=np.complex64)
+        S[0, 0, :], S[1, 1, :] = s11, s22
+        out, _, _ = _mixed_flux_magnitude_override(
+            S, box_lw, plane_msl, plan, msl_away_signs=[-1.0], n_lw=1,
+        )
+        return _mixed_reciprocity_deviation(out)[1]
+
+    # Matching diagonals -> reciprocity holds.
+    assert run(0.4, 0.4) == pytest.approx(0.0, abs=1e-5)
+    # A wrong diagonal on ONE port breaks it, and by a large margin.
+    assert run(0.4, 0.03) > 0.05
+
+
+def test_guard_requires_pec_ground_for_flux_channel():
+    """Flux box omits its bottom face; that needs a PEC z_lo (review)."""
+    from rfx.boundaries.spec import Boundary as _B, BoundarySpec as _BS
+    lx, ly, lz = 8e-3, 3e-3, 754e-6
+    sim = Simulation(
+        freq_max=5e9, domain=(lx, ly, lz), dx=_DX, cpml_layers=8,
+        boundary=_BS(x="cpml", y="cpml", z=_B(lo="cpml", hi="cpml")),
+    )
+    sim.add_material("sub", eps_r=_EPS_R)
+    sim.add(Box((0.0, 0.0, 0.0), (lx, ly, _H_SUB)), material="sub")
+    y_c = ly / 2.0
+    sim.add(Box((0.0, y_c - _W_TRACE / 2, _H_SUB),
+                (lx, y_c + _W_TRACE / 2, _H_SUB + _DX)), material="pec")
+    _add_feed(sim, y_c)
+    _add_msl(sim, y_c, n_probe_offset=10, n_probe_spacing=4)
+    with pytest.raises(NotImplementedError, match="PEC z_lo"):
+        sim.compute_mixed_s_matrix(skip_preflight=True)
+    # The wave channel makes no such assumption and must still build.
+    sim.compute_mixed_s_matrix(
+        freqs=np.linspace(1e9, 2e9, 2), num_periods=1.0,
+        skip_preflight=True, magnitude_channel="wave",
+    )
+
+
+def test_guard_rejects_horizontal_port_on_flux_channel():
+    """`pe.extent` is treated as a z height by the box builder (review)."""
+    sim, y_c = _base_sim()
+    sim.add_port(position=(2e-3, y_c, _H_SUB / 2), component="ex",
+                 impedance=50.0, extent=_H_SUB)
+    _add_msl(sim, y_c, n_probe_offset=10, n_probe_spacing=4)
+    with pytest.raises(NotImplementedError, match="component='ez'"):
+        sim.compute_mixed_s_matrix(skip_preflight=True)
+
+
+def test_negative_arriving_power_is_tracked_not_only_driven():
+    """A receive-side sign defect must be flagged, not silently |S|=0."""
+    from rfx.api._sparams import _mixed_flux_magnitude_override
+    S_wave = np.zeros((2, 2, 1), dtype=np.complex64)
+    box_lw = np.zeros((1, 1, 1))
+    plane_msl = np.zeros((1, 1, 1))
+    box_lw[0, 0, :] = 1.0            # healthy driven net power
+    plane_msl[0, 0, :] = -1.0        # mis-signed: reads as arriving < 0
+    S_out, _, neg = _mixed_flux_magnitude_override(
+        S_wave, box_lw, plane_msl, [("lw", 0)],
+        msl_away_signs=[-1.0], n_lw=1,
+    )
+    assert neg[1].all(), "receive-side negative power went untracked"
+    assert float(np.abs(np.asarray(S_out)[1, 0, 0])) == 0.0
+
+
+def test_forward_does_not_pay_for_flux_monitors(monkeypatch):
+    """Registering flux monitors must not change the plain forward() lane.
+
+    `ForwardResult` has never carried flux monitors, so accumulating them
+    inside the differentiable scan would be pure cost (including AD-tape
+    memory) with no visible result — a silent regression for existing
+    AD callers. The build is therefore gated to the raw-hook consumer.
+    """
+    import jax.numpy as jnp
+    import rfx.runners.uniform as _uni
+
+    calls = []
+    real = _uni.build_flux_monitor_cfgs
+    monkeypatch.setattr(
+        _uni, "build_flux_monitor_cfgs",
+        lambda *a, **k: (calls.append(1), real(*a, **k))[1],
+    )
+    sim = Simulation(freq_max=10e9, domain=(4e-3, 2e-3, 1e-3),
+                     dx=100e-6, cpml_layers=4)
+    sim.add_port(position=(1e-3, 1e-3, 0.5e-3), component="ez",
+                 impedance=50.0)
+    sim.add_flux_monitor(axis="x", coordinate=2e-3,
+                         freqs=jnp.asarray(np.array([5e9])))
+    sim.forward(n_steps=40, port_s11_freqs=np.array([5e9]),
+                skip_preflight=True)
+    assert calls == [], "forward() built flux monitors it cannot return"
+
+
 def test_guard_rejects_cpml_adjacent_probe_ladder():
     """Regression lock for the #488 attempt-1 defect D3.
 


### PR DESCRIPTION
Roadmap rank-1 item #488, PI-approved architecture option A.

## What this adds

`Simulation.compute_mixed_s_matrix()` — end-to-end S-parameters between two port
families on one structure (a homogeneous lumped OR wire set together with MSL
ports), e.g. a vertical probe feed launching onto a microstrip line. Each port is
driven in turn; the per-family wave machinery is reused unchanged.

**Magnitude channel (default `"flux"`).** Off-diagonal magnitudes come from
Poynting flux — an auto-registered closed 5-face box per lumped/wire port and a
probe-0 cross-section plane per MSL port — normalized as
`P_inc,j = P_net,j / (1 - |S_jj|^2)`. No Z0 anchor enters the magnitude, so the
open #313 port-cell V·I undercount and any analytic-vs-measured Z0 divergence
both drop out by construction. Wave phase is retained, `S_wave` keeps the raw
power-wave matrix, and `magnitude_channel="wave"` restores the previous behavior.

Cross-family waves are assembled in the Kurokawa power-wave convention: with
unequal reference impedances a pseudo-wave ratio is off by `sqrt(Z_j/Z_i)`
(issue #460), and a unit test pins that directly — a synthetic unit power
transfer across unequal Z0 must read |S21| = |S12| = 1.

MSL diagonals now use the **measured** line Zc (N-probe least-squares fit) with a
soft >10% caveat, rather than the analytic Hammerstad-Jensen anchor alone.

## Evidence

Probe-fed MSL fixture, falsifiers declared before every run:

| quantity | wave channel | flux channel |
|---|---|---|
| reciprocity ‖S21‖ vs ‖S12‖ (mid-band) | 55% | **9.0%** |
| settling witness | — | −101 / −100 dB |
| negative-P_net bins | — | 0 |

14 tests (11 fast + guards + one end-to-end plumbing smoke); regression batch
38/38 green across the MSL, lumped/wire, flux-monitor, and contract lanes.

## Honesty labels — please read before quoting numbers

- **Per-column power is an algebraic identity on this channel, not a passivity
  measurement.** Substituting the definition gives
  `|S_jj|^2 + (P_arr/P_net)(1 - |S_jj|^2)`, which is exactly 1 whenever the
  arriving power equals the net launched power — for *any* diagonal. The
  docstring states this and `test_flux_column_power_is_an_identity_not_a_passivity_check`
  is an anti-gate lock so nobody promotes it to a gate later. It still detects
  power gain. Reciprocity is the only independent internal witness here.
- **The residual 9% is attributed, not hand-waved.** |S11| = 0.41 vs
  |S22| = 0.03 contradicts lossless reciprocity; rescaling column 1 by
  `sqrt((1-|S22|^2)/(1-|S11|^2))` = 1.097 moves |S21| 0.9119 → 1.000 = |S12|
  exactly. An independent Poynting referee measured the same wire port's V·I
  accounting undercounting delivered power 3.2×. So arch-A's founding assumption
  (diagonals are local single-cell ratios, immune to the #313 magnitude class)
  is falsified for a near-field-dominated vertical probe.
- **Absolute magnitude is NOT validated** — the openEMS referee (Stage C) is
  still pending. Off-diagonal phase mixes two reference-plane conventions and
  stays provisional.
- v1 fences, all loud: uniform mesh only; no waveguide/Floquet/coax/TFSF; no
  bare sources or 0-Ω ports; no mixed lumped+wire set; no `reference_plane_cells`;
  imperative only.

## Next redesign (declared, deliberately NOT started here)

Derive the drive-port reflection from flux as well, via the existing validated
`port_reference_sims` machinery — an incident-power reference that never touches
the port cell. That is an architecture change and needs its own falsifier
declaration.

R3: memory=project_issue488_mixed_port_arc + feedback_gate_can_bind_artifact (consistent) | R2-attempts=1 arch-A + 1 refinement, both pre-declared, then stopped | falsifier=reciprocity on the same fixture (9.0%, was 55%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)