### PR TITLE
docs(msl): reliable-mask scope — one-sided detector, all 8 surfaces

### DIFF
--- a/docs/guides/simulation_methodology.md
+++ b/docs/guides/simulation_methodology.md
@@ -139,8 +139,11 @@ or to CW drive.
 - Treat Harminv frequency and Q as estimates from the supplied time window;
   compare stability across windows and meshes.
 - For MSL S-parameters, `reliable[p, k] == False` means the voltage/current
-  split for driven port `p` is too weak at bin `k`; exclude column `S[:, p, k]`
-  from RF interpretation. `True` is not a general accuracy guarantee.
+  split for port `p` is too weak at bin `k`; exclude the whole slice
+  `S[:, :, k]` from RF interpretation, since S is solved jointly across drives
+  (#507). `True` is neither a general accuracy guarantee nor full coverage — the
+  mask watches own-drive records only, so a passive-port plane collapse at that
+  bin is invisible to it.
 - On nonuniform MSL models, use the supported normalization documented by the
   calculator. Do not assume a uniform-grid normalization option is accepted.
 - For RCS, subtract an incident-only reference field before forming scattered

--- a/docs/guides/sparameter_support_matrix.json
+++ b/docs/guides/sparameter_support_matrix.json
@@ -136,7 +136,7 @@
       "known_limits": [
         "nonuniform mode=laplace or mode=uniform has no external comparison",
         "Result.s_params is not used; call compute_msl_s_matrix(...)",
-        "outside JAX tracing, reliable[p,k]=false invalidates S[:,p,k] for physical interpretation; true is not an accuracy guarantee",
+        "outside JAX tracing, reliable[p,k]=false invalidates the whole slice S[:,:,k] (S is solved jointly across drives, #507); true is neither an accuracy guarantee nor full coverage - the mask watches own-drive records only, so a passive-port plane collapse is invisible to it",
         "mode=eigenmode, SBP-SAT subgridding, ADI, TFSF, and mixed port families are unsupported",
         "strong-reflector |S11| has a characterized staircase-Z0 floor of about 0.16--0.22",
         "the automatic guard includes full driven-column power; passing it is not an accuracy guarantee",

--- a/docs/public/api/results-observables.mdx
+++ b/docs/public/api/results-observables.mdx
@@ -95,9 +95,11 @@ The ring-down advisory likewise requires a probe time series and is not a
 direct NTFF or DFT convergence test. Inspect unguarded arrays explicitly. The
 absence of a warning is not a passivity, convergence, or accuracy result.
 
-For MSL results, `reliable[p, k] = False` excludes the driven-port column
-`S[:, p, k]` from physical interpretation because the measured signal is too
-low for a stable wave split. A `True` entry is not an accuracy guarantee. See
+For MSL results, `reliable[p, k] = False` excludes the whole frequency slice
+`S[:, :, k]` from physical interpretation — not just the driven-port column —
+because S is solved jointly across drives (`S = B·A⁻¹`, #507). A `True` entry is
+neither an accuracy guarantee nor full coverage: the mask is computed from
+own-drive records only, so a passive-port plane collapse is invisible to it. See
 [Probes and S-Parameters](/rfx/guide/probes-sparams/#low-signal-msl-bins) for the
 threshold and filtering example.
 

--- a/docs/public/api/sources-ports.mdx
+++ b/docs/public/api/sources-ports.mdx
@@ -75,8 +75,10 @@ Use the calculator that matches the port family:
 
 During normal Python execution outside JAX tracing,
 `compute_msl_s_matrix()` returns `MSLSMatrixResult.reliable`. If
-`reliable[p, k]` is `False`, exclude the driven-port column `S[:, p, k]` from
-physical interpretation; `True` is not an accuracy guarantee. During tracing,
+`reliable[p, k]` is `False`, exclude the whole frequency slice `S[:, :, k]` from
+physical interpretation (S is solved jointly across drives, #507); `True` is
+neither an accuracy guarantee nor full coverage — the mask watches own-drive
+records only, so a passive-port plane collapse is invisible to it. During tracing,
 `.reliable` is `None`. See
 [Probes and S-Parameters](/rfx/guide/probes-sparams/#low-signal-msl-bins) for the
 threshold, array shape, and filtering example.

--- a/docs/public/guide/probes-sparams.mdx
+++ b/docs/public/guide/probes-sparams.mdx
@@ -204,13 +204,20 @@ The S-matrix is solved from the wave amplitudes of **all** drives at once
 (`S = B·A⁻¹`), so a collapsed wave pair at any one port contaminates the
 entire frequency slice `S[:, :, k]` — not just that port's column. A false
 entry at any port therefore means the whole S-matrix at that frequency should
-not be plotted, fitted, or optimized as physical data; `reliable[p, k]` tells
-you *which* port's probe plane collapsed. The values remain present for
-diagnosis. A true entry only means that the low-signal threshold was not
-triggered; it is not an accuracy guarantee.
+not be plotted, fitted, or optimized as physical data. The values remain
+present for diagnosis.
 
-The only safe per-bin filter is the one that requires every port to be
-reliable at that frequency:
+A true entry certifies less than it looks like it does, in two ways. It means
+the low-signal threshold was not triggered — never that the result is
+accurate. And the mask is computed from the **own-drive records only**
+(`raw_v[p, p, 0, :]`, `raw_i1[p, p, :]`), while the solve consumes the wave
+pair at every driven/port combination: a collapse at a *passive* port's plane
+during another port's drive is invisible to this mask and still corrupts the
+slice. So the index `p` does not reliably attribute which plane collapsed.
+
+The filter below is therefore **necessary but not sufficient** — it is the
+strongest screen this mask supports, not a guarantee that the surviving bins
+are clean:
 
 ```python
 import numpy as np

--- a/docs/public/validation/reference-lane.mdx
+++ b/docs/public/validation/reference-lane.mdx
@@ -26,7 +26,7 @@ For port calculations, also read the
 | Configuration | Current use and restriction |
 |---|---|
 | rectangular waveguide S-matrix | Use `compute_waveguide_s_matrix(...)` for the documented rectangular-guide modes, frequency bands, normalization, reference planes, and port placement. Magnitude evidence is broader than phase and arbitrary-junction evidence. |
-| microstrip-line S-matrix | Use `compute_msl_s_matrix(...)` for the documented quasi-TEM configurations. Exclude a driven-port column wherever `reliable[p, k]` is false. |
+| microstrip-line S-matrix | Use `compute_msl_s_matrix(...)` for the documented quasi-TEM configurations. Exclude the whole frequency slice `S[:, :, k]` wherever `reliable[p, k]` is false (S is solved jointly across drives, #507); a true entry is not full coverage — the mask watches own-drive records only. |
 | lumped or wire-port S-parameters | Use `run(compute_s_params=True)` or the documented differentiable S11 path. These discrete lumped/wire feed models are not modal transmission-line ports. |
 | coaxial transmission-line reflection | Use `compute_coaxial_line_reflection(...)` only with float32 precision, a nonperiodic 3D second-order uniform Yee grid, CPML on all six boundary faces with positive thickness on both z faces, `cpml_axes="z"`, and exactly one `face="top"` coaxial port. It builds its own line, source, probes, and termination, is not a general multi-port coaxial-network solver, and has no shared automatic passivity guard. See [Sources and Ports](/rfx/api/sources-ports/). |
 | nonuniform graded-z mesh | Check the limit for each source, port, and observable. Regression or finite-gradient coverage alone does not establish RF accuracy. |

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -1291,14 +1291,23 @@ class MSLSMatrixResult:
         where both voltage and current collapse below 10% of their band
         medians. S values at those bins are retained unchanged.
 
-        Blast radius under the multi-drive solve (issue #507): S is
-        ``B·A⁻¹`` over ALL drives, so a collapsed wave pair at port ``p``
-        contaminates the ENTIRE frequency slice ``S[:, :, k]`` — not just
-        the column ``S[:, p, k]`` that the pre-#507 single-ratio assembly
-        confined it to. ``reliable[p, k]`` still tells you WHICH port's
-        plane collapsed; the only safe per-bin filter is
-        ``np.all(reliable, axis=0)``. A True entry is not an accuracy
-        guarantee.
+        SCOPE — read both halves, they pull in opposite directions.
+
+        *What a False entry condemns*: more than it used to. S is ``B·A⁻¹``
+        over ALL drives (issue #507), so a collapsed wave pair anywhere
+        contaminates the ENTIRE frequency slice ``S[:, :, k]``, not just
+        the column ``S[:, p, k]`` the pre-#507 single-ratio assembly
+        confined it to. Drop the whole bin, not one column.
+
+        *What a True entry does NOT certify*: this mask is computed from
+        the OWN-DRIVE records only — ``raw_v[p, p, 0, :]`` and
+        ``raw_i1[p, p, :]`` — while the solve consumes the wave pair at
+        every (driven, port) combination. A collapse at a PASSIVE port's
+        plane during some other port's drive is therefore invisible here
+        and still corrupts the slice. ``np.all(reliable, axis=0)`` is
+        necessary but NOT sufficient, and the index ``p`` does not
+        reliably attribute which plane collapsed. Tracked as a coverage
+        gap; until it closes, treat this mask as a one-sided detector.
     settling_db : (n_ports,) float, optional
         Ring-down settling witness per driven-port run: the WORST (largest)
         over ALL port probe planes of ``10*log10(mean Ez^2 over the last 10%


### PR DESCRIPTION
Post-merge sweep of `f95240f` (PR #516) found my own F5 fix there was **both incomplete and, where it landed, overstated**. Docs/docstring only, no behaviour change.

## Incomplete — 5 of 8 surfaces still taught the unsafe rule

The corrected wording reached 3 surfaces. These five still said "exclude the driven-port column `S[:, p, k]`", which is unsafe under the multi-drive solve because S is solved jointly across drives:

- `docs/public/api/results-observables.mdx:98-99`
- `docs/public/api/sources-ports.mdx:78`
- `docs/public/validation/reference-lane.mdx:29`
- `docs/guides/simulation_methodology.md:141-142`
- `docs/guides/sparameter_support_matrix.json:139` — the .md's own machine-readable companion, contradicting the corrected .md in the same directory

## Overstated — the part that matters more

My F5 text asserted that `reliable[p, k]` *"still tells you WHICH port's plane collapsed"* and that `np.all(reliable, axis=0)` is *"the only **safe** per-bin filter"*. Neither is supportable:

```python
# rfx/api/_sparams.py — what the mask is fed
v_port = np.stack([raw_v[p, p, 0, :] for p in range(n_ports)])   # own-drive only
i_port = np.stack([raw_i1[p, p, :]   for p in range(n_ports)])

# what the solve consumes
wave_a[driven][j] = 0.5 * (v0_j + z0_j * i_j)   # every (driven, port) pair
```

A collapse at a **passive** port's plane during another port's drive never reaches the mask, yet under `S = B·A⁻¹` it corrupts the whole slice. So the `np.all` filter can pass a poisoned bin, and the index `p` does not reliably attribute the collapse. I replaced a wrong claim (column containment) with a differently wrong one (attribution + filter sufficiency).

## What all 8 surfaces now say

Two-sided, consistently:

- a **False** entry condemns the entire frequency slice `S[:, :, k]`, not one column;
- a **True** entry is neither an accuracy guarantee **nor full coverage** — the mask watches own-drive records only;
- `np.all(reliable, axis=0)` is documented as **necessary but not sufficient** — the strongest screen this mask supports, not a clean-bin guarantee.

The underlying coverage gap (mask inputs vs solve consumption) is a design decision — widen the mask's inputs, or keep it own-drive and scope the docs — and is filed separately. This PR stops the docs promising what the mask cannot deliver in the meantime.

## Verification

- `grep` for column-only claims across `docs/`: **none remain**
- support-matrix + AD-surface contract tests: **24 passed**
- `scripts/check_api_reference.py`: OK · `ruff check rfx/ tests/`: clean
- JSON parses

`R3: memory=feedback_gate_can_bind_artifact (a True that does not measure what is consumed) | R2-attempts=0 | falsifier=grep returns no column-only claim; contract gates green`

🤖 Generated with [Claude Code](https://claude.com/claude-code)