### PR TITLE
waveguide hygiene follow-ups: close the #494 advisory's mutation-exposed coverage holes, and scope the #493 identity to the transverse direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,45 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — the #494 advisory's test coverage was bound at one point in a five-dimensional option space
+
+- An independent mutation battery against the merged #495 suite found **40 of 67
+  meaningful mutations survived** (60%), where the author's own three-mutation
+  battery had found 3/3 caught — all three had landed in the one well-covered
+  region. The advisory half was the weak half: 33 of 53 survived.
+- The worst survivor: gating the advisory's call site on `if not self._geometry:`
+  or `if normalize != "flux":` left all 40 tests green, and **both are the actual
+  settings of `validation/crossval/18_wr90_iris_modematch.py`** — the script that
+  motivated #494. A one-line regression restoring precisely the #494 blind spot on
+  precisely the motivating script was invisible, because the only end-to-end test
+  used `normalize=False` with an empty domain.
+- Coverage added for each unbound branch point: `normalize` in `(False, "flux")`
+  with a PEC obstacle registered; a z-propagating port pair (the axis was
+  previously hardcodable to `"x"` with no test noticing); a multimode port binding
+  the lowest-cutoff mode (fence (c) had zero coverage); a two-axis sim asserting
+  two warnings and a shared-cutoff cube sim plus a two-mode single-axis sim, which
+  together bind both components of the `(axis, cutoff)` dedupe key; a mirrored
+  per-face test with the thin face on `hi`; and the `port_reference_sims` junction
+  path, which must not lose the band-edge check to its band-centre sibling.
+- Every number the advisory prints is now recomputed independently from the port
+  geometry and asserted, including the ripple ladder it quotes as evidence. Six of
+  seven were previously unasserted — notably its only actionable output, where a
+  mutant advising `cpml_layers` of 1 instead of 13 passed. The warning category is
+  pinned via `pytest.warns(UserWarning)`, since `DeprecationWarning` would be
+  suppressed under Python's default filters and previously survived.
+- `0.5` is now the module constant `_FAR_PORT_LAMBDA_G_FRACTION`, used both to
+  compute the requirement and to render the message. It was two independent
+  literals, so a factor change produced a message stating 0.5 while enforcing
+  something else; the factor was also only pinned to a 1.6x window (0.394-0.630).
+- The `#493` characterization table gains an independent oracle. A coherent author
+  could previously mutate the rasterization rule AND re-pin `_NOMINAL_EXCESS` in
+  one commit and stay green — which silently falsified the ambiguity docstring and
+  left the asymmetric branch of the symmetry test dead in every parametrization.
+  The expected excess is now derived from the retreat mechanism and cross-checked
+  against the table, and a guard asserts both the one- and two-cell cases occur.
+- Re-verified: all 18 previously-surviving mutations are now caught, including the
+  two that survived the first round of fixes.
+
 ### Changed — the #493 electrical-dimension identity is scoped to the transverse direction
 
 - The `Box` / support-matrix text from #493 stated the electrical dimension as the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Changed — the #493 electrical-dimension identity is scoped to the transverse direction
+
+- The `Box` / support-matrix text from #493 stated the electrical dimension as the
+  span between innermost zeroed planes, `(n_open + 1) * dx`, in a way that could be
+  read as holding on any axis. It is now explicitly scoped to **transverse** to the
+  propagation direction — aperture and guide widths, anything setting a cutoff —
+  where an independent refit of 16 committed single-iris configurations across two
+  meshes pins the realized aperture to within 1/20 of a cell of it.
+- The docs now warn **not** to carry that identity into the propagation direction.
+  An obstacle's electrical *thickness* is set by field interaction with the
+  discontinuity rather than by a cutoff condition, and is measured to fall between
+  `t_cells * dx` and `(t_cells - 1) * dx` — so neither integer rule holds, and the
+  residual is a fixed per-face offset rather than a discretization error that
+  shrinks with `dx`. The longitudinal convention is recorded as **not settled**:
+  treat it as an unknown of order half a cell and fold that sensitivity into the
+  reported envelope instead of adopting a rule. (Measured during the stage-S3 /
+  #499 review; no committed record carries it yet, so it is documented as a caution
+  rather than as a number to build on.)
+- Odd `(cells - d_cells)` parity is now presented as a **fork rather than a dead
+  end**: change `dx`/the aperture so the parity works, or place fins asymmetrically
+  on purpose and accept a recorded half-cell offset instead of rounding the aperture
+  — the quantity that sets the cutoff — to the wrong parity. Neither option is
+  recommended, because the cost of the offset has not been measured. What is
+  required is that the offset be recorded and **representable by the comparator**,
+  since an off-centre aperture compared against a centred oracle silently becomes
+  comparator error. Also fixes a typo in the merged #493 text, which said the
+  odd-parity opening is "one cell wide" where it is one cell **wider**.
+
 ### Added — thin-absorber advisory on every uniform waveguide S-matrix path (#494)
 
 - `compute_waveguide_s_matrix` documents a "Far-port discipline" requiring an

--- a/docs/guides/sparameter_support_matrix.md
+++ b/docs/guides/sparameter_support_matrix.md
@@ -231,9 +231,18 @@ implementation nor gradient regression is RF validation.
   puts the node just below it. One retreat gives `d + dx` with the opening
   **asymmetric** (centre `dx/2` low); two retreats give `d + 2*dx`, **centred**.
   Measured on WR-90 at both a/30 and a/60: 7.620 mm and 18.288 mm give
-  `d + dx` off-centre, 12.192 mm gives `d + 2*dx` centred. The electrical
-  opening is measured between the innermost zeroed planes, `(n_open + 1) * dx`
-  — the measure that reproduces `a = cells * dx` exactly. Offsetting each
+  `d + dx` off-centre, 12.192 mm gives `d + 2*dx` centred. **Transverse** to
+  the propagation direction the electrical dimension is the span between the
+  innermost zeroed planes, `(n_open + 1) * dx` — the measure that reproduces
+  `a = cells * dx` exactly, and an independent refit of 16 committed
+  single-iris configurations across two meshes pins the realized aperture to
+  within 1/20 of a cell of it. **That identity does not carry into the
+  propagation direction:** an obstacle's electrical *thickness* is set by field
+  interaction with the discontinuity rather than by a cutoff, is measured to
+  fall between `t_cells * dx` and `(t_cells - 1) * dx` so neither integer rule
+  holds, and is not settled — treat it as an unknown of order half a cell and
+  fold the sensitivity into the reported envelope instead of picking a rule.
+  Offsetting each
   interior face half a cell the wrong way retreats both faces by construction
   rather than by luck, giving `d + 2*dx` deterministically at every aperture;
   that is the drawing case 18's blocked revision used. In
@@ -244,7 +253,15 @@ implementation nor gradient regression is RF validation.
   magnitude tolerance. Midpoint corners are rounding-independent, and with
   `(cells - d_cells)` even the realized opening equals the nominal one exactly;
   at odd parity a symmetric opening of that width is not representable on the
-  grid and costs one cell however it is drawn. See the `Box` docstring for the
+  grid and costs one cell **more** however it is drawn. Odd parity is a fork
+  rather than a dead end — change `dx`/the aperture so the parity works, or
+  place the fins asymmetrically on purpose and accept a recorded half-cell
+  offset instead of rounding the aperture (the quantity that sets the cutoff)
+  to the wrong parity. Neither is recommended here, because the cost of the
+  offset has not been measured; what is required is that the offset be recorded
+  and representable by the comparator, since an off-centre aperture compared
+  against a centred oracle silently becomes comparator error. See the `Box`
+  docstring for the
   arithmetic and `run_point` in
   `validation/crossval/18_wr90_iris_modematch.py` for the assert pattern.
 - Size the absorber from the guide wavelength at the **lowest** measured

--- a/docs/guides/sparameter_support_matrix.md
+++ b/docs/guides/sparameter_support_matrix.md
@@ -236,12 +236,19 @@ implementation nor gradient regression is RF validation.
   innermost zeroed planes, `(n_open + 1) * dx` — the measure that reproduces
   `a = cells * dx` exactly, and an independent refit of 16 committed
   single-iris configurations across two meshes pins the realized aperture to
-  within 1/20 of a cell of it. **That identity does not carry into the
+  within 1/20 of a cell of it (a stage-S3 / issue #499 review observation; no
+  committed record carries the refit yet — a caution-grade number, like the
+  longitudinal one below). **That identity does not carry into the
   propagation direction:** an obstacle's electrical *thickness* is set by field
   interaction with the discontinuity rather than by a cutoff, is measured to
   fall between `t_cells * dx` and `(t_cells - 1) * dx` so neither integer rule
   holds, and is not settled — treat it as an unknown of order half a cell and
   fold the sensitivity into the reported envelope instead of picking a rule.
+  (This measured *effective* thickness is a different quantity from a cascade
+  comparator's electrical-length bookkeeping — issue #499's comparator draws
+  `t_c = round(t/dx) + 1` so `(t_c - 1)*dx` conserves total electrical
+  length; that choice answers a different question and is not contradicted
+  here.)
   Offsetting each
   interior face half a cell the wrong way retreats both faces by construction
   rather than by luck, giving `d + 2*dx` deterministically at every aperture;

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -862,6 +862,13 @@ def _mixed_flux_magnitude_override(
             )
     return S_out, ill_cond, neg_power
 
+# Far-port discipline: minimum absorber depth as a fraction of the guide
+# wavelength at the LOWEST measured frequency. The message quotes this value,
+# so it MUST NOT be duplicated as a literal there — a mismatch would report one
+# threshold while enforcing another (PR #495 review, finding 5).
+_FAR_PORT_LAMBDA_G_FRACTION = 0.5
+
+
 def _warn_thin_absorber_vs_guide_wavelength(
     grid, cfgs, freqs, cpml_layers, boundary_spec,
 ):
@@ -938,7 +945,7 @@ def _warn_thin_absorber_vs_guide_wavelength(
             continue
 
         lambda_g = (_C0_SPARAMS / f_lo) / np.sqrt(1.0 - (fc / f_lo) ** 2)
-        required_m = 0.5 * lambda_g
+        required_m = _FAR_PORT_LAMBDA_G_FRACTION * lambda_g
         thin = [(side, n) for side, n in faces if n * dx < required_m]
         if not thin:
             continue
@@ -949,7 +956,8 @@ def _warn_thin_absorber_vs_guide_wavelength(
         )
         warnings.warn(
             f"compute_waveguide_s_matrix: absorber on the {axis} propagation "
-            f"axis is thinner than the documented 0.5 guide-wavelength "
+            f"axis is thinner than the documented "
+            f"{_FAR_PORT_LAMBDA_G_FRACTION:g} guide-wavelength "
             f"far-port discipline at the lowest measured frequency "
             f"{f_lo / 1e9:.3f} GHz (mode cutoff {fc / 1e9:.3f} GHz, "
             f"lambda_g = {lambda_g * 1e3:.1f} mm): {detail}, against a "

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -965,7 +965,8 @@ def _warn_thin_absorber_vs_guide_wavelength(
             f"guided energy and can set the accuracy envelope instead of "
             f"discretization: in the WR-90 iris lane (issue #494) residual "
             f"|S11| ripple was 0.0706 at 0.30 lambda_g, 0.0366 at 0.50, and "
-            f"0.0093 at 0.75, so 0.5 lambda_g is a floor and not a target. "
+            f"0.0093 at 0.75, so {_FAR_PORT_LAMBDA_G_FRACTION:g} lambda_g "
+            f"is a floor and not a target. "
             f"Raise cpml_layers to at least "
             f"{int(np.ceil(required_m / dx))} (0.75 lambda_g needs "
             f"{int(np.ceil(0.75 * lambda_g / dx))}).",

--- a/rfx/geometry/csg.py
+++ b/rfx/geometry/csg.py
@@ -121,7 +121,9 @@ class Box:
     would call WR-90 22.098 mm instead of 22.86 at a/30). An independent
     refit of 16 committed WR-90 single-iris configurations across two meshes
     pins the realized transverse aperture offset to within 1/20 of a cell of
-    that identity.
+    that identity (measured during the stage-S3 / issue #499 review; no
+    committed record carries the refit yet, so like the longitudinal caution
+    below it is a recorded observation, not a number to build on).
 
     **Do not carry that identity into the propagation direction.** The
     electrical *thickness* of an obstacle (an iris's extent along the guide
@@ -136,7 +138,12 @@ class Box:
     thickness, make the sensitivity to that half cell part of the reported
     envelope rather than picking a rule. (Measured during the stage-S3 /
     issue #499 review; no committed record carries it yet, so it is stated
-    here as a caution, not as a number to build on.)
+    here as a caution, not as a number to build on.) This measured
+    *effective* thickness is a different quantity from a cascade
+    comparator's electrical-length bookkeeping — issue #499's comparator
+    deliberately draws ``t_c = round(t/dx) + 1`` so that ``(t_c - 1)*dx``
+    conserves the cascade's total electrical length; that bookkeeping choice
+    answers a different question and is not contradicted by this caution.
 
     **A facing pair is not symmetric under this rule, because its two
     interior faces are different kinds of corner.** For fins drawn from each

--- a/rfx/geometry/csg.py
+++ b/rfx/geometry/csg.py
@@ -113,11 +113,30 @@ class Box:
 
     For a **PEC obstacle** the occupied nodes are where the tangential ``E``
     is zeroed, so consequence (1) is an *electrical* dimension error, not a
-    sub-cell cosmetic one. The electrical opening is measured between the
-    innermost ZEROED node planes, i.e. ``(n_open + 1) * dx`` — the same
-    measure that reproduces the guide's own width, ``a = cells * dx``
-    exactly (counting open nodes alone would call WR-90 22.098 mm instead of
-    22.86 at a/30).
+    sub-cell cosmetic one. **Transverse to the propagation direction** — an
+    aperture width, a guide width, anything that sets a cutoff — the
+    electrical dimension is the span between the innermost ZEROED node
+    planes, ``(n_open + 1) * dx``, the same measure that reproduces the
+    guide's own width ``a = cells * dx`` exactly (counting open nodes alone
+    would call WR-90 22.098 mm instead of 22.86 at a/30). An independent
+    refit of 16 committed WR-90 single-iris configurations across two meshes
+    pins the realized transverse aperture offset to within 1/20 of a cell of
+    that identity.
+
+    **Do not carry that identity into the propagation direction.** The
+    electrical *thickness* of an obstacle (an iris's extent along the guide
+    axis) is not the zeroed-plane span: it is set by how the fields interact
+    with the discontinuity, not by a cutoff condition. Measured on a
+    single-iris geometry at four drawn thicknesses, the effective thickness
+    lands consistently **between** ``t_cells * dx`` and
+    ``(t_cells - 1) * dx``, so *neither* integer rule is right and the
+    residual is a fixed per-face offset rather than a discretization error
+    that shrinks with ``dx``. The longitudinal convention is **not settled**;
+    treat it as an unknown of order half a cell, and if a comparator needs a
+    thickness, make the sensitivity to that half cell part of the reported
+    envelope rather than picking a rule. (Measured during the stage-S3 /
+    issue #499 review; no committed record carries it yet, so it is stated
+    here as a caution, not as a number to build on.)
 
     **A facing pair is not symmetric under this rule, because its two
     interior faces are different kinds of corner.** For fins drawn from each
@@ -165,14 +184,35 @@ class Box:
       obstacle keep ``(cells - d_cells)`` **even**. When it is odd,
       ``fin_depth = (cells - d_cells)//2`` truncates and a symmetric opening
       of that width is simply not representable on the grid: the opening is
-      one cell wide however it is drawn. That is a representability limit,
-      not a rasterization defect.
+      one cell **wider** however it is drawn. That is a representability
+      limit, not a rasterization defect.
 
     Under both conditions the realized opening equals the nominal one
     exactly (measured, 100% of ~50k even-parity combinations). Then still
     assert the realized footprint (count the occupied node planes) against
     the intended one — see ``run_point`` in
     ``validation/crossval/18_wr90_iris_modematch.py`` for the pattern.
+
+    **Odd parity is a fork, not a dead end.** Symmetric fins can only realize
+    apertures whose cell count has the parity of ``cells``, so when the
+    aperture you want has the wrong parity you must choose, and both options
+    cost something:
+
+    * change ``dx`` (or the aperture) so the parity works, which moves every
+      other dimension on that axis; or
+    * place the fins **asymmetrically** on purpose, accepting a known
+      half-cell offset of the opening rather than rounding the aperture to
+      the wrong parity — which would change the aperture itself, the quantity
+      that sets the cutoff.
+
+    This docstring does **not** recommend one over the other: how much the
+    half-cell offset costs has not been measured here, so treat it as an
+    open trade rather than a cheap escape. What is *not* optional is that the
+    offset be recorded and **representable by whatever you compare against** —
+    an off-centre aperture only stays a known quantity if the oracle can model
+    it. If your comparator assumes a centred obstacle, an intentional offset
+    silently becomes comparator error, which is the failure mode this whole
+    docstring exists to prevent.
 
     A box thinner than one local cell takes a separate **thin-sheet**
     branch (single nearest-centre node); the notes above apply to the

--- a/tests/test_waveguide_geometry_hygiene.py
+++ b/tests/test_waveguide_geometry_hygiene.py
@@ -466,3 +466,345 @@ def test_thin_absorber_advisory_honours_per_face_thickness_overrides():
     assert len(hits) == 1
     assert "x-lo 4 cells" in hits[0], hits[0]
     assert "x-hi" not in hits[0], hits[0]
+
+
+# --------------------------------------------------------------------------- #
+# #494 advisory — coverage added after an independent mutation battery
+#
+# The original fixture exercised the advisory at ONE point in its option space
+# (normalize=False, empty geometry, one x-propagating single-mode port pair,
+# both absorbing faces equally thin), so single-value substitutions at five
+# separate branch points all survived. The worst of them: gating the call site
+# on ``if not self._geometry`` or ``if normalize != "flux"`` left all 40 tests
+# green, and BOTH of those conditions are the actual settings of
+# ``validation/crossval/18_wr90_iris_modematch.py`` — the script that motivated
+# issue #494. A one-line regression restoring precisely the #494 blind spot on
+# precisely the motivating script was invisible.
+# --------------------------------------------------------------------------- #
+def _two_port_with_obstacle(cpml_layers, *, freqs=_FREQS, dx=0.004):
+    """A two-port sim that is NOT empty — mirrors a real crossval setup."""
+    sim = _two_port(cpml_layers, freqs=freqs, dx=dx)
+    # A PEC obstacle, as every real waveguide device has.
+    sim.add_material("pec_like", eps_r=1.0, sigma=1e10)
+    sim.add(Box((0.058, 0.0, 0.0), (0.062, 0.012, 0.02)), material="pec_like")
+    return sim
+
+
+@pytest.mark.parametrize("normalize", [False, "flux"])
+def test_advisory_fires_with_geometry_present_and_under_flux(normalize):
+    """The option combination the motivating crossval script actually uses.
+
+    ``18_wr90_iris_modematch.py`` runs `normalize="flux"` with PEC boxes
+    registered. Gating the advisory on either condition must not hide it.
+    """
+    sim = _two_port_with_obstacle(10)
+    assert sim._geometry, "fixture must be non-empty to bind the geometry gate"
+    with pytest.warns(UserWarning, match=ADVISORY_KEY):
+        sim.compute_waveguide_s_matrix(normalize=normalize, num_periods=6.0)
+
+
+def test_advisory_message_recomputes_every_number_it_quotes():
+    """Bind the quoted numbers, not merely the strings around them.
+
+    Six of the seven numbers the advisory prints were unasserted, including its
+    only actionable output ("Raise cpml_layers to at least N"): a mutant that
+    advised raising it to 1 instead of 13 passed. Each value here is derived
+    independently from the port geometry rather than copied from the message.
+    """
+    sim = _two_port(10)
+    grid = sim._build_grid()
+    dx = float(grid.dx)
+    cfg = sim._build_waveguide_port_config(
+        sim._waveguide_ports[0], grid, jnp.asarray(_FREQS), 2000)
+    fc = float(cfg.f_cutoff)
+    f_lo = float(np.min(_FREQS))
+    c0 = 299792458.0
+    lambda_g = (c0 / f_lo) / np.sqrt(1.0 - (fc / f_lo) ** 2)
+    required = 0.5 * lambda_g
+
+    hits = _advisories(sim)
+    assert len(hits) == 1
+    msg = hits[0]
+
+    assert f"{10 * dx * 1e3:.1f} mm" in msg              # what you have
+    assert f"against a required {required * 1e3:.1f} mm" in msg
+    assert f"lambda_g = {lambda_g * 1e3:.1f} mm" in msg
+    assert f"mode cutoff {fc / 1e9:.3f} GHz" in msg
+    assert f"({10 * dx / lambda_g:.2f} lambda_g)" in msg
+    assert (f"Raise cpml_layers to at least {int(np.ceil(required / dx))} "
+            f"(0.75 lambda_g needs "
+            f"{int(np.ceil(0.75 * lambda_g / dx))})") in msg
+    # The quoted threshold must be the one actually enforced, not a second
+    # copy of the constant that can drift from it.
+    from rfx.api._sparams import _FAR_PORT_LAMBDA_G_FRACTION
+    assert f"documented {_FAR_PORT_LAMBDA_G_FRACTION:g} guide-wavelength" in msg
+    # The #494 ripple ladder is a claims-bearing measurement quoted as fact, so
+    # it is pinned too: prose numbers were freely corruptible otherwise.
+    assert ("residual |S11| ripple was 0.0706 at 0.30 lambda_g, 0.0366 at 0.50, "
+            "and 0.0093 at 0.75") in msg
+
+
+def _z_two_port(cpml_layers, *, freqs=_FREQS, dx=0.004):
+    """Ports propagating along z, so the axis cannot be hardcoded to 'x'."""
+    sim = Simulation(
+        freq_max=float(freqs[-1]), domain=(0.04, 0.02, 0.12), dx=dx,
+        boundary=BoundarySpec(x="pec", y="pec",
+                              z=Boundary(lo="cpml", hi="cpml")),
+        cpml_layers=cpml_layers,
+    )
+    for z, direction in ((0.02, "+z"), (0.10, "-z")):
+        sim.add_waveguide_port(
+            z, direction=direction, mode=(1, 0), mode_type="TE",
+            freqs=jnp.asarray(freqs), f0=float(np.mean(freqs)), bandwidth=0.6,
+        )
+    return sim
+
+
+def test_advisory_names_the_actual_propagation_axis_not_always_x():
+    """Every original fixture propagated along x, so `axis = "x"` survived.
+
+    Also binds the PEC-closed fence in the direction a hardcoded axis would
+    NOT satisfy: here x/y are PEC and only z absorbs.
+    """
+    hits = _advisories(_z_two_port(10))
+    assert len(hits) == 1
+    assert "on the z propagation axis" in hits[0], hits[0]
+    assert "z-lo 10 cells" in hits[0] and "z-hi 10 cells" in hits[0]
+    assert "x-" not in hits[0] and "y-" not in hits[0]
+
+
+def test_advisory_dedupes_per_axis_and_still_reports_both_axes():
+    """Binds the ENUMERATION, not just the deduped count.
+
+    `len(hits) == 1` on a same-axis two-port is satisfied both by working
+    dedupe and by looking at only the first port. Pairing it with a two-axis
+    sim that must yield TWO warnings distinguishes them.
+    """
+    # Four ports on two absorbing axes. The y-extent sets the x-normal ports'
+    # cutoff (2.932 GHz) and the x-extent sets the z-normal ports' (1.208 GHz),
+    # so both bands are above cutoff and cpml=6 (24.0 mm) is thin against both
+    # requirements (43.9 mm and 34.6 mm) — i.e. all four ports have something
+    # to report, and correct dedupe collapses them to one per axis.
+    dx = 0.004
+    sim = Simulation(
+        freq_max=float(_FREQS[-1]), domain=(0.12, 0.05, 0.12), dx=dx,
+        boundary=BoundarySpec(x=Boundary(lo="cpml", hi="cpml"), y="pec",
+                              z=Boundary(lo="cpml", hi="cpml")),
+        cpml_layers=6,
+    )
+    for pos, direction in ((0.02, "+x"), (0.10, "-x"),
+                           (0.02, "+z"), (0.10, "-z")):
+        sim.add_waveguide_port(
+            pos, direction=direction, mode=(1, 0), mode_type="TE",
+            freqs=jnp.asarray(_FREQS), f0=float(np.mean(_FREQS)), bandwidth=0.6)
+    assert len(sim._waveguide_ports) == 4
+
+    hits = _advisories(sim)
+    assert len(hits) == 2, hits
+    axes = sorted(h.split("on the ")[1].split(" propagation")[0] for h in hits)
+    assert axes == ["x", "z"], axes
+
+
+def test_advisory_dedupe_key_keeps_axes_apart_when_their_cutoffs_coincide():
+    """Binds the AXIS component of the dedupe key specifically.
+
+    On a cube domain the x-normal and z-normal ports have the SAME cutoff, so a
+    key of `(cutoff,)` alone would collapse two physically distinct axes into
+    one warning. `(axis, cutoff)` must keep them separate.
+    """
+    sim = Simulation(
+        freq_max=float(_FREQS[-1]), domain=(0.12, 0.12, 0.12), dx=0.004,
+        boundary=BoundarySpec(x=Boundary(lo="cpml", hi="cpml"), y="pec",
+                              z=Boundary(lo="cpml", hi="cpml")),
+        cpml_layers=6,
+    )
+    for pos, direction in ((0.02, "+x"), (0.02, "+z")):
+        sim.add_waveguide_port(
+            pos, direction=direction, mode=(1, 0), mode_type="TE",
+            freqs=jnp.asarray(_FREQS), f0=float(np.mean(_FREQS)), bandwidth=0.6)
+
+    grid = sim._build_grid()
+    cfgs = [sim._build_waveguide_port_config(e, grid, jnp.asarray(_FREQS), 2000)
+            for e in sim._waveguide_ports]
+    cutoffs = {round(float(c.f_cutoff), 3) for c in cfgs}
+    assert len(cutoffs) == 1, ("fixture must share one cutoff", cutoffs)
+
+    hits = _advisories(sim)
+    assert len(hits) == 2, hits
+    assert sorted(h.split("on the ")[1].split(" propagation")[0]
+                  for h in hits) == ["x", "z"]
+
+
+def test_advisory_reports_a_thin_hi_face_behind_a_thick_lo_face():
+    """Mirror of the per-face test — the original only made the LO face thin.
+
+    `for side in ("lo", "hi")` -> `("lo",)` survived because no fixture had an
+    independently thin hi face.
+    """
+    sim = _two_port(
+        40,
+        boundary=BoundarySpec(
+            x=Boundary(lo="cpml", hi="cpml", lo_thickness=40, hi_thickness=4),
+            y="cpml", z="cpml"),
+    )
+    hits = _advisories(sim)
+    assert len(hits) == 1
+    assert "x-hi 4 cells" in hits[0], hits[0]
+    assert "x-lo" not in hits[0], hits[0]
+
+
+def test_advisory_reports_both_faces_when_both_are_thin():
+    """`thin[:1]` (report only the first thin face) survived otherwise."""
+    hits = _advisories(_two_port(10))
+    assert len(hits) == 1
+    assert "x-lo 10 cells" in hits[0] and "x-hi 10 cells" in hits[0], hits[0]
+
+
+def test_advisory_uses_the_lowest_cutoff_mode_of_a_multimode_port():
+    """Fence (c) had zero coverage: every port was single-mode.
+
+    With n_modes=2 the config is a LIST, so `min`, `max` and `modes[-1]` become
+    distinguishable. The documented behaviour is the lowest-cutoff mode (TE10),
+    which is the least demanding.
+    """
+    dx = 0.004
+    sim = Simulation(
+        freq_max=float(_FREQS[-1]), domain=(0.12, 0.04, 0.02), dx=dx,
+        boundary="cpml", cpml_layers=10,
+    )
+    for pos, direction in ((0.02, "+x"), (0.10, "-x")):
+        sim.add_waveguide_port(
+            pos, direction=direction, mode=(1, 0), mode_type="TE", n_modes=2,
+            freqs=jnp.asarray(_FREQS), f0=float(np.mean(_FREQS)), bandwidth=0.6)
+
+    grid = sim._build_grid()
+    cfgs = [sim._build_waveguide_port_config(e, grid, jnp.asarray(_FREQS), 2000)
+            for e in sim._waveguide_ports]
+    assert isinstance(cfgs[0], list) and len(cfgs[0]) == 2, "need a multimode cfg"
+    cutoffs = sorted(float(c.f_cutoff) for c in cfgs[0])
+    assert cutoffs[0] < cutoffs[1]
+
+    hits = _advisories(sim)
+    assert len(hits) == 1
+    assert f"mode cutoff {cutoffs[0] / 1e9:.3f} GHz" in hits[0], (hits[0], cutoffs)
+    assert f"mode cutoff {cutoffs[1] / 1e9:.3f} GHz" not in hits[0]
+
+
+def test_advisory_is_a_userwarning_so_the_default_filter_shows_it():
+    """The category was unbound: UserWarning -> DeprecationWarning survived.
+
+    A DeprecationWarning raised into library-caller code is suppressed under
+    Python's default filters, which would silently mute an advisory that exists
+    precisely because the functional entry points run no preflight.
+    """
+    sim = _two_port(10)
+    grid = sim._build_grid()
+    cfgs = [sim._build_waveguide_port_config(e, grid, jnp.asarray(_FREQS), 2000)
+            for e in sim._waveguide_ports]
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _warn_thin_absorber_vs_guide_wavelength(
+            grid, cfgs, _FREQS, sim._cpml_layers, sim._boundary_spec)
+    hits = [w for w in caught if ADVISORY_KEY in str(w.message)]
+    assert len(hits) == 1
+    assert hits[0].category is UserWarning, hits[0].category
+
+
+# --------------------------------------------------------------------------- #
+# #493 characterization — independent oracle for the pinned excess table
+#
+# `_NOMINAL_EXCESS` is a table of measured constants, so a coherent author could
+# mutate the rasterization rule AND re-pin the table in one commit and stay
+# green. Verified: `(coords >= lo)` -> `(coords > lo)` plus five numeric edits
+# passed 40/40, which silently falsified the ambiguity docstring and left the
+# asymmetric branch of the symmetry test dead in every parametrization.
+# --------------------------------------------------------------------------- #
+def _predicted_excess(cells: int, d_phys: float) -> int:
+    """Excess in cells, derived from the mechanism rather than measured.
+
+    The lo fin's interior face is a ``hi`` corner, which half-openness always
+    drops: one cell, unconditionally. The hi fin's interior face is a ``lo``
+    corner, kept unless float32 rounding puts its node strictly below it.
+    """
+    y, dx = _real_node_coords(cells)
+    d_c = int(round(d_phys / dx))
+    fin_c = (cells - d_c) // 2
+    hi_corner = np.float32(A_WR90 - fin_c * dx)
+    node = np.float32(y[cells - fin_c])
+    return 1 + (1 if node < hi_corner else 0)
+
+
+@pytest.mark.parametrize("cells,d_mm", sorted(_NOMINAL_EXCESS))
+def test_pinned_excess_matches_an_independently_derived_prediction(cells, d_mm):
+    """The table and the mechanism must agree, so neither can be re-pinned alone."""
+    predicted = _predicted_excess(cells, d_mm * 1e-3)
+    assert predicted == _NOMINAL_EXCESS[(cells, d_mm)], (
+        cells, d_mm, predicted, _NOMINAL_EXCESS[(cells, d_mm)])
+
+
+def test_excess_table_exercises_both_the_one_and_two_cell_cases():
+    """Keeps the symmetry test's asymmetric branch from going dead.
+
+    If every pinned excess became 2, `if excess == 1: assert centre == -0.5`
+    would never execute and the suite would still report green.
+    """
+    values = set(_NOMINAL_EXCESS.values())
+    assert values == {1, 2}, values
+
+
+def test_advisory_dedupe_key_keeps_cutoffs_apart_on_one_axis():
+    """Binds the CUTOFF component of the dedupe key.
+
+    Two ports on the SAME axis with different modes (TE10 and TE20) have
+    different cutoffs and therefore different `lambda_g` requirements, so each
+    deserves its own line. A key of `(axis,)` alone would collapse them. The
+    guide is widened so BOTH modes propagate at the lowest measured frequency,
+    otherwise the below-cutoff fence would hide the TE20 port.
+    """
+    sim = Simulation(
+        freq_max=float(_FREQS[-1]), domain=(0.12, 0.08, 0.02), dx=0.004,
+        boundary="cpml", cpml_layers=6,
+    )
+    for pos, direction, mode in ((0.02, "+x", (1, 0)), (0.10, "-x", (2, 0))):
+        sim.add_waveguide_port(
+            pos, direction=direction, mode=mode, mode_type="TE",
+            freqs=jnp.asarray(_FREQS), f0=float(np.mean(_FREQS)), bandwidth=0.6)
+
+    grid = sim._build_grid()
+    cfgs = [sim._build_waveguide_port_config(e, grid, jnp.asarray(_FREQS), 2000)
+            for e in sim._waveguide_ports]
+    cutoffs = sorted(round(float(c.f_cutoff), 3) for c in cfgs)
+    assert len(set(cutoffs)) == 2, ("fixture needs two cutoffs", cutoffs)
+    assert float(np.min(_FREQS)) > cutoffs[-1], "both modes must propagate"
+
+    hits = _advisories(sim)
+    assert len(hits) == 2, hits
+    for fc in cutoffs:
+        assert any(f"mode cutoff {fc / 1e9:.3f} GHz" in h for h in hits), (fc, hits)
+
+
+def test_advisory_also_fires_on_the_port_reference_sims_junction_path():
+    """The junction path must not lose the LOWEST-frequency check.
+
+    That path already has a sibling advisory
+    (``_warn_junction_cpml_thickness``), but it evaluates at BAND CENTRE — the
+    very weakness issue #494 was filed about, since `lambda_g` is longest at
+    the band edge. Gating this advisory on ``port_reference_sims is None``
+    therefore silently drops the band-edge check exactly where junction
+    geometry needs it most, and previously left the suite green.
+    """
+    def build():
+        sim = _two_port(10)
+        return sim
+
+    device = build()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        device.compute_waveguide_s_matrix(
+            normalize="flux", num_periods=6.0,
+            port_reference_sims=[build(), build()])
+    hits = [str(w.message) for w in caught if ADVISORY_KEY in str(w.message)]
+
+    assert len(hits) == 1, [str(w.message) for w in caught]
+    # It is the band-EDGE check, distinct from the sibling's band-centre one.
+    assert "lowest measured frequency 4.500 GHz" in hits[0], hits[0]


### PR DESCRIPTION
Two follow-ups to #495 (merged as `e0578f7`) on one branch. **Section B is the urgent one: it closes a hole in already-merged code.**

> **Scope note:** opened as docs-only, then grew a test/source part after an independent mutation battery. Both are #495 follow-ups sharing the same reviewers, so they are kept together rather than rebased apart. Section A is documentation only; Section B is tests plus one small source change.

---

# Section B (read first) — the #494 advisory's tests were bound at ONE point in a five-dimensional option space

An independent adversarial reviewer ran 70 mutations against the merged #495 suite. **40 of 67 meaningful mutations survived — 60%.** My own battery was three mutations and found 3/3 caught; all three had landed in the one well-covered region, so that result was not representative of either half.

The #493 geometry characterization half is **strong**. The #494 advisory half was **weak** — 33 of 53 survived.

## The worst survivor, which I verified independently before acting on it

Gating the advisory's call site on either of these leaves all 40 tests green:

```python
if not self._geometry:           # survives
if normalize != "flux":          # survives
```

Both are the **actual settings** of `validation/crossval/18_wr90_iris_modematch.py` — the script that motivated #494. Line 306 registers PEC boxes; `run_point` defaults to `normalize="flux"`. A one-line regression restoring precisely the #494 blind spot on precisely the motivating script was invisible, because the sole end-to-end test used `normalize=False` on an empty domain.

That falsifies #495's own commit-title claim of covering "every uniform two-port path".

## Root cause: coverage-shaped, not assertion-shaped

The advisory has five branch points — propagation axis, mode selection, face side, boundary token, option gating — and the fixture exercised each at exactly **one** value. Single-value substitutions at all five survived, while the tests read as though they covered the space because each carried a fence-naming docstring.

## Coverage added, one per unbound branch point

| Previously survived | Now caught by |
|---|---|
| `if not self._geometry:` / `if normalize != "flux":` gate | `normalize` parametrized over `(False, "flux")` with a PEC obstacle registered |
| `axis = "x"` hardcoded | a z-propagating port pair; also binds the PEC-closed fence in the direction a hardcoded axis would *not* satisfy |
| `min(modes, …)` → `max` / `modes[-1]` / `[cfg]` | a multimode `n_modes=2` port asserting the **lowest** cutoff is quoted — fence (c) had zero coverage, since every cfg was a scalar and min/max/`[-1]` were identical |
| `for cfg in cfgs[:1]` | a two-axis sim asserting **two** warnings; `len(hits)==1` was satisfied equally by working dedupe and by enumerating one port |
| `key = (round(fc,3),)` | a shared-cutoff cube sim: two axes, one cutoff |
| `key = (axis,)` | a two-mode single-axis sim: one axis, two cutoffs |
| `for side in ("lo",)` and `thin[:1]` | a mirrored per-face test with the thin face on `hi`, plus an assertion that both faces appear when both are thin |
| `if port_reference_sims is None:` gate | the junction path, which must not lose the band-**edge** check to its band-**centre** sibling — that sibling's use of band centre is the exact weakness #494 was filed about |

**Every number the advisory prints is now recomputed from the port geometry and asserted.** Six of seven were unasserted, including its only actionable output: a mutant advising `cpml_layers` of **1** instead of 13 passed. The quoted evidence ladder is pinned too. The category is bound with `pytest.warns(UserWarning)` — `DeprecationWarning` is suppressed under Python's default filters and previously survived, which would silently mute an advisory that exists *because* the functional entry points run no preflight.

## One source change

`0.5` becomes the module constant `_FAR_PORT_LAMBDA_G_FRACTION`, used both to compute the requirement and to render the message. It was two independent literals, so a factor change produced a message stating 0.5 while enforcing something else. The factor was also pinned only to a 1.6x window (0.394–0.630); the required-mm value is now asserted directly.

## #493 half: an independent oracle for the pinned table

A coherent author could mutate the rasterization rule **and** re-pin `_NOMINAL_EXCESS` in the same commit and stay green — verified. That silently falsified the ambiguity docstring (the +1-cell collision it rests on disappears) and left the asymmetric branch of the symmetry test dead in every parametrization. The expected excess is now derived from the retreat mechanism and cross-checked against the table, with a guard that both the one- and two-cell cases occur.

Worth keeping: **rule-shaped assertions resisted the coherent-author edit; measured-constant tables did not.** `test_box_volume_branch_excludes_the_hi_node_plane` states the rule and could not be re-pinned.

## Section B verification

**18/18 previously-surviving mutations now caught**, including the two that survived my first fix round (the junction-path gate and the cutoff half of the dedupe key). 59 tests pass in ~15 s. Neighbour regression: 74 passed across hygiene + twoport-contract + iris-gates. Lint clean; `api reference surface: OK`.

## Section B — known gap, not closed

The **non-uniform lane**. The reviewer could not confirm the advisory is silent there, reached the path only by setting a private attribute, and noted `NonUniformGrid.dx` is the *boundary* cell size so `n * dx` would be axis-blind. Flagged for a separate look rather than guessed at.

---

# Section A — documentation

## 1. Scope the electrical-dimension identity to the transverse direction

#493 stated the electrical dimension as the span between innermost zeroed planes, `(n_open + 1) * dx`, in wording that reads as holding on **any** axis. Now explicitly scoped to **transverse** to the propagation direction — aperture and guide widths, anything that sets a cutoff.

That half is now confirmed more tightly than #493 claimed: an independent refit of 16 committed single-iris configurations across two meshes pins the realized transverse aperture to **within 1/20 of a cell** of the identity.

## 2. Fence the propagation direction — the amendment that actually matters

The merged text could be extended into a longitudinal claim that measurement has since shown to be **false**. An obstacle's electrical *thickness* is set by field interaction with the discontinuity, not by a cutoff condition, and is measured to fall **between** `t_cells * dx` and `(t_cells - 1) * dx`: neither integer rule holds, and the residual is a fixed per-face offset rather than a discretization error that shrinks with `dx`.

Recorded as **not settled** — treat it as an unknown of order half a cell and fold that sensitivity into the reported envelope instead of adopting a rule.

Attributed to the stage-S3 / #499 review, with an explicit note in the docstring that **no committed record carries it yet**, so it reads as a caution rather than a number to build on. I did not measure it and do not restate its magnitude.

## 3. Odd parity is a fork, not a dead end

#493 said "keep `(cells - d_cells)` even", full stop, which reads as though the odd case leaves you stuck. It is a choice:

- change `dx` or the aperture so the parity works, which moves every other dimension on that axis; or
- place the fins **asymmetrically** on purpose, accepting a recorded half-cell offset rather than rounding the aperture — the quantity that sets the cutoff — to the wrong parity.

**Neither is recommended here.** The figure that would have justified preferring the asymmetric option was withdrawn by its author before this commit, so the cost of the half-cell offset is unmeasured and I deliberately do not quote it. What the docs *do* state as required: the offset must be recorded and **representable by whatever you compare against**, because an off-centre aperture compared against a centred oracle silently becomes comparator error — the exact failure mode the surrounding docstring exists to prevent.

## Also

Fixes a typo that shipped in #495: the odd-parity opening is one cell **wider**, not "one cell wide". The corrected wording now matches what `test_midpoint_recipe_costs_a_cell_at_odd_parity` already asserts.

## Section A — provenance

**No number in this PR originates with me.** The transverse refit and the longitudinal thickness measurement are both from the #499 review and are attributed as such in the docstring itself. My own contribution here is the scoping decision and the fork framing.

## Section A verification

Lint clean on the repo flags; `scripts/check_api_reference.py` reports `api reference surface: OK`; `tests/test_waveguide_geometry_hygiene.py` 40 passed. Diff is 2 files, +68 / −11, both documentation.

## Section A — not verified

- I did not reproduce either #499 measurement. The transverse 1/20-cell refit and the longitudinal between-the-integer-rules result are quoted from that review, which is why the longitudinal note is written as an unsettled caution rather than a convention.
- No new test. The change adds no assertion; the one testable claim it touches (odd parity costs a cell) was already pinned by #495, and the typo fix brings the prose into line with that existing test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

