### PR TITLE
fix(test): restore the 3 coax slow-lane locks broken by the fail-loud probe layout (#508)

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -11,7 +11,9 @@ permissions:
 jobs:
   slow-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # 90 not 60: the slowest shard reached ~52 min on 2026-07-27 and the slow
+    # suite grows weekly; the 60-min ceiling left <15% headroom.
+    timeout-minutes: 90
     strategy:
       # Shard the full "not gpu" suite across parallel jobs. Each shard is a
       # FRESH process running its slice serially, so the cumulative JAX/XLA
@@ -35,9 +37,13 @@ jobs:
       - name: Install package with dev dependencies
         run: pip install -e ".[dev]"
 
+      # -v (not -q): per-test result lines stream to the log as each test
+      # finishes, so when a runner is shut down mid-run (2026-07-27, shards 1+3)
+      # the identities of already-failed tests survive in the partial log.
+      # -q's failure summary prints only at session end and dies with the runner.
       - name: Run slow suite — shard ${{ matrix.group }} of 4
         run: >
-          pytest -q -ra
+          pytest -v -ra
           -m "not gpu"
           --splits 4 --group ${{ matrix.group }}
           --ignore=tests/test_meep_crossval.py

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -3590,8 +3590,10 @@ class _SparamMixin:
             # quasi-TEM wave") and compute_msl_s_matrix's #140 dir_sign
             # comment ("a -x port's fitted z0 inherits a negative sign")
             # describe OPPOSITE conventions; that contradiction is
-            # unresolved and is tracked as a follow-up, not papered over
-            # here.
+            # unresolved and is tracked in issue #524 (together with the
+            # two orphaned #507 loose ends: the passive port's ~30 ohm
+            # termination reading and the 0.194-vs-0.073 drive
+            # asymmetry), not papered over here.
             #
             # The fit is still computed and EXPOSED (return_diagnostics)
             # because it is the only handle on the open 30-vs-48 ohm

--- a/scripts/diagnostics/coax_line_broad_e5_envelope.py
+++ b/scripts/diagnostics/coax_line_broad_e5_envelope.py
@@ -46,6 +46,12 @@ def run(term, fmax, a, b, R=None):
                          waveform=GaussianPulse(f0=8.0e9, bandwidth=1.2))
     kw = dict(termination=("matched" if term in ("matched", "res") else term),
               n_steps=NS[fmax], freqs=BAND)
+    if fmax <= 20.0e9:
+        # At fmax=20 GHz (dz~0.75 mm) this z-domain fits 9 of the default 12
+        # probe planes; the silent drop of the surplus planes became fail-loud
+        # in af167a90, so the count the sweep always ran on must be requested
+        # explicitly (same reasoning as tests/test_coaxial_line_calibration.py).
+        kw["probe_count"] = 9
     if term == "res":
         kw["dut_impedance"] = R
     return sim.compute_coaxial_line_reflection(**kw)

--- a/tests/test_coax_end_to_end_ad.py
+++ b/tests/test_coax_end_to_end_ad.py
@@ -27,6 +27,11 @@ from rfx.sources.sources import GaussianPulse
 # short-terminated. Kept minimal so the reverse-mode tape fits in memory.
 N_STEPS = 1500
 FREQ = jnp.asarray([8.0e9], dtype=jnp.float32)
+# This short z-domain fits 9 of the default 12 probe planes. Until af167a9 the
+# extractor silently dropped the planes that did not fit, so every recorded
+# result of this fixture was measured on 9 planes; the fail-loud layout check
+# now requires the count to be requested explicitly. Same measurement, declared.
+PROBE_COUNT = 9
 
 
 def _build_sim():
@@ -44,6 +49,7 @@ def _s11_mag2(deps):
     eps_scale = jnp.ones(grid.shape, dtype=jnp.float32).at[:, :, nz // 2 - 3: nz // 2 + 3].add(deps)
     res = sim.compute_coaxial_line_reflection(
         termination="short", n_steps=N_STEPS, freqs=FREQ, eps_scale=eps_scale,
+        probe_count=PROBE_COUNT,
     )
     return jnp.abs(res.s11[0]) ** 2
 
@@ -69,12 +75,14 @@ def test_coax_eps_scale_unity_matches_concrete_path():
     ``eps_scale=None`` (validated numpy path) in |S11|."""
     sim_a = _build_sim()
     res_a = sim_a.compute_coaxial_line_reflection(
-        termination="short", n_steps=N_STEPS, freqs=FREQ)
+        termination="short", n_steps=N_STEPS, freqs=FREQ,
+        probe_count=PROBE_COUNT)
     sim_b = _build_sim()
     grid = sim_b._build_grid()
     res_b = sim_b.compute_coaxial_line_reflection(
         termination="short", n_steps=N_STEPS, freqs=FREQ,
-        eps_scale=jnp.ones(grid.shape, dtype=jnp.float32))
+        eps_scale=jnp.ones(grid.shape, dtype=jnp.float32),
+        probe_count=PROBE_COUNT)
     sa = np.asarray(res_a.s11)
     sb = np.asarray(res_b.s11)
     assert np.all(np.isfinite(sa)) and np.all(np.isfinite(sb))

--- a/tests/test_coaxial_line_calibration.py
+++ b/tests/test_coaxial_line_calibration.py
@@ -28,12 +28,12 @@ from rfx.sources.coaxial_port import (
 BAND = jnp.asarray([4.0e9, 6.0e9, 8.0e9, 10.0e9, 12.0e9])
 
 
-def _run(termination, freq_max=40.0e9, n_steps=5000):
+def _run(termination, freq_max=40.0e9, n_steps=5000, **kwargs):
     sim = Simulation(domain=(0.008, 0.008, 0.040), freq_max=freq_max, boundary="cpml")
     sim.add_coaxial_port((0.004, 0.004, 0.020), face="top", pin_length=5.0e-3,
                          waveform=GaussianPulse(f0=8.0e9, bandwidth=1.2))
     return sim.compute_coaxial_line_reflection(
-        termination=termination, n_steps=n_steps, freqs=BAND)
+        termination=termination, n_steps=n_steps, freqs=BAND, **kwargs)
 
 
 @pytest.mark.slow_physics
@@ -89,7 +89,12 @@ def test_resistive_load_reflection_magnitude():
 @pytest.mark.slow_physics
 def test_under_resolved_annulus_is_flagged():
     # freq_max=20 GHz -> dx~0.75 mm -> ~1.9-cell annulus (below the >=4 recipe).
-    res = _run("short", freq_max=20.0e9, n_steps=1500)
+    # At this dx the z domain fits 9 of the default 12 probe planes. Until
+    # af167a9 the extractor silently dropped the surplus planes, so this test
+    # always measured on 9; the fail-loud layout check now requires the count
+    # to be requested explicitly. The observable under test (the under_resolved
+    # flag) is independent of the probe count.
+    res = _run("short", freq_max=20.0e9, n_steps=1500, probe_count=9)
     assert res.annulus_cells < 3.5
     assert res.status == "under_resolved"
 


### PR DESCRIPTION
## What / why

Closes #508.

The weekly slow lane has been red on the coax fixtures since 2026-07-13. Root cause: af167a90 ("Prevent unsupported RF results from looking valid") changed the coax probe-plane layout check from **silent drop** (planes that do not fit are discarded; >=3 survivors suffice) to **fail-loud** (every requested plane must fit). That change is correct — but the two short-z coax fixtures have *never* fitted the default 12 planes:

- `test_coaxial_line_calibration.py::test_under_resolved_annulus_is_flagged` (20 GHz → dz≈0.75 mm, z=0.040 m) — 9 of 12 fit
- `test_coax_end_to_end_ad.py` (both tests; 40 GHz, z=0.020 m) — 9 of 12 fit

Every recorded result of these fixtures was therefore measured on **9 planes**, silently. Since af167a90 all three die on the layout `ValueError` before reaching their assertions — the coax `under_resolved` honesty flag and the coax AD moat (AD-vs-FD 5% gate) have had **no live gate** since 2026-07-13 (CI evidence: run 29731386069, shard 1).

**Fix**: request `probe_count=9` explicitly — the identical measurement the fixtures always ran, now declared. Review-verified: both fixtures' production layouts keep the identical 9-plane prefix [28,32,...,60] (cells), and `requested_probe_count` feeds nothing downstream of the layout check, so identical planes = identical measurement. No assertion or tolerance changes.

**Scope additions after review** (same branch):
- `scripts/diagnostics/coax_line_broad_e5_envelope.py` — the sweep's fmax=20 GHz point is the same 9-of-12 geometry, so the committed broad-E5 evidence had become non-regenerable (review finding MINOR-1). `probe_count=9` for that point only; verified by a 64-step smoke on the exact geometry.
- `rfx/api/_sparams.py` — **comment-only**: the +x/-x current-convention comment now points at its real tracker, issue #524 (it previously claimed a tracker that did not exist).

**Weekly-lane readability** (the #509 infra residue): `pytest -v` streams per-test results so failure identities survive a mid-run runner shutdown (observed 2026-07-27, shards 1+3 — one-off GitHub infra event, not "most weeks" as the ledger claimed); `timeout-minutes` 60→90 restores headroom over the measured ~52 min worst shard.

## Verification

All three restored tests pass locally (64.4 s first run; reviewer reproduced at 57.6 s):

```
PASSED tests/test_coaxial_line_calibration.py::test_under_resolved_annulus_is_flagged
PASSED tests/test_coax_end_to_end_ad.py::test_coax_reflection_grad_finite_and_fd_consistent
PASSED tests/test_coax_end_to_end_ad.py::test_coax_eps_scale_unity_matches_concrete_path
```

The under-resolved test reaches its real assertions (annulus_cells < 3.5, status == "under_resolved"); the AD test passes its AD-vs-FD 5% gate.

**Review**: APPROVE (independent session), with the 9-plane identity claim re-derived from the production layout formula for both fixture geometries and the af167a90^ defaults checked. Findings applied: MINOR-1 above; MINOR-2 (stale `.test_durations`, 35% coverage → unbalanced shards) filed separately; NIT-1 fixed by this body edit.

R3: memory=feedback_root_cause_before_gate_change (no gate loosened; root cause = af167a90 silent→fail-loud) | R2-attempts=1 per red, each closed with a named cause | falsifier=three restored tests ran green locally; next weekly run (2026-08-03) is the CI-side check

🤖 Generated with [Claude Code](https://claude.com/claude-code)