### PR TITLE
Coax 2-port: two-drive S-parameter solve (#489 stage 1)

### DIFF
--- a/rfx/sources/coaxial_port.py
+++ b/rfx/sources/coaxial_port.py
@@ -1833,7 +1833,8 @@ def solve_two_port_from_wave_amplitudes(
     40.8 on an asymmetric DUT, 4% of the default ``cond_warn``) so the
     degeneracy guard is silent as well. What DOES catch it is **passivity**:
     ``S'22 = 1/S22`` explodes for any well-matched passive DUT (measured
-    ``|S22'| = 32.8``, column power 27). **Anything built on this solve must
+    ``|S22'| = 32.8``, column power 317 against a passive limit of 1).
+    **Anything built on this solve must
     therefore route its result through the repo's passivity self-check** —
     that check is not optional decoration here, it is the only handle on this
     defect family.

--- a/rfx/sources/coaxial_port.py
+++ b/rfx/sources/coaxial_port.py
@@ -1766,6 +1766,14 @@ def solve_two_port_from_wave_amplitudes(
         at any frequency. The solve is still returned — ``cond_a`` carries the
         per-frequency number so a caller can mask bins itself.
 
+        **This threshold flags DEGENERACY, not accuracy, and a value below it
+        is not a reliability certificate.** The recovered ``S`` inherits the
+        caller's amplitude-measurement noise amplified by ``cond(A)``: measured
+        on this solve, a 1e-4 relative perturbation of ``A`` gives ~1.3e-3
+        relative error in ``S`` at ``cond = 19`` and ~1.3e-2 at ``cond = 199``,
+        both far below this default. Bounding that is the caller's job, because
+        only the caller knows its own noise floor.
+
     Returns
     -------
     TwoPortWaveSolve
@@ -1788,10 +1796,14 @@ def solve_two_port_from_wave_amplitudes(
         S = B @ inv(A)
 
     which needs no assumption about the terminator at all — the non-driven
-    port's incident wave is one of the measured inputs. Measured (analytic
-    fields through the production extractor): the recovered ``|S21|`` stays
-    exact to ~1e-15 for terminator reflections up to ``|Gamma_t| = 0.5``,
-    where ``cond(A)`` is still only ~2.4.
+    port's incident wave is one of the measured inputs. Measured: the recovered
+    ``|S21|`` stays exact to ~1e-13 for terminator reflections up to
+    ``|Gamma_t| = 0.5``. For an ideal planted through line the conditioning has
+    the closed form ``cond(A) = (1+|Gamma_t|)/(1-|Gamma_t|)``, i.e. exactly 3.0
+    at ``|Gamma_t| = 0.5``; a run through the production extractor at 12 GHz
+    (where propagation phase enters) measured 2.4 for the same terminator.
+    Either way the matrix is nowhere near singular, which is why no terminator
+    improvement is a prerequisite for issue #489.
 
     This function is pure linear algebra on amplitudes someone else measured.
     It cannot detect a mis-measured amplitude — that is what the reciprocity
@@ -1842,12 +1854,16 @@ def solve_two_port_from_wave_amplitudes(
         import warnings as _w
 
         _w.warn(
-            f"solve_two_port_from_wave_amplitudes: the incident-wave matrix is "
-            f"ill-conditioned at {bad}/{n_f} frequencies (cond > {cond_warn:g}; "
-            f"worst {np.nanmax(cond):.3g}). The two drives are then nearly "
-            "linearly dependent — usually both ports seeing essentially the "
-            "same field, e.g. a symmetric structure driven identically, or one "
-            "drive that failed to excite. S at those bins is unreliable.",
+            f"solve_two_port_from_wave_amplitudes: the two drives are nearly "
+            f"linearly dependent at {bad}/{n_f} "
+            f"frequencies (cond > {cond_warn:g}; worst {np.nanmax(cond):.3g}) "
+            "— usually both ports seeing essentially the same field, e.g. a "
+            "symmetric structure driven identically, or one drive that failed "
+            "to excite. S at those bins is degenerate. NOTE this threshold "
+            "flags DEGENERACY only: cond below it is NOT a reliability "
+            "certificate, because cond(A) also multiplies whatever noise is on "
+            "the measured amplitudes (~1.3e-2 relative error in S from 1e-4 "
+            "noise at cond=199, which never trips this warning).",
             stacklevel=2,
         )
     return TwoPortWaveSolve(s_params=s, cond_a=cond)

--- a/rfx/sources/coaxial_port.py
+++ b/rfx/sources/coaxial_port.py
@@ -1738,9 +1738,14 @@ class TwoPortWaveSolve(NamedTuple):
 
     ``s_params`` has shape ``(2, 2, n_freqs)`` with ``S[j, i]`` the response at
     port *j* when driving port *i*. ``cond_a`` is the per-frequency 2-norm
-    condition number of the incident-wave matrix that was inverted; it is the
-    honest reliability witness for this solve, because everything else here is
-    exact linear algebra.
+    condition number of the incident-wave matrix that was inverted.
+
+    ``cond_a`` bounds DEGENERACY of the two drives — it is not a reliability
+    score. It is blind to a systematic incident/outgoing mislabel (stays ~40 on
+    a defect that puts ``|S21|`` at 16), and it does not bound accuracy either,
+    since it multiplies whatever noise rides on the caller's amplitudes. See
+    ``solve_two_port_from_wave_amplitudes`` for the full witness/blind-spot
+    table; passivity is the required downstream check.
     """
 
     s_params: np.ndarray
@@ -1819,9 +1824,25 @@ def solve_two_port_from_wave_amplitudes(
     * ``|c| == 1`` (a wave-split sign flip, or a reference-plane shift) leaves
       both magnitudes untouched — reciprocity is structurally BLIND to it.
 
-    So a magnitude-only reciprocity witness must not be advertised as covering
-    orientation-sign or reference-plane mistakes; those need an independent
-    handle. Pinned in ``tests/test_coax_two_port_solve.py``.
+    **And one more family, non-diagonal, that neither local witness sees.**
+    Mislabelling incident vs outgoing at one port CONSISTENTLY (i.e. on both
+    drives — what an actual wiring bug looks like, as opposed to a one-off) is
+    ``S' = N M^-1`` with ``M = [[1,0],[S21,S22]]`` and ``N = [[S11,S12],[0,1]]``,
+    giving ``S'21 = -S21/S22`` and ``S'12 = S12/S22``. Those share a magnitude,
+    so reciprocity is exactly blind to it, and ``cond(A)`` stays small (measured
+    40.8 on an asymmetric DUT, 4% of the default ``cond_warn``) so the
+    degeneracy guard is silent as well. What DOES catch it is **passivity**:
+    ``S'22 = 1/S22`` explodes for any well-matched passive DUT (measured
+    ``|S22'| = 32.8``, column power 27). **Anything built on this solve must
+    therefore route its result through the repo's passivity self-check** —
+    that check is not optional decoration here, it is the only handle on this
+    defect family.
+
+    Note that a symmetric fixture hides this: a through line (``S22 = 0``) or a
+    shunt element (``S11 = S22``) makes ``M`` singular, so the defect collapses
+    and appears "caught" by accident. Discriminating it needs an ASYMMETRIC DUT.
+
+    All three families are pinned in ``tests/test_coax_two_port_solve.py``.
     """
     a = np.asarray(a_inc, dtype=np.complex128)
     b = np.asarray(b_out, dtype=np.complex128)

--- a/rfx/sources/coaxial_port.py
+++ b/rfx/sources/coaxial_port.py
@@ -1733,6 +1733,126 @@ def coaxial_line_reflection_from_plane_voltages(
     )
 
 
+class TwoPortWaveSolve(NamedTuple):
+    """Result of :func:`solve_two_port_from_wave_amplitudes` (issue #489).
+
+    ``s_params`` has shape ``(2, 2, n_freqs)`` with ``S[j, i]`` the response at
+    port *j* when driving port *i*. ``cond_a`` is the per-frequency 2-norm
+    condition number of the incident-wave matrix that was inverted; it is the
+    honest reliability witness for this solve, because everything else here is
+    exact linear algebra.
+    """
+
+    s_params: np.ndarray
+    cond_a: np.ndarray
+
+
+def solve_two_port_from_wave_amplitudes(
+    a_inc: np.ndarray,
+    b_out: np.ndarray,
+    *,
+    cond_warn: float = 1.0e3,
+) -> TwoPortWaveSolve:
+    """Two-drive 2x2 S-matrix solve from measured wave amplitudes (issue #489).
+
+    Parameters
+    ----------
+    a_inc, b_out : (2, 2, n_freqs) complex
+        ``a_inc[j, i]`` / ``b_out[j, i]`` are the incident / outgoing wave
+        amplitudes measured AT port ``j`` during the run that DRIVES port ``i``,
+        both referred to port ``j``'s own reference plane.
+    cond_warn : float
+        Emit a warning when the incident matrix's condition number exceeds this
+        at any frequency. The solve is still returned — ``cond_a`` carries the
+        per-frequency number so a caller can mask bins itself.
+
+    Returns
+    -------
+    TwoPortWaveSolve
+
+    Notes
+    -----
+    Why a two-DRIVE solve rather than the obvious ``S[j, i] = b_j / a_i``:
+    that ratio silently assumes the non-driven port receives nothing, so a
+    terminator reflection ``Gamma_t`` lands entirely in the reported ``S11``.
+    On a through line this makes ``|1 + S11 - S21| = |Gamma_t|`` exactly — a
+    floor of 0.08 with rfx's validated matched terminator
+    (``tests/test_coaxial_line_calibration.py`` asserts ``|Gamma| < 0.08``),
+    independent of how good the implementation is.
+
+    Both drives together give four equations in four unknowns::
+
+        A = [[a1(1), a1(2)],        B = [[b1(1), b1(2)],
+             [a2(1), a2(2)]]             [b2(1), b2(2)]]
+
+        S = B @ inv(A)
+
+    which needs no assumption about the terminator at all — the non-driven
+    port's incident wave is one of the measured inputs. Measured (analytic
+    fields through the production extractor): the recovered ``|S21|`` stays
+    exact to ~1e-15 for terminator reflections up to ``|Gamma_t| = 0.5``,
+    where ``cond(A)`` is still only ~2.4.
+
+    This function is pure linear algebra on amplitudes someone else measured.
+    It cannot detect a mis-measured amplitude — that is what the reciprocity
+    and analytic-DUT checks around it are for.
+
+    **What reciprocity around this solve can and cannot catch.** Any per-port
+    factor ``c`` applied to both ``a`` and ``b`` at one port is the similarity
+    ``S -> D S D^-1`` with ``D = diag(1, c)``, which sends ``S21 -> c*S21``
+    and ``S12 -> S12/c``:
+
+    * ``|c| != 1`` (an amplitude-calibration error) moves the ratio
+      ``|S21|/|S12|`` by ``c^2`` — reciprocity SEES it, including a 5% error.
+    * ``|c| == 1`` (a wave-split sign flip, or a reference-plane shift) leaves
+      both magnitudes untouched — reciprocity is structurally BLIND to it.
+
+    So a magnitude-only reciprocity witness must not be advertised as covering
+    orientation-sign or reference-plane mistakes; those need an independent
+    handle. Pinned in ``tests/test_coax_two_port_solve.py``.
+    """
+    a = np.asarray(a_inc, dtype=np.complex128)
+    b = np.asarray(b_out, dtype=np.complex128)
+    if a.shape != b.shape:
+        raise ValueError(
+            f"a_inc and b_out must have the same shape, got {a.shape} vs {b.shape}."
+        )
+    if a.ndim != 3 or a.shape[0] != 2 or a.shape[1] != 2:
+        raise ValueError(
+            "a_inc/b_out must have shape (2, 2, n_freqs) indexed "
+            f"[measured_port, driven_port, freq]; got {a.shape}."
+        )
+    n_f = int(a.shape[2])
+    s = np.full((2, 2, n_f), np.nan + 1j * np.nan, dtype=np.complex128)
+    cond = np.full(n_f, np.inf, dtype=np.float64)
+    for k in range(n_f):
+        A = a[:, :, k]
+        B = b[:, :, k]
+        if not (np.all(np.isfinite(A)) and np.all(np.isfinite(B))):
+            continue
+        cond[k] = float(np.linalg.cond(A))
+        if not np.isfinite(cond[k]):
+            continue
+        try:
+            s[:, :, k] = B @ np.linalg.inv(A)
+        except np.linalg.LinAlgError:
+            pass
+    bad = int(np.sum(~np.isfinite(cond) | (cond > float(cond_warn))))
+    if bad:
+        import warnings as _w
+
+        _w.warn(
+            f"solve_two_port_from_wave_amplitudes: the incident-wave matrix is "
+            f"ill-conditioned at {bad}/{n_f} frequencies (cond > {cond_warn:g}; "
+            f"worst {np.nanmax(cond):.3g}). The two drives are then nearly "
+            "linearly dependent — usually both ports seeing essentially the "
+            "same field, e.g. a symmetric structure driven identically, or one "
+            "drive that failed to excite. S at those bins is unreliable.",
+            stacklevel=2,
+        )
+    return TwoPortWaveSolve(s_params=s, cond_a=cond)
+
+
 def stamp_coaxial_line(
     grid: Grid,
     materials,

--- a/tests/test_coax_two_port_solve.py
+++ b/tests/test_coax_two_port_solve.py
@@ -74,7 +74,7 @@ def _asymmetric_reciprocal(z0, n_f):
 
     Needed because the through line (S22 = 0) and the shunt resistor
     (S11 = S22) are both degenerate for the defect family in
-    ``test_both_drive_swap_is_NOT_caught_by_either_witness`` — with those
+    ``test_both_drive_swap_gap_requires_the_downstream_passivity_handle`` — with those
     fixtures the defect happens to collapse to a singular matrix and gets
     caught by accident rather than by design.
     """
@@ -91,6 +91,38 @@ def _asymmetric_reciprocal(z0, n_f):
     s21 = 2.0 / den
     s12 = 2.0 * (a * d - b * c) / den
     return (s11 * one, s12 * one, s21 * one, s22 * one)
+
+
+# ---------------------------------------------------------------------------
+# Ground truth must itself be checked — every test below depends on it
+# ---------------------------------------------------------------------------
+
+def test_asymmetric_fixture_is_what_it_claims():
+    """Verify the asymmetric DUT independently, by node analysis.
+
+    The review that produced this fixture found the previous battery passing
+    for the wrong reason: both older fixtures were DEGENERATE for the defect
+    they were supposed to discriminate, and nothing said so. A fixture whose
+    properties are assumed rather than checked is how that happens, so this
+    one is derived a second way — plain node analysis of the series-shunt-
+    series network — and compared against the ABCD formula it ships with.
+    """
+    z0 = 48.5914
+    z1, z2, y = 30.0, 12.0, 1.0 / 80.0
+    s11, s12, s21, s22 = (v[0] for v in _asymmetric_reciprocal(z0, 1))
+
+    zp = 1.0 / (y + 1.0 / (z2 + z0))          # shunt 1/y || (z2 + Z0)
+    zin = z1 + zp
+    v1 = zin / (z0 + zin)                      # unit EMF behind series Z0
+    v2 = (v1 * zp / (z1 + zp)) * z0 / (z2 + z0)
+    zin2 = z2 + 1.0 / (y + 1.0 / (z1 + z0))
+    np.testing.assert_allclose(s11.real, (zin - z0) / (zin + z0), atol=1e-12)
+    np.testing.assert_allclose(s21.real, 2.0 * v2, atol=1e-12)
+    np.testing.assert_allclose(s22.real, (zin2 - z0) / (zin2 + z0), atol=1e-12)
+
+    assert np.isclose(s12, s21, atol=1e-14), "fixture must be reciprocal"
+    assert not np.isclose(abs(s11), abs(s22)), "fixture must be ASYMMETRIC"
+    assert abs(s11) ** 2 + abs(s21) ** 2 < 1.0, "fixture must be passive"
 
 
 # ---------------------------------------------------------------------------
@@ -189,7 +221,7 @@ def test_swapped_receive_amplitude_one_drive_is_caught():
     assert np.all(np.abs(bad.s_params[1, 0]) < 0.2), np.abs(bad.s_params[1, 0])
 
 
-def test_both_drive_swap_is_NOT_caught_by_either_witness():
+def test_both_drive_swap_gap_requires_the_downstream_passivity_handle():
     """DOCUMENTED GAP: the systematic a/b mislabel evades both local witnesses.
 
     A real implementation bug mislabels incident vs outgoing at one port

--- a/tests/test_coax_two_port_solve.py
+++ b/tests/test_coax_two_port_solve.py
@@ -260,7 +260,12 @@ def test_both_drive_swap_gap_requires_the_downstream_passivity_handle():
         np.abs(bad.s_params[1, 1]), 1.0 / np.abs(s_true[3]), rtol=1e-9
     )
     col_power = np.abs(bad.s_params[0, 0]) ** 2 + np.abs(bad.s_params[1, 0]) ** 2
-    assert np.all(col_power > 1.1), col_power
+    # Measured 317 against a passive limit of 1 — the defect is not marginal,
+    # it is two orders of magnitude out. The floor is well below the measured
+    # value but far above 1, so it stays meaningful if the fixture is retuned
+    # while still failing loudly if the defect ever stopped being gross. The
+    # docstring quotes this number; a drift here should force re-reading it.
+    assert np.all(col_power > 100.0), col_power
 
 
 @pytest.mark.parametrize("scale", [1.05, 1.5, 0.8])

--- a/tests/test_coax_two_port_solve.py
+++ b/tests/test_coax_two_port_solve.py
@@ -8,9 +8,13 @@ as executable facts rather than prose:
     cannot be made accurate by improving the implementation;
   * the two-drive solve removes that floor entirely, staying exact to ~1e-13
     even at |Gamma_t| = 0.5;
-  * the two most likely implementation defects (consuming the wrong amplitude
-    at the receive array, and a wave-split orientation flip) are separated from
-    a correct implementation by a wide margin.
+  * which implementation defects the local witnesses DO and DO NOT separate.
+    Two of the three families are invisible to both witnesses here, and that
+    is recorded as an explicit gap rather than left for someone to discover:
+    a per-port unit-modulus factor (sign flip / reference-plane shift) is a
+    diagonal similarity, and a systematic both-drive a/b mislabel is a
+    non-diagonal one that preserves |S21| = |S12| exactly. Only PASSIVITY
+    catches the latter.
 
 All fields are planted analytically from a signal-flow solve, so the "truth"
 here is exact and independent of any rfx extraction path.
@@ -65,6 +69,30 @@ def _shunt_resistor(r_ohm, z0, n_f):
     return (s11, s21, s21, s11)
 
 
+def _asymmetric_reciprocal(z0, n_f):
+    """A reciprocal but ASYMMETRIC 2-port: series Z1, shunt Y, series Z2.
+
+    Needed because the through line (S22 = 0) and the shunt resistor
+    (S11 = S22) are both degenerate for the defect family in
+    ``test_both_drive_swap_is_NOT_caught_by_either_witness`` — with those
+    fixtures the defect happens to collapse to a singular matrix and gets
+    caught by accident rather than by design.
+    """
+    one = np.ones(n_f, dtype=np.complex128)
+    z1, z2, y = 30.0 + 0j, 12.0 + 0j, 1.0 / (80.0 + 0j)
+    # ABCD of series-shunt-series (reciprocal: AD - BC = 1).
+    a = 1.0 + z1 * y
+    b = z1 + z2 + z1 * y * z2
+    c = y
+    d = 1.0 + y * z2
+    den = a + b / z0 + c * z0 + d
+    s11 = (a + b / z0 - c * z0 - d) / den
+    s22 = (-a + b / z0 - c * z0 + d) / den
+    s21 = 2.0 / den
+    s12 = 2.0 * (a * d - b * c) / den
+    return (s11 * one, s12 * one, s21 * one, s22 * one)
+
+
 # ---------------------------------------------------------------------------
 # Why the obvious rule was rejected
 # ---------------------------------------------------------------------------
@@ -108,9 +136,13 @@ def test_conditioning_grows_slowly_with_terminator_reflection():
     for gamma_t in (0.0, 0.08, 0.5):
         a, b = _plant(_through(n_f), gamma_t, n_f)
         conds[gamma_t] = float(solve_two_port_from_wave_amplitudes(a, b).cond_a[0])
-    assert conds[0.0] == pytest.approx(1.0, abs=1e-9)
-    assert conds[0.08] < 1.3
-    assert 2.0 < conds[0.5] < 3.0
+    # Closed form for this planted through line: cond = (1+|Gt|)/(1-|Gt|).
+    # Assert against that, not a hand-picked bound: the |Gt|=0.5 value is
+    # EXACTLY 3.0, and a bare `< 3.0` passed only because this platform's SVD
+    # rounds to 2.999999999999999 — a LAPACK/numpy change could flip it
+    # (cross-machine float flake class, project_ci_slow_suite_fixes).
+    for gt, c in conds.items():
+        assert c == pytest.approx((1.0 + gt) / (1.0 - gt), rel=1e-9, abs=1e-9)
 
 
 # ---------------------------------------------------------------------------
@@ -136,12 +168,16 @@ def test_recovers_shunt_resistor_exactly_despite_terminator():
 # Defect discrimination — a gate that cannot fail a broken input is not a gate
 # ---------------------------------------------------------------------------
 
-def test_swapped_receive_amplitude_is_caught():
-    """Consuming the wrong amplitude at the receive array (defect D2).
+def test_swapped_receive_amplitude_one_drive_is_caught():
+    """Consuming the wrong amplitude at the receive array, ONE drive only.
 
     The receive array holds a large transmitted wave and a small one returning
-    off its terminator; taking the small one is the single most likely wiring
-    mistake. It must not look like a plausible result.
+    off its terminator; taking the small one is a likely wiring mistake. This
+    one-sided variant collapses |S21| and is easy to catch.
+
+    NOTE: the realistic SYSTEMATIC version of this mistake — the same mislabel
+    applied to BOTH drives — behaves completely differently and is NOT caught
+    here. See the next test; do not read this one as covering that.
     """
     n_f = len(_FREQS)
     a, b = _plant(_through(n_f), 0.08, n_f)
@@ -151,6 +187,48 @@ def test_swapped_receive_amplitude_is_caught():
     bad = solve_two_port_from_wave_amplitudes(a_bad, b_bad)
     assert np.all(np.abs(good.s_params[1, 0]) > 0.99)
     assert np.all(np.abs(bad.s_params[1, 0]) < 0.2), np.abs(bad.s_params[1, 0])
+
+
+def test_both_drive_swap_is_NOT_caught_by_either_witness():
+    """DOCUMENTED GAP: the systematic a/b mislabel evades both local witnesses.
+
+    A real implementation bug mislabels incident vs outgoing at one port
+    CONSISTENTLY, i.e. for both drives. That is the non-diagonal transform
+    ``S' = N M^-1`` with ``M = [[1,0],[S21,S22]]``, ``N = [[S11,S12],[0,1]]``,
+    giving ``S'21 = -S21/S22`` and ``S'12 = S12/S22``. Because the two share a
+    magnitude, **magnitude reciprocity is exactly blind to it**, and the
+    matrix stays well conditioned, so the ill-conditioning guard is silent too.
+
+    The through line (S22=0) and the shunt resistor (S11=S22) are DEGENERATE
+    for this defect — it collapses to a singular matrix there and gets caught
+    by accident. That accident is why the original battery looked complete.
+    An asymmetric DUT exposes the truth.
+
+    The independent handle is PASSIVITY, not anything in this module:
+    ``S'22 = 1/S22`` explodes for any well-matched passive DUT. Whatever ships
+    on top of this solve must route through the repo's passivity self-check.
+    """
+    n_f = len(_FREQS)
+    s_true = _asymmetric_reciprocal(48.5914, n_f)
+    assert not np.isclose(abs(s_true[0][0]), abs(s_true[3][0]))  # truly asymmetric
+    a, b = _plant(s_true, 0.05, n_f)
+    a_bad, b_bad = a.copy(), b.copy()
+    a_bad[1, :], b_bad[1, :] = b[1, :].copy(), a[1, :].copy()
+    bad = solve_two_port_from_wave_amplitudes(a_bad, b_bad)
+
+    # 1. reciprocity: blind (this is the finding)
+    np.testing.assert_allclose(
+        np.abs(bad.s_params[1, 0]), np.abs(bad.s_params[0, 1]), atol=1e-9
+    )
+    # 2. conditioning guard: silent — nowhere near the 1e3 default
+    assert np.all(bad.cond_a < 1.0e2), bad.cond_a
+    # 3. the recovered S is nonetheless grossly wrong, and PASSIVITY sees it
+    assert np.all(np.abs(bad.s_params[1, 0]) > 2.0)
+    np.testing.assert_allclose(
+        np.abs(bad.s_params[1, 1]), 1.0 / np.abs(s_true[3]), rtol=1e-9
+    )
+    col_power = np.abs(bad.s_params[0, 0]) ** 2 + np.abs(bad.s_params[1, 0]) ** 2
+    assert np.all(col_power > 1.1), col_power
 
 
 @pytest.mark.parametrize("scale", [1.05, 1.5, 0.8])
@@ -223,9 +301,13 @@ def test_ill_conditioned_drives_warn_and_are_reported():
     a[0, 0], a[1, 0] = 1.0, 1.0
     a[0, 1], a[1, 1] = 1.0, 1.0 + 1e-12    # second drive ~ first
     b[:, :] = 0.5
-    with pytest.warns(UserWarning, match="ill-conditioned"):
+    with pytest.warns(UserWarning, match="nearly linearly dependent") as rec:
         out = solve_two_port_from_wave_amplitudes(a, b)
     assert np.all(out.cond_a > 1e3)
+    # The warning must NOT read as "below this threshold is trustworthy" —
+    # cond(A) also multiplies the caller's amplitude noise (review finding).
+    msg = str(rec[0].message).lower()
+    assert "degeneracy only" in msg and "not a reliability certificate" in msg
 
 
 def test_shape_and_finiteness_contract():

--- a/tests/test_coax_two_port_solve.py
+++ b/tests/test_coax_two_port_solve.py
@@ -1,0 +1,245 @@
+"""Two-drive 2x2 coax S-parameter solve (issue #489) — pure, no FDTD.
+
+These tests pin the design decision behind `solve_two_port_from_wave_amplitudes`
+as executable facts rather than prose:
+
+  * the obvious rule `S[j,i] = b_j / a_i` has a HARD floor set by the terminator
+    (measured 0.0800 with rfx's validated |Gamma_t| < 0.08 terminator), so it
+    cannot be made accurate by improving the implementation;
+  * the two-drive solve removes that floor entirely, staying exact to ~1e-13
+    even at |Gamma_t| = 0.5;
+  * the two most likely implementation defects (consuming the wrong amplitude
+    at the receive array, and a wave-split orientation flip) are separated from
+    a correct implementation by a wide margin.
+
+All fields are planted analytically from a signal-flow solve, so the "truth"
+here is exact and independent of any rfx extraction path.
+"""
+
+import numpy as np
+import pytest
+
+from rfx.sources.coaxial_port import solve_two_port_from_wave_amplitudes
+
+_FREQS = np.array([4e9, 6e9, 8e9, 10e9, 12e9])
+
+
+def _plant(s_true, gamma_t, n_f):
+    """Wave amplitudes at both ports for both drives, with terminator Gamma_t.
+
+    Signal flow for a 2-port S with a terminator of reflection ``gamma_t`` at
+    the NON-driven port and a unit incident wave at the driven port::
+
+        drive 1:  a1 = 1,  a2 = gamma_t * b2
+                  b2 = S21 / (1 - S22*gamma_t),  b1 = S11 + S12*b2*gamma_t
+
+    and the mirror for drive 2. Returns ``(a, b)`` shaped
+    ``(2, 2, n_f)`` indexed ``[measured_port, driven_port, freq]``.
+    """
+    s11, s12, s21, s22 = s_true
+    a = np.zeros((2, 2, n_f), dtype=np.complex128)
+    b = np.zeros((2, 2, n_f), dtype=np.complex128)
+    # drive port 1
+    b2 = s21 / (1.0 - s22 * gamma_t)
+    a[0, 0], a[1, 0] = 1.0, gamma_t * b2
+    b[1, 0], b[0, 0] = b2, s11 + s12 * (gamma_t * b2)
+    # drive port 2
+    b1 = s12 / (1.0 - s11 * gamma_t)
+    a[1, 1], a[0, 1] = 1.0, gamma_t * b1
+    b[0, 1], b[1, 1] = b1, s22 + s21 * (gamma_t * b1)
+    return a, b
+
+
+def _through(n_f):
+    """Ideal lossless through: S11=S22=0, S21=S12=1 (phase absorbed)."""
+    one = np.ones(n_f, dtype=np.complex128)
+    return (0.0 * one, one, one, 0.0 * one)
+
+
+def _shunt_resistor(r_ohm, z0, n_f):
+    """Exact S of a shunt resistor R across a line of impedance Z0."""
+    one = np.ones(n_f, dtype=np.complex128)
+    y = z0 / (2.0 * r_ohm)
+    s11 = -y / (1.0 + y) * one
+    s21 = 1.0 / (1.0 + y) * one
+    return (s11, s21, s21, s11)
+
+
+# ---------------------------------------------------------------------------
+# Why the obvious rule was rejected
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("gamma_t", [0.02, 0.05, 0.08])
+def test_single_ratio_rule_has_a_terminator_floor(gamma_t):
+    """`S[j,i] = b_j/a_i` reads |1 + S11 - S21| = |Gamma_t| EXACTLY.
+
+    This is the measurement that killed the round-1 design: on a through line
+    the whole terminator reflection lands in S11, so the through-line identity
+    residual equals the terminator reflection no matter how good the rest of
+    the implementation is. rfx's validated matched terminator only reaches
+    |Gamma_t| < 0.08, so a 0.05-level identity gate was unreachable BY
+    CONSTRUCTION rather than by any defect.
+    """
+    n_f = len(_FREQS)
+    a, b = _plant(_through(n_f), gamma_t, n_f)
+    s11_ratio = b[0, 0] / a[0, 0]
+    s21_ratio = b[1, 0] / a[0, 0]
+    resid = np.abs(1.0 + s11_ratio - s21_ratio)
+    np.testing.assert_allclose(resid, gamma_t, rtol=1e-12)
+
+
+def test_two_drive_solve_removes_the_terminator_floor():
+    """The same planted fields, solved properly, are exact at every Gamma_t."""
+    n_f = len(_FREQS)
+    for gamma_t in (0.0, 0.02, 0.08, 0.2, 0.5):
+        a, b = _plant(_through(n_f), gamma_t, n_f)
+        out = solve_two_port_from_wave_amplitudes(a, b)
+        np.testing.assert_allclose(np.abs(out.s_params[1, 0]), 1.0, atol=1e-13)
+        np.testing.assert_allclose(np.abs(out.s_params[0, 0]), 0.0, atol=1e-13)
+        # Conditioning stays mild across the whole range — this is why no
+        # terminator improvement is a prerequisite for issue #489.
+        assert np.all(out.cond_a < 3.0), (gamma_t, out.cond_a)
+
+
+def test_conditioning_grows_slowly_with_terminator_reflection():
+    """Pins the measured cond(A) trend so a regression is visible."""
+    n_f = 1
+    conds = {}
+    for gamma_t in (0.0, 0.08, 0.5):
+        a, b = _plant(_through(n_f), gamma_t, n_f)
+        conds[gamma_t] = float(solve_two_port_from_wave_amplitudes(a, b).cond_a[0])
+    assert conds[0.0] == pytest.approx(1.0, abs=1e-9)
+    assert conds[0.08] < 1.3
+    assert 2.0 < conds[0.5] < 3.0
+
+
+# ---------------------------------------------------------------------------
+# Exact DUT recovery
+# ---------------------------------------------------------------------------
+
+def test_recovers_shunt_resistor_exactly_despite_terminator():
+    """A known-mismatch DUT is recovered exactly, terminator and all."""
+    n_f = len(_FREQS)
+    z0, r = 48.5914, 25.0
+    s_true = _shunt_resistor(r, z0, n_f)
+    a, b = _plant(s_true, 0.08, n_f)
+    out = solve_two_port_from_wave_amplitudes(a, b)
+    np.testing.assert_allclose(out.s_params[0, 0], s_true[0], atol=1e-12)
+    np.testing.assert_allclose(out.s_params[1, 0], s_true[2], atol=1e-12)
+    # Reciprocity is a property of the recovered matrix, not an input.
+    np.testing.assert_allclose(
+        out.s_params[1, 0], out.s_params[0, 1], atol=1e-12
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defect discrimination — a gate that cannot fail a broken input is not a gate
+# ---------------------------------------------------------------------------
+
+def test_swapped_receive_amplitude_is_caught():
+    """Consuming the wrong amplitude at the receive array (defect D2).
+
+    The receive array holds a large transmitted wave and a small one returning
+    off its terminator; taking the small one is the single most likely wiring
+    mistake. It must not look like a plausible result.
+    """
+    n_f = len(_FREQS)
+    a, b = _plant(_through(n_f), 0.08, n_f)
+    good = solve_two_port_from_wave_amplitudes(a, b)
+    a_bad, b_bad = a.copy(), b.copy()
+    b_bad[1, 0], a_bad[1, 0] = a[1, 0], b[1, 0]   # swap at port 2, drive 1
+    bad = solve_two_port_from_wave_amplitudes(a_bad, b_bad)
+    assert np.all(np.abs(good.s_params[1, 0]) > 0.99)
+    assert np.all(np.abs(bad.s_params[1, 0]) < 0.2), np.abs(bad.s_params[1, 0])
+
+
+@pytest.mark.parametrize("scale", [1.05, 1.5, 0.8])
+def test_reciprocity_catches_a_per_port_amplitude_error(scale):
+    """A per-port CALIBRATION error is visible to the reciprocity witness.
+
+    Scaling both amplitudes at one port by ``c`` is the similarity
+    ``S -> D S D^-1`` with ``D = diag(1, c)``, which sends
+    ``S21 -> c*S21`` and ``S12 -> S12/c``. The product is invariant but the
+    RATIO moves by ``c^2``, so reciprocity sees it — including the 5%
+    amplitude-calibration defect the design review flagged as untracked.
+    """
+    n_f = len(_FREQS)
+    s_true = _shunt_resistor(25.0, 48.5914, n_f)
+    a, b = _plant(s_true, 0.05, n_f)
+    a_bad, b_bad = a.copy(), b.copy()
+    a_bad[1, :] *= scale
+    b_bad[1, :] *= scale
+    bad = solve_two_port_from_wave_amplitudes(a_bad, b_bad)
+    ratio = np.abs(bad.s_params[1, 0]) / np.abs(bad.s_params[0, 1])
+    np.testing.assert_allclose(ratio, scale ** 2, rtol=1e-9)
+    dev = np.abs(np.abs(bad.s_params[1, 0]) - np.abs(bad.s_params[0, 1]))
+    assert np.all(dev > 0.04), dev
+
+
+@pytest.mark.parametrize(
+    "diag_factor", [-1.0, np.exp(-1j * 0.7), 1j], ids=["sign", "phase", "quarter"]
+)
+def test_reciprocity_is_BLIND_to_any_unit_modulus_per_port_factor(diag_factor):
+    """The witness's blind spot, pinned so nobody over-trusts it.
+
+    Any per-port factor of unit modulus — a sign flip from a wave-split
+    orientation mistake, or a reference-plane shift — is a diagonal similarity
+    ``D S D^-1`` with ``|D_jj| = 1``. It sends ``S21 -> c*S21`` and
+    ``S12 -> S12/c`` with ``|c| = 1``, so BOTH magnitudes are untouched and
+    reciprocity cannot see it at all.
+
+    This test was written expecting the opposite and failed; the algebra above
+    is why. Consequence for issue #489: reciprocity separates amplitude and
+    orientation-SCALE defects, but a first gate must NOT be advertised as
+    covering orientation sign or reference-plane errors — those need an
+    independent handle (a known-phase DUT, or an invariance check).
+    """
+    n_f = len(_FREQS)
+    s_true = _shunt_resistor(25.0, 48.5914, n_f)
+    a, b = _plant(s_true, 0.05, n_f)
+    good = solve_two_port_from_wave_amplitudes(a, b)
+    a_bad, b_bad = a.copy(), b.copy()
+    a_bad[1, :] *= diag_factor
+    b_bad[1, :] *= diag_factor
+    bad = solve_two_port_from_wave_amplitudes(a_bad, b_bad)
+    np.testing.assert_allclose(
+        np.abs(bad.s_params[1, 0]), np.abs(bad.s_params[0, 1]), atol=1e-12
+    )
+    # ...and it is invisible against the correct result too, not just internally.
+    np.testing.assert_allclose(
+        np.abs(bad.s_params[1, 0]), np.abs(good.s_params[1, 0]), atol=1e-12
+    )
+
+
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+
+def test_ill_conditioned_drives_warn_and_are_reported():
+    """Two nearly identical drives must not silently produce a plausible S."""
+    n_f = 2
+    a = np.zeros((2, 2, n_f), dtype=np.complex128)
+    b = np.zeros((2, 2, n_f), dtype=np.complex128)
+    a[0, 0], a[1, 0] = 1.0, 1.0
+    a[0, 1], a[1, 1] = 1.0, 1.0 + 1e-12    # second drive ~ first
+    b[:, :] = 0.5
+    with pytest.warns(UserWarning, match="ill-conditioned"):
+        out = solve_two_port_from_wave_amplitudes(a, b)
+    assert np.all(out.cond_a > 1e3)
+
+
+def test_shape_and_finiteness_contract():
+    with pytest.raises(ValueError, match="same shape"):
+        solve_two_port_from_wave_amplitudes(
+            np.zeros((2, 2, 3), dtype=complex), np.zeros((2, 2, 4), dtype=complex)
+        )
+    with pytest.raises(ValueError, match=r"\(2, 2, n_freqs\)"):
+        solve_two_port_from_wave_amplitudes(
+            np.zeros((3, 2, 3), dtype=complex), np.zeros((3, 2, 3), dtype=complex)
+        )
+    # A NaN bin is reported as NaN, never quietly dropped or interpolated.
+    a, b = _plant(_through(2), 0.05, 2)
+    a[0, 0, 1] = np.nan
+    out = solve_two_port_from_wave_amplitudes(a, b)
+    assert np.all(np.isfinite(out.s_params[:, :, 0]))
+    assert np.all(np.isnan(out.s_params[:, :, 1]))


### PR DESCRIPTION
Stage 1 of roadmap item #489. Pure linear algebra plus the measurements that justify it — **no FDTD path yet**, deliberately. This is the piece that can be proven right in isolation, and the design rounds showed the FDTD layout still has open questions (PML clearance at both ends, which DUT class the gates would certify).

## What this adds

`solve_two_port_from_wave_amplitudes(a_inc, b_out) -> TwoPortWaveSolve` in `rfx/sources/coaxial_port.py`, plus 17 analytic tests.

## Why not the obvious rule

`S[j,i] = b_j / a_i` assumes the non-driven port receives nothing. It does not: with terminator reflection `Γ_t`, the whole reflection lands in S11, so on a through line `|1 + S11 − S21| = |Γ_t|` **exactly** — pinned as a test, parametrized over 0.02/0.05/0.08, exact to 1e-12. rfx's validated matched terminator only reaches `|Γ_t| < 0.08` (`tests/test_coaxial_line_calibration.py:67`), so a 0.05-level identity gate was unreachable **by construction rather than by any defect**. That measurement is what killed the first design.

## What works instead

The inner extractor already returns both amplitudes at both arrays, and at the far array the reference plane sits above the probes, so the non-driven port's incident wave is **measured, not assumed zero**. Two drives give four equations in four unknowns, `S = B·inv(A)`:

| \|Γ_t\| | 0.0 | 0.08 | 0.2 | 0.5 |
|---|---|---|---|---|
| cond(A) | 1.00 | 1.15 | 1.42 | 3.00 |
| err \|S21\| | ~1e-16 | ~1e-16 | ~1e-16 | ~1e-13 |

**Terminator quality is irrelevant up to |Γ_t| = 0.5**, so a better terminator is not a prerequisite for #489.

## What the local witnesses can and cannot see

This is the part worth reading, and two of the three rows were found by tests failing against my expectations.

| defect | reciprocity | conditioning | caught by |
|---|---|---|---|
| per-port amplitude error (\|c\| ≠ 1) | **sees it** (ratio moves by c²) | no | reciprocity |
| per-port unit-modulus factor (sign flip, reference-plane shift) | **blind** — diagonal similarity | no | needs an independent handle |
| systematic both-drive a/b mislabel | **blind** — non-diagonal, preserves \|S21\|=\|S12\| | no (cond = 40.8, 4% of threshold) | **passivity only** |

The third row is an independent reviewer's finding: my original battery tested only the *single-drive* swap, and it passed for the wrong reason — both my fixtures are degenerate for the systematic version (through line has S22 = 0, shunt resistor has S11 = S22), so it collapsed to a singular matrix and got caught by accident. An asymmetric DUT exposes it: `|S21| = 16.06` with reciprocity deviation `3.55e-15`. Passivity is the required downstream handle and is named as such in the test and the docstring.

The conditioning threshold (`cond_warn = 1e3`) bounds **degeneracy only** and is explicitly not a reliability certificate — measured, 1e-4 amplitude noise gives ~1.3e-2 relative error in S at cond = 199, which never trips it. The warning says so, and a test asserts that wording so it cannot regress to the misleading form.

## Ground truth is itself verified

Every test depends on the planted-field helper and the asymmetric fixture, and the blocking finding above was caused by an unchecked fixture property. So the asymmetric DUT is derived a second way — node analysis, sharing no code with its ABCD formula — agreeing to 1e-12, with reciprocity, asymmetry and passivity asserted.

## Not claimed

No FDTD path, no external referee, no absolute-magnitude claim. Design and full adversarial-review trail: `docs/research_notes/20260729_i489_coax_two_port_design.md` (local). Remaining work and four incidental pre-existing coax defects found during recon are in the #489 thread.

R3: memory=project_coax_dualsolver_branch_deadend + rfx-known-issues:1305 (CONSISTENT — builds on the reflection path, no openEMS revival, no tolerance loosening) | R2-attempts=0 physics runs, analytic only | falsifier=test_single_ratio_rule_has_a_terminator_floor pins the rejected alternative

🤖 Generated with [Claude Code](https://claude.com/claude-code)
