### PR TITLE
Referee excitation guard: absolute floor DROPPED — the repo's D5/#465 record proves the populations overlap

### DIFF
--- a/tests/test_coax_two_port_referee_header.py
+++ b/tests/test_coax_two_port_referee_header.py
@@ -497,25 +497,31 @@ def test_check_excitation_and_trace_uses_drive_correct_channel():
     uf_inc_self)"). Checking ``uf_inc`` unconditionally, as before,
     would silently verify the WRONG channel for the reverse drive --
     this test builds a fake port where uf_inc is healthy but uf_ref is
-    near-zero (the launched channel for a reverse drive) and checks the
-    function catches it when told to look at uf_ref, and does NOT catch
-    it (wrongly reports healthy) when defaulted to uf_inc -- proving the
-    ``channel`` parameter actually changes behavior, not just exists.
+    dropped (exactly zero, the openEMS "port never coupled" signature)
+    and checks the function catches it when told to look at uf_ref, and
+    does NOT catch it (wrongly reports healthy) when defaulted to
+    uf_inc -- proving the ``channel`` parameter actually changes
+    behavior, not just exists.
 
-    Run-2 fix: fake values are now at openEMS's own REAL scale (a
-    healthy real run reads ~1.79e-13 to 1.93e-12, per the #540 round-1
-    review), not an assumed O(1) -- the ORIGINAL version of this test
-    used uf_inc=1.0, which is exactly the wrong-scale assumption that let
-    the first floor (1e-6) go unnoticed as mis-scaled by ~6 orders.
+    Run-3 rescope (PR #547 review): the guard is SCALE-FREE (see
+    ``_check_excitation_and_trace``'s own docstring -- the ``[D5]``
+    pattern, ``rfx/interop/emitters/openems.py``, and issue #465/PR #473
+    already fixed this exact false-fire class in this repo once).
+    Fake values are still at openEMS's own real scale (a healthy real
+    run reads ~1.79e-13 to 1.93e-12, per
+    ``docs/design_notes/geometry_setup_interop.md``) to keep the test
+    honest about scale, but the "broken" channel is now an EXACT zero,
+    not merely small -- a nonzero-but-small value like the previously
+    used 6e-14 is not a failure signature at all once there is no floor,
+    and asserting it would raise re-introduces the refuted invariant
+    this round removes.
     """
     module = _load_referee_module()
 
     class _FakePort:
         U_filenames: list = []
         uf_inc = np.array([5.0e-13 + 0j])   # healthy, real openEMS scale
-        uf_ref = np.array([6.0e-14 + 0j])   # near-zero -- the RECORDED
-                                             # failure value (do-not-repeat
-                                             # file), also the launched
+        uf_ref = np.array([0.0 + 0j])       # dropped -- the launched
                                              # channel for a reverse drive
 
     port = _FakePort()
@@ -525,26 +531,32 @@ def test_check_excitation_and_trace_uses_drive_correct_channel():
     assert inc_peak == 5.0e-13
 
     # channel="uf_ref" (the reverse-drive's own launched channel) MUST
-    # raise -- this is the near-zero one, mirroring the do-not-repeat
-    # file's own recorded "uf_inc~6e-14" failure signature.
+    # raise -- this one is exactly zero (the openEMS dropped-port
+    # signature), not merely small.
     try:
         module._check_excitation_and_trace(port, "/tmp/_unused", "test", channel="uf_ref")
-        assert False, "expected near-zero uf_ref to raise when channel='uf_ref'"
+        assert False, "expected zero uf_ref to raise when channel='uf_ref'"
     except RuntimeError as exc:
         assert "uf_ref" in str(exc)
 
 
-def test_excitation_floor_discriminates_recorded_healthy_and_failure_band():
-    """Run-2 fix (2026-08-03, PR #546 follow-up after VESSL 369367251627):
-    the FIRST floor (1e-6) rejected a genuinely healthy, converged Stage A
-    REAL run -- run-2's own artifact shows uf_inc=1.241e-12 tripping it,
-    a value squarely inside the healthy band the #540 round-1 review
-    itself recorded for real runs (1.79e-13 to 1.93e-12). This test pins
-    the corrected floor (``_EXCITATION_ENERGY_FLOOR``) against that exact
-    recorded band: the historical healthy-minimum must PASS, the
-    do-not-repeat file's own recorded failure (6e-14) must FAIL -- not
-    just "some floor exists", but that IT SITS BETWEEN the two recorded
-    numbers.
+def test_excitation_check_is_scale_free_not_an_absolute_floor():
+    """Run-3 fix (2026-08-03, PR #547 review): TWO successive rounds of
+    this module tuned an ABSOLUTE floor on ``inc_peak`` (1e-6, then a
+    "corrected" 1e-13) -- both refuted by the SAME repo's own proven
+    guard: ``[D5]`` in ``rfx/interop/emitters/openems.py`` (~line 1676)
+    records "a verified-good small run on this install peaked at
+    |uf_inc| ~ 3e-14" -- BELOW both tried floors AND below the
+    do-not-repeat file's own recorded "failure" value (6e-14): the
+    healthy and broken populations OVERLAP in openEMS's raw units, so no
+    absolute floor separates them. This exact false-fire was already
+    diagnosed and fixed once in this repo (issue #465, PR #473,
+    ``8578fcd``) -- the fix that shipped is scale-free (exact-zero/
+    non-finite only), which is what this test pins: a value SMALLER than
+    every floor this module has ever tried (1e-14, well below the
+    verified-good 3e-14 the D5 guard itself cites) must still PASS,
+    because it is finite and nonzero -- only an exact zero (or NaN) is a
+    defect signature.
     """
     module = _load_referee_module()
 
@@ -554,72 +566,28 @@ def test_excitation_floor_discriminates_recorded_healthy_and_failure_band():
         def __init__(self, uf_inc):
             self.uf_inc = np.array([uf_inc + 0j])
 
-    # Recorded healthy-minimum (#540 round-1 review) -- must PASS.
-    healthy = _FakePort(1.79e-13)
-    inc_peak, _ = module._check_excitation_and_trace(healthy, "/tmp/_unused", "healthy")
-    assert inc_peak == 1.79e-13
-
-    # Recorded failure (do-not-repeat file, "uf_inc~6e-14") -- must FAIL.
-    broken = _FakePort(6.0e-14)
-    try:
-        module._check_excitation_and_trace(broken, "/tmp/_unused", "broken")
-        assert False, "expected the recorded failure value (6e-14) to raise"
-    except RuntimeError:
-        pass
-
-    # The floor itself must sit strictly between the two recorded values
-    # -- a regression that moves it outside this band (either direction)
-    # should fail here even if the two cases above coincidentally still
-    # pass/fail correctly for some other reason.
-    assert 6.0e-14 < module._EXCITATION_ENERGY_FLOOR < 1.79e-13
-
-
-def test_excitation_check_smoke_mode_exempts_the_floor():
-    """Run-2 fix: a smoke run's own excitation is DELIBERATELY truncated
-    (200 timesteps, ``end_criteria=0.0``) -- a near-zero reading there is
-    EXPECTED, not a defect. ``is_smoke=True`` must only reject an exact
-    zero or non-finite reading (the pre-M1 check), never the real-run
-    floor -- this is what run-2 needed: NOT because a current caller
-    routes smoke data through this function (neither Stage A's nor Stage
-    B's smoke build ever calls ``CalcPort`` on its own ports, so none
-    currently does -- verified by reading both call sites), but because
-    the exemption must be a tested, correct invariant for whenever a
-    smoke-time check like this is wired in, and because the DEFAULT
-    (``is_smoke=False``) must still apply the real floor unchanged.
-    """
-    module = _load_referee_module()
-
-    class _FakePort:
-        U_filenames: list = []
-
-        def __init__(self, uf_inc):
-            self.uf_inc = np.array([uf_inc + 0j])
-
-    # A near-zero (but nonzero, finite) reading -- exactly what a
-    # deliberately-truncated smoke pulse would plausibly leave behind.
-    near_zero = _FakePort(1e-14)
-
-    # is_smoke=True: must NOT raise -- near-zero is expected on a smoke run.
-    inc_peak, _ = module._check_excitation_and_trace(
-        near_zero, "/tmp/_unused", "smoke", is_smoke=True)
+    # Smaller than every floor this module has tried (1e-6, then 1e-13)
+    # AND smaller than the D5 guard's own verified-good value (3e-14) --
+    # must still PASS. This is the discriminating case: an absolute-floor
+    # regression (reintroducing any positive threshold) fails here.
+    tiny_but_real = _FakePort(1e-14)
+    inc_peak, _ = module._check_excitation_and_trace(tiny_but_real, "/tmp/_unused", "tiny")
     assert inc_peak == 1e-14
 
-    # The SAME value, is_smoke=False (default): MUST raise -- this is
-    # exactly run-2's regression class if the smoke flag were forgotten.
-    try:
-        module._check_excitation_and_trace(near_zero, "/tmp/_unused", "real")
-        assert False, "expected the real-run floor to reject this near-zero value"
-    except RuntimeError:
-        pass
+    # Exact zero (the openEMS dropped-port signature) and NaN must still
+    # raise -- scale-free does not mean "anything goes".
+    for broken_value in (0.0, float("nan")):
+        broken = _FakePort(broken_value)
+        try:
+            module._check_excitation_and_trace(broken, "/tmp/_unused", "broken")
+            assert False, f"expected {broken_value!r} to raise"
+        except RuntimeError:
+            pass
 
-    # is_smoke=True must still reject a TRUE zero or non-finite reading
-    # -- the exemption is for "near-zero", not "anything at all".
-    dead = _FakePort(0.0)
-    try:
-        module._check_excitation_and_trace(dead, "/tmp/_unused", "smoke", is_smoke=True)
-        assert False, "expected an exact-zero reading to raise even under is_smoke=True"
-    except RuntimeError:
-        pass
+    assert not hasattr(module, "_EXCITATION_ENERGY_FLOOR"), (
+        "an absolute floor constant must not exist -- PR #547 review "
+        "refuted it via the repo's own D5 guard and issue #465/PR #473"
+    )
 
 
 def test_main_writes_valid_json_on_stage_b_physics_gate_failure(monkeypatch, tmp_path):

--- a/tests/test_coax_two_port_referee_header.py
+++ b/tests/test_coax_two_port_referee_header.py
@@ -500,20 +500,29 @@ def test_check_excitation_and_trace_uses_drive_correct_channel():
     near-zero (the launched channel for a reverse drive) and checks the
     function catches it when told to look at uf_ref, and does NOT catch
     it (wrongly reports healthy) when defaulted to uf_inc -- proving the
-    ``channel`` parameter actually changes behavior, not just exists."""
+    ``channel`` parameter actually changes behavior, not just exists.
+
+    Run-2 fix: fake values are now at openEMS's own REAL scale (a
+    healthy real run reads ~1.79e-13 to 1.93e-12, per the #540 round-1
+    review), not an assumed O(1) -- the ORIGINAL version of this test
+    used uf_inc=1.0, which is exactly the wrong-scale assumption that let
+    the first floor (1e-6) go unnoticed as mis-scaled by ~6 orders.
+    """
     module = _load_referee_module()
 
     class _FakePort:
         U_filenames: list = []
-        uf_inc = np.array([1.0 + 0j])       # healthy
-        uf_ref = np.array([1e-14 + 0j])     # near-zero -- the launched
+        uf_inc = np.array([5.0e-13 + 0j])   # healthy, real openEMS scale
+        uf_ref = np.array([6.0e-14 + 0j])   # near-zero -- the RECORDED
+                                             # failure value (do-not-repeat
+                                             # file), also the launched
                                              # channel for a reverse drive
 
     port = _FakePort()
 
-    # Default (uf_inc) must NOT raise -- uf_inc is healthy.
+    # Default (uf_inc) must NOT raise -- uf_inc is healthy at real scale.
     inc_peak, _ = module._check_excitation_and_trace(port, "/tmp/_unused", "test")
-    assert inc_peak == 1.0
+    assert inc_peak == 5.0e-13
 
     # channel="uf_ref" (the reverse-drive's own launched channel) MUST
     # raise -- this is the near-zero one, mirroring the do-not-repeat
@@ -523,6 +532,94 @@ def test_check_excitation_and_trace_uses_drive_correct_channel():
         assert False, "expected near-zero uf_ref to raise when channel='uf_ref'"
     except RuntimeError as exc:
         assert "uf_ref" in str(exc)
+
+
+def test_excitation_floor_discriminates_recorded_healthy_and_failure_band():
+    """Run-2 fix (2026-08-03, PR #546 follow-up after VESSL 369367251627):
+    the FIRST floor (1e-6) rejected a genuinely healthy, converged Stage A
+    REAL run -- run-2's own artifact shows uf_inc=1.241e-12 tripping it,
+    a value squarely inside the healthy band the #540 round-1 review
+    itself recorded for real runs (1.79e-13 to 1.93e-12). This test pins
+    the corrected floor (``_EXCITATION_ENERGY_FLOOR``) against that exact
+    recorded band: the historical healthy-minimum must PASS, the
+    do-not-repeat file's own recorded failure (6e-14) must FAIL -- not
+    just "some floor exists", but that IT SITS BETWEEN the two recorded
+    numbers.
+    """
+    module = _load_referee_module()
+
+    class _FakePort:
+        U_filenames: list = []
+
+        def __init__(self, uf_inc):
+            self.uf_inc = np.array([uf_inc + 0j])
+
+    # Recorded healthy-minimum (#540 round-1 review) -- must PASS.
+    healthy = _FakePort(1.79e-13)
+    inc_peak, _ = module._check_excitation_and_trace(healthy, "/tmp/_unused", "healthy")
+    assert inc_peak == 1.79e-13
+
+    # Recorded failure (do-not-repeat file, "uf_inc~6e-14") -- must FAIL.
+    broken = _FakePort(6.0e-14)
+    try:
+        module._check_excitation_and_trace(broken, "/tmp/_unused", "broken")
+        assert False, "expected the recorded failure value (6e-14) to raise"
+    except RuntimeError:
+        pass
+
+    # The floor itself must sit strictly between the two recorded values
+    # -- a regression that moves it outside this band (either direction)
+    # should fail here even if the two cases above coincidentally still
+    # pass/fail correctly for some other reason.
+    assert 6.0e-14 < module._EXCITATION_ENERGY_FLOOR < 1.79e-13
+
+
+def test_excitation_check_smoke_mode_exempts_the_floor():
+    """Run-2 fix: a smoke run's own excitation is DELIBERATELY truncated
+    (200 timesteps, ``end_criteria=0.0``) -- a near-zero reading there is
+    EXPECTED, not a defect. ``is_smoke=True`` must only reject an exact
+    zero or non-finite reading (the pre-M1 check), never the real-run
+    floor -- this is what run-2 needed: NOT because a current caller
+    routes smoke data through this function (neither Stage A's nor Stage
+    B's smoke build ever calls ``CalcPort`` on its own ports, so none
+    currently does -- verified by reading both call sites), but because
+    the exemption must be a tested, correct invariant for whenever a
+    smoke-time check like this is wired in, and because the DEFAULT
+    (``is_smoke=False``) must still apply the real floor unchanged.
+    """
+    module = _load_referee_module()
+
+    class _FakePort:
+        U_filenames: list = []
+
+        def __init__(self, uf_inc):
+            self.uf_inc = np.array([uf_inc + 0j])
+
+    # A near-zero (but nonzero, finite) reading -- exactly what a
+    # deliberately-truncated smoke pulse would plausibly leave behind.
+    near_zero = _FakePort(1e-14)
+
+    # is_smoke=True: must NOT raise -- near-zero is expected on a smoke run.
+    inc_peak, _ = module._check_excitation_and_trace(
+        near_zero, "/tmp/_unused", "smoke", is_smoke=True)
+    assert inc_peak == 1e-14
+
+    # The SAME value, is_smoke=False (default): MUST raise -- this is
+    # exactly run-2's regression class if the smoke flag were forgotten.
+    try:
+        module._check_excitation_and_trace(near_zero, "/tmp/_unused", "real")
+        assert False, "expected the real-run floor to reject this near-zero value"
+    except RuntimeError:
+        pass
+
+    # is_smoke=True must still reject a TRUE zero or non-finite reading
+    # -- the exemption is for "near-zero", not "anything at all".
+    dead = _FakePort(0.0)
+    try:
+        module._check_excitation_and_trace(dead, "/tmp/_unused", "smoke", is_smoke=True)
+        assert False, "expected an exact-zero reading to raise even under is_smoke=True"
+    except RuntimeError:
+        pass
 
 
 def test_main_writes_valid_json_on_stage_b_physics_gate_failure(monkeypatch, tmp_path):

--- a/validation/research/coax_two_port/openems_coax_two_port_referee.py
+++ b/validation/research/coax_two_port/openems_coax_two_port_referee.py
@@ -877,18 +877,34 @@ def _run_openems_capturing_stdout(fdtd, sim_path: str, *, threads: int) -> str:
         return logf.read()
 
 
-_EXCITATION_ENERGY_FLOOR = 1e-6
-"""M1 fix (PR #546 review): a FLOOR, not an exact-zero check -- the
-do-not-repeat file's own recorded failure mode for a different port
-class reads "weak/zero coupling with uf_inc~6e-14"; a floor of 1e-6 sits
-many orders of magnitude above that recorded noise floor while staying
-far below any genuinely-coupled signal for excite_amp=1.0. Documented,
-not measured from a real run (no local openEMS to calibrate against --
-external scripts get no rfx preflight, external_solver_comparator.md)."""
+_EXCITATION_ENERGY_FLOOR = 1e-13
+"""Run-2 fix (2026-08-03, PR #546 follow-up review after VESSL
+369367251627): the FIRST floor (1e-6) was mis-scaled by ~6 ORDERS OF
+MAGNITUDE and rejected a genuinely healthy, converged Stage A REAL run
+-- run-2's own artifact (.omx/coax-two-port-referee/20260803T171906Z/)
+shows the exception fired from ``_run_stage_a_reproduce_gate``'s call on
+``port1`` AFTER the real (not smoke) FDTD run and its own ``CalcPort``,
+reading uf_inc=1.241e-12 -- a value that lands squarely inside the
+healthy band the #540 round-1 review itself recorded for REAL runs in
+openEMS's own raw (non-normalized) units: 1.79e-13 to 1.93e-12. The
+recorded FAILURE mode (do-not-repeat file, a different port class) is
+6e-14 -- only ~3x below that healthy-min, not the ~7-8 orders of margin
+1e-6 assumed. This floor (1e-13) sits ~1.8x below the recorded
+healthy-min and ~1.7x above the recorded failure: a CHEAP, HONEST
+tripwire with only ~3x historical separation, not a precise
+discriminator. The load-bearing checks for genuine coupling quality are
+downstream: Stage A's ZL gate (port1.Z_ref vs the analytic closed form)
+and the matched-through witness (|S21|, phase, group delay) -- both
+fail LOUD and specifically if the excitation is subtly wrong in a way
+this coarse floor cannot catch. Do not tighten this floor without a
+freshly measured band from a real run; do not loosen it below the
+recorded failure value either.
+"""
 
 
 def _check_excitation_and_trace(port, sim_path: str, label: str, *,
-                                channel: str = "uf_inc") -> tuple[float, int]:
+                                channel: str = "uf_inc",
+                                is_smoke: bool = False) -> tuple[float, int]:
     """Hand-ported sanity checks (a) + (b): nonzero energy + nonzero trace.
 
     ``channel`` selects WHICH of the port's own two wave components is
@@ -900,17 +916,34 @@ def _check_excitation_and_trace(port, sim_path: str, label: str, *,
     (NOT uf_inc_self)"). Checking ``uf_inc`` unconditionally, as before,
     silently verified the WRONG channel for the reverse drive.
 
+    ``is_smoke`` (run-2 fix): a smoke run's own excitation is
+    DELIBERATELY truncated (``min(200, nrts)`` timesteps, per
+    ``_run_stage_a_reproduce_gate``/``_run_one_drive``) -- a near-zero
+    reading there is EXPECTED, not a defect, so ``is_smoke=True`` only
+    rejects an exact-zero or non-finite reading (the original, pre-M1
+    check), never the floor above. No current caller passes
+    ``is_smoke=True`` (neither Stage A's nor Stage B's smoke build ever
+    calls ``CalcPort`` on its own discarded ports, so this function is
+    never actually invoked on smoke data today) -- the parameter exists
+    so the exemption is a tested, enforced invariant if a smoke-time
+    excitation check is ever wired in, not an assumption.
+
     Works generically across port classes: ``CoaxialPort.U_filenames``
     holds 3 entries (its 3-plane differential probe), ``AddLumpedPort``
     held 1 -- this function just iterates whatever list is there.
     """
     launched = np.asarray(getattr(port, channel), dtype=np.complex128)
     inc_peak = float(np.max(np.abs(launched))) if launched.size else 0.0
-    if not np.isfinite(inc_peak) or inc_peak < _EXCITATION_ENERGY_FLOOR:
+    if is_smoke:
+        broken = not np.isfinite(inc_peak) or inc_peak == 0.0
+    else:
+        broken = not np.isfinite(inc_peak) or inc_peak < _EXCITATION_ENERGY_FLOOR
+    if broken:
+        floor_desc = "0 (smoke)" if is_smoke else repr(_EXCITATION_ENERGY_FLOOR)
         raise RuntimeError(
             f"[{label}] openEMS port injected/received NO (or near-zero) "
             f"wave energy on its own launched channel ({channel}="
-            f"{inc_peak!r} < floor {_EXCITATION_ENERGY_FLOOR!r}): "
+            f"{inc_peak!r} < floor {floor_desc}): "
             f"excitation did not couple or the port never saw the wave."
         )
     n_samples = 0

--- a/validation/research/coax_two_port/openems_coax_two_port_referee.py
+++ b/validation/research/coax_two_port/openems_coax_two_port_referee.py
@@ -877,35 +877,49 @@ def _run_openems_capturing_stdout(fdtd, sim_path: str, *, threads: int) -> str:
         return logf.read()
 
 
-_EXCITATION_ENERGY_FLOOR = 1e-13
-"""Run-2 fix (2026-08-03, PR #546 follow-up review after VESSL
-369367251627): the FIRST floor (1e-6) was mis-scaled by ~6 ORDERS OF
-MAGNITUDE and rejected a genuinely healthy, converged Stage A REAL run
--- run-2's own artifact (.omx/coax-two-port-referee/20260803T171906Z/)
-shows the exception fired from ``_run_stage_a_reproduce_gate``'s call on
-``port1`` AFTER the real (not smoke) FDTD run and its own ``CalcPort``,
-reading uf_inc=1.241e-12 -- a value that lands squarely inside the
-healthy band the #540 round-1 review itself recorded for REAL runs in
-openEMS's own raw (non-normalized) units: 1.79e-13 to 1.93e-12. The
-recorded FAILURE mode (do-not-repeat file, a different port class) is
-6e-14 -- only ~3x below that healthy-min, not the ~7-8 orders of margin
-1e-6 assumed. This floor (1e-13) sits ~1.8x below the recorded
-healthy-min and ~1.7x above the recorded failure: a CHEAP, HONEST
-tripwire with only ~3x historical separation, not a precise
-discriminator. The load-bearing checks for genuine coupling quality are
-downstream: Stage A's ZL gate (port1.Z_ref vs the analytic closed form)
-and the matched-through witness (|S21|, phase, group delay) -- both
-fail LOUD and specifically if the excitation is subtly wrong in a way
-this coarse floor cannot catch. Do not tighten this floor without a
-freshly measured band from a real run; do not loosen it below the
-recorded failure value either.
-"""
-
-
 def _check_excitation_and_trace(port, sim_path: str, label: str, *,
-                                channel: str = "uf_inc",
-                                is_smoke: bool = False) -> tuple[float, int]:
+                                channel: str = "uf_inc") -> tuple[float, int]:
     """Hand-ported sanity checks (a) + (b): nonzero energy + nonzero trace.
+
+    SCALE-FREE by design (run-2 fix, 2026-08-03, PR #547 review): no
+    absolute floor on ``inc_peak``, only exact-zero/non-finite, plus the
+    independent time-domain trace witness below. This is NOT a new
+    invention -- it mirrors the proven ``[D5]`` guard in
+    ``rfx/interop/emitters/openems.py`` (lines ~1673-1678) verbatim:
+    "No absolute floor is used on purpose: a verified-good small run on
+    this install peaked at |uf_inc| ~ 3e-14, so the 1e-9 floor some
+    hand-written comparators use would false-fire here." That 3e-14
+    verified-GOOD value sits BELOW both this script's own two
+    successively-tried floors (1e-6, then 1e-13) -- the healthy and
+    broken populations OVERLAP in openEMS's raw units, so no absolute
+    scale separates them.
+
+    This exact problem was already found and fixed ONCE in this repo:
+    issue #465 (closed via PR #473, ``8578fcd``) diagnosed precisely
+    this false-fire (a `uf_inc <= 1e-9` guard rejecting a normal run
+    measured at 1.9e-12) and the fix that shipped is this same
+    scale-free pattern -- ``docs/design_notes/geometry_setup_interop.md``
+    records both the healthy measurements (1.93e-12 PEC-cavity, 1.79e-13
+    MSL-thru) AND its own conclusion: "That threshold is live in
+    scripts/diagnostics/build_coaxial_line_openems_broad_comparison.py
+    ... and is worth auditing before it is reused. The emitter instead
+    tests for zero/non-finite plus an independent port time-trace
+    witness." ``build_coaxial_line_openems_broad_comparison.py`` (the
+    SAME do-not-repeat file this module's own header cites) was itself
+    updated by that fix and now carries the identical scale-free guard
+    with a comment naming issue #465 directly. Two rounds of this
+    module's own floor-tuning (1e-6, then a "corrected" 1e-13) took the
+    healthy/failure NUMBERS from these records without their own
+    concluding sentence -- this round removes the floor entirely rather
+    than re-tuning it a third time.
+
+    Weak/marginal coupling that is NOT exact-zero is NOT this function's
+    job to catch -- it is caught downstream, where it has to show up in
+    the actual physics: Stage A's ZL gate (port1.Z_ref vs the analytic
+    closed form) and matched-through witness (|S21|, phase, group
+    delay), and Stage B's passivity/reciprocity witnesses. Those fail
+    loud and specifically; an absolute floor here cannot, because it has
+    no scale to be specific about.
 
     ``channel`` selects WHICH of the port's own two wave components is
     the one THIS DRIVE actually launched (M1 fix, PR #546 review): for
@@ -916,34 +930,16 @@ def _check_excitation_and_trace(port, sim_path: str, label: str, *,
     (NOT uf_inc_self)"). Checking ``uf_inc`` unconditionally, as before,
     silently verified the WRONG channel for the reverse drive.
 
-    ``is_smoke`` (run-2 fix): a smoke run's own excitation is
-    DELIBERATELY truncated (``min(200, nrts)`` timesteps, per
-    ``_run_stage_a_reproduce_gate``/``_run_one_drive``) -- a near-zero
-    reading there is EXPECTED, not a defect, so ``is_smoke=True`` only
-    rejects an exact-zero or non-finite reading (the original, pre-M1
-    check), never the floor above. No current caller passes
-    ``is_smoke=True`` (neither Stage A's nor Stage B's smoke build ever
-    calls ``CalcPort`` on its own discarded ports, so this function is
-    never actually invoked on smoke data today) -- the parameter exists
-    so the exemption is a tested, enforced invariant if a smoke-time
-    excitation check is ever wired in, not an assumption.
-
     Works generically across port classes: ``CoaxialPort.U_filenames``
     holds 3 entries (its 3-plane differential probe), ``AddLumpedPort``
     held 1 -- this function just iterates whatever list is there.
     """
     launched = np.asarray(getattr(port, channel), dtype=np.complex128)
     inc_peak = float(np.max(np.abs(launched))) if launched.size else 0.0
-    if is_smoke:
-        broken = not np.isfinite(inc_peak) or inc_peak == 0.0
-    else:
-        broken = not np.isfinite(inc_peak) or inc_peak < _EXCITATION_ENERGY_FLOOR
-    if broken:
-        floor_desc = "0 (smoke)" if is_smoke else repr(_EXCITATION_ENERGY_FLOOR)
+    if not np.isfinite(inc_peak) or inc_peak == 0.0:
         raise RuntimeError(
-            f"[{label}] openEMS port injected/received NO (or near-zero) "
-            f"wave energy on its own launched channel ({channel}="
-            f"{inc_peak!r} < floor {floor_desc}): "
+            f"[{label}] openEMS port injected/received NO wave energy on "
+            f"its own launched channel ({channel}={inc_peak!r}): "
             f"excitation did not couple or the port never saw the wave."
         )
     n_samples = 0


### PR DESCRIPTION
## The arc, honestly

Run-2 (7.2 s exit-1) exposed that the excitation guard's floor was mis-scaled 6 orders (1e-6 vs openEMS's healthy ~1e-12 band). The first fix in this PR recalibrated to 1e-13 — and review refuted the PREMISE: the repo's own proven [D5] guard (`rfx/interop/emitters/openems.py`) records a verified-GOOD run at |uf_inc| ~ 3e-14, BELOW any workable floor and below the 6e-14 "failure" signature — the healthy and failure populations OVERLAP, so no absolute floor separates them. Both records the band numbers came from end with exactly that conclusion ("no absolute scale assumed"; "worth auditing before it is reused"), and issue #465/PR #473 already fixed this exact false-fire class once — in the same do-not-repeat file this module cites.

## Final state (f6c9e80)

- `_EXCITATION_ENERGY_FLOOR` deleted. `_check_excitation_and_trace` = exact-zero/non-finite on the drive-correct launched channel (forward=uf_inc / reverse=uf_ref) + the time-domain trace witness — identical semantics to D5 and to the post-#465 guard in the do-not-repeat file itself. `is_smoke` removed (nothing left to exempt).
- Weak-coupling discrimination is owned, as it always was, by the load-bearing witnesses: Stage A's ZL gate vs the analytic closed form + matched-through; Stage B's passivity + reciprocity.
- `test_excitation_check_is_scale_free_not_an_absolute_floor`: 1e-14 (below D5's verified-good 3e-14) must PASS; exact zero and NaN must fail; the floor constant must not exist as an attribute. The two floor-pinning tests are deleted (they cemented the refuted invariant by construction). The channel test's "broken" value is now exact zero — the real dropped-port signature.
- Docstring cites the D5 guard, geometry_setup_interop.md, and #465/PR #473 by name.

Verified: run-2's rejected healthy value (1.241e-12) passes, as does 100× smaller. 22 header tests, ruff clean, rfx-side fixtures unaffected. The PR #546 physics falsifier is untouched — run-3 is its first actual test.

R3: memory=the D5 no-floor record + #465/PR #473 (two rounds of floor-tuning contradicted a closed issue's shipped fix; the guard has now come full circle to the original scale-free design, with the rationale finally written where the next author will read it) | R2-attempts=0 physics | falsifier=the scale-freedom test, committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)