### PR TITLE
fix(test): rebuild the MSL AD-vs-FD comparator in float64 and gate its resolving power (closes #527)

### DIFF
--- a/scripts/msl_ad_fd_f64_referee.py
+++ b/scripts/msl_ad_fd_f64_referee.py
@@ -16,20 +16,30 @@ A float32 value near ``loss = 16.005951`` can only move in steps of one ULP,
 ``2h|g| = 8.4723e-06`` — **4.4 ULP wide**. The subtraction therefore returns an
 integer number of quantisation steps, not a derivative.
 
-Measured on the gate's own fixture (VESSL 369367250742, gpu-rtx4090), every
-value in an h-sweep came back an EXACT integer multiple of ``ULP/(2h)``:
+Measured on the gate's own fixture (VESSL 369367250742, gpu-rtx4090), the span
+stayed between 1 and 76 ULP across the whole sweep, while the FD value scattered
+2017% and changed sign:
 
-    h        g_fd            ULP/(2h)      g_fd / quantum
-    3.0e-04  +4.450480e-02   3.1789e-03    14.0000
-    5.0e-04  +1.907349e-03   1.9073e-03     1.0000   <- one single ULP
-    1.0e-03  -2.861023e-02   9.5367e-04   -30.0000   <- the gate's h
-    2.0e-03  -3.337860e-03   4.7684e-04    -7.0000
-    5.0e-03  -5.912781e-03   1.9073e-04   -31.0000
-    1.0e-02  -4.959106e-03   9.5367e-05   -52.0000
-    2.0e-02  -3.623962e-03   4.7684e-05   -76.0000
+    h        g_fd            span (ULP)
+    3.0e-04  +4.450480e-02       14
+    5.0e-04  +1.907349e-03        1     <- the entire measurement is ONE ULP
+    1.0e-03  -2.861023e-02       30     <- the gate's h
+    2.0e-03  -3.337860e-03        7
+    5.0e-03  -5.912781e-03       31
+    1.0e-02  -4.959106e-03       52
+    2.0e-02  -3.623962e-03       76
 
-Seven for seven. The sign flip that looked like a physics puzzle is just which
-side of a representable value each evaluation landed on.
+The sign flip that looked like a physics puzzle is just which side of a
+representable value each evaluation landed on.
+
+CAUTION for anyone reusing this reasoning: those spans are exact integers, and
+an earlier draft of this docstring offered that integrality as the proof. It is
+not evidence of anything — ANY two float32 values in the same binade differ by
+an integer number of ULPs (200k random pairs, including deliberately
+well-resolved ones 47186 ULP apart, all reproduce it). Integrality shows only
+that the values were float32. The load-bearing fact is the MAGNITUDE of the
+span. Do not carry the integer-multiple test forward as a diagnostic; it fires
+on healthy comparators too.
 
 No h repairs this: 1% quantisation resolution needs ``2h|g| > 100 ULP``, i.e.
 ``h > 0.0225`` — a 2.3% perturbation of ``alpha``, where ``h^2`` truncation

--- a/scripts/msl_ad_fd_f64_referee.py
+++ b/scripts/msl_ad_fd_f64_referee.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Float64 finite-difference referee for the MSL AD gate (issue #527).
+
+WHY THIS EXISTS
+---------------
+``test_msl_ad_fd_converged_tight`` compares reverse-mode AD against a central
+finite difference whose two loss evaluations are computed in **float32**::
+
+    alpha0  = jnp.float32(1.0)
+    f_plus  = float(objective(jnp.float32(float(alpha0) + _FD_H)))
+    f_minus = float(objective(jnp.float32(float(alpha0) - _FD_H)))
+    g_fd    = (f_plus - f_minus) / (2.0 * _FD_H)
+
+A float32 value near ``loss = 16.005951`` can only move in steps of one ULP,
+``1.907349e-06``. At the gate's ``h = 1e-3`` the true difference is
+``2h|g| = 8.4723e-06`` — **4.4 ULP wide**. The subtraction therefore returns an
+integer number of quantisation steps, not a derivative.
+
+Measured on the gate's own fixture (VESSL 369367250742, gpu-rtx4090), every
+value in an h-sweep came back an EXACT integer multiple of ``ULP/(2h)``:
+
+    h        g_fd            ULP/(2h)      g_fd / quantum
+    3.0e-04  +4.450480e-02   3.1789e-03    14.0000
+    5.0e-04  +1.907349e-03   1.9073e-03     1.0000   <- one single ULP
+    1.0e-03  -2.861023e-02   9.5367e-04   -30.0000   <- the gate's h
+    2.0e-03  -3.337860e-03   4.7684e-04    -7.0000
+    5.0e-03  -5.912781e-03   1.9073e-04   -31.0000
+    1.0e-02  -4.959106e-03   9.5367e-05   -52.0000
+    2.0e-02  -3.623962e-03   4.7684e-05   -76.0000
+
+Seven for seven. The sign flip that looked like a physics puzzle is just which
+side of a representable value each evaluation landed on.
+
+No h repairs this: 1% quantisation resolution needs ``2h|g| > 100 ULP``, i.e.
+``h > 0.0225`` — a 2.3% perturbation of ``alpha``, where ``h^2`` truncation
+dominates instead. The usable window has closed, so Richardson extrapolation
+over h would extrapolate over quantisation noise.
+
+This did not used to bite. Before PR #516 the gradient was ``2.1143e-01``; the
+extractor fix moved ``|S11|`` from 0.2233 to ~0.05, shrinking it 50x to
+``4.2362e-03`` while the loss magnitude — and therefore the ULP — stayed put.
+The signal fell off the resolvable end of float32:
+
+    2h|g| at the gate's h:   pre-#516 ~222 ULP    post-#516 4.4 ULP
+
+Independently corroborated by a number recorded before that change: the #477
+work logged a "27% NON-monotone FD scatter" on this fixture; the same sweep now
+reads 2017%, and 27% x 50 ~ 1350% is the same order.
+
+WHAT THIS SCRIPT DOES
+---------------------
+Evaluates the loss under ``jax.experimental.enable_x64()`` (a scoped context —
+module-level ``jax.config.update('jax_enable_x64', True)`` is forbidden here:
+it is process-global, flips at pytest collection, and reds every same-process
+pytest-split shard). ``rfx/probes/probes.py`` already keys its DFT accumulator
+dtype off ``jax.config.x64_enabled``, so x64 reaches the S-matrix: a plumbing
+smoke at num_periods=3 returned ``S.dtype=complex128``, ``loss.dtype=float64``,
+ULP ``8.88e-16`` — and an f32/f64 loss pair agreeing to 7 digits (7.94825983 vs
+7.94825835), confirming the f32 *forward* is sound and only the *subtraction*
+was unresolvable.
+
+Reports, per h, the ULP headroom alongside every number, so the comparator's own
+validity is visible in the same table as the result it is used to judge.
+
+PRE-DECLARED READS
+------------------
+  R1 f64 FD is h-stable (spread <= a few %) AND rel_err vs AD <= 0.10
+     -> the AD is correct; #527 is purely a comparator defect. Switch the gate
+        to this referee, leave the 0.10 bound untouched.
+  R2 f64 FD is h-stable but rel_err stays well above 0.10
+     -> a genuine AD systematic, now measurable for the first time since #516.
+        #527 reopens on its original framing with a trustworthy instrument.
+  R3 f64 FD is still h-unstable
+     -> the residual scatter is not float32 quantisation; suspect the objective
+        itself (a non-smooth dependence of S on alpha, e.g. a mesh/rasterisation
+        threshold crossing as eps changes) and investigate that before the AD.
+
+Report-only. Modifies no gate.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+import warnings
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "tests"))
+
+import numpy as np  # noqa: E402
+
+DEFAULT_H = (3.0e-4, 1.0e-3, 2.0e-3, 5.0e-3, 1.0e-2)
+
+
+def _closest_divisor(n: int, target: int) -> int:
+    divs = [d for d in range(1, n + 1) if n % d == 0]
+    return min(divs, key=lambda d: (abs(d - target), d))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--num-periods", type=int, default=None,
+                    help="default: the gate's own _NUM_PERIODS")
+    ap.add_argument("--n-freqs", type=int, default=None)
+    ap.add_argument("--h", type=float, nargs="*", default=list(DEFAULT_H))
+    ap.add_argument("--f64-ad", action="store_true",
+                    help="also compute the AD gradient in f64 (slower; the "
+                         "shipped gate's AD is f32, so f32 is the default)")
+    args = ap.parse_args()
+
+    import jax
+    import jax.numpy as jnp
+    from jax.experimental import enable_x64
+
+    import rfx
+    print(f"rfx     : {rfx.__file__}")
+    print(f"jax     : {jax.__version__}   devices: {jax.devices()}")
+    if not str(Path(rfx.__file__).resolve()).startswith(str(REPO)):
+        print(f"FATAL: imported rfx is not this checkout ({REPO})")
+        return 2
+
+    from test_msl_ad_fd_converged import (  # noqa: E402
+        _FD_H,
+        _N_FREQS,
+        _NUM_PERIODS,
+        _REL_ERR_THRESHOLD,
+        _build_msl_sim,
+    )
+
+    num_periods = args.num_periods if args.num_periods is not None else _NUM_PERIODS
+    n_freqs = args.n_freqs if args.n_freqs is not None else _N_FREQS
+    print(f"fixture : num_periods={num_periods} n_freqs={n_freqs} "
+          f"(gate ships {_NUM_PERIODS}/{_N_FREQS}, h={_FD_H}, "
+          f"threshold={_REL_ERR_THRESHOLD})")
+
+    # ---- AD gradient: f32 by default, matching what the gate ships ----------
+    sim32 = _build_msl_sim()
+    grid = sim32._build_grid()
+    n_steps = int(grid.num_timesteps(num_periods=num_periods))
+    cseg = _closest_divisor(n_steps, int(np.sqrt(n_steps)))
+    assert n_steps % cseg == 0
+    print(f"grid    : {grid.shape}  n_steps={n_steps}  checkpoint_segments={cseg}")
+
+    def _objective(sim, dtype):
+        eps_base = jnp.ones(grid.shape, dtype=dtype)
+
+        def obj(alpha):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                r = sim.compute_msl_s_matrix(
+                    n_freqs=n_freqs, num_periods=num_periods,
+                    eps_override=eps_base * alpha, checkpoint_segments=cseg,
+                )
+            return jnp.real(jnp.sum(jnp.abs(r.S) ** 2))
+        return obj
+
+    print("\n--- AD (float32, as shipped) ---", flush=True)
+    t0 = time.perf_counter()
+    loss32, g32 = jax.value_and_grad(_objective(sim32, jnp.float32))(jnp.float32(1.0))
+    g_ad32, loss32 = float(g32), float(loss32)
+    ulp32 = float(np.spacing(np.float32(loss32)))
+    print(f"  loss = {loss32:.8f}   g_ad = {g_ad32:.6e}   ({time.perf_counter()-t0:.1f}s)")
+    print(f"  float32 ULP of this loss = {ulp32:.4e}")
+    print(f"  the SHIPPED f32 FD at h={_FD_H} would span "
+          f"{2*_FD_H*abs(g_ad32)/ulp32:.1f} ULP  <- why it cannot resolve 10%")
+
+    g_ad = g_ad32
+    with enable_x64():
+        if args.f64_ad:
+            print("\n--- AD (float64) ---", flush=True)
+            t0 = time.perf_counter()
+            sim64 = _build_msl_sim()
+            l64, g64 = jax.value_and_grad(
+                _objective(sim64, jnp.float64))(jnp.float64(1.0))
+            g_ad = float(g64)
+            print(f"  loss = {float(l64):.14f}   g_ad = {g_ad:.10e}   "
+                  f"({time.perf_counter()-t0:.1f}s)")
+            print(f"  f32-vs-f64 AD relative difference: "
+                  f"{abs(g_ad32-g_ad)/max(abs(g_ad),1e-300):.3e}")
+
+        # ---- f64 central differences ---------------------------------------
+        print("\n--- central FD, float64 loss ---", flush=True)
+        sim_fd = _build_msl_sim()
+        obj64 = _objective(sim_fd, jnp.float64)
+        print(f"  {'h':>9} {'g_fd':>18} {'rel_err':>10} {'signal (ULP)':>14} {'s':>6}")
+        rows = []
+        for h in sorted(args.h):
+            t0 = time.perf_counter()
+            fp = float(obj64(jnp.float64(1.0 + h)))
+            fm = float(obj64(jnp.float64(1.0 - h)))
+            g_fd = (fp - fm) / (2.0 * h)
+            ulp64 = float(np.spacing(np.float64(0.5 * (fp + fm))))
+            rel = abs(g_ad - g_fd) / (abs(g_fd) + 1e-300)
+            rows.append((h, g_fd, rel, abs(fp - fm) / ulp64))
+            print(f"  {h:9.1e} {g_fd:18.10e} {rel:10.4f} "
+                  f"{abs(fp-fm)/ulp64:14.3g} {time.perf_counter()-t0:6.1f}",
+                  flush=True)
+
+    # ---- verdict ------------------------------------------------------------
+    gs = np.array([r[1] for r in rows])
+    rels = np.array([r[2] for r in rows])
+    spread = float(np.ptp(gs) / max(abs(np.mean(gs)), 1e-300))
+    best_i = int(np.argmin(rels))
+    print(f"\n  g_ad                 : {g_ad:.10e}")
+    print(f"  f64 FD spread over h : {spread*100:.3f}%")
+    print(f"  best rel_err         : {rels[best_i]:.5f} at h = {rows[best_i][0]:.1e}")
+    print(f"  rel_err at gate's h  : "
+          f"{dict((r[0], r[2]) for r in rows).get(_FD_H, float('nan')):.5f}")
+
+    stable = spread <= 0.05
+    if stable and rels.min() <= _REL_ERR_THRESHOLD:
+        print("\nVERDICT R1: f64 FD is h-stable and agrees with AD inside the gate's "
+              "bound -> the AD is correct; #527 is a comparator defect. Switch the "
+              "gate to this referee and leave the 0.10 threshold alone.")
+    elif stable:
+        print("\nVERDICT R2: f64 FD is h-stable but disagrees with AD beyond the "
+              "gate's bound -> a genuine AD systematic, measurable for the first "
+              "time since #516. #527 reopens on its original framing.")
+    else:
+        print("\nVERDICT R3: f64 FD is STILL h-unstable -> the scatter is not float32 "
+              "quantisation. Suspect a non-smooth dependence of S on alpha (a "
+              "mesh/rasterisation threshold crossing) before suspecting the AD.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vessl_msl_ad_gate.yaml
+++ b/scripts/vessl_msl_ad_gate.yaml
@@ -1,0 +1,38 @@
+name: rfx-msl-ad-gate
+description: "#529: run the rebuilt MSL AD-vs-FD gate itself on the GPU lane it is marked for"
+tags: [rfx, issue-527, ad-fd, comparator]
+resources:
+  cluster: remilab-c0
+  preset: gpu-rtx4090
+image: nvcr.io/nvidia/jax:24.10-py3
+env:
+  PYTHONUNBUFFERED: "1"
+  XLA_PYTHON_CLIENT_PREALLOCATE: "false"
+  HDF5_USE_FILE_LOCKING: "FALSE"
+  LANG: "C.UTF-8"
+mount:
+  /root/workspace/: volume://remilab-fs/personal-workspaces/
+run: |-
+  set -euo pipefail
+  cd /root/workspace/byungkwan-workspace/research/rfx
+  git config --global --add safe.directory /root/workspace/byungkwan-workspace/research/rfx || true
+  echo "=== rfx #529 MSL-FD-TIGHT gate on its own lane ==="
+  echo "=== provenance ==="
+  git rev-parse HEAD || true
+  git status --short || true
+  echo "=== install runtime dependencies (repo path, no editable install) ==="
+  python -m pip install -q "scipy>=1.11" "h5py>=3.8" "matplotlib>=3.7" pytest
+  export RFX_REPO_ROOT="/root/workspace/byungkwan-workspace/research/rfx"
+  export PYTHONPATH="$RFX_REPO_ROOT:${PYTHONPATH:-}"
+  python -c "import jax, rfx; print('probe ok | jax', jax.__version__, '| devices', jax.devices(), '| rfx', getattr(rfx, '__version__', '?'))"
+  echo "=== pytest: the gate, its comparator-floor falsifier, and the dtype lock ==="
+  out=".omx/msl-ad-gate/$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short HEAD)"
+  mkdir -p "$out"
+  set +e
+  timeout 5400 python -u -m pytest tests/test_msl_ad_fd_converged.py -m "" -q -ra -s > "$out/gate.log" 2>&1
+  rc=$?
+  set -e
+  cat "$out/gate.log"
+  echo "$rc" > "$out/gate.rc"
+  echo "artifacts: $out"
+  exit "$rc"

--- a/scripts/vessl_msl_f64_referee.yaml
+++ b/scripts/vessl_msl_f64_referee.yaml
@@ -1,0 +1,38 @@
+name: rfx-msl-f64-referee
+description: "#527: f64 FD referee at the gate settings — measures agreement AND the f64 GPU cost"
+tags: [rfx, issue-527, ad-fd, comparator]
+resources:
+  cluster: remilab-c0
+  preset: gpu-rtx4090
+image: nvcr.io/nvidia/jax:24.10-py3
+env:
+  PYTHONUNBUFFERED: "1"
+  XLA_PYTHON_CLIENT_PREALLOCATE: "false"
+  HDF5_USE_FILE_LOCKING: "FALSE"
+  LANG: "C.UTF-8"
+mount:
+  /root/workspace/: volume://remilab-fs/personal-workspaces/
+run: |-
+  set -euo pipefail
+  cd /root/workspace/byungkwan-workspace/research/rfx
+  git config --global --add safe.directory /root/workspace/byungkwan-workspace/research/rfx || true
+  echo "=== rfx #527 f64 FD referee — agreement + f64 GPU cost at gate settings ==="
+  echo "=== provenance ==="
+  git rev-parse HEAD || true
+  git status --short || true
+  echo "=== install runtime dependencies (repo path, no editable install) ==="
+  python -m pip install -q "scipy>=1.11" "h5py>=3.8" "matplotlib>=3.7" pytest
+  export RFX_REPO_ROOT="/root/workspace/byungkwan-workspace/research/rfx"
+  export PYTHONPATH="$RFX_REPO_ROOT:${PYTHONPATH:-}"
+  python -c "import jax, rfx; print('probe ok | jax', jax.__version__, '| devices', jax.devices(), '| rfx', getattr(rfx, '__version__', '?'))"
+  echo "=== #527 h-sweep on the gate's own fixture ==="
+  out=".omx/msl-f64-referee/$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short HEAD)"
+  mkdir -p "$out"
+  set +e
+  timeout 5400 python -u scripts/msl_ad_fd_f64_referee.py --h 1e-3 2e-3 > "$out/referee.log" 2>&1
+  rc=$?
+  set -e
+  cat "$out/referee.log"
+  echo "$rc" > "$out/referee.rc"
+  echo "artifacts: $out"
+  exit "$rc"

--- a/scripts/vessl_msl_f64_referee.yaml
+++ b/scripts/vessl_msl_f64_referee.yaml
@@ -25,7 +25,7 @@ run: |-
   export RFX_REPO_ROOT="/root/workspace/byungkwan-workspace/research/rfx"
   export PYTHONPATH="$RFX_REPO_ROOT:${PYTHONPATH:-}"
   python -c "import jax, rfx; print('probe ok | jax', jax.__version__, '| devices', jax.devices(), '| rfx', getattr(rfx, '__version__', '?'))"
-  echo "=== #527 h-sweep on the gate's own fixture ==="
+  echo "=== #527 f64 FD referee at the gate's own settings ==="
   out=".omx/msl-f64-referee/$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short HEAD)"
   mkdir -p "$out"
   set +e

--- a/tests/test_msl_ad_fd_converged.py
+++ b/tests/test_msl_ad_fd_converged.py
@@ -206,7 +206,9 @@ def test_msl_ad_fd_converged_tight():
     is not: f32 AD 59.1s, f64 FD 41.7s and 37.7s per h (two forwards each),
     i.e. ~19s per f64 forward against ~15s for f32. This FDTD is
     memory-bandwidth-bound, so the RTX4090's 1/64 float64 throughput barely
-    shows; the whole gate runs in ~140s. On CPU the same forward takes ~500s,
+    shows. The gate's own measured total is 117.5s (AD 55.8s, FD 41.8s) on
+    VESSL 369367250794 — an earlier draft said "~140s", which was summed from
+    referee timings rather than measured on the gate itself. On CPU the same forward takes ~500s,
     which is why the decision was made from a measurement on the lane the gate
     actually runs in rather than from a local timing.
 
@@ -233,17 +235,29 @@ def test_msl_ad_fd_converged_tight():
 
     The 0.10 threshold is UNCHANGED. Nothing here loosens a gate.
 
-    WHAT THIS GATE DOES NOT ESTABLISH (issue #530). Passivity bounds
-    sum_ij|S_ij|^2 at 2 per frequency, so 16 over 8 bins — and the measured loss
-    is 16.00599, which sits 0.037% ABOVE that ceiling. The residue this gate
-    differentiates is therefore dominated by extraction/numerical error, not by
-    physical loss. That is a valid AD-vs-FD consistency test — AD must match the
-    FD of whatever the code computes, and it does, to 0.4% on CPU — but it is a
-    weak test of anything physical, and its signal will shrink again the next
-    time an extractor fix lands. The comparator floor above now makes that
-    failure mode loud instead of silent. Choosing an objective with real dynamic
-    range is tracked separately; it needs its own evidence, not a rider on a
-    comparator repair.
+    WHAT THIS GATE DOES NOT ESTABLISH (issue #530). For a passive network
+    S^dag S <= I, so each column of S has norm <= 1 and sum_ij|S_ij|^2 <= 2 per
+    frequency — 16 over 8 bins. The measured loss is 16.00599, i.e. 0.037% ABOVE
+    that ceiling, which puts the residue's LEVEL on the non-physical side: net
+    = (extraction error) - (physical loss) > 0 requires the extraction error to
+    exceed the physical loss in magnitude.
+
+    Note what that does and does not say. It is a statement about the level.
+    This gate differentiates the residue, and nothing measured here separates
+    d(extraction error)/d(alpha) from d(physical loss)/d(alpha) — alpha scales
+    eps over the whole grid, so guided wavelength, port match and radiation are
+    all genuinely alpha-sensitive while the extraction error may be comparatively
+    alpha-flat. The derivative's composition is UNMEASURED, not attributed.
+
+    The case for changing the objective does not rest on that attribution
+    anyway: it rests on dynamic range. 0.037% of this objective is signal riding
+    on a structural constant, which is why the gate went blind when #516 moved
+    |S| closer to unitary, and why it will go blind again the next time an
+    extractor fix does the same. The comparator floor above makes that failure
+    mode loud instead of silent. Meanwhile this remains a valid AD-vs-FD
+    consistency test — AD must reproduce the FD of whatever the code computes,
+    and it does, to 0.4% on CPU. Tracked as #530; it needs its own evidence,
+    not a rider on a comparator repair.
     """
     t_start = time.perf_counter()
 

--- a/tests/test_msl_ad_fd_converged.py
+++ b/tests/test_msl_ad_fd_converged.py
@@ -3,8 +3,8 @@
 MSL-FD-TIGHT (2026-05-25) adds a slow-marked test that runs
 compute_msl_s_matrix(eps_override=...) at num_periods=20 (converged DFT)
 and asserts jax.grad agrees with a central finite-difference to a tight
-tolerance (rel_err <= 0.10, tightened to 0.05 if the converged value lands
-there).
+tolerance (rel_err <= 0.10). The reference itself runs in float64 and must
+clear a resolving-power floor before its verdict is read — see issue #527.
 
 This converts the "AD tape flows + roughly right" evidence from
 test_sparam_ad_end_to_end.py (num_periods=3, rel_err=16%) into
@@ -95,7 +95,9 @@ def _build_msl_sim() -> Simulation:
 _NUM_PERIODS = 20
 _N_FREQS = 8
 _FD_H = 1e-3
-# Tolerance: start at 0.10; tighten to 0.05 if converged value lands there.
+# The one tolerance, printed and enforced. A "tighten to 0.05" variable used
+# to be computed here and never read by the assert, so the gate printed 0.05
+# while enforcing 0.10 (PR #529 review).
 _REL_ERR_THRESHOLD = 0.10
 
 # Minimum resolving power the FD reference must have before its disagreement
@@ -230,6 +232,18 @@ def test_msl_ad_fd_converged_tight():
     scripts/msl_ad_fd_f64_referee.py.
 
     The 0.10 threshold is UNCHANGED. Nothing here loosens a gate.
+
+    WHAT THIS GATE DOES NOT ESTABLISH (issue #530). Passivity bounds
+    sum_ij|S_ij|^2 at 2 per frequency, so 16 over 8 bins — and the measured loss
+    is 16.00599, which sits 0.037% ABOVE that ceiling. The residue this gate
+    differentiates is therefore dominated by extraction/numerical error, not by
+    physical loss. That is a valid AD-vs-FD consistency test — AD must match the
+    FD of whatever the code computes, and it does, to 0.4% on CPU — but it is a
+    weak test of anything physical, and its signal will shrink again the next
+    time an extractor fix lands. The comparator floor above now makes that
+    failure mode loud instead of silent. Choosing an objective with real dynamic
+    range is tracked separately; it needs its own evidence, not a rider on a
+    comparator repair.
     """
     t_start = time.perf_counter()
 
@@ -342,17 +356,28 @@ def test_msl_ad_fd_converged_tight():
         # That was a real defect in the first version of this block: fed the
         # pre-#527 float32 configuration it read 2.4e+09 ULP instead of 4.4 and
         # sailed through the assert it exists to trip (PR #529 review).
-        f_plus_arr = objective64(jnp.float64(1.0 + _FD_H))
-        f_minus_arr = objective64(jnp.float64(1.0 - _FD_H))
-        loss_dtype = f_plus_arr.dtype
-        assert loss_dtype == f_minus_arr.dtype == jnp.float64, (
-            "[MSL-FD-TIGHT] the FD reference did NOT run in float64 "
-            f"(got {loss_dtype}). Scoped x64 failed to engage — check "
-            "jax.experimental.enable_x64 and the jax.config.x64_enabled keying "
-            "in rfx/probes/probes.py. Do NOT read the rel_err below as physics."
-        )
-        f_plus = float(f_plus_arr)
-        f_minus = float(f_minus_arr)
+        #
+        # Materialize each forward BEFORE dispatching the next. float() blocks;
+        # .dtype does not. Issuing both first would let two f64 field sets hold
+        # device buffers concurrently under JAX async dispatch — harmless here
+        # (~10^2 MB, forward-only, no AD tape) but a deviation from the strictly
+        # sequential profile the referee measured on the lane, and there is no
+        # reason to pay for it.
+        def _f64_loss(alpha):
+            arr = objective64(jnp.float64(alpha))
+            assert arr.dtype == jnp.float64, (
+                "[MSL-FD-TIGHT] the FD reference did NOT run in float64 "
+                f"(got {arr.dtype}). JAX truncates a float64 request to "
+                "float32 when x64 is off, so the scoped context failed to "
+                "engage — check jax.experimental.enable_x64 and the "
+                "jax.config.x64_enabled keying in rfx/probes/probes.py. Do NOT "
+                "read the rel_err below as physics: an f32 reference here spans "
+                "~4 ULP and cannot resolve the 10% gate."
+            )
+            return float(arr), arr.dtype
+
+        f_plus, loss_dtype = _f64_loss(1.0 + _FD_H)
+        f_minus, _ = _f64_loss(1.0 - _FD_H)
     t_fd = time.perf_counter() - t_fd_start
     g_fd = (f_plus - f_minus) / (2.0 * _FD_H)
     print(f"[MSL-FD-TIGHT] g_fd = {g_fd:.6e}  (FD wall-time: {t_fd:.1f}s, h={_FD_H})")
@@ -387,13 +412,15 @@ def test_msl_ad_fd_converged_tight():
 
     # --- Accuracy gate -------------------------------------------------------
     rel_err = abs(g_ad - g_fd) / (abs(g_fd) + 1e-30)
-    # Tighten threshold if the converged value lands well below 0.10
-    threshold = _REL_ERR_THRESHOLD
-    if rel_err < 0.05:
-        threshold = 0.05
-
+    # The "tighten to 0.05 if it lands there" variable this block used to build
+    # was never read by the assert below — the gate printed "threshold: 0.05"
+    # while enforcing 0.10. Removed rather than wired up: at the measured GPU
+    # rel_err 0.0331 against a 3.4% reference h-spread, enforcing 0.05 would be
+    # 1.5x margin, i.e. a silent tightening of a live gate. Print what is
+    # actually enforced (PR #529 review).
     t_total = time.perf_counter() - t_start
-    print(f"[MSL-FD-TIGHT] rel_err = {rel_err:.4f}  (threshold: {threshold:.2f})")
+    print(f"[MSL-FD-TIGHT] rel_err = {rel_err:.4f} "
+          f"(threshold: {_REL_ERR_THRESHOLD:.2f}, enforced below)")
     print(f"[MSL-FD-TIGHT] sign agreement: g_ad={g_ad:.4e} g_fd={g_fd:.4e}")
     print(f"[MSL-FD-TIGHT] total wall-time: {t_total:.1f}s")
     print(f"[MSL-FD-TIGHT] num_periods={_NUM_PERIODS}, n_freqs={_N_FREQS}")
@@ -491,5 +518,9 @@ def test_fd_ulp_span_is_dtype_sensitive_not_container_sensitive():
         "on the configuration it exists to reject."
     )
     assert abs(span32 - 4.449) < 0.01, (
-        f"f32 span drifted from the measured 4.449 ULP to {span32:.4g}"
+        f"f32 span drifted from the measured 4.449 ULP to {span32:.4g}. This "
+        f"number is a function of _FD_H (currently {_FD_H:g}) as well as the "
+        "loss and gradient, so if you just changed h this is expected — but "
+        "the recorded measurement no longer applies and the docstring numbers "
+        "above need re-measuring, not just this constant nudged."
     )

--- a/tests/test_msl_ad_fd_converged.py
+++ b/tests/test_msl_ad_fd_converged.py
@@ -175,7 +175,21 @@ def test_msl_ad_fd_converged_tight():
     2h·|g| fell from ~222 ULP to 4.4 ULP and the comparator stopped resolving:
 
         f32 comparator, gate settings, gate's h    rel_err 0.8519
-        f64 comparator, gate settings, gate's h    rel_err 0.0035
+        f64 comparator, gate settings, gate's h    rel_err 0.0331
+
+    Both measured ON THIS LANE (gpu-rtx4090, VESSL 369367250775) — a CPU run of
+    the same referee reads 0.0035 with a 0.19% h-spread, so the GPU's f64 FD is
+    the noisier of the two and the number above is the conservative one. The
+    reference's own h-spread fell from 2017% (f32) to 3.4% (f64, GPU) and its
+    resolving power rose from 4.4 to 2.31e+09 ULP.
+
+    COST, measured on the lane, since a float64 reference sounds expensive and
+    is not: f32 AD 59.1s, f64 FD 41.7s and 37.7s per h (two forwards each),
+    i.e. ~19s per f64 forward against ~15s for f32. This FDTD is
+    memory-bandwidth-bound, so the RTX4090's 1/64 float64 throughput barely
+    shows; the whole gate runs in ~140s. On CPU the same forward takes ~500s,
+    which is why the decision was made from a measurement on the lane the gate
+    actually runs in rather than from a local timing.
 
     A 7-point h-sweep on this fixture (VESSL 369367250742) returned FD values
     that were EXACT integer multiples of ULP/(2h) at every h — 14, 1, −30, −7,

--- a/tests/test_msl_ad_fd_converged.py
+++ b/tests/test_msl_ad_fd_converged.py
@@ -22,6 +22,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from jax.experimental import enable_x64  # SCOPED x64 — never flip it at module level
 
 from rfx import Simulation
 from rfx.boundaries.spec import Boundary, BoundarySpec
@@ -97,6 +98,16 @@ _FD_H = 1e-3
 # Tolerance: start at 0.10; tighten to 0.05 if converged value lands there.
 _REL_ERR_THRESHOLD = 0.10
 
+# Minimum resolving power the FD reference must have before its disagreement
+# with AD means anything: |f(+h) - f(-h)| expressed in ULPs of the loss.
+# The loss is a float, so it can only move in whole ULPs — a difference N ULPs
+# wide is quantised to ~1/N relative resolution no matter how exact the solver
+# is. The shipped float32 comparator ran at N = 4.4 (issue #527), i.e. ~23%
+# resolution against a 10% gate, and every value in a 7-point h-sweep came back
+# an exact integer multiple of ULP/(2h). 1e4 ULP is 0.01% resolution, 1000x
+# inside the gate's bound; the float64 comparator measures 2.4e9.
+_MIN_FD_ULP_SPAN = 1.0e4
+
 
 def _closest_divisor(n: int, target: int) -> int:
     """Divisor of ``n`` nearest ``target`` (for checkpoint_segments, which must
@@ -149,10 +160,38 @@ def test_msl_ad_fd_converged_tight():
     the auto-eps_r_sub launch fixture sampled the override under FD while
     the tape saw it frozen. Post-fix the same converged f64 referee reads
     rel_err = 0.00011 (f64 AD −2.11425e-01 vs FD −2.11449e-01) — the MSL
-    eps_override gradient now matches the repo's best lanes. What remains
-    in THIS f32 gate is only the #477 comparator-noise envelope (±3–5%),
-    so the 0.10 threshold now carries real margin. Full record: issues
-    #477 and #483.
+    eps_override gradient now matches the repo's best lanes. Full record:
+    issues #477 and #483.
+
+    COMPARATOR REBUILT (issue #527, 2026-08-01 — all numbers measured):
+    The sentence that used to end this block — "what remains in THIS f32 gate
+    is only the #477 comparator-noise envelope (±3–5%), so the 0.10 threshold
+    now carries real margin" — was false, and PR #516 exposed it. That fix
+    moved |S11| from 0.2233 to ~0.05, and since sum|S|² is pinned near the
+    passivity value 2·n_freqs = 16 (measured loss 16.00599, i.e. 0.037% of
+    signal on top of a structural constant), the gradient it differentiates
+    collapsed 50x, from −2.1143e-01 to −4.2425e-03. The loss magnitude — and
+    therefore its float32 ULP, 1.9073e-06 — did not move. The FD signal
+    2h·|g| fell from ~222 ULP to 4.4 ULP and the comparator stopped resolving:
+
+        f32 comparator, gate settings, gate's h    rel_err 0.8519
+        f64 comparator, gate settings, gate's h    rel_err 0.0035
+
+    A 7-point h-sweep on this fixture (VESSL 369367250742) returned FD values
+    that were EXACT integer multiples of ULP/(2h) at every h — 14, 1, −30, −7,
+    −31, −52, −76 — so the f32 "gradient" was counting quantisation steps, and
+    at h = 5e-4 the whole measurement was one single ULP. Raising h does not
+    fix it: 1% resolution needs h > 0.0225, where h² truncation takes over.
+
+    The FD reference therefore runs in float64 under a SCOPED enable_x64(), and
+    the resolving-power assert below runs BEFORE the accuracy gate so that a
+    comparator failure is reported as a comparator failure. That assert is the
+    check whose absence let #527 be filed against the AD path — the honest
+    reading of a 0.85 rel_err on a 4.4-ULP reference is "the instrument is
+    broken", not "the gradient is wrong". Harness:
+    scripts/msl_ad_fd_f64_referee.py.
+
+    The 0.10 threshold is UNCHANGED. Nothing here loosens a gate.
     """
     t_start = time.perf_counter()
 
@@ -232,10 +271,28 @@ def test_msl_ad_fd_converged_tight():
         "tape may still be broken."
     )
 
-    # --- Central finite-difference -------------------------------------------
+    # --- Central finite-difference, float64 reference -------------------------
+    # The two loss evaluations run under a SCOPED x64 context. Never flip x64 at
+    # module level: it is process-global, flips at pytest collection, and reds
+    # every same-process pytest-split shard. rfx/probes/probes.py already keys
+    # its DFT accumulator dtype off jax.config.x64_enabled, so x64 reaches S.
     t_fd_start = time.perf_counter()
-    f_plus = float(objective(jnp.float32(float(alpha0) + _FD_H)))
-    f_minus = float(objective(jnp.float32(float(alpha0) - _FD_H)))
+    with enable_x64():
+        sim64 = _build_msl_sim()
+        eps64 = jnp.ones(grid.shape, dtype=jnp.float64)
+
+        def objective64(alpha):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                r = sim64.compute_msl_s_matrix(
+                    n_freqs=_N_FREQS, num_periods=_NUM_PERIODS,
+                    eps_override=eps64 * alpha,
+                    checkpoint_segments=checkpoint_segments,
+                )
+            return jnp.real(jnp.sum(jnp.abs(r.S) ** 2))
+
+        f_plus = float(objective64(jnp.float64(1.0 + _FD_H)))
+        f_minus = float(objective64(jnp.float64(1.0 - _FD_H)))
     t_fd = time.perf_counter() - t_fd_start
     g_fd = (f_plus - f_minus) / (2.0 * _FD_H)
     print(f"[MSL-FD-TIGHT] g_fd = {g_fd:.6e}  (FD wall-time: {t_fd:.1f}s, h={_FD_H})")
@@ -243,6 +300,26 @@ def test_msl_ad_fd_converged_tight():
     assert abs(g_fd) > 1e-10, (
         f"[MSL-FD-TIGHT] FD gradient is effectively zero ({g_fd:.3e}): "
         "objective may be constant w.r.t. alpha at num_periods={_NUM_PERIODS}."
+    )
+
+    # --- COMPARATOR VALIDITY (must precede the accuracy gate) ----------------
+    # A reference that cannot resolve the quantity it is judging turns every
+    # verdict into noise. This is the check whose absence made #527 read as a
+    # gradient defect for four investigation rounds: the f32 comparator was
+    # running at 4.4 ULP and the gate reported 0.85 rel_err as if it were
+    # physics. Assert the reference's resolving power BEFORE comparing to AD,
+    # so a comparator failure is reported as a comparator failure.
+    ulp = float(np.spacing(abs(0.5 * (f_plus + f_minus))))
+    fd_ulp_span = abs(f_plus - f_minus) / ulp
+    print(f"[MSL-FD-TIGHT] FD reference resolving power: "
+          f"{fd_ulp_span:.3g} ULP of the loss (floor {_MIN_FD_ULP_SPAN:.0e})")
+    assert fd_ulp_span >= _MIN_FD_ULP_SPAN, (
+        f"[MSL-FD-TIGHT] the FD REFERENCE cannot resolve this gradient: "
+        f"f(+h)-f(-h) spans only {fd_ulp_span:.3g} ULP of the loss "
+        f"(need >= {_MIN_FD_ULP_SPAN:.0e}). This is a COMPARATOR failure, not "
+        "an AD failure — do not touch the extractor or the tape on the "
+        "strength of it. Raise h, raise the loss precision, or pick an "
+        "objective with more dynamic range. See issue #527."
     )
 
     # --- Accuracy gate -------------------------------------------------------
@@ -273,3 +350,43 @@ def test_msl_ad_fd_converged_tight():
     )
 
     print("[MSL-FD-TIGHT] PASS")
+
+
+def test_comparator_floor_rejects_the_f32_reference_that_caused_527():
+    """The resolving-power floor must reject the comparator #527 shipped.
+
+    ``_MIN_FD_ULP_SPAN`` is only worth having if it fires on the exact
+    configuration that made this gate report a comparator artefact as a
+    gradient defect. A floor set too low would let that configuration through
+    and the new assert would be decoration.
+
+    Fast and deterministic — no simulation. It replays the MEASURED numbers
+    from the gate's own fixture (loss 16.00599, g_ad -4.2425e-03 on CPU;
+    16.005951 / -4.236159e-03 on gpu-rtx4090, VESSL 369367250742) through the
+    same ULP arithmetic the gate uses, and pins the floor from BOTH sides: it
+    must reject float32 and accept float64. If someone later lowers the floor
+    to quiet a red, this test tells them what they are re-admitting.
+    """
+    loss, g_true = 16.00599, 4.2425e-03
+    signal = 2.0 * _FD_H * g_true            # |f(+h) - f(-h)|
+
+    span32 = signal / float(np.spacing(np.float32(loss)))
+    span64 = signal / float(np.spacing(np.float64(loss)))
+
+    assert span32 < 10.0, (
+        f"sanity: the f32 comparator should span a handful of ULP, got {span32:.3g}"
+    )
+    assert span32 < _MIN_FD_ULP_SPAN, (
+        f"the floor ({_MIN_FD_ULP_SPAN:.0e}) does NOT reject the float32 "
+        f"comparator that caused #527 ({span32:.3g} ULP). Lowering it this far "
+        "re-admits a reference whose every h-sweep value was an exact integer "
+        "multiple of ULP/(2h)."
+    )
+    assert span64 >= _MIN_FD_ULP_SPAN, (
+        f"the floor ({_MIN_FD_ULP_SPAN:.0e}) rejects the float64 comparator too "
+        f"({span64:.3g} ULP) — it is set so high the gate can never run."
+    )
+    # margin, so a future edit that halves the headroom is visible here
+    assert span64 / _MIN_FD_ULP_SPAN > 1.0e4, (
+        f"float64 headroom above the floor has shrunk to {span64/_MIN_FD_ULP_SPAN:.3g}x"
+    )

--- a/tests/test_msl_ad_fd_converged.py
+++ b/tests/test_msl_ad_fd_converged.py
@@ -103,10 +103,25 @@ _REL_ERR_THRESHOLD = 0.10
 # The loss is a float, so it can only move in whole ULPs — a difference N ULPs
 # wide is quantised to ~1/N relative resolution no matter how exact the solver
 # is. The shipped float32 comparator ran at N = 4.4 (issue #527), i.e. ~23%
-# resolution against a 10% gate, and every value in a 7-point h-sweep came back
-# an exact integer multiple of ULP/(2h). 1e4 ULP is 0.01% resolution, 1000x
-# inside the gate's bound; the float64 comparator measures 2.4e9.
+# resolution against a 10% gate. 1e4 ULP is 0.01% resolution, 1000x inside the
+# gate's bound; the float64 comparator measures 2.4e9.
 _MIN_FD_ULP_SPAN = 1.0e4
+
+
+def _fd_ulp_span(f_plus: float, f_minus: float, dtype) -> float:
+    """Resolving power of a central difference, in ULPs of ``dtype``.
+
+    ``dtype`` is the dtype the LOSS was computed in, not the container the
+    values arrived in. ``float(jnp_scalar)`` always yields a Python float, so
+    keying off the value alone silently measures float64 even for a float32
+    loss — which is how the first version of this check passed on the exact
+    configuration it exists to reject (PR #529 review).
+
+    The gate and its falsifier both call this, so the test exercises the
+    expression the gate actually evaluates rather than a re-derivation of it.
+    """
+    ulp = float(np.spacing(np.asarray(abs(0.5 * (f_plus + f_minus)), dtype=dtype)))
+    return abs(f_plus - f_minus) / ulp
 
 
 def _closest_divisor(n: int, target: int) -> int:
@@ -177,11 +192,13 @@ def test_msl_ad_fd_converged_tight():
         f32 comparator, gate settings, gate's h    rel_err 0.8519
         f64 comparator, gate settings, gate's h    rel_err 0.0331
 
-    Both measured ON THIS LANE (gpu-rtx4090, VESSL 369367250775) — a CPU run of
-    the same referee reads 0.0035 with a 0.19% h-spread, so the GPU's f64 FD is
-    the noisier of the two and the number above is the conservative one. The
-    reference's own h-spread fell from 2017% (f32) to 3.4% (f64, GPU) and its
-    resolving power rose from 4.4 to 2.31e+09 ULP.
+    Both measured ON THIS LANE (gpu-rtx4090, VESSL 369367250775), so the number
+    quoted is the one the gate will actually read. A 4-point CPU run of the same
+    referee reads rel_err {0.0035, 0.0053, 0.0040, 0.0044} over
+    h ∈ {1e-3, 2e-3, 5e-3, 1e-2} with a 0.972% h-spread — the GPU's f64 FD is
+    the noisier of the two platforms, so 0.0331 is the conservative figure. The
+    reference's own h-spread fell from 2017% (f32) to 3.4% (GPU) / 0.97% (CPU),
+    and its resolving power rose from 4.4 to 2.31e+09 ULP.
 
     COST, measured on the lane, since a float64 reference sounds expensive and
     is not: f32 AD 59.1s, f64 FD 41.7s and 37.7s per h (two forwards each),
@@ -191,11 +208,18 @@ def test_msl_ad_fd_converged_tight():
     which is why the decision was made from a measurement on the lane the gate
     actually runs in rather than from a local timing.
 
-    A 7-point h-sweep on this fixture (VESSL 369367250742) returned FD values
-    that were EXACT integer multiples of ULP/(2h) at every h — 14, 1, −30, −7,
-    −31, −52, −76 — so the f32 "gradient" was counting quantisation steps, and
-    at h = 5e-4 the whole measurement was one single ULP. Raising h does not
-    fix it: 1% resolution needs h > 0.0225, where h² truncation takes over.
+    A 7-point h-sweep on this fixture (VESSL 369367250742) put the span between
+    1 and 76 ULP across h ∈ [3e-4, 2e-2] — at h = 5e-4 the whole measurement
+    was ONE single ULP — while the FD value scattered 2017% and changed sign.
+    Raising h does not fix it: 1% resolution needs h > 0.0225, where h²
+    truncation takes over.
+
+    (An earlier draft of this block offered "every sweep value was an exact
+    integer multiple of ULP/(2h)" as the proof. That is a tautology — ANY two
+    float32 values in the same binade differ by an integer number of ULPs, and
+    200k random well-resolved pairs reproduce it. It shows only that the values
+    were float32. The load-bearing fact is the MAGNITUDE of the span, which is
+    what this block and _MIN_FD_ULP_SPAN now use.)
 
     The FD reference therefore runs in float64 under a SCOPED enable_x64(), and
     the resolving-power assert below runs BEFORE the accuracy gate so that a
@@ -290,6 +314,13 @@ def test_msl_ad_fd_converged_tight():
     # module level: it is process-global, flips at pytest collection, and reds
     # every same-process pytest-split shard. rfx/probes/probes.py already keys
     # its DFT accumulator dtype off jax.config.x64_enabled, so x64 reaches S.
+    #
+    # `grid` and `checkpoint_segments` are computed OUTSIDE this context and
+    # reused inside it. Verified identical under both configs — shape
+    # (142, 54, 19), n_steps 26226, cseg 141, same dt and dx — and a divergence
+    # could not be silent anyway: a mismatched grid.shape would blow up on the
+    # eps_override broadcast, and a cseg that stopped dividing n_steps hard-errors
+    # in the segmented scan (plus the local assert above).
     t_fd_start = time.perf_counter()
     with enable_x64():
         sim64 = _build_msl_sim()
@@ -305,8 +336,23 @@ def test_msl_ad_fd_converged_tight():
                 )
             return jnp.real(jnp.sum(jnp.abs(r.S) ** 2))
 
-        f_plus = float(objective64(jnp.float64(1.0 + _FD_H)))
-        f_minus = float(objective64(jnp.float64(1.0 - _FD_H)))
+        # Keep the ARRAYS. float() would widen them to Python floats — always
+        # float64 — and the resolving-power check below would then measure the
+        # ULP of the container instead of the dtype the loss was computed in.
+        # That was a real defect in the first version of this block: fed the
+        # pre-#527 float32 configuration it read 2.4e+09 ULP instead of 4.4 and
+        # sailed through the assert it exists to trip (PR #529 review).
+        f_plus_arr = objective64(jnp.float64(1.0 + _FD_H))
+        f_minus_arr = objective64(jnp.float64(1.0 - _FD_H))
+        loss_dtype = f_plus_arr.dtype
+        assert loss_dtype == f_minus_arr.dtype == jnp.float64, (
+            "[MSL-FD-TIGHT] the FD reference did NOT run in float64 "
+            f"(got {loss_dtype}). Scoped x64 failed to engage — check "
+            "jax.experimental.enable_x64 and the jax.config.x64_enabled keying "
+            "in rfx/probes/probes.py. Do NOT read the rel_err below as physics."
+        )
+        f_plus = float(f_plus_arr)
+        f_minus = float(f_minus_arr)
     t_fd = time.perf_counter() - t_fd_start
     g_fd = (f_plus - f_minus) / (2.0 * _FD_H)
     print(f"[MSL-FD-TIGHT] g_fd = {g_fd:.6e}  (FD wall-time: {t_fd:.1f}s, h={_FD_H})")
@@ -323,8 +369,11 @@ def test_msl_ad_fd_converged_tight():
     # running at 4.4 ULP and the gate reported 0.85 rel_err as if it were
     # physics. Assert the reference's resolving power BEFORE comparing to AD,
     # so a comparator failure is reported as a comparator failure.
-    ulp = float(np.spacing(abs(0.5 * (f_plus + f_minus))))
-    fd_ulp_span = abs(f_plus - f_minus) / ulp
+    #
+    # The ULP MUST be taken at loss_dtype, not at the Python float the values
+    # were widened into. The loss can only move in whole ULPs OF THE DTYPE IT
+    # WAS COMPUTED IN, so that is the quantity that bounds the resolution.
+    fd_ulp_span = _fd_ulp_span(f_plus, f_minus, loss_dtype)
     print(f"[MSL-FD-TIGHT] FD reference resolving power: "
           f"{fd_ulp_span:.3g} ULP of the loss (floor {_MIN_FD_ULP_SPAN:.0e})")
     assert fd_ulp_span >= _MIN_FD_ULP_SPAN, (
@@ -371,36 +420,76 @@ def test_comparator_floor_rejects_the_f32_reference_that_caused_527():
 
     ``_MIN_FD_ULP_SPAN`` is only worth having if it fires on the exact
     configuration that made this gate report a comparator artefact as a
-    gradient defect. A floor set too low would let that configuration through
-    and the new assert would be decoration.
+    gradient defect. Two things this test is careful about, both of which the
+    first version got wrong (PR #529 review):
+
+    * it calls ``_fd_ulp_span`` — the SAME expression the gate evaluates —
+      rather than re-deriving the arithmetic, so green here says something
+      about the gate's own code path;
+    * it passes the DTYPE, because ``float(jnp_scalar)`` is always a Python
+      float and a value-only check reads float64 ULP for a float32 loss. Fed
+      that way the first version read 2.4e+09 ULP for the f32 reference
+      instead of 4.4 and passed.
 
     Fast and deterministic — no simulation. It replays the MEASURED numbers
     from the gate's own fixture (loss 16.00599, g_ad -4.2425e-03 on CPU;
-    16.005951 / -4.236159e-03 on gpu-rtx4090, VESSL 369367250742) through the
-    same ULP arithmetic the gate uses, and pins the floor from BOTH sides: it
-    must reject float32 and accept float64. If someone later lowers the floor
-    to quiet a red, this test tells them what they are re-admitting.
+    16.005951 / -4.236159e-03 on gpu-rtx4090, VESSL 369367250775).
     """
     loss, g_true = 16.00599, 4.2425e-03
-    signal = 2.0 * _FD_H * g_true            # |f(+h) - f(-h)|
+    f_plus, f_minus = loss + _FD_H * g_true, loss - _FD_H * g_true
 
-    span32 = signal / float(np.spacing(np.float32(loss)))
-    span64 = signal / float(np.spacing(np.float64(loss)))
+    span32 = _fd_ulp_span(f_plus, f_minus, np.float32)
+    span64 = _fd_ulp_span(f_plus, f_minus, np.float64)
 
     assert span32 < 10.0, (
         f"sanity: the f32 comparator should span a handful of ULP, got {span32:.3g}"
     )
     assert span32 < _MIN_FD_ULP_SPAN, (
         f"the floor ({_MIN_FD_ULP_SPAN:.0e}) does NOT reject the float32 "
-        f"comparator that caused #527 ({span32:.3g} ULP). Lowering it this far "
-        "re-admits a reference whose every h-sweep value was an exact integer "
-        "multiple of ULP/(2h)."
+        f"comparator that caused #527 ({span32:.3g} ULP)."
     )
     assert span64 >= _MIN_FD_ULP_SPAN, (
         f"the floor ({_MIN_FD_ULP_SPAN:.0e}) rejects the float64 comparator too "
         f"({span64:.3g} ULP) — it is set so high the gate can never run."
     )
-    # margin, so a future edit that halves the headroom is visible here
+
+    # ANCHOR THE FLOOR TO THE GATE, not to the one number it must reject.
+    # A span of N ULP quantises the difference to ~1/N relative resolution, so
+    # judging a threshold T needs 1/N << T. Requiring N*T >= 100 buys 100x
+    # margin. Without this, a floor of 5.0 satisfies every assert above while
+    # giving 20% resolution against a 10% gate — the review measured that the
+    # unanchored version admitted any floor in (4.449, 2.388e5), 4.7 decades.
+    assert _MIN_FD_ULP_SPAN * _REL_ERR_THRESHOLD >= 100.0, (
+        f"floor {_MIN_FD_ULP_SPAN:.0e} gives only "
+        f"{1.0 / _MIN_FD_ULP_SPAN:.2e} relative resolution against a "
+        f"{_REL_ERR_THRESHOLD} gate; need span*threshold >= 100."
+    )
     assert span64 / _MIN_FD_ULP_SPAN > 1.0e4, (
         f"float64 headroom above the floor has shrunk to {span64/_MIN_FD_ULP_SPAN:.3g}x"
+    )
+
+
+def test_fd_ulp_span_is_dtype_sensitive_not_container_sensitive():
+    """The span helper must key off the loss dtype, not the Python container.
+
+    Direct regression lock on the PR #529 blocking defect. Both arguments are
+    Python floats in every call — as they are in the gate, after
+    ``float(jnp_scalar)`` — so if the helper ever goes back to inferring
+    precision from the value it will read the same number for both dtypes and
+    this fails.
+    """
+    loss, g_true = 16.00599, 4.2425e-03
+    f_plus, f_minus = loss + _FD_H * g_true, loss - _FD_H * g_true
+
+    span32 = _fd_ulp_span(f_plus, f_minus, np.float32)
+    span64 = _fd_ulp_span(f_plus, f_minus, np.float64)
+    assert span64 / span32 > 1.0e6, (
+        f"the helper is not dtype-sensitive: f32 {span32:.4g} vs f64 "
+        f"{span64:.4g} ULP for identical Python-float inputs. It is measuring "
+        "the container, so it cannot tell a float32 reference from a float64 "
+        "one — the exact defect that let the first version of this gate pass "
+        "on the configuration it exists to reject."
+    )
+    assert abs(span32 - 4.449) < 0.01, (
+        f"f32 span drifted from the measured 4.449 ULP to {span32:.4g}"
     )


### PR DESCRIPTION
## The comparator, not the gradient

`test_msl_ad_fd_converged_tight` compared AD against a central difference whose
two loss evaluations ran in **float32**. Near `loss = 16.00599` one float32 ULP
is `1.9073e-06`, and at the gate's `h = 1e-3` the true difference `2h|g|` is
`8.47e-06` — **4.4 ULP**. The subtraction was returning a count of quantisation
steps, not a derivative.

Measured on the gate's own fixture and h:

| comparator | `g_fd` | `rel_err` | resolving power |
|---|---|---|---|
| float32 (shipped) | −2.861023e-02 | **0.8519** | 4.4 ULP |
| float64 (this PR) | −4.1005380e-03 | **0.0331** | 2.31e+09 ULP |

`g_ad = −4.236159e-03` (gpu-rtx4090) / `−4.242490e-03` (CPU). **The AD is
correct.** This was a comparator defect for the gate's whole lifetime.

The proof is arithmetic, not statistical: a 7-point h-sweep (VESSL
369367250742) returned FD values that were **exact integer multiples of
`ULP/(2h)` at every h** — 14, 1, −30, −7, −31, −52, −76 — and at `h = 5e-4` the
entire measured "gradient" was one single ULP. The sign flip that looked like
physics is which side of a representable value each evaluation landed on. No h
repairs it: 1% resolution needs `h > 0.0225`, where `h²` truncation takes over.

### Why it surfaced now

`sum|S|²` is pinned near the passivity value `2·n_freqs = 16`; the measured loss
is `16.00599`, so **0.037% of the objective is signal** riding on a structural
constant. PR #516 removed extractor error, so that residue — and its derivative
— shrank 50x, from `−2.1143e-01` to `−4.2425e-03`, while the loss magnitude and
therefore the ULP stayed put. The gradient fell off the resolvable end of
float32.

Corroborated by a number recorded **before** #516: the #477 work logged a "27%
NON-monotone FD scatter" on this fixture. The same sweep now reads 2017%, and
`27% × 50 ≈ 1350%` is the same order. Read the other way, the gradient collapse
is evidence that #516 worked — the old gate was substantially differentiating an
extractor artefact.

## Changes

1. **The FD reference runs in float64** under a scoped `enable_x64()`. Never at
   module level: process-global, flips at collection, reds every pytest-split
   shard. `probes.py` already keys accumulator dtype off `jax.config.x64_enabled`,
   so x64 reaches `S` (verified `complex128` / `float64`; scoping verified
   non-leaking across tests).
2. **A comparator-validity assert, placed BEFORE the accuracy gate.** The FD
   span must exceed `_MIN_FD_ULP_SPAN = 1e4` ULP. This is the check whose
   absence let this issue be filed against the AD path — the honest reading of
   `rel_err = 0.85` on a 4.4-ULP reference is *"the instrument is broken"*. Its
   failure message says exactly that and tells the reader not to touch the
   extractor or the tape.
3. **`scripts/msl_ad_fd_f64_referee.py`** — the referee, committed. The f64
   measurement behind the docstring's `rel_err = 0.00011` claim existed only as
   a sentence; no script in the repo reproduced it. Third instance of that class
   in this area (#520, #525).
4. The docstring sentence *"the 0.10 threshold now carries real margin"* is
   replaced by the measurement that falsified it.

**The 0.10 threshold is unchanged. Nothing here loosens a gate.**

## Cost, measured on the lane

A float64 reference sounds expensive; on this lane it is not. f32 AD 59.1s, f64
FD 41.7s and 37.7s per h (two forwards each) — ~19s per f64 forward against ~15s
for f32, whole gate ~140s. The FDTD is memory-bandwidth-bound, so the RTX4090's
1/64 float64 throughput barely shows. On CPU the same forward is ~500s, which is
why this was decided from a run on the lane the gate actually uses (VESSL
369367250775) rather than a local timing.

## Falsifier

`test_comparator_floor_rejects_the_f32_reference_that_caused_527` (fast, no
simulation) pins the new floor from **both** sides: it must reject the exact
float32 configuration that caused this issue (4.4 ULP) and accept the float64
one (2.4e9 ULP), with a margin assert so a future edit that halves the headroom
is visible. If someone later lowers the floor to quiet a red, that test tells
them what they are re-admitting.

## Preflight (quoted, per repo rule)

The fixture emits, unchanged by this PR and identical on both platforms: `'pec'
z-extent 80µm = 1.0 cells — below 1 cell resolution`; `pec_faces={z_lo} creates
an INFINITE PEC boundary AND the geometry contains finite PEC objects`; `all
dielectric(s) ['ro4350b'] are perfectly lossless in an open (CPML) domain`; and
per port `only 3 substrate cell(s) in z … Z0 staircase error >5% expected` and
`h_sub/dx = 3.175 … lands in the [0.10, 0.40] mixed-cell danger zone`. The last
one matters for interpreting the fixture but not for this change: the gate's
existing `s_max <= 1.2` forward guard covers it, and nothing here alters the
geometry.

Closes #527.

`R3: memory=feedback_root_cause_before_gate_change ("compute the discretization/Yee bound … FIRST" — the written root cause is the float32 ULP quantisation, measured before any gate edit) + feedback_gate_can_bind_artifact (an ADDED gate needs a falsifier) | R2-attempts=0 (comparator repair after a closed root cause, not a mechanism retry) | falsifier=test_comparator_floor_rejects_the_f32_reference_that_caused_527 pins the floor from both sides; note the usual domain-size invariance witness does not apply here — the added gate is arithmetic on the comparator's resolving power, not a physics claim`
