### PR TITLE
Subgrid source injection: explicit dtype casts end the f64-into-f32 scatter FutureWarning (#485)

### DIFF
--- a/rfx/subgridding/jit_runner.py
+++ b/rfx/subgridding/jit_runner.py
@@ -1753,13 +1753,21 @@ def _make_step_fn(ctx):
         ex_f, ey_f, ez_f, hx_f, hy_f, hz_f = carry["f"]
 
         def _inject_fine_sources(ex_arr, ey_arr, ez_arr):
+            # src_vals is built from jnp.array(waveform) (jit_runner.py ~2615),
+            # which tracks x64: float32 with x64 off (matches ex/ey/ez_arr's
+            # init_state default), float64 once x64 is scoped on. ex/ey/ez_arr
+            # stay float32 regardless (init_state's field_dtype default), so
+            # the x64-on scatter mismatches dtypes and JAX raises a
+            # cast-safety FutureWarning (issue #485). Cast explicitly to the
+            # destination array's own dtype: a no-op under the float32
+            # default (bit-identical), and a safe explicit downcast under x64.
             for idx_s, (si, sj, sk, sc) in enumerate(src_meta):
                 if sc == "ez":
-                    ez_arr = ez_arr.at[si, sj, sk].add(src_vals[idx_s])
+                    ez_arr = ez_arr.at[si, sj, sk].add(src_vals[idx_s].astype(ez_arr.dtype))
                 elif sc == "ex":
-                    ex_arr = ex_arr.at[si, sj, sk].add(src_vals[idx_s])
+                    ex_arr = ex_arr.at[si, sj, sk].add(src_vals[idx_s].astype(ex_arr.dtype))
                 elif sc == "ey":
-                    ey_arr = ey_arr.at[si, sj, sk].add(src_vals[idx_s])
+                    ey_arr = ey_arr.at[si, sj, sk].add(src_vals[idx_s].astype(ey_arr.dtype))
             return ex_arr, ey_arr, ez_arr
 
         def _inject_coarse_sources(ex_arr, ey_arr, ez_arr):

--- a/rfx/subgridding/jit_runner.py
+++ b/rfx/subgridding/jit_runner.py
@@ -1753,14 +1753,25 @@ def _make_step_fn(ctx):
         ex_f, ey_f, ez_f, hx_f, hy_f, hz_f = carry["f"]
 
         def _inject_fine_sources(ex_arr, ey_arr, ez_arr):
-            # src_vals is built from jnp.array(waveform) (jit_runner.py ~2615),
-            # which tracks x64: float32 with x64 off (matches ex/ey/ez_arr's
-            # init_state default), float64 once x64 is scoped on. ex/ey/ez_arr
-            # stay float32 regardless (init_state's field_dtype default), so
-            # the x64-on scatter mismatches dtypes and JAX raises a
-            # cast-safety FutureWarning (issue #485). Cast explicitly to the
-            # destination array's own dtype: a no-op under the float32
-            # default (bit-identical), and a safe explicit downcast under x64.
+            # src_vals (this scan's xs, built from the "Precompute source
+            # waveforms matrix" src_waveforms = jnp.stack([jnp.array(s[4])
+            # ...]) below) is ALREADY float64 by the time it gets here, once
+            # x64 is scoped on: s[4] is a host numpy array built in
+            # rfx/runners/subgridded.py's _run_subgridded_once as
+            # np.array(waveform) * fine_source_scale, and dt there comes from
+            # a plain np.sqrt(...) -- numpy always defaults to float64 on the
+            # host, independent of the JAX x64 flag -- which promotes the
+            # downstream jax.vmap(waveform)(times) computation to genuine
+            # float64 once x64 is enabled (under x64 off, JAX's own
+            # canonicalization keeps that same computation at float32
+            # instead). jnp.array(...)/jnp.stack(...) here PRESERVES that
+            # host dtype rather than promoting it. ex/ey/ez_arr stay float32
+            # regardless (init_state's field_dtype default is
+            # x64-independent), so the x64-on scatter mismatches dtypes and
+            # JAX raises a cast-safety FutureWarning (issue #485). Cast
+            # explicitly to the destination array's own dtype: a no-op under
+            # the float32 default (bit-identical), and a safe explicit
+            # downcast under x64.
             for idx_s, (si, sj, sk, sc) in enumerate(src_meta):
                 if sc == "ez":
                     ez_arr = ez_arr.at[si, sj, sk].add(src_vals[idx_s].astype(ez_arr.dtype))
@@ -1771,11 +1782,14 @@ def _make_step_fn(ctx):
             return ex_arr, ey_arr, ez_arr
 
         def _inject_coarse_sources(ex_arr, ey_arr, ez_arr):
-            # Same leak as _inject_fine_sources above (issue #485): src_vals_c
-            # is built from jnp.array(waveform) (jit_runner.py ~2627), which
-            # tracks x64, while ex/ey/ez_arr stay float32 regardless
-            # (init_state's field_dtype default). Cast explicitly to the
-            # destination array's own dtype for the same reason.
+            # Same leak as _inject_fine_sources above (issue #485), same
+            # mechanism: src_vals_c's host array (np.array(waveform) *
+            # coarse_shadow_source_scale, built in _run_subgridded_once) is
+            # already float64 once x64 is scoped on; the src_waveforms_c =
+            # jnp.stack([jnp.array(s[4]) ...]) below preserves that dtype
+            # rather than promoting it, while ex/ey/ez_arr stay float32
+            # regardless (init_state's field_dtype default). Cast explicitly
+            # to the destination array's own dtype for the same reason.
             for idx_s, (si, sj, sk, sc) in enumerate(src_meta_c):
                 if sc == "ez":
                     ez_arr = ez_arr.at[si, sj, sk].add(src_vals_c[idx_s].astype(ez_arr.dtype))

--- a/rfx/subgridding/jit_runner.py
+++ b/rfx/subgridding/jit_runner.py
@@ -1771,13 +1771,18 @@ def _make_step_fn(ctx):
             return ex_arr, ey_arr, ez_arr
 
         def _inject_coarse_sources(ex_arr, ey_arr, ez_arr):
+            # Same leak as _inject_fine_sources above (issue #485): src_vals_c
+            # is built from jnp.array(waveform) (jit_runner.py ~2627), which
+            # tracks x64, while ex/ey/ez_arr stay float32 regardless
+            # (init_state's field_dtype default). Cast explicitly to the
+            # destination array's own dtype for the same reason.
             for idx_s, (si, sj, sk, sc) in enumerate(src_meta_c):
                 if sc == "ez":
-                    ez_arr = ez_arr.at[si, sj, sk].add(src_vals_c[idx_s])
+                    ez_arr = ez_arr.at[si, sj, sk].add(src_vals_c[idx_s].astype(ez_arr.dtype))
                 elif sc == "ex":
-                    ex_arr = ex_arr.at[si, sj, sk].add(src_vals_c[idx_s])
+                    ex_arr = ex_arr.at[si, sj, sk].add(src_vals_c[idx_s].astype(ex_arr.dtype))
                 elif sc == "ey":
-                    ey_arr = ey_arr.at[si, sj, sk].add(src_vals_c[idx_s])
+                    ey_arr = ey_arr.at[si, sj, sk].add(src_vals_c[idx_s].astype(ey_arr.dtype))
             return ex_arr, ey_arr, ez_arr
 
         if sync_coarse_shadow_from_fine and is_full_xy_z_slab:

--- a/tests/test_subgrid_source_injection_dtype.py
+++ b/tests/test_subgrid_source_injection_dtype.py
@@ -4,11 +4,19 @@ Both ``_inject_fine_sources`` AND ``_inject_coarse_sources``
 (``rfx/subgridding/jit_runner.py``) scatter a per-step source waveform value
 into an E-field array with ``.at[...].add(...)``. The field arrays are built
 by ``init_state`` with its explicit ``field_dtype=jnp.float32`` default
-(independent of x64), while the waveform arrays (``src_vals`` /
-``src_vals_c``) are built via ``jnp.array(...)`` (jit_runner.py ~2615 /
-~2627), which DOES track x64: float32 with x64 off, float64 once
-``jax.experimental.enable_x64()`` is scoped on. So under scoped x64 each
-scatter mixed float64 values into a float32 array, which JAX flags with:
+(independent of x64). The waveform's HOST array (``np.array(waveform) *
+fine_source_scale`` / ``* coarse_shadow_source_scale``, built in
+``rfx/runners/subgridded.py``'s ``_run_subgridded_once``) is already float64
+once x64 is scoped on: ``dt`` there comes from a plain ``np.sqrt(...)`` —
+numpy always defaults to float64 on the host, independent of the JAX x64
+flag — which promotes the downstream ``jax.vmap(waveform)(times)``
+computation to genuine float64 once x64 is enabled (under x64 off, JAX's own
+canonicalization keeps that same computation at float32 instead). Back in
+``_inject_fine_sources``/``_inject_coarse_sources``'s enclosing function, the
+``src_waveforms``/``src_waveforms_c`` builders (``jnp.stack([jnp.array(s[4])
+...])``) PRESERVE that host dtype rather than promoting it. So under scoped
+x64 each scatter mixed float64 values into a float32 array, which JAX flags
+with:
 
     FutureWarning: scatter inputs have incompatible types: cannot safely
     cast value from dtype=float64 to dtype=float32 ... In future JAX
@@ -21,36 +29,51 @@ MLIR scan-carry mismatch) and #483 (DFT-carry hardcoded dtype).
 Fix: both injection sites now cast the source value explicitly to the
 destination array's own dtype (``.astype(ez_arr.dtype)`` etc.) before the
 scatter-add. Under the float32 default this is a no-op (verified
-bit-identical against pre-fix ``time_series`` output, byte-for-byte, on each
-fixture below). Under x64 it becomes an explicit, safe downcast, so JAX no
-longer treats it as an unsafe implicit promotion.
+bit-identical against pre-fix ``time_series`` output, byte-for-byte, on
+NONZERO data on each fixture below — see the two
+``test_*_injection_default_precision_still_float32`` tests, which assert
+nonzero so they cannot pass on a fixture the injection never actually
+reaches). Under x64 it becomes an explicit, safe downcast, so JAX no longer
+treats it as an unsafe implicit promotion.
 
 Coverage note on the two paths:
   * ``_inject_fine_sources`` fires for any excited port/source that lands in
     the fine region — cheap and always exercised by a normal subgrid+port
     fixture (``_research_port_subgrid_sim`` below).
   * ``_inject_coarse_sources`` only fires when ``src_meta_c`` is non-empty,
-    which requires (a) a ``impedance=0.0`` soft source (``Simulation.add_source``,
-    NOT ``add_port`` — lumped/wire ports never populate ``sources_c``, see
-    ``rfx/runners/subgridded.py`` around the ``pe.impedance == 0.0`` branch)
-    AND (b) ``inject_sources_on_coarse_shadow`` enabled (default-on once
-    ``xy_margin`` is set, or settable directly on ``sim._refinement`` under
-    ``validation="research"``, mirroring how other tests in this repo poke
-    diagnostic subgrid knobs). Both conditions are cheap to satisfy — no
-    special coarse-fed configuration was needed — so this file gates the
-    coarse path with the same live ``simplefilter("error", ...)`` pattern as
-    the fine path, not a cast-by-symmetry-only claim.
+    which requires (a) a ``impedance=0.0`` soft source
+    (``Simulation.add_source``, NOT ``add_port`` — lumped/wire ports never
+    populate ``sources_c``, see ``rfx/runners/subgridded.py`` around the
+    ``pe.impedance == 0.0`` branch) AND (b) ``inject_sources_on_coarse_shadow``
+    enabled (default-on once ``xy_margin`` is set, or settable directly on
+    ``sim._refinement`` under ``validation="research"``, mirroring how other
+    tests in this repo poke diagnostic subgrid knobs). Both conditions are
+    cheap to satisfy, so this file gates the coarse path with the same live
+    warning-error pattern as the fine path, not a cast-by-symmetry-only
+    claim. ``_coarse_shadow_source_subgrid_sim`` co-injects the SAME soft
+    source on the fine grid AND its coarse shadow (that duplication is what
+    "coarse shadow" means), so a few steps land near the injection cell
+    before the probe (also fine-grid-resident, since it too sits inside the
+    fine ``z_range``) picks up a nonzero reading — ``n_steps=30`` was
+    measured to give a clean nonzero margin (max|E| ~1.7e-4, 24/30 nonzero
+    samples), well clear of float32 noise.
 
-Verified BOTH directions locally before landing this test, for BOTH paths:
-  * pre-fix code (bare ``src_vals[idx_s]`` / ``src_vals_c[idx_s]``, no
-    ``.astype``):
-    ``test_fine_source_injection_no_dtype_futurewarning_under_x64`` FAILED at
-    ``rfx/subgridding/jit_runner.py:1758`` inside ``_inject_fine_sources``;
-    ``test_coarse_source_injection_no_dtype_futurewarning_under_x64`` FAILED
-    at ``rfx/subgridding/jit_runner.py:1776`` inside ``_inject_coarse_sources``.
-  * fixed code (``.astype(ez_arr.dtype)`` / ``ex_arr.dtype`` /
-    ``ey_arr.dtype`` at each of the six scatter sites): both tests PASSED,
-    no FutureWarning raised.
+The warning-gate tests below use ``warnings.filterwarnings("error",
+message=...)`` scoped to the exact scatter-cast message, NOT a bare
+``simplefilter("error", FutureWarning)`` — JAX/numpy have other live
+FutureWarning sources, and a blanket filter would misattribute an unrelated
+one to this bug class.
+
+Verified BOTH directions locally before landing this test, for BOTH paths
+(pre-fix code: bare ``src_vals[idx_s]`` / ``src_vals_c[idx_s]``, no
+``.astype``; fixed code: ``.astype(ez_arr.dtype)`` / ``ex_arr.dtype`` /
+``ey_arr.dtype`` at each of the six scatter sites):
+  * pre-fix: ``test_fine_source_injection_no_dtype_futurewarning_under_x64``
+    and ``test_coarse_source_injection_no_dtype_futurewarning_under_x64``
+    each FAILED, raising the scatter-cast FutureWarning from
+    ``_inject_fine_sources`` / ``_inject_coarse_sources`` respectively (the
+    other path's test still PASSED — the two are independent).
+  * fixed: all four tests in this file PASS, no FutureWarning.
 
 x64 is scoped per-test via a context manager here — NEVER flip
 jax_enable_x64 at module level (process-global; reds every same-process
@@ -69,6 +92,13 @@ except ImportError:  # older JAX (< ~0.4.31)
     from jax.experimental import enable_x64 as _enable_x64
 
 from rfx import GaussianPulse, Simulation
+
+# Narrow, targeted at the exact scatter dtype-cast message (issue #485) so
+# this doesn't misfire on an unrelated JAX/numpy FutureWarning.
+_SCATTER_DTYPE_WARNING = {
+    "message": ".*scatter inputs have incompatible types.*",
+    "category": FutureWarning,
+}
 
 
 def _research_port_subgrid_sim() -> Simulation:
@@ -95,7 +125,14 @@ def _coarse_shadow_source_subgrid_sim() -> Simulation:
     ``_inject_coarse_sources``. A soft source (``add_source``, impedance 0)
     is required — lumped/wire ports (``add_port``) never populate
     ``sources_c`` — plus ``inject_sources_on_coarse_shadow`` explicitly
-    enabled on the research-validated refinement dict."""
+    enabled on the research-validated refinement dict.
+
+    ``n_steps=30`` (not the smaller counts used elsewhere in this file) is
+    load-bearing: the probe needs enough steps for the injected field to
+    actually propagate to it (measured max|E| ~1.7e-4 at 30 steps; a probe
+    read at only 5 steps is provably all zero regardless of whether
+    ``_inject_coarse_sources`` even runs — that would make any byte-identity
+    check on it a blind instrument, see #485 PR review)."""
     sim = Simulation(freq_max=4e9, domain=(0.012, 0.012, 0.012), boundary="pec", dx=0.004)
     sim.add_refinement(z_range=(0.004, 0.012), ratio=3, validation="research")
     sim._refinement["inject_sources_on_coarse_shadow"] = True
@@ -111,17 +148,20 @@ def test_fine_source_injection_no_dtype_futurewarning_under_x64():
     with _enable_x64():
         sim = _research_port_subgrid_sim()
         with warnings.catch_warnings():
-            warnings.simplefilter("error", FutureWarning)
+            warnings.filterwarnings("error", **_SCATTER_DTYPE_WARNING)
             result = sim.run(n_steps=20, compute_s_params=False)
     assert result.time_series.shape == (20, 1)
 
 
 def test_fine_source_injection_default_precision_still_float32():
     """x64 OFF (the default): the fine-source injection cast is a no-op —
-    time series stays float32, matching pre-#485 behaviour."""
+    time series stays float32 and (asserted, not assumed) nonzero, matching
+    pre-#485 behaviour."""
     sim = _research_port_subgrid_sim()
     result = sim.run(n_steps=20, compute_s_params=False)
-    assert np.asarray(result.time_series).dtype == np.float32
+    ts = np.asarray(result.time_series)
+    assert ts.dtype == np.float32
+    assert np.any(ts != 0.0)
 
 
 def test_coarse_source_injection_no_dtype_futurewarning_under_x64():
@@ -132,14 +172,19 @@ def test_coarse_source_injection_no_dtype_futurewarning_under_x64():
     with _enable_x64():
         sim = _coarse_shadow_source_subgrid_sim()
         with warnings.catch_warnings():
-            warnings.simplefilter("error", FutureWarning)
-            result = sim.run(n_steps=5, compute_s_params=False)
-    assert result.time_series.shape == (5, 1)
+            warnings.filterwarnings("error", **_SCATTER_DTYPE_WARNING)
+            result = sim.run(n_steps=30, compute_s_params=False)
+    assert result.time_series.shape == (30, 1)
 
 
 def test_coarse_source_injection_default_precision_still_float32():
     """x64 OFF (the default): the coarse-source injection cast is a no-op —
-    time series stays float32, matching pre-#485 behaviour."""
+    time series stays float32 and (asserted, not assumed) nonzero, matching
+    pre-#485 behaviour. The nonzero assertion is load-bearing: an all-zero
+    ``time_series`` would make this byte-identity witness pass even if
+    ``_inject_coarse_sources`` were deleted outright."""
     sim = _coarse_shadow_source_subgrid_sim()
-    result = sim.run(n_steps=5, compute_s_params=False)
-    assert np.asarray(result.time_series).dtype == np.float32
+    result = sim.run(n_steps=30, compute_s_params=False)
+    ts = np.asarray(result.time_series)
+    assert ts.dtype == np.float32
+    assert np.any(ts != 0.0)

--- a/tests/test_subgrid_source_injection_dtype.py
+++ b/tests/test_subgrid_source_injection_dtype.py
@@ -1,12 +1,13 @@
-"""Subgrid fine-source injection stays dtype-safe under scoped x64 (issue #485).
+"""Subgrid source injection stays dtype-safe under scoped x64 (issue #485).
 
-``_inject_fine_sources`` (``rfx/subgridding/jit_runner.py``) scatters the
-per-step source waveform value into the fine E-field arrays with
-``.at[...].add(...)``. The fine field arrays are built by ``init_state``
-with its explicit ``field_dtype=jnp.float32`` default (independent of x64),
-while the waveform array is built via ``jnp.array(...)`` (jit_runner.py
-~2615), which DOES track x64: float32 with x64 off, float64 once
-``jax.experimental.enable_x64()`` is scoped on. So under scoped x64 the
+Both ``_inject_fine_sources`` AND ``_inject_coarse_sources``
+(``rfx/subgridding/jit_runner.py``) scatter a per-step source waveform value
+into an E-field array with ``.at[...].add(...)``. The field arrays are built
+by ``init_state`` with its explicit ``field_dtype=jnp.float32`` default
+(independent of x64), while the waveform arrays (``src_vals`` /
+``src_vals_c``) are built via ``jnp.array(...)`` (jit_runner.py ~2615 /
+~2627), which DOES track x64: float32 with x64 off, float64 once
+``jax.experimental.enable_x64()`` is scoped on. So under scoped x64 each
 scatter mixed float64 values into a float32 array, which JAX flags with:
 
     FutureWarning: scatter inputs have incompatible types: cannot safely
@@ -17,22 +18,39 @@ Non-fatal today (JAX still performs the cast), but the FutureWarning means a
 future JAX release turns this into a hard error. Same class as #14 (NTFF
 MLIR scan-carry mismatch) and #483 (DFT-carry hardcoded dtype).
 
-Fix: the injection site now casts the source value explicitly to the
+Fix: both injection sites now cast the source value explicitly to the
 destination array's own dtype (``.astype(ez_arr.dtype)`` etc.) before the
 scatter-add. Under the float32 default this is a no-op (verified
-bit-identical against pre-fix ``time_series`` output, byte-for-byte, on this
-same fixture — see ``docs/agent-memory`` / PR record for #485). Under x64 it
-becomes an explicit, safe downcast, so JAX no longer treats it as an unsafe
-implicit promotion.
+bit-identical against pre-fix ``time_series`` output, byte-for-byte, on each
+fixture below). Under x64 it becomes an explicit, safe downcast, so JAX no
+longer treats it as an unsafe implicit promotion.
 
-Verified BOTH directions locally before landing this test:
-  * with the pre-fix code (bare ``src_vals[idx_s]``, no ``.astype``):
-    ``test_fine_source_injection_no_dtype_futurewarning_under_x64`` FAILED
-    (the ``warnings.simplefilter("error", FutureWarning)`` context turned
-    the warning into a raised ``FutureWarning`` at
-    ``rfx/subgridding/jit_runner.py:1758``, inside ``_inject_fine_sources``).
-  * with the fix (``.astype(ez_arr.dtype)`` / ``ex_arr.dtype`` /
-    ``ey_arr.dtype``) applied: the same test PASSED, no FutureWarning raised.
+Coverage note on the two paths:
+  * ``_inject_fine_sources`` fires for any excited port/source that lands in
+    the fine region — cheap and always exercised by a normal subgrid+port
+    fixture (``_research_port_subgrid_sim`` below).
+  * ``_inject_coarse_sources`` only fires when ``src_meta_c`` is non-empty,
+    which requires (a) a ``impedance=0.0`` soft source (``Simulation.add_source``,
+    NOT ``add_port`` — lumped/wire ports never populate ``sources_c``, see
+    ``rfx/runners/subgridded.py`` around the ``pe.impedance == 0.0`` branch)
+    AND (b) ``inject_sources_on_coarse_shadow`` enabled (default-on once
+    ``xy_margin`` is set, or settable directly on ``sim._refinement`` under
+    ``validation="research"``, mirroring how other tests in this repo poke
+    diagnostic subgrid knobs). Both conditions are cheap to satisfy — no
+    special coarse-fed configuration was needed — so this file gates the
+    coarse path with the same live ``simplefilter("error", ...)`` pattern as
+    the fine path, not a cast-by-symmetry-only claim.
+
+Verified BOTH directions locally before landing this test, for BOTH paths:
+  * pre-fix code (bare ``src_vals[idx_s]`` / ``src_vals_c[idx_s]``, no
+    ``.astype``):
+    ``test_fine_source_injection_no_dtype_futurewarning_under_x64`` FAILED at
+    ``rfx/subgridding/jit_runner.py:1758`` inside ``_inject_fine_sources``;
+    ``test_coarse_source_injection_no_dtype_futurewarning_under_x64`` FAILED
+    at ``rfx/subgridding/jit_runner.py:1776`` inside ``_inject_coarse_sources``.
+  * fixed code (``.astype(ez_arr.dtype)`` / ``ex_arr.dtype`` /
+    ``ey_arr.dtype`` at each of the six scatter sites): both tests PASSED,
+    no FutureWarning raised.
 
 x64 is scoped per-test via a context manager here — NEVER flip
 jax_enable_x64 at module level (process-global; reds every same-process
@@ -42,6 +60,8 @@ pytest-split shard, see repo memory
 from __future__ import annotations
 
 import warnings
+
+import numpy as np
 
 try:  # modern JAX: scoped x64 promoted to top-level (experimental removed v0.8.0)
     from jax import enable_x64 as _enable_x64
@@ -70,6 +90,20 @@ def _research_port_subgrid_sim() -> Simulation:
     return sim
 
 
+def _coarse_shadow_source_subgrid_sim() -> Simulation:
+    """Minimal subgrid + soft-source fixture that exercises
+    ``_inject_coarse_sources``. A soft source (``add_source``, impedance 0)
+    is required — lumped/wire ports (``add_port``) never populate
+    ``sources_c`` — plus ``inject_sources_on_coarse_shadow`` explicitly
+    enabled on the research-validated refinement dict."""
+    sim = Simulation(freq_max=4e9, domain=(0.012, 0.012, 0.012), boundary="pec", dx=0.004)
+    sim.add_refinement(z_range=(0.004, 0.012), ratio=3, validation="research")
+    sim._refinement["inject_sources_on_coarse_shadow"] = True
+    sim.add_source((0.004, 0.004, 0.008), "ez")
+    sim.add_probe((0.008, 0.008, 0.008), "ez")
+    return sim
+
+
 def test_fine_source_injection_no_dtype_futurewarning_under_x64():
     """Under scoped x64, running the subgrid excited-port fixture must NOT
     raise/emit the scatter dtype-cast FutureWarning from
@@ -85,8 +119,27 @@ def test_fine_source_injection_no_dtype_futurewarning_under_x64():
 def test_fine_source_injection_default_precision_still_float32():
     """x64 OFF (the default): the fine-source injection cast is a no-op —
     time series stays float32, matching pre-#485 behaviour."""
-    import numpy as np
-
     sim = _research_port_subgrid_sim()
     result = sim.run(n_steps=20, compute_s_params=False)
+    assert np.asarray(result.time_series).dtype == np.float32
+
+
+def test_coarse_source_injection_no_dtype_futurewarning_under_x64():
+    """Under scoped x64, running the coarse-shadow soft-source fixture must
+    NOT raise/emit the scatter dtype-cast FutureWarning from
+    ``_inject_coarse_sources``. Red before the #485 follow-up fix, green
+    after."""
+    with _enable_x64():
+        sim = _coarse_shadow_source_subgrid_sim()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            result = sim.run(n_steps=5, compute_s_params=False)
+    assert result.time_series.shape == (5, 1)
+
+
+def test_coarse_source_injection_default_precision_still_float32():
+    """x64 OFF (the default): the coarse-source injection cast is a no-op —
+    time series stays float32, matching pre-#485 behaviour."""
+    sim = _coarse_shadow_source_subgrid_sim()
+    result = sim.run(n_steps=5, compute_s_params=False)
     assert np.asarray(result.time_series).dtype == np.float32

--- a/tests/test_subgrid_source_injection_dtype.py
+++ b/tests/test_subgrid_source_injection_dtype.py
@@ -1,0 +1,92 @@
+"""Subgrid fine-source injection stays dtype-safe under scoped x64 (issue #485).
+
+``_inject_fine_sources`` (``rfx/subgridding/jit_runner.py``) scatters the
+per-step source waveform value into the fine E-field arrays with
+``.at[...].add(...)``. The fine field arrays are built by ``init_state``
+with its explicit ``field_dtype=jnp.float32`` default (independent of x64),
+while the waveform array is built via ``jnp.array(...)`` (jit_runner.py
+~2615), which DOES track x64: float32 with x64 off, float64 once
+``jax.experimental.enable_x64()`` is scoped on. So under scoped x64 the
+scatter mixed float64 values into a float32 array, which JAX flags with:
+
+    FutureWarning: scatter inputs have incompatible types: cannot safely
+    cast value from dtype=float64 to dtype=float32 ... In future JAX
+    releases this will result in an error.
+
+Non-fatal today (JAX still performs the cast), but the FutureWarning means a
+future JAX release turns this into a hard error. Same class as #14 (NTFF
+MLIR scan-carry mismatch) and #483 (DFT-carry hardcoded dtype).
+
+Fix: the injection site now casts the source value explicitly to the
+destination array's own dtype (``.astype(ez_arr.dtype)`` etc.) before the
+scatter-add. Under the float32 default this is a no-op (verified
+bit-identical against pre-fix ``time_series`` output, byte-for-byte, on this
+same fixture — see ``docs/agent-memory`` / PR record for #485). Under x64 it
+becomes an explicit, safe downcast, so JAX no longer treats it as an unsafe
+implicit promotion.
+
+Verified BOTH directions locally before landing this test:
+  * with the pre-fix code (bare ``src_vals[idx_s]``, no ``.astype``):
+    ``test_fine_source_injection_no_dtype_futurewarning_under_x64`` FAILED
+    (the ``warnings.simplefilter("error", FutureWarning)`` context turned
+    the warning into a raised ``FutureWarning`` at
+    ``rfx/subgridding/jit_runner.py:1758``, inside ``_inject_fine_sources``).
+  * with the fix (``.astype(ez_arr.dtype)`` / ``ex_arr.dtype`` /
+    ``ey_arr.dtype``) applied: the same test PASSED, no FutureWarning raised.
+
+x64 is scoped per-test via a context manager here — NEVER flip
+jax_enable_x64 at module level (process-global; reds every same-process
+pytest-split shard, see repo memory
+``feedback_jax_x64_module_level_tests``).
+"""
+from __future__ import annotations
+
+import warnings
+
+try:  # modern JAX: scoped x64 promoted to top-level (experimental removed v0.8.0)
+    from jax import enable_x64 as _enable_x64
+except ImportError:  # older JAX (< ~0.4.31)
+    from jax.experimental import enable_x64 as _enable_x64
+
+from rfx import GaussianPulse, Simulation
+
+
+def _research_port_subgrid_sim() -> Simulation:
+    """Minimal subgrid + excited-port fixture that exercises
+    ``_inject_fine_sources`` (mirrors ``test_subgrid_port_research.py``'s
+    ``_research_port_subgrid_sim``, trimmed to the excited-port-only case
+    that is sufficient to reach the scatter site)."""
+    sim = Simulation(freq_max=8e9, domain=(0.04, 0.04, 0.024), boundary="pec", dx=0.002, cpml_layers=0)
+    sim.add_refinement(z_range=(0.002, 0.024), ratio=2, validation="research")
+    sim._refinement["use_boundary_terminated_exterior_z_interfaces"] = True
+    sim.add_port(
+        (0.04 / 3.0, 0.04 / 3.0, 0.002 + 0.45 * 0.022),
+        "ez",
+        impedance=50.0,
+        waveform=GaussianPulse(f0=3.5e9, bandwidth=0.8),
+        excite=True,
+    )
+    sim.add_probe((0.02, 0.02, 0.002 + 0.55 * 0.022), "ez")
+    return sim
+
+
+def test_fine_source_injection_no_dtype_futurewarning_under_x64():
+    """Under scoped x64, running the subgrid excited-port fixture must NOT
+    raise/emit the scatter dtype-cast FutureWarning from
+    ``_inject_fine_sources``. Red before the #485 fix, green after."""
+    with _enable_x64():
+        sim = _research_port_subgrid_sim()
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", FutureWarning)
+            result = sim.run(n_steps=20, compute_s_params=False)
+    assert result.time_series.shape == (20, 1)
+
+
+def test_fine_source_injection_default_precision_still_float32():
+    """x64 OFF (the default): the fine-source injection cast is a no-op —
+    time series stays float32, matching pre-#485 behaviour."""
+    import numpy as np
+
+    sim = _research_port_subgrid_sim()
+    result = sim.run(n_steps=20, compute_s_params=False)
+    assert np.asarray(result.time_series).dtype == np.float32


### PR DESCRIPTION
## What / why

Closes #485. Under scoped x64, `_inject_fine_sources` leaked float64 source values into float32 scatters (`FutureWarning`, fatal on a future JAX upgrade). The identical pattern sat a few lines below in `_inject_coarse_sources` — both are fixed: each scatter site casts the injected value to the destination field array's own dtype, with inline comments (waveform arrays follow x64; `init_state` field arrays pin float32 regardless).

## Verification (per path, both directions)

- Pre-fix reproduction pinned to the exact lines (fine :1758, coarse :1776), same warning class.
- Red/green isolation: reverting ONLY the coarse hunk (fine fix applied) → exactly the coarse test fails (1 failed, 3 passed); re-applied → 4 passed. Patch-apply/revert cycle, not `git stash` (shared-tree rule).
- Byte-identity at the float32 default, per fixture: `time_series` `np.array_equal` True, max abs diff 0.0, dtype float32 both sides.
- 4 new tests in `tests/test_subgrid_source_injection_dtype.py`: per-path scoped-x64 `FutureWarning`-as-error gates (x64 via `jax.experimental.enable_x64()` context — never module-level) + per-path default-precision dtype pins. The coarse path proved cheaply exercisable (soft source + `inject_sources_on_coarse_shadow`), so it carries a live warning gate rather than a cast-by-symmetry claim.
- Full subgrid suite: 114 → 118 passed (delta = exactly the 4 new tests), 4 deselected, 2 xfailed unchanged; ruff clean.

Subgrid remains the experimental research lane (cv12/13 fence untouched); this is a mechanical dtype hygiene fix ahead of a JAX upgrade making the warning fatal.

R3: memory=feedback_jax_x64_module_level_tests (x64 scoped per-test only) | R2-attempts=0 | falsifier=the per-path warning-gated tests, red pre-fix and green post-fix, both recorded in the docstring

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Review round** (APPROVE + three applied at e81b112): the coarse byte-identity evidence was vacuous (all-zero probe series — a blind instrument per the gate-can-bind-artifact class); the coarse fixture now runs n_steps=30 with `assert np.any(ts != 0)` and the real comparison is bit-identical on 24/30 nonzero samples (max|E| = 1.72e-4). Warning gates narrowed to the exact scatter-cast message (any unrelated FutureWarning no longer reds them). Rotting line-number citations replaced with symbol names; dtype attribution corrected (the host array is already float64 under scoped x64 — `jnp.array` preserves, not promotes). Reviewer's informational sweep: the five sibling uncast sites elsewhere (nonuniform/vmap_sweep/adi/distributed) are LATENT, not live — their host waveforms stay float32; subgrid was special because runners/subgridded.py rescales the waveform in host float64 arithmetic. Under x64 the fix makes the downcast explicit (identical numbers to JAX's previous silent cast); it does not give subgrid an x64-native source path.
