### PR TITLE
MSL probe-span preflight: absorber and opposite-port-feed checks on the deepest probe (#510)

### DIFF
--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -3901,6 +3901,16 @@ class _PreflightMixin:
             # (tests/test_preflight_absorber_frame.py module docstring)
             # covers this comparison the same way it covers every other
             # consumer of those two helpers.
+            #
+            # Known limitation (issue #510 review nit A, disclosed
+            # non-regression): ``_msl_grid`` is built via
+            # ``self._build_grid()``, which is unconditionally UNIFORM (see
+            # the grid-build comment above) -- on an x-graded mesh
+            # (``dx_profile``) this can produce an observable false
+            # positive, e.g. warning about x=0.08mm when the REAL,
+            # NU-grid deepest probe sits at 3.24mm. Exact parity with
+            # every other quantity this whole function already computes
+            # off the scalar ``dx`` parameter, so not a new limitation.
             _domain_x = float(domain[0])
             _deep_idx = n_pr - 1
             _abs_margin = _ABSORBER_PROXIMITY_CELLS * dx
@@ -3960,15 +3970,22 @@ class _PreflightMixin:
             elif _coord_near_absorber(
                 x_deep, _domain_x, cpml_thick_lo[0], cpml_thick_hi[0], dx
             ):
+                # Issue #510 review round-2 (nit B): this site was missed
+                # when the "just past which" rephrasing (see the matching
+                # comments at :2561/:2601, _validate_cfg_absorber_placement)
+                # was applied elsewhere — same reasoning: _coord_in_absorber's
+                # membership predicate is strict less-than, so the domain
+                # edge coordinate itself still reads as interior; the
+                # absorber is active strictly beyond it, not at it.
                 _w.warn(
                     PreflightWarning(
                         f"MSL port '{pe.name}' (direction={pe.direction!r}): "
                         f"probe {_deep_idx} (deepest, x={x_deep*1e3:.2f}mm) is "
                         f"within {_ABSORBER_PROXIMITY_CELLS} cells "
-                        f"({_fmt_len(_abs_margin)}) of the domain edge, where "
-                        f"the CPML absorber is active. Fields there carry "
-                        f"CPML fringe/reflection error, biasing the fitted "
-                        f"Z0/S11. {_abs_interval_txt}.",
+                        f"({_fmt_len(_abs_margin)}) of the domain edge, just "
+                        f"past which the CPML absorber is active. Fields "
+                        f"there carry CPML fringe/reflection error, biasing "
+                        f"the fitted Z0/S11. {_abs_interval_txt}.",
                         code="msl_port_geometry",
                         source="_check_msl_port_geometry",
                     ),

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -502,6 +502,63 @@ def msl_nearest_downstream_reflector(
     return nearest_d, nearest_label
 
 
+def msl_absorber_compliant_offset_max(
+    grid,
+    port,
+    *,
+    n_probes: int,
+    n_spacing: int,
+    off_lo: int,
+    domain_x: float,
+    ct_lo: float,
+    ct_hi: float,
+    dx: float,
+    guess_hi: int,
+) -> int | None:
+    """Largest ``n_probe_offset >= off_lo`` (up to ``guess_hi``) whose
+    resulting GRID-SNAPPED deepest probe clears both
+    :func:`_coord_in_absorber` and :func:`_coord_near_absorber`.
+
+    Issue #510 review finding (BLOCKING 1): the first version of this
+    check derived the advertised interval endpoint by algebraically
+    INVERTING the two predicates — ``int((headroom - margin) / dx) -
+    (n_probes-1)*n_spacing``. Float division plus truncation, combined
+    with :func:`_coord_near_absorber`'s boundary sitting at exactly
+    ``n_cells*dx``, put the computed endpoint on the wrong side of an FP
+    knife edge whenever the true boundary landed within about one ULP
+    of an exact multiple of ``dx`` — reviewer's brute-force sweep found
+    roughly 12,000 ``(dx, n_spacing, feed, domain)`` combinations where
+    the ADVERTISED endpoint itself still tripped the warning it claimed
+    to clear.
+
+    This walks candidate offsets DOWN from ``guess_hi`` and asks the
+    REAL predicate at each one (via ``msl_probe_x_coords_n``, the same
+    grid-index/clamping arithmetic the extractor uses), rather than
+    computing an answer algebraically. The returned value, if any, is
+    verified compliant by construction — it cannot land on the wrong
+    side of the boundary the way an algebraic inversion can.
+
+    Returns ``None`` if no offset in ``[off_lo, guess_hi]`` clears
+    (the compliant interval is empty).
+    """
+    from rfx.sources.msl_port import msl_probe_x_coords_n as _probe_x_coords_n
+
+    off = guess_hi
+    while off >= off_lo:
+        ladder = _probe_x_coords_n(
+            grid, port, n_probes=n_probes,
+            n_offset_cells=off, n_spacing_cells=n_spacing,
+        )
+        x_deep_candidate = ladder[-1]
+        if not (
+            _coord_in_absorber(x_deep_candidate, domain_x, ct_lo, ct_hi)
+            or _coord_near_absorber(x_deep_candidate, domain_x, ct_lo, ct_hi, dx)
+        ):
+            return off
+        off -= 1
+    return None
+
+
 class _PreflightMixin:
     """Preflight / validation methods mixed into :class:`Simulation`."""
 
@@ -2488,14 +2545,20 @@ class _PreflightMixin:
                         # which (hi side only) can start up to one cell
                         # further out than the boundary this margin is
                         # measured from (see _absorber_boundary_for_axis's
-                        # docstring, and nit 3 below).
+                        # docstring, and nit 3 below). Review follow-up:
+                        # "just past which" (not "where") the absorber is
+                        # active, because _coord_in_absorber's own
+                        # membership predicate is a STRICT less-than
+                        # (coord < lo_b) -- the boundary coordinate itself
+                        # reads as interior, so the absorber is active
+                        # strictly beyond it, not exactly at it.
                         _w.warn(
                             PreflightWarning(
                                 f"Probe at {pos} is within "
                                 f"{_ABSORBER_PROXIMITY_CELLS} cells "
                                 f"({_fmt_len(_ABSORBER_PROXIMITY_CELLS * dx)}) of the "
-                                f"domain edge on the {'xyz'[ax]}-axis, where the "
-                                f"{absorber_label} absorber is active. "
+                                f"domain edge on the {'xyz'[ax]}-axis, just past which "
+                                f"the {absorber_label} absorber is active. "
                                 f"Fields there carry CPML fringe/reflection error; move "
                                 f"inward for claims-bearing measurement.",
                                 code="absorber_proximity",
@@ -2534,8 +2597,8 @@ class _PreflightMixin:
                                 f"Source/port at {pos} is within "
                                 f"{_ABSORBER_PROXIMITY_CELLS} cells "
                                 f"({_fmt_len(_ABSORBER_PROXIMITY_CELLS * dx)}) of the "
-                                f"domain edge on the {'xyz'[ax]}-axis, where the "
-                                f"{absorber_label} absorber is active. "
+                                f"domain edge on the {'xyz'[ax]}-axis, just past which "
+                                f"the {absorber_label} absorber is active. "
                                 f"Fields there carry CPML fringe/reflection error; move "
                                 f"inward for claims-bearing measurement.",
                                 code="absorber_proximity",
@@ -3501,6 +3564,31 @@ class _PreflightMixin:
         if not self._msl_ports:
             return
         domain = self._domain
+
+        # Issue #510 review (BLOCKING 2): the deepest-probe coordinate
+        # used to be a pure continuous-coordinate extrapolation
+        # (x_feed + offset*dx). The extractor places probes by GRID
+        # INDEX, with rounding AND clamping into the in-domain range
+        # (rfx.sources.msl_port._msl_x_for_index /
+        # msl_probe_x_coords_n) — for a feed not exactly grid-aligned
+        # that is an O(dx) model error (the same order as the 2-cell
+        # absorber-proximity decision margin), and when the
+        # offset+spacing ladder runs past the grid edge the continuous
+        # formula names a coordinate the real extractor never visits
+        # (several probes clamp onto the SAME cell). Build the real
+        # grid once here — same precedent as ``_wire_port_cell_centers``
+        # above, which mirrors production rasterization exactly for the
+        # same reason — so every check below quotes the coordinates
+        # ``compute_msl_s_matrix`` actually samples. Defensive: preflight
+        # must never crash a run over a diagnostics helper, so a failed
+        # grid build falls back to the pre-fix continuous formula at the
+        # site below rather than raising or skipping checks 4/4a/4b.
+        from rfx.sources.msl_port import MSLPort as _MSLPort, msl_probe_x_coords_n as _probe_x_coords_n
+        try:
+            _msl_grid = self._build_grid()
+        except Exception:
+            _msl_grid = None
+
         for pe in self._msl_ports:
             x_feed, y_centre, z_lo = pe.position
             w_trace = float(pe.width)
@@ -3678,7 +3766,66 @@ class _PreflightMixin:
             n_sp = pe.n_probe_spacing if pe.n_probe_spacing is not None else 3
             n_pr = getattr(pe, "n_probes", 5) or 5
             sign = 1.0 if pe.direction == "+x" else -1.0
-            x_deep = x_feed + sign * (n_off + (n_pr - 1) * n_sp) * dx
+
+            _mp = _MSLPort(
+                feed_x=float(x_feed),
+                y_lo=float(y_centre - w_trace / 2.0),
+                y_hi=float(y_centre + w_trace / 2.0),
+                z_lo=float(z_lo),
+                z_hi=float(z_lo + h_sub),
+                direction=pe.direction,
+                impedance=float(pe.impedance),
+                excitation=pe.waveform,
+            )
+            _probe_ladder = None
+            if _msl_grid is not None:
+                try:
+                    _probe_ladder = _probe_x_coords_n(
+                        _msl_grid, _mp, n_probes=n_pr,
+                        n_offset_cells=n_off, n_spacing_cells=n_sp,
+                    )
+                except Exception:
+                    _probe_ladder = None
+            if _probe_ladder is not None:
+                x_deep = _probe_ladder[-1]
+                _ladder_dup_count = n_pr - len(set(_probe_ladder))
+            else:
+                # Fallback (issue #510 review, BLOCKING 2): grid build
+                # or probe-ladder computation failed -- keep the
+                # pre-fix continuous extrapolation rather than skip
+                # checks 4/4a/4b outright. Degeneracy cannot be
+                # detected on this path (no real ladder to inspect).
+                x_deep = x_feed + sign * (n_off + (n_pr - 1) * n_sp) * dx
+                _ladder_dup_count = 0
+
+            if _ladder_dup_count > 0:
+                # Issue #510 review (BLOCKING 2b): a ladder that runs
+                # past the grid edge CLAMPS -- several probes land on
+                # the same cell instead of spreading out, which makes
+                # the N-probe least-squares fit rank-deficient. This is
+                # a distinct hazard from "the deepest probe is near the
+                # absorber" (4a below still fires separately on the
+                # honest, clamped x_deep).
+                _w.warn(
+                    PreflightWarning(
+                        f"MSL port '{pe.name}' (direction={pe.direction!r}): "
+                        f"the {n_pr}-probe ladder (n_probe_offset={n_off}, "
+                        f"n_probe_spacing={n_sp} cells) runs past the grid "
+                        f"and CLAMPS — only {n_pr - _ladder_dup_count} of "
+                        f"{n_pr} probes land on distinct grid cells "
+                        f"({_ladder_dup_count} duplicate probe position(s): "
+                        f"{tuple(round(c * 1e3, 2) for c in _probe_ladder)}mm). "
+                        f"The N-probe least-squares wave-decomposition fit "
+                        f"is rank-deficient on duplicated positions; "
+                        f"`compute_msl_s_matrix`'s Z0/S11 extraction is "
+                        f"unreliable for this port. Shorten "
+                        f"n_probe_offset/n_probe_spacing or extend the "
+                        f"domain so the full ladder stays in-grid.",
+                        code="msl_port_geometry",
+                        source="_check_msl_port_geometry",
+                    ),
+                    stacklevel=3,
+                )
 
             nearest_d, nearest_label = msl_nearest_downstream_reflector(
                 getattr(self, "_geometry", []),
@@ -3697,6 +3844,18 @@ class _PreflightMixin:
                 # moves the probes TOWARD the reflector, so the pre-#469
                 # "bump n_probe_offset" mitigation pointed the wrong way
                 # on short feeds.
+                # NOTE (issue #510 review, BLOCKING 1): this algebraic
+                # inversion shares the FP-knife-edge pattern fixed for
+                # 4a below via msl_absorber_compliant_offset_max's
+                # walk-down search -- not converted here because
+                # msl_nearest_downstream_reflector's continuous
+                # PEC-box-distance predicate is a different shape (a
+                # scalar clearance threshold, not the two boolean
+                # membership/proximity predicates the walk-down helper
+                # was built around) and does not drop into that helper
+                # cleanly without its own re-derivation. Revisit with
+                # the same walk-down technique if this interval is ever
+                # found to mislead the same way.
                 d_feed_to_refl = nearest_d + (n_off + (n_pr - 1) * n_sp) * dx
                 off_max = int((d_feed_to_refl - min_probe_clear) / dx) - (n_pr - 1) * n_sp
                 _hsub_cells = int(round(5.0 * h_sub / dx))
@@ -3748,14 +3907,37 @@ class _PreflightMixin:
             _abs_headroom = (
                 _domain_x - x_feed if pe.direction == "+x" else x_feed
             )
-            _abs_off_max = (
-                int((_abs_headroom - _abs_margin) / dx) - (n_pr - 1) * n_sp
-            )
             _abs_hsub_cells = int(round(5.0 * h_sub / dx))
+            _abs_off_lo = max(3, _abs_hsub_cells)
+            if _msl_grid is not None:
+                # Issue #510 review (BLOCKING 1): the advertised endpoint
+                # is now VERIFIED against the real predicate via a
+                # walk-down search, not computed algebraically -- see
+                # msl_absorber_compliant_offset_max's docstring.
+                # ``_abs_guess_hi`` is a deliberately generous, INEXACT
+                # starting point (ceil, no proximity margin subtracted,
+                # +4 cells of slack) -- only the walked-down RESULT
+                # below is ever reported.
+                _abs_guess_hi = (
+                    int(math.ceil(_abs_headroom / dx)) - (n_pr - 1) * n_sp + 4
+                )
+                _abs_off_max = msl_absorber_compliant_offset_max(
+                    _msl_grid, _mp,
+                    n_probes=n_pr, n_spacing=n_sp, off_lo=_abs_off_lo,
+                    domain_x=_domain_x, ct_lo=cpml_thick_lo[0],
+                    ct_hi=cpml_thick_hi[0], dx=dx, guess_hi=_abs_guess_hi,
+                )
+            else:
+                # Fallback (grid build failed): the pre-fix algebraic
+                # estimate -- imprecise (issue #510 review, BLOCKING 1)
+                # but better than no guidance at all.
+                _abs_off_max = (
+                    int((_abs_headroom - _abs_margin) / dx) - (n_pr - 1) * n_sp
+                )
             _abs_interval_txt = (
                 f"compliant n_probe_offset interval ≈ "
-                f"[{max(3, _abs_hsub_cells)}, {_abs_off_max}] cells"
-                if _abs_off_max >= max(3, _abs_hsub_cells)
+                f"[{_abs_off_lo}, {_abs_off_max}] cells"
+                if _abs_off_max is not None and _abs_off_max >= _abs_off_lo
                 else "no compliant n_probe_offset exists on this feed "
                 "length (interval empty)"
             )
@@ -3806,7 +3988,12 @@ class _PreflightMixin:
             # an x-only crossing test (no y/z filtering on the other
             # port) — a deliberately simple, conservative check; two
             # independent lines that merely share an x-coordinate at
-            # very different y positions would also warn here.
+            # very different y positions would also warn here. Walks
+            # only the two registries #510 named in scope -- MSL ports
+            # (self._msl_ports) and lumped/wire ports (self._ports);
+            # self._coaxial_ports and self._waveguide_ports also carry a
+            # feed / reference plane but are out of scope here (issue
+            # #510 review, disclosed rather than fixed).
             _span_lo, _span_hi = (
                 (x_feed, x_deep) if pe.direction == "+x" else (x_deep, x_feed)
             )
@@ -3816,23 +4003,28 @@ class _PreflightMixin:
                 _other_x = _other.position[0]
                 if _span_lo < _other_x < _span_hi:
                     _other_name = getattr(_other, "name", None)
-                    if _other_name is not None:
-                        _other_label = f"MSL port '{_other_name}'"
-                    else:
-                        _other_label = (
-                            f"the lumped/wire port at x={_other_x*1e3:.2f}mm "
-                            f"(component={_other.component!r})"
-                        )
+                    # Issue #510 review (BLOCKING 3): the previous label
+                    # glued a possessive onto a parenthetical component
+                    # tag and repeated the crossing coordinate twice
+                    # ("...port at x=6.40mm (component='ez')'s feed
+                    # plane at x=6.40mm"). State the owner once, with no
+                    # trailing possessive, and let "feed plane at x=..."
+                    # below carry the coordinate exactly once.
+                    _other_owner_txt = (
+                        f"MSL port '{_other_name}'" if _other_name is not None
+                        else f"the lumped/wire port (component={_other.component!r})"
+                    )
                     _w.warn(
                         PreflightWarning(
                             f"MSL port '{pe.name}' (direction={pe.direction!r}): "
                             f"probe span x∈[{_span_lo*1e3:.2f}, "
-                            f"{_span_hi*1e3:.2f}]mm crosses {_other_label}'s "
-                            f"feed plane at x={_other_x*1e3:.2f}mm. A feed is "
-                            f"a source discontinuity the reflector scan above "
-                            f"cannot see; probes sampling across it break the "
-                            f"N-probe extractor's uniform-line assumption. If "
-                            f"this crossing is intentional, verify the "
+                            f"{_span_hi*1e3:.2f}]mm crosses the feed plane "
+                            f"of {_other_owner_txt} at x={_other_x*1e3:.2f}mm. "
+                            f"A feed is a source discontinuity the "
+                            f"reflector scan above cannot see; probes "
+                            f"sampling across it break the N-probe "
+                            f"extractor's uniform-line assumption. If this "
+                            f"crossing is intentional, verify the "
                             f"extracted Z0/S11 independently.",
                             code="msl_port_geometry",
                             source="_check_msl_port_geometry",

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -132,11 +132,19 @@ def _coord_in_absorber(
 # advisory must respect so library witness probes stay exempt. Neither
 # pins a specific cell count for a GENERIC (non-MSL) probe/source
 # proximity check, so 2 cells is a deliberately modest, conservative
-# default: large enough that the helper's own up-to-one-cell hi-side
-# conservatism (see _absorber_boundary_for_axis) cannot by itself trigger
-# it for a genuinely-interior placement, small enough to stay a "you are
-# suspiciously close to the edge" advisory rather than a broad interior
-# band.
+# default: small enough to stay a "you are suspiciously close to the
+# edge" advisory rather than a broad interior band, large enough to
+# still catch the #470/#500-H1 regression-lock fixtures (a probe one
+# grid cell inside the domain) this margin must keep firing on.
+# Issue #510 nit 2: an earlier version of this comment justified the "2"
+# by invoking _absorber_boundary_for_axis's own up-to-one-cell hi-side
+# conservatism — that was a non-sequitur. That conservatism is a
+# MEMBERSHIP concern (it can shift whether a coordinate reads as
+# absorber_overlap at all, via the boundary position _coord_in_absorber
+# uses); this margin is a PROXIMITY concern — it measures distance from
+# whatever boundary _absorber_boundary_for_axis returns, unaffected by
+# how that boundary itself was derived. The two are independent; neither
+# bounds the other.
 _ABSORBER_PROXIMITY_CELLS = 2
 
 
@@ -2470,12 +2478,24 @@ class _PreflightMixin:
                         )
                         break
                     if _coord_near_absorber(coord, domain_extent, ct_lo, ct_hi, dx):
+                        # Issue #510 nit 1: worded off the domain edge, not
+                        # off "where the absorber begins" — the edge is
+                        # exactly what _coord_near_absorber measures from
+                        # (_absorber_boundary_for_axis's lo_b/hi_b), so this
+                        # framing is unconditionally true. The prior wording
+                        # ("within N cells of the {label} absorber") could
+                        # overstate proximity to the absorbing MEDIUM itself,
+                        # which (hi side only) can start up to one cell
+                        # further out than the boundary this margin is
+                        # measured from (see _absorber_boundary_for_axis's
+                        # docstring, and nit 3 below).
                         _w.warn(
                             PreflightWarning(
                                 f"Probe at {pos} is within "
                                 f"{_ABSORBER_PROXIMITY_CELLS} cells "
                                 f"({_fmt_len(_ABSORBER_PROXIMITY_CELLS * dx)}) of the "
-                                f"{absorber_label} absorber along the {'xyz'[ax]}-axis. "
+                                f"domain edge on the {'xyz'[ax]}-axis, where the "
+                                f"{absorber_label} absorber is active. "
                                 f"Fields there carry CPML fringe/reflection error; move "
                                 f"inward for claims-bearing measurement.",
                                 code="absorber_proximity",
@@ -2506,12 +2526,16 @@ class _PreflightMixin:
                         )
                         break
                     if _coord_near_absorber(coord, domain_extent, ct_lo, ct_hi, dx):
+                        # Issue #510 nit 1 — see the matching probe-loop
+                        # comment above; same unconditionally-true
+                        # domain-edge framing.
                         _w.warn(
                             PreflightWarning(
                                 f"Source/port at {pos} is within "
                                 f"{_ABSORBER_PROXIMITY_CELLS} cells "
                                 f"({_fmt_len(_ABSORBER_PROXIMITY_CELLS * dx)}) of the "
-                                f"{absorber_label} absorber along the {'xyz'[ax]}-axis. "
+                                f"domain edge on the {'xyz'[ax]}-axis, where the "
+                                f"{absorber_label} absorber is active. "
                                 f"Fields there carry CPML fringe/reflection error; move "
                                 f"inward for claims-bearing measurement.",
                                 code="absorber_proximity",
@@ -3704,6 +3728,117 @@ class _PreflightMixin:
                     ),
                     stacklevel=3,
                 )
+
+            # ---- 4a. Probe SPAN vs the absorber — the deepest probe,
+            # not just x_feed (issue #510). Checks 1 and 3 above measure
+            # clearance AT x_feed only; the probe span can leave x_feed
+            # comfortably clear of the CPML while x_deep (just computed
+            # for check 4) lands inside or near it — check 4's reflector
+            # scan only sees PEC geometry, not the absorber. Routed
+            # through the #542 canonical membership/proximity helpers
+            # directly (_coord_in_absorber / _coord_near_absorber), NOT
+            # the buffered x_abs_lo/x_abs_hi built for check 3 above, so
+            # the lo/hi-swap mutation falsifier
+            # (tests/test_preflight_absorber_frame.py module docstring)
+            # covers this comparison the same way it covers every other
+            # consumer of those two helpers.
+            _domain_x = float(domain[0])
+            _deep_idx = n_pr - 1
+            _abs_margin = _ABSORBER_PROXIMITY_CELLS * dx
+            _abs_headroom = (
+                _domain_x - x_feed if pe.direction == "+x" else x_feed
+            )
+            _abs_off_max = (
+                int((_abs_headroom - _abs_margin) / dx) - (n_pr - 1) * n_sp
+            )
+            _abs_hsub_cells = int(round(5.0 * h_sub / dx))
+            _abs_interval_txt = (
+                f"compliant n_probe_offset interval ≈ "
+                f"[{max(3, _abs_hsub_cells)}, {_abs_off_max}] cells"
+                if _abs_off_max >= max(3, _abs_hsub_cells)
+                else "no compliant n_probe_offset exists on this feed "
+                "length (interval empty)"
+            )
+            if _coord_in_absorber(x_deep, _domain_x, cpml_thick_lo[0], cpml_thick_hi[0]):
+                _w.warn(
+                    PreflightWarning(
+                        f"MSL port '{pe.name}' (direction={pe.direction!r}): "
+                        f"probe {_deep_idx} (deepest, x={x_deep*1e3:.2f}mm) is "
+                        f"past the domain edge (domain x-extent [0, "
+                        f"{_domain_x*1e3:.2f}]mm) — inside the CPML absorbing "
+                        f"region. The N-probe extractor's clean-travelling-"
+                        f"wave assumption is void there: signal is attenuated "
+                        f"and the fitted Z0/S11 are corrupted. "
+                        f"{_abs_interval_txt}.",
+                        code="msl_port_geometry",
+                        source="_check_msl_port_geometry",
+                    ),
+                    stacklevel=3,
+                )
+            elif _coord_near_absorber(
+                x_deep, _domain_x, cpml_thick_lo[0], cpml_thick_hi[0], dx
+            ):
+                _w.warn(
+                    PreflightWarning(
+                        f"MSL port '{pe.name}' (direction={pe.direction!r}): "
+                        f"probe {_deep_idx} (deepest, x={x_deep*1e3:.2f}mm) is "
+                        f"within {_ABSORBER_PROXIMITY_CELLS} cells "
+                        f"({_fmt_len(_abs_margin)}) of the domain edge, where "
+                        f"the CPML absorber is active. Fields there carry "
+                        f"CPML fringe/reflection error, biasing the fitted "
+                        f"Z0/S11. {_abs_interval_txt}.",
+                        code="msl_port_geometry",
+                        source="_check_msl_port_geometry",
+                    ),
+                    stacklevel=3,
+                )
+
+            # ---- 4b. Probe span crossing another port's feed plane
+            # (issue #510). A second port's feed is a source
+            # discontinuity — check 4's reflector scan walks registered
+            # PEC ``Box`` shapes only, so it cannot see it. Probes
+            # sampling across it violate the N-probe extractor's
+            # uniform-line assumption even with zero PEC geometry
+            # nearby. Advisory tier, not an error: an intentional
+            # multi-port line with internal witness probes between ports
+            # is a legitimate research configuration as long as those
+            # probes do not cross the OPPOSITE port's own feed. This is
+            # an x-only crossing test (no y/z filtering on the other
+            # port) — a deliberately simple, conservative check; two
+            # independent lines that merely share an x-coordinate at
+            # very different y positions would also warn here.
+            _span_lo, _span_hi = (
+                (x_feed, x_deep) if pe.direction == "+x" else (x_deep, x_feed)
+            )
+            for _other in list(self._msl_ports) + list(self._ports):
+                if _other is pe:
+                    continue
+                _other_x = _other.position[0]
+                if _span_lo < _other_x < _span_hi:
+                    _other_name = getattr(_other, "name", None)
+                    if _other_name is not None:
+                        _other_label = f"MSL port '{_other_name}'"
+                    else:
+                        _other_label = (
+                            f"the lumped/wire port at x={_other_x*1e3:.2f}mm "
+                            f"(component={_other.component!r})"
+                        )
+                    _w.warn(
+                        PreflightWarning(
+                            f"MSL port '{pe.name}' (direction={pe.direction!r}): "
+                            f"probe span x∈[{_span_lo*1e3:.2f}, "
+                            f"{_span_hi*1e3:.2f}]mm crosses {_other_label}'s "
+                            f"feed plane at x={_other_x*1e3:.2f}mm. A feed is "
+                            f"a source discontinuity the reflector scan above "
+                            f"cannot see; probes sampling across it break the "
+                            f"N-probe extractor's uniform-line assumption. If "
+                            f"this crossing is intentional, verify the "
+                            f"extracted Z0/S11 independently.",
+                            code="msl_port_geometry",
+                            source="_check_msl_port_geometry",
+                        ),
+                        stacklevel=3,
+                    )
 
     def _validate_adi_configuration(self, materials: MaterialArrays, debye_spec, lorentz_spec) -> None:
         """Validate that the current simulation is compatible with the ADI path."""

--- a/tests/test_msl_port_preflight.py
+++ b/tests/test_msl_port_preflight.py
@@ -445,3 +445,233 @@ def test_issue510_feed_crossing_falsifier_separated_ports_silences_it():
     assert not _crossing_msgs(msgs), (
         f"expected no feed-crossing advisory once ports are separated; got: {msgs}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #510 review round (PR #551 adversarial review, 3 BLOCKING findings):
+#
+# BLOCKING 1: the advertised compliant n_probe_offset interval's upper
+# endpoint was computed by ALGEBRAIC INVERSION of the two absorber
+# predicates (float division then int() truncation). Float64 arithmetic put
+# the endpoint on the wrong side of an FP knife edge whenever the true
+# boundary landed within about one ULP of an exact dx multiple -- reviewer's
+# brute-force sweep found ~12k (dx, spacing, feed, domain) combinations
+# where the ADVERTISED endpoint itself still tripped the very warning it
+# claimed to clear. Fixed by msl_absorber_compliant_offset_max: walk
+# candidate offsets DOWN from a deliberately generous starting guess and
+# test the REAL predicate (via the extractor's own msl_probe_x_coords_n) at
+# each one, so the result is verified compliant by construction.
+#
+# BLOCKING 2: x_deep was a continuous-coordinate extrapolation
+# (x_feed + offset*dx), but the extractor places probes by GRID INDEX with
+# rounding and clamping (rfx.sources.msl_port._msl_x_for_index /
+# msl_probe_x_coords_n). Consequences: (a) up to dx/2 model error for a
+# feed that is not itself grid-aligned -- the same order as the 2-cell
+# absorber-proximity decision margin; (b) when the offset+spacing ladder
+# runs past the grid, several probes CLAMP onto the same cell, and the
+# pre-fix overlap message named a coordinate the real extractor never
+# visits. Fixed by routing x_deep through the same msl_probe_x_coords_n
+# call the extractor uses, and adding a distinct degenerate-ladder
+# advisory when probes collapse.
+#
+# BLOCKING 3: the 4b lumped/wire else-branch label was untested and, when
+# exercised, read "...port at x=6.40mm (component='ez')'s feed plane at
+# x=6.40mm" -- the coordinate stated twice, and a possessive glued onto a
+# parenthetical. Reworded to state the crossing coordinate exactly once
+# with no possessive.
+# ---------------------------------------------------------------------------
+def _degenerate_ladder_msgs(msgs: list[str]) -> list[str]:
+    return [m for m in msgs if "runs past the grid and CLAMPS" in m]
+
+
+def test_issue510_absorber_offset_interval_endpoint_does_not_warn():
+    """BLOCKING 1: in THIS repo's own reproduction fixture the buggy
+    algebra (before the fix) evaluated ``(6.40e-3 - 0.16e-3) / 80e-6`` to
+    ``77.99999999999999`` in float64 -- one below the mathematically exact
+    78 -- and advertised ``[16, 29]`` where the walk-down-verified boundary
+    is actually 30 (x_deep=0.16mm sits EXACTLY at the proximity margin,
+    which the strict-less-than predicate treats as compliant). This
+    fixture's bug happened to under-report (safe direction); extract
+    whatever the CURRENTLY-advertised endpoint is from the live warning
+    (not a hardcoded expectation) and confirm it, used as n_probe_offset,
+    draws no absorber-span advisory -- the general property BLOCKING 1
+    asked for, on real Simulation-level output."""
+    import re
+
+    sim = _two_port_sim(lx=11.36e-3, msl1_x=6.40e-3)
+    msgs = _absorber_span_msgs(_msl_warnings(sim))
+    assert msgs, "expected the absorber-span advisory to fire"
+    m = re.search(r"interval ≈ \[(\d+), (\d+)\] cells", msgs[0])
+    assert m, f"expected a compliant-interval clause in: {msgs[0]}"
+    off_lo, off_hi = int(m.group(1)), int(m.group(2))
+    assert off_lo == 16, f"expected the unchanged lower bound 16; got {off_lo}"
+    assert off_hi == 30, (
+        f"expected the walk-down-verified endpoint 30 (pre-fix buggy "
+        f"algebra advertised 29 on this fixture); got {off_hi} in "
+        f"{msgs[0]!r}"
+    )
+
+    sim2 = _two_port_sim(lx=11.36e-3, msl1_x=6.40e-3, msl1_offset=off_hi)
+    msgs2 = _absorber_span_msgs(_msl_warnings(sim2))
+    assert not msgs2, (
+        f"advertised endpoint n_probe_offset={off_hi} must NOT itself "
+        f"trip the absorber-span advisory; got: {msgs2}"
+    )
+
+
+def test_issue510_absorber_offset_max_endpoint_verified_across_geometries():
+    """BLOCKING 1 continued: the reviewer's sweep found the FP-knife-edge
+    failure in BOTH directions -- this repo's own fixture happened to
+    under-report (safe), but other geometries over-reported (advertised an
+    offset that still trips). Sweep a grid of small integer-cell
+    geometries directly against msl_absorber_compliant_offset_max and
+    verify the returned endpoint, plugged into the SAME
+    msl_probe_x_coords_n arithmetic the real extractor uses, never trips
+    either absorber predicate. The walk-down cannot fail this by
+    construction -- this is a construction check, not a search for a
+    counterexample."""
+    import math
+
+    from rfx.api._preflight import (
+        _coord_in_absorber,
+        _coord_near_absorber,
+        msl_absorber_compliant_offset_max,
+    )
+    from rfx.grid import Grid
+    from rfx.sources.msl_port import MSLPort, msl_probe_x_coords_n
+
+    dx = 80e-6
+    n_pr = 5
+    ct = 2 * dx
+    n_checked = 0
+    n_found_endpoint = 0
+    for n_sp in (2, 3, 12):
+        for feed_cells in range(4, 16):
+            for domain_cells in range(feed_cells + 40, feed_cells + 70, 3):
+                domain_x = domain_cells * dx
+                feed_x = feed_cells * dx
+                headroom = domain_x - feed_x
+                guess_hi = int(math.ceil(headroom / dx)) - (n_pr - 1) * n_sp + 4
+                grid = Grid(freq_max=10e9, domain=(domain_x, 4e-3, 2e-3),
+                           dx=dx, cpml_layers=2)
+                port = MSLPort(feed_x=feed_x, y_lo=1e-3, y_hi=2e-3,
+                               z_lo=0.0, z_hi=1e-3, direction="+x",
+                               impedance=50.0)
+                off_max = msl_absorber_compliant_offset_max(
+                    grid, port, n_probes=n_pr, n_spacing=n_sp, off_lo=3,
+                    domain_x=domain_x, ct_lo=ct, ct_hi=ct, dx=dx,
+                    guess_hi=guess_hi,
+                )
+                n_checked += 1
+                if off_max is None:
+                    continue
+                n_found_endpoint += 1
+                ladder = msl_probe_x_coords_n(
+                    grid, port, n_probes=n_pr,
+                    n_offset_cells=off_max, n_spacing_cells=n_sp,
+                )
+                x_deep = ladder[-1]
+                assert not _coord_in_absorber(x_deep, domain_x, ct, ct), (
+                    n_sp, feed_cells, domain_cells, off_max, x_deep,
+                )
+                assert not _coord_near_absorber(x_deep, domain_x, ct, ct, dx), (
+                    n_sp, feed_cells, domain_cells, off_max, x_deep,
+                )
+    assert n_checked >= 300, n_checked
+    assert n_found_endpoint > 0, "sweep never found a compliant endpoint to verify"
+
+
+def test_issue510_absorber_span_names_real_snapped_coordinate_off_grid_feed():
+    """BLOCKING 2(a): offset msl_1's feed by half a cell off-grid. The
+    extractor's own probe placement (msl_probe_x_coords_n) rounds the feed
+    to the nearest grid node BEFORE walking the offset ladder, so the real
+    deepest-probe coordinate can differ from the naive continuous formula
+    ``x_feed + offset*dx`` (which never snaps the feed at all). Confirm the
+    emitted message names the coordinate msl_probe_x_coords_n actually
+    returns, not the continuous extrapolation."""
+    from rfx.sources.msl_port import MSLPort, msl_probe_x_coords_n
+
+    off_grid_x = 6.40e-3 + 40e-6  # half a cell off-grid at dx=80um
+    sim = _two_port_sim(lx=11.36e-3, msl1_x=off_grid_x)
+    msgs = _absorber_span_msgs(_msl_warnings(sim))
+    assert msgs, f"expected the advisory to still fire; got: {_msl_warnings(sim)}"
+
+    # Ground truth: the SAME production call the check itself makes.
+    grid = sim._build_grid()
+    y_c = (W_TRACE + 8 * H_SUB) / 2.0
+    port = MSLPort(feed_x=off_grid_x, y_lo=y_c - W_TRACE / 2, y_hi=y_c + W_TRACE / 2,
+                    z_lo=0.0, z_hi=H_SUB, direction="-x", impedance=50.0)
+    ladder = msl_probe_x_coords_n(grid, port, n_probes=5,
+                                  n_offset_cells=31, n_spacing_cells=12)
+    x_deep_real = ladder[-1]
+    x_deep_continuous = off_grid_x - (31 + 4 * 12) * 80e-6
+    assert abs(x_deep_real - x_deep_continuous) > 1e-9, (
+        "fixture did not actually exercise an off-grid feed discrepancy"
+    )
+
+    hit = msgs[0]
+    assert f"x={x_deep_real * 1e3:.2f}mm" in hit, (
+        f"expected the real grid-snapped coordinate "
+        f"{x_deep_real * 1e3:.2f}mm in the message; got: {hit}"
+    )
+    assert f"x={x_deep_continuous * 1e3:.2f}mm" not in hit, (
+        f"message must not name the continuous-extrapolation coordinate "
+        f"{x_deep_continuous * 1e3:.2f}mm; got: {hit}"
+    )
+
+
+def test_issue510_degenerate_ladder_warns_on_clamped_probes():
+    """BLOCKING 2(b): a probe-array ladder that runs past the grid edge
+    CLAMPS -- several probes land on the SAME cell instead of spreading
+    out, making the N-probe least-squares fit rank-deficient. This must
+    draw its own distinct advisory (not just the absorber-overlap message,
+    which fires separately on the same honest, clamped x_deep)."""
+    sim = _two_port_sim(lx=11.36e-3, msl1_x=1.00e-3,
+                        msl0_offset=31, msl1_offset=18, n_probe_spacing=12)
+    msgs = _msl_warnings(sim)
+    degenerate = _degenerate_ladder_msgs(msgs)
+    assert degenerate, f"expected a degenerate-ladder advisory; got: {msgs}"
+    hit = degenerate[0]
+    assert "msl_1" in hit, hit
+    assert "3 duplicate probe position" in hit, hit
+    assert "2 of 5 probes land on distinct grid cells" in hit, hit
+
+
+def test_issue510_feed_crossing_names_lumped_port_cleanly():
+    """BLOCKING 3: drives an MSL probe span across a LUMPED port's feed
+    (the 4b else-branch, previously untested) and asserts the cleaned-up
+    wording -- the crossing coordinate stated exactly once, and no
+    possessive glued onto the parenthetical component tag."""
+    dx = 80e-6
+    lx = 11.36e-3
+    ly = W_TRACE + 8 * H_SUB
+    sim = Simulation(
+        freq_max=10e9, domain=(lx, ly, H_SUB + 1.5e-3), dx=dx,
+        cpml_layers=8,
+        boundary=BoundarySpec(
+            x="cpml", y="cpml", z=Boundary(lo="pec", hi="cpml"),
+        ),
+    )
+    sim.add_material("ro4350b", eps_r=EPS_R)
+    sim.add(Box((0, 0, 0), (lx, ly, H_SUB)), material="ro4350b")
+    y_c = ly / 2.0
+    sim.add(
+        Box((0, y_c - W_TRACE / 2, H_SUB), (lx, y_c + W_TRACE / 2, H_SUB + dx)),
+        material="pec",
+    )
+    sim.add_msl_port(position=(2.40e-3, y_c, 0), width=W_TRACE, height=H_SUB,
+                     direction="+x", impedance=50.0, n_probe_offset=31,
+                     n_probe_spacing=12, n_probes=5, name="msl_0")
+    sim.add_port(position=(6.40e-3, y_c, H_SUB), component="ez", excite=False)
+
+    msgs = _crossing_msgs(_msl_warnings(sim))
+    assert msgs, f"expected a feed-crossing advisory naming the lumped port; got: {_msl_warnings(sim)}"
+    hit = msgs[0]
+    assert "lumped/wire port" in hit, hit
+    assert "component='ez'" in hit, hit
+    assert hit.count("6.40mm") == 1, (
+        f"expected the crossing coordinate stated exactly once; got: {hit}"
+    )
+    assert "')'s" not in hit and ")'s" not in hit, (
+        f"expected no possessive glued onto the parenthetical; got: {hit}"
+    )

--- a/tests/test_msl_port_preflight.py
+++ b/tests/test_msl_port_preflight.py
@@ -325,3 +325,123 @@ def test_reflector_clearance_silent_without_reflector():
     assert len(refl) == 0, (
         f"expected no reflector warning on thru-only short line, got: {refl}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #510: checks 1/3 above measure clearance at x_feed only, so a probe
+# SPAN could leave x_feed clear while the deepest probe (x_deep) lands
+# inside/near the absorber (4a, new below) or past a second port's own feed
+# plane (4b, new below) — check 4's reflector scan only sees PEC Box
+# geometry, not the absorber or a source discontinuity. Reproduction
+# geometry is the committed #488 diagnostic dump the issue cites: dx=80um,
+# domain_x=11.36mm (= 142 cells), CPML 8 layers, msl_0 at x=2.40mm '+x',
+# msl_1 at x=6.40mm '-x', n_probe_offset=31, n_probe_spacing=12, n_probes=5.
+# On that geometry msl_0's probes land at 4.88/5.84/6.80/7.76/8.72mm and
+# msl_1's at 3.92/2.96/2.00/1.04/0.08mm (issue body) -- msl_1's deepest
+# probe (0.08mm) is within the 2-cell/0.16mm proximity margin of the x=0
+# domain edge (NOT literally "inside the CPML" under the #500/#542
+# exterior-padding frame this fix routes through -- the issue's own
+# "x < 0.64mm" framing used the pre-#500 interior intuition), and both
+# ports' probe spans cross the OTHER port's feed plane (msl_0's span
+# [2.40, 8.72]mm contains msl_1's 6.40mm feed; msl_1's span [0.08, 6.40]mm
+# contains msl_0's 2.40mm feed).
+# ---------------------------------------------------------------------------
+def _two_port_sim(*, lx: float, msl1_x: float,
+                  msl0_offset: int = 31, msl1_offset: int = 31,
+                  n_probe_spacing: int = 12, n_probes: int = 5) -> Simulation:
+    dx = 80e-6
+    ly = W_TRACE + 8 * H_SUB
+    sim = Simulation(
+        freq_max=10e9, domain=(lx, ly, H_SUB + 1.5e-3), dx=dx,
+        cpml_layers=8,
+        boundary=BoundarySpec(
+            x="cpml", y="cpml", z=Boundary(lo="pec", hi="cpml"),
+        ),
+    )
+    sim.add_material("ro4350b", eps_r=EPS_R)
+    sim.add(Box((0, 0, 0), (lx, ly, H_SUB)), material="ro4350b")
+    y_c = ly / 2.0
+    sim.add(
+        Box((0, y_c - W_TRACE / 2, H_SUB), (lx, y_c + W_TRACE / 2, H_SUB + dx)),
+        material="pec",
+    )
+    sim.add_msl_port(position=(2.40e-3, y_c, 0), width=W_TRACE, height=H_SUB,
+                     direction="+x", impedance=50.0, n_probe_offset=msl0_offset,
+                     n_probe_spacing=n_probe_spacing, n_probes=n_probes,
+                     name="msl_0")
+    sim.add_msl_port(position=(msl1_x, y_c, 0), width=W_TRACE, height=H_SUB,
+                     direction="-x", impedance=50.0, n_probe_offset=msl1_offset,
+                     n_probe_spacing=n_probe_spacing, n_probes=n_probes,
+                     name="msl_1")
+    return sim
+
+
+def _absorber_span_msgs(msgs: list[str]) -> list[str]:
+    return [
+        m for m in msgs
+        if "CPML absorbing region" in m or "CPML absorber is active" in m
+    ]
+
+
+def _crossing_msgs(msgs: list[str]) -> list[str]:
+    return [m for m in msgs if "feed plane" in m]
+
+
+def test_issue510_reproduction_fires_both_new_warnings():
+    """The exact #488-dump geometry from the issue body: both new checks
+    must fire, naming the specific ports/probes involved."""
+    sim = _two_port_sim(lx=11.36e-3, msl1_x=6.40e-3)
+    msgs = _msl_warnings(sim)
+
+    absorber = _absorber_span_msgs(msgs)
+    assert absorber, f"expected an absorber-span advisory; got: {msgs}"
+    # Only msl_1's deepest probe (x=0.08mm) is within the proximity
+    # margin of the x=0 edge; msl_0's (x=8.72mm) is 2.64mm from the x-hi
+    # edge, far outside the 0.16mm margin.
+    assert any("msl_1" in m for m in absorber), absorber
+    assert not any("msl_0" in m for m in absorber), absorber
+    assert any("probe 4" in m and "0.08mm" in m for m in absorber), absorber
+
+    crossing = _crossing_msgs(msgs)
+    assert len(crossing) == 2, (
+        f"expected a feed-crossing advisory on BOTH ports, got: {crossing}"
+    )
+    assert any("msl_0" in m and "msl_1" in m and "6.40mm" in m for m in crossing), crossing
+    assert any("msl_1" in m and "msl_0" in m and "2.40mm" in m for m in crossing), crossing
+
+
+def test_issue510_clean_geometry_neither_new_warning_fires():
+    """Same probe-array parameters, but ports far enough apart that
+    neither the absorber-span nor the feed-crossing check has anything to
+    catch -- the half of the coverage that a warning-only test cannot
+    prove (a check that always fires is not a check)."""
+    sim = _two_port_sim(lx=20e-3, msl1_x=16.00e-3)
+    msgs = _msl_warnings(sim)
+    assert not _absorber_span_msgs(msgs), (
+        f"expected no absorber-span advisory on clean geometry; got: {msgs}"
+    )
+    assert not _crossing_msgs(msgs), (
+        f"expected no feed-crossing advisory on clean geometry; got: {msgs}"
+    )
+
+
+def test_issue510_absorber_span_falsifier_compliant_offset_silences_it():
+    """Falsifier for check 4a: the reproduction warning itself reports a
+    compliant n_probe_offset interval ([16, 30] cells on this fixture);
+    moving msl_1 inside it (offset=20) must silence the advisory."""
+    sim = _two_port_sim(lx=11.36e-3, msl1_x=6.40e-3, msl1_offset=20)
+    msgs = _msl_warnings(sim)
+    assert not _absorber_span_msgs(msgs), (
+        f"expected no absorber-span advisory at compliant offset=20; got: {msgs}"
+    )
+
+
+def test_issue510_feed_crossing_falsifier_separated_ports_silences_it():
+    """Falsifier for check 4b: moving msl_1 far enough from msl_0 (same
+    probe-array parameters) that neither probe span reaches the other
+    port's feed must silence the crossing advisory."""
+    sim = _two_port_sim(lx=11.36e-3, msl1_x=9.60e-3)
+    msgs = _msl_warnings(sim)
+    assert not _crossing_msgs(msgs), (
+        f"expected no feed-crossing advisory once ports are separated; got: {msgs}"
+    )

--- a/tests/test_preflight_absorber_frame.py
+++ b/tests/test_preflight_absorber_frame.py
@@ -114,6 +114,7 @@ from rfx.api._preflight import (
     _PreflightMixin,
     _absorber_boundary_for_axis,
     _coord_in_absorber,
+    _coord_near_absorber,
     PreflightConfigError,
 )
 from rfx.boundaries.spec import Boundary, BoundarySpec
@@ -190,6 +191,33 @@ def test_absorber_boundary_helper_matches_ground_truth():
     # Exterior coordinates are.
     assert _coord_in_absorber(-0.001, 0.090678, 27.94e-3, 27.94e-3)
     assert _coord_in_absorber(0.091, 0.090678, 27.94e-3, 27.94e-3)
+
+
+def test_last_interior_node_reads_as_overlap_not_proximity_h1_conservatism():
+    """Issue #510 nit 3: the docstring's own example (domain_extent=0.0101,
+    dx=1e-3 -> ceil(10.1)=11 -> the true last interior node sits at 0.011,
+    one cell BEYOND the nominal domain_extent, yet the real grid still
+    treats it as interior) reads as ``absorber_overlap`` here — the more
+    SEVERE membership finding — rather than the lower-severity
+    ``absorber_proximity`` a genuinely-interior placement gets. This is the
+    user-visible face of ``_absorber_boundary_for_axis``'s documented
+    "conservative by up to one cell" hi-side design (see its docstring):
+    the boundary is deliberately allowed to read slightly early rather
+    than risk missing a genuine overlap. Pinned here rather than "fixed"
+    — every other absorber_overlap/absorber_proximity consumer relies on
+    this exact membership frame (see the module docstring's mutation
+    falsifier list), so loosening it to reclassify this one case as
+    proximity would change shared semantics, not just this corner case."""
+    domain_extent, dx, ct_hi = 0.0101, 1e-3, 2e-3
+    true_last_interior_node = 0.011  # one dx beyond domain_extent
+    assert _coord_in_absorber(true_last_interior_node, domain_extent, 0.0, ct_hi)
+    # _coord_near_absorber is not even reached by a caller once membership
+    # fires (callers check overlap first, per both helpers' docstrings),
+    # but confirm directly it would not independently classify this as
+    # proximity either — the two really are mutually exclusive here.
+    assert not _coord_near_absorber(
+        true_last_interior_node, domain_extent, 0.0, ct_hi, dx
+    )
 
 
 # --------------------------------------------------------------------- #

--- a/tests/test_preflight_absorber_frame.py
+++ b/tests/test_preflight_absorber_frame.py
@@ -67,15 +67,28 @@ same frame and the same fix apply on both lanes; there is no separate NU
 code path to special-case.
 
 Mutation falsifier (manual, recorded here rather than left as a permanent
-CI assertion; re-run after the H1/MH2 additions above): with
-``_absorber_boundary_for_axis`` locally edited so
-``lo_boundary = domain_extent if ct_lo > 0 else None`` / ``hi_boundary =
-0.0 if ct_hi > 0 else None`` (swapping the lo/hi roles), 16 tests went
-RED — correctly the NON-FIRING controls plus the helper's own unit test,
-not the firing tests (an earlier draft of this docstring had this
-inverted: the firing tests stay green because the swap makes the
+CI assertion; re-run after the H1/MH2 additions above, and again after
+#510's PR #551 review round): with ``_absorber_boundary_for_axis`` locally
+edited so ``lo_boundary = domain_extent if ct_lo > 0 else None`` /
+``hi_boundary = 0.0 if ct_hi > 0 else None`` (swapping the lo/hi roles),
+**22** tests now go RED (was 16 at the H1/MH2 baseline, 19 after #510's
+first pass added 3, 22 after the #551 review round's BLOCKING 1/2 fixes
+added 3 more) — correctly the NON-FIRING controls plus the helper's own
+unit test, not the firing tests (an earlier draft of this docstring had
+this inverted: the firing tests stay green because the swap makes the
 membership/clearance tests over-inclusive on an already-interior
-coordinate, not blind to a genuinely exterior one). In this file (10):
+coordinate, not blind to a genuinely exterior one). Caveat from the #551
+review: this count is SELECTION-dependent — pytest's warning-registry
+dedup (``warnings.warn`` only re-emits an identical (message, category,
+module, lineno) tuple once per interpreter session by default) can leak
+suppression across tests depending on run order and what else shares the
+session, so the enumerated set below reproduces reliably only when these
+exact 6 files are selected together, in this order, in a fresh process —
+not as a subset, not interleaved with unrelated absorber-adjacent tests,
+and not as a universal invariant of the count "22" itself. Re-run the
+selection below (not a broader or narrower one) to reproduce it.
+
+In this file (10, unchanged by #510):
 ``test_absorber_boundary_helper_matches_ground_truth``,
 ``test_absorber_placement_silent_on_domain_centre_probe``,
 ``test_absorber_placement_proximity_advisory_fires_within_2_cells``,
@@ -85,11 +98,30 @@ coordinate, not blind to a genuinely exterior one). In this file (10):
 ``test_waveguide_reference_plane_silent_on_wr90_ports_in_valid_domain``,
 ``test_waveguide_reference_plane_silent_at_mixin_level_near_edge``,
 ``test_msl_x_cpml_clearance_silent_once_past_buffer_plus_recommended``,
-``test_msl_y_clearance_silent_on_ledger_calibrated_ly``. Outside this
-file (6, confirming M5 that the mutation now also reaches the MSL and
-proximity paths): ``test_msl_port_preflight.py::
-test_clearance_silent_on_wide_ly``, ``test_msl_port_preflight.py::
-test_well_setup_msl_port_zero_warnings``,
+``test_msl_y_clearance_silent_on_ledger_calibrated_ly`` (NOTE:
+``test_last_interior_node_reads_as_overlap_not_proximity_h1_conservatism``,
+added alongside these for #510 nit 3, deliberately does NOT count toward
+this red-set — it is a documentation pin on the helper's OWN one-cell
+conservatism, unaffected by the lo/hi swap in the coordinate range this
+fixture happens to probe).
+
+Outside this file (12, was 6 before #510 — confirming M5 that the
+mutation now also reaches the MSL/proximity paths, and #510 that it
+reaches the new absorber-span checks and the BLOCKING-1 walk-down search):
+``test_msl_port_preflight.py::test_clearance_silent_on_wide_ly``,
+``test_msl_port_preflight.py::test_well_setup_msl_port_zero_warnings``,
+``test_msl_port_preflight.py::
+test_issue510_reproduction_fires_both_new_warnings``,
+``test_msl_port_preflight.py::
+test_issue510_clean_geometry_neither_new_warning_fires``,
+``test_msl_port_preflight.py::
+test_issue510_absorber_span_falsifier_compliant_offset_silences_it``,
+``test_msl_port_preflight.py::
+test_issue510_absorber_offset_interval_endpoint_does_not_warn``,
+``test_msl_port_preflight.py::
+test_issue510_absorber_offset_max_endpoint_verified_across_geometries``,
+``test_msl_port_preflight.py::
+test_issue510_absorber_span_names_real_snapped_coordinate_off_grid_feed``,
 ``test_msl_internal_probe_advisories.py::
 test_user_probe_advisories_and_332_still_fire``,
 ``test_preflight_structured_and_guards.py::
@@ -98,7 +130,13 @@ test_absorber_overlap_no_false_positive_on_2d_collapsed_z``,
 test_full_domain_dielectric_silent_on_cpml_extension``,
 ``test_farfield_asymmetric_cpml.py::
 test_ntff_box_outside_cpml_has_no_absorber_overlap``. Reverted; see the
-PR body / rfx-known-issues.md #500 entry for the recorded run.
+PR body / rfx-known-issues.md #500 and #510 entries for the recorded run.
+(``test_issue510_degenerate_ladder_warns_on_clamped_probes``,
+``test_issue510_feed_crossing_names_lumped_port_cleanly``, and
+``test_issue510_feed_crossing_falsifier_separated_ports_silences_it``
+stay green under this mutation, correctly — the degenerate-ladder and
+feed-crossing checks do not route through
+``_absorber_boundary_for_axis`` at all.)
 """
 
 from __future__ import annotations
@@ -208,8 +246,22 @@ def test_last_interior_node_reads_as_overlap_not_proximity_h1_conservatism():
     this exact membership frame (see the module docstring's mutation
     falsifier list), so loosening it to reclassify this one case as
     proximity would change shared semantics, not just this corner case."""
-    domain_extent, dx, ct_hi = 0.0101, 1e-3, 2e-3
-    true_last_interior_node = 0.011  # one dx beyond domain_extent
+    dx = 1e-3
+    domain_extent = 0.0101
+    cpml_layers = 2
+    ct_hi = cpml_layers * dx
+    g = Grid(freq_max=10e9, domain=(domain_extent, 0.01, 0.01), dx=dx,
+             cpml_layers=cpml_layers)
+    # Issue #510 review (non-blocking #7): derive the true last interior
+    # node from rfx.grid.Grid's OWN reported sizing (like the rest of
+    # this file's ground-truth tests do), not a hand-transcribed number.
+    # nx = ceil(domain/dx) + 1 + pad_lo + pad_hi, so
+    # ceil(domain/dx) = nx - 1 - pad_lo - pad_hi is the interior cell
+    # count, and that many cells beyond user x=0 is the last interior
+    # node's user coordinate.
+    n_interior_cells = g.nx - 1 - g.pad_x_lo - g.pad_x_hi
+    true_last_interior_node = n_interior_cells * dx
+    assert true_last_interior_node == pytest.approx(0.011)
     assert _coord_in_absorber(true_last_interior_node, domain_extent, 0.0, ct_hi)
     # _coord_near_absorber is not even reached by a caller once membership
     # fires (callers check overlap first, per both helpers' docstrings),


### PR DESCRIPTION
## What / why

Closes #510. `_check_msl_port_geometry`'s existing checks (1: lateral clearance, 3: port-to-CPML distance) measure clearance at the MSL port's **feed plane** only. The N-probe array's deepest probe (`x_deep`, already computed for the existing reflector-distance check 4) can sit well past that plane — the feed can be comfortably clear of the CPML while `x_deep` lands inside or near the absorber, and check 4's reflector scan walks registered PEC `Box` shapes only, so a second port's own feed (a source discontinuity, not PEC geometry) is invisible to it. Both gaps let a probe-array sample a physically meaningless region with preflight silent.

Found while auditing a committed diagnostic fixture whose recorded `production_z0` (29.49 ohm vs analytic 47.895) turned out to be exactly this: one probe inside the absorber and three probes past the opposite port's feed.

## New checks (4a / 4b, in the same per-port loop as x_deep/x_abs_lo/x_abs_hi)

- **4a — probe span vs the absorber**: `_coord_in_absorber(x_deep, ...)` / `_coord_near_absorber(x_deep, ...)` on the deepest probe, using PR #542's canonical membership/proximity helpers directly (`_absorber_boundary_for_axis`'s exterior-padding frame) rather than the buffered `x_abs_lo`/`x_abs_hi` built for check 3 — so the existing lo/hi-swap mutation falsifier covers this comparison automatically. Names the probe index and coordinate, and quotes the #469-style compliant `n_probe_offset` interval.
- **4b — probe span crosses another port's feed plane**: walks `self._msl_ports` + `self._ports` (MSL/lumped/wire), names both ports and the crossing coordinate. Advisory tier (same as the rest of `_check_msl_port_geometry`), not an error — an intentional multi-port line with internal witness probes between ports is legitimate as long as they don't cross the *opposite* feed.

Both use `code="msl_port_geometry"` (the family already used by checks 1-4 in this function) rather than the generic `absorber_overlap`/`absorber_proximity` codes, so they don't perturb other tests' `by_code(...)` assertions on the generic absorber-placement check.

## Three carried review nits (from #510's last comment, same code region as PR #542)

1. **Proximity wording overstated proximity by one cell.** `"within N cells of the {label} absorber"` measures from the domain edge (`_coord_near_absorber`'s `lo_b`/`hi_b`), not from where the absorbing medium itself starts — which, hi side only, can sit up to one cell further out (`_absorber_boundary_for_axis`'s documented conservatism). Reworded (and tightened again in the review round below) to `"within N cells of the domain edge ... just past which the {label} absorber is active"` — unconditionally true. The #470 lock's pinned `"within 2 cells"` / `"CPML absorber"` substrings both survive unchanged (kept literal; only the surrounding words moved) — verified green, not just visually re-read.
2. **`_ABSORBER_PROXIMITY_CELLS = 2`'s rationale comment was a non-sequitur.** It justified the margin by invoking the helper's up-to-one-cell hi-side conservatism — that conservatism is a *membership* concern (whether a coordinate reads as `absorber_overlap` at all), unrelated to this *proximity* margin (distance from whatever boundary the helper returns). Comment corrected; constant unchanged.
3. **Last-interior-node placement draws `absorber_overlap` not `absorber_proximity`.** This is the user-visible face of the helper's own documented one-cell hi-side conservatism, and every other `absorber_overlap`/`absorber_proximity` consumer relies on the same membership frame — reclassifying it would change shared semantics, not just this corner case. Documented + pinned with a new unit test on `_absorber_boundary_for_axis`'s own docstring example (`domain_extent=0.0101`, `dx=1e-3` → true last interior node `0.011`) — the review round below made this test derive that coordinate from a real `Grid` instance instead of a hand-transcribed literal.

## Reproduction (issue's own numbers)

dx=80µm, domain_x=11.36mm, CPML 8 layers, `msl_0` at x=2.40mm `+x`, `msl_1` at x=6.40mm `-x`, `n_probe_offset=31`, `n_probe_spacing=12`, `n_probes=5`:
- `msl_1`'s deepest probe (probe 4, x=0.08mm) is within the 2-cell/160µm proximity margin of the x=0 domain edge — **not** literally "inside the CPML" under the #500/#542 exterior-padding frame this fix routes through (the issue's own "x < 0.64mm" framing used the pre-#500 interior intuition; that's exactly why 4a is built on the corrected helper, not a reproduction of the issue's literal framing).
- Both ports' probe spans cross the *other* port's feed plane: `msl_0`'s span [2.40, 8.72]mm contains `msl_1`'s 6.40mm feed; `msl_1`'s span [0.08, 6.40]mm contains `msl_0`'s 2.40mm feed.

---

## Review round (adversarial review of this PR — 3 BLOCKING findings, all fixed here)

The review independently CONFIRMED the exterior-padding frame (grid.py:153-154/201 + cpml.py:481 + an empirical sigma-profile dump) and re-verified the mutation-falsifier ride-along claim, but found 3 correctness bugs in the *new* checks:

**BLOCKING 1 — the advertised compliant `n_probe_offset` interval could itself trip the warning.** The endpoint was computed by algebraically INVERTING the two absorber predicates (`int((headroom - margin) / dx) - (n_pr-1)*n_sp`). Float64 division + truncation, combined with `_coord_near_absorber`'s boundary sitting at exactly `n_cells*dx`, put the endpoint on the wrong side of an FP knife edge whenever the true boundary landed within ~1 ULP of an exact `dx` multiple — reviewer's brute-force sweep found ~12k `(dx, n_spacing, feed, domain)` combinations where the advertised endpoint still tripped. On this repo's own reproduction fixture the bug under-reported (29 instead of the true 30 — `(6.40e-3 - 0.16e-3) / 80e-6` evaluates to `77.99999999999999` in float64, one below the exact 78) — safe direction here, but the reviewer's own example showed the dangerous over-report direction on a different geometry.
*Fix*: new module-level helper `msl_absorber_compliant_offset_max` walks candidate offsets DOWN from a generous starting guess and tests the REAL predicate (via `msl_probe_x_coords_n`, the extractor's own grid-index arithmetic) at each one — the result is verified compliant by construction, not computed. Check 4's pre-existing `off_max` shares the same algebraic-inversion shape but a *different* (continuous PEC-distance) predicate that doesn't drop into the same walk-down helper cleanly; left alone with a comment cross-referencing this finding, per the review's own "do not scope-creep" instruction.

**BLOCKING 2 — `x_deep` was a continuous-coordinate extrapolation; the extractor places probes by GRID INDEX with rounding and clamping** (`rfx/sources/msl_port.py`, `_msl_x_for_index` / `msl_probe_x_coords_n`). Consequences the reviewer measured: (a) up to `dx/2` model error for a feed that isn't itself grid-aligned — the same order as the 2-cell proximity decision margin; (b) when the offset+spacing ladder runs past the grid, the overlap message named a coordinate the real extractor never visits (several probes clamp onto the same cell, making the N-probe fit rank-deficient).
*Fix*: `x_deep` (and the full probe ladder) now come from `msl_probe_x_coords_n` — the exact call `compute_msl_s_matrix` makes — against a real `Grid` built once per `_check_msl_port_geometry()` call (same precedent as `_wire_port_cell_centers`, defensively wrapped: preflight must never crash a run over a diagnostics helper; falls back to the old continuous formula if grid construction fails). A NEW distinct advisory fires when the ladder degenerates (probes collapse onto duplicate cells), naming the duplicate count and the real clamped coordinates.
*Follow-up observation (disclosed per the review's instruction, not fixed here)*: `compute_mixed_s_matrix` hard-errors on duplicate `probe_xs` (`rfx/api/_sparams.py:3293-3316`), but `compute_msl_s_matrix` never validates `probe_xs` at all — that gap is **pre-existing and out of scope** for this PR.

**BLOCKING 3 — the 4b lumped/wire label was untested and malformed when exercised**: `"crosses the lumped/wire port at x=6.40mm (component='ez')'s feed plane at x=6.40mm"` — the coordinate stated twice, and a possessive glued onto a parenthetical. *Fix*: reworded to state the owner once with no possessive — `"crosses the feed plane of the lumped/wire port (component='ez') at x=6.40mm"` (the MSL-name branch got the same doubled-quote-possessive cleanup: `"crosses the feed plane of MSL port 'msl_1' at x=6.40mm"`). New test drives an MSL span across a lumped port's feed and asserts the clean wording.

**Non-blocking, same commit:**
4. Mutation-falsifier ledger docstring updated `16 → 22` RED (re-run after ALL fixes, not just predicted from the review's mid-point count of 19), with the reviewer's selection-dependence caveat (pytest's warning-registry dedup makes the count reproduce reliably only for this exact 6-file selection) and all 6 new test names appended.
5. 4b's comment now discloses it walks only `self._msl_ports`/`self._ports` (not `self._coaxial_ports`/`self._waveguide_ports`) — in scope by #510's own spec (MSL/lumped/wire), disclosed rather than silently omitted.
6. The falsifier test's docstring number (`[16, 30]`) already matched the fixed code's output once BLOCKING 1 landed — resolved naturally, no separate edit needed.
7. The nit-3 pinning test now derives its "last interior node" coordinate from a real `rfx.grid.Grid` instance's own `nx`/`pad_x_lo`/`pad_x_hi`, not a hand-transcribed literal.
8. Absorber-proximity wording tightened once more: `"...domain edge, where the absorber is active"` → `"...domain edge, just past which the absorber is active"` (`_coord_in_absorber`'s membership predicate is strict less-than, so the edge coordinate itself still reads as interior — the absorber is active strictly beyond it, not at it).

## Tests

`tests/test_msl_port_preflight.py` (+9 total: 4 from the original pass, +5 from the review round): issue reproduction, clean-geometry control, one falsifier per original warning, plus the BLOCKING-1 endpoint-verification test (extracts the live advertised endpoint and confirms it doesn't itself warn), a 360-combination sweep against `msl_absorber_compliant_offset_max` directly (construction check, not a counterexample search), the BLOCKING-2 off-grid-feed coordinate test, the degenerate-ladder advisory test, and the BLOCKING-3 lumped-port-crossing wording test. `tests/test_preflight_absorber_frame.py` (+1): nit-3 pin, now `Grid`-derived.

**Manual mutation falsifier**, re-run twice: once after the original pass (19 RED across the 6-file selection, matching the review's independent re-verification), and once more after this round's fixes (**22 RED**, exactly as the updated ledger states — the 3 new BLOCKING-1/2 tests join the red-set; the degenerate-ladder and both crossing tests correctly stay green, since neither routes through `_absorber_boundary_for_axis`). Reverted both times; `git diff` confirmed clean after each.

**Lock tests kept green, not loosened**: `tests/test_preflight_absorber_frame.py::test_absorber_placement_proximity_advisory_fires_within_2_cells` and `tests/test_msl_internal_probe_advisories.py::test_user_probe_advisories_and_332_still_fire` both still assert `"within 2 cells" in m and "CPML absorber" in m` — satisfied through both wording rounds (the substrings stayed literal; only the surrounding words moved).

## Verification

- `pytest tests/test_msl_port_preflight.py` — **26/26** (17 pre-existing + 9 new)
- `pytest tests/test_preflight_absorber_frame.py tests/test_msl_internal_probe_advisories.py tests/test_run_preflight_parity.py` — **26/26** (the #470/#500-H1 lock files)
- `pytest tests/test_farfield_asymmetric_cpml.py tests/test_preflight_structured_and_guards.py tests/test_preflight_false_positives.py tests/test_preflight_physics_thresholds.py` — **47/47** (other consumers of `absorber_overlap`/`absorber_proximity`)
- `pytest tests/test_msl_nu_sparam_gate.py tests/test_msl_nu_abscissa.py tests/test_preflight_thin_metal_nu.py tests/test_msl_port_integration.py tests/test_msl_port.py tests/test_preflight_graded_rasterization.py` — **21/21** (4 deselected, 1 pre-existing xfail) — confirms the new `self._build_grid()` call doesn't regress the non-uniform-mesh MSL/preflight lane (that call is unconditionally uniform, same simplification the rest of `_check_msl_port_geometry` already has via its scalar `dx` parameter — not a new limitation)
- `python -m pytest tests/ -q -k "preflight or msl or absorber or cpml"` (broad sweep): the **pre-review-round** run (before the BLOCKING-fix commit) completed cleanly — 467 passed / 1 skipped / 4 xfailed, 0 failures. The **post-BLOCKING-fix** run was launched in the background and, at time of writing, is still in flight (CPU-contended by a second concurrent `pytest` process sharing this worktree — 45+ minutes elapsed vs. the ~21.5-minute baseline of the first run) — not claimed complete. What actually backs this PR's correctness claim is the full targeted re-run below, not this broad sweep: every file that consumes `absorber_overlap`/`absorber_proximity` or exercises `_check_msl_port_geometry`, re-run fresh after each commit including the verify-pass fixes.
- `ruff check rfx/ tests/ --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402` — clean
- No public API surface changed (only internal warning text/comments and one new module-private helper inside `rfx/api/_preflight.py`), so no contract-test gate applies here.

---

## Verify pass (CONFIRMED, clear to merge) — 3 residual claim-accuracy items, fixed

The verify pass independently re-ran the reviewer's knife-edge case, built an independent 384-geometry under-shoot oracle against `msl_absorber_compliant_offset_max` (0 mismatches), and re-applied the lo/hi-swap mutation (22 red, exact name match with the ledger) — CONFIRMED, clear to merge. Three residuals flagged first, addressed in one micro follow-up commit:

1. **(nit B) The nit-9 "just past which" wording fix missed a third site.** It covered `_validate_cfg_absorber_placement`'s two sites but not the NEW 4a proximity message this PR itself introduced, which still read `"...domain edge, where the CPML absorber is active"`. Checked for string-pinning tests first: only `tests/test_msl_port_preflight.py`'s own `_absorber_span_msgs` helper touches this text (matches on `"CPML absorber is active"`, a substring the reworded text still contains verbatim) — no test needed updating. Fixed to `"...domain edge, just past which the CPML absorber is active."`, matching the other two sites exactly. PR body item 8 above is now actually true.
2. **(nit A) x-graded NU-lane false positive, disclosed with one comment.** `_msl_grid` (built via `self._build_grid()`) is unconditionally uniform, so on an x-graded mesh (`dx_profile`) 4a's message can name the wrong coordinate (e.g. warn about x=0.08mm when the real NU-grid deepest probe sits at 3.24mm). This is exact parity with pre-PR behavior — every other quantity in this function already comes off the scalar `dx` parameter — so it's a non-regression, not a new bug; recorded as a comment at the 4a site rather than "fixed" (fixing it would mean an NU-aware grid build, out of scope here). No code/logic change.
3. **(point C) Broad-sweep bullet reworded** to state exactly what completed (the pre-review-round sweep) and what is still in flight (the post-BLOCKING-fix sweep) — see the Verification section above. Not claiming a completed sweep no one has seen.

**Verification (this commit)**: `tests/test_msl_port_preflight.py` 26/26; the 6-file lock/consumer set (`test_preflight_absorber_frame.py` + `test_msl_internal_probe_advisories.py` + `test_run_preflight_parity.py` + `test_farfield_asymmetric_cpml.py` + `test_preflight_structured_and_guards.py` + `test_preflight_false_positives.py` + `test_preflight_physics_thresholds.py`) 73/73 — 99 total, unchanged count from the prior commit (wording/comment-only diff, no predicate logic touched). `ruff` clean. No re-run of the mutation falsifier was needed — the 22-red count from the BLOCKING-fix commit stands, since the predicate call sites it exercises are untouched by this commit.

R3: memory=PR #542 (`c1c4741`, "one exterior-padding frame helper...five consumers fixed (#500)") is the direct foundation this builds on, per #510's own last-comment instruction; the review-fix round's R3 memory is PR #551's own BLOCKING review comment, and this verify-pass round's R3 memory is PR #551's own verify-pass comment (each round's applicable "known feedback entry"). `docs/agent-memory/` is not present in this worktree (primary-checkout-only per rfx `CLAUDE.md`, gitignored in this public repo) so no further grep was possible from here | R2-attempts=1 per round (original pass, BLOCKING-fix round, verify-pass round — each addressed its findings together in one commit, not iteratively re-litigated) | falsifier=lo/hi-swap mutation on `_absorber_boundary_for_axis`, run and reverted after the original and BLOCKING-fix commits (19/19 then 22/22 RED as ledger-documented); not re-run for the wording-only verify-pass commit (no predicate logic changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

