### PR TITLE
One shared envelope-gate multiplier: per-case relaxation becomes visible (#528)

### DIFF
--- a/tests/_gate_policy.py
+++ b/tests/_gate_policy.py
@@ -1,0 +1,75 @@
+"""tests/_gate_policy.py
+
+Single shared definition of the envelope -> gate derivation used by every
+frozen-fixture crossval case that gates a measured envelope (issue #528).
+
+Every gated crossval case derives its enforced numeric gate as
+
+    gate = round-up(measured envelope x ENVELOPE_GATE_MULTIPLIER)
+
+quantized to a case-specific number of decimal places (100 -> 0.01 for
+absolute |S11| gates, 10 -> 0.1 for dB gates). Before this module existed,
+each case hardcoded the ``1.5`` multiplier independently in its own test
+file's gate-derivation assertion AND, for the crossval scripts that
+regenerate their fixtures, a second time in a script-side self-check --
+nothing cross-checked the two, so relaxing the multiplier in one case (a
+one-line find-replace touching only that case's file) read as compliance
+with a repo-wide convention while silently widening only that case's gate.
+An adversarial review of PR #499 demonstrated exactly that: 1.5 -> 3.0 in
+one case doubled its gate with every existing guard still green.
+
+Consumers (as of this writing):
+  * tests/test_wr90_iris_modematch_gates.py        (quantum=100, abs |S11|)
+  * tests/test_rcs_mie_ka_sweep_gates.py            (quantum=10,  dB)
+  * tests/test_rcs_dielectric_sphere_mie_gates.py   (quantum=10,  dB)
+  * validation/crossval/18_wr90_iris_modematch.py       (--write-fixture self-check)
+  * validation/crossval/16_pec_sphere_mie_ka_sweep.py   (--write-fixture self-check)
+  * validation/crossval/17_dielectric_sphere_mie.py     (--write-fixture self-check)
+
+The bounded-margin lanes (``test_waveguide_broad_e5_tolerance_envelope.py``
+and its phase / group-delay siblings) check a structurally different shape
+-- a PINNED module constant bounded by ``[worst_measured, worst_measured x
+MULTIPLIER]`` rather than a quantized derived value, so they do not call
+``gate_from_envelope`` -- but they share the SAME multiplier (their own
+comments already say so: "Same governance margin ceiling as the magnitude
+lane's MARGIN_CEIL=1.5"), so they import ``ENVELOPE_GATE_MULTIPLIER``
+directly instead of restating ``1.5`` as a fresh local literal.
+
+A change to ``ENVELOPE_GATE_MULTIPLIER`` here moves every one of the above
+at once -- that is the visibility guarantee issue #528 asks for: a per-case
+relaxation now requires editing a shared, reviewer-visible object instead of
+a local literal. ``tests/test_gate_policy_is_shared.py`` is the cross-check
+(no consumer may carry a local literal instead of this import) and the
+falsifier (mutating the constant moves every quantized-gate consumer's
+derived value in lockstep).
+"""
+
+from __future__ import annotations
+
+import math
+
+ENVELOPE_GATE_MULTIPLIER: float = 1.5
+"""The repo-wide margin multiplier every measured-envelope gate is derived
+from. This is a GOVERNANCE choice (how much slack a reviewer tolerates
+above the measured worst case), not a physical bound. Widening it widens
+every consumer listed in this module's docstring at once -- do not change
+it without a written root-cause per case (no-silent-gate-loosening)."""
+
+
+def gate_from_envelope(measured_envelope: float, *, quantum: float) -> float:
+    """Round ``measured_envelope * ENVELOPE_GATE_MULTIPLIER`` UP to the
+    nearest ``1 / quantum``.
+
+    ``quantum=100`` -> 2 decimal places (e.g. absolute |S11| gates).
+    ``quantum=10``  -> 1 decimal place (e.g. dB gates).
+
+    Reads ``ENVELOPE_GATE_MULTIPLIER`` from this module's namespace at call
+    time rather than capturing it as a bound default, so monkeypatching the
+    module attribute changes every subsequent call made through this same
+    function object -- including calls reached via
+    ``from tests._gate_policy import gate_from_envelope`` in a consumer
+    module, since Python functions resolve globals against their *defining*
+    module, not the importer's. This is the mechanism the falsifier test in
+    ``test_gate_policy_is_shared.py`` relies on.
+    """
+    return math.ceil(measured_envelope * ENVELOPE_GATE_MULTIPLIER * quantum) / quantum

--- a/tests/_gate_policy.py
+++ b/tests/_gate_policy.py
@@ -30,18 +30,45 @@ The bounded-margin lanes (``test_waveguide_broad_e5_tolerance_envelope.py``
 and its phase / group-delay siblings) check a structurally different shape
 -- a PINNED module constant bounded by ``[worst_measured, worst_measured x
 MULTIPLIER]`` rather than a quantized derived value, so they do not call
-``gate_from_envelope`` -- but they share the SAME multiplier (their own
-comments already say so: "Same governance margin ceiling as the magnitude
-lane's MARGIN_CEIL=1.5"), so they import ``ENVELOPE_GATE_MULTIPLIER``
-directly instead of restating ``1.5`` as a fresh local literal.
+``gate_from_envelope`` -- they import ``ENVELOPE_GATE_MULTIPLIER`` directly
+instead of restating ``1.5`` as a fresh local literal. Sharing the name is
+not what makes that binding real, though: a local ``MARGIN_CEIL = 3.0``
+plant still passes the source-grep in ``test_gate_policy_is_shared.py`` (the
+grep only rejects restating ``1.5``, not any other value, an alias, or a
+formatting variant like ``1.50``). What actually binds those three lanes to
+this constant is
+``test_margin_ceiling_lanes_are_bound_by_the_shared_multiplier_from_outside``
+in ``test_gate_policy_is_shared.py``: it independently re-derives each
+lane's ``worst`` from the same committed artifacts the lane itself reads,
+imports each lane's PINNED constant, and asserts
+``worst <= PINNED <= worst * ENVELOPE_GATE_MULTIPLIER`` from OUTSIDE the
+lane's own file -- so a coherent in-file plant (widen the local ceiling AND
+re-pin the constant to fit under it) is checked against the ONE shared
+number regardless of what the plant's own file claims.
 
 A change to ``ENVELOPE_GATE_MULTIPLIER`` here moves every one of the above
 at once -- that is the visibility guarantee issue #528 asks for: a per-case
 relaxation now requires editing a shared, reviewer-visible object instead of
-a local literal. ``tests/test_gate_policy_is_shared.py`` is the cross-check
-(no consumer may carry a local literal instead of this import) and the
-falsifier (mutating the constant moves every quantized-gate consumer's
-derived value in lockstep).
+a local literal. ``tests/test_gate_policy_is_shared.py`` carries three kinds
+of guard, in increasing order of how load-bearing they are: (1) a source
+grep that only catches the literal string ``1.5`` (cosmetic -- evadable, see
+above); (2) two falsifiers for the quantized-gate lanes -- one execs a
+source-mutated copy of this file (the exact "find-replace 1.5 -> 3.0" class
+of edit from the #499 review) and one monkeypatches the already-imported
+``ENVELOPE_GATE_MULTIPLIER`` on the live module -- both show every real
+gated case's derived value moves together and reverting reproduces every
+case's frozen CI-pinned gate bit-for-bit; (3) the from-outside numeric
+cross-check for the bounded-margin lanes described above. (1) is a tripwire,
+not a guarantee; (2) and (3) are the load-bearing checks.
+
+Coordination note: if ``ENVELOPE_GATE_MULTIPLIER`` is ever deliberately
+changed, the PROSE restatements of "x 1.5" scattered through docstrings,
+comments, and printed diagnostics in the six consumer files above (roughly
+30 occurrences, none of them load-bearing -- they are not touched by this
+module and nothing here checks them) will read stale, including the
+runtime mismatch message in ``validation/crossval/18_wr90_iris_modematch.py``
+(``f"must equal round-up(env x 1.5) = {required}"``). Re-derive and update
+those by hand in the same change; this module does not do it for you.
 """
 
 from __future__ import annotations
@@ -64,12 +91,19 @@ def gate_from_envelope(measured_envelope: float, *, quantum: float) -> float:
     ``quantum=10``  -> 1 decimal place (e.g. dB gates).
 
     Reads ``ENVELOPE_GATE_MULTIPLIER`` from this module's namespace at call
-    time rather than capturing it as a bound default, so monkeypatching the
-    module attribute changes every subsequent call made through this same
-    function object -- including calls reached via
+    time rather than capturing it as a bound default, so it is
+    monkeypatchable: patching the module attribute on an ALREADY-IMPORTED
+    copy of this module changes every subsequent call made through this
+    same function object -- including calls reached via
     ``from tests._gate_policy import gate_from_envelope`` in a consumer
     module, since Python functions resolve globals against their *defining*
-    module, not the importer's. This is the mechanism the falsifier test in
-    ``test_gate_policy_is_shared.py`` relies on.
+    module, not the importer's.
+    ``test_gate_policy_is_shared.py`` exercises BOTH falsifier mechanisms
+    against this property: ``test_mutating_the_shared_multiplier_...``
+    execs a source-mutated COPY of this file (closer to the real "edit the
+    file" attack shape, but does not touch any already-imported module) and
+    ``test_monkeypatching_the_live_shared_multiplier_...`` patches this
+    already-imported module's attribute directly (closer to proving
+    consumers read the constant at call time rather than at import time).
     """
     return math.ceil(measured_envelope * ENVELOPE_GATE_MULTIPLIER * quantum) / quantum

--- a/tests/test_gate_policy_is_shared.py
+++ b/tests/test_gate_policy_is_shared.py
@@ -1,0 +1,168 @@
+"""Issue #528 cross-check: the envelope -> gate multiplier now has exactly
+ONE definition (``tests/_gate_policy.py``), and every gated crossval case
+must consume it rather than restate ``1.5`` locally.
+
+Two properties are checked:
+
+  1. VISIBILITY -- no consumer file carries a local envelope-multiplier
+     literal any more; each imports ``tests._gate_policy`` instead. A
+     coherent per-case edit (hard pin + derived relation, both in one file)
+     can no longer relax the multiplier without touching a shared,
+     reviewer-visible object.
+  2. THE FALSIFIER -- a source-level find-replace of the ONE multiplier
+     definition (the exact class of edit an adversarial review of PR #499
+     caught doubling one case's gate while every existing guard stayed
+     green) moves every quantized-gate case's derived value together, and
+     reverting reproduces every case's frozen CI-pinned gate bit-for-bit.
+
+No FDTD runs here -- pure-Python, replays committed fixtures.
+"""
+from __future__ import annotations
+
+import json
+import re
+import types
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+GATE_POLICY = REPO / "tests" / "_gate_policy.py"
+
+# The quantized-gate consumers: `gate = ceil(env * MULTIPLIER * quantum) /
+# quantum`, hard-pinned in a test AND re-derived in the crossval script's
+# own --write-fixture self-check.
+_QUANTIZED_GATE_FILES = [
+    REPO / "tests" / "test_wr90_iris_modematch_gates.py",
+    REPO / "tests" / "test_rcs_mie_ka_sweep_gates.py",
+    REPO / "tests" / "test_rcs_dielectric_sphere_mie_gates.py",
+    REPO / "validation" / "crossval" / "16_pec_sphere_mie_ka_sweep.py",
+    REPO / "validation" / "crossval" / "17_dielectric_sphere_mie.py",
+    REPO / "validation" / "crossval" / "18_wr90_iris_modematch.py",
+]
+
+# The bounded-margin consumers: a PINNED module constant checked against
+# [worst_measured, worst_measured * MULTIPLIER] -- a different formula shape
+# (see tests/_gate_policy.py docstring), so these import the multiplier
+# directly rather than calling gate_from_envelope.
+_MARGIN_CEIL_FILES = [
+    REPO / "tests" / "test_waveguide_broad_e5_tolerance_envelope.py",
+    REPO / "tests" / "test_waveguide_broad_e5_phase_tolerance_envelope.py",
+    REPO / "tests" / "test_waveguide_group_delay_tolerance_envelope.py",
+]
+
+# (fixture path, measured-envelope key path, CI-pinned-gate key path,
+# quantum) for every quantized-gate case that exists in this repo today.
+_REAL_CASES = [
+    ("tests/fixtures/wr90_iris_modematch/fixture.json",
+     ("gates", "fine_measured_envelope_abs"), ("gates", "fine_gate_abs"), 100),
+    ("tests/fixtures/wr90_iris_modematch/fixture.json",
+     ("gates", "richardson_measured_envelope_abs"), ("gates", "richardson_gate_abs"), 100),
+    ("tests/fixtures/rcs_mie_ka_sweep/fixture.json",
+     ("gates", "coarse_measured_envelope_db"), ("gates", "coarse_gate_db"), 10),
+    ("tests/fixtures/rcs_mie_ka_sweep/fixture.json",
+     ("gates", "fine_measured_envelope_db"), ("gates", "fine_gate_db"), 10),
+    ("tests/fixtures/rcs_dielectric_sphere_mie/fixture.json",
+     ("gates", "coarse_measured_envelope_db"), ("gates", "coarse_gate_db"), 10),
+]
+
+
+def _load(rel_path: str) -> dict:
+    with open(REPO / rel_path) as f:
+        return json.load(f)
+
+
+def _dig(d: dict, path: tuple[str, ...]):
+    for k in path:
+        d = d[k]
+    return d
+
+
+def test_gate_policy_module_defines_exactly_one_multiplier():
+    from tests._gate_policy import ENVELOPE_GATE_MULTIPLIER, gate_from_envelope
+    assert ENVELOPE_GATE_MULTIPLIER == 1.5
+    assert callable(gate_from_envelope)
+
+
+@pytest.mark.parametrize(
+    "path", _QUANTIZED_GATE_FILES, ids=[p.name for p in _QUANTIZED_GATE_FILES])
+def test_quantized_gate_case_imports_shared_helper_not_a_local_literal(path):
+    src = path.read_text(encoding="utf-8")
+    assert "_gate_policy import" in src and "gate_from_envelope" in src, (
+        f"{path.name} does not import the shared gate_from_envelope helper"
+    )
+    # The exact pattern removed from every case: `<expr> * 1.5 * <quantum>`.
+    assert re.search(r"\*\s*1\.5\s*\*", src) is None, (
+        f"{path.name} still carries a local `* 1.5 *` gate-derivation "
+        f"literal instead of calling the shared helper"
+    )
+
+
+@pytest.mark.parametrize(
+    "path", _MARGIN_CEIL_FILES, ids=[p.name for p in _MARGIN_CEIL_FILES])
+def test_margin_ceil_case_imports_shared_multiplier_not_a_local_literal(path):
+    src = path.read_text(encoding="utf-8")
+    assert "_gate_policy import" in src and "ENVELOPE_GATE_MULTIPLIER" in src, (
+        f"{path.name} does not import the shared ENVELOPE_GATE_MULTIPLIER"
+    )
+    assert re.search(r"^MARGIN_CEIL\s*=\s*1\.5", src, re.MULTILINE) is None, (
+        f"{path.name} still assigns MARGIN_CEIL = 1.5 as a local literal "
+        f"instead of importing the shared constant"
+    )
+
+
+def test_mutating_the_shared_multiplier_moves_every_gated_case_and_reverts():
+    """The falsifier: reproduce the EXACT adversarial edit named in the
+    issue (a source-level find-replace of the single multiplier
+    definition) and show every quantized-gate case's derived value moves
+    together, then confirm reverting restores every case's frozen
+    CI-pinned gate exactly."""
+    original_src = GATE_POLICY.read_text(encoding="utf-8")
+    needle = "ENVELOPE_GATE_MULTIPLIER: float = 1.5"
+    assert needle in original_src, (
+        "expected literal not found -- tests/_gate_policy.py's definition "
+        "changed shape; update this falsifier to match"
+    )
+    mutated_src = original_src.replace(
+        needle, "ENVELOPE_GATE_MULTIPLIER: float = 3.0")
+    assert mutated_src != original_src
+
+    def _exec_gate_policy(src_text: str) -> types.ModuleType:
+        mod = types.ModuleType("gate_policy_under_test")
+        exec(compile(src_text, str(GATE_POLICY), "exec"), mod.__dict__)
+        return mod
+
+    baseline_mod = _exec_gate_policy(original_src)
+    mutated_mod = _exec_gate_policy(mutated_src)
+    assert baseline_mod.ENVELOPE_GATE_MULTIPLIER == 1.5
+    assert mutated_mod.ENVELOPE_GATE_MULTIPLIER == 3.0
+
+    moved = []
+    for fixture_path, env_key, gate_key, quantum in _REAL_CASES:
+        data = _load(fixture_path)
+        env = float(_dig(data, env_key))
+        pinned_gate = float(_dig(data, gate_key))
+        # CAUGHT (before the mutation): the shared helper reproduces the
+        # frozen CI-pinned gate exactly -- behavior-preserving migration.
+        baseline = baseline_mod.gate_from_envelope(env, quantum=quantum)
+        assert baseline == pytest.approx(pinned_gate, abs=1e-9), (
+            fixture_path, env_key, baseline, pinned_gate)
+        # CAUGHT (the falsifier): the mutated multiplier widens this case's
+        # derived gate too -- it did not need its own file touched.
+        mutated = mutated_mod.gate_from_envelope(env, quantum=quantum)
+        assert mutated > baseline, (fixture_path, env_key, baseline, mutated)
+        moved.append((fixture_path, env_key, baseline, mutated))
+
+    assert len(moved) == len(_REAL_CASES), "not every real gated case responded"
+
+    # REVERT: re-deriving from the UNMODIFIED module reproduces every
+    # case's pinned gate again, bit-for-bit -- nothing was left mutated
+    # (this test only ever exec'd source text into throwaway module
+    # objects; the file on disk was never touched).
+    assert GATE_POLICY.read_text(encoding="utf-8") == original_src
+    for fixture_path, env_key, gate_key, quantum in _REAL_CASES:
+        data = _load(fixture_path)
+        env = float(_dig(data, env_key))
+        pinned_gate = float(_dig(data, gate_key))
+        reverted = baseline_mod.gate_from_envelope(env, quantum=quantum)
+        assert reverted == pytest.approx(pinned_gate, abs=1e-9)

--- a/tests/test_gate_policy_is_shared.py
+++ b/tests/test_gate_policy_is_shared.py
@@ -2,28 +2,43 @@
 ONE definition (``tests/_gate_policy.py``), and every gated crossval case
 must consume it rather than restate ``1.5`` locally.
 
-Two properties are checked:
+The guards here are NOT all equally load-bearing (adversarial review of
+PR #539 flagged this explicitly -- be honest about it):
 
-  1. VISIBILITY -- no consumer file carries a local envelope-multiplier
-     literal any more; each imports ``tests._gate_policy`` instead. A
-     coherent per-case edit (hard pin + derived relation, both in one file)
-     can no longer relax the multiplier without touching a shared,
-     reviewer-visible object.
-  2. THE FALSIFIER -- a source-level find-replace of the ONE multiplier
-     definition (the exact class of edit an adversarial review of PR #499
-     caught doubling one case's gate while every existing guard stayed
-     green) moves every quantized-gate case's derived value together, and
-     reverting reproduces every case's frozen CI-pinned gate bit-for-bit.
+  * The source-grep tests below (``..._imports_shared_helper_not_a_local_literal``,
+    ``..._imports_shared_multiplier_not_a_local_literal``) only reject the
+    LITERAL string ``1.5`` being restated. They are a tripwire, not a
+    guarantee: a plant using ``1.50``, an aliased name, or any OTHER value
+    (e.g. a local ``MARGIN_CEIL = 3.0``) sails through them untouched.
+  * The load-bearing guards are the numeric cross-derivations: the two
+    falsifiers for the quantized-gate lanes
+    (``test_mutating_the_shared_multiplier_...`` and
+    ``test_monkeypatching_the_live_shared_multiplier_...``) and the
+    from-outside numeric cross-check for the bounded-margin lanes
+    (``test_margin_ceiling_lanes_are_bound_by_the_shared_multiplier_from_outside``).
+    These recompute a case's gate/bound from the shared constant and the
+    committed data independently of whatever the case's own file claims,
+    so a coherent in-file plant (relax the local check AND re-pin the
+    constant to fit under it) is still caught.
+  * The import-route test
+    (``test_crossval_script_import_route_resolves_the_repo_gate_policy_module``)
+    guards a DIFFERENT failure mode entirely: not a relaxed multiplier, but
+    a site-packages ``tests`` package (grcwa installs a non-namespace one)
+    winning the ``import tests`` race and silently -- or loudly, see that
+    test's docstring -- resolving to the wrong module.
 
-No FDTD runs here -- pure-Python, replays committed fixtures.
+No FDTD runs here -- pure-Python, replays committed fixtures and artifacts.
 """
 from __future__ import annotations
 
 import json
 import re
+import subprocess
+import sys
 import types
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 REPO = Path(__file__).resolve().parents[1]
@@ -51,20 +66,54 @@ _MARGIN_CEIL_FILES = [
     REPO / "tests" / "test_waveguide_group_delay_tolerance_envelope.py",
 ]
 
-# (fixture path, measured-envelope key path, CI-pinned-gate key path,
-# quantum) for every quantized-gate case that exists in this repo today.
-_REAL_CASES = [
-    ("tests/fixtures/wr90_iris_modematch/fixture.json",
-     ("gates", "fine_measured_envelope_abs"), ("gates", "fine_gate_abs"), 100),
-    ("tests/fixtures/wr90_iris_modematch/fixture.json",
-     ("gates", "richardson_measured_envelope_abs"), ("gates", "richardson_gate_abs"), 100),
-    ("tests/fixtures/rcs_mie_ka_sweep/fixture.json",
-     ("gates", "coarse_measured_envelope_db"), ("gates", "coarse_gate_db"), 10),
-    ("tests/fixtures/rcs_mie_ka_sweep/fixture.json",
-     ("gates", "fine_measured_envelope_db"), ("gates", "fine_gate_db"), 10),
-    ("tests/fixtures/rcs_dielectric_sphere_mie/fixture.json",
-     ("gates", "coarse_measured_envelope_db"), ("gates", "coarse_gate_db"), 10),
+_CROSSVAL_SCRIPTS = [
+    REPO / "validation" / "crossval" / "16_pec_sphere_mie_ka_sweep.py",
+    REPO / "validation" / "crossval" / "17_dielectric_sphere_mie.py",
+    REPO / "validation" / "crossval" / "18_wr90_iris_modematch.py",
 ]
+
+_ENVELOPE_KEY_RE = re.compile(r"^(?P<prefix>.+)_measured_envelope_(?P<suffix>abs|db)$")
+_QUANTUM_BY_SUFFIX = {"abs": 100, "db": 10}
+
+
+def _discover_real_cases() -> list[tuple[str, tuple[str, str], tuple[str, str], int]]:
+    """Pair every ``<prefix>_measured_envelope_<abs|db>`` gates-key with its
+    ``<prefix>_gate_<abs|db>`` sibling across every committed
+    ``tests/fixtures/**/fixture.json`` -- derived from the glob rather than
+    hand-maintained (#528 review MEDIUM 2), so a new quantized-gate case
+    (e.g. #499's case 19 fixture, once that PR lands) is picked up
+    automatically instead of needing this file edited too.
+
+    Descriptive, not authoritative: as of this writing this discovers
+    exactly 5 cases -- wr90_iris_modematch {fine, richardson},
+    rcs_mie_ka_sweep {coarse, fine}, rcs_dielectric_sphere_mie {coarse}.
+    Four OTHER committed fixture.json files exist
+    (rcs280_reference_subtraction, rcs_cube_bem, rcs_sphere_mie,
+    rcs_sphere_three_way) and are correctly excluded: none has a top-level
+    ``gates`` dict with a matching envelope/gate key pair. Dielectric's
+    ``fine_rung_witness_envelope_db`` is also correctly excluded -- it has
+    no ``fine_gate_db`` sibling (that rung is reported, never gated).
+    """
+    cases: list[tuple[str, tuple[str, str], tuple[str, str], int]] = []
+    for fixture_path in sorted(REPO.glob("tests/fixtures/**/fixture.json")):
+        data = json.loads(fixture_path.read_text())
+        gates = data.get("gates")
+        if not isinstance(gates, dict):
+            continue
+        rel = fixture_path.relative_to(REPO).as_posix()
+        for key in gates:
+            m = _ENVELOPE_KEY_RE.match(key)
+            if not m:
+                continue
+            gate_key = f"{m.group('prefix')}_gate_{m.group('suffix')}"
+            if gate_key not in gates:
+                continue
+            cases.append((rel, ("gates", key), ("gates", gate_key),
+                          _QUANTUM_BY_SUFFIX[m.group("suffix")]))
+    return cases
+
+
+_REAL_CASES = _discover_real_cases()
 
 
 def _load(rel_path: str) -> dict:
@@ -78,15 +127,85 @@ def _dig(d: dict, path: tuple[str, ...]):
     return d
 
 
+# ---------------------------------------------------------------------------
+# Independent re-derivation of `worst` for the bounded-margin lanes, from the
+# SAME committed artifacts each lane itself reads -- duplicated here on
+# purpose (not imported from the lane modules) so a coordinated edit to a
+# lane's own worst-computation cannot also blind this outside check.
+# ---------------------------------------------------------------------------
+
+_BROAD_E5_FIXTURES = REPO / "tests" / "fixtures" / "waveguide_broad_e5"
+_GROUP_DELAY_ENVELOPE = (
+    REPO / "tests/fixtures/waveguide_group_delay/wr340_near_cutoff_group_delay_envelope.json")
+
+sys.path.insert(0, str(REPO / "scripts" / "diagnostics"))
+from build_waveguide_band_broad_e5_envelope import MAX_TOL  # type: ignore  # noqa: E402
+from build_waveguide_band_broad_e5_phase_envelope import MAX_PHASE_TOL_DEG  # type: ignore  # noqa: E402
+from build_waveguide_group_delay_envelope import MAX_GROUP_DELAY_TOL_NS  # type: ignore  # noqa: E402
+
+
+def _worst_broad_e5_magnitude_diff() -> float:
+    diffs = [float(c["max_mag_abs_diff"])
+             for f in sorted(_BROAD_E5_FIXTURES.glob("waveguide_*_broad_e5_envelope.json"))
+             for c in json.loads(f.read_text())["cases"]]
+    assert diffs, "no committed broad-E5 magnitude cases found"
+    return max(diffs)
+
+
+def _worst_broad_e5_phase_diff() -> float:
+    diffs = [float(c["max_phase_diff_deg"])
+             for f in sorted(_BROAD_E5_FIXTURES.glob("waveguide_*_broad_e5_phase_envelope.json"))
+             for c in json.loads(f.read_text())["cases"]]
+    assert diffs, "no committed broad-E5 phase cases found"
+    return max(diffs)
+
+
+def _worst_group_delay_diff_ns() -> float:
+    env = json.loads(_GROUP_DELAY_ENVELOPE.read_text())
+    meas = np.array(env["tau_g_measured_ns"])
+    ana_stencil = np.array(env["tau_g_analytic_via_stencil_ns"])
+    idx = env["interior_indices"]
+    return float(np.abs(meas[idx] - ana_stencil[idx]).max())
+
+
 def test_gate_policy_module_defines_exactly_one_multiplier():
     from tests._gate_policy import ENVELOPE_GATE_MULTIPLIER, gate_from_envelope
     assert ENVELOPE_GATE_MULTIPLIER == 1.5
     assert callable(gate_from_envelope)
 
 
+def test_real_cases_are_discovered_from_the_fixture_glob_not_hand_maintained():
+    """#528 review MEDIUM 2: an empty or broken glob must not silently pass
+    every other assertion in this file (they'd vacuously succeed over zero
+    cases) -- assert a floor AND that today's 5 known cases are all in it."""
+    assert len(_REAL_CASES) >= 5, (
+        f"only {len(_REAL_CASES)} real gated cases discovered via the "
+        f"fixture glob -- an empty or broken glob would silently pass "
+        f"every other case-driven assertion in this file"
+    )
+    discovered = {(rel, env_key) for rel, env_key, _, _ in _REAL_CASES}
+    expected = {
+        ("tests/fixtures/wr90_iris_modematch/fixture.json",
+         ("gates", "fine_measured_envelope_abs")),
+        ("tests/fixtures/wr90_iris_modematch/fixture.json",
+         ("gates", "richardson_measured_envelope_abs")),
+        ("tests/fixtures/rcs_mie_ka_sweep/fixture.json",
+         ("gates", "coarse_measured_envelope_db")),
+        ("tests/fixtures/rcs_mie_ka_sweep/fixture.json",
+         ("gates", "fine_measured_envelope_db")),
+        ("tests/fixtures/rcs_dielectric_sphere_mie/fixture.json",
+         ("gates", "coarse_measured_envelope_db")),
+    }
+    assert expected <= discovered
+
+
 @pytest.mark.parametrize(
     "path", _QUANTIZED_GATE_FILES, ids=[p.name for p in _QUANTIZED_GATE_FILES])
 def test_quantized_gate_case_imports_shared_helper_not_a_local_literal(path):
+    """Tripwire only (see module docstring): rejects the literal `1.5`
+    restated as a `* 1.5 *` gate-derivation expression. Does not, and
+    cannot by grep alone, rule out a different multiplier value -- that is
+    what the falsifier tests below are for."""
     src = path.read_text(encoding="utf-8")
     assert "_gate_policy import" in src and "gate_from_envelope" in src, (
         f"{path.name} does not import the shared gate_from_envelope helper"
@@ -101,6 +220,11 @@ def test_quantized_gate_case_imports_shared_helper_not_a_local_literal(path):
 @pytest.mark.parametrize(
     "path", _MARGIN_CEIL_FILES, ids=[p.name for p in _MARGIN_CEIL_FILES])
 def test_margin_ceil_case_imports_shared_multiplier_not_a_local_literal(path):
+    """Tripwire only (see module docstring): rejects `MARGIN_CEIL = 1.5`
+    restated as a local literal. A plant of `MARGIN_CEIL = 3.0` (any OTHER
+    value) passes this grep untouched -- caught instead by
+    test_margin_ceiling_lanes_are_bound_by_the_shared_multiplier_from_outside,
+    which does not read MARGIN_CEIL at all."""
     src = path.read_text(encoding="utf-8")
     assert "_gate_policy import" in src and "ENVELOPE_GATE_MULTIPLIER" in src, (
         f"{path.name} does not import the shared ENVELOPE_GATE_MULTIPLIER"
@@ -111,12 +235,85 @@ def test_margin_ceil_case_imports_shared_multiplier_not_a_local_literal(path):
     )
 
 
+def test_margin_ceiling_lanes_are_bound_by_the_shared_multiplier_from_outside():
+    """#528 review MEDIUM 1 -- the load-bearing guard for the three
+    bounded-margin lanes. Each lane's OWN test file checks
+    `worst <= PINNED <= worst * MARGIN_CEIL` using its OWN `MARGIN_CEIL`
+    name -- which a plant can locally repoint to any value with the source
+    grep above none the wiser. This test re-derives `worst` independently
+    (see the `_worst_*` helpers above, which read the same committed
+    artifacts the lanes read but do not call into the lane modules) and
+    checks the SAME bound using `ENVELOPE_GATE_MULTIPLIER` imported fresh
+    from `tests._gate_policy` -- so the bound is enforced regardless of
+    what any lane file's own `MARGIN_CEIL` name is bound to.
+
+    Verified (all three currently well inside the shared 1.5x ceiling):
+    magnitude 0.05 / 0.0414 = 1.21, phase 15.0 / 11.99 = 1.25, group delay
+    0.042 / 0.0320 = 1.31.
+
+    Reviewer's plant, manually re-run against this exact check and
+    confirmed to red (see PR #539 review response / commit body for the
+    numbers): planting a local `MARGIN_CEIL = 3.0` in
+    test_waveguide_broad_e5_tolerance_envelope.py and re-pinning
+    `MAX_TOL` to 0.09 (0.09 / 0.0414 = 2.17 -- passes that file's own
+    3.0x-ceiling check) still fails THIS assertion, because
+    `0.09 > 0.0414 * ENVELOPE_GATE_MULTIPLIER (0.0621)` regardless of the
+    planted local ceiling.
+    """
+    from tests._gate_policy import ENVELOPE_GATE_MULTIPLIER
+
+    lanes = (
+        (_worst_broad_e5_magnitude_diff(), MAX_TOL, "broad-E5 magnitude"),
+        (_worst_broad_e5_phase_diff(), MAX_PHASE_TOL_DEG, "broad-E5 phase"),
+        (_worst_group_delay_diff_ns(), MAX_GROUP_DELAY_TOL_NS,
+         "near-cutoff group delay"),
+    )
+    for worst, pinned, label in lanes:
+        assert worst <= pinned, (
+            label, worst, pinned,
+            "pinned constant is below the independently-recomputed worst "
+            "case -- would fail a validated case")
+        assert pinned <= worst * ENVELOPE_GATE_MULTIPLIER, (
+            label, worst, pinned, ENVELOPE_GATE_MULTIPLIER,
+            "pinned constant exceeds worst * ENVELOPE_GATE_MULTIPLIER -- "
+            "slack beyond the shared repo-wide ceiling, regardless of "
+            "whatever a local MARGIN_CEIL name in the lane's own file "
+            "claims")
+
+
+def test_margin_ceiling_plant_is_caught_by_the_from_outside_cross_check():
+    """Permanent regression coverage for the reviewer's plant described
+    above, using the REAL committed broad-E5 magnitude worst case (no file
+    is touched -- this only proves the arithmetic mechanism): a re-pin
+    that fits under a locally-planted 3.0x ceiling still violates the
+    shared 1.5x one."""
+    from tests._gate_policy import ENVELOPE_GATE_MULTIPLIER
+
+    worst = _worst_broad_e5_magnitude_diff()
+    planted_local_ceiling = 3.0
+    re_pinned = 0.09
+    assert re_pinned <= worst * planted_local_ceiling, (
+        "test setup invalid: the planted re-pin must itself pass the "
+        "attacker's own local (widened) ceiling")
+    assert re_pinned > worst * ENVELOPE_GATE_MULTIPLIER, (
+        "test setup invalid: the planted re-pin must violate the shared "
+        "ceiling for this to demonstrate anything")
+    with pytest.raises(AssertionError):
+        assert re_pinned <= worst * ENVELOPE_GATE_MULTIPLIER
+
+
 def test_mutating_the_shared_multiplier_moves_every_gated_case_and_reverts():
-    """The falsifier: reproduce the EXACT adversarial edit named in the
-    issue (a source-level find-replace of the single multiplier
-    definition) and show every quantized-gate case's derived value moves
-    together, then confirm reverting restores every case's frozen
-    CI-pinned gate exactly."""
+    """Falsifier 1 of 2 (source-mutation shape): reproduce the EXACT
+    adversarial edit named in the issue (a source-level find-replace of
+    the single multiplier definition, as if someone had actually edited
+    tests/_gate_policy.py on disk) and show every quantized-gate case's
+    derived value moves together, then confirm reverting restores every
+    case's frozen CI-pinned gate exactly. This execs mutated SOURCE TEXT
+    into throwaway module objects -- it never touches any already-imported
+    module or the file on disk. See
+    test_monkeypatching_the_live_shared_multiplier_moves_every_gated_case
+    for the complementary live-module falsifier.
+    """
     original_src = GATE_POLICY.read_text(encoding="utf-8")
     needle = "ENVELOPE_GATE_MULTIPLIER: float = 1.5"
     assert needle in original_src, (
@@ -137,6 +334,7 @@ def test_mutating_the_shared_multiplier_moves_every_gated_case_and_reverts():
     assert baseline_mod.ENVELOPE_GATE_MULTIPLIER == 1.5
     assert mutated_mod.ENVELOPE_GATE_MULTIPLIER == 3.0
 
+    assert _REAL_CASES, "no real cases discovered -- see the glob-discovery test"
     moved = []
     for fixture_path, env_key, gate_key, quantum in _REAL_CASES:
         data = _load(fixture_path)
@@ -166,3 +364,117 @@ def test_mutating_the_shared_multiplier_moves_every_gated_case_and_reverts():
         pinned_gate = float(_dig(data, gate_key))
         reverted = baseline_mod.gate_from_envelope(env, quantum=quantum)
         assert reverted == pytest.approx(pinned_gate, abs=1e-9)
+
+
+def test_monkeypatching_the_live_shared_multiplier_moves_every_gated_case():
+    """Falsifier 2 of 2 (live-module shape, #528 review L1): patches
+    `ENVELOPE_GATE_MULTIPLIER` on the ALREADY-IMPORTED `tests._gate_policy`
+    module -- the actual module object every consumer's
+    `from tests._gate_policy import gate_from_envelope` is bound to in this
+    process -- rather than exec'ing a source copy. This is the cheaper and
+    more direct proof that consumers read the constant at CALL time, not
+    at import time: `gate_from_envelope` is not re-imported anywhere below,
+    only called again after the patch.
+
+    Concretely verified: the dielectric-sphere coarse case moves 6.3 dB ->
+    12.6 dB (measured envelope 4.181 dB, multiplier 1.5 -> 3.0).
+
+    Uses `pytest.MonkeyPatch.context()` explicitly (rather than the
+    function-scoped `monkeypatch` fixture) so the revert is demonstrated
+    INSIDE this test, not merely implied by fixture teardown.
+    """
+    from tests import _gate_policy
+
+    assert _REAL_CASES, "no real cases discovered -- see the glob-discovery test"
+    baseline = {}
+    for fixture_path, env_key, gate_key, quantum in _REAL_CASES:
+        data = _load(fixture_path)
+        env = float(_dig(data, env_key))
+        pinned_gate = float(_dig(data, gate_key))
+        baseline_gate = _gate_policy.gate_from_envelope(env, quantum=quantum)
+        assert baseline_gate == pytest.approx(pinned_gate, abs=1e-9)
+        baseline[(fixture_path, env_key)] = baseline_gate
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(_gate_policy, "ENVELOPE_GATE_MULTIPLIER", 3.0)
+        assert _gate_policy.ENVELOPE_GATE_MULTIPLIER == 3.0
+        for fixture_path, env_key, gate_key, quantum in _REAL_CASES:
+            data = _load(fixture_path)
+            env = float(_dig(data, env_key))
+            mutated_gate = _gate_policy.gate_from_envelope(env, quantum=quantum)
+            assert mutated_gate > baseline[(fixture_path, env_key)], (
+                fixture_path, env_key, baseline[(fixture_path, env_key)],
+                mutated_gate)
+
+    # REVERT (outside the context manager): the live module's constant and
+    # every case's re-derived gate are back to the pinned values.
+    assert _gate_policy.ENVELOPE_GATE_MULTIPLIER == 1.5
+    for fixture_path, env_key, gate_key, quantum in _REAL_CASES:
+        data = _load(fixture_path)
+        env = float(_dig(data, env_key))
+        pinned_gate = float(_dig(data, gate_key))
+        reverted_gate = _gate_policy.gate_from_envelope(env, quantum=quantum)
+        assert reverted_gate == pytest.approx(pinned_gate, abs=1e-9)
+
+
+_IMPORT_ROUTE_PROBE = """
+import runpy, sys, os
+script = {script!r}
+# Reproduce the exact scenario a bare `python script.py` invoked from an
+# arbitrary cwd sets up: sys.path[0] = the SCRIPT'S OWN directory, not the
+# repo root and not cwd -- the harshest ordering, since nothing points at
+# the repo until the script's own sys.path.insert(0, _REPO_ROOT) line runs.
+sys.path.insert(0, os.path.dirname(script))
+ns = runpy.run_path(script, run_name="not_main")
+gfe = ns["gate_from_envelope"]
+print(gfe.__globals__.get("__file__", ""))
+"""
+
+
+@pytest.mark.parametrize(
+    "script", _CROSSVAL_SCRIPTS, ids=[p.name for p in _CROSSVAL_SCRIPTS])
+def test_crossval_script_import_route_resolves_the_repo_gate_policy_module(script):
+    """#528 review L3: guards a DIFFERENT failure mode than the rest of
+    this file -- not a relaxed multiplier, an import-route collision.
+    `/root/.local/lib/python3.10/site-packages/tests/` is a REGULAR
+    (non-namespace) package installed by `grcwa` (used by the Floquet-RCWA
+    referee lane). If anything resolves `import tests` before a crossval
+    script's own `sys.path.insert(0, _REPO_ROOT)` line runs, that binding
+    is cached in `sys.modules['tests']` for the rest of the process and the
+    script's own insert cannot undo it -- confirmed by hand: pre-importing
+    the site-packages `tests` package and then running one of these
+    scripts' prologue raises `ModuleNotFoundError: No module named
+    'tests._gate_policy'` (loud, not silently wrong, but still a crash).
+
+    This test reproduces the reviewer's exact method -- `runpy.run_path`
+    with `run_name != "__main__"` (so the heavy FDTD `__main__` block never
+    executes) and `sys.path[0]` set to the script's own directory -- in a
+    FRESH SUBPROCESS per script, not in-process. In-process would be
+    non-discriminating: this pytest session has already imported the
+    correct `tests._gate_policy` (to collect this very file), so
+    `sys.modules['tests']` is already correctly bound before this test
+    runs regardless of whether the script's OWN sys.path-insert logic is
+    even correct -- an in-process check could not tell a working script
+    from a broken one. The subprocess starts with an empty
+    `sys.modules` and a `cwd` outside the repo (so `''`/cwd cannot
+    accidentally save it either), so passing here is real evidence the
+    script's own `sys.path.insert(0, _REPO_ROOT)` -> import ordering is
+    what resolves `tests` correctly, not an artifact of the test
+    environment.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", _IMPORT_ROUTE_PROBE.format(script=str(script))],
+        cwd=str(REPO / "validation"),
+        capture_output=True, text=True, timeout=180,
+    )
+    assert proc.returncode == 0, (
+        f"{script.name} import-route probe crashed "
+        f"(this is exactly the ModuleNotFoundError shape a site-packages "
+        f"`tests` shadow produces):\n{proc.stdout}\n{proc.stderr}"
+    )
+    resolved_file = proc.stdout.strip().splitlines()[-1] if proc.stdout.strip() else ""
+    assert resolved_file == str(GATE_POLICY), (
+        f"{script.name} resolved gate_from_envelope to {resolved_file!r}, "
+        f"not this repo's {GATE_POLICY} -- a shadowing `tests` package won "
+        f"the import race"
+    )

--- a/tests/test_rcs_dielectric_sphere_mie_gates.py
+++ b/tests/test_rcs_dielectric_sphere_mie_gates.py
@@ -39,6 +39,8 @@ import numpy as np
 import pytest
 from scipy.special import spherical_jn, spherical_yn
 
+from tests._gate_policy import gate_from_envelope
+
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _FIXTURE = _REPO_ROOT / "tests/fixtures/rcs_dielectric_sphere_mie/fixture.json"
 _ARTIFACT = _REPO_ROOT / "validation/crossval/_17_dielectric_results/rfx.json"
@@ -132,7 +134,7 @@ def test_gate_is_hard_pinned_and_equals_recomputed_envelope(fixture):
     env = max(_gated_coarse_deltas(fixture))
     assert abs(g["coarse_measured_envelope_db"] - env) < 5e-3
     assert g["coarse_gate_db"] == pytest.approx(
-        math.ceil(env * 1.5 * 10) / 10, abs=1e-9)
+        gate_from_envelope(env, quantum=10), abs=1e-9)
     # HARD pin — widening requires editing this line with a root-cause.
     assert g["coarse_gate_db"] == 6.3
 

--- a/tests/test_rcs_mie_ka_sweep_gates.py
+++ b/tests/test_rcs_mie_ka_sweep_gates.py
@@ -31,13 +31,14 @@ the recorded physics (no-silent-gate-loosening rule).
 from __future__ import annotations
 
 import json
-import math
 import re
 from pathlib import Path
 
 import numpy as np
 import pytest
 from scipy.special import spherical_jn, spherical_yn
+
+from tests._gate_policy import gate_from_envelope
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _FIXTURE = _REPO_ROOT / "tests/fixtures/rcs_mie_ka_sweep/fixture.json"
@@ -141,9 +142,9 @@ def test_gate_equals_recomputed_envelope_times_1p5(fixture):
     assert abs(g["coarse_measured_envelope_db"] - env_coarse) < 5e-3
     assert abs(g["fine_measured_envelope_db"] - env_fine) < 5e-3
     assert g["coarse_gate_db"] == pytest.approx(
-        math.ceil(env_coarse * 1.5 * 10) / 10, abs=1e-9)
+        gate_from_envelope(env_coarse, quantum=10), abs=1e-9)
     assert g["fine_gate_db"] == pytest.approx(
-        math.ceil(env_fine * 1.5 * 10) / 10, abs=1e-9)
+        gate_from_envelope(env_fine, quantum=10), abs=1e-9)
     # D1 (review): HARD numeric ceiling, deliberately redundant with the
     # derived relation above. Without it a physics regression widens its own
     # gate and stays green (the derived assert alone is self-ratifying).

--- a/tests/test_waveguide_broad_e5_phase_tolerance_envelope.py
+++ b/tests/test_waveguide_broad_e5_phase_tolerance_envelope.py
@@ -19,9 +19,14 @@ FIXTURES = REPO / "tests" / "fixtures" / "waveguide_broad_e5"
 sys.path.insert(0, str(REPO / "scripts" / "diagnostics"))
 from build_waveguide_band_broad_e5_phase_envelope import MAX_PHASE_TOL_DEG  # type: ignore  # noqa: E402
 
-# Same governance margin ceiling as the magnitude lane's MARGIN_CEIL=1.5.
+from tests._gate_policy import ENVELOPE_GATE_MULTIPLIER
+
+# Same governance margin ceiling as the magnitude lane's MARGIN_CEIL (1.5).
 # 15.0 / 11.99 = 1.25, well inside 1.5.
-MARGIN_CEIL = 1.5
+# Issue #528: imported from tests/_gate_policy.py (the shared repo-wide
+# multiplier) instead of restated, so a relaxation here is visible alongside
+# every other consumer rather than a fresh local literal.
+MARGIN_CEIL = ENVELOPE_GATE_MULTIPLIER
 
 
 def _all_case_phase_diffs() -> list[float]:

--- a/tests/test_waveguide_broad_e5_tolerance_envelope.py
+++ b/tests/test_waveguide_broad_e5_tolerance_envelope.py
@@ -34,11 +34,16 @@ from build_waveguide_band_broad_e5_envelope import (  # type: ignore  # noqa: E4
     _committed_noise_floor,
 )
 
+from tests._gate_policy import ENVELOPE_GATE_MULTIPLIER
+
 # Margin ceiling: MAX_TOL may exceed the worst measured diff by at most this
 # factor. This is a GOVERNANCE choice (how much slack a reviewer tolerates), NOT
 # a physical bound. 0.05 / 0.0414 = 1.21, so 1.5 leaves headroom but rejects a
 # slack round-up (e.g. bumping MAX_TOL to 0.08 -> 1.93x would breach it).
-MARGIN_CEIL = 1.5
+# Issue #528: this is the SAME repo-wide multiplier the quantized-gate cases
+# derive from (tests/_gate_policy.py) -- imported rather than restated so a
+# relaxation here is visible alongside theirs, not a fresh local literal.
+MARGIN_CEIL = ENVELOPE_GATE_MULTIPLIER
 
 
 def _all_case_diffs() -> list[float]:

--- a/tests/test_waveguide_group_delay_tolerance_envelope.py
+++ b/tests/test_waveguide_group_delay_tolerance_envelope.py
@@ -30,9 +30,14 @@ ENVELOPE = REPO / "tests/fixtures/waveguide_group_delay/wr340_near_cutoff_group_
 sys.path.insert(0, str(REPO / "scripts" / "diagnostics"))
 from build_waveguide_group_delay_envelope import MAX_GROUP_DELAY_TOL_NS  # type: ignore  # noqa: E402
 
+from tests._gate_policy import ENVELOPE_GATE_MULTIPLIER
+
 # Same governance margin ceiling as the magnitude (1.5) and phase (1.5) lanes.
 # 0.042 / 0.0320 = 1.31, well inside 1.5.
-MARGIN_CEIL = 1.5
+# Issue #528: imported from tests/_gate_policy.py (the shared repo-wide
+# multiplier) instead of restated, so a relaxation here is visible alongside
+# every other consumer rather than a fresh local literal.
+MARGIN_CEIL = ENVELOPE_GATE_MULTIPLIER
 
 
 def _load():

--- a/tests/test_wr90_iris_modematch_gates.py
+++ b/tests/test_wr90_iris_modematch_gates.py
@@ -29,12 +29,13 @@ from __future__ import annotations
 
 import ast
 import json
-import math
 import re
 from pathlib import Path
 
 import numpy as np
 import pytest
+
+from tests._gate_policy import gate_from_envelope
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _FIXTURE = _REPO_ROOT / "tests/fixtures/wr90_iris_modematch/fixture.json"
@@ -168,9 +169,9 @@ def test_gates_are_hard_pinned_and_equal_recomputed_envelopes(fixture):
     assert abs(g["fine_measured_envelope_abs"] - env_fine) < 5e-4
     assert abs(g["richardson_measured_envelope_abs"] - env_rich) < 5e-4
     assert g["fine_gate_abs"] == pytest.approx(
-        math.ceil(env_fine * 1.5 * 100) / 100, abs=1e-9)
+        gate_from_envelope(env_fine, quantum=100), abs=1e-9)
     assert g["richardson_gate_abs"] == pytest.approx(
-        math.ceil(env_rich * 1.5 * 100) / 100, abs=1e-9)
+        gate_from_envelope(env_rich, quantum=100), abs=1e-9)
     assert g["fine_gate_abs"] == 0.04       # hard pin — root-cause to change
     assert g["richardson_gate_abs"] == 0.01
 

--- a/validation/crossval/16_pec_sphere_mie_ka_sweep.py
+++ b/validation/crossval/16_pec_sphere_mie_ka_sweep.py
@@ -113,6 +113,8 @@ _REPO_ROOT = os.path.abspath(os.path.join(_SCRIPT_DIR, "..", ".."))
 sys.path.insert(0, _REPO_ROOT)
 sys.path.insert(0, os.path.join(_REPO_ROOT, "tests", "fixtures", "rcs_sphere_mie"))
 
+from tests._gate_policy import gate_from_envelope  # noqa: E402
+
 import rfx  # noqa: E402
 
 _RFX_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(rfx.__file__)))
@@ -300,11 +302,11 @@ def main(argv):
               f"(gate {GATE_COARSE_DB}), fine {env_fine:.3f} dB "
               f"(gate {GATE_FINE_DB})")
         if not (GATE_COARSE_DB >= env_coarse and
-                GATE_COARSE_DB <= np.ceil(env_coarse * 1.5 * 10) / 10 + 0.05):
+                GATE_COARSE_DB <= gate_from_envelope(env_coarse, quantum=10) + 0.05):
             print("  ENVELOPE/GATE MISMATCH (coarse) — fix GATE_COARSE_DB")
             ok = False
         if not (GATE_FINE_DB >= env_fine and
-                GATE_FINE_DB <= np.ceil(env_fine * 1.5 * 10) / 10 + 0.05):
+                GATE_FINE_DB <= gate_from_envelope(env_fine, quantum=10) + 0.05):
             print("  ENVELOPE/GATE MISMATCH (fine) — fix GATE_FINE_DB")
             ok = False
 

--- a/validation/crossval/17_dielectric_sphere_mie.py
+++ b/validation/crossval/17_dielectric_sphere_mie.py
@@ -109,6 +109,8 @@ _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.abspath(os.path.join(_SCRIPT_DIR, "..", ".."))
 sys.path.insert(0, _REPO_ROOT)
 
+from tests._gate_policy import gate_from_envelope  # noqa: E402
+
 import rfx  # noqa: E402
 
 _RFX_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(rfx.__file__)))
@@ -323,7 +325,7 @@ def main(argv):
               f"(gate {GATE_COARSE_DB}); fine WITNESS {env_fine_witness:.3f} dB "
               f"(not gated)")
         if not (GATE_COARSE_DB >= env_coarse and
-                GATE_COARSE_DB <= np.ceil(env_coarse * 1.5 * 10) / 10 + 0.05):
+                GATE_COARSE_DB <= gate_from_envelope(env_coarse, quantum=10) + 0.05):
             print("  ENVELOPE/GATE MISMATCH (coarse) — fix the constant")
             ok = False
 

--- a/validation/crossval/18_wr90_iris_modematch.py
+++ b/validation/crossval/18_wr90_iris_modematch.py
@@ -116,6 +116,8 @@ _SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 _REPO_ROOT = os.path.abspath(os.path.join(_SCRIPT_DIR, "..", ".."))
 sys.path.insert(0, _REPO_ROOT)
 
+from tests._gate_policy import gate_from_envelope  # noqa: E402
+
 import rfx  # noqa: E402
 
 _RFX_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(rfx.__file__)))
@@ -478,7 +480,7 @@ def main(argv):
               f"first-order ratios {ratios}")
         for gate, env, tier in ((GATE_FINE_ABS, env_fine, "fine"),
                                 (GATE_RICH_ABS, env_rich, "richardson")):
-            required = np.ceil(env * 1.5 * 100) / 100
+            required = gate_from_envelope(env, quantum=100)
             if abs(gate - required) > 1e-9:   # EXACT ceil(x1.5) — R480
                 print(f"  ENVELOPE/GATE MISMATCH ({tier}): gate {gate} "
                       f"must equal round-up(env x 1.5) = {required}")


### PR DESCRIPTION
## What / why

Closes #528. Every gated crossval case hardcoded the envelope-multiplier 1.5 independently — the adversarial finding was that a find-replace 1.5→3.0 in ONE case doubles that case's gate with every guard still passing. The guarantee now lives OUTSIDE the things it guards:

- `tests/_gate_policy.py` (new): `ENVELOPE_GATE_MULTIPLIER = 1.5` + `gate_from_envelope(measured, *, quantum)` (reads the constant at call time, so the mutation falsifier works through imports).
- Migrated: 3 test-file gate assertions (WR-90 modematch, Mie ka-sweep, dielectric sphere) + the 3 crossval scripts' `--write-fixture` self-checks (the second copy of the same literal in each case).
- The 3 structurally-different bounded-margin lanes (broad-E5 magnitude/phase, group-delay tolerance envelopes) import the shared constant as their ceiling — and the coupling is ENFORCED from outside the case files (review round 2): `test_gate_policy_is_shared.py` recomputes each lane's `worst` from its committed artifacts and asserts `worst ≤ PINNED ≤ worst × ENVELOPE_GATE_MULTIPLIER` — a local `MARGIN_CEIL = 3.0` plant plus a re-pinned tolerance now reds the from-outside cross-check (plant verified, kept as a permanent regression test).
- `tests/test_gate_policy_is_shared.py`: asserts no consumer carries a local multiplier literal anymore, and the falsifier — an in-memory source-mutated copy (the exact 1.5→3.0 attack) — shows all 5 real gate values move TOGETHER while the unmutated module reproduces every frozen CI-pinned gate bit-for-bit.

## Behavior-preserving evidence (asserted in-test, abs=1e-9)

| case | measured envelope | gate (before = after) |
|---|---|---|
| modematch fine | 0.0232 | 0.04 |
| modematch richardson | 0.0051 | 0.01 |
| mie ka-sweep coarse | 2.178 dB | 3.3 dB |
| mie ka-sweep fine | 2.651 dB | 4.0 dB |
| dielectric sphere coarse | 4.181 dB | 6.3 dB |

Scope note: the issue's 4th case (case-19 iris filter) lives in the unmerged draft PR #499 and is not on main — listed in the policy docstring as a consumer for when it lands.

## Verification

51 passed across the new policy test + 3 quantized-gate files + 3 margin-ceiling files; ruff clean; py_compile on all edited crossval scripts; the scripts' sys.path import route smoke-tested (reproduces the pinned 3.3 dB gate).

R3: memory=feedback_gate_can_bind_artifact (the falsifier is the issue's own named attack, run and shown to move all cases together) + the two-copies-drift incident class | R2-attempts=0 | falsifier=test_mutating_the_shared_multiplier_moves_every_gated_case_and_reverts, committed and green

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Review round 2** (all findings applied at 0639335): (M1) margin-ceiling lanes now numerically bound from outside the case files — the reviewer's plant (local MARGIN_CEIL=3.0 + re-pin) reds; (M2) `_REAL_CASES` is glob-derived from `tests/fixtures/**` gate/envelope key pairs (verified to yield exactly the 5 cases; auto-covers #499's case-19 when it lands; non-empty floor asserted); (L1) the falsifier docstring corrected AND the stronger live-module monkeypatch falsifier added (patching the constant moves every derived gate of an already-imported consumer); (L2) the source-grep's literal-1.5-only limit disclosed — the numeric cross-derivations are the load-bearing guards; (L3) the crossval scripts' import route is now covered by committed subprocess tests (runpy, script-dir sys.path[0], guarding against the site-packages `tests` shadow grcwa installed); (L4) coordination note in the policy docstring lists the prose restatements that must move with the constant. 18 policy tests; 58 across the touched suite.
