### PR TITLE
fix(nonuniform): restore the missing bounding node so the NU grid realizes the requested extent (#562)

### DIFF
--- a/docs/guides/sparameter_support_matrix.md
+++ b/docs/guides/sparameter_support_matrix.md
@@ -282,6 +282,21 @@ differentiation is implemented only with `normalize="flux"`.
 there is no corresponding nonuniform `sigma_override` AD-vs-FD test. Neither
 implementation nor gradient regression is RF validation.
 
+**Those nonuniform fixtures are STALE and pending regeneration (issue #562).**
+`tests/fixtures/waveguide_nu_broad_e5/waveguide_wr90_nu_flux_broad_e5_envelope.json`
+and
+`tests/fixtures/waveguide_nu_broad_e4/waveguide_wr90_nu_flux_broad_e4_comparison.json`
+were generated while the nonuniform grid realized every axis one cell short of
+the requested domain, so their guide is `a - dy_edge` wide rather than `a`, and
+their gate tests replay the frozen numbers rather than re-running FDTD — the
+tests therefore pass while describing the earlier geometry. Nothing was
+re-blessed: the numbers above stand exactly as measured, and the lane stays
+experimental, so the matrix is conservative rather than wrong. Regenerating
+them is expected to *improve* agreement (the guide finally being the requested
+width); until it happens, treat the cited magnitude differences as an upper
+bound obtained on a slightly narrow guide, and do not compare them against
+newly generated nonuniform numbers.
+
 **Setup restrictions:**
 
 - Prefer `normalize="flux"`; it uses a matched reference run for Poynting-flux

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -1655,6 +1655,29 @@ class _ExecuteMixin:
         self._check_stencil_order_supported()
         from rfx.runners.nonuniform import run_nonuniform_path
 
+        # A grid-shaped override is (cells + 1) per axis, because N cells are
+        # bounded by N+1 E-nodes (#562) — the same shape the uniform path has
+        # always wanted. Caller code that sized arrays from the PROFILE length
+        # is one sample short, and without this check the mismatch surfaces
+        # deep inside XLA as an opaque broadcast TypeError (#562 review F9).
+        _grid = self._build_nonuniform_grid()
+        for _name, _arr in (("eps_override", eps_override),
+                            ("sigma_override", sigma_override),
+                            ("pec_mask_override", pec_mask_override),
+                            ("pec_occupancy_override", pec_occupancy_override),
+                            ("design_mask", design_mask)):
+            if _arr is None or not hasattr(_arr, "shape"):
+                continue
+            if tuple(_arr.shape) != tuple(_grid.shape):
+                raise ValueError(
+                    f"{_name} has shape {tuple(_arr.shape)} but this "
+                    f"non-uniform grid is {tuple(_grid.shape)}. Grid-shaped "
+                    f"arrays are one sample larger per axis than the cell "
+                    f"counts / profile lengths you requested: N cells are "
+                    f"bounded by N+1 field nodes (#562). Build the array from "
+                    f"the grid shape rather than from the profile length."
+                )
+
         result = run_nonuniform_path(
             self,
             n_steps=n_steps,

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2028,7 +2028,24 @@ class _PreflightMixin:
         if dz.size == 0:
             return
         edges = np.concatenate(([0.0], np.cumsum(dz)))
-        centers = 0.5 * (edges[:-1] + edges[1:])
+        # Sample positions must be the ones the RUN uses, and the occupancy
+        # rule must be the run's rule. This validator previously modelled both
+        # by hand — cell centres plus a bare half-open span — and was wrong on
+        # each count: coordinates are E-NODES (cell edges) since #562, and
+        # ``Box.mask_on_coords`` has a THIN-SHEET branch that snaps a box no
+        # thicker than its local cell onto a single nearest node (#48/#75/#371).
+        # With the hand model this check diverged from the rasterizer on boxes
+        # straddling a grading transition — the #325 signature it exists to
+        # catch — and went SILENT on one of them (#562 review, F2). So call the
+        # production path instead of imitating it: node positions through the
+        # same two steps the grid builder composes, and the shape's own mask.
+        # x/y are passed as single-sample arrays because only the z profile is
+        # needed here; either mask branch admits the box's own midpoint, so the
+        # combined mask's z profile is the z-axis mask.
+        from rfx.geometry.rasterize_grid import _axis_node_positions
+        from rfx.nonuniform import _append_bounding_node
+        z_nodes = np.asarray(_axis_node_positions(_append_bounding_node(dz), 0),
+                             dtype=np.float64)
 
         for entry in self._geometry:
             if not isinstance(entry.shape, Box):
@@ -2039,8 +2056,10 @@ class _PreflightMixin:
             if thickness <= 0.0:
                 continue
 
-            rasterized = (centers >= z_lo) & (centers < z_hi)
-            actual = int(np.count_nonzero(rasterized))
+            x_mid = np.array([0.5 * (float(c1[0]) + float(c2[0]))])
+            y_mid = np.array([0.5 * (float(c1[1]) + float(c2[1]))])
+            mask = np.asarray(entry.shape.mask_on_coords(x_mid, y_mid, z_nodes))
+            actual = int(np.count_nonzero(mask))
             local = (edges[:-1] < z_hi) & (edges[1:] > z_lo)
             if not np.any(local):
                 continue

--- a/rfx/geometry/rasterize_grid.py
+++ b/rfx/geometry/rasterize_grid.py
@@ -39,20 +39,26 @@ def coords_from_uniform_grid(grid) -> GridCoords:
     return GridCoords(x=x, y=y, z=z, shape=(nx, ny, nz))
 
 
-def _axis_cell_centers(d_arr: np.ndarray, cpml: int) -> np.ndarray:
-    """Cell-center positions for a padded cell-size array.
+def _axis_node_positions(d_arr: np.ndarray, cpml: int) -> np.ndarray:
+    """E-node positions for a padded cell-size array.
 
-    Matches the existing ``coords_from_nonuniform_grid`` z convention:
-    the first interior cell's LEFT edge is at physical position 0, so
-    its CENTER is at ``d[cpml]/2``. This is off by half a cell from
-    the legacy uniform-Grid convention (cell[cpml] center at 0) — the
-    two conventions are not unified anywhere in rfx today.
+    The nodes this grid steps sit on cell EDGES, not centres: the
+    non-uniform E update divides by ``2/(d[i-1]+d[i])``, the dual spacing
+    of a node straddling cells ``i-1`` and ``i``. Node ``cpml`` (the first
+    interior one) is the origin, so the interior spans
+    ``[0, sum(interior d)]`` and the last interior node lands exactly on
+    the requested domain face — the same convention
+    ``coords_from_uniform_grid`` uses (``(arange - pad) * dx``).
+
+    Until #562 this returned cell CENTRES, half a cell off the nodes the
+    stencil differences and half a cell off the uniform builder, which put
+    every rasterized material half a cell away from the fields acting on
+    it and (with the missing bounding node) made a PEC-bounded guide one
+    cell narrower than requested.
     """
     d = np.asarray(d_arr, dtype=np.float64)
     edges = np.insert(np.cumsum(d), 0, 0.0)           # len = n+1
-    offset = edges[cpml]                              # first-interior left edge
-    centers = (edges[:-1] + edges[1:]) / 2.0 - offset
-    return centers
+    return edges[:-1] - edges[cpml]                   # n nodes, origin at cpml
 
 
 def coords_from_nonuniform_grid(grid) -> GridCoords:
@@ -83,11 +89,10 @@ def coords_from_nonuniform_grid(grid) -> GridCoords:
             d_j = jnp.asarray(d_arr)
             cum = jnp.concatenate([jnp.zeros((1,), dtype=d_j.dtype),
                                    jnp.cumsum(d_j)])
-            offset = cum[pad_lo]
-            centers = (cum[:-1] + cum[1:]) / 2.0 - offset
-            return centers.astype(jnp.float32)
+            nodes = cum[:-1] - cum[pad_lo]
+            return nodes.astype(jnp.float32)
         d_np = np.asarray(d_arr)
-        return jnp.asarray(_axis_cell_centers(d_np, pad_lo), dtype=jnp.float32)
+        return jnp.asarray(_axis_node_positions(d_np, pad_lo), dtype=jnp.float32)
 
     x = _axis_centers(grid.dx_arr, pad_x_lo)
     y = _axis_centers(grid.dy_arr, pad_y_lo)

--- a/rfx/geometry/rasterize_grid.py
+++ b/rfx/geometry/rasterize_grid.py
@@ -21,7 +21,23 @@ from rfx.geometry._pole_keying import (
 
 
 class GridCoords(NamedTuple):
-    """Physical cell-center coordinates for rasterization."""
+    """Physical sample coordinates for rasterization.
+
+    **Two conventions live behind this type, deliberately.**
+    ``coords_from_uniform_grid`` and ``coords_from_nonuniform_grid`` return
+    E-NODE positions (cell edges) — the samples the Yee stencil differences and
+    that PEC/geometry act on. ``coords_from_fine_grid`` genuinely returns cell
+    CENTRES for the subgrid fine region (subgrid-fenced, unchanged).
+
+    Reading the wrong one is not cosmetic. This type's docstring said
+    "cell-center" for every producer until #562, and a consumer
+    (``compute_smoothed_eps_nonuniform``) named its variables ``centers_*``
+    accordingly and derived the node as ``centre - d/2``; when the NU producer
+    became node-based, that derivation silently inverted and displaced every
+    smoothed voxel by half a cell. Consumers that need both should derive the
+    centre FROM the node (``centre = node + d/2``), and any new producer must
+    say which convention it returns.
+    """
     x: jnp.ndarray  # (nx,)
     y: jnp.ndarray  # (ny,)
     z: jnp.ndarray  # (nz,)
@@ -29,7 +45,11 @@ class GridCoords(NamedTuple):
 
 
 def coords_from_uniform_grid(grid) -> GridCoords:
-    """Extract cell-center coordinates from a uniform Grid."""
+    """Extract E-NODE coordinates from a uniform Grid.
+
+    ``(arange - pad) * dx`` — node i at i*dx from the first interior node,
+    despite the historical "cell-center" wording this docstring carried.
+    """
     nx, ny, nz = grid.shape
     dx = grid.dx
     pad_x, pad_y, pad_z = grid.axis_pads
@@ -62,7 +82,7 @@ def _axis_node_positions(d_arr: np.ndarray, cpml: int) -> np.ndarray:
 
 
 def coords_from_nonuniform_grid(grid) -> GridCoords:
-    """Extract cell-center coordinates from a NonUniformGrid.
+    """Extract E-NODE coordinates from a NonUniformGrid (#562).
 
     All three axes use the per-cell spacing arrays (``dx_arr``,
     ``dy_arr``, ``dz``). The first interior cell on each axis is
@@ -80,7 +100,7 @@ def coords_from_nonuniform_grid(grid) -> GridCoords:
     pad_z_lo = int(getattr(grid, "pad_z_lo", grid.cpml_layers))
     nx, ny, nz = grid.nx, grid.ny, grid.nz
 
-    def _axis_centers(d_arr, pad_lo):
+    def _axis_nodes(d_arr, pad_lo):
         # Mesh-as-design-variable path: any axis cell-size profile may be
         # a JAX tracer. Route the cumsum / offset arithmetic through jnp
         # in-trace; fall back to the numpy path on concrete inputs to keep
@@ -94,9 +114,9 @@ def coords_from_nonuniform_grid(grid) -> GridCoords:
         d_np = np.asarray(d_arr)
         return jnp.asarray(_axis_node_positions(d_np, pad_lo), dtype=jnp.float32)
 
-    x = _axis_centers(grid.dx_arr, pad_x_lo)
-    y = _axis_centers(grid.dy_arr, pad_y_lo)
-    z = _axis_centers(grid.dz, pad_z_lo)
+    x = _axis_nodes(grid.dx_arr, pad_x_lo)
+    y = _axis_nodes(grid.dy_arr, pad_y_lo)
+    z = _axis_nodes(grid.dz, pad_z_lo)
 
     return GridCoords(x=x, y=y, z=z, shape=(nx, ny, nz))
 
@@ -134,7 +154,9 @@ def rasterize_geometry(
     material_resolver : callable(name) -> MaterialSpec
         Resolves material name to MaterialSpec.
     coords : GridCoords
-        Cell-center coordinates from any grid type.
+        Sample coordinates from any grid type — E-NODES for the uniform and
+        non-uniform builders, cell centres for the subgrid fine region (see
+        ``GridCoords``).
     pec_sigma_threshold : float
         Conductivity above which a material is treated as PEC.
     thin_conductors : list or None

--- a/rfx/geometry/smoothing.py
+++ b/rfx/geometry/smoothing.py
@@ -213,14 +213,18 @@ def _get_normal_fn(shape: Shape):
 # ---------------------------------------------------------------------------
 
 def _yee_coords(grid: Grid):
-    """Return cell-center coordinates (x, y, z) as 1-D arrays.
+    """Return E-NODE coordinates (x, y, z) as 1-D arrays.
 
     On the Yee grid:
     - Ex lives at (i+0.5, j, k)
     - Ey lives at (i, j+0.5, k)
     - Ez lives at (i, j, k+0.5)
 
-    We return the integer-grid positions; the caller applies +0.5*dx offsets.
+    We return the integer-grid positions (nodes); the caller ADDS +0.5*dx to
+    reach a centre. That direction is the contract: the NU sibling
+    ``compute_smoothed_eps_nonuniform`` subtracted instead, and when #562 made
+    the NU coordinates node-based the subtraction put every smoothed voxel half
+    a cell off (review F1). Derive centres FROM nodes, never the reverse.
     """
     nx, ny, nz = grid.shape
     dx = grid.dx
@@ -308,17 +312,26 @@ def compute_smoothed_eps_nonuniform(
     from rfx.geometry.rasterize_grid import coords_from_nonuniform_grid
 
     coords = coords_from_nonuniform_grid(nu_grid)
-    centers_x = coords.x  # (nx,)
-    centers_y = coords.y  # (ny,)
-    centers_z = coords.z  # (nz,)
+    # `coords` are E-NODE positions (cell edges) since #562 unified the NU
+    # convention with the uniform builder's. This function needs BOTH the node
+    # and the cell centre per axis, so the centre is derived FROM the node
+    # rather than the other way round. Getting that direction wrong is not a
+    # cosmetic slip: it displaces every smoothed voxel by half a cell, which is
+    # exactly the defect #562 removed elsewhere, and the committed
+    # interface-value bound (1 < eps < 4) passes under either sign — see
+    # test_compute_smoothed_eps_nonuniform_reduces_to_uniform, which is the
+    # assertion that catches it.
+    node_x = coords.x  # (nx,)
+    node_y = coords.y  # (ny,)
+    node_z = coords.z  # (nz,)
     dx_arr = jnp.asarray(nu_grid.dx_arr, dtype=jnp.float32)
     dy_arr = jnp.asarray(nu_grid.dy_arr, dtype=jnp.float32)
     dz_arr = jnp.asarray(nu_grid.dz, dtype=jnp.float32)
 
-    # Cell corners (for x/y/z) — corner[i] = center[i] - d_arr[i]/2
-    corner_x = centers_x - dx_arr / 2.0
-    corner_y = centers_y - dy_arr / 2.0
-    corner_z = centers_z - dz_arr / 2.0
+    # Cell centres — centre[i] = node[i] + d_arr[i]/2
+    centers_x = node_x + dx_arr / 2.0
+    centers_y = node_y + dy_arr / 2.0
+    centers_z = node_z + dz_arr / 2.0
 
     # Local-cell characteristic length (geometric mean of three cell
     # widths) — used to normalise SDF → fill fraction. Anisotropic cell
@@ -377,12 +390,12 @@ def compute_smoothed_eps_nonuniform(
             continue
 
         # Per-component half-cell offsets along the COMPONENT axis only:
-        # Ex sits at (center_x, corner_y, corner_z); Ey at (corner_x,
-        # center_y, corner_z); Ez at (corner_x, corner_y, center_z).
+        # Ex sits at (center_x, node_y, node_z); Ey at (node_x, center_y,
+        # node_z); Ez at (node_x, node_y, center_z).
         for comp, (axx, ayy, azz) in [
-            ("ex", (centers_x, corner_y, corner_z)),
-            ("ey", (corner_x, centers_y, corner_z)),
-            ("ez", (corner_x, corner_y, centers_z)),
+            ("ex", (centers_x, node_y, node_z)),
+            ("ey", (node_x, centers_y, node_z)),
+            ("ez", (node_x, node_y, centers_z)),
         ]:
             Xc = axx[:, None, None] * jnp.ones((1, ny, nz))
             Yc = jnp.ones((nx, 1, 1)) * ayy[None, :, None] * jnp.ones((1, 1, nz))

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -121,6 +121,31 @@ def _pad_profile(profile, pad_lo: int, pad_hi: int | None = None):
     return np.concatenate([lo_pad, np.asarray(profile, dtype=np.float64), hi_pad])
 
 
+def _append_bounding_node(profile_full):
+    """Append one duplicate boundary cell so an N-cell profile yields N+1
+    E-nodes — the node count the uniform ``Grid`` allocates for N cells.
+
+    N cells are bounded by N+1 nodes, and the E-nodes this grid steps sit on
+    cell EDGES (``inv_d_e[i] = 2/(d[i-1]+d[i])`` is the dual spacing of an
+    edge-centred node). Without this the array carried only N nodes, the
+    stencil zeroed the last cell's H term (``inv_d_h[N-1] = 0``), and the
+    realized wall-to-wall extent came out ``sum(d) - d[-1]`` — one cell
+    short of what the caller asked for (#562: +2.47 % of TM110 on a
+    45 x 39-cell PEC box, +37 MHz of WR-90 TE101 centre frequency from the
+    guide-width axis alone).
+
+    Duplicating the boundary cell is what makes the far node's coefficient
+    the mirror of the near one's: ``inv_d_e[N] = 2/(d[N-1]+d[N])``, which is
+    ``1/d[N-1]`` exactly when ``d[N] == d[N-1]``, matching the existing
+    ``inv_d_e[0] = 1/d[0]`` boundary treatment. The appended cell's own H
+    term is the one the stencil zeroes, so it adds a node without adding a
+    cell of physical extent.
+    """
+    if is_tracer(profile_full):
+        return jnp.concatenate([profile_full, profile_full[-1:]])
+    return np.concatenate([profile_full, profile_full[-1:]])
+
+
 def _profile_to_inv_arrays(profile_full: np.ndarray) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Return ``(inv_d_e, inv_d_h)`` — the E-update and H-update inverse
     cell-spacing arrays for a padded 1-D cell-size profile ``d``.
@@ -243,7 +268,7 @@ def make_nonuniform_grid(
                 f"dx_profile[-1]={float(dx_prof_phys[-1])} must equal boundary "
                 f"dx={float(dx)}."
             )
-    dx_full = _pad_profile(dx_prof_phys, pad_x_lo, pad_x_hi)
+    dx_full = _append_bounding_node(_pad_profile(dx_prof_phys, pad_x_lo, pad_x_hi))
     nx = int(dx_full.shape[0])
 
     # --- y profile ---
@@ -266,11 +291,11 @@ def make_nonuniform_grid(
                 f"dy_profile boundary cells must match each other "
                 f"(got lo={dy_boundary}, hi={float(dy_prof_phys[-1])})."
             )
-    dy_full = _pad_profile(dy_prof_phys, pad_y_lo, pad_y_hi)
+    dy_full = _append_bounding_node(_pad_profile(dy_prof_phys, pad_y_lo, pad_y_hi))
     ny = int(dy_full.shape[0])
 
     # --- z profile ---
-    dz_full = _pad_profile(dz_profile, pad_z_lo, pad_z_hi)
+    dz_full = _append_bounding_node(_pad_profile(dz_profile, pad_z_lo, pad_z_hi))
     nz = int(dz_full.shape[0])
 
     # --- CFL from minimum cell size on every axis ---

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -61,6 +61,12 @@ class NonUniformGrid(NamedTuple):
                            # Readers must not apply float() / .item() without
                            # an is_tracer(dt) guard or a host-boundary context.
     cpml_layers: int
+    # Cell-size arrays are padded AND carry one trailing duplicate cell so N
+    # cells are bounded by N+1 E-nodes (#562, see _append_bounding_node). The
+    # duplicate is a node-provider, not physical extent: its H term is the one
+    # the stencil zeroes. Read extents from node positions
+    # (coords_from_nonuniform_grid, or cumsum edges up to index nx-1) — NEVER
+    # from sum(dx_arr), which overshoots by that trailing cell.
     # Pre-computed inverse spacing arrays (length N, padded).
     # CORE-C2: inv_d* feed the E update (mean spacing), inv_d*_h feed
     # the H update (local cell width). See _profile_to_inv_arrays.
@@ -144,6 +150,22 @@ def _append_bounding_node(profile_full):
     if is_tracer(profile_full):
         return jnp.concatenate([profile_full, profile_full[-1:]])
     return np.concatenate([profile_full, profile_full[-1:]])
+
+
+def interior_cells(d_full, pad_lo: int, pad_hi: int):
+    """The physical interior cells of a padded NU cell-size array.
+
+    The array is ``[lo pad | interior | hi pad | bounding-node duplicate]``
+    (#562, see ``_append_bounding_node``), so the interior ends one entry
+    before ``len - pad_hi``. Slicing without that ``-1`` pulls in a pad cell
+    — or the duplicate itself on a face with no pad — and overstates the
+    extent by one cell, which is the same class of error #562 was.
+
+    Returns the CELLS; ``np.insert(np.cumsum(cells), 0, 0.0)`` then gives the
+    ``N+1`` interior NODE positions, the last of which lands exactly on the
+    requested domain face.
+    """
+    return d_full[pad_lo : len(d_full) - pad_hi - 1]
 
 
 def _profile_to_inv_arrays(profile_full: np.ndarray) -> tuple[jnp.ndarray, jnp.ndarray]:
@@ -348,7 +370,7 @@ def _interior_line_positions(
     """
     if pad_hi is None:
         pad_hi = pad_lo
-    interior = d_arr_np[pad_lo : len(d_arr_np) - pad_hi]
+    interior = interior_cells(d_arr_np, pad_lo, pad_hi)
     edges = np.insert(np.cumsum(interior), 0, 0.0)
     return edges
 

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -97,10 +97,14 @@ def assemble_materials_nu(
     # cell can differ from a >=1-cell VOLUME box at the same nominal z. That is
     # correct: a zero-thickness sheet and a one-cell-thick box are different
     # objects. apply_pec_mask realizes the sheet's conductor at the selected
-    # cell CENTRE (collocated tangential Ex/Ey), so Box's argmin-nearest-centre
-    # thin branch minimizes the realized-plane error |centre - z0|; a genuinely
+    # E-NODE, where tangential Ex/Ey actually sit, so Box's argmin-nearest thin
+    # branch minimizes the realized-plane error |node - z0|; a genuinely
     # matching-thickness (sub-cell) box takes the same thin branch and selects
     # the identical layer (verified, tests/test_thin_conductor.py). No fix here.
+    # (This said "cell CENTRE" until #562: the NU coordinates the argmin runs
+    # over were centres then, half a cell off the fields. The #371 argument is
+    # STRENGTHENED by the correction — the minimized quantity is now the
+    # distance to the plane the conductor is actually realized on.)
     if sim._thin_conductors:
         pec_tcs = [tc for tc in sim._thin_conductors
                    if getattr(tc, "is_pec", False)]

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -11,6 +11,7 @@ from rfx.materials.debye import init_debye
 from rfx.materials.lorentz import init_lorentz
 from rfx.nonuniform import (
     NonUniformGrid,
+    interior_cells,
     make_nonuniform_grid,
     run_nonuniform,
     run_nonuniform_until_decay,
@@ -186,7 +187,7 @@ def _build_waveguide_port_config_nu(sim, entry, grid: NonUniformGrid,
         d_np = np.asarray(d_arr_jnp)
         # Cell-edge positions in physical coords (interior only, edge=0 at first
         # interior face). Length = n_interior + 1.
-        interior = d_np[pad_lo : n_axis - pad_hi]
+        interior = interior_cells(d_np, pad_lo, pad_hi)
         edges = np.insert(np.cumsum(interior), 0, 0.0)
         if value_range is None:
             return (pad_lo, n_axis - pad_hi), float(edges[-1])
@@ -226,7 +227,7 @@ def _build_waveguide_port_config_nu(sim, entry, grid: NonUniformGrid,
     else:
         d_axis_np = np.asarray(grid.dz)
     _pad_lo_axis, _pad_hi_axis = pads_lo_hi[normal_axis]
-    _interior = d_axis_np[_pad_lo_axis : len(d_axis_np) - _pad_hi_axis]
+    _interior = interior_cells(d_axis_np, _pad_lo_axis, _pad_hi_axis)
     _edges_axis = np.insert(np.cumsum(_interior), 0, 0.0)
     _local_axis = max(0, min(x_index - _pad_lo_axis, len(_edges_axis) - 1))
     snapped_source_plane = float(_edges_axis[_local_axis])

--- a/rfx/sources/msl_port.py
+++ b/rfx/sources/msl_port.py
@@ -841,7 +841,8 @@ def _msl_x_for_index(grid, target_i: int) -> float:
         return float(u * grid.dx)
     # NonUniformGrid — cumulative interior cell-edge positions.
     pad_hi = int(getattr(grid, "pad_x_hi", 0))
-    interior = np.asarray(dx_arr, dtype=float)[pad : nx - pad_hi]
+    from rfx.nonuniform import interior_cells
+    interior = interior_cells(np.asarray(dx_arr, dtype=float), pad, pad_hi)
     edges = np.insert(np.cumsum(interior), 0, 0.0)
     u_c = max(0, min(u, len(edges) - 1))
     return float(edges[u_c])

--- a/tests/test_distributed_nu_composition.py
+++ b/tests/test_distributed_nu_composition.py
@@ -90,6 +90,18 @@ def _require_two_devices() -> list:
     return list(devices[:2])
 
 
+def _field_shape(nx: int, ny: int, nz: int) -> tuple[int, int, int]:
+    """Field-grid shape for an ``(nx, ny, nz)``-CELL request.
+
+    N cells are bounded by N+1 nodes, so a grid-shaped override array (eps,
+    design mask, PEC occupancy) is one sample larger per axis than the cell
+    counts these tests parameterize on (#562). Stated once here rather than at
+    the call sites, which all used to restate ``(nx, ny, nz)`` and would
+    silently mis-size again if the node convention ever moved.
+    """
+    return (nx + 1, ny + 1, nz + 1)
+
+
 def _make_nu_sim_small(
     *,
     nx: int = 16,
@@ -532,8 +544,8 @@ def test_forward_distributed_pec_occupancy_two_device_matches_single_device():
         return sim
 
     # Build a soft-PEC occupancy mask: partial conductivity in a slab near the seam
-    # Shape matches the field grid (nx, ny, nz)
-    pec_occ = jnp.zeros((nx, ny, nz))
+    # Shape matches the FIELD GRID, which is cells+1 per axis (#562)
+    pec_occ = jnp.zeros(_field_shape(nx, ny, nz))
     pec_occ = pec_occ.at[7:9, :, :].set(0.5)  # partial occupancy near seam
 
     sim_s = _build_sim()
@@ -587,7 +599,7 @@ def test_forward_distributed_checkpoint_every_matches_no_segment_small_grad_case
         sim.add_probe(position=(5 * dx, ny // 2 * dx, nz // 2 * dx), component="ez")
         return sim
 
-    eps = jnp.ones((nx, ny, nz)) * 1.0
+    eps = jnp.ones(_field_shape(nx, ny, nz)) * 1.0
 
     def loss_no_segment(eps_val):
         sim = _build_sim()
@@ -646,7 +658,7 @@ def test_forward_distributed_n_warmup_tail_grad_matches_single_device():
         sim.add_probe(position=(5 * dx, ny // 2 * dx, nz // 2 * dx), component="ez")
         return sim
 
-    eps = jnp.ones((nx, ny, nz)) * 1.0
+    eps = jnp.ones(_field_shape(nx, ny, nz)) * 1.0
 
     def loss_single(eps_val):
         sim = _build_sim()
@@ -697,9 +709,9 @@ def test_forward_distributed_design_mask_stop_grad_matches_single_device():
         sim.add_probe(position=(5 * dx, ny // 2 * dx, nz // 2 * dx), component="ez")
         return sim
 
-    eps = jnp.ones((nx, ny, nz)) * 1.0
+    eps = jnp.ones(_field_shape(nx, ny, nz)) * 1.0
     # Design mask: only cells x=3..7 are design cells
-    design_mask = jnp.zeros((nx, ny, nz), dtype=bool)
+    design_mask = jnp.zeros(_field_shape(nx, ny, nz), dtype=bool)
     design_mask = design_mask.at[3:8, :, :].set(True)
 
     def loss_single(eps_val):
@@ -754,7 +766,7 @@ def test_forward_distributed_pec_mask_seam_exchange_preserves_field():
     n_steps = 20
 
     # PEC mask: a thin conductor near the seam (x = nx//2 - 1 to nx//2 + 1)
-    pec_mask = jnp.zeros((nx, ny, nz), dtype=bool)
+    pec_mask = jnp.zeros(_field_shape(nx, ny, nz), dtype=bool)
     pec_mask = pec_mask.at[nx // 2 - 1 : nx // 2 + 2, :, :].set(True)
 
     def _build_sim():
@@ -821,7 +833,7 @@ def test_forward_distributed_grad_per_cell_matches_single_device_near_seam():
         sim.add_probe(position=(5 * dx, ny // 2 * dx, nz // 2 * dx), component="ez")
         return sim
 
-    eps = jnp.ones((nx, ny, nz)) * 1.0
+    eps = jnp.ones(_field_shape(nx, ny, nz)) * 1.0
 
     def loss_single(eps_val):
         sim = _build_sim()
@@ -898,7 +910,7 @@ def test_forward_distributed_nan_propagates_via_ghost_exchange():
     )
 
     # Inject NaN into rank 0's eps slab (x = 0..nx//2-1)
-    eps_nan = jnp.ones((nx, ny, nz))
+    eps_nan = jnp.ones(_field_shape(nx, ny, nz))
     eps_nan = eps_nan.at[: nx // 2, :, :].set(jnp.nan)
 
     res = sim.forward(

--- a/tests/test_nonuniform_api.py
+++ b/tests/test_nonuniform_api.py
@@ -20,7 +20,8 @@ class TestNonUniformGrid:
         grid = make_nonuniform_grid((0.05, 0.05), dz_profile, 0.5e-3, 12)
         assert grid.nx > 24  # domain + 2*cpml
         assert grid.ny > 24
-        assert grid.nz == len(dz_profile) + 24  # profile + 2*cpml
+        # N cells are bounded by N+1 nodes (#562): profile + 2*cpml pads + 1
+        assert grid.nz == len(dz_profile) + 24 + 1
         assert grid.dt > 0
         assert len(grid.inv_dz) == grid.nz
 

--- a/tests/test_nonuniform_cavity_accuracy.py
+++ b/tests/test_nonuniform_cavity_accuracy.py
@@ -32,6 +32,17 @@ TM111 error 3.46% @ dx=2mm -> 2.66% @ dx=1mm (shrinks with refinement;
 cell counts (no in-plane dimension-snapping confound), so the residual is
 dominated by the graded-z effective-d offset + coarse-mesh dispersion — exactly
 what a graded-mesh accuracy gate should bound.
+
+WHAT THE "effective-d offset" WAS (#562, 2026-08-04): the NU grid allocated one
+E-node per profile cell, but N cells need N+1 bounding nodes, so the realized
+z extent was ``sum(dz) - dz[-1]`` — one coarse cell short of the ``d`` this test
+feeds the closed form. That was most of the residual this docstring bounded:
+after the missing bounding node was restored, **TM111 error 2.66% -> 0.025%**
+(same geometry, same 4:1 grading, same harminv extraction) — the remainder is
+coarse-mesh dispersion, which is what the gate was meant to bound in the first
+place. The 4% gate below is therefore now ~160x looser than the measured
+residual; tightening it is a separate, evidence-first decision (it must be
+re-measured across resolutions before being pinned, not simply divided down).
 """
 
 from __future__ import annotations

--- a/tests/test_nonuniform_grid_extent_contract.py
+++ b/tests/test_nonuniform_grid_extent_contract.py
@@ -1,0 +1,139 @@
+"""The NU grid must realize the extent it was asked for (#562).
+
+`NonUniformGrid` allocated one E-node per profile cell, but the non-uniform
+Yee stencil zeroes the last cell's H term (`inv_d_h[N-1] = 0`), so an
+N-cell profile realized only N-1 usable gaps: the wall-to-wall extent came
+out `sum(d) - d[-1]`. Independently, `coords_from_nonuniform_grid` placed
+sample *i* at the cell CENTRE while the E-nodes the stencil differences sit
+at cell EDGES (`inv_d_e[i] = 2/(d[i-1]+d[i])` is the dual spacing of an
+edge-centred node), and while `coords_from_uniform_grid` returns edges.
+
+Measured consequence before the fix (a=45, b=39 cells at dx=1 mm, PEC box,
+TM110 by harminv): the uniform builder read -0.007 % against the closed
+form, the NU builder +2.469 % — and -0.008 % against the closed form
+evaluated at the extent it had actually built. Both solvers were accurate;
+only one built the requested cavity.
+
+These are grid-construction checks: no FDTD, no fixtures.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rfx.api import Simulation
+from rfx.geometry.rasterize_grid import (coords_from_nonuniform_grid,
+                                         coords_from_uniform_grid)
+
+A = 22.86e-3
+DX = 0.254e-3
+NB = 8
+
+
+def _sim(**kw):
+    return Simulation(freq_max=13e9, domain=(A, A, NB * DX),
+                      boundary="pec", dx=DX, **kw)
+
+
+def _spans(sim, nonuniform):
+    grid = (sim._build_nonuniform_grid() if nonuniform else sim._build_grid())
+    coords = (coords_from_nonuniform_grid(grid) if nonuniform
+              else coords_from_uniform_grid(grid))
+    out = []
+    for axis in range(3):
+        v = np.asarray(coords[axis], dtype=float)
+        out.append((len(v), float(v[0]), float(v[-1] - v[0])))
+    return grid.shape, out
+
+
+REQUESTED = (A, A, NB * DX)
+
+# rfx grids are float32 by design, so coordinates carry ~1e-7 relative
+# representation error (2.7e-9 m on a 22.86 mm span). The tolerances below are
+# set just above that floor and are still 1e-5 of a cell — four orders tighter
+# than the one-cell defect this file pins, and tighter than any physical
+# registration question.
+_ABS_TOL = 1e-8
+
+
+@pytest.mark.parametrize("profiles", [
+    pytest.param({}, id="uniform-builder"),
+    pytest.param({"dx_profile": np.full(90, DX)}, id="dx-only"),
+    pytest.param({"dy_profile": np.full(90, DX)}, id="dy-only"),
+    pytest.param({"dz_profile": np.full(NB, DX)}, id="dz-only"),
+    pytest.param({"dx_profile": np.full(90, DX),
+                  "dy_profile": np.full(90, DX),
+                  "dz_profile": np.full(NB, DX)}, id="all-three"),
+])
+def test_realized_extent_equals_requested_domain(profiles):
+    """Wall-to-wall extent == requested domain, on every axis, either builder.
+
+    A PEC face is enforced at the outermost E-node, so the span between the
+    first and last node IS the electrical cavity/guide dimension. It has to
+    be what the caller asked for: at WR-90's 0.254 mm this defect cost one
+    cell = 1.11 % of the guide width = +37 MHz of TE101 centre frequency.
+    """
+    shape, axes = _spans(_sim(**profiles), nonuniform=bool(profiles))
+    for name, requested, (n, first, span) in zip("xyz", REQUESTED, axes):
+        assert first == pytest.approx(0.0, abs=1e-12), (
+            f"{name}: first node at {first * 1e3:.4f} mm, not on the domain "
+            f"face — geometry and the PEC wall disagree by that offset")
+        assert span == pytest.approx(requested, rel=0, abs=_ABS_TOL), (
+            f"{name}: realized {span * 1e3:.4f} mm vs requested "
+            f"{requested * 1e3:.4f} mm "
+            f"(deficit {(requested - span) / DX:+.2f} cells)")
+        assert n == round(requested / DX) + 1, (
+            f"{name}: {n} nodes for {round(requested / DX)} cells — a cell "
+            f"count of N needs N+1 bounding nodes")
+
+
+def test_uniform_profile_through_the_nu_builder_reduces_to_the_uniform_grid():
+    """A uniform mesh expressed as profiles must BE the uniform mesh.
+
+    This is the reduction property that makes NU-vs-uniform comparisons
+    meaningful, and the one that failed silently: the shapes differed by
+    one sample per axis and every coordinate by half a cell, so the two
+    builders described different structures for identical input. A
+    committed accuracy test read +2.4 % on both a graded and an ungraded
+    profile and attributed the shared bias to "the standard coarse-Yee
+    PEC-cavity extent-convention" — both legs had gone through this
+    builder.
+    """
+    su = _sim()
+    sn = _sim(dx_profile=np.full(90, DX), dy_profile=np.full(90, DX),
+              dz_profile=np.full(NB, DX))
+    shape_u, axes_u = _spans(su, nonuniform=False)
+    shape_n, axes_n = _spans(sn, nonuniform=True)
+    assert shape_n == shape_u, (shape_n, shape_u)
+
+    cu = coords_from_uniform_grid(su._build_grid())
+    cn = coords_from_nonuniform_grid(sn._build_nonuniform_grid())
+    for axis, name in enumerate("xyz"):
+        vu = np.asarray(cu[axis], dtype=float)
+        vn = np.asarray(cn[axis], dtype=float)
+        assert vn.shape == vu.shape, (name, vn.shape, vu.shape)
+        worst = float(np.max(np.abs(vn - vu)))
+        assert worst < _ABS_TOL, (
+            f"{name}: NU coordinates differ from the uniform ones by up to "
+            f"{worst * 1e3:.4f} mm ({worst / DX:.2f} cells) on an identical "
+            f"mesh")
+
+
+def test_graded_profile_realizes_its_own_sum():
+    """The contract has to hold for a genuinely graded profile too, where
+    the dropped cell was the (largest) boundary cell rather than a
+    representative one."""
+    fine, coarse = DX / 2, DX
+    prof = np.array([coarse] * 10 + [fine] * 20 + [coarse] * 10)
+    total = float(np.sum(prof))
+    sim = Simulation(freq_max=13e9, domain=(total, A, NB * DX),
+                     boundary="pec", dx=coarse, dx_profile=prof)
+    coords = coords_from_nonuniform_grid(sim._build_nonuniform_grid())
+    x = np.asarray(coords[0], dtype=float)
+    assert float(x[0]) == pytest.approx(0.0, abs=1e-12)
+    assert float(x[-1] - x[0]) == pytest.approx(total, abs=_ABS_TOL)
+    assert len(x) == len(prof) + 1
+    # every interior node sits on a cumulative cell edge of the profile
+    edges = np.concatenate([[0.0], np.cumsum(prof)])
+    assert np.max(np.abs(x - edges)) < _ABS_TOL

--- a/tests/test_nonuniform_grid_extent_contract.py
+++ b/tests/test_nonuniform_grid_extent_contract.py
@@ -137,3 +137,38 @@ def test_graded_profile_realizes_its_own_sum():
     # every interior node sits on a cumulative cell edge of the profile
     edges = np.concatenate([[0.0], np.cumsum(prof)])
     assert np.max(np.abs(x - edges)) < _ABS_TOL
+
+
+def test_extent_and_pad_symmetry_hold_with_cpml_pads():
+    """The contract must hold with absorber pads, and the pads must be
+    symmetric (#562 review F6/F3).
+
+    The cases above are all PEC-bounded (pad = 0), which is the half of the
+    convention with no absorber interaction — and the absorber is where the
+    added bounding node changes an existing behaviour: before it, the hi face
+    carried one physical cell fewer than the lo face, so the CPML sigma ramps
+    were not mirror images. That is a behaviour change on every open-boundary
+    NU run and belongs under test, not only in a PR note.
+    """
+    prof = np.full(60, DX)
+    sim = Simulation(freq_max=13e9, domain=(60 * DX, A, NB * DX),
+                     dx=DX, cpml_layers=8, dx_profile=prof)
+    grid = sim._build_nonuniform_grid()
+    coords = coords_from_nonuniform_grid(grid)
+    x = np.asarray(coords[0], dtype=float)
+
+    # interior span: first interior node at 0, last interior node on the far face
+    assert float(x[grid.pad_x_lo]) == pytest.approx(0.0, abs=1e-12)
+    interior_last = grid.nx - grid.pad_x_hi - 1
+    assert float(x[interior_last] - x[grid.pad_x_lo]) == pytest.approx(
+        60 * DX, abs=_ABS_TOL), (
+        f"interior span {float(x[interior_last] - x[grid.pad_x_lo]) * 1e3:.4f} mm "
+        f"vs requested {60 * DX * 1e3:.4f} mm")
+
+    # pad symmetry: the absorber occupies the same physical depth on both faces
+    lo_depth = float(x[grid.pad_x_lo] - x[0])
+    hi_depth = float(x[grid.nx - 1] - x[interior_last])
+    assert lo_depth == pytest.approx(hi_depth, abs=_ABS_TOL), (
+        f"absorber depth lo {lo_depth * 1e3:.4f} mm vs hi {hi_depth * 1e3:.4f} mm "
+        "— the CPML ramps are not mirror images")
+    assert lo_depth == pytest.approx(8 * DX, abs=_ABS_TOL)

--- a/tests/test_nonuniform_xy.py
+++ b/tests/test_nonuniform_xy.py
@@ -109,7 +109,15 @@ def test_position_to_index_nonuniform_xy():
 # ---------------------------------------------------------------------
 # 4. coords_from_nonuniform_grid cell centers
 # ---------------------------------------------------------------------
-def test_coords_from_nonuniform_grid_cell_centers():
+def test_coords_from_nonuniform_grid_node_positions():
+    """Coordinates are E-NODE positions (cumulative cell edges), not centres.
+
+    The non-uniform E update divides by ``2/(d[i-1]+d[i])`` — the dual spacing
+    of a node straddling cells ``i-1`` and ``i`` — so the samples geometry is
+    rasterized onto sit on cell EDGES. This test previously pinned cell
+    CENTRES, half a cell off both the stencil's own nodes and
+    ``coords_from_uniform_grid``; #562 unified them.
+    """
     dz = np.full(4, 1e-3)
     dx_prof = np.array([1e-3, 1e-3, 0.5e-3, 0.5e-3, 1e-3, 1e-3])
     g = make_nonuniform_grid(
@@ -120,15 +128,17 @@ def test_coords_from_nonuniform_grid_cell_centers():
     x = np.asarray(coords.x)
     cpml = g.cpml_layers
 
-    # The first interior cell's center should be dx[cpml]/2 above the
-    # interior-left-edge offset, matching the existing z convention.
-    assert abs(float(x[cpml]) - 0.5e-3) < 1e-6
+    # The first interior node IS the interior origin (user x = 0).
+    assert abs(float(x[cpml]) - 0.0) < 1e-9
 
-    # x[cpml+1] center = dx[cpml] + dx[cpml+1]/2 - 0 = 1 + 0.5 = 1.5mm
-    assert abs(float(x[cpml + 1]) - 1.5e-3) < 1e-6
+    # Then each node sits on the running sum of the profile's cell sizes:
+    # 1mm, 2mm, 2.5mm (after the first 0.5mm cell), 3mm, 4mm.
+    for k, want in enumerate([0.0, 1e-3, 2e-3, 2.5e-3, 3e-3, 4e-3]):
+        assert abs(float(x[cpml + k]) - want) < 1e-6, (k, float(x[cpml + k]), want)
 
-    # x[cpml+2] (0.5mm cell) center = 2 + 0.25 = 2.25mm
-    assert abs(float(x[cpml + 2]) - 2.25e-3) < 1e-6
+    # N cells need N+1 bounding nodes, so the last interior node lands exactly
+    # on the profile's total extent — the requested domain face.
+    assert abs(float(x[cpml + len(dx_prof)]) - float(np.sum(dx_prof))) < 1e-6
 
 
 # ---------------------------------------------------------------------

--- a/tests/test_nonuniform_xy_cavity_accuracy.py
+++ b/tests/test_nonuniform_xy_cavity_accuracy.py
@@ -39,15 +39,28 @@ proved argmax gates are FFT-bin-blind, harminv resolves <0.05%):
   * UNIFORM mesh, SAME extents (grading OFF): TM110 signed error **+2.47%**.
 
 The +2.4% bias is therefore NOT introduced by grading — it is present, to within
-0.04 pt, on the uniform mesh of the same coarse resolution. It is the standard
-coarse-Yee PEC-cavity extent-convention bias (~1 cell: the tangential-Ez cavity
-is ~1 cell narrower than the nominal ``sum(dx)`` extent; on a ~45mm/1mm cavity a
-1-cell narrowing is ~2.3%, which is what we see). The graded run reproducing the
-uniform run's accuracy is the POSITIVE finding: in-plane ``dx_profile`` /
-``dy_profile`` grading is faithful — it does not corrupt the resonance beyond the
-uniform-mesh discretization floor. Convergence direction (independent evidence the
-agreement is genuine): the error is dominated by the coarse 1mm bulk, not the
-0.25mm fine band, exactly what a graded-mesh accuracy gate should bound.
+0.04 pt, on the ungraded profile of the same coarse resolution. **The POSITIVE
+finding stands and is why this comparison was worth making: in-plane
+``dx_profile`` / ``dy_profile`` grading is faithful — it does not corrupt the
+resonance beyond the shared baseline.** Convergence direction (independent
+evidence the agreement is genuine): the error is dominated by the coarse 1mm
+bulk, not the 0.25mm fine band.
+
+WHAT THAT SHARED BASELINE ACTUALLY WAS — correction (#562, 2026-08-04). This
+docstring attributed the +2.4% to "the standard coarse-Yee PEC-cavity
+extent-convention bias (~1 cell)". **There is no such Yee/PEC convention bias,
+and that attribution is withdrawn.** Both legs above ran through the NU grid
+builder (a *uniform profile* still routes to ``make_nonuniform_grid``), which
+allocated one E-node per profile cell where N cells need N+1 bounding nodes — so
+both realized ``sum(dx) - dx[-1]``, one cell narrow, which is exactly the ~2.3%
+seen. Measured, same PEC box at integer cell counts (45 x 39 cells, dx=1mm,
+TM110 by harminv), before the fix: uniform builder **-0.007%**, NU builder
+**+2.469%** (and -0.008% against the closed form at the extent it had actually
+built — both solvers were accurate; only one built the requested cavity). After
+restoring the bounding node the two builders are bit-identical on an identical
+mesh, and THIS test reads **0.028%** (was 2.43%) on the same graded geometry.
+The 3.5% gate below is now ~125x looser than the measured residual; tightening
+it is a separate, evidence-first decision.
 
 LEVERAGE (honest power of this gate): because TM110's frequency is set 100% by the
 graded in-plane extents, this gate catches graded-metric errors on x/y directly

--- a/tests/test_preflight_absorber_frame.py
+++ b/tests/test_preflight_absorber_frame.py
@@ -160,13 +160,20 @@ def test_nonuniform_grid_pads_absorber_exterior_to_requested_domain():
     ng = make_nonuniform_grid((0.03, 0.03), dz_profile, 0.5e-3, cpml_layers=cpml_layers)
 
     assert (ng.pad_z_lo, ng.pad_z_hi) == (cpml_layers, cpml_layers)
-    assert ng.nz == len(dz_profile) + ng.pad_z_lo + ng.pad_z_hi
+    # N cells are bounded by N+1 nodes (#562) — the outermost node is the
+    # absorber's outer face, which is why the interior extent below is exact.
+    assert ng.nz == len(dz_profile) + ng.pad_z_lo + ng.pad_z_hi + 1
 
     dz_full = np.asarray(ng.dz)
     edges = np.concatenate(([0.0], np.cumsum(dz_full)))
     # Node pad_z_lo is user z=0 (mirrors Grid's node pad_x_lo convention).
+    # The LAST node is edges[nz-1], not edges[-1]: the cell array carries one
+    # trailing duplicate whose only job is to bound the last real cell with a
+    # node (#562), and whose own H term the stencil zeroes — it is not physical
+    # extent, so extents must be read from the node positions, never from
+    # sum(dz).
     z_node0 = edges[0] - edges[ng.pad_z_lo]
-    z_node_last = edges[-1] - edges[ng.pad_z_lo]
+    z_node_last = edges[ng.nz - 1] - edges[ng.pad_z_lo]
     physical_extent = float(np.sum(dz_profile))
 
     # float32 storage (NonUniformGrid.dz) — loosen tolerance accordingly.

--- a/tests/test_preflight_graded_rasterization.py
+++ b/tests/test_preflight_graded_rasterization.py
@@ -36,7 +36,15 @@ def test_shifted_box_warns_with_actual_and_implied_counts():
 
     issues = _issues(sim)
 
-    assert _has(issues, "rasterizes to 1 z cells (implied 6.0)"), issues
+    # 2, not 1: the advisory reports what the RUN realizes, and the run puts
+    # this box on the nodes at z = 1.0 and 2.0 mm (measured on the production
+    # rasterize path). The former "1" came from the validator modelling the
+    # rasterizer with cell centres — of which exactly one, z = 1.5 mm, fell in
+    # the span. #562 made coordinates nodes and this validator now calls
+    # Box.mask_on_coords instead of imitating it, so the number is the true
+    # one. The ADVISORY still fires, which is what this test is about: 2 is
+    # still below ceil(0.5 * 6.0) = 3.
+    assert _has(issues, "rasterizes to 2 z cells (implied 6.0)"), issues
     assert _has(issues, "smooth_grading transition cells may have shifted"), issues
 
 
@@ -59,3 +67,79 @@ def test_uniform_dz_simulation_skips_check():
     sim.add_source((10e-3, 10e-3, 1e-3), "ez")
 
     assert not _has(_issues(sim), "smooth_grading transition cells may have shifted")
+
+
+# --------------------------------------------------------------------------- #
+# The validator MODELS the rasterizer, so it has to agree with it (#562 F2).
+# --------------------------------------------------------------------------- #
+_AGREEMENT_CASES = [
+    # (z_lo_mm, z_hi_mm) — the 4.50-5.50 case is the reviewer's: it straddles a
+    # grading transition, is classified THIN by Box.mask_on_coords (extent ==
+    # one local cell) and so realizes ONE plane, and the hand-rolled
+    # centre-model counted three and stayed silent where it should warn.
+    (4.50, 5.50),
+    (5.00, 6.00),
+    (5.00, 7.00),
+    (4.00, 5.00),
+    (5.25, 6.75),
+    (0.00, 5.00),
+]
+
+
+def _real_rasterized_z_count(sim) -> int:
+    """The z-cell count the RUN actually produces, from the production path."""
+    import numpy as _np
+    from rfx.geometry.rasterize_grid import (rasterize_geometry,
+                                             coords_from_nonuniform_grid)
+    grid = sim._build_nonuniform_grid()
+    coords = coords_from_nonuniform_grid(grid)
+    out = rasterize_geometry(sim._geometry, sim._resolve_material, coords,
+                             pec_sigma_threshold=sim._PEC_SIGMA_THRESHOLD)
+    eps = _np.asarray(getattr(out[0], "eps_r", out[0]))
+    # the substrate is the only non-background material in these fixtures
+    return int(_np.count_nonzero((eps > 1.0 + 1e-6).max(axis=(0, 1))))
+
+
+def _validator_z_count(sim):
+    for issue in _issues(sim):
+        if "rasterizes to" in issue:
+            return int(issue.split("rasterizes to")[1].split()[0])
+    return None
+
+
+import pytest  # noqa: E402
+
+
+@pytest.mark.parametrize("z_lo_mm,z_hi_mm", _AGREEMENT_CASES,
+                         ids=[f"{a:.2f}-{b:.2f}mm" for a, b in _AGREEMENT_CASES])
+def test_validator_count_matches_the_real_rasterizer(z_lo_mm, z_hi_mm):
+    """This advisory predicts what the rasterizer will do, and a prediction
+    that disagrees with the thing it predicts is worse than no advisory: it
+    reads as a clean bill of health.
+
+    Two separate ways the hand-rolled model was wrong before #562's review:
+    it sampled cell CENTRES where the rasterizer samples E-NODES, and it knew
+    nothing of the THIN-SHEET branch that snaps a box no thicker than its
+    local cell onto a single nearest node. The validator now calls
+    ``Box.mask_on_coords`` on node positions built by the same composition the
+    grid builder uses, so agreement is by construction rather than by a copy
+    that can drift — but only a test that runs both can say it stayed that way.
+    """
+    dz = np.array([1.0e-3] * 5 + [0.25e-3] * 8 + [1.0e-3] * 5)
+    sim = Simulation(freq_max=30e9, domain=(4e-3, 4e-3, float(np.sum(dz))),
+                     dx=1e-3, boundary="pec", dz_profile=dz)
+    sim.add_material("substrate", eps_r=4.0)
+    sim.add(Box((0.0, 0.0, z_lo_mm * 1e-3), (4e-3, 4e-3, z_hi_mm * 1e-3)),
+            material="substrate")
+    sim.add_source((2e-3, 2e-3, 1e-3), "ez")
+
+    real = _real_rasterized_z_count(sim)
+    predicted = _validator_z_count(sim)
+    if predicted is not None:
+        assert predicted == real, (
+            f"validator predicts {predicted} z cells, rasterizer realizes "
+            f"{real} for z-span [{z_lo_mm}, {z_hi_mm}) mm")
+    # and the reviewer's case must actually fire: 1 realized against 4 implied
+    if (z_lo_mm, z_hi_mm) == (4.50, 5.50):
+        assert real == 1, real
+        assert predicted == 1, predicted

--- a/tests/test_silent_drop_warnings.py
+++ b/tests/test_silent_drop_warnings.py
@@ -283,7 +283,9 @@ def test_nu_grid_asymmetric_pmc_allocation():
     assert g.pad_y_hi == 4
     assert g.pad_x_lo == 4 and g.pad_x_hi == 4
     # ny = interior + pad_y_hi (no lo padding) = 8 + 4 = 12.
-    assert g.ny == 12, f"expected ny=12, got {g.ny}"
+    # 8 interior cells + 0 lo pad (PMC face) + 4 hi pad = 12 cells,
+    # bounded by 13 nodes (#562).
+    assert g.ny == 13, f"expected ny=13, got {g.ny}"
     # axis_pads property carries the leading (lo) pad per axis.
     assert g.axis_pads == (4, 0, 4)
 

--- a/tests/test_subpixel_nonuniform.py
+++ b/tests/test_subpixel_nonuniform.py
@@ -132,3 +132,50 @@ def test_compute_smoothed_eps_nonuniform_interface_values():
         f"interface voxel ε should be between 1.0 and {eps_bulk}, "
         f"got {boundary}"
     )
+
+
+def test_compute_smoothed_eps_nonuniform_reduces_to_uniform():
+    """On a UNIFORM profile the NU smoother must equal the uniform smoother
+    elementwise (#562 review, F1).
+
+    The sibling of `test_nonuniform_grid_extent_contract`'s reduction test,
+    applied to the consumer that hid the bug: `compute_smoothed_eps_nonuniform`
+    needs both the node and the cell centre per axis, and derived one from the
+    other. When #562 flipped `coords_from_nonuniform_grid` from centres to
+    nodes, that derivation silently inverted and every smoothed voxel moved
+    half a cell — reintroducing, on the public `subpixel_smoothing=True` path,
+    the exact defect #562 removed from the rasterizer.
+
+    The committed interface-value test cannot see it: a `1 < eps < 4` bound
+    holds under either placement. Identity against the uniform path can, and
+    only for a mesh where the two builders describe the same structure — which
+    is what the extent fix guarantees.
+    """
+    from rfx.geometry.smoothing import (compute_smoothed_eps,
+                                        compute_smoothed_eps_nonuniform)
+    from rfx.geometry.csg import Box as CsgBox
+    from rfx.nonuniform import make_nonuniform_grid
+    from rfx.grid import Grid
+
+    dx = 1e-3
+    n = 8
+    eps_bulk = 4.0
+    # Interface deliberately INSIDE a voxel (z = 4.3 dx) — a face-aligned
+    # interface would agree under both conventions and prove nothing.
+    box = CsgBox((0.0, 0.0, 4.3 * dx), (n * dx, n * dx, n * dx))
+    shapes = [(box, eps_bulk)]
+
+    ug = Grid(freq_max=30e9, domain=(n * dx, n * dx, n * dx), dx=dx,
+              cpml_layers=0)
+    nug = make_nonuniform_grid(domain_xy=(n * dx, n * dx),
+                              dz_profile=np.full(n, dx), dx=dx, cpml_layers=0)
+    assert nug.shape == ug.shape, (nug.shape, ug.shape)
+
+    for comp, u_arr, n_arr in zip(("ex", "ey", "ez"),
+                                  compute_smoothed_eps(ug, shapes),
+                                  compute_smoothed_eps_nonuniform(nug, shapes)):
+        worst = float(np.max(np.abs(np.asarray(u_arr) - np.asarray(n_arr))))
+        assert worst < 1e-5, (
+            f"{comp}: NU smoother differs from the uniform smoother by "
+            f"{worst:.4f} on an identical mesh — a half-cell coordinate "
+            f"placement error (#562 review F1)")


### PR DESCRIPTION
Closes #562. Draft until CI reports; the physics is measured and in the commit bodies.

## The defect

N cells are bounded by N+1 nodes. `make_nonuniform_grid` allocated **one E-node per profile cell**, and the non-uniform Yee stencil zeroes the last cell's H term (`inv_d_h[N-1] = 0`), so an N-cell profile realized only N-1 usable gaps: the wall-to-wall extent came out `sum(d) - d[-1]`. Independently, `coords_from_nonuniform_grid` placed sample *i* at the cell **centre** while the E-nodes the stencil differences sit on cell **edges** (`inv_d_e[i] = 2/(d[i-1]+d[i])` is a node's dual spacing), and while `coords_from_uniform_grid` returns edges — so rasterized material sat half a cell from the fields acting on it.

Drawn geometry is placed by physical coordinates and so rasterizes consistently; only **boundary-defined** dimensions were wrong. That is exactly waveguides and closed cavities, which is why this survived so long.

## Isolation (integer cell counts, so no dimension-snapping confound)

45 × 39 cells at dx = 1 mm, PEC box, TM110 by harminv:

| builder | realized extents | vs closed form @ requested | vs closed form @ realized |
|---|---|---|---|
| uniform `Grid` | 45.000 / 39.000 | **−0.007 %** | −0.007 % |
| `NonUniformGrid` | 44.000 / 38.000 | **+2.469 %** | −0.008 % |

Both solvers were accurate — only one built the requested cavity. Builder delta **+2.477 % (+126 MHz) → 0.000 % (bit-identical) after this PR.**

A WR-90 TE101 cavity requested as (15.748, 22.860) mm realized (15.494, 22.606) and read 11.728274 GHz; it now realizes the requested extents and reads 11.557967 GHz — the uniform path's value to every printed digit, −0.004 % from the closed form.

## The fix (~10 lines of production code)

1. **`_append_bounding_node`** — append one duplicate boundary cell per padded profile. That yields N+1 nodes *and* gives the far boundary node the mirror of the near one's coefficient: `inv_d_e[N] = 2/(d[N-1]+d[N]) = 1/d[N-1]` when the appended cell duplicates the last, matching the existing `inv_d_e[0] = 1/d[0]`. The appended cell's own H term is the one the stencil already zeroes, so it adds a node without adding physical extent.
2. **`coords_from_nonuniform_grid`** returns node positions (cumulative edges, origin at the first interior node) — the uniform builder's convention.

`tests/test_nonuniform_grid_extent_contract.py` pins the contract: realized extent == requested on every axis for both builders, node count == cells + 1, a uniform mesh expressed as profiles reproduces the uniform grid's coordinates elementwise, and a graded profile realizes its own sum with every node on a cumulative edge. **6 of its 7 cases failed before this change; the one that passed was the uniform builder.**

## Effect on committed analytic-gated tests (geometry unchanged)

| test | before | after |
|---|---|---|
| `test_nonuniform_xy_cavity_accuracy` TM110, x&y graded 4:1 | 2.43 % | **0.028 %** |
| `test_nonuniform_cavity_accuracy` TM111, z graded | 2.66 % | **0.025 %** |

~100× each, landing at the discretization floor. Both still pass; their gates (3.5 %, 4 %) are now ~125×/160× looser than the residual. **Tightening them is deliberately NOT in this PR** — gates pin measured envelopes, and these want re-measuring across resolutions first.

### A prior attribution is withdrawn, with the isolating measurement

`test_nonuniform_xy_cavity_accuracy`'s docstring recorded that same +2.4 % on both a graded and an ungraded profile and concluded it was "the standard coarse-Yee PEC-cavity extent-convention bias (~1 cell)". There is no such Yee/PEC bias — the uniform builder reads −0.007 % at integer cell counts — and both of its legs had gone through the NU builder, because a *uniform profile* still routes to `make_nonuniform_grid`. The docstring now carries the withdrawal, the before/after, and the two-builder isolation. **Its comparative finding is untouched and still valid: in-plane grading is faithful — both legs shared the same baseline.** (I also had to withdraw a claim of my own in #562: I wrote that the consequence was undocumented, which was false — that docstring had recorded it.)

## Blast radius, all classified (fast NU set: 196 passed, 0 failed)

- **7 distributed-composition tests** hand-built grid-shaped override arrays (eps, design mask, PEC occupancy) sized to CELL counts. Routed through one `_field_shape()` helper so the cells-vs-nodes rule is stated once instead of at 8 call sites. **API note for users:** a hand-built grid-shaped array on the NU path is now cells+1 per axis, as it always was on the uniform path.
- **3 node-count assertions** (`nz == len(profile) + pads`) gain the bounding node.
- **`test_coords_from_nonuniform_grid_cell_centers`** pinned the old centre convention by name → rewritten as `..._node_positions`.
- Supporting evidence the node convention was the intended one: `test_preflight_absorber_frame` already computed positions as cumulative edges, commented "mirrors Grid's node pad_x_lo convention" — only the count was wrong.

## A landmine this PR introduced, then closed

Four core sites sliced interiors as `d[pad_lo : len(d) - pad_hi]`, which now pulls in the trailing duplicate (or a pad cell) and overstates the extent by one cell — the same class of error as #562 itself. Consolidated into **one** definition, `rfx.nonuniform.interior_cells(d_full, pad_lo, pad_hi)`, rather than the rule restated four times. Subgridding's `nx - pad_hi` sites are NODE index bounds, not cell slices, and became more correct with the extra node.

## Open items for the approver — I am the author and am not merging this

1. **Committed NU fixtures are stale by construction.** They were generated under the one-cell-short geometry, and the NU gate tests *replay* fixtures rather than re-running FDTD, so they pass while describing the old geometry. Regeneration is a compute + review decision; expected direction is improved agreement (e.g. the NU broad-E5 lane's guide finally being `A` wide instead of `A − dy_edge`).
2. **Gate tightening** on the two cavity accuracy tests (see above) — evidence-first, separate change.
3. **Out of scope, unchanged:** the waveguide port samples its modal profile at cell centres on *both* builders (`cumsum(w) − 0.5·w`). That is a pre-existing internal port convention, not something this PR exposes or alters.

Found while measuring a mitigation for the #557 aperture-edge residual; the mitigation line itself turned out to be measuring this defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round 1 (adversarial, PI-requested) — both blockers closed in `b5fe569`

F1 (smoother half-cell) and F2 (#325 advisory false negative) were real and mine; see that commit and the review reply for the measurements. F5/F6/F4/F7/F9 landed with them. F3 is now under test rather than only noted: the extent contract's new `cpml_layers>0` case pins interior span **and** absorber-depth symmetry, which is the reviewer's unclaimed improvement — the hi face carried one physical cell fewer than the lo face before this PR, so the CPML ramps were not mirror images. The out-of-scope NU+subpixel observation is filed as #565.

**Blast radius, amended (F3):** open-boundary NU runs change beyond the extent fix — the hi-face absorber gains its missing cell, so σ ramps become mirror-symmetric. An approver weighing fixture regeneration should read that as a second, independent reason NU numbers move.

R3: memory=this PR's own reduction pattern, reapplied to the two consumers the review found — "on a uniform profile the NU path must reduce to the uniform path elementwise" is what closes F1, and "call the production rasterizer instead of modelling it" is what closes F2; both were derived from the reviewer's measurements after re-deriving them here first (max|Δ| 2.4000 on eps_ex reproduced from the shipped state; the 4.50–5.50 mm box's real count of 1 confirmed against the centre model's 3 and a node-only model's 2)
