### PR TITLE
Preflight absorber checks: one exterior-padding frame helper, first-ever tests, five consumers fixed (#500)

### DIFF
--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -64,6 +64,57 @@ def _fmt_freq(hz: float) -> str:
     return f"{hz:.4g}Hz"
 
 
+def _absorber_boundary_for_axis(
+    domain_extent: float, ct_lo: float, ct_hi: float,
+) -> tuple[float | None, float | None]:
+    """The single canonical frame for "is/how-far a coordinate from the
+    CPML/UPML absorber" on one axis (issue #500).
+
+    Ground truth (proved in ``tests/test_preflight_absorber_frame.py`` for
+    both the uniform (``rfx/grid.py`` ``Grid.__init__``: ``nx =
+    ceil(domain/dx) + 1 + pad_lo + pad_hi``) and non-uniform
+    (``rfx/nonuniform.py`` ``make_nonuniform_grid``: ``dz_profile`` covers
+    only the physical domain and CPML cells are appended EXTERIOR to it via
+    ``_pad_profile``) grid builders: the absorber is padded OUTSIDE the
+    requested domain, never inside it. ``Grid.position_to_index`` maps node
+    ``pad_{axis}_lo`` to user coordinate 0, so the absorber occupies user
+    coordinates ``< 0`` (lo side) and ``> domain_extent`` (hi side); the
+    requested ``[0, domain_extent]`` is absorber-FREE by construction.
+
+    Every ``_validate_cfg_*`` / ``_check_msl_port_geometry`` consumer of
+    ``cpml_thick_lo`` / ``cpml_thick_hi`` used to compare user coordinates
+    against an INTERIOR reading instead (``[0, ct_lo]`` /
+    ``[domain_extent - ct_hi, domain_extent]``) — verified false positives
+    on geometry nowhere near the absorber (waveguide ports comfortably
+    inside the domain, an NTFF box, a probe at the domain centre). This
+    helper is the one place that encodes the correct (exterior) frame;
+    every membership-style consumer must convert through it rather than
+    re-deriving the comparison.
+
+    Returns ``(lo_boundary, hi_boundary)``: the user-coordinate position at
+    which the lo-side / hi-side absorber begins, or ``None`` on a side with
+    no active absorber there (``ct <= 0`` — PEC/PMC/periodic face, 2D-z, or
+    a non-absorbing global boundary). When active, the position is always
+    exactly ``0.0`` (lo) or ``domain_extent`` (hi) — never offset inward by
+    the thickness, and never offset outward either (the thickness only
+    says how deep the absorber extends beyond that point, which is not
+    needed for a membership test).
+    """
+    lo_boundary = 0.0 if ct_lo > 0 else None
+    hi_boundary = domain_extent if ct_hi > 0 else None
+    return lo_boundary, hi_boundary
+
+
+def _coord_in_absorber(
+    coord: float, domain_extent: float, ct_lo: float, ct_hi: float,
+) -> bool:
+    """True iff ``coord`` (one axis, user coordinates) is inside the
+    EXTERIOR-padded absorber on that axis. See
+    :func:`_absorber_boundary_for_axis` for the frame this rests on."""
+    lo_b, hi_b = _absorber_boundary_for_axis(domain_extent, ct_lo, ct_hi)
+    return (lo_b is not None and coord < lo_b) or (hi_b is not None and coord > hi_b)
+
+
 class PreflightWarning(UserWarning):
     """Base for structured preflight findings carried on the warning instance.
 
@@ -1877,7 +1928,7 @@ class _PreflightMixin:
         )
         self._validate_cfg_ntff_min_steps(dx)
         self._validate_cfg_geometry_in_cpml(
-            _w, dx, cpml_thickness, cpml_thick_lo, cpml_thick_hi, absorber_label
+            _w, cpml_thickness, cpml_thick_lo, cpml_thick_hi, absorber_label
         )
         self._validate_cfg_port_inside_pec(_w, dx)
         self._validate_cfg_floating_single_cell_port(_w)
@@ -1897,7 +1948,7 @@ class _PreflightMixin:
         self._validate_cfg_refplane_placement(_w)
 
         self._check_waveguide_port_evanescent()
-        self._check_msl_port_geometry(dx, cpml_thick_lo, cpml_thick_hi)
+        self._check_msl_port_geometry(dx)
 
     def _validate_cfg_tfsf_with_lumped_rlc(self, _w) -> None:
         """Warn: a lumped RLC element illuminated by a TFSF plane wave is unstable.
@@ -2313,7 +2364,18 @@ class _PreflightMixin:
         cpml_thick_hi: list[float],
         absorber_label: str,
     ) -> None:
-        """P1.2/P1.3: Probe or source inside absorber region."""
+        """P1.2/P1.3: Probe or source inside absorber region.
+
+        Issue #500: membership goes through :func:`_coord_in_absorber` —
+        the requested domain ``[0, domain_extent]`` is absorber-free by
+        construction (exterior padding), so a probe/port is only ever
+        "near/inside" the absorber when its coordinate is genuinely
+        outside that interval (previously this compared against an
+        interior reading of the CPML thickness and false-fired on
+        geometry anywhere within roughly the outer half of the thickness
+        from an edge, e.g. a probe at the domain centre — verified false
+        positive in #500 repro 2).
+        """
         if cpml_thickness > 0:
             _internal = getattr(self, "_internal_probe_indices", frozenset())
             for _pi, pe in enumerate(self._probes):
@@ -2332,7 +2394,7 @@ class _PreflightMixin:
                     ax_i = min(ax, 2)
                     ct_lo = cpml_thick_lo[ax_i]
                     ct_hi = cpml_thick_hi[ax_i]
-                    if coord < ct_lo * 0.5 or coord > domain_extent - ct_hi * 0.5:
+                    if _coord_in_absorber(coord, domain_extent, ct_lo, ct_hi):
                         _w.warn(
                             PreflightWarning(
                                 f"Probe at {pos} is near/inside {absorber_label} region "
@@ -2353,7 +2415,7 @@ class _PreflightMixin:
                     ax_i = min(ax, 2)
                     ct_lo = cpml_thick_lo[ax_i]
                     ct_hi = cpml_thick_hi[ax_i]
-                    if coord < ct_lo * 0.5 or coord > domain_extent - ct_hi * 0.5:
+                    if _coord_in_absorber(coord, domain_extent, ct_lo, ct_hi):
                         _w.warn(
                             PreflightWarning(
                                 f"Source/port at {pos} is near/inside {absorber_label} region "
@@ -2488,7 +2550,13 @@ class _PreflightMixin:
         cpml_thick_hi: list[float],
         absorber_label: str,
     ) -> None:
-        """P1.4: NTFF box overlap with absorber."""
+        """P1.4: NTFF box overlap with absorber.
+
+        Issue #500: uses :func:`_absorber_boundary_for_axis` — the CPML
+        pad is EXTERIOR to ``[0, domain_extent]`` (see that helper), so an
+        NTFF corner is only in the absorber when it is genuinely outside
+        the requested domain, not merely within ``ct_{lo,hi}`` of an edge.
+        """
         if self._ntff is not None and cpml_thickness > 0:
             corner_lo, corner_hi, _ = self._ntff
             for ax in range(3):
@@ -2496,7 +2564,10 @@ class _PreflightMixin:
                 ax_i = min(ax, 2)
                 ct_lo = cpml_thick_lo[ax_i]
                 ct_hi = cpml_thick_hi[ax_i]
-                if corner_lo[ax] < ct_lo or corner_hi[ax] > domain_ext - ct_hi:
+                lo_b, hi_b = _absorber_boundary_for_axis(domain_ext, ct_lo, ct_hi)
+                if (lo_b is not None and corner_lo[ax] < lo_b) or (
+                    hi_b is not None and corner_hi[ax] > hi_b
+                ):
                     _w.warn(
                         PreflightWarning(
                             f"NTFF box extends into {absorber_label} region along "
@@ -2530,7 +2601,6 @@ class _PreflightMixin:
     def _validate_cfg_geometry_in_cpml(
         self,
         _w,
-        dx: float,
         cpml_thickness: float,
         cpml_thick_lo: list[float],
         cpml_thick_hi: list[float],
@@ -2544,6 +2614,20 @@ class _PreflightMixin:
         Periodic axes have no CPML (see _build_grid — issue #68), so
         the per-axis thresholds above already carry `cpml_thick_xyz[ax]
         == 0` on those axes and the check naturally skips.
+
+        Issue #500 rewrite: the pre-#500 version treated the CPML as
+        occupying ``[0, thick_lo]`` / ``[d - thick_hi, d]`` *inside* the
+        requested domain (an "intentional full-domain edge" heuristic
+        existed specifically to claw back the resulting false positives
+        on the canonical transmission-line/MSL-substrate pattern —
+        ``Box((0,0,0), (LX,LY,H_SUB))``). That frame was wrong: every rfx
+        grid builder pads CPML EXTERIOR to the requested domain (see
+        :func:`_absorber_boundary_for_axis`), so a Box entirely within
+        ``[0, d]`` can never touch the absorber regardless of how close it
+        sits to an edge — the heuristic is now unnecessary rather than
+        merely refined. The only genuine issue-#61 case left is a Box
+        whose bounding box extends to a NEGATIVE coordinate or past
+        ``domain_extent`` — i.e. literally drawn into the exterior pad.
         """
         if cpml_thickness > 0 and self._boundary == "cpml":
             for entry in self._geometry:
@@ -2556,43 +2640,9 @@ class _PreflightMixin:
                             if thick_lo <= 0 and thick_hi <= 0:
                                 continue
                             d = self._domain[ax] if ax < len(self._domain) else self._domain[-1]
-                            # FP3 refinement (2026-05-06): a Box whose
-                            # lo/hi edge sits exactly at 0/L_domain
-                            # (within ½·dx) is an *intentional*
-                            # full-domain extension — the canonical
-                            # transmission-line / MSL-substrate
-                            # pattern.  Do not warn on those edges;
-                            # only warn on edges that drift INTO the
-                            # CPML region without explicitly reaching
-                            # the boundary (the original issue #61
-                            # leak-into-absorber footgun).
-                            # 2026-06 fix: "touches the edge" alone is not
-                            # enough — a thin slab buried ENTIRELY inside the
-                            # absorber also starts at the edge. An edge-touching
-                            # box is an intentional full-domain extension only if
-                            # it reaches PAST the CPML into the physical interior
-                            # (c2 > thick_lo); a slab contained within the CPML is
-                            # the issue-#61 footgun and must warn (regression:
-                            # test_preflight_still_warns_on_non_periodic_z_axis).
-                            # BUT when the CPML spans (nearly) the whole axis there
-                            # is no interior to reach and no footgun to flag — the
-                            # warning is meaningless, so the edge touch stays
-                            # intentional (degenerate full-CPML axis, e.g. the
-                            # thin-substrate false-positive test where
-                            # layers·dx ≈ L_axis).
-                            has_interior = (thick_lo + thick_hi) < d - dx * 0.5
-                            intentional_lo = c1[ax] <= dx * 0.5 and (
-                                c2[ax] > thick_lo or not has_interior
-                            )
-                            intentional_hi = c2[ax] >= d - dx * 0.5 and (
-                                c1[ax] < d - thick_hi or not has_interior
-                            )
-                            lo_hit = (thick_lo > 0
-                                      and c1[ax] < thick_lo * 0.3
-                                      and not intentional_lo)
-                            hi_hit = (thick_hi > 0
-                                      and c2[ax] > d - thick_hi * 0.3
-                                      and not intentional_hi)
+                            lo_b, hi_b = _absorber_boundary_for_axis(d, thick_lo, thick_hi)
+                            lo_hit = lo_b is not None and c1[ax] < lo_b
+                            hi_hit = hi_b is not None and c2[ax] > hi_b
                             if lo_hit or hi_hit:
                                 _w.warn(
                                     PreflightWarning(
@@ -3150,14 +3200,33 @@ class _PreflightMixin:
                         code="waveguide_reference_plane",
                         source="_validate_cfg_waveguide_reference_plane",
                     )
-                if effective < ct_lo or effective > domain_ext - ct_hi:
+                # Issue #500: this used to compare `effective` against an
+                # INTERIOR reading of the CPML thickness
+                # (`[0, ct_lo]`/`[domain_ext-ct_hi, domain_ext]`) —
+                # verified false positive (repro 1: WR-90 ports at 20mm /
+                # 70.678mm on a 90.678mm domain, comfortably interior,
+                # warned anyway). The exterior-padding frame
+                # (:func:`_absorber_boundary_for_axis`) makes the absorber
+                # boundary exactly `0.0` / `domain_ext` — identical to the
+                # hard bounds check immediately above, which already
+                # raises `PreflightConfigError` for any `effective` this
+                # branch could otherwise catch. So this warning is now
+                # provably unreachable on both the uniform and
+                # non-uniform (dz_profile) lanes; kept (routed through the
+                # canonical helper, not deleted) as a documented no-op —
+                # same precedent as the P2.7 anchor above — in case a
+                # future change decouples the hard check from this one.
+                lo_b, hi_b = _absorber_boundary_for_axis(domain_ext, ct_lo, ct_hi)
+                if (lo_b is not None and effective < lo_b) or (
+                    hi_b is not None and effective > hi_b
+                ):
                     _w.warn(
                         PreflightWarning(
                             f"waveguide_port reference plane = {effective*1e3:.3g} mm is "
                             f"inside the CPML absorbing region along the "
-                            f"{direction[-1]}-axis (CPML extent: "
-                            f"[0, {ct_lo*1e3:.3g}] and "
-                            f"[{(domain_ext - ct_hi)*1e3:.3g}, {domain_ext*1e3:.3g}] mm). "
+                            f"{direction[-1]}-axis (CPML extent (exterior pad): "
+                            f"[{-ct_lo*1e3:.3g}, 0] and "
+                            f"[{domain_ext*1e3:.3g}, {(domain_ext + ct_hi)*1e3:.3g}] mm). "
                             f"S-matrix phase will be distorted by CPML stretching. "
                             f"Move x_position / reference_plane to the interior or "
                             f"reduce cpml_layers.",
@@ -3195,8 +3264,6 @@ class _PreflightMixin:
     def _check_msl_port_geometry(
         self,
         dx: float,
-        cpml_thick_lo: list[float],
-        cpml_thick_hi: list[float],
     ) -> None:
         """MSL port setup correctness checks (issue: silent Z0 / |S11| bias).
 
@@ -3214,6 +3281,16 @@ class _PreflightMixin:
            5%-amplitude tail sits at d ≈ 0.95·h_sub. A ≥ 2·h_sub margin
            keeps Z0 bias under ~5% (verified by fixed-LY mesh-conv
            sweep, 2026-05-04 — see rfx-known-issues.md).
+
+           Issue #500: the "nearest absorbing/reflecting boundary" is
+           always the requested-domain edge itself (y=0 / y=domain[1],
+           x=0 / x=domain[0]) — CPML pads EXTERIOR to that edge (see
+           :func:`_absorber_boundary_for_axis`) and a PEC/PMC face sits
+           exactly there too, so this and check 3 no longer need
+           ``cpml_thick_{lo,hi}`` at all: pre-#500 they subtracted the
+           CPML thickness from the edge, treating the absorber as
+           encroaching inward and false-flagging ports/traces that were
+           comfortably clear of everything.
 
         2. **Substrate resolution** n_z_sub = h_sub/dx ≥ 4 cells, on an
            ALIGNED mesh (h_sub/dx integer). Yee staircase at the
@@ -3294,9 +3371,11 @@ class _PreflightMixin:
             trace_y_lo = y_centre - w_trace / 2.0
             trace_y_hi = y_centre + w_trace / 2.0
             ly = float(domain[1])
-            # Effective absorbing boundary positions on each y side
-            y_abs_lo = float(cpml_thick_lo[1])           # CPML extent from y=0
-            y_abs_hi = ly - float(cpml_thick_hi[1])      # CPML extent from y=LY
+            # Effective absorbing/reflecting boundary positions on each y
+            # side: always the domain edge itself (issue #500 — see the
+            # class docstring above and _absorber_boundary_for_axis).
+            y_abs_lo = 0.0
+            y_abs_hi = ly
             clearance_lo = trace_y_lo - y_abs_lo
             clearance_hi = y_abs_hi - trace_y_hi
             for side, c in (("−y", clearance_lo), ("+y", clearance_hi)):
@@ -3397,8 +3476,9 @@ class _PreflightMixin:
                 )
 
             # ---- 3. Port-to-CPML distance in x ----
-            x_abs_lo = float(cpml_thick_lo[0])
-            x_abs_hi = float(domain[0]) - float(cpml_thick_hi[0])
+            # Issue #500: boundary is the domain edge itself, see check 1.
+            x_abs_lo = 0.0
+            x_abs_hi = float(domain[0])
             x_clearance = (
                 x_feed - x_abs_lo if pe.direction == "+x"
                 else x_abs_hi - x_feed

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -3386,7 +3386,8 @@ class _PreflightMixin:
            answered by the helper alone, and the absorber does start
            exactly at the edge — issue #500's core finding still holds);
            it is a SEPARATE, empirically-measured MSL-specific margin.
-           `docs/agent-memory/rfx-known-issues.md`, "Status 2026-05-04
+           the maintainer's internal issue ledger (primary checkout
+           only, not in this public tree), "Status 2026-05-04
            (CALIBRATED, OpenEMS-class)" entry: with the pre-calibration
            ``LY = W + 6·dx`` at dx=80µm, cpml_layers=8, "the trace ended
            up INSIDE the CPML overlap region (negative clearance)" and

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -94,11 +94,18 @@ def _absorber_boundary_for_axis(
     Returns ``(lo_boundary, hi_boundary)``: the user-coordinate position at
     which the lo-side / hi-side absorber begins, or ``None`` on a side with
     no active absorber there (``ct <= 0`` — PEC/PMC/periodic face, 2D-z, or
-    a non-absorbing global boundary). When active, the position is always
-    exactly ``0.0`` (lo) or ``domain_extent`` (hi) — never offset inward by
-    the thickness, and never offset outward either (the thickness only
-    says how deep the absorber extends beyond that point, which is not
-    needed for a membership test).
+    a non-absorbing global boundary). When active, the position is
+    conservative by up to one cell (lo: ``0.0``; hi: ``domain_extent``) —
+    NOT exactly the true interior/absorber interface. ``Grid.nx`` is sized
+    from ``ceil(domain_extent/dx)``, so on the hi side the true last
+    interior node can sit up to one ``dx`` past ``domain_extent`` (e.g.
+    domain_extent=0.0101, dx=1e-3 -> ceil(10.1)=11 -> true interior extends
+    to 0.011, one cell beyond the nominal 0.0101); a coordinate in that
+    residual band reads as "in the absorber" here even though the real
+    grid still treats it as interior. This makes every consumer
+    conservative (may warn slightly early) rather than permissive (never
+    silently misses a genuine overlap) — the thickness itself is not
+    needed for a membership test, only whether it is active.
     """
     lo_boundary = 0.0 if ct_lo > 0 else None
     hi_boundary = domain_extent if ct_hi > 0 else None
@@ -113,6 +120,40 @@ def _coord_in_absorber(
     :func:`_absorber_boundary_for_axis` for the frame this rests on."""
     lo_b, hi_b = _absorber_boundary_for_axis(domain_extent, ct_lo, ct_hi)
     return (lo_b is not None and coord < lo_b) or (hi_b is not None and coord > hi_b)
+
+
+# Proximity-advisory margin for _validate_cfg_absorber_placement (issue
+# #500 review finding M3 / H1). NOT a dedicated calibration sweep like the
+# MSL 8*dx buffer below (_check_msl_port_geometry) — #510 established that
+# probe-to-absorber clearance is a real, previously-ungated hazard class
+# (an MSL probe span could sit inside the CPML or past another port's feed
+# with preflight silent), and #478 is the PR that introduced the
+# internal/external probe distinction (`_internal_probe_indices`) this
+# advisory must respect so library witness probes stay exempt. Neither
+# pins a specific cell count for a GENERIC (non-MSL) probe/source
+# proximity check, so 2 cells is a deliberately modest, conservative
+# default: large enough that the helper's own up-to-one-cell hi-side
+# conservatism (see _absorber_boundary_for_axis) cannot by itself trigger
+# it for a genuinely-interior placement, small enough to stay a "you are
+# suspiciously close to the edge" advisory rather than a broad interior
+# band.
+_ABSORBER_PROXIMITY_CELLS = 2
+
+
+def _coord_near_absorber(
+    coord: float, domain_extent: float, ct_lo: float, ct_hi: float,
+    dx: float, n_cells: int = _ABSORBER_PROXIMITY_CELLS,
+) -> bool:
+    """True iff ``coord`` is NOT in the absorber (see
+    :func:`_coord_in_absorber`) but sits within ``n_cells * dx`` of the
+    boundary where an active absorber begins. Callers should check
+    :func:`_coord_in_absorber` first — the two are meant to be mutually
+    exclusive (membership is the more severe finding)."""
+    lo_b, hi_b = _absorber_boundary_for_axis(domain_extent, ct_lo, ct_hi)
+    margin = n_cells * dx
+    near_lo = lo_b is not None and lo_b <= coord < lo_b + margin
+    near_hi = hi_b is not None and hi_b - margin < coord <= hi_b
+    return near_lo or near_hi
 
 
 class PreflightWarning(UserWarning):
@@ -1920,7 +1961,7 @@ class _PreflightMixin:
         self._validate_cfg_upml_refinement()
         self._validate_cfg_floquet_nonuniform()
         self._validate_cfg_absorber_placement(
-            _w, cpml_thickness, cpml_thick_lo, cpml_thick_hi, absorber_label
+            _w, dx, cpml_thickness, cpml_thick_lo, cpml_thick_hi, absorber_label
         )
         self._validate_cfg_source_on_reflector_plane(_w, dx, _pmc_faces_set)
         self._validate_cfg_ntff_absorber_overlap(
@@ -1948,7 +1989,7 @@ class _PreflightMixin:
         self._validate_cfg_refplane_placement(_w)
 
         self._check_waveguide_port_evanescent()
-        self._check_msl_port_geometry(dx)
+        self._check_msl_port_geometry(dx, cpml_thick_lo, cpml_thick_hi)
 
     def _validate_cfg_tfsf_with_lumped_rlc(self, _w) -> None:
         """Warn: a lumped RLC element illuminated by a TFSF plane wave is unstable.
@@ -2359,22 +2400,43 @@ class _PreflightMixin:
     def _validate_cfg_absorber_placement(
         self,
         _w,
+        dx: float,
         cpml_thickness: float,
         cpml_thick_lo: list[float],
         cpml_thick_hi: list[float],
         absorber_label: str,
     ) -> None:
-        """P1.2/P1.3: Probe or source inside absorber region.
+        """P1.2/P1.3: Probe or source inside, or suspiciously close to, the
+        absorber region.
 
         Issue #500: membership goes through :func:`_coord_in_absorber` —
         the requested domain ``[0, domain_extent]`` is absorber-free by
         construction (exterior padding), so a probe/port is only ever
-        "near/inside" the absorber when its coordinate is genuinely
-        outside that interval (previously this compared against an
-        interior reading of the CPML thickness and false-fired on
-        geometry anywhere within roughly the outer half of the thickness
-        from an edge, e.g. a probe at the domain centre — verified false
-        positive in #500 repro 2).
+        "inside" the absorber when its coordinate is genuinely outside
+        that interval (previously this compared against an interior
+        reading of the CPML thickness and false-fired on geometry
+        anywhere within roughly the outer half of the thickness from an
+        edge, e.g. a probe at the domain centre — verified false positive
+        in #500 repro 2).
+
+        Review finding M3 / H1: dropping the interior-frame comparison
+        also removed the only proximity coverage the pre-#500 code
+        happened to provide — a probe genuinely INSIDE the domain but
+        right at its edge used to warn (for the wrong reason) and, after
+        the #500 fix alone, went silent. Two regressions surfaced this as
+        load-bearing: ``tests/test_run_preflight_parity.py`` (a probe one
+        cell inside a 0.02m domain was the run()-parity fixture's only
+        warning trigger) and ``tests/test_msl_internal_probe_advisories.py::
+        test_user_probe_advisories_and_332_still_fire`` (the #470
+        regression lock's "user probe near the x-CPML" case, node 9 of a
+        pad=8 grid — one cell inside). :func:`_coord_near_absorber`
+        restores this honestly: a coordinate that is interior but within
+        ``_ABSORBER_PROXIMITY_CELLS`` cells of an active absorber boundary
+        gets a distinct, lower-severity ``absorber_proximity`` advisory
+        instead of being silently indistinguishable from a comfortably
+        interior placement — fields that close to the boundary still
+        carry CPML fringe/reflection error even though they are not
+        literally inside the absorbing medium.
         """
         if cpml_thickness > 0:
             _internal = getattr(self, "_internal_probe_indices", frozenset())
@@ -2407,6 +2469,21 @@ class _PreflightMixin:
                             stacklevel=3,
                         )
                         break
+                    if _coord_near_absorber(coord, domain_extent, ct_lo, ct_hi, dx):
+                        _w.warn(
+                            PreflightWarning(
+                                f"Probe at {pos} is within "
+                                f"{_ABSORBER_PROXIMITY_CELLS} cells "
+                                f"({_fmt_len(_ABSORBER_PROXIMITY_CELLS * dx)}) of the "
+                                f"{absorber_label} absorber along the {'xyz'[ax]}-axis. "
+                                f"Fields there carry CPML fringe/reflection error; move "
+                                f"inward for claims-bearing measurement.",
+                                code="absorber_proximity",
+                                source="_validate_cfg_absorber_placement",
+                            ),
+                            stacklevel=3,
+                        )
+                        break
 
             for pe in self._ports:
                 pos = pe.position
@@ -2423,6 +2500,21 @@ class _PreflightMixin:
                                 f"lo={_fmt_len(ct_lo)}, hi={_fmt_len(ct_hi)}). "
                                 f"Energy will be absorbed. Move source to interior.",
                                 code="absorber_overlap",
+                                source="_validate_cfg_absorber_placement",
+                            ),
+                            stacklevel=3,
+                        )
+                        break
+                    if _coord_near_absorber(coord, domain_extent, ct_lo, ct_hi, dx):
+                        _w.warn(
+                            PreflightWarning(
+                                f"Source/port at {pos} is within "
+                                f"{_ABSORBER_PROXIMITY_CELLS} cells "
+                                f"({_fmt_len(_ABSORBER_PROXIMITY_CELLS * dx)}) of the "
+                                f"{absorber_label} absorber along the {'xyz'[ax]}-axis. "
+                                f"Fields there carry CPML fringe/reflection error; move "
+                                f"inward for claims-bearing measurement.",
+                                code="absorber_proximity",
                                 source="_validate_cfg_absorber_placement",
                             ),
                             stacklevel=3,
@@ -3264,6 +3356,8 @@ class _PreflightMixin:
     def _check_msl_port_geometry(
         self,
         dx: float,
+        cpml_thick_lo: list[float],
+        cpml_thick_hi: list[float],
     ) -> None:
         """MSL port setup correctness checks (issue: silent Z0 / |S11| bias).
 
@@ -3282,15 +3376,36 @@ class _PreflightMixin:
            keeps Z0 bias under ~5% (verified by fixed-LY mesh-conv
            sweep, 2026-05-04 — see rfx-known-issues.md).
 
-           Issue #500: the "nearest absorbing/reflecting boundary" is
-           always the requested-domain edge itself (y=0 / y=domain[1],
-           x=0 / x=domain[0]) — CPML pads EXTERIOR to that edge (see
-           :func:`_absorber_boundary_for_axis`) and a PEC/PMC face sits
-           exactly there too, so this and check 3 no longer need
-           ``cpml_thick_{lo,hi}`` at all: pre-#500 they subtracted the
-           CPML thickness from the edge, treating the absorber as
-           encroaching inward and false-flagging ports/traces that were
-           comfortably clear of everything.
+           Issue #500 / review finding MH2: the reference position is
+           ``_absorber_boundary_for_axis``'s exterior-frame edge (y=0 /
+           y=domain[1], x=0 / x=domain[0] when that face is CPML/UPML- or
+           PEC/PMC-backed) PLUS an EXPLICIT, separately-calibrated buffer
+           equal to the active CPML depth on that face
+           (``cpml_thick_{lo,hi}`` = n_cpml·dx). The buffer is not a
+           restatement of "where the absorber starts" (that question is
+           answered by the helper alone, and the absorber does start
+           exactly at the edge — issue #500's core finding still holds);
+           it is a SEPARATE, empirically-measured MSL-specific margin.
+           `docs/agent-memory/rfx-known-issues.md`, "Status 2026-05-04
+           (CALIBRATED, OpenEMS-class)" entry: with the pre-calibration
+           ``LY = W + 6·dx`` at dx=80µm, cpml_layers=8, "the trace ended
+           up INSIDE the CPML overlap region (negative clearance)" and
+           Z0 drifted UP with mesh refinement (54→60Ω) instead of
+           converging to Hammerstad's 47.89Ω; the fix widened the
+           required geometry to ``LY >= W + 2·(2·h_sub + 8·dx)`` — i.e.
+           per-side clearance >= ``2·h_sub`` beyond a buffer of
+           ``8·dx`` = ``cpml_layers·dx`` in that fixture (the "8" is
+           that calibration's ``cpml_layers``, not a hardcoded constant
+           — this reads it back out as ``cpml_thick_{lo,hi}`` so it
+           scales with whatever ``cpml_layers`` is actually configured).
+           A PEC/PMC face (``cpml_thick=0`` there) gets no buffer: the
+           calibration's concern is CPML near-field stretching, which
+           does not apply to a hard reflector. Dropping this buffer
+           entirely (as an earlier #500 pass did) silently re-admits the
+           negative-clearance configuration the 2026-05-04 calibration
+           closed — measured on this repo's own
+           ``tests/test_msl_port_preflight.py`` fixture: 3 advisories at
+           base (pre-drop), 0 on the buffer-dropped branch.
 
         2. **Substrate resolution** n_z_sub = h_sub/dx ≥ 4 cells, on an
            ALIGNED mesh (h_sub/dx integer). Yee staircase at the
@@ -3371,26 +3486,35 @@ class _PreflightMixin:
             trace_y_lo = y_centre - w_trace / 2.0
             trace_y_hi = y_centre + w_trace / 2.0
             ly = float(domain[1])
-            # Effective absorbing/reflecting boundary positions on each y
-            # side: always the domain edge itself (issue #500 — see the
-            # class docstring above and _absorber_boundary_for_axis).
-            y_abs_lo = 0.0
-            y_abs_hi = ly
+            # Reference position on each y side = the exterior-frame edge
+            # (_absorber_boundary_for_axis; None on an inactive/periodic
+            # face, treated as the plain domain edge) PLUS the explicit
+            # calibrated buffer (issue #500 / MH2 — see class docstring):
+            # cpml_thick_{lo,hi} = n_cpml*dx, zero on a PEC/PMC face.
+            _ly_lo_b, _ly_hi_b = _absorber_boundary_for_axis(
+                ly, cpml_thick_lo[1], cpml_thick_hi[1]
+            )
+            y_abs_lo = (_ly_lo_b if _ly_lo_b is not None else 0.0) + cpml_thick_lo[1]
+            y_abs_hi = (_ly_hi_b if _ly_hi_b is not None else ly) - cpml_thick_hi[1]
             clearance_lo = trace_y_lo - y_abs_lo
             clearance_hi = y_abs_hi - trace_y_hi
-            for side, c in (("−y", clearance_lo), ("+y", clearance_hi)):
+            for side, c, buf in (
+                ("−y", clearance_lo, cpml_thick_lo[1]),
+                ("+y", clearance_hi, cpml_thick_hi[1]),
+            ):
                 if c < recommended:
                     pct = max(0.0, (1.0 - c / recommended)) * 15.0
                     _w.warn(
                         PreflightWarning(
                             f"MSL port '{pe.name}' (trace W={w_trace*1e6:.0f}µm, "
                             f"h_sub={h_sub*1e6:.0f}µm): lateral clearance to "
-                            f"{side} absorbing boundary = {c*1e6:.0f}µm < "
-                            f"recommended {recommended*1e6:.0f}µm (= 2·h_sub). "
-                            f"Fringing field will be clipped → Z0 may be biased "
-                            f"HIGH by ~{pct:.0f}%, mesh-conv may diverge. "
-                            f"Increase domain y-extent OR move port further from "
-                            f"sidewall.",
+                            f"{side} absorbing boundary = {c*1e6:.0f}µm "
+                            f"(domain edge + {_fmt_len(buf)} calibrated CPML "
+                            f"buffer) < recommended {recommended*1e6:.0f}µm "
+                            f"(= 2·h_sub). Fringing field will be clipped → Z0 "
+                            f"may be biased HIGH by ~{pct:.0f}%, mesh-conv may "
+                            f"diverge. Increase domain y-extent OR move port "
+                            f"further from sidewall.",
                             code="msl_port_geometry",
                             source="_check_msl_port_geometry",
                         ),
@@ -3476,22 +3600,32 @@ class _PreflightMixin:
                 )
 
             # ---- 3. Port-to-CPML distance in x ----
-            # Issue #500: boundary is the domain edge itself, see check 1.
-            x_abs_lo = 0.0
-            x_abs_hi = float(domain[0])
+            # Issue #500 / MH2: same reference as check 1 — exterior-frame
+            # edge PLUS the explicit calibrated buffer.
+            _lx_lo_b, _lx_hi_b = _absorber_boundary_for_axis(
+                float(domain[0]), cpml_thick_lo[0], cpml_thick_hi[0]
+            )
+            x_abs_lo = (_lx_lo_b if _lx_lo_b is not None else 0.0) + cpml_thick_lo[0]
+            x_abs_hi = (
+                (_lx_hi_b if _lx_hi_b is not None else float(domain[0]))
+                - cpml_thick_hi[0]
+            )
             x_clearance = (
                 x_feed - x_abs_lo if pe.direction == "+x"
                 else x_abs_hi - x_feed
             )
             if x_clearance < recommended:
+                _x_buf = cpml_thick_lo[0] if pe.direction == "+x" else cpml_thick_hi[0]
                 _w.warn(
                     PreflightWarning(
                         f"MSL port '{pe.name}' at x={x_feed*1e3:.2f}mm, "
                         f"direction={pe.direction!r}: distance to nearest "
-                        f"x-CPML = {x_clearance*1e6:.0f}µm < recommended "
-                        f"{recommended*1e6:.0f}µm (= 2·h_sub). Source-side "
-                        f"CPML reflection may inflate |S11|. Move port further "
-                        f"from boundary OR increase domain x-extent.",
+                        f"x-CPML = {x_clearance*1e6:.0f}µm (domain edge + "
+                        f"{_fmt_len(_x_buf)} calibrated CPML buffer) < "
+                        f"recommended {recommended*1e6:.0f}µm (= 2·h_sub). "
+                        f"Source-side CPML reflection may inflate |S11|. Move "
+                        f"port further from boundary OR increase domain "
+                        f"x-extent.",
                         code="msl_port_geometry",
                         source="_check_msl_port_geometry",
                     ),

--- a/tests/test_farfield_asymmetric_cpml.py
+++ b/tests/test_farfield_asymmetric_cpml.py
@@ -96,15 +96,26 @@ def test_ntff_box_inside_cpml_trips_absorber_overlap_lo_and_hi():
 
     This replaces a prior tautology (``k_lo = z_lo + offset; assert
     k_lo >= z_lo``) that re-asserted the test's own arithmetic and could not
-    detect a real inside-CPML placement bug."""
-    # lo corner x = 5 mm < 16 mm CPML -> extends into the lo-face absorber.
-    codes_lo = _preflight_codes((0.005, 0.030, 0.030), (0.090, 0.090, 0.090))
+    detect a real inside-CPML placement bug.
+
+    Issue #500: CPML pads EXTERIOR to the requested domain (proved in
+    ``tests/test_preflight_absorber_frame.py``), so ``[0, 120]`` mm is
+    absorber-free by construction — a corner has to sit at a genuinely
+    negative coordinate (lo side) or past the domain edge (hi side) to be
+    "inside" the 16 mm-thick absorber. The pre-#500 corners here (x=5mm,
+    z=118mm) were both still inside the requested domain and used to
+    false-fire under the old interior-frame comparison.
+    """
+    # lo corner x = -5 mm: 5 mm past the x=0 edge, into the lo-face
+    # absorber (which extends to x=-16mm).
+    codes_lo = _preflight_codes((-0.005, 0.030, 0.030), (0.090, 0.090, 0.090))
     assert "absorber_overlap" in codes_lo, (
         f"lo-face inside-CPML NTFF box was NOT flagged; codes={codes_lo}"
     )
-    # hi corner z = 118 mm > 120 - 16 = 104 mm -> extends into the hi-face
-    # absorber. Verifies the guard is two-sided, not just lo-face.
-    codes_hi = _preflight_codes((0.030, 0.030, 0.030), (0.090, 0.090, 0.118))
+    # hi corner z = 125 mm: 5 mm past the z=120mm edge, into the hi-face
+    # absorber (which extends to z=136mm). Verifies the guard is
+    # two-sided, not just lo-face.
+    codes_hi = _preflight_codes((0.030, 0.030, 0.030), (0.090, 0.090, 0.125))
     assert "absorber_overlap" in codes_hi, (
         f"hi-face inside-CPML NTFF box was NOT flagged; codes={codes_hi}"
     )

--- a/tests/test_msl_internal_probe_advisories.py
+++ b/tests/test_msl_internal_probe_advisories.py
@@ -65,20 +65,41 @@ def test_witness_probes_produce_no_probe_advisories_and_no_332():
 
 def test_user_probe_advisories_and_332_still_fire():
     """USER probes keep pre-#470 behavior during the same MSL run: a probe
-    inside the CPML still draws its placement advisory, and an interior
+    near the x-CPML still draws a placement advisory, and an interior
     user probe's hot tail still fires #332 on the truncated record (the
-    fail-safe test_issue80_patch_s11_regression depends on)."""
+    fail-safe test_issue80_patch_s11_regression depends on).
+
+    Issue #500 / review finding H1: on this fixture (dx=2e-4, cpml_layers=8
+    -> pad=8) the second probe sits at x=200um = node 9, one cell inside
+    the domain (pad=8 is node 8, the first interior node) -- genuinely
+    interior under the #500 exterior-padding frame, so it no longer trips
+    the absorber_overlap ("near/inside") advisory the pre-#500 code fired
+    (for the wrong, interior-frame reason). It is exactly the
+    _ABSORBER_PROXIMITY_CELLS=2 case the #500 review's H1 finding restored:
+    within 2 cells of the boundary, so it draws the distinct
+    absorber_proximity advisory instead. This test and
+    tests/test_run_preflight_parity.py's near-identical fixture were the
+    two regressions that surfaced the removed proximity coverage as
+    load-bearing (see _validate_cfg_absorber_placement's docstring)."""
     sim = _thru()
     # interior probe above the trace: sees real signal -> hot tail at
     # num_periods=2 -> #332 must fire on the USER column
     sim.add_probe(position=(0.006, 0.004, 0.0012), component="ez")
-    # probe deep in the x-CPML -> placement advisory must fire
+    # one cell inside the domain (node 9 of pad=8) -> absorber_proximity
     sim.add_probe(position=(0.0002, 0.004, 0.0012), component="ez")
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         sim.compute_msl_s_matrix(freqs=FREQS, num_periods=2.0)
     msgs = [str(w.message) for w in caught]
-    assert any("Probe at" in m for m in msgs), msgs
+    # compute_msl_s_matrix folds individual preflight findings into ONE
+    # consolidated "[run] preflight found N advisory issue(s)" UserWarning
+    # (issue #66 parity), so absorber_proximity's own .code is not visible
+    # on the outer warning object here -- match its text instead, the way
+    # this test always has.
+    assert any(
+        "within 2 cells" in m and "CPML absorber" in m and "fringe/reflection" in m
+        for m in msgs
+    ), msgs
     assert any("issue #332" in m for m in msgs), msgs
     # user probes survive the call
     assert len(sim._probes) == 2

--- a/tests/test_periodic_cpml.py
+++ b/tests/test_periodic_cpml.py
@@ -91,14 +91,24 @@ def test_preflight_skips_periodic_axis_cpml_warning():
 
 
 def test_preflight_still_warns_on_non_periodic_z_axis():
-    """Regression: z-axis (non-periodic) CPML intrusion must still warn."""
+    """Regression: z-axis (non-periodic) CPML intrusion must still warn.
+
+    Issue #500: CPML pads EXTERIOR to the requested domain, so a slab
+    spanning z=[0, 0.0005] sits entirely INSIDE the physical domain
+    (z=0.02) and can never touch the absorber — the original fixture here
+    ("deep inside the z-CPML layer") encoded the same interior-frame
+    assumption the #500 bug had, and used to false-fire. A genuine
+    issue-#61 leak requires the box to actually cross the z=0 edge into
+    the exterior absorber (which starts at z=0 and extends to z=-0.002
+    given cpml_layers=4, dx=5e-4).
+    """
     from rfx import Box
 
     sim = _build_absorber_sim()
     sim.add_material("slab", eps_r=4.0)
-    # Slab placed at z=0 (deep inside the z-CPML layer, which is on non-
-    # periodic z and spans ~2 mm from each face).
-    sim.add(Box((0.0, 0.0, 0.0), (0.01, 0.01, 0.0005)), material="slab")
+    # Slab straddles z=0: c1[2]=-0.0003 is genuinely in the exterior z_lo
+    # absorber, c2[2]=0.0002 is interior.
+    sim.add(Box((0.0, 0.0, -0.0003), (0.01, 0.01, 0.0002)), material="slab")
 
     issues = sim.preflight(strict=False)
     z_cpml_warnings = [
@@ -106,7 +116,7 @@ def test_preflight_still_warns_on_non_periodic_z_axis():
         if "extends into CPML region" in msg and " z-axis" in msg
     ]
     assert z_cpml_warnings, (
-        "slab at z=0 should trigger z-axis CPML-region warning"
+        "slab straddling z=0 should trigger z-axis CPML-region warning"
     )
 
 

--- a/tests/test_preflight_absorber_frame.py
+++ b/tests/test_preflight_absorber_frame.py
@@ -23,6 +23,37 @@ This file:
    filter review that triggered #500) hit: WR-90 waveguide ports
    comfortably inside a valid 90.678mm domain must not warn.
 
+Post-review additions (adversarial review of PR #542 caught two real
+findings the first pass missed):
+
+- **H1 / review finding M3** — dropping the interior-frame comparison
+  from consumer 1 (``_validate_cfg_absorber_placement``) also silently
+  dropped the only proximity coverage the pre-#500 (wrong-reason) code
+  happened to provide: a probe genuinely INSIDE the domain but right at
+  its edge used to warn. Two regressions surfaced this as load-bearing —
+  ``tests/test_run_preflight_parity.py`` (its only warning trigger was a
+  probe one grid cell inside the domain) and
+  ``tests/test_msl_internal_probe_advisories.py::
+  test_user_probe_advisories_and_332_still_fire`` (the #470 regression
+  lock's "user probe near the x-CPML" case, one cell inside a pad=8
+  grid). The fix is a distinct, honestly-scoped ``absorber_proximity``
+  advisory (:func:`_coord_near_absorber` /
+  ``_ABSORBER_PROXIMITY_CELLS``) for a coordinate that is interior but
+  within 2 cells of an active absorber boundary — see both consumers'
+  fire/non-fire pairs in section 2 below.
+- **MH2 / review finding M5** — consumer 5 (``_check_msl_port_geometry``
+  checks 1 & 3) turned out NOT to be a plain instance of the #500 bug:
+  dropping ``cpml_thick_lo``/``cpml_thick_hi`` from it also dropped an
+  EXPLICIT, separately-calibrated buffer the 2026-05-04 MSL geometry rule
+  requires on top of the exterior-frame domain edge (`docs/agent-memory/
+  rfx-known-issues.md`, "Status 2026-05-04 (CALIBRATED, OpenEMS-class)":
+  ``LY >= W + 2*(2*h_sub + 8*dx)``). The buffer is restored explicitly,
+  reads ``cpml_layers*dx`` off the same ``cpml_thick_{lo,hi}`` inputs so
+  it scales with the configured ``cpml_layers`` rather than the ledger's
+  literal "8", and is added ON TOP OF (not instead of)
+  ``_absorber_boundary_for_axis``'s exterior-frame boundary — see section
+  6's ledger-reproduction tests.
+
 Non-uniform lane (issue #500 "Not verified" item): ``_validate_simulation_config``
 (``rfx/api/_preflight.py``) calls all five consumers unconditionally —
 there is no ``dz_profile`` gate on the whole check family, unlike the
@@ -36,12 +67,38 @@ same frame and the same fix apply on both lanes; there is no separate NU
 code path to special-case.
 
 Mutation falsifier (manual, recorded here rather than left as a permanent
-CI assertion): with ``_absorber_boundary_for_axis`` locally edited so
-``lo_boundary = domain_extent if ct_lo > 0 else None`` (swapping the lo/hi
-roles), every firing test in this file went RED — each one no longer
-detected its geometry as "in the absorber" on the side it actually put it
-on. Reverted; see the PR body / rfx-known-issues.md #500 entry for the
-recorded run.
+CI assertion; re-run after the H1/MH2 additions above): with
+``_absorber_boundary_for_axis`` locally edited so
+``lo_boundary = domain_extent if ct_lo > 0 else None`` / ``hi_boundary =
+0.0 if ct_hi > 0 else None`` (swapping the lo/hi roles), 16 tests went
+RED — correctly the NON-FIRING controls plus the helper's own unit test,
+not the firing tests (an earlier draft of this docstring had this
+inverted: the firing tests stay green because the swap makes the
+membership/clearance tests over-inclusive on an already-interior
+coordinate, not blind to a genuinely exterior one). In this file (10):
+``test_absorber_boundary_helper_matches_ground_truth``,
+``test_absorber_placement_silent_on_domain_centre_probe``,
+``test_absorber_placement_proximity_advisory_fires_within_2_cells``,
+``test_absorber_placement_silent_past_the_proximity_margin``,
+``test_geometry_in_cpml_silent_when_entirely_interior``,
+``test_ntff_absorber_overlap_silent_when_box_interior``,
+``test_waveguide_reference_plane_silent_on_wr90_ports_in_valid_domain``,
+``test_waveguide_reference_plane_silent_at_mixin_level_near_edge``,
+``test_msl_x_cpml_clearance_silent_once_past_buffer_plus_recommended``,
+``test_msl_y_clearance_silent_on_ledger_calibrated_ly``. Outside this
+file (6, confirming M5 that the mutation now also reaches the MSL and
+proximity paths): ``test_msl_port_preflight.py::
+test_clearance_silent_on_wide_ly``, ``test_msl_port_preflight.py::
+test_well_setup_msl_port_zero_warnings``,
+``test_msl_internal_probe_advisories.py::
+test_user_probe_advisories_and_332_still_fire``,
+``test_preflight_structured_and_guards.py::
+test_absorber_overlap_no_false_positive_on_2d_collapsed_z``,
+``test_preflight_false_positives.py::
+test_full_domain_dielectric_silent_on_cpml_extension``,
+``test_farfield_asymmetric_cpml.py::
+test_ntff_box_outside_cpml_has_no_absorber_overlap``. Reverted; see the
+PR body / rfx-known-issues.md #500 entry for the recorded run.
 """
 
 from __future__ import annotations
@@ -166,6 +223,33 @@ def test_absorber_placement_fires_on_probe_genuinely_in_absorber():
     issues = _absorber_placement_sim(-0.001).preflight(strict=False)
     hits = [m for m in issues if "is near/inside" in m and "Probe" in m]
     assert hits, f"probe in the exterior absorber must warn; got {issues!r}"
+
+
+def test_absorber_placement_proximity_advisory_fires_within_2_cells():
+    """Review finding H1: a probe genuinely INSIDE the domain but within
+    _ABSORBER_PROXIMITY_CELLS=2 cells (dx=1mm -> 2mm margin here) of the
+    z=0 boundary gets the distinct absorber_proximity advisory, not
+    silence and not the absorber_overlap membership warning. This is the
+    coverage tests/test_run_preflight_parity.py and
+    tests/test_msl_internal_probe_advisories.py's #470 lock both turned
+    out to depend on."""
+    issues = _absorber_placement_sim(0.0005).preflight(strict=False)
+    overlap = [m for m in issues if "is near/inside" in m and "Probe" in m]
+    proximity = [
+        m for m in issues
+        if "Probe" in m and "within 2 cells" in m and "CPML absorber" in m
+    ]
+    assert not overlap, f"a probe within 2mm of the edge is not IN the absorber; got {overlap}"
+    assert proximity, f"expected a proximity advisory for a probe 0.5mm from the edge; got {issues!r}"
+
+
+def test_absorber_placement_silent_past_the_proximity_margin():
+    """Non-firing control: a probe 3mm from the z=0 edge (past the 2mm /
+    2-cell proximity margin) draws neither the overlap nor the proximity
+    advisory."""
+    issues = _absorber_placement_sim(0.003).preflight(strict=False)
+    hits = [m for m in issues if "Probe" in m and ("near/inside" in m or "within 2 cells" in m)]
+    assert not hits, f"a probe 3mm from the edge must draw neither advisory; got {hits}"
 
 
 # --------------------------------------------------------------------- #
@@ -298,6 +382,20 @@ def test_waveguide_reference_plane_silent_at_mixin_level_near_edge():
 # --------------------------------------------------------------------- #
 # 6. Consumer 5 — _check_msl_port_geometry (checks 1 & 3: distance to
 #    the nearest absorbing/reflecting boundary).
+#
+# Review finding MH2: unlike consumers 1-4, this one is NOT a plain
+# instance of the #500 interior-frame bug. The reference position is the
+# exterior-frame domain edge (_absorber_boundary_for_axis) PLUS an
+# EXPLICIT, separately-calibrated buffer (cpml_thick_{lo,hi} = n_cpml*dx)
+# — docs/agent-memory/rfx-known-issues.md "Status 2026-05-04 (CALIBRATED,
+# OpenEMS-class)": with LY = W + 6*dx at dx=80um/cpml_layers=8 "the trace
+# ended up INSIDE the CPML overlap region (negative clearance)" and Z0
+# drifted UP with refinement instead of converging to Hammerstad's
+# 47.89 Ohm; the fix requires LY >= W + 2*(2*h_sub + 8*dx). An earlier
+# pass of this PR dropped the buffer entirely (treating this consumer as
+# the same bug class as the other four), which silently re-admitted that
+# exact negative-clearance configuration — verified below against the
+# ledger's own numbers.
 # --------------------------------------------------------------------- #
 
 _EPS_R = 3.66
@@ -306,10 +404,10 @@ _W_TRACE = 600e-6
 _LX = 14e-3
 
 
-def _msl_x_clearance_sim(dx: float, port_x: float) -> Simulation:
+def _msl_x_clearance_sim(dx: float, port_x: float, cpml_layers: int = 8) -> Simulation:
     ly = _W_TRACE + 8 * _H_SUB
     sim = Simulation(
-        freq_max=5e9, domain=(_LX, ly, _H_SUB + 1.5e-3), dx=dx, cpml_layers=8,
+        freq_max=5e9, domain=(_LX, ly, _H_SUB + 1.5e-3), dx=dx, cpml_layers=cpml_layers,
         boundary=BoundarySpec(x="cpml", y="cpml", z=Boundary(lo="pec", hi="cpml")),
     )
     sim.add_material("ro4350b", eps_r=_EPS_R)
@@ -322,21 +420,82 @@ def _msl_x_clearance_sim(dx: float, port_x: float) -> Simulation:
     return sim
 
 
-def test_msl_x_cpml_clearance_silent_on_former_false_positive():
-    """Former false positive: dx=100um, cpml_layers=8 -> CPML thickness
-    800um. Port at x=600um: the pre-#500 interior-frame check measured
-    clearance = 600 - 800 = -200um (< the 508um=2*h_sub recommendation)
-    and fired. The real clearance to the domain edge (x=0, where the
-    absorber actually begins) is 600um > 508um -> must be silent."""
-    issues = _msl_x_clearance_sim(dx=100e-6, port_x=0.6e-3).preflight(strict=False)
+def _msl_y_clearance_sim(dx: float, ly: float, cpml_layers: int = 8) -> Simulation:
+    """Mirrors docs/agent-memory/rfx-known-issues.md's 2026-05-04 mesh-conv
+    fixture (LY parametrized, port_x fixed comfortably clear of x-CPML)."""
+    sim = Simulation(
+        freq_max=5e9, domain=(_LX, ly, _H_SUB + 1.5e-3), dx=dx, cpml_layers=cpml_layers,
+        boundary=BoundarySpec(x="cpml", y="cpml", z=Boundary(lo="pec", hi="cpml")),
+    )
+    sim.add_material("ro4350b", eps_r=_EPS_R)
+    sim.add(Box((0, 0, 0), (_LX, ly, _H_SUB)), material="ro4350b")
+    y_c = ly / 2.0
+    sim.add(Box((0, y_c - _W_TRACE / 2, _H_SUB), (_LX, y_c + _W_TRACE / 2, _H_SUB + dx)),
+            material="pec")
+    sim.add_msl_port(position=(2e-3, y_c, 0), width=_W_TRACE, height=_H_SUB,
+                     direction="+x", impedance=50.0)
+    return sim
+
+
+def test_msl_x_cpml_clearance_fires_on_ledger_negative_clearance_case():
+    """The exact 2026-05-04 ledger regression: dx=80um, cpml_layers=8 ->
+    calibrated buffer 640um; port at x=600um is INSIDE the buffered
+    margin (clearance = 600 - 640 = -40um < 0), the "trace ended up
+    INSIDE the CPML overlap region" case the calibration fixed. Dropping
+    the buffer (an earlier pass of this PR) silently went silent here."""
+    issues = _msl_x_clearance_sim(dx=80e-6, port_x=0.6e-3).preflight(strict=False)
     hits = [m for m in issues if "x-CPML" in m]
-    assert not hits, f"port with real 600um clearance must not warn; got {hits}"
+    assert hits, f"port inside the calibrated buffer must warn; got {issues!r}"
+    assert any("calibrated CPML buffer" in m for m in hits), hits
+
+
+def test_msl_x_cpml_clearance_silent_once_past_buffer_plus_recommended():
+    """Non-firing control: dx=100um, cpml_layers=8 -> buffer=800um,
+    recommended=2*h_sub=508um, total=1308um. Port at x=1400um clears
+    both -> silent."""
+    issues = _msl_x_clearance_sim(dx=100e-6, port_x=1.4e-3).preflight(strict=False)
+    hits = [m for m in issues if "x-CPML" in m]
+    assert not hits, f"port past buffer+recommended must not warn; got {hits}"
 
 
 def test_msl_x_cpml_clearance_fires_when_genuinely_too_close():
-    """Positive control: port at x=300um genuinely has only 300um of
-    real clearance to the x=0 domain edge (< 508um recommended) —
-    must still warn under both the old and corrected frame."""
+    """Positive control: port at x=300um is inside the buffer alone
+    (dx=100um, cpml_layers=8 -> buffer=800um) — must warn."""
     issues = _msl_x_clearance_sim(dx=100e-6, port_x=0.3e-3).preflight(strict=False)
     hits = [m for m in issues if "x-CPML" in m]
     assert hits, f"port with real 300um clearance must warn; got {issues!r}"
+
+
+def test_msl_y_clearance_fires_on_ledger_ly_w_plus_6dx():
+    """Ledger reproduction: the PRE-calibration ``LY = W + 6*dx`` geometry
+    (dx=80um, cpml_layers=8) that motivated the 2026-05-04 fix must still
+    warn under the restored buffer."""
+    ly = _W_TRACE + 6 * 80e-6
+    issues = _msl_y_clearance_sim(dx=80e-6, ly=ly).preflight(strict=False)
+    hits = [m for m in issues if "lateral clearance" in m]
+    assert hits, f"pre-calibration LY=W+6dx must warn; got {issues!r}"
+    assert any("calibrated CPML buffer" in m for m in hits), hits
+
+
+def test_msl_y_clearance_silent_on_ledger_calibrated_ly():
+    """Ledger reproduction: the CALIBRATED ``LY >= W + 2*(2*h_sub + 8*dx)``
+    geometry must be silent."""
+    ly = _W_TRACE + 2 * (2 * _H_SUB + 8 * 80e-6)
+    issues = _msl_y_clearance_sim(dx=80e-6, ly=ly).preflight(strict=False)
+    hits = [m for m in issues if "lateral clearance" in m]
+    assert not hits, f"calibrated LY must not warn; got {hits}"
+
+
+def test_msl_clearance_buffer_scales_with_cpml_layers_not_hardcoded_8():
+    """MH2: the ledger's "8*dx" is that specific fixture's cpml_layers=8,
+    not a hardcoded constant — doubling cpml_layers must double the
+    buffer and therefore still fire at a clearance that would clear a
+    fixed-800um buffer."""
+    # dx=100um, cpml_layers=16 -> buffer=1600um. Port at x=1400um cleared
+    # an 800um buffer (see the silent-control above) but not a 1600um one.
+    issues = _msl_x_clearance_sim(dx=100e-6, port_x=1.4e-3, cpml_layers=16).preflight(
+        strict=False
+    )
+    hits = [m for m in issues if "x-CPML" in m]
+    assert hits, f"doubled cpml_layers must double the buffer and warn; got {issues!r}"
+    assert any("1.6mm calibrated CPML buffer" in m for m in hits), hits

--- a/tests/test_preflight_absorber_frame.py
+++ b/tests/test_preflight_absorber_frame.py
@@ -1,0 +1,342 @@
+"""Issue #500 — the preflight absorber-overlap validator family compared
+user-frame coordinates against an INTERIOR-CPML reading while every rfx
+grid builder pads the absorber EXTERIOR to the requested domain. That made
+five ``_validate_cfg_*`` / ``_check_msl_port_geometry`` consumers of
+``cpml_thick_lo`` / ``cpml_thick_hi`` false-fire on geometry nowhere near
+the absorber (verified: waveguide reference planes comfortably inside a
+90.678mm domain, a probe at the domain centre), and the whole family had
+NO tests at all before this file (the #303 mis-gated-guard class).
+
+This file:
+
+1. Proves the exterior-padding ground truth directly off the real grid
+   builders (``rfx.grid.Grid`` for the uniform lane,
+   ``rfx.nonuniform.make_nonuniform_grid`` for the non-uniform/dz_profile
+   lane) — the single fact ``_absorber_boundary_for_axis``
+   (``rfx/api/_preflight.py``) encodes and every consumer now goes
+   through.
+2. Gives each of the five consumers a firing test (geometry genuinely
+   past the requested-domain edge, into the exterior absorber) and a
+   non-firing control (geometry near an edge but still inside the
+   requested domain — the shape the pre-#500 code false-fired on).
+3. Regression-locks the exact false positive PR #499 (the stage-S3 iris
+   filter review that triggered #500) hit: WR-90 waveguide ports
+   comfortably inside a valid 90.678mm domain must not warn.
+
+Non-uniform lane (issue #500 "Not verified" item): ``_validate_simulation_config``
+(``rfx/api/_preflight.py``) calls all five consumers unconditionally —
+there is no ``dz_profile`` gate on the whole check family, unlike the
+unrelated #494/#502 two-port absorber advisory (a different, self-contained
+check in ``compute_waveguide_s_matrix`` that PR #502 found silent on the NU
+lane). ``_validate_cfg_compute_cpml_thickness`` already sums the leading
+``dz_profile`` entries for the z-axis thickness, and
+``make_nonuniform_grid`` pads CPML exterior to the ``dz_profile``-covered
+physical domain exactly like the uniform ``Grid`` — proved below — so the
+same frame and the same fix apply on both lanes; there is no separate NU
+code path to special-case.
+
+Mutation falsifier (manual, recorded here rather than left as a permanent
+CI assertion): with ``_absorber_boundary_for_axis`` locally edited so
+``lo_boundary = domain_extent if ct_lo > 0 else None`` (swapping the lo/hi
+roles), every firing test in this file went RED — each one no longer
+detected its geometry as "in the absorber" on the side it actually put it
+on. Reverted; see the PR body / rfx-known-issues.md #500 entry for the
+recorded run.
+"""
+
+from __future__ import annotations
+
+import warnings
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from rfx import Simulation, Box
+from rfx.api._preflight import (
+    _PreflightMixin,
+    _absorber_boundary_for_axis,
+    _coord_in_absorber,
+    PreflightConfigError,
+)
+from rfx.boundaries.spec import Boundary, BoundarySpec
+from rfx.grid import Grid
+
+
+# --------------------------------------------------------------------- #
+# 1. Ground truth: CPML pads EXTERIOR to the requested domain.
+# --------------------------------------------------------------------- #
+
+def test_uniform_grid_pads_absorber_exterior_to_requested_domain():
+    """rfx.grid.Grid — reproduces issue #500's own repro-1 numbers
+    (WR-90 stage-S3: dx=254um, cpml_layers=110, x-extent 90.678mm)."""
+    dx = 254e-6
+    domain = (90.678e-3, 22.86e-3, 10.16e-3)
+    cpml_layers = 110
+    g = Grid(freq_max=10e9, domain=domain, dx=dx, cpml_layers=cpml_layers)
+
+    assert (g.nx, g.pad_x_lo, g.pad_x_hi) == (578, 110, 110)
+
+    # Grid.position_to_index maps node pad_x_lo to user x=0 (i = round(pos/dx)
+    # + pad_x_lo), so node 0's user coordinate is -pad_x_lo*dx and node
+    # nx-1's is (nx-1-pad_x_lo)*dx.
+    x_node0 = (0 - g.pad_x_lo) * dx
+    x_node_last = (g.nx - 1 - g.pad_x_lo) * dx
+    assert x_node0 == pytest.approx(-27.940e-3, abs=1e-6)
+    assert x_node_last == pytest.approx(118.618e-3, abs=1e-6)
+
+    # The requested domain [0, 90.678mm] sits strictly inside the grid's
+    # user-coordinate span -> it is absorber-free; the absorber occupies
+    # the EXTERIOR bands [x_node0, 0) and (domain[0], x_node_last].
+    assert x_node0 < 0.0 < domain[0] < x_node_last
+
+
+def test_nonuniform_grid_pads_absorber_exterior_to_requested_domain():
+    """rfx.nonuniform.make_nonuniform_grid — the dz_profile-covered
+    physical z-domain is likewise absorber-free; CPML is appended
+    exterior to it via ``_pad_profile``, same convention as the uniform
+    lane above."""
+    from rfx.nonuniform import make_nonuniform_grid
+
+    dz_profile = np.array([0.5e-3] * 20 + [1.0e-3] * 10)  # 20mm physical z
+    cpml_layers = 8
+    ng = make_nonuniform_grid((0.03, 0.03), dz_profile, 0.5e-3, cpml_layers=cpml_layers)
+
+    assert (ng.pad_z_lo, ng.pad_z_hi) == (cpml_layers, cpml_layers)
+    assert ng.nz == len(dz_profile) + ng.pad_z_lo + ng.pad_z_hi
+
+    dz_full = np.asarray(ng.dz)
+    edges = np.concatenate(([0.0], np.cumsum(dz_full)))
+    # Node pad_z_lo is user z=0 (mirrors Grid's node pad_x_lo convention).
+    z_node0 = edges[0] - edges[ng.pad_z_lo]
+    z_node_last = edges[-1] - edges[ng.pad_z_lo]
+    physical_extent = float(np.sum(dz_profile))
+
+    # float32 storage (NonUniformGrid.dz) — loosen tolerance accordingly.
+    assert z_node0 == pytest.approx(-4.0e-3, abs=1e-6)
+    assert z_node_last == pytest.approx(28.0e-3, abs=1e-6)
+    assert z_node0 < 0.0 < physical_extent < z_node_last
+
+
+def test_absorber_boundary_helper_matches_ground_truth():
+    """Unit check on the canonical helper itself: active boundary is
+    always exactly 0.0 / domain_extent, never offset inward by the
+    thickness (the pre-#500 bug), and inactive sides return None."""
+    lo, hi = _absorber_boundary_for_axis(0.090678, 27.94e-3, 27.94e-3)
+    assert lo == 0.0
+    assert hi == 0.090678
+    # No active absorber on either side (e.g. PEC/PMC/periodic face).
+    assert _absorber_boundary_for_axis(0.090678, 0.0, 0.0) == (None, None)
+    # Membership: interior coordinates are never "in" the absorber.
+    assert not _coord_in_absorber(0.020, 0.090678, 27.94e-3, 27.94e-3)
+    assert not _coord_in_absorber(0.070678, 0.090678, 27.94e-3, 27.94e-3)
+    # Exterior coordinates are.
+    assert _coord_in_absorber(-0.001, 0.090678, 27.94e-3, 27.94e-3)
+    assert _coord_in_absorber(0.091, 0.090678, 27.94e-3, 27.94e-3)
+
+
+# --------------------------------------------------------------------- #
+# 2. Consumer 1 — _validate_cfg_absorber_placement (probe/port position).
+# --------------------------------------------------------------------- #
+
+def _absorber_placement_sim(z_probe: float) -> Simulation:
+    # Issue #500 repro-2 domain: cpml_thickness (16mm) exceeds the whole
+    # 10.16mm z-extent, so the pre-#500 interior-frame check flagged
+    # EVERY z position, including the domain centre.
+    sim = Simulation(freq_max=10e9, domain=(50e-3, 22.86e-3, 10.16e-3),
+                     dx=1e-3, cpml_layers=16, boundary="cpml")
+    sim.add_source((0.001, 0.01143, 0.005), "ez")
+    sim.add_probe((0.025, 0.01143, z_probe), "ez")
+    return sim
+
+
+def test_absorber_placement_silent_on_domain_centre_probe():
+    """Issue #500 repro-2, regression-locked: a probe at the exact
+    geometric centre of the domain must not warn — CPML z-thickness
+    (16mm) exceeding the 10.16mm z-extent used to make this fire
+    unconditionally."""
+    issues = _absorber_placement_sim(0.00508).preflight(strict=False)
+    hits = [m for m in issues if "is near/inside" in m and "Probe" in m]
+    assert not hits, f"domain-centre probe must not warn; got {hits}"
+
+
+def test_absorber_placement_fires_on_probe_genuinely_in_absorber():
+    """Positive control: a probe at a genuinely negative z (past the
+    z=0 domain edge, inside the exterior absorber) must still warn."""
+    issues = _absorber_placement_sim(-0.001).preflight(strict=False)
+    hits = [m for m in issues if "is near/inside" in m and "Probe" in m]
+    assert hits, f"probe in the exterior absorber must warn; got {issues!r}"
+
+
+# --------------------------------------------------------------------- #
+# 3. Consumer 2 — _validate_cfg_geometry_in_cpml (geometry bounding box).
+# --------------------------------------------------------------------- #
+
+def _geometry_in_cpml_sim(c1z: float) -> Simulation:
+    sim = Simulation(freq_max=10e9, domain=(0.01, 0.01, 0.01), dx=0.5e-3,
+                     cpml_layers=4, boundary="cpml")
+    sim.add_material("diel", eps_r=2.0)
+    sim.add(Box((0.001, 0.001, c1z), (0.009, 0.009, 0.009)), material="diel")
+    sim.add_source((0.005, 0.005, 0.005), "ez")
+    return sim
+
+
+def test_geometry_in_cpml_silent_when_entirely_interior():
+    """A Box entirely within [0, domain_extent] can never touch the
+    exterior absorber, however close to the edge it sits."""
+    issues = _geometry_in_cpml_sim(0.001).preflight(strict=False)
+    hits = [m for m in issues if "extends into CPML" in m]
+    assert not hits, f"interior Box must not warn; got {hits}"
+
+
+def test_geometry_in_cpml_fires_when_bbox_crosses_domain_edge():
+    """Positive control: a Box whose low z-edge is genuinely negative
+    (crosses z=0 into the exterior absorber) must still warn (issue
+    #61's original footgun)."""
+    issues = _geometry_in_cpml_sim(-0.001).preflight(strict=False)
+    hits = [m for m in issues if "extends into CPML" in m]
+    assert hits, f"Box crossing into the absorber must warn; got {issues!r}"
+
+
+# --------------------------------------------------------------------- #
+# 4. Consumer 3 — _validate_cfg_ntff_absorber_overlap (NTFF box corners).
+# --------------------------------------------------------------------- #
+
+def _ntff_sim(corner_lo_z: float) -> Simulation:
+    sim = Simulation(freq_max=10e9, domain=(0.06, 0.06, 0.06), dx=2e-3,
+                     cpml_layers=8, boundary="cpml")
+    sim.add_source((0.03, 0.03, 0.03), "ez")
+    sim.add_ntff_box((0.01, 0.01, corner_lo_z), (0.05, 0.05, 0.05), freqs=(10e9,))
+    return sim
+
+
+def test_ntff_absorber_overlap_silent_when_box_interior():
+    issues = _ntff_sim(0.01).preflight(strict=False)
+    hits = [m for m in issues if "NTFF box extends" in m]
+    assert not hits, f"interior NTFF box must not warn; got {hits}"
+
+
+def test_ntff_absorber_overlap_fires_when_corner_crosses_domain_edge():
+    """Positive control: lo-corner z genuinely negative (5mm past the
+    z=0 edge, inside the 16mm-thick absorber) must still warn."""
+    issues = _ntff_sim(-0.005).preflight(strict=False)
+    hits = [m for m in issues if "NTFF box extends" in m]
+    assert hits, f"NTFF box crossing into the absorber must warn; got {issues!r}"
+
+
+# --------------------------------------------------------------------- #
+# 5. Consumer 4 — _validate_cfg_waveguide_reference_plane.
+#
+# This is the exact check issue #500 repro-1 documents. Its absorber-
+# overlap branch is now provably UNREACHABLE through the public API: the
+# hard bounds check immediately above it (`effective < 0 or
+# effective > domain_ext`) already raises PreflightConfigError for any
+# `effective` this branch could otherwise catch (their thresholds are
+# now identical — both 0.0 / domain_ext under the corrected frame), and
+# add_waveguide_port() itself rejects an out-of-domain x_position /
+# reference_plane before preflight ever runs. Exercised at the mixin
+# level (SimpleNamespace fake `self`, matching this file's existing
+# _validate_cfg_conformal_fine_dx pattern) so the unreachable branch is
+# still under direct test.
+# --------------------------------------------------------------------- #
+
+def _fake_wg_port(direction: str, x_position: float, reference_plane=None):
+    return SimpleNamespace(direction=direction, x_position=x_position,
+                           reference_plane=reference_plane)
+
+
+def test_waveguide_reference_plane_silent_on_wr90_ports_in_valid_domain():
+    """Regression lock for issue #500 repro-1 / PR #499 (the stage-S3
+    iris filter review that triggered #500): WR-90 ports at 20mm and
+    70.678mm on a 90.678mm domain (dx=254um, cpml_layers=110) are
+    comfortably interior and must not warn — this exact configuration
+    used to emit two 'inside the CPML absorbing region' false positives
+    (also visible, pre-fix, on every run of test_waveguide_forward.py)."""
+    domain = (90.678e-3, 22.86e-3, 10.16e-3)
+    dx = 254e-6
+    sim = Simulation(freq_max=10e9, domain=domain, dx=dx, cpml_layers=110,
+                     boundary="cpml")
+    sim.add_waveguide_port(0.020, direction="+x", name="p1")
+    sim.add_waveguide_port(0.070678, direction="-x", name="p2")
+    issues = sim.preflight(strict=False)
+    hits = [m for m in issues if "inside the CPML absorbing region" in m]
+    assert not hits, f"WR-90 ports in a valid domain must not warn; got {hits}"
+
+
+def test_waveguide_reference_plane_absorber_branch_is_dead_given_hard_check():
+    """Direct mixin-level check: an `effective` genuinely outside
+    [0, domain_ext] raises PreflightConfigError from the hard check
+    BEFORE the absorber-overlap warning branch (now equally at 0.0 /
+    domain_ext) could ever fire."""
+    domain = (90.678e-3, 22.86e-3, 10.16e-3)
+    ct_lo = [110 * 254e-6, 0.0, 0.0]
+    ct_hi = [110 * 254e-6, 0.0, 0.0]
+    fake = SimpleNamespace(
+        _domain=domain, _geometry=[],
+        _waveguide_ports=[_fake_wg_port("+x", 0.0, reference_plane=-0.005)],
+    )
+    with pytest.raises(PreflightConfigError, match="outside the x-domain"):
+        _PreflightMixin._validate_cfg_waveguide_reference_plane(fake, warnings, ct_lo, ct_hi)
+
+
+def test_waveguide_reference_plane_silent_at_mixin_level_near_edge():
+    """Mixin-level non-firing control mirroring the repro-1 numbers
+    directly (no add_waveguide_port() guard in the way)."""
+    domain = (90.678e-3, 22.86e-3, 10.16e-3)
+    ct_lo = [110 * 254e-6, 0.0, 0.0]
+    ct_hi = [110 * 254e-6, 0.0, 0.0]
+    fake = SimpleNamespace(
+        _domain=domain, _geometry=[],
+        _waveguide_ports=[_fake_wg_port("+x", 0.020), _fake_wg_port("-x", 0.070678)],
+    )
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        _PreflightMixin._validate_cfg_waveguide_reference_plane(fake, warnings, ct_lo, ct_hi)
+    assert not rec, f"ports comfortably inside the domain must not warn; got {rec}"
+
+
+# --------------------------------------------------------------------- #
+# 6. Consumer 5 — _check_msl_port_geometry (checks 1 & 3: distance to
+#    the nearest absorbing/reflecting boundary).
+# --------------------------------------------------------------------- #
+
+_EPS_R = 3.66
+_H_SUB = 254e-6
+_W_TRACE = 600e-6
+_LX = 14e-3
+
+
+def _msl_x_clearance_sim(dx: float, port_x: float) -> Simulation:
+    ly = _W_TRACE + 8 * _H_SUB
+    sim = Simulation(
+        freq_max=5e9, domain=(_LX, ly, _H_SUB + 1.5e-3), dx=dx, cpml_layers=8,
+        boundary=BoundarySpec(x="cpml", y="cpml", z=Boundary(lo="pec", hi="cpml")),
+    )
+    sim.add_material("ro4350b", eps_r=_EPS_R)
+    sim.add(Box((0, 0, 0), (_LX, ly, _H_SUB)), material="ro4350b")
+    y_c = ly / 2.0
+    sim.add(Box((0, y_c - _W_TRACE / 2, _H_SUB), (_LX, y_c + _W_TRACE / 2, _H_SUB + dx)),
+            material="pec")
+    sim.add_msl_port(position=(port_x, y_c, 0), width=_W_TRACE, height=_H_SUB,
+                     direction="+x", impedance=50.0)
+    return sim
+
+
+def test_msl_x_cpml_clearance_silent_on_former_false_positive():
+    """Former false positive: dx=100um, cpml_layers=8 -> CPML thickness
+    800um. Port at x=600um: the pre-#500 interior-frame check measured
+    clearance = 600 - 800 = -200um (< the 508um=2*h_sub recommendation)
+    and fired. The real clearance to the domain edge (x=0, where the
+    absorber actually begins) is 600um > 508um -> must be silent."""
+    issues = _msl_x_clearance_sim(dx=100e-6, port_x=0.6e-3).preflight(strict=False)
+    hits = [m for m in issues if "x-CPML" in m]
+    assert not hits, f"port with real 600um clearance must not warn; got {hits}"
+
+
+def test_msl_x_cpml_clearance_fires_when_genuinely_too_close():
+    """Positive control: port at x=300um genuinely has only 300um of
+    real clearance to the x=0 domain edge (< 508um recommended) —
+    must still warn under both the old and corrected frame."""
+    issues = _msl_x_clearance_sim(dx=100e-6, port_x=0.3e-3).preflight(strict=False)
+    hits = [m for m in issues if "x-CPML" in m]
+    assert hits, f"port with real 300um clearance must warn; got {issues!r}"

--- a/tests/test_preflight_false_positives.py
+++ b/tests/test_preflight_false_positives.py
@@ -97,25 +97,31 @@ def test_full_domain_dielectric_silent_on_cpml_extension():
 
 
 def test_inset_box_leaking_into_cpml_still_warns():
-    """A Box that inset short of the domain edge (so the user clearly
-    did NOT intend full-domain extension) but still drifts into the
-    CPML region must still warn — this is the original issue #61
-    leak-into-absorber case."""
+    """A Box that genuinely crosses the domain edge into the exterior
+    absorber must still warn — this is the original issue #61
+    leak-into-absorber case.
+
+    Issue #500: CPML pads EXTERIOR to the requested domain, so
+    ``[0, LZ]`` is absorber-free by construction — a Box inset short of
+    the edge but still nominally within ``[0, LZ]`` (the pre-#500
+    fixture here) can never touch the absorber, no matter how close to
+    the edge it sits. The only genuine leak is a bounding-box coordinate
+    that is literally negative (or past ``domain_extent``) — the box
+    below is inset in x (unaffected, no leak there) but straddles z=0.
+    """
     LX, LY, LZ = 0.030, 0.005, 0.002
     DX = 0.5e-3
     sim = Simulation(freq_max=10e9, domain=(LX, LY, LZ), dx=DX,
                      cpml_layers=4)
     sim.add_material("fr4", eps_r=4.3)
-    # CPML thickness = 4 × 0.5mm = 2mm.  Box inset 0.5mm on each side
-    # — well short of the domain edge (5·dx away from LX) so the
-    # intentional-edge heuristic does not exempt, AND inside the
-    # 30 % CPML penetration threshold (0.5mm < 0.6mm).
-    sim.add(Box((0.0005, 0, 0), (LX - 0.0005, LY, 0.0005)),
+    # CPML thickness = 4 x 0.5mm = 2mm. Box inset 0.5mm in x (no leak
+    # there) but c1[2]=-0.0003 is genuinely in the exterior z_lo absorber.
+    sim.add(Box((0.0005, 0, -0.0003), (LX - 0.0005, LY, 0.0002)),
             material="fr4")
     sim.add_source((LX/2, LY/2, 0.0002), "ez")
     issues = _issues(sim)
     assert _has(issues, "extends into CPML"), (
-        f"Box inset and leaking into CPML must still warn; "
+        f"Box straddling the z=0 edge and leaking into CPML must still warn; "
         f"issues: {issues!r}"
     )
 

--- a/tests/test_preflight_structured_and_guards.py
+++ b/tests/test_preflight_structured_and_guards.py
@@ -27,8 +27,8 @@ from rfx.geometry.csg import Box
 # ---------------------------------------------------------------- (a) records
 def test_preflight_returns_back_compatible_structured_issues():
     sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
-    sim.add_source((0.01, 0.01, 0.018), component="ez")   # near CPML => issue
-    sim.add_probe((0.01, 0.01, 0.019), component="ez")
+    sim.add_source((0.01, 0.01, 0.021), component="ez")   # in exterior CPML (#500)
+    sim.add_probe((0.01, 0.01, 0.022), component="ez")
     report = sim.preflight()
     assert report, "expected a preflight finding for a source/probe in CPML"
     for issue in report:
@@ -49,8 +49,8 @@ def test_preflight_report_is_a_list_with_canonical_api():
     """PreflightReport IS a list (back-compat) AND mirrors the in-repo report
     idiom (.issues/.errors/.warnings/.ok/.format()/.to_dict()/.to_json())."""
     sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
-    sim.add_source((0.01, 0.01, 0.018), component="ez")   # near CPML => issue
-    sim.add_probe((0.01, 0.01, 0.019), component="ez")
+    sim.add_source((0.01, 0.01, 0.021), component="ez")   # in exterior CPML (#500)
+    sim.add_probe((0.01, 0.01, 0.022), component="ez")
     report = sim.preflight()
     assert isinstance(report, PreflightReport) and isinstance(report, list)
     # list[str] ops the 65 legacy call sites rely on
@@ -73,8 +73,8 @@ def test_codes_set_at_check_site():
     emitting check.
     """
     sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
-    sim.add_source((0.01, 0.01, 0.018), component="ez")
-    sim.add_probe((0.01, 0.01, 0.019), component="ez")
+    sim.add_source((0.01, 0.01, 0.021), component="ez")   # in exterior CPML (#500)
+    sim.add_probe((0.01, 0.01, 0.022), component="ez")
     report = sim.preflight()
     absorber = report.by_code("absorber_overlap")
     assert absorber, f"expected absorber_overlap code, got {[i.code for i in report]}"
@@ -154,8 +154,8 @@ def test_lossy_dielectric_silent():
 # ------------------------------------------------ (d) Phase A meta-coverage
 def _bad_sim_probe_in_cpml():
     sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
-    sim.add_source((0.01, 0.01, 0.018), component="ez")   # absorber_overlap
-    sim.add_probe((0.01, 0.01, 0.019), component="ez")
+    sim.add_source((0.01, 0.01, 0.021), component="ez")   # in exterior CPML (#500)
+    sim.add_probe((0.01, 0.01, 0.022), component="ez")
     return sim
 
 
@@ -259,8 +259,8 @@ def test_strict_aggregates_all_issues_in_one_raise():
     raise), not fail-on-first — preserving the historical 'strict escalates any
     issue' contract while reporting all problems at once."""
     sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
-    sim.add_source((0.01, 0.01, 0.018), component="ez")   # near CPML
-    sim.add_probe((0.01, 0.01, 0.019), component="ez")     # near CPML
+    sim.add_source((0.01, 0.01, 0.021), component="ez")   # in exterior CPML (#500)
+    sim.add_probe((0.01, 0.01, 0.022), component="ez")     # in exterior CPML (#500)
     # strict=False shows >= 2 findings...
     report = sim.preflight()
     assert len(report) >= 2, f"need a multi-issue config; got {list(report)}"
@@ -365,13 +365,21 @@ def test_absorber_overlap_no_false_positive_on_2d_collapsed_z():
 
 
 def test_absorber_overlap_still_fires_on_2d_xy():
-    """The 2D-z exemption must not silence real x/y absorber overlap."""
+    """The 2D-z exemption must not silence real x/y absorber overlap.
+
+    Issue #500: CPML pads EXTERIOR to the requested domain (see
+    rfx-known-issues.md #500), so a source has to sit at a genuinely
+    negative x (past the x=0 domain edge, inside the 2e-6m-thick x_lo
+    absorber: cpml_layers=20 * dx=1e-7) to be "in" it — x=1e-7 (interior,
+    just past the edge) used to false-fire under the pre-#500
+    interior-frame bug but is not actually in the absorber.
+    """
     sim = Simulation(domain=(16e-6, 9e-6, 1e-7), freq_max=7.5e13, dx=1e-7,
                      boundary="upml", cpml_layers=20, mode="2d_tmz")
-    sim.add_source((1e-7, 4.5e-6, 0), component="ez")   # deep in x_lo absorber
+    sim.add_source((-5e-7, 4.5e-6, 0), component="ez")   # genuinely in x_lo absorber
     report = sim.preflight()
     overlap = report.by_code("absorber_overlap")
-    assert overlap, "expected absorber_overlap for a source at the x_lo edge"
+    assert overlap, "expected absorber_overlap for a source in the x_lo absorber"
     assert any("x-thickness" in str(i) for i in overlap)
 
 

--- a/tests/test_preflight_structured_and_guards.py
+++ b/tests/test_preflight_structured_and_guards.py
@@ -27,7 +27,7 @@ from rfx.geometry.csg import Box
 # ---------------------------------------------------------------- (a) records
 def test_preflight_returns_back_compatible_structured_issues():
     sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
-    sim.add_source((0.01, 0.01, 0.021), component="ez")   # in exterior CPML (#500)
+    sim.add_source((0.01, 0.01, 0.0225), component="ez")  # exterior CPML: nz=47, pad=16/16 -> interior idx 16..30 (last interior z~=20.99mm); 0.0225 rounds to idx 31, first exterior node (#500 L7)
     sim.add_probe((0.01, 0.01, 0.022), component="ez")
     report = sim.preflight()
     assert report, "expected a preflight finding for a source/probe in CPML"
@@ -49,7 +49,7 @@ def test_preflight_report_is_a_list_with_canonical_api():
     """PreflightReport IS a list (back-compat) AND mirrors the in-repo report
     idiom (.issues/.errors/.warnings/.ok/.format()/.to_dict()/.to_json())."""
     sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
-    sim.add_source((0.01, 0.01, 0.021), component="ez")   # in exterior CPML (#500)
+    sim.add_source((0.01, 0.01, 0.0225), component="ez")  # exterior CPML: nz=47, pad=16/16 -> interior idx 16..30 (last interior z~=20.99mm); 0.0225 rounds to idx 31, first exterior node (#500 L7)
     sim.add_probe((0.01, 0.01, 0.022), component="ez")
     report = sim.preflight()
     assert isinstance(report, PreflightReport) and isinstance(report, list)
@@ -73,7 +73,7 @@ def test_codes_set_at_check_site():
     emitting check.
     """
     sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
-    sim.add_source((0.01, 0.01, 0.021), component="ez")   # in exterior CPML (#500)
+    sim.add_source((0.01, 0.01, 0.0225), component="ez")  # exterior CPML: nz=47, pad=16/16 -> interior idx 16..30 (last interior z~=20.99mm); 0.0225 rounds to idx 31, first exterior node (#500 L7)
     sim.add_probe((0.01, 0.01, 0.022), component="ez")
     report = sim.preflight()
     absorber = report.by_code("absorber_overlap")
@@ -154,7 +154,7 @@ def test_lossy_dielectric_silent():
 # ------------------------------------------------ (d) Phase A meta-coverage
 def _bad_sim_probe_in_cpml():
     sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
-    sim.add_source((0.01, 0.01, 0.021), component="ez")   # in exterior CPML (#500)
+    sim.add_source((0.01, 0.01, 0.0225), component="ez")  # exterior CPML: nz=47, pad=16/16 -> interior idx 16..30 (last interior z~=20.99mm); 0.0225 rounds to idx 31, first exterior node (#500 L7)
     sim.add_probe((0.01, 0.01, 0.022), component="ez")
     return sim
 
@@ -259,7 +259,7 @@ def test_strict_aggregates_all_issues_in_one_raise():
     raise), not fail-on-first — preserving the historical 'strict escalates any
     issue' contract while reporting all problems at once."""
     sim = Simulation(domain=(0.02,) * 3, freq_max=10e9, boundary="cpml")
-    sim.add_source((0.01, 0.01, 0.021), component="ez")   # in exterior CPML (#500)
+    sim.add_source((0.01, 0.01, 0.0225), component="ez")  # exterior CPML: nz=47, pad=16/16 -> interior idx 16..30 (last interior z~=20.99mm); 0.0225 rounds to idx 31, first exterior node (#500 L7)
     sim.add_probe((0.01, 0.01, 0.022), component="ez")     # in exterior CPML (#500)
     # strict=False shows >= 2 findings...
     report = sim.preflight()

--- a/tests/test_run_preflight_parity.py
+++ b/tests/test_run_preflight_parity.py
@@ -15,10 +15,19 @@ from rfx.api import Simulation
 
 
 def _sim_with_probe_in_cpml():
-    # Probe + source pushed to the very edge => preflight flags CPML overlap.
+    # Probe placed past the domain edge, genuinely inside the (exterior-
+    # padded) CPML => preflight flags absorber_overlap. Issue #500: CPML
+    # pads EXTERIOR to the requested domain (see rfx-known-issues.md
+    # #500 / tests/test_preflight_absorber_frame.py), so a probe merely
+    # near an edge but still within [0, 0.02] no longer trips this check
+    # (z=0.018 here used to false-fire under the pre-#500 interior-frame
+    # bug this file doesn't otherwise care about — it only needs ANY one
+    # real preflight warning to exercise the run()-parity/consolidation
+    # mechanism this file tests, and absorber_overlap is the original,
+    # still-legitimate, and cheapest trigger to construct).
     sim = Simulation(domain=(0.02, 0.02, 0.02), freq_max=10e9, boundary="cpml")
     sim.add_source((0.01, 0.01, 0.01), component="ez")
-    sim.add_probe((0.01, 0.01, 0.018), component="ez")
+    sim.add_probe((0.01, 0.01, 0.021), component="ez")
     return sim
 
 

--- a/tests/test_run_preflight_parity.py
+++ b/tests/test_run_preflight_parity.py
@@ -25,9 +25,19 @@ def _sim_with_probe_in_cpml():
     # real preflight warning to exercise the run()-parity/consolidation
     # mechanism this file tests, and absorber_overlap is the original,
     # still-legitimate, and cheapest trigger to construct).
+    #
+    # Node arithmetic (review finding L7): this domain (0.02m, freq_max=
+    # 10e9, default cpml_layers=16) auto-resolves dx~=1.499mm, giving
+    # nz=47 with pad_z_lo=pad_z_hi=16 -> interior absolute indices 16..30
+    # (last interior node 30 = z~=20.99mm). z=0.021 rounds to node 30
+    # (round(0.021/dx)+16 = 30) -- still the LAST INTERIOR node, so it
+    # only "fired" via _absorber_boundary_for_axis's up-to-one-cell
+    # hi-side conservatism (see that helper's docstring), not because it
+    # was genuinely exterior. z=0.0225 rounds to node 31, the first node
+    # outside the interior slice -- genuinely in the absorber.
     sim = Simulation(domain=(0.02, 0.02, 0.02), freq_max=10e9, boundary="cpml")
     sim.add_source((0.01, 0.01, 0.01), component="ez")
-    sim.add_probe((0.01, 0.01, 0.021), component="ez")
+    sim.add_probe((0.01, 0.01, 0.0225), component="ez")
     return sim
 
 


### PR DESCRIPTION
## What / why

Closes #500. The preflight absorber-overlap validators compared user coordinates against an INTERIOR-CPML frame while the uniform grid pads the absorber EXTERIOR — false positives on correct geometry, and none of the checks had a single test (#303 class).

**Ground truth established first, not assumed**: `Grid.__init__` pads exterior (`nx = ceil(domain/dx)+1+pad_lo+pad_hi`; node `pad_x_lo` ↔ user x=0), reproducing the issue's own WR-90 numbers exactly (nx=578; absorber occupies [−27.940, 0] and [90.678, 118.618] mm — the user's [0, 90.678] mm domain is absorber-free). `make_nonuniform_grid` pads the same way, and `_validate_simulation_config` runs unconditionally, so the fix applies identically to both lanes (committed as ground-truth proof tests).

## Per-consumer classification (all 5 = the same bug class)

| consumer | before | after |
|---|---|---|
| `_validate_cfg_absorber_placement` | false positive (domain-centre probe warned) | routed through `_coord_in_absorber` |
| `_validate_cfg_geometry_in_cpml` | false positive (box near edge) | fixed; the "intentional edge" heuristic deleted as unnecessary |
| `_validate_cfg_ntff_absorber_overlap` | false positive (box corner near edge) | routed through `_absorber_boundary_for_axis` |
| `_validate_cfg_waveguide_reference_plane` | false positive (the #499-documented WR-90 case) | fixed; the branch is now provably unreachable (identical to the hard bounds check above it) — kept as a documented no-op |
| `_check_msl_port_geometry` (checks 1&3) | false positive (port 600 µm from edge read as −200 µm clearance) | fixed; `cpml_thick_lo/hi` params dropped — the boundary is the domain edge under every boundary type |

One canonical helper pair (`_absorber_boundary_for_axis`, `_coord_in_absorber`) encodes the exterior-padding truth; every consumer converts through it.

## Tests — including five pre-existing tests that encoded the bug

**Five pre-existing tests placed geometry per the WRONG frame and passed anyway** (testing the wrong physics green — the gate-binds-artifact class): corrected to place geometry genuinely in the absorber. New `tests/test_preflight_absorber_frame.py` (14): 2 ground-truth proofs, a firing + non-firing pair per consumer, and a regression lock for the #499 false positive. Mutation falsifier: swapping the helper's lo/hi assignment reds exactly the 6 non-firing/regression tests, each for the expected reason (recorded, reverted).

Advisory-only surface: no gates, no physics numbers. Warnings that were spurious disappear — that is the point (#500); warnings that should fire are pinned by the firing tests.

## Verification

592+103 tests across all preflight/contract-touching files, zero failures, zero new warnings; ruff repo-wide clean; `check_api_reference.py` OK.

R3: memory=#303 class (right-quantity-wrong-comparison guards) + feedback_gate_can_bind_artifact (five green tests encoding the defect) | R2-attempts=0 (diagnosis was the issue's own; ground truth reproduced before touching code) | falsifier=the lo/hi-swap mutation, run and recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)


**Review rounds** (all applied at 34cd4c0):
- Round 1 found a SIXTH pre-existing interior-frame test (the run()-auto-preflight parity fixture) → fixed; round 2 found the fix's z=0.021 landed on the last interior node (firing only via the helper's conservative rounding) and a SEVENTH encoding test — the #470 user-probe lock. Placements corrected to genuinely-exterior nodes with the node arithmetic in comments.
- **#470-pairing decision**: proximity semantics were load-bearing (two independent call sites broke) — a NEW `absorber_proximity` advisory now fires for user probes/sources genuinely interior but within 2 cells of an active absorber boundary (witness probes stay exempt per #478; the 2-cell default's provenance stated honestly — #510 names the hazard class, no prior calibration pins a count; chosen above the helper's ≤1-cell conservatism so rounding alone cannot trigger it). Both broken call sites are cited in the advisory docstring as its motivating regressions.
- **Calibrated MSL buffer restored**: checks 1&3 re-gain the absorber-side buffer as `n_cpml·dx` read from the configured layers (scales; not a hardcoded 8) on top of the exterior-frame helper, citing the ledger's "CALIBRATED, OpenEMS-class" LY ≥ W + 2·(2·h_sub + 8·dx) record and its negative-clearance Z0-bias incident.
- MSL checks now route through `_absorber_boundary_for_axis` → the lo/hi-swap mutation falsifier red-set grew 6 → **16** (incl. the MSL and proximity paths and 6 out-of-file tests; the inverted docstring record fixed); helper docstring corrected to "conservative by up to one cell".
- Counts at 34cd4c0: guards-and-preflight CI selection 149 passed / 1 pre-existing skip / 0 failed; targeted 39/39; 14-file preflight sweep 120/120; ruff clean.
