### PR TITLE
Mixed-fixture n_live disagreement: preflight advisory now shares the assembler's ground-truth pec_mask (closes #544)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — wire-port dead-cell preflight advisory now shares the assembler's ground-truth PEC mask (issue #544)
+
+- The `wire_port_dead_extent_cells`/`wire_port_midpoint_in_pec` preflight
+  advisory classified a rasterized cell as PEC-dead by comparing a
+  computed cell-CENTER (node + half-cell Yee offset) against the PEC
+  bounding box, closed interval — a different reference point than the
+  real rasterization (node coordinates, half-open interval, or the
+  thin-sheet nearest-node rule for a sub-cell-thick box). On the #488
+  lane's committed lumped/wire↔MSL fixture this made the advisory report
+  `n_live/n = 3/4` while the assembler's actual `n_live_lw` was `4`
+  (measured passive-port `Z_in = Z0/4 = 12.5 ohm`, matching `n_live=4`).
+  The advisory now calls `_wire_port_live_cells` against the SAME
+  assembled `pec_mask` the assembler uses, so the two paths cannot drift
+  apart again. Uniform meshes only — on a non-uniform mesh
+  (`dz_profile`/`dx_profile`/`dy_profile`) the advisory now emits a
+  `wire_port_dead_cell_classification_unavailable` note instead of either
+  silently skipping the check or checking a mismatched uniform substitute
+  (pre-existing NU-blindness, previously undisclosed).
+
 ### Fixed — the #494 advisory's test coverage was bound at one point in a five-dimensional option space
 
 - An independent mutation battery against the merged #495 suite found **40 of 67
@@ -338,7 +357,13 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   physics in the same change.
 - The `wire_port_dead_extent_cells` preflight advisory now states the
   post-fix semantics (dead cells excluded; the `Z0*(n_live/n)`
-  termination is cited as the historical pre-fix behaviour).
+  termination is cited as the historical pre-fix behaviour). **Update
+  (issue #544, see the Unreleased section below)**: the advisory's own
+  live/dead cell *counting method* — separate from this wording fix —
+  was itself found to disagree with the assembler's actual `n_live_lw`
+  on some fixtures (a bounding-box-vs-cell-center approximation drifting
+  from the real node-based rasterization); it now shares
+  `_wire_port_live_cells` with the assembler directly.
 
 ### Added — opt-in reference-plane port waves for the wire S-matrix off-diagonals (`add_port(reference_plane_cells=)`, issue #313)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,14 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   (`dz_profile`/`dx_profile`/`dy_profile`) the advisory now emits a
   `wire_port_dead_cell_classification_unavailable` note instead of either
   silently skipping the check or checking a mismatched uniform substitute
-  (pre-existing NU-blindness, previously undisclosed).
+  (pre-existing NU-blindness, previously undisclosed). **Behaviour change
+  for `preflight(strict=True)`**: an otherwise-clean non-uniform-mesh sim
+  with a wire port now RAISES `ValueError` where it previously did not —
+  the new note is a warning-severity issue like any other, and `strict`
+  escalates every issue (contract-consistent, not a new exception to that
+  contract). Callers that want errors-only escalation and this warning
+  passed through should call `preflight(strict=False).raise_for_failure()`
+  instead of `preflight(strict=True)`.
 
 ### Fixed — the #494 advisory's test coverage was bound at one point in a five-dimensional option space
 

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2893,11 +2893,41 @@ class _PreflightMixin:
         # ground-truth count (and the measured passive-port Z_in = Z0/4 =
         # 12.5 ohm, PR #543) was 4/4 — every cell live. Sharing the
         # primitive makes the two paths unable to drift again by
-        # construction.
+        # construction ON THE UNIFORM-MESH PATH — see the NU disclosure
+        # immediately below; the shared primitive itself never runs on a
+        # non-uniform mesh, so the invariant does not (and is not claimed
+        # to) extend there.
+        #
+        # Known limitation (issue #544 adversarial review; same
+        # non-regression disclosure pattern as the #510 review nit A a few
+        # hundred lines above): ``self._build_grid()`` /
+        # ``self._assemble_materials(grid)`` are unconditionally UNIFORM.
+        # A ``dz_profile``/``dx_profile``/``dy_profile`` (NU) sim's REAL
+        # run instead uses ``_build_nonuniform_grid()`` +
+        # ``_assemble_materials_nu()`` — a different ``Grid`` class with
+        # different shape/padding (measured: uniform PEC node k=[4] vs NU
+        # PEC node(s) k=[4,5] on the same nominal geometry), and
+        # ``_wire_port_live_cells`` cannot even run against a
+        # ``NonUniformGrid`` (no ``position_to_index``). Building a
+        # uniform substitute for an NU sim would therefore MISCLASSIFY
+        # cells rather than reflect the real run, so this advisory does
+        # NOT attempt that — it emits a "classification unavailable" note
+        # (issue #544 review item 6: a silent skip here is the #303
+        # silently-skipped-check-family class) instead of either guessing
+        # or going fully silent. This is the SAME pre-existing scope limit
+        # the OLD (pre-#544) advisory had (it was equally NU-blind:
+        # ``_wire_port_cell_centers`` also calls ``self._build_grid()``)
+        # — not a new limitation, just now disclosed instead of silent.
         grid = None
         pec_mask = None
-        pec_entry_masks: list[tuple[str, np.ndarray]] = []
+        pec_entry_masks: list[tuple[str, np.ndarray]] | None = None
         materials_attempted = False
+        classification_unavailable_reason: str | None = None
+        is_nonuniform = (
+            self._dz_profile is not None
+            or self._dx_profile is not None
+            or self._dy_profile is not None
+        )
         for pe in self._ports:
             if not getattr(pe, "extent", None):
                 continue
@@ -2909,26 +2939,25 @@ class _PreflightMixin:
 
             if not materials_attempted:
                 materials_attempted = True
-                try:
-                    grid = self._build_grid()
-                    _, _, _, pec_mask, _, _, _ = self._assemble_materials(grid)
-                    if pec_mask is not None:
-                        for entry in self._geometry:
-                            mat = self._resolve_material(entry.material_name)
-                            if mat.sigma < self._PEC_SIGMA_THRESHOLD:
-                                continue
-                            pec_entry_masks.append(
-                                (entry.material_name,
-                                 np.asarray(entry.shape.mask(grid)))
-                            )
-                except Exception:
-                    # Defensive (matches ``_wire_port_cell_centers``):
-                    # preflight must never crash a run over a diagnostics
-                    # helper. Falling back to "no dead cells known" keeps
-                    # this advisory silent rather than wrong.
-                    grid = None
-                    pec_mask = None
-                    pec_entry_masks = []
+                if is_nonuniform:
+                    classification_unavailable_reason = (
+                        "non-uniform mesh (dz_profile/dx_profile/"
+                        "dy_profile set) -- the shared ground-truth "
+                        "primitive only covers the uniform-grid path "
+                        "(issue #544)"
+                    )
+                else:
+                    try:
+                        grid = self._build_grid()
+                        _, _, _, pec_mask, _, _, _ = \
+                            self._assemble_materials(grid)
+                    except Exception as exc:
+                        # Defensive (matches ``_wire_port_cell_centers``):
+                        # preflight must never crash a run over a
+                        # diagnostics helper.
+                        grid = None
+                        pec_mask = None
+                        classification_unavailable_reason = str(exc)
 
             dead_indices: list[int] = []
             dead_names: list[str] = []
@@ -2953,19 +2982,71 @@ class _PreflightMixin:
                     # degenerate split. Report all cells dead.
                     cells = _wire_port_cells(grid, wp)
                     live_flags = [False] * len(cells)
-                for idx, live in enumerate(live_flags):
-                    if live:
-                        continue
-                    dead_indices.append(idx)
-                    ci, cj, ck = cells[idx]
-                    for name, mask_arr in pec_entry_masks:
-                        if bool(mask_arr[ci, cj, ck]) and name not in dead_names:
-                            dead_names.append(name)
+                dead_indices = [
+                    idx for idx, live in enumerate(live_flags) if not live
+                ]
+                if dead_indices:
+                    if pec_entry_masks is None:
+                        # Lazy (issue #544 review item 8): only rasterize
+                        # per-entry masks the first time any port actually
+                        # has a dead cell to name — the common clean case
+                        # (no dead cells anywhere) never pays for it.
+                        # Covers BOTH ``self._geometry`` PEC entries AND
+                        # ``self._thin_conductors`` PEC sheets (issue #544
+                        # review item 3: thin conductors also feed the
+                        # assembled ``pec_mask`` --
+                        # ``rfx/api/_compile.py``:232-238 -- and were
+                        # missing here, which produced an empty
+                        # ``dead_names`` and a false ``'pec'`` fallback
+                        # label for a thin-conductor-only dead cell).
+                        pec_entry_masks = []
+                        for entry in self._geometry:
+                            mat = self._resolve_material(entry.material_name)
+                            if mat.sigma < self._PEC_SIGMA_THRESHOLD:
+                                continue
+                            pec_entry_masks.append(
+                                (entry.material_name,
+                                 np.asarray(entry.shape.mask(grid)))
+                            )
+                        for _tc_i, tc in enumerate(self._thin_conductors):
+                            if not tc.is_pec:
+                                continue
+                            pec_entry_masks.append(
+                                (f"thin_conductor[{_tc_i}]",
+                                 np.asarray(tc.shape.mask(grid)))
+                            )
+                    for idx in dead_indices:
+                        ci, cj, ck = cells[idx]
+                        for name, mask_arr in pec_entry_masks:
+                            if (bool(mask_arr[ci, cj, ck])
+                                    and name not in dead_names):
+                                dead_names.append(name)
+                    if not dead_names:
+                        # Defensive net only: pec_mask is exactly the OR
+                        # of the per-entry masks above, so this should be
+                        # unreachable -- kept honest (an explicit
+                        # "unknown" label) rather than silently inventing
+                        # a specific, possibly wrong material name.
+                        dead_names = ["unknown"]
+            elif classification_unavailable_reason is not None:
+                _w.warn(
+                    PreflightWarning(
+                        f"Wire port at {pe.position} (extent {pe.extent}): "
+                        f"dead-cell classification unavailable "
+                        f"({classification_unavailable_reason}). The "
+                        f"#314/#319 PEC-overlap advisories are skipped "
+                        f"for this port -- verify manually that its "
+                        f"rasterized extent does not land on PEC.",
+                        code="wire_port_dead_cell_classification_unavailable",
+                        source="_validate_cfg_port_inside_pec",
+                    ),
+                    stacklevel=3,
+                )
 
             if mid_idx in dead_indices:
                 # Kept verbatim from the #314 fix (PR #317): probe-cell
                 # corruption is the stronger, measured failure mode.
-                name = dead_names[0] if dead_names else "pec"
+                name = dead_names[0] if dead_names else "an assembled PEC region"
                 _w.warn(
                     PreflightWarning(
                         f"Wire port at {pe.position} (extent "
@@ -3007,8 +3088,11 @@ class _PreflightMixin:
                         f"Verify the extent was MEANT to end on/inside "
                         f"the conductor, and keep the midpoint V/I probe "
                         f"cell live; to silence, shorten the extent or "
-                        f"move the port so every cell center sits "
-                        f"outside PEC.",
+                        f"move the port so none of its rasterized cells "
+                        f"land on PEC (per the assembled geometry -- not "
+                        f"a cell-center guess; a thin PEC sheet snaps to "
+                        f"its nearest grid NODE, which can be a full cell "
+                        f"away from the sheet's midpoint).",
                         code="wire_port_dead_extent_cells",
                         source="_validate_cfg_port_inside_pec",
                     ),

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2874,6 +2874,30 @@ class _PreflightMixin:
         # normalization consequence), and the dead-extent live-cell count
         # includes every dead cell — midpoint included — because the live
         # split does not care which cell holds the probe.
+        #
+        # Issue #544: the dead/live classification below is derived from
+        # the SAME primitive the assembler uses to compute ``n_live_lw``
+        # (``_wire_port_live_cells`` against the actual assembled
+        # ``pec_mask``) — not a standalone bounding-box-vs-cell-center
+        # approximation, which is what this advisory used before and which
+        # had DRIFTED from the assembler. The approximation compared a
+        # CENTER coordinate (node position + 0.5*dx along the component
+        # axis) against a closed-interval ``[lo, hi]`` PEC bounding box;
+        # the real rasterization (``Box.mask``, ``rfx/geometry/csg.py``)
+        # evaluates occupancy at NODE coordinates with a half-open
+        # interval ``[lo, hi)`` (or the thin-sheet nearest-node rule for a
+        # sub-cell-thick box) — a different reference point that can, and
+        # on the #488 mixed lumped/wire<->MSL fixture did, put the "dead"
+        # node one cell away from what the approximation assumed: the
+        # advisory reported n_live/n=3/4 while the assembler's
+        # ground-truth count (and the measured passive-port Z_in = Z0/4 =
+        # 12.5 ohm, PR #543) was 4/4 — every cell live. Sharing the
+        # primitive makes the two paths unable to drift again by
+        # construction.
+        grid = None
+        pec_mask = None
+        pec_entry_masks: list[tuple[str, np.ndarray]] = []
+        materials_attempted = False
         for pe in self._ports:
             if not getattr(pe, "extent", None):
                 continue
@@ -2883,36 +2907,65 @@ class _PreflightMixin:
             centers, mid_idx = rasterized
             mid_center = centers[mid_idx]
 
-            pec_bboxes = []
-            for entry in self._geometry:
-                if entry.material_name != "pec":
-                    continue
-                if not hasattr(entry.shape, "bounding_box"):
-                    continue
+            if not materials_attempted:
+                materials_attempted = True
                 try:
-                    c1, c2 = entry.shape.bounding_box()
-                except (NotImplementedError, TypeError):
-                    continue
-                pec_bboxes.append((entry.material_name, c1, c2))
+                    grid = self._build_grid()
+                    _, _, _, pec_mask, _, _, _ = self._assemble_materials(grid)
+                    if pec_mask is not None:
+                        for entry in self._geometry:
+                            mat = self._resolve_material(entry.material_name)
+                            if mat.sigma < self._PEC_SIGMA_THRESHOLD:
+                                continue
+                            pec_entry_masks.append(
+                                (entry.material_name,
+                                 np.asarray(entry.shape.mask(grid)))
+                            )
+                except Exception:
+                    # Defensive (matches ``_wire_port_cell_centers``):
+                    # preflight must never crash a run over a diagnostics
+                    # helper. Falling back to "no dead cells known" keeps
+                    # this advisory silent rather than wrong.
+                    grid = None
+                    pec_mask = None
+                    pec_entry_masks = []
 
             dead_indices: list[int] = []
             dead_names: list[str] = []
-            for idx, center in enumerate(centers):
-                for name, c1, c2 in pec_bboxes:
-                    if all(c1[ax] <= center[ax] <= c2[ax] for ax in range(3)):
-                        dead_indices.append(idx)
-                        if name not in dead_names:
+            if grid is not None and pec_mask is not None:
+                from rfx.sources.sources import (
+                    WirePort, _wire_port_cells, _wire_port_live_cells,
+                )
+                axis = {"ex": 0, "ey": 1, "ez": 2}[pe.component]
+                end = list(pe.position)
+                end[axis] += pe.extent
+                wp = WirePort(
+                    start=tuple(pe.position), end=tuple(end),
+                    component=pe.component, impedance=pe.impedance,
+                )
+                try:
+                    cells, live_flags, _ = _wire_port_live_cells(
+                        grid, wp, pec_mask)
+                except ValueError:
+                    # Every extent cell is dead: _wire_port_live_cells
+                    # raises there (issue #318 — such a port has no live
+                    # cell to terminate or drive) instead of returning a
+                    # degenerate split. Report all cells dead.
+                    cells = _wire_port_cells(grid, wp)
+                    live_flags = [False] * len(cells)
+                for idx, live in enumerate(live_flags):
+                    if live:
+                        continue
+                    dead_indices.append(idx)
+                    ci, cj, ck = cells[idx]
+                    for name, mask_arr in pec_entry_masks:
+                        if bool(mask_arr[ci, cj, ck]) and name not in dead_names:
                             dead_names.append(name)
-                        break
 
             if mid_idx in dead_indices:
                 # Kept verbatim from the #314 fix (PR #317): probe-cell
                 # corruption is the stronger, measured failure mode.
-                name = next(
-                    name for name, c1, c2 in pec_bboxes
-                    if all(c1[ax] <= mid_center[ax] <= c2[ax]
-                           for ax in range(3))
-                )
+                name = dead_names[0] if dead_names else "pec"
                 _w.warn(
                     PreflightWarning(
                         f"Wire port at {pe.position} (extent "

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2899,8 +2899,11 @@ class _PreflightMixin:
         # to) extend there.
         #
         # Known limitation (issue #544 adversarial review; same
-        # non-regression disclosure pattern as the #510 review nit A a few
-        # hundred lines above): ``self._build_grid()`` /
+        # non-regression disclosure pattern as the #510 review nit A —
+        # grep this file for "issue #510 review nit A" to find that
+        # comment; citing it by line number/direction rots as the file
+        # grows, which is exactly what happened to an earlier draft of
+        # this comment): ``self._build_grid()`` /
         # ``self._assemble_materials(grid)`` are unconditionally UNIFORM.
         # A ``dz_profile``/``dx_profile``/``dy_profile`` (NU) sim's REAL
         # run instead uses ``_build_nonuniform_grid()`` +

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2954,10 +2954,44 @@ class _PreflightMixin:
                         grid = self._build_grid()
                         _, _, _, pec_mask, _, _, _ = \
                             self._assemble_materials(grid)
-                    except Exception as exc:
+                    except (ValueError, TypeError, NotImplementedError,
+                            KeyError, AttributeError, IndexError) as exc:
                         # Defensive (matches ``_wire_port_cell_centers``):
                         # preflight must never crash a run over a
-                        # diagnostics helper.
+                        # diagnostics helper -- but this tuple is
+                        # DELIBERATELY NOT ``except Exception`` (CI
+                        # incident on PR #555's own head: a broad
+                        # ``except Exception`` here caught
+                        # ``rfx.experiments.worker.RunTimedOut``, a
+                        # ``TimeoutError`` subclass a SIGALRM handler
+                        # raises asynchronously while this exact call is
+                        # in flight -- ``execute_run`` arms the alarm
+                        # BEFORE calling ``compiled.preflight()``, so a
+                        # slow ``_assemble_materials`` here is squarely
+                        # inside the timeout window. Swallowing it here
+                        # meant the worker's top-level
+                        # ``except RunTimedOut`` handler never ran, so a
+                        # 1-second-timeout experiment kept simulating for
+                        # its full 500k-step run instead of exiting —
+                        # the worker process hung rather than dying,
+                        # timing out the parent's ``subprocess.wait``
+                        # (tests/test_durable_worker_lifecycle.py
+                        # ::test_worker_timeout_is_durable_failed_outcome,
+                        # 60s). ``rfx/api`` must not import
+                        # ``rfx.experiments`` to name that exception type
+                        # directly (wrong dependency direction), so the
+                        # general fix is this narrow, purpose-scoped
+                        # tuple: only the errors ``_build_grid``/
+                        # ``_assemble_materials`` are actually documented
+                        # to raise for a malformed config (bad domain,
+                        # unresolved material -- ``_resolve_material``
+                        # raises ``KeyError`` -- unsupported shape
+                        # method). Any signal-driven exception
+                        # (``TimeoutError``, ``RuntimeError``-based
+                        # cancellation, ``KeyboardInterrupt``,
+                        # ``MemoryError``, ...) now propagates through
+                        # this advisory untouched, exactly like it did
+                        # before this advisory existed.
                         grid = None
                         pec_mask = None
                         classification_unavailable_reason = str(exc)

--- a/rfx/sources/sources.py
+++ b/rfx/sources/sources.py
@@ -357,8 +357,9 @@ def _wire_port_live_cells(grid, port, pec_mask=None):
             f"WirePort {port.start} -> {port.end} ({port.component}): all "
             f"{len(cells)} extent cells land inside PEC geometry, so the "
             "port has no live cell to terminate or drive (issue #318). "
-            "Shorten the extent or move the port so at least one cell "
-            "center sits outside PEC."
+            "Shorten the extent or move the port so at least one of its "
+            "rasterized cells is not PEC (per the assembled geometry -- "
+            "not a cell-center guess)."
         )
     return cells, live_flags, n_live
 

--- a/scripts/diagnostics/i517_mixed_solve_vs_ratio_measurement.py
+++ b/scripts/diagnostics/i517_mixed_solve_vs_ratio_measurement.py
@@ -301,15 +301,24 @@ the degenerate input it was fed").
 everywhere); the raw number's scale was dominated by the trivial Z0c=12.5
 vs Z0_hj~48 column-norm mismatch, not near-singularity.
 
-**INFO 9 — n_live disagreement (unfiled candidate, reported not fixed this
-session)**: preflight's advisory text says "n_live/n = 3/4" and "terminates
-at 50 ohm across its 3 live cells", but the ASSEMBLER's actual
-`n_live_lw = [4]` (captured from the exact call `_assemble_mixed_power_wave_s`
-receives) — `Z0c = 50/4 = 12.5 ohm`, not `50/3 = 16.67 ohm`. The degeneracy
-proof's exact match to `n_live=4` (not 3) is itself evidence the assembler,
-not the preflight advisory, is internally consistent with what the wave
-formulas actually used; which of the two is the geometrically correct count
-is a separate question this script does not resolve.
+**INFO 9 — n_live disagreement (filed as issue #544, RESOLVED by PR #555)**:
+at the time this script's RESULT section was written, preflight's advisory
+text said "n_live/n = 3/4" and "terminates at 50 ohm across its 3 live
+cells", but the ASSEMBLER's actual `n_live_lw = [4]` (captured from the
+exact call `_assemble_mixed_power_wave_s` receives) — `Z0c = 50/4 = 12.5
+ohm`, not `50/3 = 16.67 ohm`. The degeneracy proof's exact match to
+`n_live=4` (not 3) is itself evidence the assembler, not the preflight
+advisory, was internally consistent with what the wave formulas actually
+used. PR #555 (`scripts/diagnostics/i544_n_live_advisory_vs_assembler.py`)
+resolved which count is geometrically correct — the assembler's 4, not the
+advisory's 3 — by dumping the actual assembled `pec_mask`: the PEC trace is
+exactly one cell thick and rasterizes to node k=4, one cell OUTSIDE this
+port's k=0..3 extent, so all 4 cells are genuinely live. The advisory now
+shares `_wire_port_live_cells` with the assembler and is silent on this
+fixture. `main()`'s INFO 9 block below now quotes whatever the LIVE
+`preflight_text` actually contains (searched at print time) instead of the
+pre-#555 "n_live/n = 3/4" literal, so it stays accurate across future
+advisory changes too.
 
 **Free finding — a constant per-port rescale is not sufficient**: the
 per-port factor that would equalize `|S01|` and `|S10|` (wave channel),
@@ -760,15 +769,33 @@ def main(reuse_json=None) -> int:
 
     S_shipped = captured["S_shipped"]
 
-    # ---- INFO 9: n_live disagreement (preflight advisory vs assembler) --
+    # ---- INFO 9: n_live advisory-vs-assembler cross-check (issue #544,
+    #      RESOLVED by PR #555 -- this now reads whatever the LIVE
+    #      preflight_text actually says instead of a hardcoded pre-#555
+    #      quote, so a future regression back to the old wording, or a
+    #      further change to the advisory, shows up here rather than
+    #      silently being masked by a stale literal string). ------------
     z0_lw = captured["z0_lw"]
     z0c_lw = z0_lw / np.maximum(n_live_lw.astype(np.int64), 1)
     print()
     print("=" * 78)
-    print("INFO 9 — n_live advisory-vs-assembler disagreement")
+    print("INFO 9 — n_live advisory-vs-assembler cross-check "
+         "(issue #544, RESOLVED by PR #555)")
     print("=" * 78)
-    print("  preflight text says (verbatim above): 'n_live/n = 3/4' and "
-         "'terminates at 50 ohm across its 3 live cells'")
+    _wire_port_line = next(
+        (ln.strip() for ln in preflight_text.splitlines()
+         if "Wire port" in ln and "rasterizes" in ln),
+        None,
+    )
+    if _wire_port_line is not None:
+        print(f"  live preflight text (quoted from this run's "
+             f"preflight_text, not hardcoded): {_wire_port_line}")
+    else:
+        print("  live preflight text: no 'Wire port ... rasterizes' "
+             "dead-extent advisory fired this run -- post-PR-#555 the "
+             "advisory shares _wire_port_live_cells with the assembler "
+             "and stays silent when every rasterized cell is live, which "
+             "is ground truth on this fixture.")
     print(f"  the ASSEMBLER's actual n_live_lw (captured from the exact "
          f"call _assemble_mixed_power_wave_s receives): {n_live_lw.tolist()}")
     print(f"  => Z0c = Z0/n_live = {z0c_lw.tolist()} ohm "

--- a/scripts/diagnostics/i544_n_live_advisory_vs_assembler.py
+++ b/scripts/diagnostics/i544_n_live_advisory_vs_assembler.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Issue #544: preflight advisory says n_live/n=3/4, the assembler uses 4.
+
+======================================================================
+PRE-DECLARED (RF-intensifier discipline, R2 tightened -- one attempt)
+======================================================================
+
+Question: which count is geometrically correct for the #488 lane's
+committed lumped/wire<->MSL fixture (dx=80um) -- does the boundary-adjacent
+extent cell of the wire port conduct (live) or not?
+
+Method: dump, for the EXACT committed fixture
+(`tests/test_mixed_port_sparam.py::_base_sim/_add_feed/_add_msl`, reused
+verbatim, imitating i517_mixed_solve_vs_ratio_measurement.py's precedent):
+
+  (a) the ADVISORY's counting path as it existed BEFORE this issue's fix
+      -- a standalone bounding-box-vs-cell-CENTER geometric approximation
+      (frozen here verbatim as `_old_buggy_dead_cell_classification`; the
+      live code in `rfx/api/_preflight.py::_validate_cfg_port_inside_pec`
+      no longer contains this path -- see the PR diff for the fix),
+  (b) the ASSEMBLER's actual per-cell classification -- the exact call
+      `rfx/api/_sparams.py`'s `compute_mixed_s_matrix` makes,
+      `_wire_port_live_cells(grid, wp, pec_mask)` (`rfx/sources/sources.py`),
+  (c) the GROUND TRUTH -- the rasterized PEC occupancy the FDTD solver
+      itself will see: `Simulation._assemble_materials(grid)`'s `pec_mask`,
+      dumped at every node index the wire port's extent covers.
+
+Verdict rule (pre-declared): the count that matches (c) is correct. PR
+#543's measured passive-port Z_in = Z0/4 = 12.5 ohm flat is the INDEPENDENT
+physics witness -- if (c) contradicted that arithmetic, this script STOPS
+and reports rather than reconciling by hand. (c) is read directly from the
+same `pec_mask` array the solver's Yee update masks against
+(`rfx/api/_compile.py::_assemble_materials`), not re-derived.
+
+======================================================================
+R1 memory citations
+======================================================================
+  - `rfx-known-issues.md` "#318 RESOLVED" entry: dead cells are excluded
+    from the port's sigma distribution/drive/normalization by design --
+    this script does not question THAT mechanism, only which cells the
+    ADVISORY (vs the assembler) classifies as dead on this one fixture.
+  - `i517_mixed_solve_vs_ratio.json` (PR #543, committed): `n_live_lw =
+    [4]`, `z0_lw = [50.0]` -- the exact assembler value this script
+    independently reproduces below via `_wire_port_live_cells`, read from
+    the committed artifact rather than re-run (no new FDTD needed: this
+    is a static geometry/rasterization question, zero solve).
+  - `feedback_gate_can_bind_artifact.md`: no gate is strengthened here;
+    this is a diagnosis-then-fix, with the ground-truth dump as the
+    falsifier for the fix, matching the "mandate: falsifier re-run" spirit
+    for a *changed* advisory (it changes from firing to silent on this
+    fixture).
+
+======================================================================
+R3 pre-commit self-audit
+======================================================================
+  1. Contradicted by known memory? No -- see R1; this SHARPENS the #318/
+     #319 dead-cell-accounting class (docs/agent-memory/rfx-known-issues.md
+     "#318 RESOLVED" entry), it does not contradict it.
+  2. R2 trip? No new FDTD run, no new mechanism-hypothesis attempt -- one
+     geometry-only instrumented comparison, pre-declared above, first
+     attempt on this question.
+  3. Falsifier: the ground-truth `pec_mask` dump IS the falsifier -- if it
+     had shown the boundary cell (index 3, z=280um center) genuinely PEC,
+     the advisory would have been right and the assembler wrong (and
+     PR #543's Z0/4 physics would need re-explaining, not this advisory).
+
+======================================================================
+Fixture (pre-declared, the #488 lane's own committed lumped/wire<->MSL
+fixture, `tests/test_mixed_port_sparam.py::_base_sim/_add_feed/_add_msl`,
+reused verbatim) -- IDENTICAL to `i517_mixed_solve_vs_ratio_measurement.py`.
+======================================================================
+
+  RO4350B-like substrate eps_r=3.66, h_sub=254um, trace width=600um,
+  dx=80um, domain 8mm x 3mm x 754um, PEC z_lo / CPML elsewhere,
+  cpml_layers=8. Vertical wire feed (`add_port`, component="ez",
+  impedance=50, extent=h_sub) at x=2mm; MSL port (`add_msl_port`,
+  direction="-x") at x=5.5mm. wire_mode=True. This script needs no FDTD
+  run at all -- (a)/(b)/(c) are all static, geometry-only quantities
+  (grid + `_assemble_materials`), so it is a ZERO-solve diagnostic.
+
+======================================================================
+RESULT (2026-08-04)
+======================================================================
+
+Ground truth (c): the PEC trace box spans z in [254um, 334um], exactly
+ONE cell thick (== dx), so `Box.mask` takes the THIN-SHEET branch
+(`rfx/geometry/csg.py::Box.mask_on_coords`): the single z-NODE nearest the
+box's midpoint 294um. Node coordinates are z_k = k*dx = 0, 80, 160, 240,
+320, ... um (no half-cell offset -- `Grid.position_to_index` and
+`_grid_coords` both use `round(pos/dx)`, not `pos/dx + 0.5`). Nearest node
+to 294um is z_4=320um (|294-320|=26um vs |294-240|=54um) -- so pec_mask is
+True ONLY at k=4. The wire port's 4 rasterized cells are k=0..3 (z=0 to
+254um -> `round(254e-6/80e-6)=3`) -- k=4 is OUTSIDE the port's extent
+entirely. GROUND TRUTH: all 4 port cells are LIVE. n_live/n = 4/4.
+
+(b) assembler: `_wire_port_live_cells(grid, wp, pec_mask)` returns
+`live_flags=[True,True,True,True]`, `n_live=4` -- MATCHES ground truth
+exactly, confirming the committed `i517` artifact's `n_live_lw=[4]`.
+
+(a) old advisory: `_wire_port_cell_centers` computed cell CENTERS by
+adding a +0.5*dx Yee-component offset (z=40,120,200,280um) then tested
+each center against the PEC box's bounding box with a CLOSED interval
+`c1<=center<=c2`. Cell index 3's center (280um) falls inside [254,334]um
+-> flagged DEAD. This is WRONG: it uses a reference point (component
+center, closed interval) that does not match how `Box.mask` actually
+rasterizes (node coordinate, half-open interval, thin-sheet nearest-node
+rule) -- the true PEC node (k=4, z=320um) is a full cell away from what
+the approximation flagged (k=3, z=280um center). n=4, dead=[3], n_live/n
+= 3/4 -- the exact text from the committed `i517` JSON's
+`preflight_text` ("... n_live/n = 3/4 ... terminates at 50 ohm across its
+3 live cells ...").
+
+VERDICT: (b) matches (c); (a) does not. Per the pre-declared rule, the
+ASSEMBLER's count (4) is geometrically correct; the ADVISORY (3) was
+wrong. Z0/4 = 12.5 ohm stays fully consistent with ground truth -- no
+contradiction, no STOP. Fixed in `rfx/api/_preflight.py` by making the
+advisory call `_wire_port_live_cells` against the SAME assembled
+`pec_mask`, i.e. sharing (b)'s primitive directly rather than
+re-approximating it -- the two paths cannot drift again by construction.
+Post-fix, `sim.preflight()` on this exact fixture no longer emits
+`wire_port_dead_extent_cells` for the lw port (dumped below, "AFTER").
+"""
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+# Stale-editable-install guard (workspace memory
+# feedback_stale_editable_install_shadow.md): running this file as
+# ``python scripts/diagnostics/i544_....py`` puts the script's own
+# directory on sys.path[0], not the repo root, so a plain ``import rfx``
+# can silently resolve to a DIFFERENT installed checkout instead of this
+# worktree. Force the worktree root first (same precedent as
+# ``build_waveguide_wr90_nu_flux_broad_e4_comparison.py``).
+sys.path.insert(0, str(REPO))
+
+import numpy as np
+
+from rfx import Box, Simulation
+from rfx.boundaries.spec import Boundary, BoundarySpec
+from rfx.sources.sources import (
+    GaussianPulse, WirePort, _wire_port_cells, _wire_port_live_cells,
+)
+
+OUT_DIR = REPO / "scripts" / "diagnostics" / "i544_n_live_advisory_vs_assembler"
+I517_JSON = (REPO / "scripts" / "diagnostics" / "i517_mixed_solve_vs_ratio"
+             / "i517_mixed_solve_vs_ratio.json")
+
+# ---------------------------------------------------------------------------
+# Fixture -- verbatim from tests/test_mixed_port_sparam.py (_base_sim,
+# _add_feed, _add_msl), the #488 lane's own committed lumped/wire<->MSL
+# fixture. Not re-derived; imitates the lane's own test invocation (same
+# precedent as i517_mixed_solve_vs_ratio_measurement.py).
+# ---------------------------------------------------------------------------
+_EPS_R = 3.66
+_H_SUB = 254e-6
+_W_TRACE = 600e-6
+_DX = 80e-6
+
+
+def _base_sim(**kw):
+    lx, ly, lz = 8e-3, 3e-3, 754e-6
+    sim = Simulation(
+        freq_max=5e9, domain=(lx, ly, lz), dx=_DX, cpml_layers=8,
+        boundary=BoundarySpec(x="cpml", y="cpml",
+                              z=Boundary(lo="pec", hi="cpml")),
+        **kw,
+    )
+    sim.add_material("sub", eps_r=_EPS_R)
+    sim.add(Box((0.0, 0.0, 0.0), (lx, ly, _H_SUB)), material="sub")
+    y_c = ly / 2.0
+    sim.add(Box((0.0, y_c - _W_TRACE / 2, _H_SUB),
+                (lx, y_c + _W_TRACE / 2, _H_SUB + _DX)), material="pec")
+    return sim, y_c
+
+
+def _add_msl(sim, y_c, x=5.5e-3, direction="-x", **kw):
+    sim.add_msl_port(position=(x, y_c, 0.0), width=_W_TRACE,
+                     height=_H_SUB, direction=direction, impedance=50.0,
+                     waveform=GaussianPulse(f0=2.5e9, bandwidth=0.5), **kw)
+
+
+def _add_feed(sim, y_c, x=2e-3):
+    sim.add_port(position=(x, y_c, 0.0), component="ez",
+                 impedance=50.0, extent=_H_SUB)
+
+
+# ---------------------------------------------------------------------------
+# (a) The OLD (pre-#544) advisory counting path, frozen verbatim for the
+# historical record. This is a STANDALONE reimplementation -- the live
+# `rfx/api/_preflight.py::_validate_cfg_port_inside_pec` no longer contains
+# this logic (see the PR diff). It is reproduced here ONLY so this script
+# can show numerically what the advisory used to compute, without needing
+# to check out a pre-fix commit.
+# ---------------------------------------------------------------------------
+def _old_buggy_dead_cell_classification(sim, grid, wp, extent):
+    """Pre-#544 geometric approximation: cell CENTER (+0.5*dx Yee offset
+    along the component axis) vs PEC bounding box, closed interval.
+    """
+    axis = {"ex": 0, "ey": 1, "ez": 2}[wp.component]
+    d = (grid.dx, getattr(grid, "dy", grid.dx), getattr(grid, "dz", grid.dx))
+    pad = (getattr(grid, "pad_x_lo", 0), getattr(grid, "pad_y_lo", 0),
+           getattr(grid, "pad_z_lo", 0))
+    cells = _wire_port_cells(grid, wp)
+    centers = []
+    for cell in cells:
+        pos = [(cell[ax] - pad[ax]) * d[ax] for ax in range(3)]
+        pos[axis] += 0.5 * d[axis]
+        centers.append(tuple(pos))
+
+    pec_bboxes = []
+    for entry in sim._geometry:
+        if entry.material_name != "pec":
+            continue
+        if not hasattr(entry.shape, "bounding_box"):
+            continue
+        c1, c2 = entry.shape.bounding_box()
+        pec_bboxes.append((entry.material_name, c1, c2))
+
+    dead_indices = []
+    for idx, center in enumerate(centers):
+        for name, c1, c2 in pec_bboxes:
+            if all(c1[ax] <= center[ax] <= c2[ax] for ax in range(3)):
+                dead_indices.append(idx)
+                break
+    n = len(centers)
+    n_live = n - len(dead_indices)
+    return {
+        "cells": cells, "centers": centers, "dead_indices": dead_indices,
+        "n": n, "n_live": n_live,
+    }
+
+
+def main() -> int:
+    sim, y_c = _base_sim()
+    _add_feed(sim, y_c, x=2e-3)
+    _add_msl(sim, y_c, x=5.5e-3, n_probe_offset=10, n_probe_spacing=4)
+
+    grid = sim._build_grid()
+    wp = WirePort(start=(2e-3, y_c, 0.0), end=(2e-3, y_c, _H_SUB),
+                  component="ez", impedance=50.0)
+    cells = _wire_port_cells(grid, wp)
+    i0, j0 = cells[0][0], cells[0][1]
+
+    materials, debye, lorentz, pec_mask, pec_shapes, boundary_pec, kerr = \
+        sim._assemble_materials(grid)
+    pec_mask_np = np.asarray(pec_mask)
+
+    print("=" * 78)
+    print("(c) GROUND TRUTH -- rasterized pec_mask at the wire port's (i,j) column")
+    print("=" * 78)
+    k_span = list(range(0, 9))
+    col = pec_mask_np[i0, j0, k_span].tolist()
+    print(f"  wire port cells (i,j,k): {cells}")
+    print(f"  pec_mask[i={i0}, j={j0}, k=0..8]: {col}")
+    print(f"  node z (um) for k=0..8: {[round(k * grid.dx * 1e6, 3) for k in k_span]}")
+    dead_k_ground_truth = [k for k in k_span if col[k]]
+    print(f"  PEC node index/indices (ground truth): {dead_k_ground_truth}")
+
+    # (b) assembler's actual call (rfx/api/_sparams.py:3426)
+    cells_b, live_flags_b, n_live_b = _wire_port_live_cells(grid, wp, pec_mask)
+    print()
+    print("=" * 78)
+    print("(b) ASSEMBLER -- _wire_port_live_cells(grid, wp, pec_mask)")
+    print("=" * 78)
+    print(f"  live_flags: {live_flags_b}  n_live: {n_live_b}/{len(cells_b)}")
+
+    # (a) old buggy advisory path, frozen verbatim
+    old = _old_buggy_dead_cell_classification(sim, grid, wp, _H_SUB)
+    print()
+    print("=" * 78)
+    print("(a) OLD ADVISORY (pre-#544, frozen verbatim reimplementation)")
+    print("=" * 78)
+    print(f"  centers (m): {old['centers']}")
+    print(f"  dead_indices: {old['dead_indices']}  "
+         f"n_live: {old['n_live']}/{old['n']}")
+
+    ground_truth_n_live = sum(1 for c in cells if not bool(
+        pec_mask_np[c[0], c[1], c[2]]))
+    verdict_b_matches_c = (n_live_b == ground_truth_n_live)
+    verdict_a_matches_c = (old["n_live"] == ground_truth_n_live)
+
+    print()
+    print("=" * 78)
+    print("VERDICT (pre-declared rule: the count matching (c) is correct)")
+    print("=" * 78)
+    print(f"  ground truth n_live (directly from pec_mask): {ground_truth_n_live}")
+    print(f"  (b) assembler matches ground truth: {verdict_b_matches_c}")
+    print(f"  (a) old advisory matches ground truth: {verdict_a_matches_c}")
+
+    # Cross-check against the committed i517 artifact (no new FDTD run --
+    # static comparison against an already-committed measurement).
+    i517_n_live = None
+    i517_preflight_line = None
+    if I517_JSON.exists():
+        i517 = json.loads(I517_JSON.read_text())
+        i517_n_live = i517["n_live_lw"]
+        for line in i517["preflight_text"].splitlines():
+            if "Wire port" in line and "rasterizes" in line:
+                i517_preflight_line = line.strip()
+                break
+    print()
+    print("=" * 78)
+    print("CROSS-CHECK vs committed i517 artifact (PR #543, no new FDTD)")
+    print("=" * 78)
+    print(f"  i517 n_live_lw: {i517_n_live}  (this script's (b): [{n_live_b}])")
+    print(f"  i517 preflight text (pre-#544-fix, quoted verbatim): "
+         f"{i517_preflight_line}")
+    i517_consistent = (i517_n_live == [n_live_b])
+
+    # AFTER: run the CURRENT (fixed) preflight on this exact fixture and
+    # show the advisory now agrees with ground truth (silent for this
+    # port -- no dead cells).
+    stdout_buf = io.StringIO()
+    with contextlib.redirect_stdout(stdout_buf):
+        issues_after = sim.preflight()
+    preflight_text_after = stdout_buf.getvalue()
+    codes_after = [getattr(s, "code", None) for s in issues_after]
+    dead_extent_fires_after = "wire_port_dead_extent_cells" in codes_after
+    midpoint_fires_after = "wire_port_midpoint_in_pec" in codes_after
+    print()
+    print("=" * 78)
+    print("AFTER THE FIX -- sim.preflight() on the identical fixture")
+    print("=" * 78)
+    print(f"  wire_port_dead_extent_cells fires: {dead_extent_fires_after}")
+    print(f"  wire_port_midpoint_in_pec fires: {midpoint_fires_after}")
+    print("  (expected: both False -- ground truth is fully live, 4/4)")
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = OUT_DIR / "i544_n_live_advisory_vs_assembler.json"
+    out_path.write_text(json.dumps({
+        "fixture": {
+            "eps_r": _EPS_R, "h_sub_m": _H_SUB, "w_trace_m": _W_TRACE,
+            "dx_m": _DX, "feed_x_m": 2e-3, "msl_x_m": 5.5e-3,
+        },
+        "wire_port_cells_ijk": cells,
+        "ground_truth": {
+            "pec_mask_column_k0_8": col,
+            "node_z_um_k0_8": [round(k * grid.dx * 1e6, 3) for k in k_span],
+            "pec_node_indices": dead_k_ground_truth,
+            "n_live": ground_truth_n_live,
+            "n": len(cells),
+        },
+        "b_assembler": {
+            "live_flags": live_flags_b, "n_live": n_live_b, "n": len(cells_b),
+            "matches_ground_truth": verdict_b_matches_c,
+        },
+        "a_old_advisory": {
+            "centers_m": old["centers"], "dead_indices": old["dead_indices"],
+            "n_live": old["n_live"], "n": old["n"],
+            "matches_ground_truth": verdict_a_matches_c,
+        },
+        "i517_cross_check": {
+            "i517_n_live_lw": i517_n_live,
+            "i517_preflight_line": i517_preflight_line,
+            "consistent_with_this_scripts_b": i517_consistent,
+        },
+        "after_fix": {
+            "wire_port_dead_extent_cells_fires": dead_extent_fires_after,
+            "wire_port_midpoint_in_pec_fires": midpoint_fires_after,
+            "preflight_text": preflight_text_after,
+        },
+        "verdict": {
+            "ground_truth_n_live": ground_truth_n_live,
+            "assembler_correct": verdict_b_matches_c,
+            "old_advisory_correct": verdict_a_matches_c,
+            "z0_over_4_consistent_with_ground_truth": (
+                ground_truth_n_live == 4
+            ),
+            "conclusion": (
+                "assembler (n_live=4) matches ground truth pec_mask; "
+                "old advisory (n_live=3) did not -- the advisory was "
+                "wrong, fixed by sharing _wire_port_live_cells against "
+                "the same assembled pec_mask."
+            ),
+        },
+    }, indent=2) + "\n")
+    print(f"\nwrote {out_path}", flush=True)
+
+    assert verdict_b_matches_c, "assembler must match ground truth"
+    assert not verdict_a_matches_c, (
+        "expected the OLD advisory to disagree with ground truth on this "
+        "fixture (that disagreement is issue #544) -- if this assertion "
+        "fails, the frozen reimplementation no longer reproduces the bug "
+        "and the historical record above needs revisiting"
+    )
+    assert i517_consistent, (
+        "this script's (b) must match the already-committed i517 artifact"
+    )
+    assert not dead_extent_fires_after and not midpoint_fires_after, (
+        "post-fix preflight must be silent on this fixture (ground truth "
+        "is fully live)"
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diagnostics/i544_n_live_advisory_vs_assembler/i544_n_live_advisory_vs_assembler.json
+++ b/scripts/diagnostics/i544_n_live_advisory_vs_assembler/i544_n_live_advisory_vs_assembler.json
@@ -1,0 +1,121 @@
+{
+  "fixture": {
+    "eps_r": 3.66,
+    "h_sub_m": 0.000254,
+    "w_trace_m": 0.0006,
+    "dx_m": 8e-05,
+    "feed_x_m": 0.002,
+    "msl_x_m": 0.0055
+  },
+  "wire_port_cells_ijk": [
+    [
+      33,
+      27,
+      0
+    ],
+    [
+      33,
+      27,
+      1
+    ],
+    [
+      33,
+      27,
+      2
+    ],
+    [
+      33,
+      27,
+      3
+    ]
+  ],
+  "ground_truth": {
+    "pec_mask_column_k0_8": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      false
+    ],
+    "node_z_um_k0_8": [
+      0.0,
+      80.0,
+      160.0,
+      240.0,
+      320.0,
+      400.0,
+      480.0,
+      560.0,
+      640.0
+    ],
+    "pec_node_indices": [
+      4
+    ],
+    "n_live": 4,
+    "n": 4
+  },
+  "b_assembler": {
+    "live_flags": [
+      true,
+      true,
+      true,
+      true
+    ],
+    "n_live": 4,
+    "n": 4,
+    "matches_ground_truth": true
+  },
+  "a_old_advisory": {
+    "centers_m": [
+      [
+        0.002,
+        0.00152,
+        4e-05
+      ],
+      [
+        0.002,
+        0.00152,
+        0.00012000000000000002
+      ],
+      [
+        0.002,
+        0.00152,
+        0.0002
+      ],
+      [
+        0.002,
+        0.00152,
+        0.00028000000000000003
+      ]
+    ],
+    "dead_indices": [
+      3
+    ],
+    "n_live": 3,
+    "n": 4,
+    "matches_ground_truth": false
+  },
+  "i517_cross_check": {
+    "i517_n_live_lw": [
+      4
+    ],
+    "i517_preflight_line": "[PREFLIGHT] Wire port at (0.002, 0.0015, 0.0) (extent 0.000254) rasterizes to n=4 cells of which 1 land inside PEC geometry ['pec'] (n_live/n = 3/4). Dead cells are shorted by the PEC and are excluded from the port's resistance distribution, drive injection, and wave normalization (issue #318 fix): the port terminates at 50 ohm across its 3 live cells. (rfx versions before the #318 fix counted all 4 cells and physically terminated at Z0*(n_live/n) = 37.5 ohm \u2014 the issue-#313 finding.) Verify the extent was MEANT to end on/inside the conductor, and keep the midpoint V/I probe cell live; to silence, shorten the extent or move the port so every cell center sits outside PEC.",
+    "consistent_with_this_scripts_b": true
+  },
+  "after_fix": {
+    "wire_port_dead_extent_cells_fires": false,
+    "wire_port_midpoint_in_pec_fires": false,
+    "preflight_text": "  [PREFLIGHT] 'pec' z-extent 80\u00b5m = 1.0 cells \u2014 below 1 cell resolution. A conductor thinner than a cell is modelled as a one-cell PEC surface \u2014 tangential E is zeroed on it and the normal component survives as surface charge. That is usually what you want for metal many skin depths thick, and switching to add_thin_conductor() would not change it; but it means the sheet carries no conductor loss and its thickness is not modelled.\n  [PREFLIGHT] pec_faces={z_lo} creates an INFINITE PEC boundary AND the geometry contains finite PEC objects. For antennas or finite-GP structures, the pec_faces boundary makes the ground plane cover the entire domain face, which changes the physics (cavity vs radiating antenna). If you need a finite ground plane, remove pec_faces and use an explicit PEC Box instead.\n  [PREFLIGHT] all dielectric(s) ['sub'] are perfectly lossless in an open (CPML) domain. If you are measuring Q / resonance, this gives an ARTIFICIALLY infinite Q (design-guide Anti-Pattern #1, an R5 surface-metric trap) \u2014 add loss, e.g. sigma = 2*pi*f*eps0*eps_r*tan_delta. (Harmless if you are not measuring Q.)\n  [PREFLIGHT] MSL port 'msl_0': only 3 substrate cell(s) in z (h_sub=254\u00b5m, dx=80\u00b5m). Yee staircase at dielectric interface is O(dx) \u2014 Z0 staircase error >5% expected. Refine to dx \u2264 64\u00b5m (4+ substrate cells) AND keep h_sub/dx an integer (aligned) for <5% Z0 bias \u2014 measured post-#511/#507 at -3.8%/-1.2%/+0.7% for h_sub/4, h_sub/5, h_sub/6 (scripts/diagnostics/msl_z0_bias_floor_sweep.py). Refining WITHOUT alignment does not reach that: a mixed-cell mesh at a similar cell count measured +11% (h_sub/dx=4.233) \u2014 see the mixed-cell-danger-zone check below.\n  [PREFLIGHT] MSL port 'msl_0': h_sub/dx = 3.175 (fractional part 0.175) lands in the [0.10, 0.40] mixed-cell danger zone. The substrate-air interface bisects the same Yee cell that holds the trace; AD-traceable ``pec_occupancy_override`` zeros the whole cell and produces unphysical |S21|\u00b2 > 1 in this regime. Hard ``Box(material='pec')`` avoids that specific bug, but Z0 bias itself is still 2.56-2.94x worse than an aligned mesh at a comparable cell count (measured +20.2% vs -7.9% at ~3 cells, +11.0% vs -3.8% at ~4 cells; scripts/diagnostics/msl_z0_bias_floor_sweep.py) \u2014 refining cell count alone will not reach the aligned-mesh bias. To snap onto a safe alignment regardless, set dx = 63.5\u00b5m (= h_sub/4) or 84.7\u00b5m (= h_sub/3).\n"
+  },
+  "verdict": {
+    "ground_truth_n_live": 4,
+    "assembler_correct": true,
+    "old_advisory_correct": false,
+    "z0_over_4_consistent_with_ground_truth": true,
+    "conclusion": "assembler (n_live=4) matches ground truth pec_mask; old advisory (n_live=3) did not -- the advisory was wrong, fixed by sharing _wire_port_live_cells against the same assembled pec_mask."
+  }
+}

--- a/tests/test_mixed_port_sparam.py
+++ b/tests/test_mixed_port_sparam.py
@@ -744,6 +744,12 @@ def test_wire_port_dead_cell_advisory_matches_ground_truth_on_488_fixture():
         "midpoint cell (index 2, z=200um) is live -- #314 must stay "
         "silent too: " + "\n".join(str(s) for s in issues)
     )
+    assert "wire_port_dead_cell_classification_unavailable" not in codes, (
+        "issue #544 review R1: the classification-unavailable note is "
+        "reserved for NU meshes / a materials-build exception -- this "
+        "fixture is a clean uniform mesh with a working build, so it "
+        "must NOT fire here: " + "\n".join(str(s) for s in issues)
+    )
 
 
 def test_wire_port_dead_cell_advisory_stays_correct_on_an_already_agreeing_case():
@@ -821,4 +827,79 @@ def test_wire_port_dead_cell_advisory_old_method_would_have_drifted():
     assert "wire_port_dead_extent_cells" not in codes, (
         "current advisory (sharing the ground-truth primitive) must NOT "
         "reproduce the old method's wrong classification"
+    )
+
+
+def test_wire_port_dead_cell_classification_unavailable_on_nu_mesh():
+    """Issue #544 review R1: BLOCKING-1's fix (skip the classification on
+    a non-uniform mesh rather than building a mismatched uniform
+    substitute) had zero test coverage. On a dz_profile sim with a wire
+    port, the new ``wire_port_dead_cell_classification_unavailable``
+    advisory must fire (warning severity) and BOTH #314/#319 dead-cell
+    advisories must stay silent (there is nothing safe to classify).
+    """
+    sim, y_c = _base_sim(dz_profile=np.full(10, 75.4e-6))
+    _add_feed(sim, y_c, x=2e-3)
+
+    issues = sim.preflight()
+    codes = [getattr(s, "code", None) for s in issues]
+    hits = [s for s in issues
+            if getattr(s, "code", None)
+            == "wire_port_dead_cell_classification_unavailable"]
+    assert len(hits) == 1, (
+        "expected exactly one classification-unavailable note on an NU "
+        "sim with one wire port: " + "\n".join(str(s) for s in issues)
+    )
+    assert getattr(hits[0], "severity", None) == "warning", (
+        f"classification-unavailable note must be warning-severity, got "
+        f"{getattr(hits[0], 'severity', None)!r}"
+    )
+    assert "non-uniform mesh" in hits[0] and "dz_profile" in hits[0], (
+        f"note must name the NU reason: {hits[0]}"
+    )
+    assert "wire_port_dead_extent_cells" not in codes, (
+        "the uniform-only ground-truth path must not have run on an NU "
+        "mesh: " + "\n".join(str(s) for s in issues)
+    )
+    assert "wire_port_midpoint_in_pec" not in codes, (
+        "the uniform-only ground-truth path must not have run on an NU "
+        "mesh: " + "\n".join(str(s) for s in issues)
+    )
+
+
+def test_wire_port_dead_cell_classification_unavailable_on_assemble_exception(
+    monkeypatch,
+):
+    """Issue #544 review R1: the OTHER trigger for the same advisory --
+    a materials-build exception on an otherwise-uniform sim (defensive
+    fallback, review item 6) -- also had zero coverage. Monkeypatches
+    ``_assemble_materials`` to raise on a clean uniform #488-style
+    fixture and asserts the note fires carrying the exception text.
+    """
+    sim, y_c = _base_sim()
+    _add_feed(sim, y_c, x=2e-3)
+    _add_msl(sim, y_c, x=5.5e-3, n_probe_offset=10, n_probe_spacing=4)
+
+    def _raise_materials_build(*_args, **_kwargs):
+        raise RuntimeError(
+            "synthetic materials-assembly failure (issue #544 review "
+            "item 1 falsifier)"
+        )
+
+    monkeypatch.setattr(sim, "_assemble_materials", _raise_materials_build)
+
+    issues = sim.preflight()
+    hits = [s for s in issues
+            if getattr(s, "code", None)
+            == "wire_port_dead_cell_classification_unavailable"]
+    assert len(hits) == 1, (
+        "expected exactly one classification-unavailable note when "
+        "_assemble_materials raises: " + "\n".join(str(s) for s in issues)
+    )
+    assert getattr(hits[0], "severity", None) == "warning", (
+        f"classification-unavailable note must be warning-severity, got "
+        f"{getattr(hits[0], 'severity', None)!r}"
+    )
+    assert "synthetic materials-assembly failure" in hits[0], (
+        f"note must carry the caught exception's text verbatim: {hits[0]}"
     )

--- a/tests/test_mixed_port_sparam.py
+++ b/tests/test_mixed_port_sparam.py
@@ -749,16 +749,24 @@ def test_wire_port_dead_cell_advisory_matches_ground_truth_on_488_fixture():
 def test_wire_port_dead_cell_advisory_stays_correct_on_an_already_agreeing_case():
     """No false-positive introduction: a case where the pre-#544 advisory
     and the assembler ALREADY agreed must still report the same n_live/n
-    after the fix. dx=0.5mm, trace z in [1.0,1.5]mm, port extent=1.0mm ->
-    3 cells (centers 0.25/0.75/1.25mm); the top cell (index 2, z=1.25mm)
-    is genuinely dead both under the old center-based check AND under the
-    real node-based rasterization (this box's thin-sheet nearest-node is
-    z=1.0mm=node 2, INSIDE the port's cell range, unlike the #488 case).
+    after the fix. dx=0.5mm, trace z in [0.9,1.4]mm (1 cell thick -> the
+    thin-sheet branch), port extent=1.0mm -> 3 cells (centers
+    0.25/0.75/1.25mm). The thin-sheet midpoint is 1.15mm, UNAMBIGUOUSLY
+    closer to node z=1.0mm (0.15mm away) than to node z=1.5mm (0.35mm
+    away) -- not a tie, so the ground-truth node is deterministic
+    regardless of platform/dtype rounding (issue #544 review item 5: an
+    EARLIER version of this fixture used trace z in [1.0,1.5]mm, whose
+    thin-sheet midpoint 1.25mm sits EXACTLY equidistant between nodes
+    1.0mm and 1.5mm -- Box's own docstring calls that tie unpredictable
+    across float32 double-rounding, so it was replaced). Cell index 2
+    (z-node=1.0mm, cell center 1.25mm) is genuinely dead both under the
+    old center-based check AND under the real node-based rasterization,
+    and is NOT the midpoint cell (index 1, z-node=0.5mm).
     """
     dx = 0.5e-3
     sim = Simulation(freq_max=10e9, domain=(0.016, 0.010, 0.006),
                      boundary="cpml", cpml_layers=6, dx=dx)
-    sim.add(Box((0.004, 0.003, 1.0e-3), (0.012, 0.007, 1.5e-3)),
+    sim.add(Box((0.004, 0.003, 0.9e-3), (0.012, 0.007, 1.4e-3)),
             material="pec")
     sim.add_port(position=(0.008, 0.005, 0.0), component="ez",
                  impedance=50.0, extent=1.0e-3)

--- a/tests/test_mixed_port_sparam.py
+++ b/tests/test_mixed_port_sparam.py
@@ -24,7 +24,9 @@ from rfx import Box, Simulation
 from rfx.api._sparams import _assemble_mixed_power_wave_s
 from rfx.boundaries.spec import Boundary, BoundarySpec
 from rfx.probes.probes import DFTPlaneProbe
-from rfx.sources.sources import GaussianPulse
+from rfx.sources.sources import (
+    GaussianPulse, WirePort, _wire_port_cells, _wire_port_live_cells,
+)
 
 _EPS_R = 3.66
 _H_SUB = 254e-6
@@ -637,3 +639,178 @@ def test_mixed_lane_v_span_reaches_the_rasterized_trace_on_bisecting_mesh():
         "#511/F2 off-by-one has returned in the mixed lane's own copy."
     )
     assert sim._ports[0].excite is True
+
+
+# ---------------------------------------------------------------------------
+# Issue #544: preflight's wire-port dead-extent-cell advisory disagreed
+# with the assembler's actual n_live_lw on this fixture (3/4 advisory vs 4
+# actual). The fix makes the advisory derive its count from the SAME
+# primitive the assembler uses (_wire_port_live_cells against the real
+# assembled pec_mask) instead of a standalone bounding-box-vs-cell-center
+# approximation. These tests pin the corrected fixture, confirm a
+# previously-agreeing case stays unchanged (no false positive introduced),
+# and falsify the OLD method against ground truth (mutation-style: the
+# geometry is identical, only the classification method differs).
+# ---------------------------------------------------------------------------
+
+def _ground_truth_wire_port_n_live(sim, position, component, extent,
+                                   impedance=50.0):
+    """Independent ground-truth n_live: build grid + assembled pec_mask
+    FRESH (not reusing anything preflight computed) and classify with the
+    same primitive the assembler calls
+    (rfx/api/_sparams.py:3426, compute_mixed_s_matrix's n_live_lw).
+    """
+    grid = sim._build_grid()
+    axis = {"ex": 0, "ey": 1, "ez": 2}[component]
+    end = list(position)
+    end[axis] += extent
+    wp = WirePort(start=tuple(position), end=tuple(end),
+                  component=component, impedance=impedance)
+    _, _, _, pec_mask, _, _, _ = sim._assemble_materials(grid)
+    _, live_flags, n_live = _wire_port_live_cells(grid, wp, pec_mask)
+    return n_live, len(live_flags)
+
+
+def _old_buggy_dead_cell_classification(sim, position, component, extent,
+                                        impedance=50.0):
+    """Frozen, standalone reimplementation of the PRE-#544 advisory
+    counting path (bounding-box-vs-cell-CENTER, closed interval). The live
+    ``rfx/api/_preflight.py::_validate_cfg_port_inside_pec`` no longer
+    contains this logic — kept here only so this test can demonstrate,
+    on the exact fixture geometry, that it disagreed with ground truth
+    (the #544 bug) without needing a pre-fix checkout.
+    """
+    grid = sim._build_grid()
+    axis = {"ex": 0, "ey": 1, "ez": 2}[component]
+    end = list(position)
+    end[axis] += extent
+    wp = WirePort(start=tuple(position), end=tuple(end),
+                  component=component, impedance=impedance)
+    d = (grid.dx, getattr(grid, "dy", grid.dx), getattr(grid, "dz", grid.dx))
+    pad = (getattr(grid, "pad_x_lo", 0), getattr(grid, "pad_y_lo", 0),
+           getattr(grid, "pad_z_lo", 0))
+    cells = _wire_port_cells(grid, wp)
+    centers = []
+    for cell in cells:
+        pos = [(cell[ax] - pad[ax]) * d[ax] for ax in range(3)]
+        pos[axis] += 0.5 * d[axis]
+        centers.append(tuple(pos))
+    pec_bboxes = []
+    for entry in sim._geometry:
+        if entry.material_name != "pec":
+            continue
+        if not hasattr(entry.shape, "bounding_box"):
+            continue
+        c1, c2 = entry.shape.bounding_box()
+        pec_bboxes.append((c1, c2))
+    dead = [idx for idx, c in enumerate(centers)
+            if any(all(c1[ax] <= c[ax] <= c2[ax] for ax in range(3))
+                  for c1, c2 in pec_bboxes)]
+    return len(cells) - len(dead), len(cells)
+
+
+def test_wire_port_dead_cell_advisory_matches_ground_truth_on_488_fixture():
+    """Regression lock (issue #544): on the #488 lane's own committed
+    fixture, the trace is exactly one cell thick (dx=80um) and rasterizes
+    to node k=4 (see test_mixed_lane_v_span_reaches_the_rasterized_trace_
+    on_bisecting_mesh's docstring: "the trace rasterizes at node 4"),
+    which is OUTSIDE the wire port's 4 rasterized cells (k=0..3) — every
+    port cell is genuinely live. Before the fix, the advisory reported
+    n_live/n=3/4 ("terminates at 50 ohm across its 3 live cells") because
+    it compared a cell-CENTER (node + half-cell Yee offset) against the
+    PEC bounding box instead of the real rasterization; the assembler's
+    actual n_live_lw was always 4 (PR #543 measured Z_in = Z0/4 = 12.5 ohm
+    flat, matching n_live=4 to 5.8e-4).
+    """
+    sim, y_c = _base_sim()
+    _add_feed(sim, y_c, x=2e-3)
+    _add_msl(sim, y_c, x=5.5e-3, n_probe_offset=10, n_probe_spacing=4)
+
+    n_live_truth, n = _ground_truth_wire_port_n_live(
+        sim, position=(2e-3, y_c, 0.0), component="ez", extent=_H_SUB)
+    assert (n_live_truth, n) == (4, 4), (
+        f"ground truth changed ({n_live_truth}/{n}) -- re-derive the "
+        "expected preflight behaviour before trusting the rest of this "
+        "test"
+    )
+
+    issues = sim.preflight()
+    codes = [getattr(s, "code", None) for s in issues]
+    assert "wire_port_dead_extent_cells" not in codes, (
+        "corrected advisory must be silent: ground truth is n_live/n=4/4 "
+        "(issue #544): " + "\n".join(str(s) for s in issues)
+    )
+    assert "wire_port_midpoint_in_pec" not in codes, (
+        "midpoint cell (index 2, z=200um) is live -- #314 must stay "
+        "silent too: " + "\n".join(str(s) for s in issues)
+    )
+
+
+def test_wire_port_dead_cell_advisory_stays_correct_on_an_already_agreeing_case():
+    """No false-positive introduction: a case where the pre-#544 advisory
+    and the assembler ALREADY agreed must still report the same n_live/n
+    after the fix. dx=0.5mm, trace z in [1.0,1.5]mm, port extent=1.0mm ->
+    3 cells (centers 0.25/0.75/1.25mm); the top cell (index 2, z=1.25mm)
+    is genuinely dead both under the old center-based check AND under the
+    real node-based rasterization (this box's thin-sheet nearest-node is
+    z=1.0mm=node 2, INSIDE the port's cell range, unlike the #488 case).
+    """
+    dx = 0.5e-3
+    sim = Simulation(freq_max=10e9, domain=(0.016, 0.010, 0.006),
+                     boundary="cpml", cpml_layers=6, dx=dx)
+    sim.add(Box((0.004, 0.003, 1.0e-3), (0.012, 0.007, 1.5e-3)),
+            material="pec")
+    sim.add_port(position=(0.008, 0.005, 0.0), component="ez",
+                 impedance=50.0, extent=1.0e-3)
+
+    n_live_truth, n = _ground_truth_wire_port_n_live(
+        sim, position=(0.008, 0.005, 0.0), component="ez", extent=1.0e-3)
+    n_live_old, n_old = _old_buggy_dead_cell_classification(
+        sim, position=(0.008, 0.005, 0.0), component="ez", extent=1.0e-3)
+    assert (n_live_truth, n) == (n_live_old, n_old) == (2, 3), (
+        f"expected this fixture to be an ALREADY-AGREEING case (2/3 "
+        f"either way); got ground_truth={n_live_truth}/{n} "
+        f"old={n_live_old}/{n_old}"
+    )
+
+    issues = sim.preflight()
+    dead = [s for s in issues
+            if getattr(s, "code", None) == "wire_port_dead_extent_cells"]
+    assert len(dead) == 1 and "2/3" in dead[0], (
+        "advisory text must be unchanged on an already-agreeing fixture: "
+        + "\n".join(str(s) for s in issues)
+    )
+
+
+def test_wire_port_dead_cell_advisory_old_method_would_have_drifted():
+    """Mutation-style falsifier (issue #544): SAME geometry (the #488
+    fixture), two classification methods. The frozen pre-#544 method
+    (bbox-vs-cell-center) disagrees with ground truth here (that
+    disagreement IS the bug); the current advisory -- which now shares
+    _wire_port_live_cells with the assembler -- agrees. If a future edit
+    reintroduced a standalone approximation in the advisory, this test's
+    second assertion would start failing loudly.
+    """
+    sim, y_c = _base_sim()
+    _add_feed(sim, y_c, x=2e-3)
+    _add_msl(sim, y_c, x=5.5e-3, n_probe_offset=10, n_probe_spacing=4)
+
+    n_live_truth, n = _ground_truth_wire_port_n_live(
+        sim, position=(2e-3, y_c, 0.0), component="ez", extent=_H_SUB)
+    n_live_old, n_old = _old_buggy_dead_cell_classification(
+        sim, position=(2e-3, y_c, 0.0), component="ez", extent=_H_SUB)
+
+    assert n_live_old != n_live_truth, (
+        "expected the OLD bbox-vs-center method to DISAGREE with ground "
+        f"truth on this fixture (that disagreement is issue #544); got "
+        f"old={n_live_old}/{n_old} == ground_truth={n_live_truth}/{n} -- "
+        "the frozen reimplementation no longer reproduces the historical "
+        "bug and the regression-lock premise needs revisiting"
+    )
+
+    issues = sim.preflight()
+    codes = [getattr(s, "code", None) for s in issues]
+    assert "wire_port_dead_extent_cells" not in codes, (
+        "current advisory (sharing the ground-truth primitive) must NOT "
+        "reproduce the old method's wrong classification"
+    )

--- a/tests/test_mixed_port_sparam.py
+++ b/tests/test_mixed_port_sparam.py
@@ -873,15 +873,20 @@ def test_wire_port_dead_cell_classification_unavailable_on_assemble_exception(
     """Issue #544 review R1: the OTHER trigger for the same advisory --
     a materials-build exception on an otherwise-uniform sim (defensive
     fallback, review item 6) -- also had zero coverage. Monkeypatches
-    ``_assemble_materials`` to raise on a clean uniform #488-style
-    fixture and asserts the note fires carrying the exception text.
+    ``_assemble_materials`` to raise a REALISTIC build failure
+    (``ValueError`` -- matches what a malformed domain/grid config or
+    ``_resolve_material``'s own ``KeyError`` class of failure looks like;
+    NOT ``RuntimeError``/``TimeoutError``, which are the classes this
+    advisory must NOT swallow -- see the sibling propagation test below)
+    on a clean uniform #488-style fixture, and asserts the note fires
+    carrying the exception text.
     """
     sim, y_c = _base_sim()
     _add_feed(sim, y_c, x=2e-3)
     _add_msl(sim, y_c, x=5.5e-3, n_probe_offset=10, n_probe_spacing=4)
 
     def _raise_materials_build(*_args, **_kwargs):
-        raise RuntimeError(
+        raise ValueError(
             "synthetic materials-assembly failure (issue #544 review "
             "item 1 falsifier)"
         )
@@ -903,3 +908,44 @@ def test_wire_port_dead_cell_classification_unavailable_on_assemble_exception(
     assert "synthetic materials-assembly failure" in hits[0], (
         f"note must carry the caught exception's text verbatim: {hits[0]}"
     )
+
+
+def test_wire_port_advisory_does_not_swallow_a_timeout_signal(monkeypatch):
+    """Regression test for the studio-packaging CI failure on PR #555's
+    original head (f3a3db7): a broad ``except Exception`` in the new
+    dead-cell classification code caught
+    ``rfx.experiments.worker.RunTimedOut`` (a ``TimeoutError`` subclass a
+    SIGALRM handler raises asynchronously while ``_assemble_materials``
+    was in flight), silently converting the timeout into a
+    "classification unavailable" advisory instead of letting it
+    propagate -- so a 500,000-step experiment with a 1-second timeout
+    kept simulating instead of dying, hanging
+    ``tests/test_durable_worker_lifecycle.py::
+    test_worker_timeout_is_durable_failed_outcome``'s subprocess wait
+    (60s) with NO worker-side sign of the timeout ever having fired.
+
+    Reproduces the class directly (no subprocess/signal needed): monkeypatch
+    ``_assemble_materials`` to raise ``TimeoutError`` -- the same family
+    the worker's SIGALRM handler uses (``RunTimedOut(TimeoutError)``) --
+    and assert ``preflight()`` does NOT catch it: it must propagate all
+    the way out uncaught, exactly as it would have before this advisory
+    existed. A ``RuntimeError`` (the family ``RunCancelled`` -- the
+    worker's SIGTERM/SIGINT handler -- uses) must propagate too.
+    """
+    sim, y_c = _base_sim()
+    _add_feed(sim, y_c, x=2e-3)
+    _add_msl(sim, y_c, x=5.5e-3, n_probe_offset=10, n_probe_spacing=4)
+
+    def _raise_timeout(*_args, **_kwargs):
+        raise TimeoutError("worker exceeded the experiment timeout")
+
+    monkeypatch.setattr(sim, "_assemble_materials", _raise_timeout)
+    with pytest.raises(TimeoutError, match="exceeded the experiment timeout"):
+        sim.preflight()
+
+    def _raise_cancel(*_args, **_kwargs):
+        raise RuntimeError("worker received signal 15")
+
+    monkeypatch.setattr(sim, "_assemble_materials", _raise_cancel)
+    with pytest.raises(RuntimeError, match="worker received signal"):
+        sim.preflight()


### PR DESCRIPTION
## Summary

- Closes #544: the wire-port dead-extent-cell preflight advisory
  (`_validate_cfg_port_inside_pec`, `rfx/api/_preflight.py`) classified a
  cell as PEC-dead by testing a computed cell-**CENTER** (node + 0.5·dx
  Yee offset along the component axis) against the PEC bounding box with
  a closed interval. The real rasterization (`Box.mask`,
  `rfx/geometry/csg.py`) evaluates occupancy at **NODE** coordinates with
  a half-open interval `[lo, hi)` (or the thin-sheet nearest-node rule for
  a sub-cell-thick box) — a different reference point.
- On the #488 lane's committed lumped/wire↔MSL fixture (dx=80 µm) this
  made the advisory report `n_live/n = 3/4` while the assembler's actual
  `n_live_lw` was `[4]` (PR #543 measured passive-port `Z_in = Z0/4 =
  12.5 Ω` flat, matching `n_live=4` to 5.8e-4 — would not match at 3).
- Fix: the advisory now calls `_wire_port_live_cells` against the **same
  assembled `pec_mask`** the assembler uses (`rfx/api/_sparams.py:3426`)
  instead of re-approximating it — the two paths cannot drift again by
  construction **on the uniform-mesh path** (see the adversarial-review
  section below for the non-uniform-mesh scope limit, now disclosed).

**Update (2026-08-04): adversarial review requested changes, applied in
this same PR** — see "Adversarial review — findings and fixes" below for
the two BLOCKING items and nine same-pass items, all addressed. A
follow-up issue (#556) was filed for the review's open scope question.

**Update (2026-08-04, second): a real `studio-packaging` CI regression
was found on all three prior heads** (traced to this PR's original
commit) — a broad `except Exception` in the new preflight code caught a
worker's `SIGALRM`-driven timeout exception and silently converted it
into an advisory instead of letting the worker exit, hanging a durable
worker lifecycle test. Fixed in `05508b0` — see "CI regression" below
for the full root cause and fix.

## Verdict (pre-declared, one instrumented attempt)

Question: does the boundary-adjacent extent cell of the #488 fixture's
wire port conduct (live) or not — ground truth decides.

`scripts/diagnostics/i544_n_live_advisory_vs_assembler.py` (committed,
zero-FDTD, dumps the actual assembled `pec_mask` for this exact fixture):

- **Ground truth (c)**: the PEC trace box is exactly one cell thick
  (254–334 µm = dx), so `Box.mask` takes the thin-sheet branch — the
  single z-**node** nearest the box midpoint (294 µm). Node coordinates
  are `z_k = k·dx` (no half-cell offset — `Grid.position_to_index` and
  `_grid_coords` both use `round(pos/dx)`). Nearest node is `z_4 = 320 µm`
  (26 µm away) vs `z_3 = 240 µm` (54 µm away) → `pec_mask` is **True only
  at k=4**. The wire port's 4 rasterized cells are k=0..3 — **k=4 is
  outside the port's extent entirely**. All 4 port cells are live.
  (Independent corroboration already in the repo:
  `test_mixed_lane_v_span_reaches_the_rasterized_trace_on_bisecting_mesh`'s
  own docstring states "the trace rasterizes at node 4" for this same
  mesh class.)
- **(b) assembler** (`_wire_port_live_cells(grid, wp, pec_mask)`, the
  exact call `compute_mixed_s_matrix` makes): `live_flags=[True]*4`,
  `n_live=4` — **matches ground truth**, and matches the committed
  `i517_mixed_solve_vs_ratio.json`'s `n_live_lw=[4]` exactly.
- **(a) old advisory** (frozen verbatim in the diagnostic script for the
  historical record — no longer live code): cell-center method flags
  index 3 (center 280 µm) as dead → `n_live=3` — **does not match ground
  truth**.

**Verdict: the assembler was right; the advisory was wrong.** Z0/4 =
12.5 Ω physics (PR #543) stays fully consistent with ground truth — no
contradiction, no STOP.

### Preflight text, quoted verbatim (R5 — the advisory text IS the observable)

**BEFORE** (from the committed `i517_mixed_solve_vs_ratio.json`,
pre-#544-fix):
```
[PREFLIGHT] Wire port at (0.002, 0.0015, 0.0) (extent 0.000254) rasterizes to n=4 cells of which 1 land inside PEC geometry ['pec'] (n_live/n = 3/4). Dead cells are shorted by the PEC and are excluded from the port's resistance distribution, drive injection, and wave normalization (issue #318 fix): the port terminates at 50 ohm across its 3 live cells. (rfx versions before the #318 fix counted all 4 cells and physically terminated at Z0*(n_live/n) = 37.5 ohm — the issue-#313 finding.) Verify the extent was MEANT to end on/inside the conductor, and keep the midpoint V/I probe cell live; to silence, shorten the extent or move the port so every cell center sits outside PEC.
```

**AFTER** (this PR, same fixture — the wire-port dead-extent advisory is
now silent; all other advisories on this fixture are unchanged):
```
[PREFLIGHT] 'pec' z-extent 80µm = 1.0 cells — below 1 cell resolution. A conductor thinner than a cell is modelled as a one-cell PEC surface — tangential E is zeroed on it and the normal component survives as surface charge. That is usually what you want for metal many skin depths thick, and switching to add_thin_conductor() would not change it; but it means the sheet carries no conductor loss and its thickness is not modelled.
[PREFLIGHT] pec_faces={z_lo} creates an INFINITE PEC boundary AND the geometry contains finite PEC objects. For antennas or finite-GP structures, the pec_faces boundary makes the ground plane cover the entire domain face, which changes the physics (cavity vs radiating antenna). If you need a finite ground plane, remove pec_faces and use an explicit PEC Box instead.
[PREFLIGHT] all dielectric(s) ['sub'] are perfectly lossless in an open (CPML) domain. If you are measuring Q / resonance, this gives an ARTIFICIALLY infinite Q (design-guide Anti-Pattern #1, an R5 surface-metric trap) — add loss, e.g. sigma = 2*pi*f*eps0*eps_r*tan_delta. (Harmless if you are not measuring Q.)
[PREFLIGHT] MSL port 'msl_0': only 3 substrate cell(s) in z (h_sub=254µm, dx=80µm). Yee staircase at dielectric interface is O(dx) — Z0 staircase error >5% expected. Refine to dx ≤ 64µm (4+ substrate cells) AND keep h_sub/dx an integer (aligned) for <5% Z0 bias — measured post-#511/#507 at -3.8%/-1.2%/+0.7% for h_sub/4, h_sub/5, h_sub/6 (scripts/diagnostics/msl_z0_bias_floor_sweep.py). Refining WITHOUT alignment does not reach that: a mixed-cell mesh at a similar cell count measured +11% (h_sub/dx=4.233) — see the mixed-cell-danger-zone check below.
[PREFLIGHT] MSL port 'msl_0': h_sub/dx = 3.175 (fractional part 0.175) lands in the [0.10, 0.40] mixed-cell danger zone. The substrate-air interface bisects the same Yee cell that holds the trace; AD-traceable ``pec_occupancy_override`` zeros the whole cell and produces unphysical |S21|² > 1 in this regime. Hard ``Box(material='pec')`` avoids that specific bug, but Z0 bias itself is still 2.56-2.94x worse than an aligned mesh at a comparable cell count (measured +20.2% vs -7.9% at ~3 cells, +11.0% vs -3.8% at ~4 cells; scripts/diagnostics/msl_z0_bias_floor_sweep.py) — refining cell count alone will not reach the aligned-mesh bias. To snap onto a safe alignment regardless, set dx = 63.5µm (= h_sub/4) or 84.7µm (= h_sub/3).
```

## Fix + consistency mechanism

- `rfx/api/_preflight.py::_validate_cfg_port_inside_pec`: replaced the
  standalone bbox-vs-cell-center approximation with a call to
  `_wire_port_live_cells(grid, wp, pec_mask)` against the actual assembled
  `pec_mask` (`self._assemble_materials(grid)`, the same array the
  solver's Yee update masks against). Cell "dead" names for the message
  text are looked up (lazily, only when a dead cell is actually found) via
  each PEC-material `self._geometry` entry's own `shape.mask(grid)` AND
  each PEC `self._thin_conductors` entry's `shape.mask(grid)` — see review
  item 3 below.
- Because the advisory and the assembler now call the **identical
  primitive** against the **identical array**, they cannot drift apart
  again by construction — **scoped to the uniform-mesh path**; see below.

## Adversarial review — findings and fixes (applied in this PR)

An independent adversarial review re-derived the fix by hand from
`Box._axis_mask`/`_grid_coords` (node-4 PEC vs port k=0..3, 2.08x margin)
and confirmed it, checked the `pec_faces` loophole (closed), and restated
the resistor-law arithmetic (12.5 vs 16.67 Ω) — all CONFIRMED. It found
two BLOCKING issues and nine same-pass fixes, all applied here:

**BLOCKING 1 — the "cannot drift again by construction" claim was
unqualified.** Measured falsification: on a `dz_profile` sim, preflight's
`self._build_grid()` + `self._assemble_materials(grid)` produce a
**uniform** `Grid` (shape `(117,55,19)`, PEC node `k=[4]`), while the
REAL run uses `_build_nonuniform_grid()` + `_assemble_materials_nu()` (a
4-tuple, different `NonUniformGrid`, shape `(116,54,19)`, PEC node(s)
`k=[4,5]`) — and `_wire_port_live_cells(NonUniformGrid, ...)` cannot even
run (`position_to_index` missing). This is a **pre-existing** limitation
(the OLD advisory was equally NU-blind — `_wire_port_cell_centers` also
calls `self._build_grid()`), not a regression, but the invariant sentence
was unqualified. **Fix**: `_validate_cfg_port_inside_pec` now detects
`is_nonuniform` (the standard `self._dz_profile is not None or
self._dx_profile is not None or self._dy_profile is not None` check used
elsewhere in this file) up front and does NOT attempt the uniform
ground-truth build on an NU mesh — it emits a new
`wire_port_dead_cell_classification_unavailable` note instead (see
review item 6). A disclosure comment following the `#510` review-nit-A
pattern (`rfx/api/_preflight.py:4045-4053`) is now in the code at the
new advisory site, cited by grep-able anchor text ("issue #510 review
nit A") rather than a line-number/direction offset — an earlier draft of
that same in-code citation drifted stale within this same PR (said "a
few hundred lines above"; the target was actually ~1140 lines below by
the time this citation was written) the moment this PR's own +84-line
diff shifted the file, which is exactly the failure mode a grep-able
anchor avoids. The claim is now scoped to the uniform path everywhere it
is made (code comment, this PR body, the ledger snippet).

**BLOCKING 2 — the mirror-direction / "structurally closed" claim
over-reached.** My original PR-body quote of the #488-arc ledger
truncated the deciding lines. Corrected claim, using the SOURCE's exact
wording (not a paraphrase — a grep for the original string must find
it): this fix closes the #488-arc unfiled follow-up **"preflight n_live
geometry-vs-pm mismatch"** (`pm` = `pec_mask`) (arc note
`docs/research_notes/20260728_i488_mixed_port_arc.md:196`; ledger
`docs/research_notes/20260728_i488_falsifier_ledger.md` D5, lines
138-140) — same instance, now structurally closed. **D5's PRIMARY
finding is unrelated to this fix**: a fixture-discretization defect (a
galvanically OPEN end-fed probe — 1-cell vacuum gap, capacitive-only
coupling, S21 rising with frequency; lines 134-137) was closed at
attempt 4 (line 149) by changing the mesh to **dx = 63.5 µm**, not by any
preflight change. I also drop the "mirror direction" label from my
original PR body — on inspection this is the SAME direction, the SAME
numbers (`n_live=3/4` on the same dx=80 µm / h_sub=254 µm fixture class),
plausibly the identical instance recorded twice — and correct "ceil
convention" (the note's own informal phrasing, quoted verbatim below)
to the verified mechanism, the thin-sheet nearest-node rule (see the
"#488-arc unfiled follow-up check" section below for the full corrected
citation and quotes).

**Same-pass fixes (all reviewer-verified, all applied):**
3. **Thin-conductor dead cells printed an empty name** (`inside PEC
   geometry [] (n_live/n = 4/5)`, and the `else "pec"` fallback would
   have named a nonexistent material) because the per-entry name lookup
   only iterated `self._geometry`, but `pec_mask` also absorbs
   `self._thin_conductors` (`rfx/api/_compile.py:232-238`). Fixed by
   extending the lookup loop over `self._thin_conductors` (`tc.is_pec`,
   `tc.shape.mask(grid)`, labelled `thin_conductor[i]`). Verified with a
   reproducer: `['thin_conductor[0]']` now appears correctly instead of
   `[]`.
4. **Remediation text taught the retired mental model** ("move the port
   so every cell center sits outside PEC") in both
   `rfx/api/_preflight.py` (`wire_port_dead_extent_cells` message) and
   `rfx/sources/sources.py:361` (the `_wire_port_live_cells` all-dead
   `ValueError`, reachable from this PR's own except-branch). Both now
   describe the real rule: rasterized cells vs. the assembled geometry,
   with a note that a thin PEC sheet snaps to its nearest grid NODE.
5. **The "already-agreeing" control fixture sat on an exact float32
   knife edge**: trace z∈[1.0,1.5]mm at dx=0.5mm → thin-sheet midpoint
   1.25mm exactly equidistant from nodes at 1.0mm and 1.5mm, an
   `argmin` tie `Box`'s own docstring calls platform/dtype-dependent.
   Moved to z∈[0.9,1.4]mm (midpoint 1.15mm, unambiguously 0.15mm from
   node 1.0mm vs 0.35mm from node 1.5mm — a 0.2mm margin, not a knife
   edge), re-derived and verified the same `n_live/n=2/3` headline
   holds, and dropped the determinism language from the test docstring.
6. **The broadened exception fallback went silent** for ALL ports
   (`grid=pec_mask=None` on any build exception disabled both #319 and
   #314 advisories with no trace — the #303 silently-skipped-check-family
   class). Fixed: a new `wire_port_dead_cell_classification_unavailable`
   advisory now fires with the reason (NU mesh, or the caught exception
   text) instead of going silent.
7. **Stale carriers in
   `scripts/diagnostics/i517_mixed_solve_vs_ratio_measurement.py`**: the
   INFO 9 docstring presented the 3/4 bug as live+unfiled — added a
   "RESOLVED by PR #555" pointer with the ground-truth finding. The INFO
   9 print block hardcoded `'n_live/n = 3/4'` while claiming to quote
   live `preflight_text` — now searches `preflight_text` at print time
   for the actual `Wire port ... rasterizes` line (falls back to an
   explicit "no advisory fired" message when none exists, as is now the
   case on a fresh run of this fixture). Re-ran in `--from-json` mode
   against the committed artifact: output unchanged (`git diff` on the
   committed JSON is empty), confirming the frozen record's byte content
   is untouched — only the script's print logic changed. (The committed
   JSON's schema has no comment field to add a frozen/date marker to
   without changing the frozen data itself, so it was left untouched;
   the pointer lives in the script's docstring instead.)
8. **`pec_entry_masks` is now built lazily** — only the first time any
   port in the sim actually has a dead cell to name, so the common clean
   case (no PEC overlap anywhere) never pays for the extra per-entry
   rasterization.
9. **CHANGELOG**: added an `[Unreleased]` entry for this fix, and
   appended an "Update (issue #544)" note to the existing released
   `#318` entry (`CHANGELOG.md:360-361`), which described only the
   post-#318 wording and not the counting-method bug this PR fixes.
   Also added a clause to the new `[Unreleased]` entry: `preflight
   (strict=True)` now RAISES on an otherwise-clean non-uniform-mesh +
   wire-port sim (the new note is warning-severity and `strict`
   escalates every issue — contract-consistent, not a special case);
   named `preflight(strict=False).raise_for_failure()` as the
   errors-only-escalation alternative for callers who want this
   specific warning to pass through.

**Filed follow-up**: #556, "Wire-port 'terminates in vacuum, not on a
rasterized conductor' preflight advisory" — the open scope question the
reviewer raised: post-#555 there is still no preflight witness for D5's
*primary* failure mode (a wire port whose top does not galvanically
reach the rasterized conductor — capacitive-only coupling). #544/#555
only closed the false-positive direction (advisory saying dead when
live); #556 proposes the false-negative direction (silent when a
galvanic-contact mismatch exists).

### #488-arc unfiled follow-up check (corrected; was mislabeled "mirror direction")

Filed at `docs/research_notes/20260728_i488_mixed_port_arc.md:196`
("Follow-up candidates (not yet filed)"):
```
- preflight n_live geometry-vs-pm mismatch in the mixed-cell danger zone.
```
and detailed in `docs/research_notes/20260728_i488_falsifier_ledger.md`,
D5 (lines 134-142, quoted verbatim):
```
- D5 NAMED (fixture discretization; witness = the preflight warning IGNORED since
  attempt 1): h_sub/dx = 3.175 (fractional 0.175, the flagged [0.10,0.40] danger zone).
  The solver's PEC rasterization (ceil convention) puts the trace at k=4 (320-400 um),
  66 um ABOVE the geometric trace (254-334 um) and the wire top — the end-fed probe is
  galvanically OPEN (1-cell vacuum gap), coupling only capacitively. The preflight
  n_live=3/4 "inside PEC" witness is GEOMETRY-based and does not reflect the solver's
  pm shorting in this zone (preflight-vs-solver mismatch — file as follow-up issue).
  Preflight PRESCRIBED the fix every attempt: dx = 63.5 um = h_sub/4 (aligned interface,
  4 substrate cells; also clears the >5% Z0-staircase advisory).
```
(The note's own "ceil convention" phrasing is informal; this PR's own
analysis of `Box.mask_on_coords` verified the actual mechanism is the
thin-sheet nearest-node rule for sub-cell-thick boxes, combined with a
half-open `[lo,hi)` interval elsewhere — not a literal ceiling function.)

This fix closes ONLY the geometry-witness sub-clause quoted above (D5
lines 138-140 / arc line 196) — same instance, now structurally closed,
since the advisory reads the real assembled `pec_mask` directly instead
of approximating it. **D5's PRIMARY finding (fixture discretization →
galvanically open end-fed probe at dx=80 µm) is unrelated to this fix
and was closed at attempt 4 by dx=63.5 µm** (line 149: "D5 fix effective:
galvanic contact restored"), not by any preflight change — filed as
follow-up issue #556 above.

I did not touch the separate, simpler `port_in_pec` check for
single-point lumped ports/probes a few lines below
(`rfx/api/_preflight.py:3110-3132`) — it tests the user-specified port
**position** directly (not a computed cell center), so it is not the
same mechanism and is out of scope here.

## Tests (`tests/test_mixed_port_sparam.py`)

1. `test_wire_port_dead_cell_advisory_matches_ground_truth_on_488_fixture`
   — regression lock: the #488 fixture's corrected (silent) advisory,
   cross-checked against an independently-built ground-truth `pec_mask`.
2. `test_wire_port_dead_cell_advisory_stays_correct_on_an_already_agreeing_case`
   — no false-positive introduction: a microstrip fixture where the old
   and new methods already agreed (`n_live/n = 2/3`) is asserted
   unchanged. (Revised per review item 5 to avoid a float32 tie — see
   above.)
3. `test_wire_port_dead_cell_advisory_old_method_would_have_drifted` —
   mutation-style falsifier: the frozen pre-#544 method (reimplemented
   standalone, historical-record only) is shown to disagree with ground
   truth on the #488 geometry (proving the bug was real), while the
   current (fixed) advisory agrees.

All pre-existing tests in `tests/test_inverse_design_preflight.py` (the
file with the other `wire_port_dead_extent_cells`/
`wire_port_midpoint_in_pec` string-pinning tests) and
`tests/test_wire_port.py` pass **unmodified**.

## Diagnostic artifact

`scripts/diagnostics/i544_n_live_advisory_vs_assembler.py` (committed,
zero-FDTD — pure geometry/rasterization) +
`scripts/diagnostics/i544_n_live_advisory_vs_assembler/i544_n_live_advisory_vs_assembler.json`
(committed output, re-verified byte-stable after the follow-up commit).
Cross-checks against the already-committed
`scripts/diagnostics/i517_mixed_solve_vs_ratio/i517_mixed_solve_vs_ratio.json`
(PR #543) with no new FDTD run.

## Ledger snippet (paste into `docs/agent-memory/rfx-known-issues.md` at merge time)

```
## Added 2026-08-04 — #544 RESOLVED: wire-port dead-cell advisory now shares the assembler's ground-truth pec_mask
- **Symptom**: on the #488 lane's committed lumped/wire<->MSL fixture
  (dx=80um), the preflight wire-port dead-extent advisory reported
  n_live/n=3/4 while the assembler's actual n_live_lw was [4] (found
  during #517 step 1, PR #543 — the Z0/4=12.5 ohm resistor-law degeneracy
  proof matched n_live=4, not 3).
- **Root cause**: the advisory (`_validate_cfg_port_inside_pec`) compared
  a computed cell-CENTER (node + 0.5*dx Yee offset) against the PEC
  bounding box, closed interval. The real rasterization (`Box.mask`)
  evaluates occupancy at NODE coordinates, half-open interval (or
  thin-sheet nearest-node for sub-cell boxes) -- different reference
  point. Ground truth (dumped pec_mask): the 1-cell-thick trace
  rasterizes to node k=4, outside the port's k=0..3 extent -- all 4 cells
  are live. The assembler was right; the advisory was wrong.
- **Fix (PR #555)**: the advisory now calls `_wire_port_live_cells`
  against the SAME assembled `pec_mask` the assembler uses -- shared
  primitive, cannot drift again ON THE UNIFORM-MESH PATH (a dz_profile/
  dx_profile/dy_profile sim's REAL run uses a different, NonUniformGrid-
  based assembly this shared primitive cannot run against; the advisory
  now emits a `wire_port_dead_cell_classification_unavailable` note on
  NU meshes instead of guessing or going silently wrong -- this NU scope
  limit is PRE-EXISTING, shared by the pre-#544 advisory too, now
  disclosed rather than silent). Diagnostic:
  `scripts/diagnostics/i544_n_live_advisory_vs_assembler.py` (+ committed
  JSON). Regression tests: `tests/test_mixed_port_sparam.py` (3 new:
  #488-fixture lock, already-agreeing-case-unchanged, old-method
  mutation falsifier).
- **Also closes** the #488-arc unfiled follow-up "preflight n_live
  geometry-vs-pm mismatch" (pm = pec_mask) (arc note
  `docs/research_notes/20260728_i488_mixed_port_arc.md:196`; ledger
  `docs/research_notes/20260728_i488_falsifier_ledger.md` D5 lines
  138-140) -- same instance, now structurally closed. D5's PRIMARY
  finding (fixture discretization -> galvanically open end-fed probe at
  dx=80um) is UNRELATED to this fix and was closed separately at attempt
  4 by dx=63.5um -- do not conflate the two. **Open follow-up**: issue
  #556 proposes the mirror-direction advisory (wire port terminates in
  vacuum, not on a rasterized conductor) that #544/#555 does NOT cover.
- **Adversarial review** (2026-08-04) found 2 BLOCKING + 9 same-pass
  issues, all fixed in the same PR: NU-path scope disclosure, thin-
  conductor dead-cell naming (rfx/api/_compile.py:232-238 feeds
  pec_mask, was missing from the name lookup), remediation-text wording
  (2 sites), a float32-knife-edge test fixture, a silent (not disclosed)
  exception fallback, stale hardcoded text in the i517 diagnostic
  script's INFO 9 section, lazy pec_entry_masks construction, and a
  CHANGELOG entry + update to the existing #318 entry.
```

## CI regression — a broad `except Exception` swallowed a worker timeout signal

`studio-packaging`'s `quality-gates` job failed on **all three** prior
heads of this PR (`f3a3db7`, `e7c17a9`, `01ed016`) while `main` and every
other branch passed in the same window — a real regression, traced to
the **original** commit's preflight rewire (not the two review
follow-ups). This PR's final commit (`05508b0`) fixes it.

**Root cause**: `rfx/experiments/worker.py::execute_run` arms a SIGALRM
(`signal.setitimer`) for the experiment's `timeout_seconds` *before*
calling `compiled.preflight()` (`rfx/experiments/compiler.py`), which
builds a fresh `Simulation` and calls `.preflight(strict=False)` —
routing through `_validate_cfg_port_inside_pec`. That validator's new
#544 dead-cell ground-truth build (`self._build_grid()` +
`self._assemble_materials(grid)`) was wrapped in a broad `except
Exception`. On the failing test (`timeout_seconds=1`, `n_steps=500_000`,
a wire-port patch-antenna fixture — `tests/fixtures/experiments/
patch_antenna_v2.json` has `extent_m` on its feed, so it routes through
this exact code), the SIGALRM handler raises `RunTimedOut(TimeoutError)`
**asynchronously**, wherever the interpreter happens to be when the
1-second alarm fires. My new try block does meaningfully more work than
the pre-#544 code (a full materials assembly, not just a cheap grid
build), widening the window in which that raise can land inside it —
and when it does, `except Exception` catches it, converts it into the
"classification unavailable" advisory, and silently discards it. The
worker's own top-level `except RunTimedOut` handler (the one that turns
a timeout into a clean `"failed"` state and exits) then never runs;
execution falls through into the full 500,000-step simulation instead,
and the worker process never exits — hanging
`tests/test_durable_worker_lifecycle.py::
test_worker_timeout_is_durable_failed_outcome`'s 60-second
`subprocess.wait` (reproduced 100% locally: a hang, not a flake).

**Fix**: narrowed that `except Exception` to `(ValueError, TypeError,
NotImplementedError, KeyError, AttributeError, IndexError)` — the
realistic failure modes `_build_grid()`/`_assemble_materials()` actually
raise for a malformed config (e.g. `_resolve_material` raises `KeyError`
for an unregistered material). None of these overlap with `TimeoutError`
(the worker's timeout signal) or `RuntimeError` (`RunCancelled`, the
worker's SIGTERM/SIGINT signal), so both now propagate through this
advisory untouched — exactly as they did before the advisory existed.
`rfx/api` must not import `rfx.experiments.worker` to name its exception
types directly (wrong dependency direction for a foundational library
module), so this is a general, type-based fix rather than an explicit
exclusion list. One existing test
(`test_wire_port_dead_cell_classification_unavailable_on_assemble_exception`)
had used a synthetic `RuntimeError` for its "materials build failed"
case — updated to `ValueError` (a realistic build failure; `RuntimeError`
is no longer caught, correctly, since `RunCancelled` is a `RuntimeError`
subclass). A new test,
`test_wire_port_advisory_does_not_swallow_a_timeout_signal`, is the
direct regression falsifier: monkeypatches `_assemble_materials` to
raise `TimeoutError` (and separately `RuntimeError`) and asserts
`preflight()` propagates both uncaught.

**Process note for future preflight edits**: none of the review test
sets (mine or the reviewer's) included the Studio/experiments-worker
suite — that is how a broad `except Exception` slipped through 3 heads
of review. Any preflight-touching change should include
`pytest tests/test_durable_worker_lifecycle.py tests/test_durable_experiments.py`
(or the full `studio-packaging` `quality-gates` selection,
`.github/workflows/studio-packaging.yml` lines ~40-55) in its
verification set going forward, in addition to the usual
preflight-focused files — a subprocess-boundary timeout mechanism is not
something a same-process pytest run against `rfx.api` alone exercises.

## Verification

- `pytest tests/test_durable_worker_lifecycle.py::test_worker_timeout_is_durable_failed_outcome -x -q` → was `TimeoutExpired` after 60s (100% local repro of the CI failure); now passes in 6.83s.
- Full `studio-packaging` `quality-gates` test selection (14 files, `.github/workflows/studio-packaging.yml` lines ~40-55) → **83 passed** (was 82 passed / 1 failed in CI).
- `pytest tests/test_mixed_port_sparam.py tests/test_inverse_design_preflight.py tests/test_wire_port.py -q` → **47 passed** (all pre-existing preflight-behavior tests unmodified and green, plus 4 new/revised tests across the whole PR).
- `ruff check rfx/api/_preflight.py rfx/sources/sources.py tests/test_mixed_port_sparam.py scripts/diagnostics/i544_n_live_advisory_vs_assembler.py scripts/diagnostics/i517_mixed_solve_vs_ratio_measurement.py --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402` → all checks passed.
- `python scripts/diagnostics/i544_n_live_advisory_vs_assembler.py` → exits 0 (internal assertions: assembler matches ground truth, old method does not, i517 cross-check consistent, post-fix preflight silent); committed JSON re-verified byte-stable.
- `python scripts/diagnostics/i517_mixed_solve_vs_ratio_measurement.py --from-json scripts/diagnostics/i517_mixed_solve_vs_ratio/i517_mixed_solve_vs_ratio.json` → exits 0; committed JSON `git diff` is empty (frozen record untouched, only print logic changed).
- Manual reproducers for review items 3 and 6 (thin-conductor naming; NU-mesh disclosure note) — both confirmed working as described above.

## R3 pre-commit self-audit

1. Contradicted by known memory? No — consistent with / sharpens
   `docs/agent-memory/rfx-known-issues.md` "#318 RESOLVED" entry (the
   dead-cell-accounting class); no contradiction found after grep.
2. R2 trip? No — RF-intensifier tightened threshold (N≥1), one
   pre-declared instrumented comparison, geometry-only (zero FDTD runs).
   The follow-up commit responding to review is the SAME attempt (fixing
   defects found by review of the original fix, not a new mechanism
   hypothesis), so it does not add an R2 attempt count.
3. Falsifier: the ground-truth `pec_mask` dump itself — if it had shown
   the boundary cell genuinely PEC, the advisory would have been right
   and this PR would report that instead of fixing the advisory.

Closes #544. Follow-up filed as #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
