### PR TITLE
PR #516 verification debt: the bisecting-mesh V·I/flux identity measured for the first time (HELD) + three discriminating tests (#520)

### DIFF
--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -137,8 +137,9 @@ def msl_modal_voltage(ez_plane, *, j_centre: int, k_lo: int, k_hi: int,
     unterminated single-port reading of this same identity on the
     bisecting mesh (issue #525) read low (0.54-0.69) for two compounding,
     non-extractor reasons — a convention slip (see #525's own correction)
-    and a reactive, non-travelling fixture (reactive fraction 0.963-0.995) —
-    neither of which is present in the committed measurement.
+    and a reactive, non-travelling fixture (reactive fraction 0.963-0.995,
+    PR #549 review reconstruction) — neither of which is present in the
+    committed measurement.
     """
     if k_hi <= k_lo:
         raise ValueError(

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -128,6 +128,17 @@ def msl_modal_voltage(ez_plane, *, j_centre: int, k_lo: int, k_hi: int,
     frequencies — **on the aligned dx = 84.67 µm mesh**; that identity is
     the falsifier for THIS span (ground→trace underside) and holds only
     when the top anchor is the true trace node.
+
+    The BISECTING mesh (dx = 80 µm, the mesh class this span anchoring
+    actually changes behaviour on) has since been measured too, on a
+    properly terminated two-port fixture (issue #520 leg 1;
+    ``scripts/diagnostics/msl_vi_flux_oracle.py`` + its committed JSON):
+    HELD, ratio 1.0105-1.0118, 30/30 admissible cells. An earlier
+    unterminated single-port reading of this same identity on the
+    bisecting mesh (issue #525) read low (0.54-0.69) for two compounding,
+    non-extractor reasons — a convention slip (see #525's own correction)
+    and a reactive, non-travelling fixture (reactive fraction 0.963-0.995) —
+    neither of which is present in the committed measurement.
     """
     if k_hi <= k_lo:
         raise ValueError(

--- a/scripts/diagnostics/msl_vi_flux_oracle.py
+++ b/scripts/diagnostics/msl_vi_flux_oracle.py
@@ -14,8 +14,16 @@ V and I are built from the trace-anchored span (``msl_modal_voltage`` /
 Poynting flux is accumulated by a DIFFERENT kernel entirely
 (``rfx/probes/probes.py:flux_spectrum``, fed by ``rfx/simulation.py``'s own
 H-field spatial-averaging + half-step phase correction — see
-``rfx/simulation.py:1470-1523``). The two paths share no code, so agreement
-is a genuine, independent check, not a tautology.
+``rfx/simulation.py:1470-1523``). Agreement is not tautological: R is not
+computed from its own numerator or denominator restated (unlike the
+now-deleted convention check this PR replaced, see CONVENTION below). But
+code-path separation is not the relevant strength claim, and this script
+does not claim "genuine, independent" as if that closed the question --
+``scripts/msl_flux_ratio_dof.py`` (the #525/#531 closure artifact) shows R
+constrains exactly ONE real degree of freedom of (V, I) -- the product
+``Re(V·conj(I))`` -- while the wave split the extractor actually uses
+(``a, b = 0.5·(V ± Z0_ref·I)``) and the separately reported analytic Z0
+both depend on V and I SEPARATELY. See DOF BLINDNESS below.
 
 PR #516 measured this identity ONLY on the aligned mesh (dx = h_sub/3 =
 84.667 µm, h_sub/dx = 3.0000) and got 1.006-1.009 — the EASY case, where the
@@ -45,9 +53,10 @@ This script is the committed re-measurement #525's own follow-up comment
      test_msl_thru_line_passive_gate``, drives only the near port, and
      leaves the far port passively matched (``add_msl_port(..., excite=
      False)`` → resistive Z0 termination via the port's own σ distribution,
-     ``rfx/sources/msl_port.py`` ``MSLPort`` docstring: "False → passive
-     matched termination only") — NOT relying on CPML alone to absorb the
-     guided mode;
+     ``rfx/api/__init__.py`` ``add_msl_port`` docstring: "``True`` →
+     resistive termination + active source; ``False`` → passive matched
+     termination only") — NOT relying on CPML alone to absorb the guided
+     mode;
   4. BOTH mesh classes: aligned (dx = h_sub/3, frac(h_sub/dx) = 0) and
      bisecting (dx = 80 µm, frac = 0.175, the MESH-ALIGNMENT RULE danger
      zone — docs/agent-memory/rfx-known-issues.md, "Added 2026-07-30").
@@ -57,16 +66,24 @@ CONVENTION (assert, not comment)
 ``flux_spectrum()`` returns ``sum(Re(E1·conj(H2) - E2·conj(H1)) * dA)`` with
 NO ½ prefactor (``rfx/probes/probes.py`` docstring, verbatim: "∫ Re(E × H*)
 · n̂ dA"). The oracle therefore compares ``Re(V·conj(I))`` — ALSO no ½ —
-directly against ``flux_spectrum()``. A "time-averaged power" reading would
-put ½ on BOTH sides, which is a mathematical no-op on the RATIO — #525
-root-caused the prior session's factor-of-2 discrepancy to applying ½ to the
-V·I side only, while the flux side stayed unhalved. ``run_one()`` computes
-the ratio both ways (no halves; halves on both) and asserts they are
-numerically identical, so a future asymmetric-½ slip fails loudly instead of
-silently reintroducing the factor-of-2 bug. A second defensive assertion
-greps ``flux_spectrum``'s own source for a stray ``0.5 *`` so a convention
-change in the library itself cannot silently invalidate this script's
-premise.
+directly against ``flux_spectrum()``, via the single choke point
+``_oracle_ratio()``. A "time-averaged power" reading would put ½ on BOTH
+sides, which is a mathematical no-op on the RATIO — #525 root-caused the
+prior session's factor-of-2 discrepancy to applying ½ to the V·I side only,
+while the flux side stayed unhalved.
+
+An earlier version of this script "verified" that by computing the ratio
+both ways (no halves; halves on both) and asserting they matched — which is
+a TAUTOLOGY (``X/Y == (0.5X)/(0.5Y)`` for any ``X, Y`` whatsoever) and was
+removed on review (PR #549), the same defect class PR #531's review blocked
+in the sibling ``scripts/msl_flux_ratio_dof.py`` arc. The real guard is
+``_assert_half_factor_regression_is_caught()``, run once at the top of
+``main()``: it plants a ½ at the ``p_vi`` build site ONLY (exactly #525's
+own bug) on a small synthetic fixture and requires the ratio to visibly
+move (1.0 -> 0.5), which a symmetric both-sides check structurally cannot
+do. A second, independent defensive assertion greps ``flux_spectrum``'s own
+source for a stray ``0.5 *`` so a convention change in the library itself
+cannot silently invalidate this script's premise.
 
 ADMISSIBILITY WITNESS
 ----------------------
@@ -78,19 +95,55 @@ diverge:
     reactive_fraction = 1 − |Re(Σ integrand·dA)| / Σ |integrand|·dA
         (0 = fully travelling/real; 1 = fully reactive/cancelling)
     spread(f) = (max(flux_real) − min(flux_real)) / mean(|flux_real|)
-        across the 5 planes, at each frequency (a physical travelling wave
-        should read nearly flat across planes over this short line span).
+        across the 5 planes, at each frequency.
+
+These are NOT redundant checks of the same thing. ``spread`` follows from
+LOSSLESSNESS (conservation of net guided power along the lossless line),
+not from travelling-wave purity: a lossless line's net real Poynting flux
+through any cross-section is constant WHETHER OR NOT a standing wave is
+present (the standing wave lives in the REACTIVE part) — this is directly
+measured on a healthy, reciprocating-wave fixture in
+``scripts/msl_flux_ratio_dof.py`` ("R is flat because BOTH numerator and
+denominator are conserved along a lossless line"). ``reactive_fraction`` is
+the leg that actually flags a non-travelling, reactive-dominated plane —
+verified empirically (PR #549 review): re-running this admissibility
+witness on #525's original UNTERMINATED single-port fixture reads
+``spread`` in [0.011, 0.067] (i.e. it PASSES the 0.5 threshold below —
+spread alone would not have refused that fixture) while
+``reactive_fraction`` reads [0.963, 0.995] (decisively fails). So the
+witness legs are complementary, not interchangeable, and this script's
+AND-gate needs both; do not read either one alone as "the" admissibility
+check.
 
 A (plane, frequency) cell is ADMISSIBLE only if
 ``reactive_fraction <= REACTIVE_FRACTION_MAX`` (0.5 — majority-real) AND
-``spread <= SPREAD_MAX`` (0.5 — 50%), both pre-declared below and chosen to
-be far looser than #525's failed single-port fixture (472% spread) — a
-properly terminated fixture should clear them easily if the travelling-wave
-premise holds; failing even these loose bounds would itself be a finding.
-The oracle ratio is still printed at every cell for transparency, but
-INADMISSIBLE cells are excluded from the pass/fail verdict and flagged in
-the JSON — reporting a ratio computed from mostly-reactive power as a
-physics claim is refused, per #525 comment 2.
+``spread <= SPREAD_MAX`` (0.5 — 50%), both pre-declared below. The oracle
+ratio is still printed at every cell for transparency, but INADMISSIBLE
+cells are excluded from the pass/fail verdict and flagged in the JSON —
+reporting a ratio computed from mostly-reactive power as a physics claim is
+refused, per #525 comment 2.
+
+DOF BLINDNESS (both witness legs, not just the ratio)
+--------------------------------------------------------
+``scripts/msl_flux_ratio_dof.py`` proves algebraically AND measures that
+``R = Re(V·conj(I)) / flux`` is EXACTLY invariant under the power-preserving
+rescale ``(V, I) -> (aV, I/a)`` — ``Re(aV·conj(I/a)) = Re(V·conj(I))``
+identically — while the reported analytic Z0 and the wave split the
+extractor actually uses move under the SAME rescale. R constrains ONE real
+combination of (V, I); the extractor depends on the pair separately. This
+oracle's admissibility witnesses do not close that gap — they make it
+WORSE, structurally: both ``reactive_fraction`` and ``spread`` are computed
+purely from the flux monitor's own ``e1/e2/h1/h2`` fields, never from V or
+I at all, so they are ALSO exactly invariant under a ``(V, I) -> (aV, I/a)``
+defect — flux does not see V or I, so nothing about V or I individually can
+move a witness that never reads them. A defect that moves V and I in
+exactly that opposing pattern (constant product) would pass this script's
+ratio check AND both admissibility witnesses while corrupting every S value
+downstream. This is stated as a known, structural blind direction, not
+closed by this script; closing it needs a check on V and I SEPARATELY (the
+``v_abs``/``i_abs`` fields recorded per cell in the committed JSON exist
+for exactly that future purpose — e.g. against a closed-form Z0 on a
+matched line).
 
 FIXTURE
 -------
@@ -141,20 +194,121 @@ every admissible cell of both meshes:
     aligned  h_sub/3 (dx=84.667um, frac=0.0000): ratio 1.0083 .. 1.0090
     bisecting 80um   (dx=80.000um, frac=0.1750): ratio 1.0105 .. 1.0118
 
-This is the first-ever measurement of the bisecting-mesh identity (PR #516
-shipped only the aligned-mesh number). It does NOT reproduce #525's
-0.54-0.69 read on the bisecting class -- that number came from an
-untermined single-port-into-CPML fixture with a measured 472% plane-to-
-plane spread (a reactive, non-travelling-wave regime this script's
-admissibility witness exists to refuse) COMBINED with #525's own follow-up
-finding of an asymmetric 1/2-factor convention bug in that earlier,
-never-committed script. With a properly terminated fixture (far port
+This is the first-COMMITTED measurement of the bisecting-mesh identity (PR
+#516 shipped only the aligned-mesh number; #525 measured the bisecting mesh
+twice in an uncommitted /tmp harness -- see CORRECTION below, not
+"first-ever"). It does NOT reproduce #525's 0.54-0.69 as-posted read on the
+bisecting class -- that number came from an unterminated
+single-port-into-CPML fixture COMBINED with #525's own follow-up finding of
+an asymmetric 1/2-factor convention bug in that earlier, never-committed
+script (see CORRECTION below for the precise provenance and the
+convention-corrected comparison -- an earlier version of this note
+mis-attributed the 472%-spread/-122.9dB figures to the bisecting mesh --
+they are the ALIGNED mesh's). With a properly terminated fixture (far port
 `excite=False` -> resistive Z0 termination, not bare CPML absorption) and
 the symmetric no-half convention asserted here, the extractor-independent
 flux oracle holds tightly on BOTH mesh classes. This does not relitigate
 #525's own numbers (that script was never committed and is not re-run
 here); it establishes what the committed, falsifiable artifact reads on a
 fixture built to satisfy the admissibility bar #525 itself set.
+
+CORRECTION (PR #549 review, same day -- dated append, prior text above
+UNTOUCHED)
+--------------------------------------------------------------------------
+Five items from review (the reviewer reproduced this script's committed
+numbers byte-for-byte, then ran an independent unterminated-fixture control
+to check the provenance claims) -- two factual errors (1, 2), one code
+defect (3), and two additions (4, 5):
+
+1. PROVENANCE (MAJOR). The "472% plane-to-plane spread at a -122.9 dB
+   settling witness" figure quoted in the PRE-DECLARATION above is #525's
+   own measurement on the ALIGNED mesh (dx=84.67um), not the bisecting one
+   -- #525's own comment states it verbatim: "at dx = 84.67 µm the net flux
+   is ~1e-30 W with 472% / 147% / 304% plane-to-plane spread and random
+   sign, on a record settled to −122.9 dB". #525's own EARLIER "Probe 1"
+   comment independently confirms the bisecting column was the well-behaved
+   one: "The dx=80 column is smooth, monotone in k_top, and consistent
+   across frequency ... The dx=84.67 column is sign-flipping across
+   frequency ... It is the signature of a contaminated denominator." So the
+   reactive/spread pathology in #525's own record was an ALIGNED-mesh
+   phenomenon, and the PRE-DECLARATION's phrasing ("that fixture cannot see
+   a travelling wave") was correct about the OLD fixture in general but
+   wrongly localized the specific 472%/-122.9dB evidence to the bisecting
+   mesh discussion it appears next to.
+
+   Second: the ADMISSIBILITY WITNESS leg that actually refuses #525's old
+   UNTERMINATED fixture is REACTIVE_FRACTION, not spread. Reviewer's
+   reproduction of this script's own witness computation on that fixture:
+   spread in [0.011, 0.067] (PASSES this script's 0.5 threshold -- spread
+   alone would not have refused it) while reactive_fraction reads
+   [0.963, 0.995] (decisively fails). The ADMISSIBILITY WITNESS section
+   above has been corrected in place to state this (spread measures
+   losslessness/conservation, not travelling-wave purity; reactive_fraction
+   is the leg that catches a reactive, non-travelling plane).
+
+2. COMPARISON TO #525's CORRECTED NUMBER (MAJOR). #525 comment 2 itself
+   supplies the convention-corrected bisecting figure: the as-posted
+   0.54-0.69 read, once the asymmetric-1/2 bug is removed (both sides
+   un-halfed, doubling the ratio), becomes 1.20-1.34 -- table quoted
+   verbatim from #525: "dx = 80 µm (bisecting) | 0.54 – 0.69 | 1.20 – 1.34".
+   Review's own broader reconstruction across #525's full recorded data
+   reads 1.076-1.387, and review's independent re-run of the SAME
+   unterminated fixture (spread/reactive numbers in item 1 above) measured
+   ratio 1.0898-1.3867 -- matching #525's corrected figure to ~1%. So
+   #525's bisecting-mesh measurement is fully reproducible, and the
+   original 0.54-0.69 headline is jointly explained by (a) the 1/2-factor
+   convention bug and (b) the reactive, non-admissible fixture -- NOT by an
+   extractor defect on the bisecting mesh. This script's own committed
+   bisecting number (1.0105-1.0118, terminated fixture) is a DIFFERENT,
+   cleaner measurement, not a replication of #525's fixture, and should not
+   be read as "explaining away" #525's number by itself -- the
+   reconciliation above is what does that.
+
+   Also new: this script's ALIGNED-mesh number (1.0083-1.0090) resolves a
+   question #525 comment 2 explicitly left open -- "PR #516's '1.006–1.009
+   ⇒ the corrected V span is right' is only sound if that measurement
+   paired ½ with ½ — which I cannot check, because its harness was never
+   committed." This script's aligned measurement, built with the
+   convention explicitly stated and asserted (not assumed), lands at
+   1.0083-1.0090 -- matching PR #516's original 1.006-1.009 closely. That
+   resolves #525's open doubt IN PR #516's FAVOUR: PR #516's original
+   aligned-mesh measurement did use the correctly-paired convention: it was
+   not a coincidence that it read close to 1.
+
+3. THE TAUTOLOGICAL CONVENTION ASSERT (MAJOR). The CONVENTION section
+   above has been corrected in place: this script no longer asserts
+   ``p_vi/flux == (0.5*p_vi)/(0.5*flux)`` (true for any fixture, healthy or
+   broken -- the exact defect class PR #531's review blocked in
+   ``scripts/msl_flux_ratio_dof.py``). Removed; replaced by
+   ``_assert_half_factor_regression_is_caught()``, which plants a ½ at the
+   ``p_vi`` build site only and requires the ratio to move.
+
+4. THE FREE PROXY-SPAN MUTATION TWIN (MODERATE). The committed JSON now
+   carries, per plane per frequency, ``ratio_proxy_span`` -- the retired
+   ``round(h_sub/dx)`` (pre-#511/F2) span applied to the SAME
+   already-recorded fields, zero additional FDTD -- plus a per-mesh
+   ``proxy_ratio_range`` / ``proxy_span_falls_outside_band`` summary. On
+   the aligned mesh the proxy span equals the corrected span by
+   construction (k_top == trace_lo there), so this is an honest null
+   result. On the bisecting mesh it demonstrably falls outside
+   [0.85, 1.15] -- see the committed JSON for this run's exact numbers;
+   the oracle can tell the retired span from the corrected one.
+
+5. DOF BLINDNESS (MODERATE). Addressed in place above (new DOF BLINDNESS
+   subsection): the admissibility witnesses are not tautological with the
+   ratio's own numerator (they read the flux monitor's e1/e2/h1/h2 fields
+   directly, never V or I), but they share the ratio's blindness to a
+   product-preserving ``(V, I) -> (aV, I/a)`` defect, because neither
+   witness reads V or I at all. ``|V|``/``|I|`` are now recorded per cell
+   in the JSON (``v_abs``/``i_abs``) for a future check that closes this
+   direction; this script does not close it.
+
+Not relitigated here: #525's own numbers and its uncommitted harness are
+not re-run by this script (per its own recommendation, item 3: "commit the
+harness"). This script IS that committed harness, built to satisfy the bar
+#525 set, and the reconciliation above is arithmetic on #525's OWN
+published numbers plus the reviewer's independent reproduction -- not a new
+FDTD investigation into #525's fixture.
 """
 
 from __future__ import annotations
@@ -211,6 +365,64 @@ def _assert_flux_convention_unchanged() -> None:
         "flux_spectrum() source now contains a 0.5 factor — the no-half "
         "convention this script asserts against has changed upstream; "
         "re-derive the convention before trusting any ratio below."
+    )
+
+
+def _oracle_ratio(v, i, flux):
+    """The oracle's core arithmetic, and its ONLY choke point: no half
+    anywhere, on either side. ``run_one`` calls this rather than inlining
+    the expression so the anti-regression guard below tests the same code
+    path it is guarding, not a duplicate that could silently drift from
+    it.
+
+    Returns ``(p_vi, ratio)`` with ``p_vi = Re(V·conj(I))`` and
+    ``ratio = p_vi / flux``.
+    """
+    p_vi = np.real(v * np.conj(i))
+    ratio = p_vi / np.where(np.abs(flux) > 1e-300, flux, np.nan)
+    return p_vi, ratio
+
+
+def _assert_half_factor_regression_is_caught() -> None:
+    """Anti-regression guard for the #525 / PR #531 factor-of-2 class.
+
+    A prior version of this script asserted ``p_vi/flux == (0.5*p_vi)/(0.5*
+    flux)`` — TAUTOLOGICALLY true for any V, I, flux whatsoever, since
+    multiplying both the numerator and the denominator of a ratio by the
+    same constant never changes it. PR #549 review (correctly) named this
+    the exact defect class PR #531's review blocked in the sibling
+    ``scripts/msl_flux_ratio_dof.py`` arc: a "falsifier" whose alternative
+    outcome is algebraically unreachable is not a falsifier.
+
+    The regression this guards against is asymmetric, not symmetric: a
+    stray ``0.5`` at the ``p_vi`` BUILD site only (exactly #525's own bug —
+    a time-averaged ``0.5·Re(V·conj(I))`` divided by the un-averaged
+    ``flux_spectrum``). This plants that specific asymmetric mutation
+    through :func:`_oracle_ratio`'s own numerator expression and requires
+    the ratio to visibly move — a real discrimination, since the mutant
+    and the original are compared against each other, not each against a
+    correspondingly-scaled version of itself.
+    """
+    v = np.array([1.0 + 0.3j, 0.7 - 0.4j])
+    i = np.array([0.9 - 0.2j, 0.5 + 0.1j])
+    flux = np.real(v * np.conj(i))  # constructed so the healthy ratio is 1
+    p_vi, ratio = _oracle_ratio(v, i, flux)
+    assert np.allclose(ratio, 1.0), (
+        f"self-test fixture is not honest (expected ratio 1.0): {ratio}"
+    )
+    # THE regression: someone edits the p_vi expression (inside
+    # _oracle_ratio or a call site) to read `0.5 * np.real(v * np.conj(i))`
+    # without touching the flux side. Reproduce exactly that, over the SAME
+    # (unhalfed) flux used above.
+    p_vi_bad = 0.5 * np.real(v * np.conj(i))
+    ratio_bad = p_vi_bad / flux
+    assert np.allclose(ratio_bad, 0.5), (
+        f"planting a half at the p_vi build site should halve the ratio; "
+        f"got {ratio_bad} — this fixture no longer discriminates the bug"
+    )
+    assert not np.allclose(ratio_bad, ratio), (
+        "the anti-regression guard did not move the ratio relative to the "
+        "healthy computation — it is not discriminating"
     )
 
 
@@ -295,13 +507,16 @@ def run_one(label: str, dx: float) -> dict:
     dz_arr = _msl_cell_profile(grid, "z", grid.nz)
     hs_phase = np.exp(1j * 2.0 * np.pi * FREQS * float(grid.dt) * 0.5)
 
-    # Settling witness (end/peak Ez^2, dB) at every plane probe.
+    # Settling witness at every plane probe: PEAK-of-tail vs peak Ez^2, dB
+    # (not mean-of-tail -- mean is the more lenient of the two, ~5.6 dB so
+    # on the sibling msl_flux_ratio_dof.py fixture, PR #531 review; this is
+    # the label's own convention, applied honestly rather than relabelled).
     ts = np.asarray(res.time_series, dtype=float)
     settling_db = []
     for idx in range(len(plane_x)):
         p = ts[:, idx] ** 2
         tail = max(1, p.shape[0] // 10)
-        end = float(p[-tail:].mean())
+        end = float(p[-tail:].max())
         peak = float(p.max())
         tiny = np.finfo(float).tiny
         settling_db.append(10.0 * np.log10((end + tiny) / (peak + tiny)))
@@ -323,7 +538,6 @@ def run_one(label: str, dx: float) -> dict:
             jnp.asarray(hy_plane), jnp.asarray(hz_plane),
             j_lo=j_lo, j_hi=j_hi, k_trace_lo=trace_lo, k_trace_hi=trace_hi,
             dy_arr=dy_arr, dz_arr=dz_arr, direction="+x"))
-        p_vi = np.real(v * np.conj(i))  # no 1/2 -- see CONVENTION above
 
         mon = flux_mons[f"p{idx}_flux"]
         flux_lib = np.real(np.asarray(flux_spectrum(mon)))
@@ -347,17 +561,20 @@ def run_one(label: str, dx: float) -> dict:
         reactive_fraction = 1.0 - np.abs(flux_real_hand) / np.where(
             flux_mag > 0, flux_mag, np.nan)
 
-        # CONVENTION assertion: applying 1/2 to BOTH sides must be a no-op
-        # on the ratio (the only way #525's bug reproduces is an ASYMMETRIC
-        # half -- this assertion would catch that class of regression).
-        ratio_no_half = p_vi / np.where(np.abs(flux_lib) > 1e-300, flux_lib, np.nan)
-        ratio_both_halved = (0.5 * p_vi) / np.where(
-            np.abs(0.5 * flux_lib) > 1e-300, 0.5 * flux_lib, np.nan)
-        assert np.allclose(ratio_no_half, ratio_both_halved, equal_nan=True), (
-            f"{label} plane {idx}: half-both-sides ratio diverged from "
-            "no-half ratio -- this should be mathematically impossible and "
-            "signals a bug in this script's arithmetic, not the extractor."
-        )
+        p_vi, ratio_no_half = _oracle_ratio(v, i, flux_lib)
+
+        # Free mutation twin (#520 leg-1 MODERATE 1, PR #549 review): the
+        # RETIRED round(h_sub/dx) proxy span (k_hi=k_top, pre-#511/F2),
+        # recomputed from the SAME already-recorded ez_plane/i of this run
+        # -- zero additional FDTD. On the aligned mesh k_top == trace_lo so
+        # this is a no-op (matches PR #516's own bit-identical finding); on
+        # the bisecting mesh it drops the in-phase edge 3 and should read
+        # far outside the admissible band, demonstrating the oracle CAN
+        # tell the retired span from the corrected one.
+        v_proxy = np.asarray(msl_modal_voltage(
+            jnp.asarray(ez_plane), j_centre=j_c, k_lo=k_lo, k_hi=k_top,
+            dz_arr=dz_arr))
+        _, ratio_proxy = _oracle_ratio(v_proxy, i, flux_lib)
 
         flux_real_by_plane.append(flux_real_hand)
         per_plane.append(dict(
@@ -366,6 +583,18 @@ def run_one(label: str, dx: float) -> dict:
             flux_real=[float(x) for x in flux_real_hand],
             reactive_fraction=[float(x) for x in reactive_fraction],
             ratio=[float(x) for x in ratio_no_half],
+            ratio_proxy_span=[float(x) for x in ratio_proxy],
+            # |V|, |I| per cell (PR #549 review MODERATE 2): scripts/
+            # msl_flux_ratio_dof.py shows R = Re(V.conj(I))/flux is exactly
+            # invariant under the power-preserving rescale (V,I) ->
+            # (aV, I/a) -- and so, by construction, are reactive_fraction
+            # and spread above (both built from flux's own e1/e2/h1/h2
+            # fields, never from V or I). Recording |V|,|I| here is what a
+            # future re-run needs to additionally check the pair
+            # SEPARATELY (e.g. against a closed-form Z0) and close that
+            # blind direction; this script does not close it.
+            v_abs=[float(x) for x in np.abs(v)],
+            i_abs=[float(x) for x in np.abs(i)],
         ))
 
     flux_stack = np.array(flux_real_by_plane)  # (n_planes, n_freqs)
@@ -377,16 +606,19 @@ def run_one(label: str, dx: float) -> dict:
 
     admissible_cells = []
     all_cells = []
+    all_ratio_proxy = []
     for idx, row in enumerate(per_plane):
         for f_idx in range(len(FREQS)):
             rf = row["reactive_fraction"][f_idx]
             sp = float(spread_per_freq[f_idx])
             ratio = row["ratio"][f_idx]
+            ratio_proxy = row["ratio_proxy_span"][f_idx]
+            all_ratio_proxy.append(ratio_proxy)
             ok = (np.isfinite(rf) and rf <= REACTIVE_FRACTION_MAX
                  and np.isfinite(sp) and sp <= SPREAD_MAX)
             cell = dict(plane_idx=idx, freq_ghz=float(FREQS[f_idx] / 1e9),
                        reactive_fraction=rf, spread=sp, ratio=ratio,
-                       admissible=bool(ok))
+                       ratio_proxy_span=ratio_proxy, admissible=bool(ok))
             all_cells.append(cell)
             if ok:
                 admissible_cells.append(cell)
@@ -397,6 +629,15 @@ def run_one(label: str, dx: float) -> dict:
     verdict = (
         "INCONCLUSIVE" if inconclusive else
         ("HELD" if admissible_ratios and all(within_band) else "FALSIFIED")
+    )
+
+    # Free mutation twin verdict (#520 leg-1 MODERATE 1): does the oracle
+    # actually distinguish the retired proxy span from the corrected one?
+    # On the aligned mesh (k_top == trace_lo) it CANNOT by construction --
+    # that is the expected, honest null result there.
+    proxy_ratio_range = [round(min(all_ratio_proxy), 4), round(max(all_ratio_proxy), 4)]
+    proxy_falls_outside_band = any(
+        r < RATIO_LO or r > RATIO_HI for r in all_ratio_proxy
     )
 
     return dict(
@@ -416,12 +657,15 @@ def run_one(label: str, dx: float) -> dict:
             [round(min(admissible_ratios), 4), round(max(admissible_ratios), 4)]
             if admissible_ratios else None
         ),
+        proxy_ratio_range=proxy_ratio_range,
+        proxy_span_falls_outside_band=bool(proxy_falls_outside_band),
         verdict=verdict,
     )
 
 
 def main() -> int:
     _assert_flux_convention_unchanged()
+    _assert_half_factor_regression_is_caught()
 
     rows = []
     for label, dx in MESH_CLASSES:
@@ -434,6 +678,10 @@ def main() -> int:
         print(f"  spread_per_freq: {row['spread_per_freq']}")
         print(f"  admissible cells: {row['n_admissible']}/{row['n_total']}")
         print(f"  admissible ratio range: {row['admissible_ratio_range']}")
+        print(f"  retired-proxy-span ratio range (free mutation twin, zero "
+              f"new FDTD): {row['proxy_ratio_range']} "
+              f"{'OUTSIDE' if row['proxy_span_falls_outside_band'] else 'inside'} "
+              f"[{RATIO_LO}, {RATIO_HI}]")
         print(f"  VERDICT: {row['verdict']}")
         print("  --- preflight / warnings (verbatim) ---")
         for w in row["preflight_warnings"]:

--- a/scripts/diagnostics/msl_vi_flux_oracle.py
+++ b/scripts/diagnostics/msl_vi_flux_oracle.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""MSL modal V·I flux oracle — the standing falsifier for the extractor's
+core physical claim (issue #520 top item; origin: #525).
+
+PRE-DECLARATION (written before this script was run — R2-tight, one campaign)
+-------------------------------------------------------------------------------
+The extractor-independent oracle for the #511/#507-corrected modal voltage
+and Ampère-loop current is
+
+    Re(V · conj(I)) / flux_spectrum  ==  1
+
+V and I are built from the trace-anchored span (``msl_modal_voltage`` /
+``msl_loop_current``, ``rfx/api/_sparams.py`` / ``rfx/sources/msl_port.py``);
+Poynting flux is accumulated by a DIFFERENT kernel entirely
+(``rfx/probes/probes.py:flux_spectrum``, fed by ``rfx/simulation.py``'s own
+H-field spatial-averaging + half-step phase correction — see
+``rfx/simulation.py:1470-1523``). The two paths share no code, so agreement
+is a genuine, independent check, not a tautology.
+
+PR #516 measured this identity ONLY on the aligned mesh (dx = h_sub/3 =
+84.667 µm, h_sub/dx = 3.0000) and got 1.006-1.009 — the EASY case, where the
+rounding proxy and the rasterized trace node coincide (the PR's F2 anchoring
+fix is measured bit-identical there). The mesh class the fix actually
+changes behaviour on — dx = 80 µm, h_sub/dx = 3.175 (the committed
+``test_msl_thru_line_passive_gate`` mesh, inside preflight's [0.10, 0.40]
+mixed-cell danger zone) — had never had this identity measured; the PR body
+said so verbatim ("expected ~1 by construction; not yet measured on this
+mesh"). #525 then measured it on an UNTERMINATED single-port-into-CPML
+fixture and found the ratio dominated by reactive residue (0.54-0.69, later
+also found convention-contaminated by an asymmetric ½ factor — see
+CONVENTION below) with 472% plane-to-plane spread at a −122.9 dB settling
+witness — i.e. that fixture cannot see a travelling wave and its number is
+not a valid oracle measurement. Neither harness was ever committed.
+
+This script is the committed re-measurement #525's own follow-up comment
+(2026-08-02 priority bump) specified as the bar for the artifact:
+  1. state the convention and ASSERT it (not just comment it) — see
+     CONVENTION below and the runtime ``assert`` in ``run_one``;
+  2. an admissibility witness BEFORE the ratio — Re(E·H*) vs |E·H*| at each
+     plane (a reactive fraction) plus plane-to-plane flux spread — and
+     REFUSE to certify the ratio where the witness fails;
+  3. a TERMINATED fixture (matched thru, not a bare port into CPML) so the
+     plane sees a travelling wave — this script uses the SAME two-port thru
+     geometry as ``tests/test_msl_port_integration.py::
+     test_msl_thru_line_passive_gate``, drives only the near port, and
+     leaves the far port passively matched (``add_msl_port(..., excite=
+     False)`` → resistive Z0 termination via the port's own σ distribution,
+     ``rfx/sources/msl_port.py`` ``MSLPort`` docstring: "False → passive
+     matched termination only") — NOT relying on CPML alone to absorb the
+     guided mode;
+  4. BOTH mesh classes: aligned (dx = h_sub/3, frac(h_sub/dx) = 0) and
+     bisecting (dx = 80 µm, frac = 0.175, the MESH-ALIGNMENT RULE danger
+     zone — docs/agent-memory/rfx-known-issues.md, "Added 2026-07-30").
+
+CONVENTION (assert, not comment)
+---------------------------------
+``flux_spectrum()`` returns ``sum(Re(E1·conj(H2) - E2·conj(H1)) * dA)`` with
+NO ½ prefactor (``rfx/probes/probes.py`` docstring, verbatim: "∫ Re(E × H*)
+· n̂ dA"). The oracle therefore compares ``Re(V·conj(I))`` — ALSO no ½ —
+directly against ``flux_spectrum()``. A "time-averaged power" reading would
+put ½ on BOTH sides, which is a mathematical no-op on the RATIO — #525
+root-caused the prior session's factor-of-2 discrepancy to applying ½ to the
+V·I side only, while the flux side stayed unhalved. ``run_one()`` computes
+the ratio both ways (no halves; halves on both) and asserts they are
+numerically identical, so a future asymmetric-½ slip fails loudly instead of
+silently reintroducing the factor-of-2 bug. A second defensive assertion
+greps ``flux_spectrum``'s own source for a stray ``0.5 *`` so a convention
+change in the library itself cannot silently invalidate this script's
+premise.
+
+ADMISSIBILITY WITNESS
+----------------------
+Before trusting ``Re(V·conj(I)) / flux`` at a plane/frequency cell, this
+script reports — computed from the SAME flux-monitor accumulator fields the
+oracle divides by, so the witness and the ratio denominator can never
+diverge:
+
+    reactive_fraction = 1 − |Re(Σ integrand·dA)| / Σ |integrand|·dA
+        (0 = fully travelling/real; 1 = fully reactive/cancelling)
+    spread(f) = (max(flux_real) − min(flux_real)) / mean(|flux_real|)
+        across the 5 planes, at each frequency (a physical travelling wave
+        should read nearly flat across planes over this short line span).
+
+A (plane, frequency) cell is ADMISSIBLE only if
+``reactive_fraction <= REACTIVE_FRACTION_MAX`` (0.5 — majority-real) AND
+``spread <= SPREAD_MAX`` (0.5 — 50%), both pre-declared below and chosen to
+be far looser than #525's failed single-port fixture (472% spread) — a
+properly terminated fixture should clear them easily if the travelling-wave
+premise holds; failing even these loose bounds would itself be a finding.
+The oracle ratio is still printed at every cell for transparency, but
+INADMISSIBLE cells are excluded from the pass/fail verdict and flagged in
+the JSON — reporting a ratio computed from mostly-reactive power as a
+physics claim is refused, per #525 comment 2.
+
+FIXTURE
+-------
+Identical materials/geometry to the committed gate fixture
+(``tests/test_msl_port_integration.py``: EPS_R=3.66, H_SUB=254 µm,
+W_TRACE=600 µm, L_LINE=10 mm, one-cell PEC trace, PEC ground + CPML), TWO
+MSL ports (near driven ``+x``, far ``excite=False`` matched ``-x``), 5
+Ez/Hy/Hz DFT-plane probes + flux monitors placed at 30/40/50/60/70% of
+L_LINE — well clear of both the source-launch fringing zone (~5·h_sub ≈
+1.27 mm) and the passive-port termination near field, on EITHER end.
+
+PRE-DECLARED EXPECTATION (falsifiable, not adjusted after the run)
+--------------------------------------------------------------------
+On EVERY (plane, frequency) cell judged ADMISSIBLE by the witness above, on
+BOTH mesh classes:
+
+    0.85 <= Re(V·conj(I)) / flux_spectrum <= 1.15
+
+(a wider band than PR #516's 1.006-1.009 aligned-only number, because this
+is a fresh fixture/probe placement, not a replication of that run.)
+FALSIFIED if any admissible cell falls outside that band on EITHER mesh
+class — STOP and report the per-plane dump; a bisecting-mesh failure would
+be a FINDING (the extractor is imperfect there, consistent with #525's
+prior unterminated-fixture read of 0.54-0.69), not a script defect,
+PROVIDED the admissibility witness passed at that cell. If fewer than half
+of a mesh's (plane, frequency) cells are admissible, that mesh's identity
+check is INCONCLUSIVE (not a pass or a fail) and is reported as such — that
+would be a finding about this fixture's own regime, not a verdict on the
+extractor.
+
+RUNTIME
+-------
+2 mesh points x 1 FDTD run each (near port driven, far port passive;
+n_freqs=6, num_periods=30). ~2-5 min/point on one CPU core.
+
+    python scripts/diagnostics/msl_vi_flux_oracle.py
+
+POST-RUN REVIEW NOTE (2026-08-04, appended after the run; not part of the
+pre-declaration -- the committed JSON is the AS-RUN record, untouched)
+--------------------------------------------------------------------------
+OVERALL: HELD. Both mesh classes admitted all 30/30 (plane, frequency)
+cells (reactive_fraction and spread both far inside the pre-declared
+bounds on every cell -- the matched-thru fixture is nowhere near the
+472%-spread, reactive-dominated regime #525 measured on the single-port
+fixture) and the ratio landed inside the pre-declared [0.85, 1.15] band on
+every admissible cell of both meshes:
+
+    aligned  h_sub/3 (dx=84.667um, frac=0.0000): ratio 1.0083 .. 1.0090
+    bisecting 80um   (dx=80.000um, frac=0.1750): ratio 1.0105 .. 1.0118
+
+This is the first-ever measurement of the bisecting-mesh identity (PR #516
+shipped only the aligned-mesh number). It does NOT reproduce #525's
+0.54-0.69 read on the bisecting class -- that number came from an
+untermined single-port-into-CPML fixture with a measured 472% plane-to-
+plane spread (a reactive, non-travelling-wave regime this script's
+admissibility witness exists to refuse) COMBINED with #525's own follow-up
+finding of an asymmetric 1/2-factor convention bug in that earlier,
+never-committed script. With a properly terminated fixture (far port
+`excite=False` -> resistive Z0 termination, not bare CPML absorption) and
+the symmetric no-half convention asserted here, the extractor-independent
+flux oracle holds tightly on BOTH mesh classes. This does not relitigate
+#525's own numbers (that script was never committed and is not re-run
+here); it establishes what the committed, falsifiable artifact reads on a
+fixture built to satisfy the admissibility bar #525 itself set.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import sys
+import time
+import warnings
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+
+import numpy as np  # noqa: E402
+import jax.numpy as jnp  # noqa: E402
+
+from rfx import Box, Simulation  # noqa: E402
+from rfx.api._sparams import _msl_cell_profile, msl_modal_voltage  # noqa: E402
+from rfx.boundaries.spec import Boundary, BoundarySpec  # noqa: E402
+from rfx.probes.probes import flux_spectrum  # noqa: E402
+from rfx.sources.msl_port import MSLPort, _msl_yz_cells, msl_loop_current  # noqa: E402
+
+# --- gate-fixture geometry, verbatim from tests/test_msl_port_integration.py ---
+EPS_R = 3.66
+H_SUB = 254e-6
+W_TRACE = 600e-6
+L_LINE = 10e-3
+PORT_MARGIN = 2e-3
+F_MAX = 5e9
+
+FREQS = np.array([2.0e9, 2.5e9, 3.0e9, 3.5e9, 4.0e9, 4.5e9])
+PLANE_FRACS = [0.30, 0.40, 0.50, 0.60, 0.70]
+NUM_PERIODS = 30.0
+
+REACTIVE_FRACTION_MAX = 0.5
+SPREAD_MAX = 0.5
+RATIO_LO, RATIO_HI = 0.85, 1.15
+
+OUT_DIR = REPO / "scripts" / "diagnostics" / "msl_vi_flux_oracle"
+
+MESH_CLASSES = [
+    ("aligned h_sub/3", H_SUB / 3.0),
+    ("bisecting 80um (gate mesh)", 80e-6),
+]
+
+
+def _assert_flux_convention_unchanged() -> None:
+    """Defensive tripwire: fail loudly if ``flux_spectrum`` grows a stray
+    ½ prefactor this script's convention assumption did not anticipate."""
+    src = inspect.getsource(flux_spectrum)
+    body = src.split("def flux_spectrum", 1)[1]
+    assert "0.5 *" not in body and "* 0.5" not in body, (
+        "flux_spectrum() source now contains a 0.5 factor — the no-half "
+        "convention this script asserts against has changed upstream; "
+        "re-derive the convention before trusting any ratio below."
+    )
+
+
+def run_one(label: str, dx: float) -> dict:
+    lx = L_LINE + 2 * PORT_MARGIN
+    ly = W_TRACE + 2 * (2 * H_SUB + 8 * dx)
+    lz = H_SUB + 1.5e-3
+    y_c = ly / 2.0
+
+    sim = Simulation(
+        freq_max=F_MAX, domain=(lx, ly, lz), dx=dx, cpml_layers=8,
+        boundary=BoundarySpec(x="cpml", y="cpml",
+                              z=Boundary(lo="pec", hi="cpml")),
+    )
+    sim.add_material("ro4350b", eps_r=EPS_R)
+    sim.add(Box((0.0, 0.0, 0.0), (lx, ly, H_SUB)), material="ro4350b")
+    sim.add(Box((0.0, y_c - W_TRACE / 2.0, H_SUB),
+                (lx, y_c + W_TRACE / 2.0, H_SUB + dx)), material="pec")
+    # Near port: driven. Far port: excite=False -> passive matched
+    # termination (resistive sigma at Z0, not bare CPML absorption) so the
+    # planes between the two ports see a travelling wave, per #525 comment 2.
+    sim.add_msl_port(position=(PORT_MARGIN, y_c, 0.0), width=W_TRACE,
+                     height=H_SUB, direction="+x", impedance=50.0)
+    sim.add_msl_port(position=(PORT_MARGIN + L_LINE, y_c, 0.0), width=W_TRACE,
+                     height=H_SUB, direction="-x", impedance=50.0,
+                     excite=False)
+
+    plane_x = [PORT_MARGIN + f * L_LINE for f in PLANE_FRACS]
+    fj = jnp.asarray(FREQS)
+    for idx, x in enumerate(plane_x):
+        for comp in ("ez", "hy", "hz"):
+            sim.add_dft_plane_probe(axis="x", coordinate=float(x),
+                                    component=comp, freqs=fj,
+                                    name=f"p{idx}_{comp}")
+        sim.add_flux_monitor(axis="x", coordinate=float(x), freqs=fj,
+                             name=f"p{idx}_flux")
+        # Settling-witness point probe at the same plane, mid-substrate
+        # under the trace (project rule: quote end/peak energy for any
+        # fixed-length open-domain claims-bearing record).
+        sim.add_probe(position=(float(x), y_c, H_SUB / 2.0), component="ez")
+
+    grid = sim._build_grid()
+    mp0 = MSLPort(feed_x=PORT_MARGIN, y_lo=y_c - W_TRACE / 2.0,
+                  y_hi=y_c + W_TRACE / 2.0, z_lo=0.0, z_hi=H_SUB,
+                  direction="+x", impedance=50.0, excitation=None)
+    cells = _msl_yz_cells(grid, mp0)
+    j_set = sorted({c[1] for c in cells})
+    k_set = sorted({c[2] for c in cells})
+    j_lo, j_hi = j_set[0], j_set[-1]
+    k_lo, k_top = k_set[0], k_set[-1]
+    j_c = (j_lo + j_hi) // 2
+
+    pec_mask = np.asarray(sim._assemble_materials(grid)[3])
+    col = pec_mask[cells[0][0], j_c, k_top:]
+    kp = np.where(col)[0]
+    if kp.size == 0:
+        raise RuntimeError(f"{label}: no PEC trace conductor found above "
+                           "the substrate top — cannot locate trace node.")
+    trace_lo = int(k_top + kp.min())
+    trace_hi = int(k_top + kp.max())
+
+    n_sub_exact = H_SUB / dx
+    frac = n_sub_exact - int(n_sub_exact)
+
+    t0 = time.time()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        res = sim.run(num_periods=NUM_PERIODS, compute_s_params=False)
+    dt = time.time() - t0
+    # Filter the generic "x64 disabled" JAX dtype-fallback spam (fires on
+    # every accumulator allocation in this codebase when x64 is off, which
+    # this script deliberately leaves off -- repo rule forbids module-level
+    # x64) -- it is not a preflight/physics message and duplicates dozens of
+    # times per run. Genuine preflight/physics warnings are kept verbatim.
+    preflight_warnings = [
+        str(w.message) for w in caught
+        if "JAX_ENABLE_X64" not in str(w.message)
+        and "current-gotchas" not in str(w.message)
+    ]
+
+    dy_arr = _msl_cell_profile(grid, "y", grid.ny)
+    dz_arr = _msl_cell_profile(grid, "z", grid.nz)
+    hs_phase = np.exp(1j * 2.0 * np.pi * FREQS * float(grid.dt) * 0.5)
+
+    # Settling witness (end/peak Ez^2, dB) at every plane probe.
+    ts = np.asarray(res.time_series, dtype=float)
+    settling_db = []
+    for idx in range(len(plane_x)):
+        p = ts[:, idx] ** 2
+        tail = max(1, p.shape[0] // 10)
+        end = float(p[-tail:].mean())
+        peak = float(p.max())
+        tiny = np.finfo(float).tiny
+        settling_db.append(10.0 * np.log10((end + tiny) / (peak + tiny)))
+
+    planes = res.dft_planes
+    flux_mons = res.flux_monitors
+
+    per_plane = []
+    flux_real_by_plane = []  # (n_planes, n_freqs) for the spread witness
+    for idx in range(len(plane_x)):
+        ez_plane = np.asarray(planes[f"p{idx}_ez"].accumulator)
+        hy_plane = np.asarray(planes[f"p{idx}_hy"].accumulator) * hs_phase[:, None, None]
+        hz_plane = np.asarray(planes[f"p{idx}_hz"].accumulator) * hs_phase[:, None, None]
+
+        v = np.asarray(msl_modal_voltage(
+            jnp.asarray(ez_plane), j_centre=j_c, k_lo=k_lo, k_hi=trace_lo,
+            dz_arr=dz_arr))
+        i = np.asarray(msl_loop_current(
+            jnp.asarray(hy_plane), jnp.asarray(hz_plane),
+            j_lo=j_lo, j_hi=j_hi, k_trace_lo=trace_lo, k_trace_hi=trace_hi,
+            dy_arr=dy_arr, dz_arr=dz_arr, direction="+x"))
+        p_vi = np.real(v * np.conj(i))  # no 1/2 -- see CONVENTION above
+
+        mon = flux_mons[f"p{idx}_flux"]
+        flux_lib = np.real(np.asarray(flux_spectrum(mon)))
+
+        e1 = np.asarray(mon.e1_dft); e2 = np.asarray(mon.e2_dft)
+        h1 = np.asarray(mon.h1_dft); h2 = np.asarray(mon.h2_dft)
+        dA = np.asarray(mon.dA)
+        integrand = e1 * np.conj(h2) - e2 * np.conj(h1)
+        flux_real_hand = np.real(np.sum(integrand * dA, axis=(-2, -1)))
+        # Normalisation witness: the hand recompute from the monitor's own
+        # accumulator fields must match the library call bit-for-bit (same
+        # formula) -- this pins that reading mon.e1_dft/e2_dft/h1_dft/h2_dft
+        # directly (for the admissibility witness) is not a second, silently
+        # different convention from flux_spectrum() itself.
+        assert np.allclose(flux_real_hand, flux_lib, rtol=1e-6, atol=1e-30), (
+            f"{label} plane {idx}: hand Poynting recompute from mon.*_dft "
+            f"disagrees with flux_spectrum() -- convention mismatch, not a "
+            f"physics finding. hand={flux_real_hand} lib={flux_lib}"
+        )
+        flux_mag = np.sum(np.abs(integrand) * dA, axis=(-2, -1))
+        reactive_fraction = 1.0 - np.abs(flux_real_hand) / np.where(
+            flux_mag > 0, flux_mag, np.nan)
+
+        # CONVENTION assertion: applying 1/2 to BOTH sides must be a no-op
+        # on the ratio (the only way #525's bug reproduces is an ASYMMETRIC
+        # half -- this assertion would catch that class of regression).
+        ratio_no_half = p_vi / np.where(np.abs(flux_lib) > 1e-300, flux_lib, np.nan)
+        ratio_both_halved = (0.5 * p_vi) / np.where(
+            np.abs(0.5 * flux_lib) > 1e-300, 0.5 * flux_lib, np.nan)
+        assert np.allclose(ratio_no_half, ratio_both_halved, equal_nan=True), (
+            f"{label} plane {idx}: half-both-sides ratio diverged from "
+            "no-half ratio -- this should be mathematically impossible and "
+            "signals a bug in this script's arithmetic, not the extractor."
+        )
+
+        flux_real_by_plane.append(flux_real_hand)
+        per_plane.append(dict(
+            plane_idx=idx, x_frac=PLANE_FRACS[idx],
+            p_vi_real=[float(x) for x in p_vi],
+            flux_real=[float(x) for x in flux_real_hand],
+            reactive_fraction=[float(x) for x in reactive_fraction],
+            ratio=[float(x) for x in ratio_no_half],
+        ))
+
+    flux_stack = np.array(flux_real_by_plane)  # (n_planes, n_freqs)
+    spread_per_freq = (
+        (flux_stack.max(axis=0) - flux_stack.min(axis=0))
+        / np.where(np.abs(flux_stack).mean(axis=0) > 0,
+                  np.abs(flux_stack).mean(axis=0), np.nan)
+    )
+
+    admissible_cells = []
+    all_cells = []
+    for idx, row in enumerate(per_plane):
+        for f_idx in range(len(FREQS)):
+            rf = row["reactive_fraction"][f_idx]
+            sp = float(spread_per_freq[f_idx])
+            ratio = row["ratio"][f_idx]
+            ok = (np.isfinite(rf) and rf <= REACTIVE_FRACTION_MAX
+                 and np.isfinite(sp) and sp <= SPREAD_MAX)
+            cell = dict(plane_idx=idx, freq_ghz=float(FREQS[f_idx] / 1e9),
+                       reactive_fraction=rf, spread=sp, ratio=ratio,
+                       admissible=bool(ok))
+            all_cells.append(cell)
+            if ok:
+                admissible_cells.append(cell)
+
+    admissible_ratios = [c["ratio"] for c in admissible_cells]
+    within_band = [RATIO_LO <= r <= RATIO_HI for r in admissible_ratios]
+    inconclusive = len(admissible_cells) < 0.5 * len(all_cells)
+    verdict = (
+        "INCONCLUSIVE" if inconclusive else
+        ("HELD" if admissible_ratios and all(within_band) else "FALSIFIED")
+    )
+
+    return dict(
+        label=label, dx_um=round(dx * 1e6, 4),
+        n_sub_exact=round(n_sub_exact, 4), frac=round(frac, 4),
+        mixed_cell_danger_zone=bool(0.10 <= frac <= 0.40),
+        trace_node=trace_lo, k_lo=k_lo, k_top_proxy=k_top,
+        wallclock_s=round(dt, 1),
+        preflight_warnings=preflight_warnings,
+        settling_db=[round(x, 1) for x in settling_db],
+        spread_per_freq=[round(float(x), 4) for x in spread_per_freq],
+        per_plane=per_plane,
+        cells=all_cells,
+        n_admissible=len(admissible_cells),
+        n_total=len(all_cells),
+        admissible_ratio_range=(
+            [round(min(admissible_ratios), 4), round(max(admissible_ratios), 4)]
+            if admissible_ratios else None
+        ),
+        verdict=verdict,
+    )
+
+
+def main() -> int:
+    _assert_flux_convention_unchanged()
+
+    rows = []
+    for label, dx in MESH_CLASSES:
+        print(f"\n=== {label} (dx={dx * 1e6:.3f} um) ===", flush=True)
+        row = run_one(label, dx)
+        rows.append(row)
+        print(f"  h_sub/dx={row['n_sub_exact']:.4f} frac={row['frac']:.4f} "
+              f"trace_node={row['trace_node']} (proxy k_top={row['k_top_proxy']})")
+        print(f"  settling_db per plane: {row['settling_db']}")
+        print(f"  spread_per_freq: {row['spread_per_freq']}")
+        print(f"  admissible cells: {row['n_admissible']}/{row['n_total']}")
+        print(f"  admissible ratio range: {row['admissible_ratio_range']}")
+        print(f"  VERDICT: {row['verdict']}")
+        print("  --- preflight / warnings (verbatim) ---")
+        for w in row["preflight_warnings"]:
+            print(f"    {w}")
+
+    overall = "HELD" if all(r["verdict"] == "HELD" for r in rows) else (
+        "INCONCLUSIVE" if any(r["verdict"] == "INCONCLUSIVE" for r in rows)
+        and all(r["verdict"] in ("HELD", "INCONCLUSIVE") for r in rows)
+        else "FALSIFIED"
+    )
+    print(f"\nOVERALL: {overall}")
+    if overall == "FALSIFIED":
+        print("STOP: the flux identity failed on at least one admissible "
+              "cell of at least one mesh class. Per-plane dumps are in the "
+              "committed JSON below -- this is a finding, report it, do not "
+              "adjust the pre-declared band.")
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = OUT_DIR / "msl_vi_flux_oracle.json"
+    out_path.write_text(json.dumps({
+        "reactive_fraction_max": REACTIVE_FRACTION_MAX,
+        "spread_max": SPREAD_MAX,
+        "ratio_band": [RATIO_LO, RATIO_HI],
+        "rows": rows,
+        "overall": overall,
+    }, indent=2) + "\n")
+    print(f"\nwrote {out_path}", flush=True)
+    return 0 if overall in ("HELD", "INCONCLUSIVE") else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diagnostics/msl_vi_flux_oracle.py
+++ b/scripts/diagnostics/msl_vi_flux_oracle.py
@@ -78,12 +78,22 @@ a TAUTOLOGY (``X/Y == (0.5X)/(0.5Y)`` for any ``X, Y`` whatsoever) and was
 removed on review (PR #549), the same defect class PR #531's review blocked
 in the sibling ``scripts/msl_flux_ratio_dof.py`` arc. The real guard is
 ``_assert_half_factor_regression_is_caught()``, run once at the top of
-``main()``: it plants a ½ at the ``p_vi`` build site ONLY (exactly #525's
-own bug) on a small synthetic fixture and requires the ratio to visibly
-move (1.0 -> 0.5), which a symmetric both-sides check structurally cannot
-do. A second, independent defensive assertion greps ``flux_spectrum``'s own
-source for a stray ``0.5 *`` so a convention change in the library itself
-cannot silently invalidate this script's premise.
+``main()``. Its FIRST assertion — that the real, unmutated
+``_oracle_ratio()`` reads 1.0 on an honest synthetic fixture — IS the
+guard; everything after checks that the guard has discriminating power. It
+plants TWO independent mutations, both routed through the real
+``_oracle_ratio()`` call (not a hand-inlined duplicate expression): a ½ on
+the ``v`` (numerator) side only, exactly #525's own bug, which must halve
+the ratio (1.0 -> 0.5); and a ½ on the ``flux`` (denominator) side only —
+the mirror-image bug an unhalved-numerator check alone would miss — which
+must double it (1.0 -> 2.0). The second case matters because an unhalved
+numerator over a halved denominator is exactly the shape of #525's own
+"convention-corrected 2.01-2.02" misdiagnosis: a script-side factor bug
+that would surface as a false PHYSICS over-report rather than a caught
+regression. A second, independent defensive assertion greps
+``flux_spectrum``'s own source for a stray ``0.5 *`` so a convention
+change in the library itself cannot silently invalidate this script's
+premise.
 
 ADMISSIBILITY WITNESS
 ----------------------
@@ -106,10 +116,12 @@ measured on a healthy, reciprocating-wave fixture in
 ``scripts/msl_flux_ratio_dof.py`` ("R is flat because BOTH numerator and
 denominator are conserved along a lossless line"). ``reactive_fraction`` is
 the leg that actually flags a non-travelling, reactive-dominated plane —
-verified empirically (PR #549 review): re-running this admissibility
-witness on #525's original UNTERMINATED single-port fixture reads
-``spread`` in [0.011, 0.067] (i.e. it PASSES the 0.5 threshold below —
-spread alone would not have refused that fixture) while
+verified empirically (PR #549 review): running this admissibility witness
+on a reconstruction of #525's UNTERMINATED single-port fixture CLASS
+(#525's own harness was never committed, so this is this script's own
+geometry with the far port's termination removed, not a re-run of #525's
+literal code) reads ``spread`` in [0.011, 0.067] (i.e. it PASSES the 0.5
+threshold below — spread alone would not have refused that fixture) while
 ``reactive_fraction`` reads [0.963, 0.995] (decisively fails). So the
 witness legs are complementary, not interchangeable, and this script's
 AND-gate needs both; do not read either one alone as "the" admissibility
@@ -212,8 +224,10 @@ flux oracle holds tightly on BOTH mesh classes. This does not relitigate
 here); it establishes what the committed, falsifiable artifact reads on a
 fixture built to satisfy the admissibility bar #525 itself set.
 
-CORRECTION (PR #549 review, same day -- dated append, prior text above
-UNTOUCHED)
+CORRECTION (PR #549 review, same day -- dated append, plus in-place fixes
+to non-falsifiable explanatory prose only; every DECIDABLE pre-declaration
+element -- the 0.85-1.15 band, the two mesh classes, the fixture, the
+REACTIVE_FRACTION_MAX/SPREAD_MAX thresholds -- is untouched)
 --------------------------------------------------------------------------
 Five items from review (the reviewer reproduced this script's committed
 numbers byte-for-byte, then ran an independent unterminated-fixture control
@@ -238,13 +252,16 @@ defect (3), and two additions (4, 5):
 
    Second: the ADMISSIBILITY WITNESS leg that actually refuses #525's old
    UNTERMINATED fixture is REACTIVE_FRACTION, not spread. Reviewer's
-   reproduction of this script's own witness computation on that fixture:
-   spread in [0.011, 0.067] (PASSES this script's 0.5 threshold -- spread
-   alone would not have refused it) while reactive_fraction reads
-   [0.963, 0.995] (decisively fails). The ADMISSIBILITY WITNESS section
-   above has been corrected in place to state this (spread measures
-   losslessness/conservation, not travelling-wave purity; reactive_fraction
-   is the leg that catches a reactive, non-travelling plane).
+   reproduction of this script's own witness computation on the same
+   fixture CLASS, reconstructed (this script's geometry, far port
+   termination removed -- #525's own harness was never committed, so this
+   is not a re-run of its literal code): spread in [0.011, 0.067] (PASSES
+   this script's 0.5 threshold -- spread alone would not have refused it)
+   while reactive_fraction reads [0.963, 0.995] (decisively fails). The
+   ADMISSIBILITY WITNESS section above has been corrected in place to
+   state this (spread measures losslessness/conservation, not
+   travelling-wave purity; reactive_fraction is the leg that catches a
+   reactive, non-travelling plane).
 
 2. COMPARISON TO #525's CORRECTED NUMBER (MAJOR). #525 comment 2 itself
    supplies the convention-corrected bisecting figure: the as-posted
@@ -252,9 +269,10 @@ defect (3), and two additions (4, 5):
    un-halfed, doubling the ratio), becomes 1.20-1.34 -- table quoted
    verbatim from #525: "dx = 80 µm (bisecting) | 0.54 – 0.69 | 1.20 – 1.34".
    Review's own broader reconstruction across #525's full recorded data
-   reads 1.076-1.387, and review's independent re-run of the SAME
-   unterminated fixture (spread/reactive numbers in item 1 above) measured
-   ratio 1.0898-1.3867 -- matching #525's corrected figure to ~1%. So
+   reads 1.076-1.387, and review's independent measurement on the same
+   unterminated fixture CLASS, reconstructed (spread/reactive numbers in
+   item 1 above) measured ratio 1.0898-1.3867 -- matching #525's corrected
+   figure to ~1%. So
    #525's bisecting-mesh measurement is fully reproducible, and the
    original 0.54-0.69 headline is jointly explained by (a) the 1/2-factor
    convention bug and (b) the reactive, non-admissible fixture -- NOT by an
@@ -280,8 +298,21 @@ defect (3), and two additions (4, 5):
    ``p_vi/flux == (0.5*p_vi)/(0.5*flux)`` (true for any fixture, healthy or
    broken -- the exact defect class PR #531's review blocked in
    ``scripts/msl_flux_ratio_dof.py``). Removed; replaced by
-   ``_assert_half_factor_regression_is_caught()``, which plants a ½ at the
-   ``p_vi`` build site only and requires the ratio to move.
+   ``_assert_half_factor_regression_is_caught()``.
+
+   Strengthened in a second review pass (same PR): the first version of the
+   replacement still had two gaps -- the mutation was hand-inlined
+   (``0.5 * np.real(v * np.conj(i))``) rather than routed through
+   :func:`_oracle_ratio` itself, so the docstring's claim of exercising the
+   real code path was not yet true; and only the numerator side was
+   mutated, leaving a denominator-side (``flux``) half uncaught -- exactly
+   the shape of #525's own "convention-corrected 2.01-2.02" misdiagnosis,
+   where a script-side factor bug would surface as a false physics
+   over-report instead of a caught regression. Both fixed: the guard now
+   plants the numerator mutation via ``_oracle_ratio(0.5*v, i, flux)`` and
+   the denominator mutation via ``_oracle_ratio(v, i, 0.5*flux)``, both
+   through the real function, requiring the ratio to move to 0.5 and 2.0
+   respectively.
 
 4. THE FREE PROXY-SPAN MUTATION TWIN (MODERATE). The committed JSON now
    carries, per plane per frequency, ``ratio_proxy_span`` -- the retired
@@ -394,35 +425,62 @@ def _assert_half_factor_regression_is_caught() -> None:
     ``scripts/msl_flux_ratio_dof.py`` arc: a "falsifier" whose alternative
     outcome is algebraically unreachable is not a falsifier.
 
-    The regression this guards against is asymmetric, not symmetric: a
-    stray ``0.5`` at the ``p_vi`` BUILD site only (exactly #525's own bug —
-    a time-averaged ``0.5·Re(V·conj(I))`` divided by the un-averaged
-    ``flux_spectrum``). This plants that specific asymmetric mutation
-    through :func:`_oracle_ratio`'s own numerator expression and requires
-    the ratio to visibly move — a real discrimination, since the mutant
-    and the original are compared against each other, not each against a
-    correspondingly-scaled version of itself.
+    THE ACTUAL GUARD is assertion 1 below: the real, unmutated
+    :func:`_oracle_ratio` — the single choke point ``run_one`` calls — must
+    read 1.0 on a fixture constructed so that is the honest answer. That is
+    what "no half anywhere" MEANS operationally; everything after it is a
+    discriminating-power check on the guard itself, not a second guard.
+
+    Two mutations, BOTH routed through the real :func:`_oracle_ratio` (not
+    a hand-inlined duplicate expression, which would test nothing about the
+    actual code path):
+
+    * NUMERATOR half (#525's own bug — a time-averaged
+      ``0.5·Re(V·conj(I))`` divided by the un-averaged ``flux_spectrum``):
+      call ``_oracle_ratio(0.5*v, i, flux)``. Since the function's
+      numerator is ``Re(v·conj(i))``, halving ``v`` halves it — this
+      exercises the function itself, not a copy of its formula.
+    * DENOMINATOR half — the mirror-image bug (e.g. a call site dividing by
+      ``0.5 * flux_spectrum(...)``): call ``_oracle_ratio(v, i, 0.5*flux)``.
+      Mutation A alone does NOT cover this; an unhalved numerator over a
+      halved flux reads ratio ≈ 2.0, which would surface downstream as a
+      "physics over-report" finding rather than a caught script defect —
+      exactly the shape of #525's own "convention-corrected 2.01-2.02"
+      misdiagnosis class (see PRE-DECLARATION above). Both directions must
+      be caught here, not discovered as a false physics claim later.
     """
     v = np.array([1.0 + 0.3j, 0.7 - 0.4j])
     i = np.array([0.9 - 0.2j, 0.5 + 0.1j])
     flux = np.real(v * np.conj(i))  # constructed so the healthy ratio is 1
-    p_vi, ratio = _oracle_ratio(v, i, flux)
+
+    # THE ACTUAL GUARD: the real, unmutated _oracle_ratio must read 1.0.
+    _, ratio = _oracle_ratio(v, i, flux)
     assert np.allclose(ratio, 1.0), (
         f"self-test fixture is not honest (expected ratio 1.0): {ratio}"
     )
-    # THE regression: someone edits the p_vi expression (inside
-    # _oracle_ratio or a call site) to read `0.5 * np.real(v * np.conj(i))`
-    # without touching the flux side. Reproduce exactly that, over the SAME
-    # (unhalfed) flux used above.
-    p_vi_bad = 0.5 * np.real(v * np.conj(i))
-    ratio_bad = p_vi_bad / flux
-    assert np.allclose(ratio_bad, 0.5), (
-        f"planting a half at the p_vi build site should halve the ratio; "
-        f"got {ratio_bad} — this fixture no longer discriminates the bug"
+
+    # Mutation A — numerator-side half, through the real function.
+    _, ratio_num_half = _oracle_ratio(0.5 * v, i, flux)
+    assert np.allclose(ratio_num_half, 0.5), (
+        f"planting a half on the numerator (v) side should halve the "
+        f"ratio; got {ratio_num_half} — this fixture no longer "
+        "discriminates the bug"
     )
-    assert not np.allclose(ratio_bad, ratio), (
-        "the anti-regression guard did not move the ratio relative to the "
-        "healthy computation — it is not discriminating"
+    assert not np.allclose(ratio_num_half, ratio), (
+        "mutation A did not move the ratio relative to the healthy "
+        "computation — it is not discriminating"
+    )
+
+    # Mutation B — denominator-side (flux) half, through the real function.
+    _, ratio_den_half = _oracle_ratio(v, i, 0.5 * flux)
+    assert np.allclose(ratio_den_half, 2.0), (
+        f"planting a half on the flux (denominator) side should double "
+        f"the ratio; got {ratio_den_half} — this fixture no longer "
+        "discriminates the bug"
+    )
+    assert not np.allclose(ratio_den_half, ratio), (
+        "mutation B did not move the ratio relative to the healthy "
+        "computation — it is not discriminating"
     )
 
 

--- a/scripts/diagnostics/msl_vi_flux_oracle/msl_vi_flux_oracle.json
+++ b/scripts/diagnostics/msl_vi_flux_oracle/msl_vi_flux_oracle.json
@@ -15,16 +15,16 @@
       "trace_node": 3,
       "k_lo": 0,
       "k_top_proxy": 3,
-      "wallclock_s": 424.9,
+      "wallclock_s": 412.4,
       "preflight_warnings": [
         "[run] preflight found 5 advisory issue(s) - pass skip_preflight=True to suppress:\n  - 'pec' z-extent 84.67\u00b5m = 1.0 cells \u2014 below 1 cell resolution. A conductor thinner than a cell is modelled as a one-cell PEC surface \u2014 tangential E is zeroed on it and the normal component survives as surface charge. That is usually what you want for metal many skin depths thick, and switching to add_thin_conductor() would not change it; but it means the sheet carries no conductor loss and its thickness is not modelled.\n  - pec_faces={z_lo} creates an INFINITE PEC boundary AND the geometry contains finite PEC objects. For antennas or finite-GP structures, the pec_faces boundary makes the ground plane cover the entire domain face, which changes the physics (cavity vs radiating antenna). If you need a finite ground plane, remove pec_faces and use an explicit PEC Box instead.\n  - all dielectric(s) ['ro4350b'] are perfectly lossless in an open (CPML) domain. If you are measuring Q / resonance, this gives an ARTIFICIALLY infinite Q (design-guide Anti-Pattern #1, an R5 surface-metric trap) \u2014 add loss, e.g. sigma = 2*pi*f*eps0*eps_r*tan_delta. (Harmless if you are not measuring Q.)\n  - MSL port 'msl_0': only 3 substrate cell(s) in z (h_sub=254\u00b5m, dx=85\u00b5m). Yee staircase at dielectric interface is O(dx) \u2014 Z0 staircase error >5% expected. Refine to dx \u2264 64\u00b5m (4+ substrate cells) AND keep h_sub/dx an integer (aligned) for <5% Z0 bias \u2014 measured post-#511/#507 at -3.8%/-1.2%/+0.7% for h_sub/4, h_sub/5, h_sub/6 (scripts/diagnostics/msl_z0_bias_floor_sweep.py). Refining WITHOUT alignment does not reach that: a mixed-cell mesh at a similar cell count measured +11% (h_sub/dx=4.233) \u2014 see the mixed-cell-danger-zone check below.\n  - MSL port 'msl_1': only 3 substrate cell(s) in z (h_sub=254\u00b5m, dx=85\u00b5m). Yee staircase at dielectric interface is O(dx) \u2014 Z0 staircase error >5% expected. Refine to dx \u2264 64\u00b5m (4+ substrate cells) AND keep h_sub/dx an integer (aligned) for <5% Z0 bias \u2014 measured post-#511/#507 at -3.8%/-1.2%/+0.7% for h_sub/4, h_sub/5, h_sub/6 (scripts/diagnostics/msl_z0_bias_floor_sweep.py). Refining WITHOUT alignment does not reach that: a mixed-cell mesh at a similar cell count measured +11% (h_sub/dx=4.233) \u2014 see the mixed-cell-danger-zone check below."
       ],
       "settling_db": [
-        -118.2,
-        -116.4,
-        -118.7,
-        -121.9,
-        -118.0
+        -111.0,
+        -109.7,
+        -111.8,
+        -112.8,
+        -111.6
       ],
       "spread_per_freq": [
         0.0007,
@@ -69,6 +69,30 @@
             1.0082842111587524,
             1.0084660053253174,
             1.0088307857513428
+          ],
+          "ratio_proxy_span": [
+            1.008420467376709,
+            1.0083287954330444,
+            1.0082508325576782,
+            1.0082842111587524,
+            1.0084660053253174,
+            1.0088307857513428
+          ],
+          "v_abs": [
+            5.17677589163823e-13,
+            3.787332860522019e-13,
+            2.3616959082817246e-13,
+            1.2690529508328774e-13,
+            5.90052299013176e-14,
+            2.3772332030397997e-14
+          ],
+          "i_abs": [
+            1.4986204958196067e-14,
+            1.053413033072579e-14,
+            6.232349417768053e-15,
+            3.1371580443281203e-15,
+            1.350207046219205e-15,
+            4.982805778703798e-16
           ]
         },
         {
@@ -105,6 +129,30 @@
             1.0087246894836426,
             1.0087924003601074,
             1.0089893341064453
+          ],
+          "ratio_proxy_span": [
+            1.0088151693344116,
+            1.0088205337524414,
+            1.0087581872940063,
+            1.0087246894836426,
+            1.0087924003601074,
+            1.0089893341064453
+          ],
+          "v_abs": [
+            5.078458812333986e-13,
+            3.678772781193218e-13,
+            2.2694487348401404e-13,
+            1.2067870845417633e-13,
+            5.561242249043155e-14,
+            2.2264577808901558e-14
+          ],
+          "i_abs": [
+            1.51566686447651e-14,
+            1.0728499828165181e-14,
+            6.404782032422979e-15,
+            3.2600496077222737e-15,
+            1.421792659327863e-15,
+            5.326789564352914e-16
           ]
         },
         {
@@ -141,6 +189,30 @@
             1.0089561939239502,
             1.0089209079742432,
             1.0089608430862427
+          ],
+          "ratio_proxy_span": [
+            1.0089335441589355,
+            1.0090254545211792,
+            1.00901198387146,
+            1.0089561939239502,
+            1.0089209079742432,
+            1.0089608430862427
+          ],
+          "v_abs": [
+            4.998986793090798e-13,
+            3.5880789984142625e-13,
+            2.1892570764049657e-13,
+            1.1500726044243181e-13,
+            5.23502648294618e-14,
+            2.072207151964517e-14
+          ],
+          "i_abs": [
+            1.5290408370872977e-14,
+            1.0883683887398694e-14,
+            6.5451862137598515e-15,
+            3.362610898074666e-15,
+            1.483371001681185e-15,
+            5.634143939593609e-16
           ]
         },
         {
@@ -177,6 +249,30 @@
             1.0090155601501465,
             1.0089472532272339,
             1.00886869430542
+          ],
+          "ratio_proxy_span": [
+            1.0087883472442627,
+            1.0089638233184814,
+            1.0090328454971313,
+            1.0090155601501465,
+            1.0089472532272339,
+            1.00886869430542
+          ],
+          "v_abs": [
+            4.94483197877732e-13,
+            3.5244704832577967e-13,
+            2.1309845977656589e-13,
+            1.1071346069741958e-13,
+            4.9760288798510535e-14,
+            1.94307968966103e-14
+          ],
+          "i_abs": [
+            1.537918928220649e-14,
+            1.0988464404072893e-14,
+            6.641810226668465e-15,
+            3.4347215657315033e-15,
+            1.5277462107548905e-15,
+            5.861785632354979e-16
           ]
         },
         {
@@ -213,6 +309,30 @@
             1.008786678314209,
             1.0087519884109497,
             1.0086634159088135
+          ],
+          "ratio_proxy_span": [
+            1.0083129405975342,
+            1.0085543394088745,
+            1.0087248086929321,
+            1.008786678314209,
+            1.0087519884109497,
+            1.0086634159088135
+          ],
+          "v_abs": [
+            4.908029278133386e-13,
+            3.4798268325024473e-13,
+            2.0884757410879334e-13,
+            1.0744194840458035e-13,
+            4.7691830953183745e-14,
+            1.8345253023936345e-14
+          ],
+          "i_abs": [
+            1.543780904435417e-14,
+            1.1059417812965544e-14,
+            6.709046854988564e-15,
+            3.4862944372745022e-15,
+            1.5603719081798764e-15,
+            6.034053604980782e-16
           ]
         }
       ],
@@ -223,6 +343,7 @@
           "reactive_fraction": 0.02408701181411743,
           "spread": 0.0007492531440220773,
           "ratio": 1.008420467376709,
+          "ratio_proxy_span": 1.008420467376709,
           "admissible": true
         },
         {
@@ -231,6 +352,7 @@
           "reactive_fraction": 0.03709447383880615,
           "spread": 0.0007313623209483922,
           "ratio": 1.0083287954330444,
+          "ratio_proxy_span": 1.0083287954330444,
           "admissible": true
         },
         {
@@ -239,6 +361,7 @@
           "reactive_fraction": 0.051323115825653076,
           "spread": 0.0006314163329079747,
           "ratio": 1.0082508325576782,
+          "ratio_proxy_span": 1.0082508325576782,
           "admissible": true
         },
         {
@@ -247,6 +370,7 @@
           "reactive_fraction": 0.06487506628036499,
           "spread": 0.0005876363720744848,
           "ratio": 1.0082842111587524,
+          "ratio_proxy_span": 1.0082842111587524,
           "admissible": true
         },
         {
@@ -255,6 +379,7 @@
           "reactive_fraction": 0.07545685768127441,
           "spread": 0.0006318631349131465,
           "ratio": 1.0084660053253174,
+          "ratio_proxy_span": 1.0084660053253174,
           "admissible": true
         },
         {
@@ -263,6 +388,7 @@
           "reactive_fraction": 0.08071213960647583,
           "spread": 0.0008698120363987982,
           "ratio": 1.0088307857513428,
+          "ratio_proxy_span": 1.0088307857513428,
           "admissible": true
         },
         {
@@ -271,6 +397,7 @@
           "reactive_fraction": 0.016465604305267334,
           "spread": 0.0007492531440220773,
           "ratio": 1.0088151693344116,
+          "ratio_proxy_span": 1.0088151693344116,
           "admissible": true
         },
         {
@@ -279,6 +406,7 @@
           "reactive_fraction": 0.02675706148147583,
           "spread": 0.0007313623209483922,
           "ratio": 1.0088205337524414,
+          "ratio_proxy_span": 1.0088205337524414,
           "admissible": true
         },
         {
@@ -287,6 +415,7 @@
           "reactive_fraction": 0.0395197868347168,
           "spread": 0.0006314163329079747,
           "ratio": 1.0087581872940063,
+          "ratio_proxy_span": 1.0087581872940063,
           "admissible": true
         },
         {
@@ -295,6 +424,7 @@
           "reactive_fraction": 0.0539698600769043,
           "spread": 0.0005876363720744848,
           "ratio": 1.0087246894836426,
+          "ratio_proxy_span": 1.0087246894836426,
           "admissible": true
         },
         {
@@ -303,6 +433,7 @@
           "reactive_fraction": 0.0687781572341919,
           "spread": 0.0006318631349131465,
           "ratio": 1.0087924003601074,
+          "ratio_proxy_span": 1.0087924003601074,
           "admissible": true
         },
         {
@@ -311,6 +442,7 @@
           "reactive_fraction": 0.08219730854034424,
           "spread": 0.0008698120363987982,
           "ratio": 1.0089893341064453,
+          "ratio_proxy_span": 1.0089893341064453,
           "admissible": true
         },
         {
@@ -319,6 +451,7 @@
           "reactive_fraction": 0.009661436080932617,
           "spread": 0.0007492531440220773,
           "ratio": 1.0089335441589355,
+          "ratio_proxy_span": 1.0089335441589355,
           "admissible": true
         },
         {
@@ -327,6 +460,7 @@
           "reactive_fraction": 0.016499459743499756,
           "spread": 0.0007313623209483922,
           "ratio": 1.0090254545211792,
+          "ratio_proxy_span": 1.0090254545211792,
           "admissible": true
         },
         {
@@ -335,6 +469,7 @@
           "reactive_fraction": 0.025880932807922363,
           "spread": 0.0006314163329079747,
           "ratio": 1.00901198387146,
+          "ratio_proxy_span": 1.00901198387146,
           "admissible": true
         },
         {
@@ -343,6 +478,7 @@
           "reactive_fraction": 0.03789240121841431,
           "spread": 0.0005876363720744848,
           "ratio": 1.0089561939239502,
+          "ratio_proxy_span": 1.0089561939239502,
           "admissible": true
         },
         {
@@ -351,6 +487,7 @@
           "reactive_fraction": 0.05224210023880005,
           "spread": 0.0006318631349131465,
           "ratio": 1.0089209079742432,
+          "ratio_proxy_span": 1.0089209079742432,
           "admissible": true
         },
         {
@@ -359,6 +496,7 @@
           "reactive_fraction": 0.06821626424789429,
           "spread": 0.0008698120363987982,
           "ratio": 1.0089608430862427,
+          "ratio_proxy_span": 1.0089608430862427,
           "admissible": true
         },
         {
@@ -367,6 +505,7 @@
           "reactive_fraction": 0.004700183868408203,
           "spread": 0.0007492531440220773,
           "ratio": 1.0087883472442627,
+          "ratio_proxy_span": 1.0087883472442627,
           "admissible": true
         },
         {
@@ -375,6 +514,7 @@
           "reactive_fraction": 0.008420765399932861,
           "spread": 0.0007313623209483922,
           "ratio": 1.0089638233184814,
+          "ratio_proxy_span": 1.0089638233184814,
           "admissible": true
         },
         {
@@ -383,6 +523,7 @@
           "reactive_fraction": 0.013983309268951416,
           "spread": 0.0006314163329079747,
           "ratio": 1.0090328454971313,
+          "ratio_proxy_span": 1.0090328454971313,
           "admissible": true
         },
         {
@@ -391,6 +532,7 @@
           "reactive_fraction": 0.021830856800079346,
           "spread": 0.0005876363720744848,
           "ratio": 1.0090155601501465,
+          "ratio_proxy_span": 1.0090155601501465,
           "admissible": true
         },
         {
@@ -399,6 +541,7 @@
           "reactive_fraction": 0.03229457139968872,
           "spread": 0.0006318631349131465,
           "ratio": 1.0089472532272339,
+          "ratio_proxy_span": 1.0089472532272339,
           "admissible": true
         },
         {
@@ -407,6 +550,7 @@
           "reactive_fraction": 0.04550886154174805,
           "spread": 0.0008698120363987982,
           "ratio": 1.00886869430542,
+          "ratio_proxy_span": 1.00886869430542,
           "admissible": true
         },
         {
@@ -415,6 +559,7 @@
           "reactive_fraction": 0.0011888742446899414,
           "spread": 0.0007492531440220773,
           "ratio": 1.0083129405975342,
+          "ratio_proxy_span": 1.0083129405975342,
           "admissible": true
         },
         {
@@ -423,6 +568,7 @@
           "reactive_fraction": 0.002324223518371582,
           "spread": 0.0007313623209483922,
           "ratio": 1.0085543394088745,
+          "ratio_proxy_span": 1.0085543394088745,
           "admissible": true
         },
         {
@@ -431,6 +577,7 @@
           "reactive_fraction": 0.00424504280090332,
           "spread": 0.0006314163329079747,
           "ratio": 1.0087248086929321,
+          "ratio_proxy_span": 1.0087248086929321,
           "admissible": true
         },
         {
@@ -439,6 +586,7 @@
           "reactive_fraction": 0.007312774658203125,
           "spread": 0.0005876363720744848,
           "ratio": 1.008786678314209,
+          "ratio_proxy_span": 1.008786678314209,
           "admissible": true
         },
         {
@@ -447,6 +595,7 @@
           "reactive_fraction": 0.011951684951782227,
           "spread": 0.0006318631349131465,
           "ratio": 1.0087519884109497,
+          "ratio_proxy_span": 1.0087519884109497,
           "admissible": true
         },
         {
@@ -455,6 +604,7 @@
           "reactive_fraction": 0.01862788200378418,
           "spread": 0.0008698120363987982,
           "ratio": 1.0086634159088135,
+          "ratio_proxy_span": 1.0086634159088135,
           "admissible": true
         }
       ],
@@ -464,6 +614,11 @@
         1.0083,
         1.009
       ],
+      "proxy_ratio_range": [
+        1.0083,
+        1.009
+      ],
+      "proxy_span_falls_outside_band": false,
       "verdict": "HELD"
     },
     {
@@ -475,16 +630,16 @@
       "trace_node": 4,
       "k_lo": 0,
       "k_top_proxy": 3,
-      "wallclock_s": 499.7,
+      "wallclock_s": 440.3,
       "preflight_warnings": [
         "[run] preflight found 7 advisory issue(s) - pass skip_preflight=True to suppress:\n  - 'pec' z-extent 80\u00b5m = 1.0 cells \u2014 below 1 cell resolution. A conductor thinner than a cell is modelled as a one-cell PEC surface \u2014 tangential E is zeroed on it and the normal component survives as surface charge. That is usually what you want for metal many skin depths thick, and switching to add_thin_conductor() would not change it; but it means the sheet carries no conductor loss and its thickness is not modelled.\n  - pec_faces={z_lo} creates an INFINITE PEC boundary AND the geometry contains finite PEC objects. For antennas or finite-GP structures, the pec_faces boundary makes the ground plane cover the entire domain face, which changes the physics (cavity vs radiating antenna). If you need a finite ground plane, remove pec_faces and use an explicit PEC Box instead.\n  - all dielectric(s) ['ro4350b'] are perfectly lossless in an open (CPML) domain. If you are measuring Q / resonance, this gives an ARTIFICIALLY infinite Q (design-guide Anti-Pattern #1, an R5 surface-metric trap) \u2014 add loss, e.g. sigma = 2*pi*f*eps0*eps_r*tan_delta. (Harmless if you are not measuring Q.)\n  - MSL port 'msl_0': only 3 substrate cell(s) in z (h_sub=254\u00b5m, dx=80\u00b5m). Yee staircase at dielectric interface is O(dx) \u2014 Z0 staircase error >5% expected. Refine to dx \u2264 64\u00b5m (4+ substrate cells) AND keep h_sub/dx an integer (aligned) for <5% Z0 bias \u2014 measured post-#511/#507 at -3.8%/-1.2%/+0.7% for h_sub/4, h_sub/5, h_sub/6 (scripts/diagnostics/msl_z0_bias_floor_sweep.py). Refining WITHOUT alignment does not reach that: a mixed-cell mesh at a similar cell count measured +11% (h_sub/dx=4.233) \u2014 see the mixed-cell-danger-zone check below.\n  - MSL port 'msl_0': h_sub/dx = 3.175 (fractional part 0.175) lands in the [0.10, 0.40] mixed-cell danger zone. The substrate-air interface bisects the same Yee cell that holds the trace; AD-traceable ``pec_occupancy_override`` zeros the whole cell and produces unphysical |S21|\u00b2 > 1 in this regime. Hard ``Box(material='pec')`` avoids that specific bug, but Z0 bias itself is still 2.56-2.94x worse than an aligned mesh at a comparable cell count (measured +20.2% vs -7.9% at ~3 cells, +11.0% vs -3.8% at ~4 cells; scripts/diagnostics/msl_z0_bias_floor_sweep.py) \u2014 refining cell count alone will not reach the aligned-mesh bias. To snap onto a safe alignment regardless, set dx = 63.5\u00b5m (= h_sub/4) or 84.7\u00b5m (= h_sub/3).\n  - MSL port 'msl_1': only 3 substrate cell(s) in z (h_sub=254\u00b5m, dx=80\u00b5m). Yee staircase at dielectric interface is O(dx) \u2014 Z0 staircase error >5% expected. Refine to dx \u2264 64\u00b5m (4+ substrate cells) AND keep h_sub/dx an integer (aligned) for <5% Z0 bias \u2014 measured post-#511/#507 at -3.8%/-1.2%/+0.7% for h_sub/4, h_sub/5, h_sub/6 (scripts/diagnostics/msl_z0_bias_floor_sweep.py). Refining WITHOUT alignment does not reach that: a mixed-cell mesh at a similar cell count measured +11% (h_sub/dx=4.233) \u2014 see the mixed-cell-danger-zone check below.\n  - MSL port 'msl_1': h_sub/dx = 3.175 (fractional part 0.175) lands in the [0.10, 0.40] mixed-cell danger zone. The substrate-air interface bisects the same Yee cell that holds the trace; AD-traceable ``pec_occupancy_override`` zeros the whole cell and produces unphysical |S21|\u00b2 > 1 in this regime. Hard ``Box(material='pec')`` avoids that specific bug, but Z0 bias itself is still 2.56-2.94x worse than an aligned mesh at a comparable cell count (measured +20.2% vs -7.9% at ~3 cells, +11.0% vs -3.8% at ~4 cells; scripts/diagnostics/msl_z0_bias_floor_sweep.py) \u2014 refining cell count alone will not reach the aligned-mesh bias. To snap onto a safe alignment regardless, set dx = 63.5\u00b5m (= h_sub/4) or 84.7\u00b5m (= h_sub/3)."
       ],
       "settling_db": [
-        -115.4,
-        -116.7,
-        -120.8,
-        -119.8,
-        -114.6
+        -108.7,
+        -109.0,
+        -115.2,
+        -111.1,
+        -106.3
       ],
       "spread_per_freq": [
         0.0008,
@@ -529,6 +684,30 @@
             1.0105167627334595,
             1.0106861591339111,
             1.011061191558838
+          ],
+          "ratio_proxy_span": [
+            0.7443298697471619,
+            0.7443127036094666,
+            0.7442650198936462,
+            0.7442629337310791,
+            0.744391918182373,
+            0.7446763515472412
+          ],
+          "v_abs": [
+            9.906832298955948e-13,
+            6.940012800549233e-13,
+            4.1491148624478447e-13,
+            2.152096995619926e-13,
+            9.766558221879773e-14,
+            3.889431975817072e-14
+          ],
+          "i_abs": [
+            2.026176671105287e-14,
+            1.4697654714384417e-14,
+            9.001158244323695e-15,
+            4.69716953998894e-15,
+            2.0946932085603347e-15,
+            7.984299849826118e-16
           ]
         },
         {
@@ -565,6 +744,30 @@
             1.011245846748352,
             1.0112683773040771,
             1.0114359855651855
+          ],
+          "ratio_proxy_span": [
+            0.7447622418403625,
+            0.7448511719703674,
+            0.7448340654373169,
+            0.7448018193244934,
+            0.74482262134552,
+            0.7449511289596558
+          ],
+          "v_abs": [
+            9.931573792532067e-13,
+            6.938789278397584e-13,
+            4.120218435096218e-13,
+            2.1119218841184756e-13,
+            9.426671682827292e-14,
+            3.6824798039462175e-14
+          ],
+          "i_abs": [
+            2.0225854208155182e-14,
+            1.4699953561803265e-14,
+            9.041059425370004e-15,
+            4.751395742239213e-15,
+            2.1406206055098837e-15,
+            8.271539839547484e-16
           ]
         },
         {
@@ -601,6 +804,30 @@
             1.0116826295852661,
             1.0116018056869507,
             1.0115748643875122
+          ],
+          "ratio_proxy_span": [
+            0.7449015974998474,
+            0.7450954914093018,
+            0.7451506853103638,
+            0.7451250553131104,
+            0.745069682598114,
+            0.7450565099716187
+          ],
+          "v_abs": [
+            9.97623424842109e-13,
+            6.966246698415779e-13,
+            4.121399673363141e-13,
+            2.0952326245521347e-13,
+            9.224535740294526e-14,
+            3.535224481318773e-14
+          ],
+          "i_abs": [
+            2.0159677218052098e-14,
+            1.466104764446998e-14,
+            9.039231528269829e-15,
+            4.7730840208536594e-15,
+            2.1664161468855662e-15,
+            8.459012053576502e-16
           ]
         },
         {
@@ -637,6 +864,30 @@
             1.0118415355682373,
             1.0117599964141846,
             1.0116268396377563
+          ],
+          "ratio_proxy_span": [
+            0.7447704076766968,
+            0.7450593113899231,
+            0.745211124420166,
+            0.7452443242073059,
+            0.7451865077018738,
+            0.7450928092002869
+          ],
+          "v_abs": [
+            1.0034087276344916e-12,
+            7.01591399993734e-13,
+            4.149066073350083e-13,
+            2.102174906587831e-13,
+            9.184224425895157e-14,
+            3.4737170144473126e-14
+          ],
+          "i_abs": [
+            2.0072729286016444e-14,
+            1.4589342917353115e-14,
+            9.000662730049552e-15,
+            4.763286390752769e-15,
+            2.1710197709538933e-15,
+            8.531622364793101e-16
           ]
         },
         {
@@ -673,6 +924,30 @@
             1.011628270149231,
             1.011616587638855,
             1.0114904642105103
+          ],
+          "ratio_proxy_span": [
+            0.7443415522575378,
+            0.7446886897087097,
+            0.7449448704719543,
+            0.7450856566429138,
+            0.7450814247131348,
+            0.7449914813041687
+          ],
+          "v_abs": [
+            1.0106385129812767e-12,
+            7.086878284733034e-13,
+            4.2005732659583517e-13,
+            2.1300244012166514e-13,
+            9.289429983702288e-14,
+            3.4937503600894135e-14
+          ],
+          "i_abs": [
+            1.9962303294748796e-14,
+            1.4485007092976225e-14,
+            8.927720487796748e-15,
+            4.725252070322209e-15,
+            2.1569082020526367e-15,
+            8.503122353095954e-16
           ]
         }
       ],
@@ -683,6 +958,7 @@
           "reactive_fraction": 0.00014460086822509766,
           "spread": 0.000849010597448796,
           "ratio": 1.010625958442688,
+          "ratio_proxy_span": 0.7443298697471619,
           "admissible": true
         },
         {
@@ -691,6 +967,7 @@
           "reactive_fraction": 0.0002219080924987793,
           "spread": 0.0007792802643962204,
           "ratio": 1.0105983018875122,
+          "ratio_proxy_span": 0.7443127036094666,
           "admissible": true
         },
         {
@@ -699,6 +976,7 @@
           "reactive_fraction": 0.00288313627243042,
           "spread": 0.0006263581453822553,
           "ratio": 1.0105270147323608,
+          "ratio_proxy_span": 0.7442650198936462,
           "admissible": true
         },
         {
@@ -707,6 +985,7 @@
           "reactive_fraction": 0.010563850402832031,
           "spread": 0.00048236912698484957,
           "ratio": 1.0105167627334595,
+          "ratio_proxy_span": 0.7442629337310791,
           "admissible": true
         },
         {
@@ -715,6 +994,7 @@
           "reactive_fraction": 0.024718165397644043,
           "spread": 0.00037614788743667305,
           "ratio": 1.0106861591339111,
+          "ratio_proxy_span": 0.744391918182373,
           "admissible": true
         },
         {
@@ -723,6 +1003,7 @@
           "reactive_fraction": 0.04455149173736572,
           "spread": 0.0005031442851759493,
           "ratio": 1.011061191558838,
+          "ratio_proxy_span": 0.7446763515472412,
           "admissible": true
         },
         {
@@ -731,6 +1012,7 @@
           "reactive_fraction": 0.0008287429809570312,
           "spread": 0.000849010597448796,
           "ratio": 1.0112121105194092,
+          "ratio_proxy_span": 0.7447622418403625,
           "admissible": true
         },
         {
@@ -739,6 +1021,7 @@
           "reactive_fraction": 0.00014853477478027344,
           "spread": 0.0007792802643962204,
           "ratio": 1.0113260746002197,
+          "ratio_proxy_span": 0.7448511719703674,
           "admissible": true
         },
         {
@@ -747,6 +1030,7 @@
           "reactive_fraction": 0.00031512975692749023,
           "spread": 0.0006263581453822553,
           "ratio": 1.0112967491149902,
+          "ratio_proxy_span": 0.7448340654373169,
           "admissible": true
         },
         {
@@ -755,6 +1039,7 @@
           "reactive_fraction": 0.0033572912216186523,
           "spread": 0.00048236912698484957,
           "ratio": 1.011245846748352,
+          "ratio_proxy_span": 0.7448018193244934,
           "admissible": true
         },
         {
@@ -763,6 +1048,7 @@
           "reactive_fraction": 0.01154249906539917,
           "spread": 0.00037614788743667305,
           "ratio": 1.0112683773040771,
+          "ratio_proxy_span": 0.74482262134552,
           "admissible": true
         },
         {
@@ -771,6 +1057,7 @@
           "reactive_fraction": 0.026426196098327637,
           "spread": 0.0005031442851759493,
           "ratio": 1.0114359855651855,
+          "ratio_proxy_span": 0.7449511289596558,
           "admissible": true
         },
         {
@@ -779,6 +1066,7 @@
           "reactive_fraction": 0.002024352550506592,
           "spread": 0.000849010597448796,
           "ratio": 1.0114017724990845,
+          "ratio_proxy_span": 0.7449015974998474,
           "admissible": true
         },
         {
@@ -787,6 +1075,7 @@
           "reactive_fraction": 0.0014140605926513672,
           "spread": 0.0007792802643962204,
           "ratio": 1.0116571187973022,
+          "ratio_proxy_span": 0.7450954914093018,
           "admissible": true
         },
         {
@@ -795,6 +1084,7 @@
           "reactive_fraction": 0.0004006028175354004,
           "spread": 0.0006263581453822553,
           "ratio": 1.0117237567901611,
+          "ratio_proxy_span": 0.7451506853103638,
           "admissible": true
         },
         {
@@ -803,6 +1093,7 @@
           "reactive_fraction": 8.398294448852539e-05,
           "spread": 0.00048236912698484957,
           "ratio": 1.0116826295852661,
+          "ratio_proxy_span": 0.7451250553131104,
           "admissible": true
         },
         {
@@ -811,6 +1102,7 @@
           "reactive_fraction": 0.0022136569023132324,
           "spread": 0.00037614788743667305,
           "ratio": 1.0116018056869507,
+          "ratio_proxy_span": 0.745069682598114,
           "admissible": true
         },
         {
@@ -819,6 +1111,7 @@
           "reactive_fraction": 0.008907854557037354,
           "spread": 0.0005031442851759493,
           "ratio": 1.0115748643875122,
+          "ratio_proxy_span": 0.7450565099716187,
           "admissible": true
         },
         {
@@ -827,6 +1120,7 @@
           "reactive_fraction": 0.0034831762313842773,
           "spread": 0.000849010597448796,
           "ratio": 1.0112242698669434,
+          "ratio_proxy_span": 0.7447704076766968,
           "admissible": true
         },
         {
@@ -835,6 +1129,7 @@
           "reactive_fraction": 0.003612697124481201,
           "spread": 0.0007792802643962204,
           "ratio": 1.0116069316864014,
+          "ratio_proxy_span": 0.7450593113899231,
           "admissible": true
         },
         {
@@ -843,6 +1138,7 @@
           "reactive_fraction": 0.002836287021636963,
           "spread": 0.0006263581453822553,
           "ratio": 1.0118046998977661,
+          "ratio_proxy_span": 0.745211124420166,
           "admissible": true
         },
         {
@@ -851,6 +1147,7 @@
           "reactive_fraction": 0.0014377832412719727,
           "spread": 0.00048236912698484957,
           "ratio": 1.0118415355682373,
+          "ratio_proxy_span": 0.7452443242073059,
           "admissible": true
         },
         {
@@ -859,6 +1156,7 @@
           "reactive_fraction": 0.00019431114196777344,
           "spread": 0.00037614788743667305,
           "ratio": 1.0117599964141846,
+          "ratio_proxy_span": 0.7451865077018738,
           "admissible": true
         },
         {
@@ -867,6 +1165,7 @@
           "reactive_fraction": 0.00041371583938598633,
           "spread": 0.0005031442851759493,
           "ratio": 1.0116268396377563,
+          "ratio_proxy_span": 0.7450928092002869,
           "admissible": true
         },
         {
@@ -875,6 +1174,7 @@
           "reactive_fraction": 0.005159497261047363,
           "spread": 0.000849010597448796,
           "ratio": 1.010644793510437,
+          "ratio_proxy_span": 0.7443415522575378,
           "admissible": true
         },
         {
@@ -883,6 +1183,7 @@
           "reactive_fraction": 0.0065177083015441895,
           "spread": 0.0007792802643962204,
           "ratio": 1.0111061334609985,
+          "ratio_proxy_span": 0.7446886897087097,
           "admissible": true
         },
         {
@@ -891,6 +1192,7 @@
           "reactive_fraction": 0.0070879459381103516,
           "spread": 0.0006263581453822553,
           "ratio": 1.0114444494247437,
+          "ratio_proxy_span": 0.7449448704719543,
           "admissible": true
         },
         {
@@ -899,6 +1201,7 @@
           "reactive_fraction": 0.006677031517028809,
           "spread": 0.00048236912698484957,
           "ratio": 1.011628270149231,
+          "ratio_proxy_span": 0.7450856566429138,
           "admissible": true
         },
         {
@@ -907,6 +1210,7 @@
           "reactive_fraction": 0.0053057074546813965,
           "spread": 0.00037614788743667305,
           "ratio": 1.011616587638855,
+          "ratio_proxy_span": 0.7450814247131348,
           "admissible": true
         },
         {
@@ -915,6 +1219,7 @@
           "reactive_fraction": 0.003252685070037842,
           "spread": 0.0005031442851759493,
           "ratio": 1.0114904642105103,
+          "ratio_proxy_span": 0.7449914813041687,
           "admissible": true
         }
       ],
@@ -924,6 +1229,11 @@
         1.0105,
         1.0118
       ],
+      "proxy_ratio_range": [
+        0.7443,
+        0.7452
+      ],
+      "proxy_span_falls_outside_band": true,
       "verdict": "HELD"
     }
   ],

--- a/scripts/diagnostics/msl_vi_flux_oracle/msl_vi_flux_oracle.json
+++ b/scripts/diagnostics/msl_vi_flux_oracle/msl_vi_flux_oracle.json
@@ -1,0 +1,931 @@
+{
+  "reactive_fraction_max": 0.5,
+  "spread_max": 0.5,
+  "ratio_band": [
+    0.85,
+    1.15
+  ],
+  "rows": [
+    {
+      "label": "aligned h_sub/3",
+      "dx_um": 84.6667,
+      "n_sub_exact": 3.0,
+      "frac": 0.0,
+      "mixed_cell_danger_zone": false,
+      "trace_node": 3,
+      "k_lo": 0,
+      "k_top_proxy": 3,
+      "wallclock_s": 424.9,
+      "preflight_warnings": [
+        "[run] preflight found 5 advisory issue(s) - pass skip_preflight=True to suppress:\n  - 'pec' z-extent 84.67\u00b5m = 1.0 cells \u2014 below 1 cell resolution. A conductor thinner than a cell is modelled as a one-cell PEC surface \u2014 tangential E is zeroed on it and the normal component survives as surface charge. That is usually what you want for metal many skin depths thick, and switching to add_thin_conductor() would not change it; but it means the sheet carries no conductor loss and its thickness is not modelled.\n  - pec_faces={z_lo} creates an INFINITE PEC boundary AND the geometry contains finite PEC objects. For antennas or finite-GP structures, the pec_faces boundary makes the ground plane cover the entire domain face, which changes the physics (cavity vs radiating antenna). If you need a finite ground plane, remove pec_faces and use an explicit PEC Box instead.\n  - all dielectric(s) ['ro4350b'] are perfectly lossless in an open (CPML) domain. If you are measuring Q / resonance, this gives an ARTIFICIALLY infinite Q (design-guide Anti-Pattern #1, an R5 surface-metric trap) \u2014 add loss, e.g. sigma = 2*pi*f*eps0*eps_r*tan_delta. (Harmless if you are not measuring Q.)\n  - MSL port 'msl_0': only 3 substrate cell(s) in z (h_sub=254\u00b5m, dx=85\u00b5m). Yee staircase at dielectric interface is O(dx) \u2014 Z0 staircase error >5% expected. Refine to dx \u2264 64\u00b5m (4+ substrate cells) AND keep h_sub/dx an integer (aligned) for <5% Z0 bias \u2014 measured post-#511/#507 at -3.8%/-1.2%/+0.7% for h_sub/4, h_sub/5, h_sub/6 (scripts/diagnostics/msl_z0_bias_floor_sweep.py). Refining WITHOUT alignment does not reach that: a mixed-cell mesh at a similar cell count measured +11% (h_sub/dx=4.233) \u2014 see the mixed-cell-danger-zone check below.\n  - MSL port 'msl_1': only 3 substrate cell(s) in z (h_sub=254\u00b5m, dx=85\u00b5m). Yee staircase at dielectric interface is O(dx) \u2014 Z0 staircase error >5% expected. Refine to dx \u2264 64\u00b5m (4+ substrate cells) AND keep h_sub/dx an integer (aligned) for <5% Z0 bias \u2014 measured post-#511/#507 at -3.8%/-1.2%/+0.7% for h_sub/4, h_sub/5, h_sub/6 (scripts/diagnostics/msl_z0_bias_floor_sweep.py). Refining WITHOUT alignment does not reach that: a mixed-cell mesh at a similar cell count measured +11% (h_sub/dx=4.233) \u2014 see the mixed-cell-danger-zone check below."
+      ],
+      "settling_db": [
+        -118.2,
+        -116.4,
+        -118.7,
+        -121.9,
+        -118.0
+      ],
+      "spread_per_freq": [
+        0.0007,
+        0.0007,
+        0.0006,
+        0.0006,
+        0.0006,
+        0.0009
+      ],
+      "per_plane": [
+        {
+          "plane_idx": 0,
+          "x_frac": 0.3,
+          "p_vi_real": [
+            7.563832552340299e-27,
+            3.835893544349513e-27,
+            1.3934391074168337e-27,
+            3.712830617207803e-28,
+            7.341055733811782e-29,
+            1.0845990338539936e-29
+          ],
+          "flux_real": [
+            7.500674376116041e-27,
+            3.8042089152764316e-27,
+            1.3820355799196197e-27,
+            3.6823255720774104e-28,
+            7.279420558913422e-29,
+            1.0751055533976566e-29
+          ],
+          "reactive_fraction": [
+            0.02408701181411743,
+            0.03709447383880615,
+            0.051323115825653076,
+            0.06487506628036499,
+            0.07545685768127441,
+            0.08071213960647583
+          ],
+          "ratio": [
+            1.008420467376709,
+            1.0083287954330444,
+            1.0082508325576782,
+            1.0082842111587524,
+            1.0084660053253174,
+            1.0088307857513428
+          ]
+        },
+        {
+          "plane_idx": 1,
+          "x_frac": 0.4,
+          "p_vi_real": [
+            7.564872554510268e-27,
+            3.836759442452509e-27,
+            1.393853182354877e-27,
+            3.714000619649018e-28,
+            7.343369859010585e-29,
+            1.0849004870292732e-29
+          ],
+          "flux_real": [
+            7.498768475843076e-27,
+            3.80321436505315e-27,
+            1.3817513126598281e-27,
+            3.681876348917882e-28,
+            7.279365188427521e-29,
+            1.0752354032056259e-29
+          ],
+          "reactive_fraction": [
+            0.016465604305267334,
+            0.02675706148147583,
+            0.0395197868347168,
+            0.0539698600769043,
+            0.0687781572341919,
+            0.08219730854034424
+          ],
+          "ratio": [
+            1.0088151693344116,
+            1.0088205337524414,
+            1.0087581872940063,
+            1.0087246894836426,
+            1.0087924003601074,
+            1.0089893341064453
+          ]
+        },
+        {
+          "plane_idx": 2,
+          "x_frac": 0.5,
+          "p_vi_real": [
+            7.56577774158413e-27,
+            3.837537132964053e-27,
+            1.394210057173572e-27,
+            3.7150218440020295e-28,
+            7.345300603779833e-29,
+            1.085141453967237e-29
+          ],
+          "flux_real": [
+            7.498788505514497e-27,
+            3.80321089837925e-27,
+            1.3817574756356502e-27,
+            3.682044145564287e-28,
+            7.28035463493645e-29,
+            1.0755042058498171e-29
+          ],
+          "reactive_fraction": [
+            0.009661436080932617,
+            0.016499459743499756,
+            0.025880932807922363,
+            0.03789240121841431,
+            0.05224210023880005,
+            0.06821626424789429
+          ],
+          "ratio": [
+            1.0089335441589355,
+            1.0090254545211792,
+            1.00901198387146,
+            1.0089561939239502,
+            1.0089209079742432,
+            1.0089608430862427
+          ]
+        },
+        {
+          "plane_idx": 3,
+          "x_frac": 0.6,
+          "p_vi_real": [
+            7.566403283630067e-27,
+            3.8381283934569796e-27,
+            1.3944850799696304e-27,
+            3.7158579383391366e-28,
+            7.346798616164702e-29,
+            1.085284394080297e-29
+          ],
+          "flux_real": [
+            7.500486405353469e-27,
+            3.804030574163581e-27,
+            1.3820016835525985e-27,
+            3.682656591286602e-28,
+            7.281651026530265e-29,
+            1.0757438186182887e-29
+          ],
+          "reactive_fraction": [
+            0.004700183868408203,
+            0.008420765399932861,
+            0.013983309268951416,
+            0.021830856800079346,
+            0.03229457139968872,
+            0.04550886154174805
+          ],
+          "ratio": [
+            1.0087883472442627,
+            1.0089638233184814,
+            1.0090328454971313,
+            1.0090155601501465,
+            1.0089472532272339,
+            1.00886869430542
+          ]
+        },
+        {
+          "plane_idx": 4,
+          "x_frac": 0.7,
+          "p_vi_real": [
+            7.566769980691478e-27,
+            3.838550942486778e-27,
+            1.3946866285383106e-27,
+            3.716411161715662e-28,
+            7.347714034741393e-29,
+            1.0853634625323107e-29
+          ],
+          "flux_real": [
+            7.504388339420798e-27,
+            3.805993096776912e-27,
+            1.38262395151763e-27,
+            3.684040371951644e-28,
+            7.283965753582176e-29,
+            1.076041058821815e-29
+          ],
+          "reactive_fraction": [
+            0.0011888742446899414,
+            0.002324223518371582,
+            0.00424504280090332,
+            0.007312774658203125,
+            0.011951684951782227,
+            0.01862788200378418
+          ],
+          "ratio": [
+            1.0083129405975342,
+            1.0085543394088745,
+            1.0087248086929321,
+            1.008786678314209,
+            1.0087519884109497,
+            1.0086634159088135
+          ]
+        }
+      ],
+      "cells": [
+        {
+          "plane_idx": 0,
+          "freq_ghz": 2.0,
+          "reactive_fraction": 0.02408701181411743,
+          "spread": 0.0007492531440220773,
+          "ratio": 1.008420467376709,
+          "admissible": true
+        },
+        {
+          "plane_idx": 0,
+          "freq_ghz": 2.5,
+          "reactive_fraction": 0.03709447383880615,
+          "spread": 0.0007313623209483922,
+          "ratio": 1.0083287954330444,
+          "admissible": true
+        },
+        {
+          "plane_idx": 0,
+          "freq_ghz": 3.0,
+          "reactive_fraction": 0.051323115825653076,
+          "spread": 0.0006314163329079747,
+          "ratio": 1.0082508325576782,
+          "admissible": true
+        },
+        {
+          "plane_idx": 0,
+          "freq_ghz": 3.5,
+          "reactive_fraction": 0.06487506628036499,
+          "spread": 0.0005876363720744848,
+          "ratio": 1.0082842111587524,
+          "admissible": true
+        },
+        {
+          "plane_idx": 0,
+          "freq_ghz": 4.0,
+          "reactive_fraction": 0.07545685768127441,
+          "spread": 0.0006318631349131465,
+          "ratio": 1.0084660053253174,
+          "admissible": true
+        },
+        {
+          "plane_idx": 0,
+          "freq_ghz": 4.5,
+          "reactive_fraction": 0.08071213960647583,
+          "spread": 0.0008698120363987982,
+          "ratio": 1.0088307857513428,
+          "admissible": true
+        },
+        {
+          "plane_idx": 1,
+          "freq_ghz": 2.0,
+          "reactive_fraction": 0.016465604305267334,
+          "spread": 0.0007492531440220773,
+          "ratio": 1.0088151693344116,
+          "admissible": true
+        },
+        {
+          "plane_idx": 1,
+          "freq_ghz": 2.5,
+          "reactive_fraction": 0.02675706148147583,
+          "spread": 0.0007313623209483922,
+          "ratio": 1.0088205337524414,
+          "admissible": true
+        },
+        {
+          "plane_idx": 1,
+          "freq_ghz": 3.0,
+          "reactive_fraction": 0.0395197868347168,
+          "spread": 0.0006314163329079747,
+          "ratio": 1.0087581872940063,
+          "admissible": true
+        },
+        {
+          "plane_idx": 1,
+          "freq_ghz": 3.5,
+          "reactive_fraction": 0.0539698600769043,
+          "spread": 0.0005876363720744848,
+          "ratio": 1.0087246894836426,
+          "admissible": true
+        },
+        {
+          "plane_idx": 1,
+          "freq_ghz": 4.0,
+          "reactive_fraction": 0.0687781572341919,
+          "spread": 0.0006318631349131465,
+          "ratio": 1.0087924003601074,
+          "admissible": true
+        },
+        {
+          "plane_idx": 1,
+          "freq_ghz": 4.5,
+          "reactive_fraction": 0.08219730854034424,
+          "spread": 0.0008698120363987982,
+          "ratio": 1.0089893341064453,
+          "admissible": true
+        },
+        {
+          "plane_idx": 2,
+          "freq_ghz": 2.0,
+          "reactive_fraction": 0.009661436080932617,
+          "spread": 0.0007492531440220773,
+          "ratio": 1.0089335441589355,
+          "admissible": true
+        },
+        {
+          "plane_idx": 2,
+          "freq_ghz": 2.5,
+          "reactive_fraction": 0.016499459743499756,
+          "spread": 0.0007313623209483922,
+          "ratio": 1.0090254545211792,
+          "admissible": true
+        },
+        {
+          "plane_idx": 2,
+          "freq_ghz": 3.0,
+          "reactive_fraction": 0.025880932807922363,
+          "spread": 0.0006314163329079747,
+          "ratio": 1.00901198387146,
+          "admissible": true
+        },
+        {
+          "plane_idx": 2,
+          "freq_ghz": 3.5,
+          "reactive_fraction": 0.03789240121841431,
+          "spread": 0.0005876363720744848,
+          "ratio": 1.0089561939239502,
+          "admissible": true
+        },
+        {
+          "plane_idx": 2,
+          "freq_ghz": 4.0,
+          "reactive_fraction": 0.05224210023880005,
+          "spread": 0.0006318631349131465,
+          "ratio": 1.0089209079742432,
+          "admissible": true
+        },
+        {
+          "plane_idx": 2,
+          "freq_ghz": 4.5,
+          "reactive_fraction": 0.06821626424789429,
+          "spread": 0.0008698120363987982,
+          "ratio": 1.0089608430862427,
+          "admissible": true
+        },
+        {
+          "plane_idx": 3,
+          "freq_ghz": 2.0,
+          "reactive_fraction": 0.004700183868408203,
+          "spread": 0.0007492531440220773,
+          "ratio": 1.0087883472442627,
+          "admissible": true
+        },
+        {
+          "plane_idx": 3,
+          "freq_ghz": 2.5,
+          "reactive_fraction": 0.008420765399932861,
+          "spread": 0.0007313623209483922,
+          "ratio": 1.0089638233184814,
+          "admissible": true
+        },
+        {
+          "plane_idx": 3,
+          "freq_ghz": 3.0,
+          "reactive_fraction": 0.013983309268951416,
+          "spread": 0.0006314163329079747,
+          "ratio": 1.0090328454971313,
+          "admissible": true
+        },
+        {
+          "plane_idx": 3,
+          "freq_ghz": 3.5,
+          "reactive_fraction": 0.021830856800079346,
+          "spread": 0.0005876363720744848,
+          "ratio": 1.0090155601501465,
+          "admissible": true
+        },
+        {
+          "plane_idx": 3,
+          "freq_ghz": 4.0,
+          "reactive_fraction": 0.03229457139968872,
+          "spread": 0.0006318631349131465,
+          "ratio": 1.0089472532272339,
+          "admissible": true
+        },
+        {
+          "plane_idx": 3,
+          "freq_ghz": 4.5,
+          "reactive_fraction": 0.04550886154174805,
+          "spread": 0.0008698120363987982,
+          "ratio": 1.00886869430542,
+          "admissible": true
+        },
+        {
+          "plane_idx": 4,
+          "freq_ghz": 2.0,
+          "reactive_fraction": 0.0011888742446899414,
+          "spread": 0.0007492531440220773,
+          "ratio": 1.0083129405975342,
+          "admissible": true
+        },
+        {
+          "plane_idx": 4,
+          "freq_ghz": 2.5,
+          "reactive_fraction": 0.002324223518371582,
+          "spread": 0.0007313623209483922,
+          "ratio": 1.0085543394088745,
+          "admissible": true
+        },
+        {
+          "plane_idx": 4,
+          "freq_ghz": 3.0,
+          "reactive_fraction": 0.00424504280090332,
+          "spread": 0.0006314163329079747,
+          "ratio": 1.0087248086929321,
+          "admissible": true
+        },
+        {
+          "plane_idx": 4,
+          "freq_ghz": 3.5,
+          "reactive_fraction": 0.007312774658203125,
+          "spread": 0.0005876363720744848,
+          "ratio": 1.008786678314209,
+          "admissible": true
+        },
+        {
+          "plane_idx": 4,
+          "freq_ghz": 4.0,
+          "reactive_fraction": 0.011951684951782227,
+          "spread": 0.0006318631349131465,
+          "ratio": 1.0087519884109497,
+          "admissible": true
+        },
+        {
+          "plane_idx": 4,
+          "freq_ghz": 4.5,
+          "reactive_fraction": 0.01862788200378418,
+          "spread": 0.0008698120363987982,
+          "ratio": 1.0086634159088135,
+          "admissible": true
+        }
+      ],
+      "n_admissible": 30,
+      "n_total": 30,
+      "admissible_ratio_range": [
+        1.0083,
+        1.009
+      ],
+      "verdict": "HELD"
+    },
+    {
+      "label": "bisecting 80um (gate mesh)",
+      "dx_um": 80.0,
+      "n_sub_exact": 3.175,
+      "frac": 0.175,
+      "mixed_cell_danger_zone": true,
+      "trace_node": 4,
+      "k_lo": 0,
+      "k_top_proxy": 3,
+      "wallclock_s": 499.7,
+      "preflight_warnings": [
+        "[run] preflight found 7 advisory issue(s) - pass skip_preflight=True to suppress:\n  - 'pec' z-extent 80\u00b5m = 1.0 cells \u2014 below 1 cell resolution. A conductor thinner than a cell is modelled as a one-cell PEC surface \u2014 tangential E is zeroed on it and the normal component survives as surface charge. That is usually what you want for metal many skin depths thick, and switching to add_thin_conductor() would not change it; but it means the sheet carries no conductor loss and its thickness is not modelled.\n  - pec_faces={z_lo} creates an INFINITE PEC boundary AND the geometry contains finite PEC objects. For antennas or finite-GP structures, the pec_faces boundary makes the ground plane cover the entire domain face, which changes the physics (cavity vs radiating antenna). If you need a finite ground plane, remove pec_faces and use an explicit PEC Box instead.\n  - all dielectric(s) ['ro4350b'] are perfectly lossless in an open (CPML) domain. If you are measuring Q / resonance, this gives an ARTIFICIALLY infinite Q (design-guide Anti-Pattern #1, an R5 surface-metric trap) \u2014 add loss, e.g. sigma = 2*pi*f*eps0*eps_r*tan_delta. (Harmless if you are not measuring Q.)\n  - MSL port 'msl_0': only 3 substrate cell(s) in z (h_sub=254\u00b5m, dx=80\u00b5m). Yee staircase at dielectric interface is O(dx) \u2014 Z0 staircase error >5% expected. Refine to dx \u2264 64\u00b5m (4+ substrate cells) AND keep h_sub/dx an integer (aligned) for <5% Z0 bias \u2014 measured post-#511/#507 at -3.8%/-1.2%/+0.7% for h_sub/4, h_sub/5, h_sub/6 (scripts/diagnostics/msl_z0_bias_floor_sweep.py). Refining WITHOUT alignment does not reach that: a mixed-cell mesh at a similar cell count measured +11% (h_sub/dx=4.233) \u2014 see the mixed-cell-danger-zone check below.\n  - MSL port 'msl_0': h_sub/dx = 3.175 (fractional part 0.175) lands in the [0.10, 0.40] mixed-cell danger zone. The substrate-air interface bisects the same Yee cell that holds the trace; AD-traceable ``pec_occupancy_override`` zeros the whole cell and produces unphysical |S21|\u00b2 > 1 in this regime. Hard ``Box(material='pec')`` avoids that specific bug, but Z0 bias itself is still 2.56-2.94x worse than an aligned mesh at a comparable cell count (measured +20.2% vs -7.9% at ~3 cells, +11.0% vs -3.8% at ~4 cells; scripts/diagnostics/msl_z0_bias_floor_sweep.py) \u2014 refining cell count alone will not reach the aligned-mesh bias. To snap onto a safe alignment regardless, set dx = 63.5\u00b5m (= h_sub/4) or 84.7\u00b5m (= h_sub/3).\n  - MSL port 'msl_1': only 3 substrate cell(s) in z (h_sub=254\u00b5m, dx=80\u00b5m). Yee staircase at dielectric interface is O(dx) \u2014 Z0 staircase error >5% expected. Refine to dx \u2264 64\u00b5m (4+ substrate cells) AND keep h_sub/dx an integer (aligned) for <5% Z0 bias \u2014 measured post-#511/#507 at -3.8%/-1.2%/+0.7% for h_sub/4, h_sub/5, h_sub/6 (scripts/diagnostics/msl_z0_bias_floor_sweep.py). Refining WITHOUT alignment does not reach that: a mixed-cell mesh at a similar cell count measured +11% (h_sub/dx=4.233) \u2014 see the mixed-cell-danger-zone check below.\n  - MSL port 'msl_1': h_sub/dx = 3.175 (fractional part 0.175) lands in the [0.10, 0.40] mixed-cell danger zone. The substrate-air interface bisects the same Yee cell that holds the trace; AD-traceable ``pec_occupancy_override`` zeros the whole cell and produces unphysical |S21|\u00b2 > 1 in this regime. Hard ``Box(material='pec')`` avoids that specific bug, but Z0 bias itself is still 2.56-2.94x worse than an aligned mesh at a comparable cell count (measured +20.2% vs -7.9% at ~3 cells, +11.0% vs -3.8% at ~4 cells; scripts/diagnostics/msl_z0_bias_floor_sweep.py) \u2014 refining cell count alone will not reach the aligned-mesh bias. To snap onto a safe alignment regardless, set dx = 63.5\u00b5m (= h_sub/4) or 84.7\u00b5m (= h_sub/3)."
+      ],
+      "settling_db": [
+        -115.4,
+        -116.7,
+        -120.8,
+        -119.8,
+        -114.6
+      ],
+      "spread_per_freq": [
+        0.0008,
+        0.0008,
+        0.0006,
+        0.0005,
+        0.0004,
+        0.0005
+      ],
+      "per_plane": [
+        {
+          "plane_idx": 0,
+          "x_frac": 0.3,
+          "p_vi_real": [
+            2.007156887200943e-26,
+            1.019675057926869e-26,
+            3.722116151396926e-27,
+            9.991634995738566e-28,
+            1.9917540169146382e-28,
+            2.9595238833929485e-29
+          ],
+          "flux_real": [
+            1.9860528550191388e-26,
+            1.0089823719128288e-26,
+            3.683342559384544e-27,
+            9.887652112111154e-28,
+            1.9706945748258714e-28,
+            2.927146292688815e-29
+          ],
+          "reactive_fraction": [
+            0.00014460086822509766,
+            0.0002219080924987793,
+            0.00288313627243042,
+            0.010563850402832031,
+            0.024718165397644043,
+            0.04455149173736572
+          ],
+          "ratio": [
+            1.010625958442688,
+            1.0105983018875122,
+            1.0105270147323608,
+            1.0105167627334595,
+            1.0106861591339111,
+            1.011061191558838
+          ]
+        },
+        {
+          "plane_idx": 1,
+          "x_frac": 0.4,
+          "p_vi_real": [
+            2.0074425411302946e-26,
+            1.0199335177254057e-26,
+            3.723393428136043e-27,
+            9.99572855983536e-28,
+            1.9925653149037114e-28,
+            2.960577728184393e-29
+          ],
+          "flux_real": [
+            1.985184029502627e-26,
+            1.0085111353740361e-26,
+            3.681803741358979e-27,
+            9.884571587165107e-28,
+            1.9703619907986e-28,
+            2.9271041629712813e-29
+          ],
+          "reactive_fraction": [
+            0.0008287429809570312,
+            0.00014853477478027344,
+            0.00031512975692749023,
+            0.0033572912216186523,
+            0.01154249906539917,
+            0.026426196098327637
+          ],
+          "ratio": [
+            1.0112121105194092,
+            1.0113260746002197,
+            1.0112967491149902,
+            1.011245846748352,
+            1.0112683773040771,
+            1.0114359855651855
+          ]
+        },
+        {
+          "plane_idx": 2,
+          "x_frac": 0.5,
+          "p_vi_real": [
+            2.0076648704830746e-26,
+            1.0201537670738458e-26,
+            3.724487741530444e-27,
+            9.999161529961231e-28,
+            1.9932209736791537e-28,
+            2.9614149058570937e-29
+          ],
+          "flux_real": [
+            1.9850307254790536e-26,
+            1.0083987381024817e-26,
+            3.681327266290737e-27,
+            9.883693363110466e-28,
+            1.970361509316114e-28,
+            2.927528469412154e-29
+          ],
+          "reactive_fraction": [
+            0.002024352550506592,
+            0.0014140605926513672,
+            0.0004006028175354004,
+            8.398294448852539e-05,
+            0.0022136569023132324,
+            0.008907854557037354
+          ],
+          "ratio": [
+            1.0114017724990845,
+            1.0116571187973022,
+            1.0117237567901611,
+            1.0116826295852661,
+            1.0116018056869507,
+            1.0115748643875122
+          ]
+        },
+        {
+          "plane_idx": 3,
+          "x_frac": 0.6,
+          "p_vi_real": [
+            2.007812319679617e-26,
+            1.0203066859114302e-26,
+            3.725300098780987e-27,
+            1.0001647905519435e-27,
+            1.9937221969471805e-28,
+            2.9619887727952103e-29
+          ],
+          "flux_real": [
+            1.9855266909583322e-26,
+            1.0085998051886757e-26,
+            3.681834941424078e-27,
+            9.884596624254384e-28,
+            1.9705491671150702e-28,
+            2.927944650836074e-29
+          ],
+          "reactive_fraction": [
+            0.0034831762313842773,
+            0.003612697124481201,
+            0.002836287021636963,
+            0.0014377832412719727,
+            0.00019431114196777344,
+            0.00041371583938598633
+          ],
+          "ratio": [
+            1.0112242698669434,
+            1.0116069316864014,
+            1.0118046998977661,
+            1.0118415355682373,
+            1.0117599964141846,
+            1.0116268396377563
+          ]
+        },
+        {
+          "plane_idx": 4,
+          "x_frac": 0.7,
+          "p_vi_real": [
+            2.007864088676522e-26,
+            1.0203927364613454e-26,
+            3.7257908257308165e-27,
+            1.0003443835192576e-27,
+            1.9940004938241444e-28,
+            2.9622283103320435e-29
+          ],
+          "flux_real": [
+            1.9867166075151724e-26,
+            1.0091848256685828e-26,
+            3.6836337599921354e-27,
+            9.88846196565277e-28,
+            1.97110275160346e-28,
+            2.928577198452184e-29
+          ],
+          "reactive_fraction": [
+            0.005159497261047363,
+            0.0065177083015441895,
+            0.0070879459381103516,
+            0.006677031517028809,
+            0.0053057074546813965,
+            0.003252685070037842
+          ],
+          "ratio": [
+            1.010644793510437,
+            1.0111061334609985,
+            1.0114444494247437,
+            1.011628270149231,
+            1.011616587638855,
+            1.0114904642105103
+          ]
+        }
+      ],
+      "cells": [
+        {
+          "plane_idx": 0,
+          "freq_ghz": 2.0,
+          "reactive_fraction": 0.00014460086822509766,
+          "spread": 0.000849010597448796,
+          "ratio": 1.010625958442688,
+          "admissible": true
+        },
+        {
+          "plane_idx": 0,
+          "freq_ghz": 2.5,
+          "reactive_fraction": 0.0002219080924987793,
+          "spread": 0.0007792802643962204,
+          "ratio": 1.0105983018875122,
+          "admissible": true
+        },
+        {
+          "plane_idx": 0,
+          "freq_ghz": 3.0,
+          "reactive_fraction": 0.00288313627243042,
+          "spread": 0.0006263581453822553,
+          "ratio": 1.0105270147323608,
+          "admissible": true
+        },
+        {
+          "plane_idx": 0,
+          "freq_ghz": 3.5,
+          "reactive_fraction": 0.010563850402832031,
+          "spread": 0.00048236912698484957,
+          "ratio": 1.0105167627334595,
+          "admissible": true
+        },
+        {
+          "plane_idx": 0,
+          "freq_ghz": 4.0,
+          "reactive_fraction": 0.024718165397644043,
+          "spread": 0.00037614788743667305,
+          "ratio": 1.0106861591339111,
+          "admissible": true
+        },
+        {
+          "plane_idx": 0,
+          "freq_ghz": 4.5,
+          "reactive_fraction": 0.04455149173736572,
+          "spread": 0.0005031442851759493,
+          "ratio": 1.011061191558838,
+          "admissible": true
+        },
+        {
+          "plane_idx": 1,
+          "freq_ghz": 2.0,
+          "reactive_fraction": 0.0008287429809570312,
+          "spread": 0.000849010597448796,
+          "ratio": 1.0112121105194092,
+          "admissible": true
+        },
+        {
+          "plane_idx": 1,
+          "freq_ghz": 2.5,
+          "reactive_fraction": 0.00014853477478027344,
+          "spread": 0.0007792802643962204,
+          "ratio": 1.0113260746002197,
+          "admissible": true
+        },
+        {
+          "plane_idx": 1,
+          "freq_ghz": 3.0,
+          "reactive_fraction": 0.00031512975692749023,
+          "spread": 0.0006263581453822553,
+          "ratio": 1.0112967491149902,
+          "admissible": true
+        },
+        {
+          "plane_idx": 1,
+          "freq_ghz": 3.5,
+          "reactive_fraction": 0.0033572912216186523,
+          "spread": 0.00048236912698484957,
+          "ratio": 1.011245846748352,
+          "admissible": true
+        },
+        {
+          "plane_idx": 1,
+          "freq_ghz": 4.0,
+          "reactive_fraction": 0.01154249906539917,
+          "spread": 0.00037614788743667305,
+          "ratio": 1.0112683773040771,
+          "admissible": true
+        },
+        {
+          "plane_idx": 1,
+          "freq_ghz": 4.5,
+          "reactive_fraction": 0.026426196098327637,
+          "spread": 0.0005031442851759493,
+          "ratio": 1.0114359855651855,
+          "admissible": true
+        },
+        {
+          "plane_idx": 2,
+          "freq_ghz": 2.0,
+          "reactive_fraction": 0.002024352550506592,
+          "spread": 0.000849010597448796,
+          "ratio": 1.0114017724990845,
+          "admissible": true
+        },
+        {
+          "plane_idx": 2,
+          "freq_ghz": 2.5,
+          "reactive_fraction": 0.0014140605926513672,
+          "spread": 0.0007792802643962204,
+          "ratio": 1.0116571187973022,
+          "admissible": true
+        },
+        {
+          "plane_idx": 2,
+          "freq_ghz": 3.0,
+          "reactive_fraction": 0.0004006028175354004,
+          "spread": 0.0006263581453822553,
+          "ratio": 1.0117237567901611,
+          "admissible": true
+        },
+        {
+          "plane_idx": 2,
+          "freq_ghz": 3.5,
+          "reactive_fraction": 8.398294448852539e-05,
+          "spread": 0.00048236912698484957,
+          "ratio": 1.0116826295852661,
+          "admissible": true
+        },
+        {
+          "plane_idx": 2,
+          "freq_ghz": 4.0,
+          "reactive_fraction": 0.0022136569023132324,
+          "spread": 0.00037614788743667305,
+          "ratio": 1.0116018056869507,
+          "admissible": true
+        },
+        {
+          "plane_idx": 2,
+          "freq_ghz": 4.5,
+          "reactive_fraction": 0.008907854557037354,
+          "spread": 0.0005031442851759493,
+          "ratio": 1.0115748643875122,
+          "admissible": true
+        },
+        {
+          "plane_idx": 3,
+          "freq_ghz": 2.0,
+          "reactive_fraction": 0.0034831762313842773,
+          "spread": 0.000849010597448796,
+          "ratio": 1.0112242698669434,
+          "admissible": true
+        },
+        {
+          "plane_idx": 3,
+          "freq_ghz": 2.5,
+          "reactive_fraction": 0.003612697124481201,
+          "spread": 0.0007792802643962204,
+          "ratio": 1.0116069316864014,
+          "admissible": true
+        },
+        {
+          "plane_idx": 3,
+          "freq_ghz": 3.0,
+          "reactive_fraction": 0.002836287021636963,
+          "spread": 0.0006263581453822553,
+          "ratio": 1.0118046998977661,
+          "admissible": true
+        },
+        {
+          "plane_idx": 3,
+          "freq_ghz": 3.5,
+          "reactive_fraction": 0.0014377832412719727,
+          "spread": 0.00048236912698484957,
+          "ratio": 1.0118415355682373,
+          "admissible": true
+        },
+        {
+          "plane_idx": 3,
+          "freq_ghz": 4.0,
+          "reactive_fraction": 0.00019431114196777344,
+          "spread": 0.00037614788743667305,
+          "ratio": 1.0117599964141846,
+          "admissible": true
+        },
+        {
+          "plane_idx": 3,
+          "freq_ghz": 4.5,
+          "reactive_fraction": 0.00041371583938598633,
+          "spread": 0.0005031442851759493,
+          "ratio": 1.0116268396377563,
+          "admissible": true
+        },
+        {
+          "plane_idx": 4,
+          "freq_ghz": 2.0,
+          "reactive_fraction": 0.005159497261047363,
+          "spread": 0.000849010597448796,
+          "ratio": 1.010644793510437,
+          "admissible": true
+        },
+        {
+          "plane_idx": 4,
+          "freq_ghz": 2.5,
+          "reactive_fraction": 0.0065177083015441895,
+          "spread": 0.0007792802643962204,
+          "ratio": 1.0111061334609985,
+          "admissible": true
+        },
+        {
+          "plane_idx": 4,
+          "freq_ghz": 3.0,
+          "reactive_fraction": 0.0070879459381103516,
+          "spread": 0.0006263581453822553,
+          "ratio": 1.0114444494247437,
+          "admissible": true
+        },
+        {
+          "plane_idx": 4,
+          "freq_ghz": 3.5,
+          "reactive_fraction": 0.006677031517028809,
+          "spread": 0.00048236912698484957,
+          "ratio": 1.011628270149231,
+          "admissible": true
+        },
+        {
+          "plane_idx": 4,
+          "freq_ghz": 4.0,
+          "reactive_fraction": 0.0053057074546813965,
+          "spread": 0.00037614788743667305,
+          "ratio": 1.011616587638855,
+          "admissible": true
+        },
+        {
+          "plane_idx": 4,
+          "freq_ghz": 4.5,
+          "reactive_fraction": 0.003252685070037842,
+          "spread": 0.0005031442851759493,
+          "ratio": 1.0114904642105103,
+          "admissible": true
+        }
+      ],
+      "n_admissible": 30,
+      "n_total": 30,
+      "admissible_ratio_range": [
+        1.0105,
+        1.0118
+      ],
+      "verdict": "HELD"
+    }
+  ],
+  "overall": "HELD"
+}

--- a/tests/test_mixed_port_sparam.py
+++ b/tests/test_mixed_port_sparam.py
@@ -14,12 +14,16 @@ Layer 1 (this file, fast suite):
     is the separate slow-lane battery.
 """
 
+from types import MethodType
+
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
 from rfx import Box, Simulation
 from rfx.api._sparams import _assemble_mixed_power_wave_s
 from rfx.boundaries.spec import Boundary, BoundarySpec
+from rfx.probes.probes import DFTPlaneProbe
 from rfx.sources.sources import GaussianPulse
 
 _EPS_R = 3.66
@@ -514,4 +518,122 @@ def test_mixed_probe_fed_msl_plumbing_smoke():
     assert len(sim._dft_planes) == 0
     assert len(sim._probes) == 0
     assert sim._msl_ports[0].excite is True
+
+
+# ---------------------------------------------------------------------------
+# Layer 1d (issue #520 leg 3) — the mixed lane's OWN V-span anchor
+# ---------------------------------------------------------------------------
+#
+# compute_msl_s_matrix's V-span anchoring fix (issue #511/PR #516 finding
+# F2: anchor k_hi on the RASTERIZED trace node, not round(h_sub/dx)) was
+# copied by hand into compute_mixed_s_matrix's own MSL leg (the
+# msl_modal_voltage call at _sparams.py that reads
+# trace_k_per_port[p_idx][0] — the call site's own comment says it
+# "mirrors compute_msl_s_matrix line-for-line"). Nothing exercises that
+# copy: every existing mixed-lane test drives real FDTD fields, where the
+# F2 defect's effect is a single-digit-percent V bias lost in ordinary
+# run-to-run noise, not a loud, well-defined discriminator. This plants a
+# per-z-node Ez marker — same technique and same bisecting dx=80um mesh as
+# test_v_span_on_bisecting_mesh_reaches_the_rasterized_trace in
+# test_msl_modal_voltage_and_wave_solve.py, where the real trace node (4)
+# and the retired round(h_sub/dx) proxy (3) disagree — directly into the
+# mixed lane's own ``_forward_from_materials`` scan hook (the mixed lane
+# does not call ``self.run()``, so that file's ``sim.run`` stub does not
+# apply here), and reads back the raw V via ``return_diagnostics=True``.
+# This proves the MIXED LANE'S OWN copy, independently of the shared
+# helper's own unit tests.
+
+
+def _fake_forward_mixed_z_profile(nz_markers, n_lw):
+    """``_forward_from_materials`` stub: MSL Ez planes carry a fixed
+    per-z-node profile; every registered probe plane gets it (retargets
+    ``_fake_run_z_profile`` from test_msl_modal_voltage_and_wave_solve.py
+    at the mixed lane's own scan hook).
+
+    Hy/Hz carry a z-RAMP, not a uniform value: a uniform H makes the
+    closed Ampere-loop current cancel to EXACTLY zero (bottom leg equals
+    top leg, left leg equals right leg), which would make ``i_msl`` -- and
+    everything downstream of it -- degenerate. Same trap documented next
+    to ``_fake_run_drive_dependent`` in that file.
+    """
+
+    def fake_forward(self, grid, materials, debye_spec, lorentz_spec,
+                     n_steps=None, checkpoint=False, pec_mask=None,
+                     port_s11_freqs=None, _return_raw_port_sparams=False):
+        del materials, debye_spec, lorentz_spec, n_steps, checkpoint, pec_mask
+        freqs = jnp.asarray(port_s11_freqs)
+        n_f = int(freqs.shape[0])
+        zramp = jnp.asarray(
+            [1.0 + 0.6 * k for k in range(grid.nz)], dtype=jnp.complex64)
+        planes = {}
+        for entry in self._dft_planes:
+            if entry.component == "ez":
+                prof = jnp.asarray(
+                    [complex(nz_markers.get(k, 0.0)) for k in range(grid.nz)],
+                    dtype=jnp.complex64,
+                )
+                acc = jnp.broadcast_to(
+                    prof[None, None, :], (n_f, grid.ny, grid.nz))
+            elif entry.component == "hy":
+                acc = jnp.broadcast_to(
+                    ((0.018 + 0.004j) * zramp)[None, None, :],
+                    (n_f, grid.ny, grid.nz))
+            else:  # hz
+                acc = jnp.broadcast_to(
+                    ((0.005 + 0.001j) * zramp)[None, None, :],
+                    (n_f, grid.ny, grid.nz))
+            planes[entry.name] = DFTPlaneProbe(
+                accumulator=acc, freqs=entry.freqs,
+                component=entry.component, axis=0, index=0,
+                total_steps=1, window="rect", window_alpha=0.25,
+            )
+        wire_accs = [
+            (None, (np.full(n_f, 0.7 + 0.1j, dtype=np.complex128),
+                   np.full(n_f, 0.02 - 0.01j, dtype=np.complex128)))
+            for _ in range(n_lw)
+        ]
+        return {"lumped": wire_accs, "wire": wire_accs,
+               "dft_planes": planes, "time_series": None}
+
+    return fake_forward
+
+
+def test_mixed_lane_v_span_reaches_the_rasterized_trace_on_bisecting_mesh():
+    """The mixed lane's MSL V must use the SAME corrected span as
+    compute_msl_s_matrix, on the SAME bisecting mesh class (dx=80um,
+    h_sub/dx=3.175) that made the difference measurable in the first place.
+
+    Marker + expected numbers mirror
+    test_v_span_on_bisecting_mesh_reaches_the_rasterized_trace exactly:
+    the trace rasterizes at node 4, so the real trace-anchored span (edges
+    0..3) sums to (1+1+1+10)*dz; the retired round(h_sub/dx)=3 proxy (edges
+    0..2) would give (1+1+1)*dz — a >4x difference, not a tolerance-level
+    slip, so this is a loud discriminator, not a regression-lock on noise.
+    """
+    marker = {0: 1.0, 1: 1.0, 2: 1.0, 3: 10.0, 4: -1000.0}
+    sim, y_c = _base_sim()
+    _add_feed(sim, y_c)
+    _add_msl(sim, y_c, n_probe_offset=10, n_probe_spacing=4)
+    n_lw = len(sim._ports)
+    sim._forward_from_materials = MethodType(
+        _fake_forward_mixed_z_profile(marker, n_lw), sim)
+
+    result, diag = sim.compute_mixed_s_matrix(
+        freqs=np.asarray([1.0e9]), magnitude_channel="wave",
+        return_diagnostics=True, skip_preflight=True,
+    )
+    del result
+    v0_msl = np.asarray(diag["v0_msl"])  # (n_runs, n_msl, n_freqs)
+    assert v0_msl.shape[1:] == (1, 1)
+
+    dz = 80e-6  # _DX, uniform grid -- msl_modal_voltage weights each edge by dz
+    expected_correct = (1.0 + 1.0 + 1.0 + 10.0) * dz
+    expected_proxy = (1.0 + 1.0 + 1.0) * dz
+    v_msl0 = v0_msl[:, 0, 0]  # every drive run, MSL port 0, the one frequency
+    np.testing.assert_allclose(v_msl0.real, expected_correct, rtol=1e-5)
+    assert not np.isclose(v_msl0[0].real, expected_proxy, rtol=1e-3), (
+        f"V read the retired round(h_sub/dx) proxy span ({expected_proxy}) "
+        f"instead of the trace-anchored span ({expected_correct}) — the "
+        "#511/F2 off-by-one has returned in the mixed lane's own copy."
+    )
     assert sim._ports[0].excite is True

--- a/tests/test_msl_modal_voltage_and_wave_solve.py
+++ b/tests/test_msl_modal_voltage_and_wave_solve.py
@@ -389,6 +389,134 @@ def test_solve_handles_a_one_port_system():
 
 
 # --------------------------------------------------------------------------
+# Issue #520 leg 2 — S vs Sᵀ: every committed fixture up to this point is
+# SYMMETRIC (``_planted_s`` sets S[0,0]=S[1,1] and S[1,0]=S[0,1]), so a
+# solve that silently returned Sᵀ instead of S — e.g. the shipped
+# ``jnp.swapaxes(..., -1, -2)`` "flip back" after the batched
+# ``jnp.linalg.solve`` on (Aᵀ, Bᵀ) being dropped — would pass every existing
+# test here. Worse: for a RECIPROCAL 2-port (S12 = S21, true of any real
+# passive non-magnetized MSL structure — this is the reciprocity theorem,
+# not an rfx property) S = Sᵀ identically REGARDLESS of how asymmetric the
+# two ports are (S11 != S22 does not help: transpose only swaps the
+# off-diagonal pair, and reciprocity already makes that pair equal). So no
+# PHYSICALLY REALIZABLE MSL fixture can ever expose this bug — only a
+# fixture that violates reciprocity on purpose can, which is legitimate
+# here because ``msl_solve_s_from_waves`` is a pure n-port linear solve
+# with no reciprocity assumption built in. The re-review that opened this
+# item verified the [receiver, driven] orientation numerically but did not
+# commit a test; this is that test.
+# --------------------------------------------------------------------------
+
+def _nonreciprocal_planted_s(n_freqs=N_FREQS):
+    """A deliberately NON-reciprocal 2-port S (S12 != S21, S11 != S22).
+
+    No real rfx MSL geometry could produce this (reciprocity would force
+    S12 == S21), which is exactly why it is needed: it is the only kind of
+    fixture that can tell a correct [receiver, driven] assembly apart from
+    a transposed one.
+    """
+    f = np.linspace(0.0, 1.0, n_freqs)
+    S = np.zeros((2, 2, n_freqs), dtype=np.complex128)
+    S[0, 0] = 0.20 * np.exp(1j * (0.3 + 0.4 * f))
+    S[1, 1] = 0.35 * np.exp(1j * (-0.5 + 0.2 * f))
+    S[0, 1] = 0.55 * np.exp(1j * (1.1 - 0.6 * f))
+    S[1, 0] = 0.80 * np.exp(1j * (-0.2 + 0.9 * f))
+    return S
+
+
+def _naive_transposed_solve(wave_a, wave_b):
+    """The bug this section guards against: drop the final Sᵀ->S flip.
+
+    ``msl_solve_s_from_waves`` solves the batched system in the
+    ``(Aᵀ, Bᵀ)`` layout ``jnp.linalg.solve`` needs, then swaps the last two
+    axes back (``jnp.swapaxes(..., -1, -2)``) to return S in the
+    documented [receiver, driven] orientation. Omitting that final swap is
+    a plausible, easy-to-miss implementation slip; this reproduces exactly
+    that slip so the test below can show it is caught.
+    """
+    n_ports = len(wave_a)
+    A = jnp.stack([
+        jnp.stack([wave_a[d][j] for d in range(n_ports)], axis=-1)
+        for j in range(n_ports)
+    ], axis=-2)
+    B = jnp.stack([
+        jnp.stack([wave_b[d][j] for d in range(n_ports)], axis=-1)
+        for j in range(n_ports)
+    ], axis=-2)
+    S_T = jnp.linalg.solve(jnp.swapaxes(A, -1, -2), jnp.swapaxes(B, -1, -2))
+    # BUG: no swapaxes back here -- returns S^T, not S.
+    return jnp.moveaxis(S_T, 0, -1)
+
+
+def test_nonreciprocal_fixture_is_actually_asymmetric():
+    """Ground truth must itself be checked (mirrors
+    test_coax_two_port_solve.py's test_asymmetric_fixture_is_what_it_claims):
+    a fixture whose defining property is assumed rather than asserted is
+    exactly how a previous review found a battery that looked complete but
+    was measuring nothing (test_coax_two_port_solve.py's own
+    ``_both_drive_swap`` history)."""
+    S = _nonreciprocal_planted_s()
+    assert not np.allclose(S[0, 1], S[1, 0]), "fixture must be non-reciprocal"
+    assert not np.isclose(abs(S[0, 0][0]), abs(S[1, 1][0])), (
+        "fixture must also be port-asymmetric"
+    )
+
+
+def test_multi_drive_solve_recovers_a_nonreciprocal_planted_s():
+    """The actual S-vs-Sᵀ proof: exact recovery of a NON-symmetric S.
+
+    Unlike test_multi_drive_solve_recovers_the_planted_s (symmetric S,
+    where S == S^T so this assertion cannot tell the two apart), a pass
+    here is only possible if the solve returns S in the declared
+    [receiver, driven] orientation, not its transpose.
+    """
+    S = _nonreciprocal_planted_s()
+    assert not np.allclose(S, np.swapaxes(S, 0, 1))  # sanity: S != S^T
+    for gamma in (0.0, 0.07, 0.2, 0.45):
+        wave_a, wave_b = _waves_from(S, gamma)
+        with enable_x64():
+            S_out = np.asarray(msl_solve_s_from_waves(wave_a, wave_b)[0])
+        np.testing.assert_allclose(S_out, S, rtol=F64_TOL, atol=F64_TOL)
+
+
+def test_transpose_bug_is_caught_only_by_the_nonreciprocal_fixture():
+    """Proves the discriminating power directly: the naive Sᵀ-returning
+    variant visibly diverges from the shipped solve on the non-reciprocal
+    fixture, and is numerically INDISTINGUISHABLE from it on the old
+    reciprocal fixture — exactly the blind spot issue #520 opened on.
+    """
+    S = _nonreciprocal_planted_s()
+    gamma = 0.2
+    wave_a, wave_b = _waves_from(S, gamma)
+    with enable_x64():
+        S_out = np.asarray(msl_solve_s_from_waves(wave_a, wave_b)[0])
+        S_naive_T = np.asarray(_naive_transposed_solve(wave_a, wave_b))
+
+    np.testing.assert_allclose(S_out, S, rtol=F64_TOL, atol=F64_TOL)
+    np.testing.assert_allclose(
+        S_naive_T, np.swapaxes(S, 0, 1), rtol=F64_TOL, atol=F64_TOL)
+    assert np.max(np.abs(S_naive_T - S)) > 0.1, (
+        "the transposed variant should visibly diverge from S on a "
+        "non-reciprocal fixture -- if this fails the fixture is not "
+        "discriminating"
+    )
+
+    # ... and the historical blind spot: on the OLD symmetric fixture the
+    # same bug is invisible, which is why nothing caught it before.
+    S_sym = _planted_s()
+    assert np.allclose(S_sym, np.swapaxes(S_sym, 0, 1))  # S == S^T here
+    wave_a_sym, wave_b_sym = _waves_from(S_sym, gamma)
+    with enable_x64():
+        S_out_sym = np.asarray(msl_solve_s_from_waves(wave_a_sym, wave_b_sym)[0])
+        S_naive_T_sym = np.asarray(_naive_transposed_solve(wave_a_sym, wave_b_sym))
+    np.testing.assert_allclose(
+        S_out_sym, S_naive_T_sym, rtol=F64_TOL, atol=F64_TOL,
+        err_msg="the reciprocal fixture should NOT be able to tell the "
+                "transposed variant apart from the correct one",
+    )
+
+
+# --------------------------------------------------------------------------
 # F2 (PR #516 review) — the WIRING: the assembly must anchor the V span on
 # the RASTERIZED trace node, not on round(h_sub/dx)
 # --------------------------------------------------------------------------

--- a/tests/test_msl_modal_voltage_and_wave_solve.py
+++ b/tests/test_msl_modal_voltage_and_wave_solve.py
@@ -296,6 +296,86 @@ def test_cond_a_reports_a_degenerate_drive_system():
     assert float(np.max(cond_bad)) > 100.0
 
 
+# --------------------------------------------------------------------------
+# Issue #520 leg 4 — cond_a on an EXACTLY-singular f32 drive matrix
+# (regression lock for the NEP-50 fix in a5acfa9, PR #516 review)
+# --------------------------------------------------------------------------
+#
+# The only committed cond_a test above uses gamma=0.999 (near-, not
+# exactly-, singular) INSIDE ``enable_x64()`` — the production default runs
+# ``msl_solve_s_from_waves`` in complex64 (no x64 scoping anywhere in
+# compute_msl_s_matrix's drive loop), so that test never exercised the f32
+# SVD branch the fix actually touches. Pre-fix, ``cond_a``'s
+# ``np.maximum(_sv[..., -1], 1e-300)`` floor ran on the RAW float32 SVD
+# output; under NEP-50 weak promotion the Python float ``1e-300`` adopts
+# the array's dtype BEFORE the comparison and underflows to exactly 0.0
+# (float32's smallest subnormal is ~1.4e-45), so an exactly-singular A
+# divided by zero instead of saturating at a huge, still-meaningful,
+# finite value.
+
+def test_cond_a_on_exactly_singular_f32_matrix_saturates_not_divides_by_zero():
+    """An exactly rank-deficient complex64 drive matrix (production dtype,
+    no x64) must give a FINITE, huge cond_a -- not inf/nan.
+
+    Drive 1's column is EXACTLY zero (a totally undriven/dead port — the
+    realistic failure mode the downstream warning names: "check that each
+    drive actually excited its port"). A zero column is a clean rank
+    deficiency: unlike two nominally-equal nonzero columns (which measured
+    a smallest singular value ~1e-16 relative, not bit-exact, on this
+    platform's LAPACK and so does not even reach the 1e-300 floor), a
+    genuinely zero column measures an EXACTLY 0.0 smallest singular value
+    in the float32 SVD (verified below), which is what actually exercises
+    the underflow.
+    """
+    a_col = jnp.asarray(
+        [1.0 + 0.3j, 0.9 - 0.1j, 1.1 + 0.05j], dtype=jnp.complex64)
+    zero_col = jnp.zeros(3, dtype=jnp.complex64)
+    wave_a = [[a_col, zero_col], [a_col, zero_col]]
+    wave_b = [[0.3 * a_col, 0.1 * zero_col], [0.2 * a_col, 0.1 * zero_col]]
+
+    S_out, cond_a = msl_solve_s_from_waves(wave_a, wave_b)
+    assert cond_a is not None
+    assert cond_a.dtype == np.float64, (
+        "the fix casts the SVD to float64 BEFORE the 1e-300 floor -- a "
+        "float32 cond_a here means the floor is back in the underflowing "
+        "dtype"
+    )
+    assert np.all(np.isfinite(cond_a)), (
+        f"cond_a is non-finite on an exactly-singular f32 drive matrix "
+        f"({cond_a}) -- the 1e-300 floor divided by zero instead of "
+        "saturating (the a5acfa9 regression)"
+    )
+    assert np.all(cond_a > 1.0e100), (
+        f"an exactly-singular A's cond_a should SATURATE near sv_max/1e-300, "
+        f"got {cond_a}"
+    )
+    del S_out  # solve itself is expected to be non-finite here; not this test's claim
+
+    # Mutation twin: reproduce the PRE-FIX arithmetic directly (float32 SVD,
+    # no cast) and show it actually breaks on this exact fixture -- proving
+    # the fixture discriminates the fix rather than merely being finite by
+    # accident.
+    n_ports = 2
+    A = jnp.stack([
+        jnp.stack([wave_a[d][j] for d in range(n_ports)], axis=-1)
+        for j in range(n_ports)
+    ], axis=-2)
+    sv_f32 = np.linalg.svd(np.asarray(A), compute_uv=False)
+    assert sv_f32.dtype == np.float32
+    assert np.all(sv_f32[..., -1] == 0.0), (
+        "fixture precondition: the smallest singular value must be "
+        f"BIT-EXACT 0.0 for the underflow to engage at all; got "
+        f"{sv_f32[..., -1]}"
+    )
+    with np.errstate(divide="ignore", invalid="ignore"):
+        cond_a_prefix = sv_f32[..., 0] / np.maximum(sv_f32[..., -1], 1e-300)
+    assert not np.all(np.isfinite(cond_a_prefix)), (
+        "the pre-fix (float32, uncast) arithmetic should have produced a "
+        f"non-finite cond_a here; got {cond_a_prefix} -- if this fails the "
+        "fixture no longer discriminates the a5acfa9 fix"
+    )
+
+
 def test_solve_handles_a_one_port_system():
     """n_ports=1 degenerates to b/a and must not raise."""
     n_f = N_FREQS


### PR DESCRIPTION
## What / why

Four of #520's legs, each with a mutation twin proving discriminating power. Leg 5 (stale warning strings, raw_3probe metadata, the 7 PLAUSIBLE overflow findings) is honestly UNSTARTED — it needs its own research pass.

## Leg 1 — the flux oracle (the standing falsifier #520 asked for)

`scripts/diagnostics/msl_vi_flux_oracle.py` + committed JSON. Built to #525's own follow-up bar: the convention is stated AND runtime-asserted (no asymmetric ½ factor, via a real anti-regression guard — see below), an admissibility witness (reactive fraction + plane-to-plane spread from the flux monitor's own accumulators) gates each cell before the ratio is trusted, the far port is genuinely terminated (excite=False → resistive Z0, not bare absorption), and BOTH mesh classes run.

**First-COMMITTED bisecting-mesh measurement (#525 measured it twice in an uncommitted harness): the identity HELD on both classes, 30/30 admissible cells** — aligned h_sub/3: Re(V·I*)/flux = 1.0083–1.0090; bisecting 80 µm (the gate mesh): 1.0105–1.0118.

This does NOT reproduce #525's as-posted 0.54–0.69 bisecting read, and the reconciliation is now explicit in the script's append-only correction note: #525's own comment 2 supplies the convention-corrected figure (0.54–0.69, un-halved, → **1.20–1.34**), and review's independent measurement on the same unterminated fixture class, reconstructed (#525's own harness was never committed) measured **1.0898–1.3867**, matching #525's corrected figure to ~1%. The provenance of the reactive-witness evidence was also fixed: the 472%-spread/−122.9 dB figures are #525's own **ALIGNED**-mesh measurement, not bisecting (#525's own text says so); the witness leg that actually refuses that unterminated fixture is **reactive fraction** (0.963–0.995), not spread (0.011–0.067, which passes this script's 0.5 threshold). Both corrections are documented in the script's docstring.

New this round: the aligned-mesh number (1.0083–1.0090) resolves a question #525 comment 2 left open — whether PR #516's original 1.006–1.009 paired the convention correctly. It does: this script's independently convention-audited aligned measurement lands almost exactly on PR #516's own number, which stands validated, not coincidentally close.

Also fixed on review: the script's own "convention regression guard" was tautological (`p_vi/flux == (0.5·p_vi)/(0.5·flux)` — true for any fixture, the same defect class PR #531's review blocked in `scripts/msl_flux_ratio_dof.py`). Removed; replaced with `_oracle_ratio()` (the single choke-point implementation) plus a guard that plants TWO independent mutations, both routed through the real function (not a hand-inlined duplicate): a ½ on the numerator (`v`) side only — #525's own bug, ratio moves 1.0 → 0.5 — and a ½ on the denominator (`flux`) side only, the mirror-image bug an earlier version of the guard missed, ratio moves 1.0 → 2.0 (the shape of #525's own "convention-corrected 2.01–2.02" misdiagnosis: a script-side factor bug surfacing as a false physics over-report rather than a caught regression). The committed JSON now also carries a free mutation twin — the retired `round(h_sub/dx)` proxy span re-applied to the already-recorded fields (zero new FDTD): on the bisecting mesh it reads 0.7443–0.7452, hard outside [0.85, 1.15], proving the oracle can tell the retired span from the corrected one — and `|V|`/`|I|` per cell, since `scripts/msl_flux_ratio_dof.py` shows this ratio (and, structurally, both admissibility witnesses, which read only the flux monitor's own fields) is exactly invariant under the power-preserving rescale `(V,I) → (aV, I/a)` — a blind direction now stated explicitly rather than implied closed.

## Legs 2–4 — discriminating tests

- **S-vs-Sᵀ** (`test_msl_modal_voltage_and_wave_solve.py`): a deliberately NON-reciprocal planted-S fixture (any physical MSL S is symmetric, so only such a fixture can expose a transpose bug); the mutation twin shows the historical blind spot — the dropped-transpose bug is caught on the new fixture and invisible on every committed symmetric one.
- **Mixed-lane V-span wiring** (`test_mixed_port_sparam.py`): per-z-node Ez marker through the lane's own scan hook, raw V read back via return_diagnostics; reverting the call site to the retired `round(h_sub/dx)` proxy fails loudly (verified, then reverted clean).
- **cond_a exactly-singular**: a zero drive column reaches bit-exact 0.0 in float32 SVD (two near-identical columns do NOT — the first attempt was caught by its own mutation twin and replaced); the pre-fix uncast arithmetic reproduces `inf`, the shipped floor masks correctly.

## Verification

Tests pass across the two touched test files (own process), ruff clean, no gates/tolerances touched, no module-level x64. All commits carry R3 lines; the oracle script's original pre-declaration is append-only disciplined for every DECIDABLE element (band, mesh classes, fixture, thresholds) — this round's fixes are a dated append plus in-place corrections to non-falsifiable explanatory prose only, documented in the script itself.

R3: memory=#525's closure record (consistent — the oracle gates the measurable DOF with an admissibility witness; the historical non-reproduction is now explained AND reconciled to ~1% against #525's own convention-corrected number) + `scripts/msl_flux_ratio_dof.py` (DOF-blindness framing) | R2-attempts=1 oracle campaign, pre-declared, plus two review-response passes (the JSON-regenerating pass RE-EXECUTED the full 2-mesh campaign — not skipped — with `p_vi_real`/`flux_real`/`ratio`/`reactive_fraction` bit-identical to the original committed run: reviewer-verified, and independently re-confirmed field-by-field from the two committed JSON commits in this pass, so the new fields are pure re-analysis of the same physics) | falsifier=every leg's mutation twin, committed; the proxy-span twin's numbers are in the committed JSON; the guard's own two mutations are verified to move the ratio to 0.5 and 2.0 respectively

🤖 Generated with [Claude Code](https://claude.com/claude-code)
