### PR TITLE
test(nonuniform): derive the two NU cavity accuracy gates from measured envelopes (3.5%/4% -> 0.05%/0.04%)

### DIFF
--- a/scripts/stage1_nu_cavity_physics_gate.py
+++ b/scripts/stage1_nu_cavity_physics_gate.py
@@ -17,8 +17,15 @@ estimator, NOT rfft-argmax. At ``num_periods=20`` the record is only ~10 cycles
 of f_tm110, so FFT bins span 10% of f and argmax can place the peak only to ±5%
 — the sub-0.1% "error" it used to print was bin-quantization luck (issue #396).
 harminv resolves far below the bin width, exposing the fixture's true ~2.5%
-NU-air-cavity discretization error (consistent with the sibling analytic gate
-``test_nonuniform_cavity_accuracy.py``: 2.66% @ dx=1mm, gated 4%).
+NU-air-cavity discretization error.
+
+STALE AS OF #562 (2026-08-05): that ~2.5% was dominated by the non-uniform grid
+building every axis one cell short of the requested domain, now fixed. The
+sibling analytic gate this used to cite for corroboration moved from 2.66% @ 4%
+to 0.025% @ 0.04% (#573), and THIS script's own residual measures 0.0144%
+against its unchanged 3.5% gate — 243x loose. Its gate wants the same
+envelope-derived treatment; that is a follow-up, not something to leave
+undocumented here.
 
 Run:
     python scripts/stage1_nu_cavity_physics_gate.py
@@ -137,12 +144,16 @@ def run_gate() -> Stage1NUGateResult:
         raise AssertionError(
             f"cell savings {gate.cell_savings_factor:.2f}x below 40x gate"
         )
-    # Resolution-honest gate. harminv measures ~2.54% error here (HIGH; a one-cell
-    # effective-a registration effect, stable across record lengths 20→160 periods
-    # and corroborated by zero-padded-FFT + parabolic-peak ~2.55-2.58% (the exact
-    # secondary number is window/pad-factor dependent). This is a MEASURED
-    # NU-air-cavity discretization envelope, consistent with the sibling analytic
-    # gate test_nonuniform_cavity_accuracy.py (2.66% @ dx=1mm, gated 4%). The old
+    # Resolution-honest gate. The ~2.54% this comment was written around, and the
+    # "one-cell effective-a registration effect" it attributed it to, were the
+    # #562 grid defect: the NU builder realized every axis one cell short of the
+    # requested domain. Post-fix this script measures 0.0144% against the 3.5%
+    # gate below (243x loose), and the sibling analytic gate moved 2.66% -> 0.025%
+    # with its gate re-derived to 0.04% (#573). Re-deriving THIS gate from a fresh
+    # envelope is the obvious follow-up; the numbers below are kept as the
+    # historical record of what the defect-era measurement was, not as current
+    # values. Corroborated then by zero-padded-FFT + parabolic-peak ~2.55-2.58%
+    # (the exact secondary number is window/pad-factor dependent). The old
     # "1%" gate was luck: the true 5.433 GHz peak snapped down into the 5.298 GHz
     # bin (0.03%). 3.5% = measured 2.54% + margin; harminv resolves <0.05% so this
     # now actually binds a real regression, unlike the ±5% argmax window (#396).

--- a/scripts/stage1_nu_cavity_physics_gate.py
+++ b/scripts/stage1_nu_cavity_physics_gate.py
@@ -156,7 +156,10 @@ def run_gate() -> Stage1NUGateResult:
     # (the exact secondary number is window/pad-factor dependent). The old
     # "1%" gate was luck: the true 5.433 GHz peak snapped down into the 5.298 GHz
     # bin (0.03%). 3.5% = measured 2.54% + margin; harminv resolves <0.05% so this
-    # now actually binds a real regression, unlike the ±5% argmax window (#396).
+    # now actually binds a real regression, unlike the ±5% argmax window (#396)
+    # — TRUE WHEN WRITTEN, stale now: post-#562 the measured residual is 0.0144%,
+    # so this 3.5% bound is ~243x loose and binds nothing. Re-deriving it from a
+    # fresh envelope is the follow-up this file promises and does not yet have.
     if gate.resonance_error_pct > 3.5:
         raise AssertionError(
             f"resonance error {gate.resonance_error_pct:.3f}% exceeds the "

--- a/tests/test_nonuniform_cavity_accuracy.py
+++ b/tests/test_nonuniform_cavity_accuracy.py
@@ -41,8 +41,8 @@ after the missing bounding node was restored, **TM111 error 2.66% -> 0.025%**
 (same geometry, same 4:1 grading, same harminv extraction) — the remainder is
 coarse-mesh dispersion, which is what the gate was meant to bound in the first
 place. The 4% gate below is therefore now ~160x looser than the measured
-residual; tightening it is a separate, evidence-first decision (it must be
-re-measured across resolutions before being pinned, not simply divided down).
+residual; this PR makes that tightening, re-measured across resolutions and
+grading ratios first rather than divided down (see the gate block in the body).
 """
 
 from __future__ import annotations

--- a/tests/test_nonuniform_cavity_accuracy.py
+++ b/tests/test_nonuniform_cavity_accuracy.py
@@ -174,6 +174,22 @@ def test_nonuniform_z_graded_cavity_tm111_accuracy():
     #                                              re-parameterize to 2 mm
     #                                              without re-deriving the gate
     #
+    # Domain-SIZE sensitivity, measured by the #573 reviewer at fixed dx and
+    # fixed 4:1 grading while sweeping cavity size (z, percent error):
+    #
+    #     0.0373 / 0.0306 / 0.0252 / 0.0264 / 0.0213
+    #
+    # The residual tracks f0, so the gate binds the dispersion floor rather than
+    # a fixture artifact — but the worst case is inside the gate, so the
+    # "do NOT re-parameterize without re-deriving" warning covers cavity SIZE as
+    # well as dx.
+    #
+    # Harminv window sensitivity, same source: over n_steps in {4k, 8k, 12k, 16k}
+    # the error spans 0.0071 pt (xy) / 0.0110 pt (z), and the committed 8000-step
+    # point is each family's MAXIMUM — so the envelope already covers estimator
+    # scatter by construction rather than by luck. z's margin over that scatter
+    # is ~1.35x, which makes z the more fragile of the two gates.
+    #
     # The envelope is taken at THIS configuration, not over the scan: the test
     # runs one configuration, so the gate is a regression lock on it and the
     # neighbours are evidence. Both cavity tests are `slow`-marked and so run

--- a/tests/test_nonuniform_cavity_accuracy.py
+++ b/tests/test_nonuniform_cavity_accuracy.py
@@ -56,7 +56,10 @@ def test_nonuniform_z_graded_cavity_tm111_accuracy():
     """A genuinely z-graded NU mesh reproduces the closed-form TM111 cavity
     resonance to within a measured tolerance.
 
-    Gate: |f_sim - f_analytic(actual d)| / f_analytic < 4% (measured 2.66% on a
+    Gate: |f_sim - f_analytic(actual d)| / f_analytic < 0.04%, DERIVED from the
+    measured envelope via the shared envelope multiplier (see the gate block in
+    the body for the scan and the reasoning). It was < 4% while the #562 extent
+    defect dominated the residual (measured 2.66% on a
     0.25mm fine band / dx=1mm air cavity, 2026-06-18; ~1.5x margin for cross-
     machine float). Mode-ID is robust: TM111 sits >1 GHz from its nearest sim
     neighbour (measured 1.08 GHz), so the nearest-to-analytic match is unambiguous.
@@ -152,8 +155,59 @@ def test_nonuniform_z_graded_cavity_tm111_accuracy():
 
     # The ANALYTIC accuracy gate (the gap this test fills): the z-graded NU mesh
     # reproduces the z-DEPENDENT closed-form TM111 to within the measured tolerance.
-    assert err < 0.04, (
-        f"NU-graded TM111 error {err*100:.3f}% >= 4% — the non-uniform grid does "
-        f"not reproduce the closed-form z-dependent cavity resonance "
+    # DERIVED gate: measured envelope x the repo-wide envelope multiplier,
+    # quantized up by the shared helper (#528/#539), in percent units.
+    # Envelope 0.0252 % at this test's configuration -> 0.04 %.
+    #
+    # It was 4 % until #562 removed the one-cell z-extent defect that dominated
+    # the residual (2.66 % -> 0.025 %, ~106x). A 4 % gate on a 0.025 % residual
+    # is 160x loose — it could not catch the defect class it exists for.
+    #
+    # Measured surrounding sensitivity (single machine; percent error of TM111
+    # vs the closed form):
+    #
+    #     dx = 1.0 mm, grading 4:1  ->  0.0252   <- this test
+    #     dx = 1.0 mm, grading 2:1  ->  0.0164
+    #     dx = 1.0 mm, uniform      ->  0.0011
+    #     dx = 0.5 mm, grading 4:1  ->  0.0032
+    #     dx = 2.0 mm, grading 4:1  ->  1.2567   <- 50x worse; do NOT
+    #                                              re-parameterize to 2 mm
+    #                                              without re-deriving the gate
+    #
+    # The envelope is taken at THIS configuration, not over the scan: the test
+    # runs one configuration, so the gate is a regression lock on it and the
+    # neighbours are evidence. Both cavity tests are `slow`-marked and so run
+    # only in the weekly slow lane; the envelope is therefore single-machine.
+    # If another runner reds, re-measure and widen with the new datum recorded
+    # — do not blanket-loosen.
+    from tests._gate_policy import gate_from_envelope
+    _MEASURED_ENVELOPE_PCT = 0.0252
+    GATE = gate_from_envelope(_MEASURED_ENVELOPE_PCT, quantum=100) / 100.0
+
+    # In-test FALSIFIER, added with the tightening: a gate is worth only what it
+    # rejects. +-0.5 % is 12x the new gate and 8x BELOW the old one, so this
+    # demonstrates discrimination the 4 % gate did not have.
+    _FALSIFIER = 0.005
+    # And the gate must reject the REAL historical regression, not only a
+    # synthetic perturbation: the residual this configuration measured while the
+    # #562 extent defect was live was 2.66 %, which the new gate rejects
+    # by 66x. The old gate accepted it.
+    assert 0.0266 > GATE, (
+        "the derived gate would NOT have caught the #562-era residual "
+        f"(2.66 % vs gate {GATE*100:.3f} %) — tightening bought nothing")
+
+    for _sign in (+1.0, -1.0):
+        _f_wrong = f_tm111 * (1.0 + _sign * _FALSIFIER)
+        _err_wrong = abs(f_sim - _f_wrong) / _f_wrong
+        assert _err_wrong > GATE, (
+            f"falsifier failed: a {_sign*_FALSIFIER*100:+.2f}% frequency error "
+            f"(anchor {_f_wrong/1e9:.4f} GHz) gives err {_err_wrong*100:.4f}% "
+            f"which does NOT exceed the {GATE*100:.3f}% gate"
+        )
+
+    assert err < GATE, (
+        f"NU-graded TM111 error {err*100:.4f}% >= {GATE*100:.3f}% — the "
+        f"non-uniform grid does not reproduce the closed-form z-dependent "
+        f"cavity resonance "
         f"(f_sim={f_sim/1e9:.4f} vs analytic={f_tm111/1e9:.4f} GHz)"
     )

--- a/tests/test_nonuniform_cavity_accuracy.py
+++ b/tests/test_nonuniform_cavity_accuracy.py
@@ -66,9 +66,9 @@ def test_nonuniform_z_graded_cavity_tm111_accuracy():
 
     LEVERAGE (honest power of this gate): the graded-z (p=1) term contributes only
     ~29% of f^2 here (the (1/d)^2 term vs (1/a)^2+(1/b)^2), so f's sensitivity to the
-    graded-z extent is diluted ~sqrt. This gate therefore catches GROSS graded-z
-    metric errors (an effective-d wrong by more than ~12-17% would trip 4%), NOT
-    sub-percent ones — sub-percent graded-stencil correctness is the job of the
+    graded-z extent is diluted ~sqrt. Even so, at the 0.04% gate this catches
+    sub-percent graded-z metric errors (an effective-d wrong by ~0.14% =
+    0.04/0.2884 already trips it) — graded-STENCIL correctness is the job of the
     CORE-C2 per-stencil guard (test_review_tier1_validation_battery.py::test_corec2_*).
     This test's role is the end-to-end full-FDTD analytic anchor the oracle-free
     sibling lacks, not a high-resolution stencil probe.

--- a/tests/test_nonuniform_xy_cavity_accuracy.py
+++ b/tests/test_nonuniform_xy_cavity_accuracy.py
@@ -286,8 +286,9 @@ def test_nonuniform_xy_graded_cavity_tm110_accuracy():
 
     # The ANALYTIC accuracy gate (the coverage #403 flags as missing): the x&y
     # graded NU mesh reproduces the closed-form in-plane-dependent TM110 to within
-    # the measured tolerance. (The grading-faithful finding is now 0.028% graded
-    # against the same ~0.03% class ungraded; the 2.43% == 2.47% pair it used to
+    # the measured tolerance. (The grading-faithful finding is 0.0282% graded vs
+    # 0.0084% ungraded at identical extents — factor 3.35x, grading DOMINANT, as
+    # measured at :48-50; the 2.43% == 2.47% pair it used to
     # cite was the #562-era baseline both legs shared.)
     assert err < GATE, (
         f"NU in-plane-graded TM110 error {err*100:.4f}% >= {GATE*100:.3f}% — the "

--- a/tests/test_nonuniform_xy_cavity_accuracy.py
+++ b/tests/test_nonuniform_xy_cavity_accuracy.py
@@ -65,8 +65,11 @@ it is a separate, evidence-first decision.
 LEVERAGE (honest power of this gate): because TM110's frequency is set 100% by the
 graded in-plane extents, this gate catches graded-metric errors on x/y directly
 (no sqrt-dilution). It is a full-FDTD end-to-end analytic anchor — the coverage
-the #403 blind-spot lacked — not a sub-percent stencil probe (that is the CORE-C2
-per-stencil guard's job, test_review_tier1_validation_battery.py::test_corec2_*).
+the #403 blind-spot lacked. Since the gate became 0.05% it IS a sub-percent
+probe: an effective-extent error of roughly 0.12-0.17% now trips it, where the
+3.5% gate needed 12-17%. (The per-stencil CORE-C2 guard,
+test_review_tier1_validation_battery.py::test_corec2_*, still covers the
+stencil-level question this end-to-end test cannot isolate.)
 """
 
 from __future__ import annotations
@@ -80,12 +83,17 @@ def test_nonuniform_xy_graded_cavity_tm110_accuracy():
     """A genuinely x- AND y-graded NU mesh reproduces the closed-form TM110 cavity
     resonance to within a measured tolerance.
 
-    Gate: |f_sim - f_analytic(actual a,b)| / f_analytic < 3.5% (measured 2.43% on a
-    4:1 graded x/y air cavity, main @199aafc 2026-07-20; ~1.44x margin for
-    cross-machine float32 drift, matching the z-sibling's ~1.5x discipline). The
-    error is grading-INVARIANT (uniform-mesh same extents = 2.47%), so the gate
-    bounds the coarse-Yee PEC-extent floor, and a grading regression that corrupted
-    the in-plane metric beyond that floor would trip it.
+    Gate: |f_sim - f_analytic(actual a,b)| / f_analytic < 0.05%, DERIVED from the
+    measured envelope via the shared envelope multiplier (see the gate block in
+    the body for the scan, the reasoning, and the limits). It was < 3.5% while
+    the #562 one-cell extent defect dominated the residual (2.43% then, 0.028%
+    now — an ~87x improvement on unchanged geometry).
+
+    The error remains grading-INVARIANT, which is the finding this test exists
+    for. What it bounds is the coarse-mesh DISPERSION floor: the "coarse-Yee
+    PEC-extent floor" this paragraph used to name was the #562 grid defect, and
+    the module docstring above withdraws that attribution — both legs of the
+    2.43% == 2.47% comparison had gone through the NU builder.
 
     Mode-ID is robust: TM110 sits >2.5 GHz from its nearest Ez-coupling neighbour
     (TM210), so the nearest-to-analytic match is unambiguous. The separation gate
@@ -93,7 +101,9 @@ def test_nonuniform_xy_graded_cavity_tm110_accuracy():
     would shrink the separation and trip it.
 
     Discrimination is proven IN-TEST (not asserted by construction): a solver or
-    analytic wrong by +/-10% is shown to trip the accuracy gate. Anti-vacuity is
+    analytic wrong by +/-0.5% is shown to trip the accuracy gate (it was +/-10%
+    against the old 3.5% gate; +/-10% would clear a 0.05% gate by 200x and prove
+    nothing about it). Anti-vacuity is
     enforced by a genuine-grading assert (max/min cell ratio > 2 on both in-plane
     axes) — verified externally that a near-uniform profile (ratio 1.11) FAILS it,
     so the gate cannot silently degrade into a uniform-mesh check.
@@ -207,6 +217,22 @@ def test_nonuniform_xy_graded_cavity_tm110_accuracy():
     #     dx = 0.5 mm, grading 4:1  ->  0.0458   (fixed n_steps = shorter record)
     #     dx = 2.0 mm, grading 4:1  ->  0.0868
     #
+    # Domain-SIZE sensitivity, measured by the #573 reviewer at fixed dx and
+    # fixed 4:1 grading while sweeping cavity size (xy, percent error):
+    #
+    #     0.0489 / 0.0390 / 0.0282 / 0.0139 / 0.0203
+    #
+    # The residual tracks f0, so the gate binds the dispersion floor rather than
+    # a fixture artifact — but the worst case is 97.8% of the gate, so the
+    # "do NOT re-parameterize without re-deriving" warning covers cavity SIZE as
+    # well as dx.
+    #
+    # Harminv window sensitivity, same source: over n_steps in {4k, 8k, 12k, 16k}
+    # the error spans 0.0071 pt (xy) / 0.0110 pt (z), and the committed 8000-step
+    # point is each family's MAXIMUM — so the envelope already covers estimator
+    # scatter by construction rather than by luck. z's margin over that scatter
+    # is ~1.35x, which makes z the more fragile of the two gates.
+    #
     # The envelope is deliberately taken at THIS configuration rather than over
     # the whole scan: the test only ever runs this one, so the gate is a
     # regression lock on it, and the neighbours are recorded as evidence rather
@@ -243,7 +269,9 @@ def test_nonuniform_xy_graded_cavity_tm110_accuracy():
 
     # The ANALYTIC accuracy gate (the coverage #403 flags as missing): the x&y
     # graded NU mesh reproduces the closed-form in-plane-dependent TM110 to within
-    # the measured tolerance (2.43% graded == 2.47% uniform -> grading faithful).
+    # the measured tolerance. (The grading-faithful finding is now 0.028% graded
+    # against the same ~0.03% class ungraded; the 2.43% == 2.47% pair it used to
+    # cite was the #562-era baseline both legs shared.)
     assert err < GATE, (
         f"NU in-plane-graded TM110 error {err*100:.4f}% >= {GATE*100:.3f}% — the "
         f"non-uniform x/y grid does not reproduce the closed-form cavity resonance "

--- a/tests/test_nonuniform_xy_cavity_accuracy.py
+++ b/tests/test_nonuniform_xy_cavity_accuracy.py
@@ -38,13 +38,24 @@ proved argmax gates are FFT-bin-blind, harminv resolves <0.05%):
     8000/12000/16000 steps; the mode is high-Q clean).
   * UNIFORM mesh, SAME extents (grading OFF): TM110 signed error **+2.47%**.
 
-The +2.4% bias is therefore NOT introduced by grading — it is present, to within
-0.04 pt, on the ungraded profile of the same coarse resolution. **The POSITIVE
-finding stands and is why this comparison was worth making: in-plane
-``dx_profile`` / ``dy_profile`` grading is faithful — it does not corrupt the
-resonance beyond the shared baseline.** Convergence direction (independent
-evidence the agreement is genuine): the error is dominated by the coarse 1mm
-bulk, not the 0.25mm fine band.
+The +2.4% bias was therefore NOT introduced by grading — it was present, to
+within 0.04 pt, on the ungraded profile of the same coarse resolution. That
+comparison was worth making, but read it for what it shows: **both legs shared a
+baseline that #562 dominated**, so it established that grading did not ADD to a
+2.4% defect, not that grading is free.
+
+With the defect gone the same comparison resolves the real grading term, measured
+at IDENTICAL extents on this harness: **graded 4:1 = 0.0282%, ungraded = 0.0084%
+— grading adds ~0.02 pt, a factor 3.35x above the uniform floor.** So grading is
+now the DOMINANT contribution rather than a null effect; both numbers remain
+negligible against the 0.05% gate, which is the honest form of the original
+claim. (Caveat checked, not assumed: matching the graded extents forces uniform
+cells of 1.0083/1.0096 mm, +0.83%/+0.96% over the nominal 1 mm — far too small to
+account for 3.35x. Corroborating points at the ~0.01% floor: the round-1 uniform
+leg 0.0108% and #564's committed -0.007%.)
+
+Convergence direction (independent evidence the agreement is genuine): the error
+is dominated by the coarse 1mm bulk, not the 0.25mm fine band.
 
 WHAT THAT SHARED BASELINE ACTUALLY WAS — correction (#562, 2026-08-04). This
 docstring attributed the +2.4% to "the standard coarse-Yee PEC-cavity
@@ -59,15 +70,21 @@ TM110 by harminv), before the fix: uniform builder **-0.007%**, NU builder
 built — both solvers were accurate; only one built the requested cavity). After
 restoring the bounding node the two builders are bit-identical on an identical
 mesh, and THIS test reads **0.028%** (was 2.43%) on the same graded geometry.
-The 3.5% gate below is now ~125x looser than the measured residual; tightening
-it is a separate, evidence-first decision.
+That left the then-3.5% gate ~125x looser than the measured residual; this PR
+makes the tightening, deriving 0.05% from the measured envelope (see the gate
+block in the body).
 
 LEVERAGE (honest power of this gate): because TM110's frequency is set 100% by the
 graded in-plane extents, this gate catches graded-metric errors on x/y directly
 (no sqrt-dilution). It is a full-FDTD end-to-end analytic anchor — the coverage
 the #403 blind-spot lacked. Since the gate became 0.05% it IS a sub-percent
-probe: an effective-extent error of roughly 0.12-0.17% now trips it, where the
-3.5% gate needed 12-17%. (The per-stencil CORE-C2 guard,
+probe, and because there is no dilution here the numbers follow the gate almost
+directly: TM110's f^2 shares are 0.4296 (a-axis) and 0.5704 (b-axis), so tripping
+0.05% takes an effective-extent error of 0.05% (both axes together) to 0.12%
+(a-axis alone), where the old 3.5% gate needed 3.5-8.1%. (An earlier revision of
+this paragraph imported the z-sibling's sqrt-diluted 12-17% figure into this
+file, two sentences after asserting there is no dilution, and rescaled it by the
+z gate's ratio — corrected here from the closed form.) (The per-stencil CORE-C2 guard,
 test_review_tier1_validation_battery.py::test_corec2_*, still covers the
 stencil-level question this end-to-end test cannot isolate.)
 """

--- a/tests/test_nonuniform_xy_cavity_accuracy.py
+++ b/tests/test_nonuniform_xy_cavity_accuracy.py
@@ -188,25 +188,64 @@ def test_nonuniform_xy_graded_cavity_tm110_accuracy():
     print(f"[NU-xy-cavity] TM110 f_sim={f_sim/1e9:.4f} GHz, err={err*100:.3f}% "
           f"(2nd-nearest delta {d_second/1e9:.3f} GHz, sep ratio {d_second/d_near:.1f}x)")
 
-    # In-test FALSIFIER (proves the gate has discrimination power, not vacuous):
-    # a solver/analytic wrong by +/-10% MUST trip the accuracy gate. +/-10% clears
-    # the gate (3.5%) plus the base +2.4% bias in either sign, so both directions
-    # fail unambiguously (measured: +10% -> 6.9% err, -10% -> 13.8% err).
-    GATE = 0.035
+    # The gate is DERIVED, not chosen: measured envelope x the repo-wide
+    # envelope multiplier, quantized up by the shared helper (#528/#539), in
+    # percent units. Envelope = 0.0282 % measured at this test's own
+    # configuration; gate_from_envelope(0.0282, quantum=100) = 0.05 %.
+    #
+    # It was 3.5 % until #562 removed the one-cell extent defect that dominated
+    # the residual (2.43 % -> 0.028 %, an ~87x improvement on unchanged
+    # geometry). A 3.5 % gate on a 0.028 % residual could not catch the defect
+    # class it exists for — a 125x-loose gate is a formality.
+    #
+    # Measured surrounding sensitivity (single machine, this configuration and
+    # four neighbours; percent error of TM110 vs the closed form):
+    #
+    #     dx = 1.0 mm, grading 4:1  ->  0.0282   <- this test
+    #     dx = 1.0 mm, grading 2:1  ->  0.0224
+    #     dx = 1.0 mm, uniform      ->  0.0108
+    #     dx = 0.5 mm, grading 4:1  ->  0.0458   (fixed n_steps = shorter record)
+    #     dx = 2.0 mm, grading 4:1  ->  0.0868
+    #
+    # The envelope is deliberately taken at THIS configuration rather than over
+    # the whole scan: the test only ever runs this one, so the gate is a
+    # regression lock on it, and the neighbours are recorded as evidence rather
+    # than folded into the margin. These cases run only in the weekly slow lane
+    # (both cavity tests are `slow`-marked), so the envelope is single-machine.
+    # If another runner reds, the response is to re-measure and widen with the
+    # new datum recorded — not to blanket-loosen.
+    from tests._gate_policy import gate_from_envelope
+    _MEASURED_ENVELOPE_PCT = 0.0282
+    GATE = gate_from_envelope(_MEASURED_ENVELOPE_PCT, quantum=100) / 100.0
+
+    # In-test FALSIFIER (proves the gate has discrimination power, not vacuous).
+    # The perturbation has to scale with the gate: +/-10 % proved nothing about
+    # a 0.05 % gate, since it clears it by 200x. +/-0.5 % is 10x the gate and
+    # still an order of magnitude below the old one — so this now demonstrates
+    # discrimination the 3.5 % gate never had.
+    _FALSIFIER = 0.005
+    # And the gate must reject the REAL historical regression, not only a
+    # synthetic perturbation: the residual this configuration measured while the
+    # #562 extent defect was live was 2.43 %, which the new gate rejects
+    # by 49x. The old gate accepted it.
+    assert 0.0243 > GATE, (
+        "the derived gate would NOT have caught the #562-era residual "
+        f"(2.43 % vs gate {GATE*100:.3f} %) — tightening bought nothing")
+
     for sign in (+1.0, -1.0):
-        f_wrong = f_tm110 * (1.0 + sign * 0.10)
+        f_wrong = f_tm110 * (1.0 + sign * _FALSIFIER)
         err_wrong = abs(f_sim - f_wrong) / f_wrong
         assert err_wrong > GATE, (
-            f"falsifier failed: a {sign*10:+.0f}% frequency error (anchor "
-            f"{f_wrong/1e9:.4f} GHz) gives err {err_wrong*100:.3f}% which does NOT "
-            f"exceed the {GATE*100:.1f}% gate — the gate would not catch it"
+            f"falsifier failed: a {sign*_FALSIFIER*100:+.2f}% frequency error "
+            f"(anchor {f_wrong/1e9:.4f} GHz) gives err {err_wrong*100:.4f}% which "
+            f"does NOT exceed the {GATE*100:.3f}% gate — the gate would not catch it"
         )
 
     # The ANALYTIC accuracy gate (the coverage #403 flags as missing): the x&y
     # graded NU mesh reproduces the closed-form in-plane-dependent TM110 to within
     # the measured tolerance (2.43% graded == 2.47% uniform -> grading faithful).
     assert err < GATE, (
-        f"NU in-plane-graded TM110 error {err*100:.3f}% >= {GATE*100:.1f}% — the "
+        f"NU in-plane-graded TM110 error {err*100:.4f}% >= {GATE*100:.3f}% — the "
         f"non-uniform x/y grid does not reproduce the closed-form cavity resonance "
         f"whose frequency is set by the graded in-plane extents "
         f"(f_sim={f_sim/1e9:.4f} vs analytic={f_tm110/1e9:.4f} GHz)"

--- a/validation/research/nu_cavity_gates/nu_cavity_gate_scan.py
+++ b/validation/research/nu_cavity_gates/nu_cavity_gate_scan.py
@@ -2,15 +2,21 @@
 
 The #573 review noted that the scan numbers had become load-bearing in three
 committed files with no committed artifact behind them. This script reproduces
-every one of them, so the gates' basis is auditable rather than quoted:
+the xy-lane scans (nine values), so that gate's basis is auditable rather than
+quoted:
 
-  * resolution / grading scan  -> the per-configuration envelope each gate uses
-  * domain-size scan           -> that the residual tracks f0 (dispersion floor)
-  * harminv window scan        -> that the committed 8000-step point is the
-                                  family maximum, so the envelope covers
-                                  estimator scatter by construction
+  * xy resolution / grading scan -> the per-configuration envelope the xy gate
+                                    uses (5 points)
+  * xy harminv window scan       -> that the committed 8000-step point is the
+                                    family maximum, so the envelope covers
+                                    estimator scatter by construction (4 points)
   * graded-vs-ungraded at IDENTICAL extents -> the grading term itself
-                                  (0.0282% vs 0.0084%, factor 3.35x)
+                                    (0.0282% vs 0.0084%, factor 3.35x)
+
+NOT reproduced here (reviewer-measured, no committed producer yet): the
+domain-size sweeps quoted in both gate blocks, and every z-lane number
+(z resolution scan, z harminv span). Issue #596 tracks committing a producer
+for those.
 
 Research-lane script: no gate, no fixture. Run it to re-derive, not in CI.
 

--- a/validation/research/nu_cavity_gates/nu_cavity_gate_scan.py
+++ b/validation/research/nu_cavity_gates/nu_cavity_gate_scan.py
@@ -1,0 +1,107 @@
+"""Committed record of the scans the two NU cavity gates are derived from.
+
+The #573 review noted that the scan numbers had become load-bearing in three
+committed files with no committed artifact behind them. This script reproduces
+every one of them, so the gates' basis is auditable rather than quoted:
+
+  * resolution / grading scan  -> the per-configuration envelope each gate uses
+  * domain-size scan           -> that the residual tracks f0 (dispersion floor)
+  * harminv window scan        -> that the committed 8000-step point is the
+                                  family maximum, so the envelope covers
+                                  estimator scatter by construction
+  * graded-vs-ungraded at IDENTICAL extents -> the grading term itself
+                                  (0.0282% vs 0.0084%, factor 3.35x)
+
+Research-lane script: no gate, no fixture. Run it to re-derive, not in CI.
+
+    python validation/research/nu_cavity_gates/nu_cavity_gate_scan.py [--quick]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import numpy as np
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO = os.path.abspath(os.path.join(_HERE, "..", "..", ".."))
+sys.path.insert(0, _REPO)
+
+from rfx import GaussianPulse, Simulation  # noqa: E402
+from rfx.auto_config import smooth_grading  # noqa: E402
+from rfx.grid import C0  # noqa: E402
+
+
+def _graded(coarse_mm: float, fine_mm: float, dx: float, fine: float) -> list[float]:
+    n_c = int(round(coarse_mm * 1e-3 / dx))
+    n_f = int(round(fine_mm * 1e-3 / fine))
+    return list(smooth_grading([dx] * n_c + [fine] * n_f + [dx] * n_c, max_ratio=1.3))
+
+
+def _tm110_error(dx_prof, dy_prof, dz_prof, dx_boundary, steps=8000) -> float:
+    a = float(np.sum(dx_prof))
+    b = float(np.sum(dy_prof))
+    d = float(np.sum(dz_prof))
+    f = (C0 / 2) * np.sqrt((1 / a) ** 2 + (1 / b) ** 2)
+    sim = Simulation(freq_max=2 * f, domain=(0, 0, 0), boundary="pec",
+                     dx=dx_boundary, dx_profile=np.asarray(dx_prof),
+                     dy_profile=np.asarray(dy_prof), dz_profile=np.asarray(dz_prof))
+    sim.add_source((a / 3, b / 3, d / 2), "ez",
+                   waveform=GaussianPulse(f0=f, bandwidth=0.8))
+    sim.add_probe((2 * a / 3, 2 * b / 3, d / 2), "ez")
+    res = sim.run(n_steps=steps, skip_preflight=True)
+    modes = sorted((m.freq for m in res.find_resonances(
+        freq_range=(0.6 * f, 1.5 * f))), key=lambda v: abs(v - f))
+    if not modes:
+        return float("nan")
+    return abs(modes[0] - f) / f * 100.0
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--quick", action="store_true",
+                    help="the two committed-envelope points only")
+    args = ap.parse_args(argv)
+
+    dx, fine = 1e-3, 0.25e-3
+    dxp = _graded(19.0, 2.0, dx, fine)
+    dyp = _graded(16.0, 2.0, dx, fine)
+    dzp = [dx] * 10
+    a, b = float(np.sum(dxp)), float(np.sum(dyp))
+
+    print(f"xy extents a={a * 1e3:.4f} b={b * 1e3:.4f} mm")
+    e_graded = _tm110_error(dxp, dyp, dzp, dx)
+    print(f"  graded 4:1 (the committed configuration) : {e_graded:.4f} %"
+          "   <- xy envelope")
+
+    nx, ny = int(round(a / dx)), int(round(b / dx))
+    cx, cy = a / nx, b / ny
+    e_uniform = _tm110_error(np.full(nx, cx), np.full(ny, cy), dzp, cx)
+    print(f"  UNGRADED at identical extents            : {e_uniform:.4f} %"
+          f"   (cells {cx * 1e3:.4f}/{cy * 1e3:.4f} mm, "
+          f"{(cx / dx - 1) * 100:+.2f}%/{(cy / dx - 1) * 100:+.2f}% vs 1 mm)")
+    print(f"  -> grading adds {e_graded - e_uniform:+.4f} pt, "
+          f"factor {e_graded / max(e_uniform, 1e-12):.2f}x above the uniform floor")
+
+    if args.quick:
+        return 0
+
+    print("\nresolution / grading scan (xy):")
+    for dx_mm, ratio in ((1.0, 4), (1.0, 2), (1.0, 1), (0.5, 4), (2.0, 4)):
+        d_ = dx_mm * 1e-3
+        f_ = d_ / ratio if ratio > 1 else d_
+        e = _tm110_error(_graded(19.0, 2.0, d_, f_), _graded(16.0, 2.0, d_, f_),
+                         [d_] * 10, d_)
+        print(f"  dx {dx_mm:.2f} mm, grading {ratio}:1 -> {e:.4f} %")
+
+    print("\nharminv window scan (xy, committed configuration):")
+    for steps in (4000, 8000, 12000, 16000):
+        print(f"  n_steps {steps:6d} -> {_tm110_error(dxp, dyp, dzp, dx, steps):.4f} %")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Follow-up to #562, and the "evidence-first decision" I explicitly deferred out of PR #564 rather than doing silently in it.

## Why

Both gates were set while #562's one-cell extent defect dominated their residuals. With it gone they are formalities:

| test | residual now | gate | ratio |
|---|---|---|---|
| `test_nonuniform_xy_cavity_accuracy` (TM110, x&y graded) | 0.028 % | 3.5 % | **125x loose** |
| `test_nonuniform_cavity_accuracy` (TM111, z graded) | 0.025 % | 4 % | **160x loose** |

#562 itself sat inside both of them. A gate that cannot catch the defect class it exists for is a formality.

## Tightened by measurement, not by division

Scanned each test's configuration plus four neighbours (single machine; percent error vs the closed form):

| configuration | xy TM110 | z TM111 |
|---|---|---|
| dx 1.0 mm, grading 4:1 | **0.0282** ← this test | **0.0252** ← this test |
| dx 1.0 mm, grading 2:1 | 0.0224 | 0.0164 |
| dx 1.0 mm, uniform | 0.0108 | 0.0011 |
| dx 0.5 mm, grading 4:1 | 0.0458 | 0.0032 |
| dx 2.0 mm, grading 4:1 | 0.0868 | **1.2567** ← 50x worse |

The envelope is taken at each test's **own** configuration rather than over the scan: each test runs exactly one configuration, so its gate is a regression lock on that one, and the neighbours belong in the record as evidence rather than folded into the margin. The dx = 2 mm z-case datum is kept as an explicit warning against re-parameterizing to 2 mm without re-deriving.

Gate = `gate_from_envelope(envelope_pct, quantum=100)` in percent units — the repo-wide multiplier and quantization from #528/#539, not a fresh local literal. Result: **0.05 %** (xy) and **0.04 %** (z).

## Two checks make the tightening mean something

- **Falsifier retargeted** from ±10 % to ±0.5 %. ±10 % cleared a 0.05 % gate by 200x and proved nothing about it; ±0.5 % is ~10x the new gate and 8x *below* the old one, so it demonstrates discrimination neither gate previously had.
- **A new assertion requires the gate to reject the real historical residual** (2.43 % / 2.66 %, measured while #562 was live), not just a synthetic perturbation. Both rejected by 49–66x; the old gates accepted them.

## Honest limits, stated in both gate blocks

Both cavity tests are `slow`-marked, so they run only in the weekly slow lane and this envelope is single-machine. If another runner reds, the response is to re-measure and widen with the new datum recorded — not to blanket-loosen.

Measured after the change: xy 0.028 % against 0.05 %, z 0.025 % against 0.04 %.

R3: memory=evidence-first gate changes — I flagged this tightening as a separate decision when #562 landed instead of bundling it, and this is that decision with the scan attached; the envelope choice (per-configuration, not per-scan) is stated explicitly so a reviewer can disagree with the reasoning rather than only with the number

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round 1 — both mandate runs recorded, blocking prose cleared (`dec14f0`)

The reviewer ran the two checks this PR should have carried and both land in its favour. Recording them here as the mandate requires:

**1. Planted-defect falsifier** (production-only mutation: `rfx.nonuniform._append_bounding_node` → identity and `interior_cells` → the old slice, test files untouched):

| test | measured error | gate | margin |
|---|---|---|---|
| xy TM110 | **2.4257 %** | 0.05 % | **48.5×** |
| z TM111 | **2.6584 %** | 0.04 % | **66.5×** |

So the tightened gates do catch the #562 defect class, and this independently validates the 2.43 % / 2.66 % literals the historical-rejection assertions are built on — which is exactly the "arithmetic guard vs demonstrated catch" gap the Codex pass also flagged.

**2. Domain-size invariance** (fixed dx = 1 mm, fixed 4:1 grading, cavity size swept): xy 0.0489 / 0.0390 / 0.0282 / 0.0139 / 0.0203 %, z 0.0373 / 0.0306 / 0.0252 / 0.0264 / 0.0213 %. The residual tracks f₀, i.e. the gate binds the dispersion floor rather than a fixture artifact. **Caveat taken:** the xy worst case is 97.8 % of the gate, so the "do NOT re-parameterize without re-deriving" warning now covers cavity **size**, not only dx.

**3. Harminv window sensitivity** (non-blocking, folded in): over n_steps ∈ {4k, 8k, 12k, 16k} the error spans 0.0071 pt (xy) / 0.0110 pt (z), and the committed 8000-step point is each family's **maximum** — so the envelope covers estimator scatter by construction rather than by luck. z's margin over that scatter is ~1.35×, making z the more fragile gate; both facts are now in the gate blocks.

**Blocking prose fixed.** The xy test's own docstring still stated `< 3.5% (measured 2.43% …)` — 70× wrong — and re-asserted the "coarse-Yee PEC-extent floor" attribution that the same file's module docstring withdraws. Rewritten to mirror the z form. Four more stale sites went with it: the LEVERAGE paragraph understated the gate's reach by 100×; the falsifier prose still advertised ±10%; the 2.43 % == 2.47 % pair was cited as current; and `scripts/stage1_nu_cavity_physics_gate.py` cross-referenced "2.66 % @ 4 %" twice while attributing its own residual to a "one-cell effective-a registration effect" — the #562 defect under another name. That script now records its own post-fix measurement (**0.0144 % against an unchanged 3.5 % gate, 243× loose**) with the re-derivation flagged as a follow-up.

**Open question acknowledged:** there is still no post-#562 CI datapoint for either test (slow-marked; the weekly lane last ran 16 commits before the fix; first exposure 2026-08-10). The in-file instruction — re-measure and widen with the new datum recorded, never blanket-loosen — stands as the fallback, and a single VESSL GPU-lane run would convert the cross-platform question from unknown to known if you want it before merge rather than after.

R3: memory=the two mandate runs above were the reviewer's, not mine — recorded verbatim with their margins because a gate PR that cannot show its own falsifier is asking to be trusted rather than checked | R2-attempts=0 | falsifier=replant #562 in rfx.nonuniform → gates red 48.5×/66.5×


---

## Review rounds 2–3 — fix-round errors corrected, scan producer committed, claims narrowed (`b2046b9`, `3af5e83`)

**Round 2 (`b2046b9`)** corrected two numbers the round-1 fix itself introduced and committed the scan producer (`validation/research/nu_cavity_gates/nu_cavity_gate_scan.py`) so the load-bearing scan values re-derive from an artifact instead of being quoted. A correction to the round-1 narration above: the round-1 LEVERAGE edit this body credits was itself wrong — it imported the z-sibling's sqrt-diluted figure into the xy file two sentences after asserting there is no dilution there. The xy paragraph now derives from its own closed form (f² shares 0.4296/0.5704 → an effective-extent error of 0.05–0.12 % trips the 0.05 % gate, vs 3.5–8.1 % for the old gate). The durable lesson, from the round-3 commit: **verify WHICH file a number belongs to before rewriting it** — the correct z number written into the xy file is still a wrong sentence.

**Round 3 (`3af5e83`)** closed the two residual one-liners round 3 held the merge on, both digit-checked against in-file measurements:
- xy `:289` no longer contradicts `:48-50` — the ungraded leg is the measured **0.0084 % (factor 3.35×, grading dominant)**, not "~0.03 % class".
- z `:70` leverage arithmetic re-done for the tightened gate: an effective-d error of **~0.14 % (= 0.04/0.2884)** trips 0.04 %, so the gate now catches **sub-percent** effective-d errors — the inverse of the pre-tightening clause it replaced.
- The scan script's docstring now claims exactly the nine xy-lane values it runs; the domain-size sweeps and all z-lane numbers are explicitly marked producer-less, tracked in **#596** (which also carries the stage1 3.5 %-bound re-derivation the script promises).

Physics, gates, fixtures, and falsifiers: CONFIRMED since round 1, unchanged since.
