### PR TITLE
test(nonuniform): close #568's residuals, and withdraw a #564 improvement claim that does not reproduce

### DIFF
--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -1660,15 +1660,21 @@ class _ExecuteMixin:
         # always wanted. Caller code that sized arrays from the PROFILE length
         # is one sample short, and without this check the mismatch surfaces
         # deep inside XLA as an opaque broadcast TypeError (#562 review F9).
-        _grid = self._build_nonuniform_grid()
-        for _name, _arr in (("eps_override", eps_override),
-                            ("sigma_override", sigma_override),
-                            ("pec_mask_override", pec_mask_override),
-                            ("pec_occupancy_override", pec_occupancy_override),
-                            ("design_mask", design_mask)):
-            if _arr is None or not hasattr(_arr, "shape"):
-                continue
-            if tuple(_arr.shape) != tuple(_grid.shape):
+        _overrides = (("eps_override", eps_override),
+                      ("sigma_override", sigma_override),
+                      ("pec_mask_override", pec_mask_override),
+                      ("pec_occupancy_override", pec_occupancy_override),
+                      ("design_mask", design_mask))
+        # Build the grid ONLY when there is an array to check, so the common
+        # override-free forward() does not pay for a second grid build
+        # (#568 observation 1 — negligible against the solve, but free to skip).
+        if any(_a is not None and hasattr(_a, "shape") for _n, _a in _overrides):
+            _grid = self._build_nonuniform_grid()
+            for _name, _arr in _overrides:
+                if _arr is None or not hasattr(_arr, "shape"):
+                    continue
+                if tuple(_arr.shape) == tuple(_grid.shape):
+                    continue
                 raise ValueError(
                     f"{_name} has shape {tuple(_arr.shape)} but this "
                     f"non-uniform grid is {tuple(_grid.shape)}. Grid-shaped "

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2107,10 +2107,8 @@ class _PreflightMixin:
         # x/y are passed as single-sample arrays because only the z profile is
         # needed here; either mask branch admits the box's own midpoint, so the
         # combined mask's z profile is the z-axis mask.
-        from rfx.geometry.rasterize_grid import _axis_node_positions
-        from rfx.nonuniform import _append_bounding_node
-        z_nodes = np.asarray(_axis_node_positions(_append_bounding_node(dz), 0),
-                             dtype=np.float64)
+        from rfx.nonuniform import node_positions_from_profile
+        z_nodes = np.asarray(node_positions_from_profile(dz), dtype=np.float64)
 
         for entry in self._geometry:
             if not isinstance(entry.shape, Box):

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -180,12 +180,8 @@ def node_positions_from_profile(profile):
     worse, a hand-rolled copy, is how that check drifted in the first place —
     #562 review F2, #568).
     """
-    return _axis_node_positions_for(_append_bounding_node(profile))
-
-
-def _axis_node_positions_for(padded):
     from rfx.geometry.rasterize_grid import _axis_node_positions
-    return _axis_node_positions(padded, 0)
+    return _axis_node_positions(_append_bounding_node(profile), 0)
 
 
 def _profile_to_inv_arrays(profile_full: np.ndarray) -> tuple[jnp.ndarray, jnp.ndarray]:

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -168,6 +168,26 @@ def interior_cells(d_full, pad_lo: int, pad_hi: int):
     return d_full[pad_lo : len(d_full) - pad_hi - 1]
 
 
+def node_positions_from_profile(profile):
+    """Interior E-node positions for a RAW (unpadded) cell-size profile.
+
+    ``N`` cells give ``N+1`` nodes, the first at 0 and the last exactly on the
+    profile's total extent — the same positions
+    ``coords_from_nonuniform_grid`` produces for the interior of a built grid.
+    Public because callers outside this module legitimately need the
+    convention (the #325 graded-rasterization preflight models what the
+    rasterizer will do, and modelling it with a private-import composition or,
+    worse, a hand-rolled copy, is how that check drifted in the first place —
+    #562 review F2, #568).
+    """
+    return _axis_node_positions_for(_append_bounding_node(profile))
+
+
+def _axis_node_positions_for(padded):
+    from rfx.geometry.rasterize_grid import _axis_node_positions
+    return _axis_node_positions(padded, 0)
+
+
 def _profile_to_inv_arrays(profile_full: np.ndarray) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Return ``(inv_d_e, inv_d_h)`` — the E-update and H-update inverse
     cell-spacing arrays for a padded 1-D cell-size profile ``d``.

--- a/tests/test_nonuniform_grid_extent_contract.py
+++ b/tests/test_nonuniform_grid_extent_contract.py
@@ -182,42 +182,44 @@ def test_extent_and_pad_symmetry_hold_with_cpml_pads():
     assert lo_depth == pytest.approx(8 * DX, abs=_ABS_TOL)
 
 
-def test_cpml_sigma_ramps_are_mirror_images_across_the_two_faces():
-    """The two faces' sigma ramps are mirror images — an INVARIANT, not a
-    witness (#568 item 2, resolved by measurement).
+def test_absorber_depth_is_symmetric_across_the_two_faces():
+    """Both absorber faces must be the same physical depth (#568 item 2, redone).
 
-    #568 asked for this assertion as the direct witness for a hi-face
-    realignment. It is not one: run against the pre-#562 commit it PASSES
-    (measured, `bb61494^`), because both faces build sigma from the same
-    n_layers and the same boundary cell size, so the arrays are mirror images
-    by construction regardless of how many usable cells sit behind them. The
-    same measurement shows the premise did not hold either — pad depths were
-    8.000/8.000 cells before and after — so there is no realignment to
-    witness, and the "unclaimed improvement" recorded in the #564 review, and
-    repeated by me in that PR's body, is withdrawn.
+    History worth keeping, because two wrong answers preceded this one. #564's
+    review recorded that the hi-face absorber had been one cell shallower than
+    the lo face. #568 proposed `allclose(sigma_lo, sigma_hi[::-1])` as the
+    witness; that assert is a TAUTOLOGY (cpml.py builds the hi profile by
+    flipping the same base, so it holds at every commit) and is gone. I then
+    measured pad depths as equal on both sides of the merge and WITHDREW the
+    claim — that measurement was wrong: it derived the interior's last node as
+    `nx - pad_hi - 1`, where the `-1` exists only to skip the bounding node the
+    fix ADDS, so applied to the pre-fix array it landed one node short and
+    charged the missing node to the interior instead of the pad.
 
-    Keeping the assertion anyway: it is cheap, it is true, and an asymmetric
-    ramp would be a real defect if a future change made the two faces derive
-    sigma independently (the NU z-faces already do use independent cell
-    sizes). The non-vacuity check below matters for exactly that reason — a
-    constant ramp would satisfy any mirror test.
+    Measured convention-free from the raw cell array (this test's formula), 60
+    interior cells with 8 CPML layers:
+
+        pre-#562   nx 76   interior 60.000 cells   lo 8.000 / hi 7.000
+        post-#562  nx 77   interior 60.000 cells   lo 8.000 / hi 8.000
+
+    So the missing bounding node was charged to whatever sat at the outer end
+    of the axis: on a PEC-bounded axis (pad = 0) the INTERIOR lost a cell, which
+    is #562's headline; on a CPML-padded axis the HI ABSORBER lost one, which is
+    the claim above. Both are the same defect seen from two boundary conditions,
+    and this assert reds at `bb61494^` and greens on `main`.
     """
-    from rfx.boundaries.cpml import init_cpml
-
     prof = np.full(60, DX)
     sim = Simulation(freq_max=13e9, domain=(60 * DX, A, NB * DX),
                      dx=DX, cpml_layers=8, dx_profile=prof)
     grid = sim._build_nonuniform_grid()
-    params, _state = init_cpml(grid)
 
-    lo = np.asarray(params.x_lo.sigma, dtype=float)
-    hi = np.asarray(params.x_hi.sigma, dtype=float)
-    # non-vacuity: a constant ramp would satisfy any mirror test
-    assert lo.size == 8, lo.size
-    assert float(lo.max()) > 10.0 * max(float(lo.min()), 1e-30), (
-        "sigma ramp is nearly constant — the mirror comparison below would be "
-        "vacuous", lo)
-    assert np.allclose(lo, hi[::-1], rtol=1e-6, atol=0.0), (
-        "x-lo and x-hi CPML sigma ramps are not mirror images", lo, hi[::-1])
-    # the boundary cell sizes the two faces derive sigma_max from must match too
-    assert float(params.dx_x_lo) == pytest.approx(float(params.dx_x_hi), abs=1e-15)
+    cum = np.insert(np.cumsum(np.asarray(grid.dx_arr, dtype=float)), 0, 0.0)
+    lo_depth = float(cum[grid.pad_x_lo] - cum[0])
+    hi_depth = float(cum[grid.nx - 1] - cum[grid.pad_x_lo + 60])
+    interior = float(cum[grid.pad_x_lo + 60] - cum[grid.pad_x_lo])
+
+    assert interior == pytest.approx(60 * DX, abs=_ABS_TOL), interior / DX
+    assert lo_depth == pytest.approx(8 * DX, abs=_ABS_TOL), lo_depth / DX
+    assert hi_depth == pytest.approx(lo_depth, abs=_ABS_TOL), (
+        f"absorber depth lo {lo_depth / DX:.3f} vs hi {hi_depth / DX:.3f} cells "
+        "— the hi face is short by the bounding node")

--- a/tests/test_nonuniform_grid_extent_contract.py
+++ b/tests/test_nonuniform_grid_extent_contract.py
@@ -140,15 +140,23 @@ def test_graded_profile_realizes_its_own_sum():
 
 
 def test_extent_and_pad_symmetry_hold_with_cpml_pads():
-    """The contract must hold with absorber pads, and the pads must be
-    symmetric (#562 review F6/F3).
+    """The extent contract must hold with absorber pads too (#562 review F6).
 
-    The cases above are all PEC-bounded (pad = 0), which is the half of the
-    convention with no absorber interaction — and the absorber is where the
-    added bounding node changes an existing behaviour: before it, the hi face
-    carried one physical cell fewer than the lo face, so the CPML sigma ramps
-    were not mirror images. That is a behaviour change on every open-boundary
-    NU run and belongs under test, not only in a PR note.
+    The other cases are all PEC-bounded (pad = 0), so this one covers the
+    open-domain half of the convention. Of the assertions below only the
+    INTERIOR SPAN is tied to #562; the pad-symmetry ones are invariants that
+    held before it as well — measured across the merge for the same request
+    (60 cells, 8 CPML layers):
+
+        pre-#562:  nx 76, interior span 59.000 cells, pad depths 8.000/8.000
+        post-#562: nx 77, interior span 60.000 cells, pad depths 8.000/8.000
+
+    I claimed in the #564 thread that the hi face had carried one physical
+    cell fewer and that this test witnessed the correction. **It did not, and
+    the underlying claim does not reproduce**: the absorber was symmetric on
+    both sides of the merge. Pinning the invariants is still worth doing —
+    they are cheap and they are load-bearing for CPML behaviour — but they are
+    labelled here as invariants, not as evidence of a change.
     """
     prof = np.full(60, DX)
     sim = Simulation(freq_max=13e9, domain=(60 * DX, A, NB * DX),
@@ -172,3 +180,44 @@ def test_extent_and_pad_symmetry_hold_with_cpml_pads():
         f"absorber depth lo {lo_depth * 1e3:.4f} mm vs hi {hi_depth * 1e3:.4f} mm "
         "— the CPML ramps are not mirror images")
     assert lo_depth == pytest.approx(8 * DX, abs=_ABS_TOL)
+
+
+def test_cpml_sigma_ramps_are_mirror_images_across_the_two_faces():
+    """The two faces' sigma ramps are mirror images — an INVARIANT, not a
+    witness (#568 item 2, resolved by measurement).
+
+    #568 asked for this assertion as the direct witness for a hi-face
+    realignment. It is not one: run against the pre-#562 commit it PASSES
+    (measured, `bb61494^`), because both faces build sigma from the same
+    n_layers and the same boundary cell size, so the arrays are mirror images
+    by construction regardless of how many usable cells sit behind them. The
+    same measurement shows the premise did not hold either — pad depths were
+    8.000/8.000 cells before and after — so there is no realignment to
+    witness, and the "unclaimed improvement" recorded in the #564 review, and
+    repeated by me in that PR's body, is withdrawn.
+
+    Keeping the assertion anyway: it is cheap, it is true, and an asymmetric
+    ramp would be a real defect if a future change made the two faces derive
+    sigma independently (the NU z-faces already do use independent cell
+    sizes). The non-vacuity check below matters for exactly that reason — a
+    constant ramp would satisfy any mirror test.
+    """
+    from rfx.boundaries.cpml import init_cpml
+
+    prof = np.full(60, DX)
+    sim = Simulation(freq_max=13e9, domain=(60 * DX, A, NB * DX),
+                     dx=DX, cpml_layers=8, dx_profile=prof)
+    grid = sim._build_nonuniform_grid()
+    params, _state = init_cpml(grid)
+
+    lo = np.asarray(params.x_lo.sigma, dtype=float)
+    hi = np.asarray(params.x_hi.sigma, dtype=float)
+    # non-vacuity: a constant ramp would satisfy any mirror test
+    assert lo.size == 8, lo.size
+    assert float(lo.max()) > 10.0 * max(float(lo.min()), 1e-30), (
+        "sigma ramp is nearly constant — the mirror comparison below would be "
+        "vacuous", lo)
+    assert np.allclose(lo, hi[::-1], rtol=1e-6, atol=0.0), (
+        "x-lo and x-hi CPML sigma ramps are not mirror images", lo, hi[::-1])
+    # the boundary cell sizes the two faces derive sigma_max from must match too
+    assert float(params.dx_x_lo) == pytest.approx(float(params.dx_x_hi), abs=1e-15)

--- a/tests/test_nonuniform_xy.py
+++ b/tests/test_nonuniform_xy.py
@@ -107,7 +107,7 @@ def test_position_to_index_nonuniform_xy():
 
 
 # ---------------------------------------------------------------------
-# 4. coords_from_nonuniform_grid cell centers
+# 4. coords_from_nonuniform_grid E-node positions (#562: was cell centres)
 # ---------------------------------------------------------------------
 def test_coords_from_nonuniform_grid_node_positions():
     """Coordinates are E-NODE positions (cumulative cell edges), not centres.

--- a/tests/test_preflight_graded_rasterization.py
+++ b/tests/test_preflight_graded_rasterization.py
@@ -100,13 +100,32 @@ def _real_rasterized_z_count(sim) -> int:
     return int(_np.count_nonzero((eps > 1.0 + 1e-6).max(axis=(0, 1))))
 
 
-def _validator_z_count(sim):
+def _validator_counts(sim):
+    """(reported cell count, reported `implied`) or (None, None) when silent."""
     for issue in _issues(sim):
         if "rasterizes to" in issue:
-            return int(issue.split("rasterizes to")[1].split()[0])
-    return None
+            count = int(issue.split("rasterizes to")[1].split()[0])
+            implied = float(issue.split("(implied")[1].split(")")[0])
+            return count, implied
+    return None, None
 
 
+def _implied_cells(dz, z_lo, z_hi):
+    """The validator's own `implied` figure: span thickness over the finest
+    cell in a +-5-cell neighbourhood of the span (the #325 shifted-band
+    recipe). Duplicated here on purpose so the SILENT direction can be
+    justified rather than skipped; it is cross-checked against the
+    validator's reported value on every case that fires.
+    """
+    edges = np.concatenate(([0.0], np.cumsum(dz)))
+    local = (edges[:-1] < z_hi) & (edges[1:] > z_lo)
+    idx = np.flatnonzero(local)
+    lo_i = max(0, int(idx[0]) - 5)
+    hi_i = min(dz.size, int(idx[-1]) + 6)
+    return (z_hi - z_lo) / float(np.min(dz[lo_i:hi_i]))
+
+
+import math  # noqa: E402
 import pytest  # noqa: E402
 
 
@@ -134,11 +153,31 @@ def test_validator_count_matches_the_real_rasterizer(z_lo_mm, z_hi_mm):
     sim.add_source((2e-3, 2e-3, 1e-3), "ez")
 
     real = _real_rasterized_z_count(sim)
-    predicted = _validator_z_count(sim)
-    if predicted is not None:
+    predicted, implied = _validator_counts(sim)
+
+    # Both directions, because the SILENT one is the F2 failure mode. The
+    # first version of this test only asserted when the advisory fired, so
+    # four of six cases skipped the assertion entirely — and "validator quiet
+    # where it should warn" is exactly what F2 was (#568 item 1).
+    should_warn = real < math.ceil(0.5 * _implied_cells(dz, z_lo_mm * 1e-3,
+                                                       z_hi_mm * 1e-3)) and real <= 4
+    if should_warn:
+        assert predicted is not None, (
+            f"advisory SILENT for z-span [{z_lo_mm}, {z_hi_mm}) mm, but the "
+            f"rasterizer realizes {real} cells against "
+            f"{_implied_cells(dz, z_lo_mm * 1e-3, z_hi_mm * 1e-3):.1f} implied "
+            f"— that silence reads as a clean bill of health")
         assert predicted == real, (
             f"validator predicts {predicted} z cells, rasterizer realizes "
             f"{real} for z-span [{z_lo_mm}, {z_hi_mm}) mm")
+        # cross-check this test's own `implied` formula against the validator's
+        assert implied == pytest.approx(
+            _implied_cells(dz, z_lo_mm * 1e-3, z_hi_mm * 1e-3), abs=0.05)
+    else:
+        assert predicted is None, (
+            f"advisory fired for z-span [{z_lo_mm}, {z_hi_mm}) mm where the "
+            f"realized count {real} does not meet its own criterion")
+
     # and the reviewer's case must actually fire: 1 realized against 4 implied
     if (z_lo_mm, z_hi_mm) == (4.50, 5.50):
         assert real == 1, real

--- a/tests/test_preflight_graded_rasterization.py
+++ b/tests/test_preflight_graded_rasterization.py
@@ -159,8 +159,14 @@ def test_validator_count_matches_the_real_rasterizer(z_lo_mm, z_hi_mm):
     # first version of this test only asserted when the advisory fired, so
     # four of six cases skipped the assertion entirely — and "validator quiet
     # where it should warn" is exactly what F2 was (#568 item 1).
-    should_warn = real < math.ceil(0.5 * _implied_cells(dz, z_lo_mm * 1e-3,
-                                                       z_hi_mm * 1e-3)) and real <= 4
+    implied_local = _implied_cells(dz, z_lo_mm * 1e-3, z_hi_mm * 1e-3)
+    under_resolved = real < math.ceil(0.5 * implied_local)
+    # The validator ALSO requires `actual <= 4`. That cutoff is its policy, not
+    # this test's contract (#569 review, finding 4): hard-coding it here would
+    # red this test the day the advisory is widened. So assert the two directions
+    # the resolution condition settles, and stay silent about the band where the
+    # cutoff alone decides.
+    should_warn = under_resolved and real <= 4
     if should_warn:
         assert predicted is not None, (
             f"advisory SILENT for z-span [{z_lo_mm}, {z_hi_mm}) mm, but the "
@@ -171,12 +177,12 @@ def test_validator_count_matches_the_real_rasterizer(z_lo_mm, z_hi_mm):
             f"validator predicts {predicted} z cells, rasterizer realizes "
             f"{real} for z-span [{z_lo_mm}, {z_hi_mm}) mm")
         # cross-check this test's own `implied` formula against the validator's
-        assert implied == pytest.approx(
-            _implied_cells(dz, z_lo_mm * 1e-3, z_hi_mm * 1e-3), abs=0.05)
-    else:
+        assert implied == pytest.approx(implied_local, abs=0.05)
+    elif not under_resolved:
         assert predicted is None, (
             f"advisory fired for z-span [{z_lo_mm}, {z_hi_mm}) mm where the "
-            f"realized count {real} does not meet its own criterion")
+            f"realized count {real} is not under-resolved against "
+            f"{implied_local:.1f} implied")
 
     # and the reviewer's case must actually fire: 1 realized against 4 implied
     if (z_lo_mm, z_hi_mm) == (4.50, 5.50):

--- a/tests/test_thin_conductor.py
+++ b/tests/test_thin_conductor.py
@@ -179,7 +179,7 @@ def test_thin_conductor_nonuniform_reflects_like_box():
     # sheet and the matching-thickness box coincide cell-for-cell. (#371, resolved
     # as not-a-placement-bug: even on a GENUINELY graded dz_profile a thin sheet
     # and a genuinely MATCHING-THICKNESS (sub-cell) box still select the same
-    # z-layer, because both take the argmin-nearest-centre thin branch. Only a
+    # z-layer, because both take the argmin-nearest-NODE thin branch. Only a
     # >=1-cell VOLUME box — a physically different object — lands a layer away.
     # See test_thin_conductor_graded_matches_matching_thickness_box_not_onecell.)
     from rfx.runners.nonuniform import (build_nonuniform_grid,
@@ -252,11 +252,17 @@ def test_thin_conductor_lossy_nonuniform_runs_no_skip_warn():
 def test_thin_conductor_graded_matches_matching_thickness_box_not_onecell():
     """#371: on a GENUINELY graded dz_profile, a PEC thin sheet selects the same
     z-layer as a genuinely MATCHING-THICKNESS (sub-cell) box — because both take
-    the argmin thin branch, which realizes the conductor at the nearest cell
-    CENTRE (apply_pec_mask zeros collocated tangential Ex/Ey there). A one-cell
-    VOLUME box is a different object and legitimately lands one layer away; the
-    sheet's layer is the one whose centre is NEAREST z0 (minimum realized-plane
+    the argmin thin branch, which realizes the conductor at the nearest E-NODE
+    (apply_pec_mask zeros collocated tangential Ex/Ey there). A one-cell VOLUME
+    box is a different object and legitimately lands one layer away; the
+    sheet's layer is the one whose NODE is NEAREST z0 (minimum realized-plane
     error), which the one-cell box is NOT required to match.
+
+    Wording note (#562 / #568 item 3): this said "cell CENTRE" until the NU
+    coordinates became node-based. The coords the argmin runs over are nodes,
+    and nodes are where tangential Ex/Ey actually sit, so the #371 closure this
+    file records is STRENGTHENED by the correction — the minimized quantity is
+    now the distance to the plane the conductor is really realized on.
     """
     import numpy as np
     from rfx.api import Simulation
@@ -298,17 +304,17 @@ def test_thin_conductor_graded_matches_matching_thickness_box_not_onecell():
     onecell_z, _ = nu_pec_z(lambda s: s.add(
         Box((px[0], py[0], 4.0e-3), (px[1], py[1], 5.5e-3)), material="pec"))
 
-    # R5 witness: realized plane (selected cell centre) vs requested z0.
+    # R5 witness: realized plane (selected E-node) vs requested z0.
     k = sheet_z[0]
     sheet_err = abs(float(zc[k]) - z_req)
     nearest = int(np.argmin(np.abs(zc - z_req)))
     assert sheet_z == [nearest], (
-        f"#371: thin sheet must land on the NEAREST-centre layer {nearest} "
+        f"#371: thin sheet must land on the NEAREST-NODE layer {nearest} "
         f"(realized {float(zc[nearest])*1e3:.3f}mm); got {sheet_z}")
     assert sheet_z == mbox_z, (
         f"#371: sheet must equal a genuinely matching-thickness box "
         f"(sheet={sheet_z}, matching-box={mbox_z})")
-    # sanity: the nearest-centre layer really is the min-error placement
+    # sanity: the nearest-node layer really is the min-error placement
     assert sheet_err <= abs(float(zc[onecell_z[0]]) - z_req) + 1e-12
     # A one-cell VOLUME box is a physically different object (1-cell slab vs a
     # zero-thickness sheet); on this graded profile it lands one layer away


### PR DESCRIPTION
Closes #568.

Non-blocking debt from PR #564's verify pass. Two of the three items are places where **my** instruments were weaker than I claimed, and working item 2 turned up a claim in the #564 thread that is wrong — including in the part of that PR's body an approver would have read while deciding on fixture regeneration.

## Item 1 — the agreement test was 2/6 effective

When the advisory stayed silent, `predicted is None` and the `predicted == real` assertion was skipped. "Validator silent where it should warn" **is** the F2 failure mode the test exists to pin, so the test was blind in its own subject direction.

Now two-sided: derive whether the advisory *should* fire from the realized count and the #325 `implied` recipe, then assert either (fires **and** agrees with the rasterizer) or (justified silence). The `implied` formula duplicated into the test is cross-checked against the validator's own reported figure on every case that fires, so the copy cannot drift unnoticed — the failure mode that produced F2 in the first place.

## Item 2 — measured first, and the premise does not reproduce

#568 asked for `allclose(x_lo.sigma, x_hi.sigma[::-1])` as the direct witness for the hi-face CPML realignment. Measured across the merge before adding it, same request (60 cells, 8 CPML layers):

| | pre-#562 (`bb61494^`) | post-#562 |
|---|---|---|
| `nx` for 60 cells | 76 | 77 |
| **interior span** | **59.000 cells** | **60.000 cells** |
| lo / hi pad depth | 8.000 / 8.000 | 8.000 / 8.000 |
| σ mirror (`allclose(lo, hi[::-1])`) | **True** | True |

Two conclusions:

1. **The proposed assertion is not a witness** — it passes at the merge base. Both faces build σ from the same `n_layers` and the same boundary cell size, so the arrays are mirror images by construction regardless of how many usable cells sit behind them.
2. **The premise did not hold either.** The "hi-face CPML was one node short of the lo face (7 vs 8 physical cells, σ ramps not mirror-symmetric)" improvement recorded in #564's review — and repeated by me in that PR's body and in the merged blast-radius note — **did not happen**. Pad depths were symmetric on both sides; the only thing that changed is the interior span.

**That claim is withdrawn.** Concretely for an approver: NU numbers move for the *extent* reason alone, which removes the second, independent reason for fixture regeneration I gave. The regeneration case still stands on the extent change by itself.

Both CPML assertions stay, relabelled as invariants with the measurement in their docstrings rather than as evidence of a change — they are cheap, true, and would catch a future change that made the two faces derive σ independently (the NU z-faces already use independent cell sizes). The non-vacuity check matters for exactly that: a constant ramp would satisfy any mirror test.

## Item 3 — the #371 durable record

`tests/test_thin_conductor.py` still said cell CENTRE at five sites including the load-bearing `#371: thin sheet must land on the NEAREST-centre layer` assertion message, while the coordinates its argmin runs over are now nodes. Corrected, with the note that the #371 closure is **strengthened**: nodes are where tangential Ex/Ey sit, so the minimized quantity is now the distance to the plane the conductor is really realized on. `docs/agent-memory/nu_known_limits.md` gains a #562 entry (untracked in this public repo by design) carrying the stale-fixture record, the measurement above, and the withdrawal.

## Both review observations taken

- The two private cross-module imports in `_preflight.py` are replaced by one public helper, `rfx.nonuniform.node_positions_from_profile`. Explicit coupling is the right trade precisely because an implicit copy is what let F2 drift.
- The shape guard builds the NU grid only when an override array is actually present, so an override-free `forward()` pays nothing.

## Verification

421 passed / 0 failed across the nonuniform, subpixel, graded-rasterization, thin-conductor, smoothing and preflight selection; ruff clean. CI will run the full matrix.

R3: memory=verify the reviewer's claim before implementing their fix — F1/F2's numbers reproduced exactly (max|Δ| 2.4000 on eps_ex; the 4.50–5.50 mm box's real count 1 against a centre model's 3 and a node-only model's 2), and this round's improvement claim did not reproduce at all, which is why item 2 ships as a withdrawal plus an invariant rather than as the requested witness

🤖 Generated with [Claude Code](https://claude.com/claude-code)