### PR TITLE
coax to MSL transition extractor, diagnostic-only (issue 489 leg 4)

### DIFF
--- a/docs/agent/repo-map.mdx
+++ b/docs/agent/repo-map.mdx
@@ -50,7 +50,7 @@ command is verified to return at least one hit on the current tree.
 | Materials / dispersion | `grep "def add_material" rfx/api/__init__.py` | `rfx/materials/` |
 | Boundaries | `grep -rl "cpml\|upml\|pec\|floquet" rfx/boundaries/` | `rfx/boundaries/` |
 | Post-processing (flux, Harminv) | `grep "def flux_spectrum\|def harminv" rfx/probes/probes.py rfx/harminv.py` | `rfx/probes/probes.py`, `rfx/harminv.py` |
-| S-parameters and port-family calculators (high-level, use these first) | `grep -rn "def compute_.*_s_matrix\|def compute_coaxial_line_reflection\|def compute_coaxial_two_port" rfx/api/` | `rfx/api/_sparams.py`, `rfx/ports/` |
+| S-parameters and port-family calculators (high-level, use these first) | `grep -rn "def compute_.*_s_matrix\|def compute_coaxial_line_reflection\|def compute_coaxial_two_port\|def compute_coax_msl_transition" rfx/api/` | `rfx/api/_sparams.py`, `rfx/ports/` |
 | S-parameter low-level helpers | `grep "extract_waveguide_s_matrix\|extract_s_matrix\|extract_s11" rfx/api/__init__.py rfx/probes/probes.py` | `rfx/ports/` |
 
 ## Current port-family caveat
@@ -63,7 +63,11 @@ against is azimuthally symmetric (TM0n only), it has no external referee, and it
 makes no phase claim (see its docstring / `CoaxialTwoPortResult` for the full scope
 limitation). The older `Simulation.compute_coaxial_s_matrix(...)` path remains
 deprecated/experimental and must not be presented as the promoted coaxial claims
-surface.
+surface. For a coax<->microstrip transition, `Simulation.compute_coax_msl_transition(...)`
+(issue #489 leg 4) exists but is **EXPERIMENTAL, DIAGNOSTIC-ONLY**: the one committed
+fixture trips its own pre-declared reciprocity falsifier (see
+`docs/guides/sparameter_support_matrix.md`'s "Coax<->MSL transition" section and
+`tests/test_coax_msl_transition.py`) — do not cite it as a validated transition result.
 
 ## What NOT to do
 

--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -2417,6 +2417,22 @@
       "result",
       "kwargs"
     ],
+    "compute_coax_msl_transition": [
+      "junction_x",
+      "eps_r_sub",
+      "n_steps",
+      "num_periods",
+      "freqs",
+      "n_freqs",
+      "field_scale",
+      "probe_count",
+      "probe_start_cells",
+      "probe_spacing_cells",
+      "feed_impedance",
+      "cond_warn",
+      "strict_passivity",
+      "skip_preflight"
+    ],
     "compute_coaxial_line_reflection": [
       "termination",
       "n_steps",

--- a/docs/guides/sparameter_support_matrix.json
+++ b/docs/guides/sparameter_support_matrix.json
@@ -277,7 +277,7 @@
       "supported_configurations": [
         "3d_float32_second_order_uniform_yee_positive_z_cpml_no_periodic_rf_coaxial_line_reflection_exactly_one_top_face_port"
       ],
-      "validation_status": "The one-port TEM-line reflection API has broad analytic validation over termination, impedance, frequency, and mesh axes plus a broad MEEP short/open comparison. It is differentiable through eps_scale. The older single-plane V/I S-matrix API is deprecated and experimental. compute_coaxial_two_port(...) (issue #489 stage 2) is a separate, EXPERIMENTAL two-drive through-line extension \u2014 not covered by the 1-port evidence above; see its own known_limits entry and tests/test_coax_two_port_fdtd.py.",
+      "validation_status": "The one-port TEM-line reflection API has broad analytic validation over termination, impedance, frequency, and mesh axes plus a broad MEEP short/open comparison. It is differentiable through eps_scale. The older single-plane V/I S-matrix API is deprecated and experimental. compute_coaxial_two_port(...) (issue #489 stage 2) is a separate, EXPERIMENTAL two-drive through-line extension — not covered by the 1-port evidence above; see its own known_limits entry and tests/test_coax_two_port_fdtd.py.",
       "known_limits": [
         "compute_coaxial_line_reflection(...) requires exactly one registered coaxial port with face='top' and no mixed port family",
         "compute_coaxial_line_reflection(...) is not a general multi-port coaxial network solver",
@@ -316,7 +316,7 @@
         "matched single-cell resistor fixture is reported separately with max |Gamma| deviation 0.0929",
         "MEEP short/open comparison over 4--12 GHz: max_mag_abs_diff 0.0628 and mean_mag_abs_diff 0.0235",
         "end-to-end eps_scale AD versus finite difference discrepancy 2.6%",
-        "compute_coaxial_two_port single measured run (60 mm / 40 GHz fixture, 4-12 GHz): |S21|,|S12| 0.74-0.96, |S11|,|S22| <= 0.05, reciprocity within 0.3% magnitude / 0.21 degree phase, cond(A) <= 1.11; a post-hoc consistency check found the |S21| deficit matches the matrix-pencil-fitted exp(-Re(gamma)*L12) to within about 2% at every measured frequency (scale-sensitive, referral-blind \u2014 see the method docstring)"
+        "compute_coaxial_two_port single measured run (60 mm / 40 GHz fixture, 4-12 GHz): |S21|,|S12| 0.74-0.96, |S11|,|S22| <= 0.05, reciprocity within 0.3% magnitude / 0.21 degree phase, cond(A) <= 1.11; a post-hoc consistency check found the |S21| deficit matches the matrix-pencil-fitted exp(-Re(gamma)*L12) to within about 2% at every measured frequency (scale-sensitive, referral-blind — see the method docstring)"
       ],
       "validated_scope": "The self-contained TEM coaxial-line model using the documented Simulation, port, and method arguments, in float32 precision on a three-dimensional, second-order uniform Yee grid with positive CPML on both z faces, cpml_axes='z', CPML tokens on all six BoundarySpec faces, no periodic boundary axes, exactly one face='top' coaxial port, at least three requested probe planes that all fit before the source, and the termination, frequency, characteristic-impedance, and mesh ranges in the committed fixtures. Separately registered geometry, sources, monitors, termination helpers, arbitrary launches, face='bottom', mixed port families, and multi-port networks are outside this result.",
       "caveats": [
@@ -325,7 +325,7 @@
         "MEEP covers short/open; resistive cases are covered by the analytic transmission-line fixture"
       ],
       "ad_traceable": "yes",
-      "ad_evidence": "eps_scale -> FDTD -> DFT plane accumulators -> modal voltage -> matrix-pencil reflection -> Gamma; tests/test_coax_end_to_end_ad.py::test_coax_reflection_grad_finite_and_fd_consistent (compute_coaxial_line_reflection). compute_coaxial_s_matrix (deprecated) is NOT traceable \u2014 concrete numpy extraction, no eps_scale/traced-input channel wired. compute_coaxial_two_port (issue #489 stage 2, experimental) gained the same eps_scale channel: gate compares float32 AD (as shipped) against a float64-loss central finite difference (scoped enable_x64 around the forward call \u2014 the FDTD fields stay float32, same baseline as the MSL f64 referee, but the DFT-accumulator-and-downstream math runs at float64, per rfx/probes/probes.py's jax.config.x64_enabled keying, independent of the precision='float32' pin); measured rel_err 0.51% at h=2e-3 against a 2% gate (tests/test_coax_two_port_ad.py::test_compute_coaxial_two_port_ad_grad_finite_and_fd_consistent; regenerate/extend via scripts/coax_two_port_ad_fd_f64_referee.py), owner-platform (GPU) re-measurement pending. See tests/test_ad_surface_contract.py::AD_CLASSIFICATION for the per-calculator classification this family-level field cannot express."
+      "ad_evidence": "eps_scale -> FDTD -> DFT plane accumulators -> modal voltage -> matrix-pencil reflection -> Gamma; tests/test_coax_end_to_end_ad.py::test_coax_reflection_grad_finite_and_fd_consistent (compute_coaxial_line_reflection). compute_coaxial_s_matrix (deprecated) is NOT traceable — concrete numpy extraction, no eps_scale/traced-input channel wired. compute_coaxial_two_port (issue #489 stage 2, experimental) gained the same eps_scale channel: gate compares float32 AD (as shipped) against a float64-loss central finite difference (scoped enable_x64 around the forward call — the FDTD fields stay float32, same baseline as the MSL f64 referee, but the DFT-accumulator-and-downstream math runs at float64, per rfx/probes/probes.py's jax.config.x64_enabled keying, independent of the precision='float32' pin); measured rel_err 0.51% at h=2e-3 against a 2% gate (tests/test_coax_two_port_ad.py::test_compute_coaxial_two_port_ad_grad_finite_and_fd_consistent; regenerate/extend via scripts/coax_two_port_ad_fd_f64_referee.py), owner-platform (GPU) re-measurement pending. See tests/test_ad_surface_contract.py::AD_CLASSIFICATION for the per-calculator classification this family-level field cannot express."
     },
     {
       "primitive": "add_floquet_port(...)",
@@ -489,8 +489,8 @@
       ],
       "validation_status": "EXPERIMENTAL. Diagonals come from the per-family extractors but are NOT verified on this lane (both the wire port-cell V*I accounting and the MSL analytic-Z0 anchor are open), and the shipped values are additionally rewritten by the passivity projection when the raw matrix is non-passive. off-diagonal MAGNITUDES come from Poynting flux with the incident power normalized as P_net/(1-|S_jj|^2). Internal reciprocity witness measured 9% on the probe-fed MSL fixture (the wave channel measured 55% on the same fixture). NO external-solver referee has been run, so ABSOLUTE magnitude is NOT validated. Off-diagonal PHASE mixes two reference-plane conventions and is provisional. Do not cite this family as validation.",
       "known_limits": [
-        "absolute |S| unvalidated \u2014 openEMS referee pending",
-        "with enforce_passivity=True (default) the returned diagonal is a JOINT SVD-projected value, not the raw per-family measurement \u2014 measured ~4x its unprojected value on the committed test fixture; read S_raw/passivity_correction for what was measured",
+        "absolute |S| unvalidated — openEMS referee pending",
+        "with enforce_passivity=True (default) the returned diagonal is a JOINT SVD-projected value, not the raw per-family measurement — measured ~4x its unprojected value on the committed test fixture; read S_raw/passivity_correction for what was measured",
         "off-diagonal phase provisional (cross-family reference-plane mismatch)",
         "per-column power is an ALGEBRAIC IDENTITY on the flux channel and is not a passivity check; reciprocity is the only independent internal witness",
         "residual reciprocity disagreement traced to a driven-port diagonal; which diagonal is open (issue #313 wire port-cell vs the MSL analytic Z0 anchor)",
@@ -509,7 +509,7 @@
         "reciprocity deviation 9.0% (flux channel) vs 55% (wave channel), probe-fed MSL fixture, dx=63.5um, settling -101/-100 dB",
         "reciprocity witness default tolerance 0.06, set BELOW the 9% reference-fixture residual so that fixture warns rather than passing silently"
       ],
-      "validated_scope": "NONE \u2014 this is a diagnostic CALCULATION over the already-registered lumped/wire and microstrip_line port families, not a new port primitive and not a validated result. It is listed so the matrix does not read as 'mixed families are impossible in rfx', which the per-extractor limits elsewhere in this document would otherwise imply. Those per-extractor statements remain accurate: compute_msl_s_matrix, the lumped/wire scan driver, and the coaxial calculators each still reject foreign port families.",
+      "validated_scope": "NONE — this is a diagnostic CALCULATION over the already-registered lumped/wire and microstrip_line port families, not a new port primitive and not a validated result. It is listed so the matrix does not read as 'mixed families are impossible in rfx', which the per-extractor limits elsewhere in this document would otherwise imply. Those per-extractor statements remain accurate: compute_msl_s_matrix, the lumped/wire scan driver, and the coaxial calculators each still reject foreign port families.",
       "caveats": [
         "quote the preflight output and settling_db with any number from this lane",
         "a green passivity/column-power result here is structurally uninformative"
@@ -533,12 +533,15 @@
         "the junction geometry (ground plane, clearance hole, pin-to-trace post, substrate, trace) is the caller's own registered Box/Cylinder geometry, mirroring compute_mixed_s_matrix's own MSL-DUT delegation",
         "imperative forward path only (no AD channel for this leg)"
       ],
-      "validation_status": "EXPERIMENTAL, DIAGNOSTIC-ONLY. The power-wave cross-family normalization (per-port sqrt(Z0) division before the two-drive solve) is validated by planted-voltage unit tests under UNEQUAL port impedances, independent of any FDTD run. The one committed FDTD fixture is internally self-consistent (finite, deterministic, settles below -40 dB) but trips its own pre-declared reciprocity falsifier: |S12| vs |S21| disagree by 94-100% across the three measured frequencies, with the two-drive solve's cond_a in the 1e3-1e7 range at every bin -- root-caused to near-degenerate two-drive amplification (both ports strongly reflecting their own port), not to the assembler (ruled out by the planted-voltage tests) or a missing-PEC defect (ruled out by direct pec_mask inspection during construction). Do not cite this family as a validated transition.",
+      "validation_status": "EXPERIMENTAL, DIAGNOSTIC-ONLY. The power-wave cross-family normalization (per-port sqrt(Z0) division before the two-drive solve) is validated by planted-voltage unit tests under UNEQUAL port impedances, independent of any FDTD run. The one committed FDTD fixture is internally self-consistent (finite, deterministic, settles below -40 dB) but trips its own pre-declared reciprocity falsifier: |S12| vs |S21| disagree by 94-100% across the three measured frequencies, with the two-drive solve's raw cond_a in the 1e3-1e7 range at every bin. ATTRIBUTION (corrected after adversarial PR #581 review, findings B2/B3 -- the original attribution, 'near-degenerate two-drive amplification from junction reflection', did NOT survive its own data): cond_a_equilibrated (column-equilibrated, invariant to per-drive amplitude scale) is near 1 (1.0004/1.0001/1.0040) with near-ORTHOGONAL incident-wave columns, refuting near-parallelism; |S22| is 0.000/0.000/0.500 (not uniformly near 1), refuting 'both ports strongly reflecting'; the actual signature is a 5-9-order-of-magnitude drive-amplitude mismatch between the two unrelated source constructions (coax TEM plane source vs MSL Ez injection). The PREDECLARED alternative -- an MSL wave-extraction instrument-scoping limit, not junction physics -- is positively supported instead: the MSL probe ladder spans only 0.34%-3.37% of the guided wavelength, and the fitted propagation constant on the MSL array does not track analytic Hammerstad-Jensen beta at all (off by 4-32x, non-monotonic with frequency, and the two drives' own independent fits of the SAME array disagree by 1-2 orders of magnitude). Whether junction reflection ALSO contributes is genuinely UNRESOLVED by this one fixture -- preflight names a third, also-unruled-out candidate (the MSL port sits 200um from its own x-CPML face; 'source-side CPML reflection may inflate |S11|') -- but the extraction-class explanation is the better-supported one and NAMES the implementation defect (probe ladder length) that would justify a future, separately pre-declared retry. Do not cite this family as a validated transition, and do not cite the reciprocity/degeneracy numbers as evidence about coax-to-MSL launch physics in general -- they are dominated by this fixture's own MSL-side instrument scoping.",
       "known_limits": [
         "reciprocity falsifier TRIPPED on the one committed fixture (94-100% deviation) -- locked as a regression/reproducibility witness in tests/test_coax_msl_transition.py, not as a passing accuracy gate",
-        "off-diagonal magnitude on the one fixture is near-zero and unreliable (consistent with the ill-conditioned two-drive solve, see cond_a)",
+        "root cause (corrected after review, PR #581 B2/B3): the MSL probe ladder spans only 0.34%-3.37% of the guided wavelength on this fixture, too short for the matrix-pencil forward/backward split to resolve -- an instrument-scoping limit of the probe geometry, NOT confirmed junction physics and NOT an assembler defect (the power-wave normalization is independently verified correct by the planted-voltage tests) and NOT a missing-PEC defect (independently verified by tests/test_coax_msl_transition.py::test_pin_axis_pec_connectivity_is_continuous)",
+        "raw cond_a (1e3-1e7) is dominated by a 5-9-order-of-magnitude per-drive amplitude-scale mismatch between the coax and MSL source constructions, not geometric near-degeneracy -- see cond_a_equilibrated (near 1) on CoaxMSLTransitionResult",
+        "a third, unruled-out candidate mechanism: preflight flags the MSL port as only 200um from its own x-CPML face (recommended 600um), which could independently contaminate the MSL-side near-field measurement",
+        "off-diagonal magnitude on the one fixture is near-zero and unreliable given the above",
         "the MSL side is extracted via the coax matrix-pencil fit (coaxial_line_reflection_from_plane_voltages) rather than the mixed lane's own N-probe fit, a deliberate deviation made because the coax fit deterministically pins the propagation-constant branch while the N-probe fit's sign is documented as unstable",
-        "preflight on the committed fixture independently flags the same resolution class as the finding: pin-post diameter under the 5-cell PEC-volume floor, 3-cell substrate flagged for >5% Z0 staircase bias, and the substrate gap itself flagged 'coupling may be under-resolved'",
+        "preflight on the committed fixture also flags: pin-post diameter under the 5-cell PEC-volume floor, 3-cell substrate flagged for >5% Z0 staircase bias",
         "no external-solver referee has been run",
         "AD is out of scope for this leg (no eps_scale-style channel)",
         "waveguide, Floquet, TFSF, lumped RLC, and any second coaxial or MSL port are all rejected loudly"
@@ -547,21 +550,25 @@
       "validation_gaps": [
         "no external-solver cross-check",
         "no mesh-convergence study",
-        "single fixture class (vertical coax landing on a grounded substrate edge, thin unmatched pin-to-trace post, no matching structure)",
-        "the one fixture's own reciprocity falsifier is tripped, not passing"
+        "single fixture class (vertical coax landing on a grounded substrate edge, thin unmatched pin-to-trace post, no matching structure, MSL probe ladder far shorter than a usable fraction of a guided wavelength)",
+        "the one fixture's own reciprocity falsifier is tripped, not passing, and the dominant cause is believed to be the probe-ladder instrument scoping rather than the junction -- a longer-ladder retry has not been run"
       ],
       "evidence_artifacts": [
         "tests/test_coax_msl_transition.py"
       ],
       "numeric_metrics": [
         "reciprocity deviation 94-100% across 3 frequencies (0.6/3.3/6.0 GHz), one committed fixture, dx=100um",
-        "cond_a 7.0e4 / 4.6e3 / 4.3e7 at the same 3 frequencies (two-drive solve degeneracy witness)",
+        "cond_a (raw) 7.0e4 / 4.6e3 / 4.3e7; cond_a_equilibrated 1.0004 / 1.0001 / 1.0040 at the same 3 frequencies -- the equilibrated value is the geometric-degeneracy discriminant, near 1 (not degenerate)",
+        "a_inc magnitude (own drive): coax 5.8e-9/5.8e-8/3.0e-9, msl 8.2e-14/1.3e-11/7.1e-17 -- 5-9 orders of magnitude apart",
+        "MSL array fitted Im(gamma) (coax-driven) 673.0/853.6/885.0 rad/m vs analytic Hammerstad-Jensen beta 21.2/116.4/211.7 rad/m (4-32x off, non-monotonic with frequency)",
+        "MSL probe ladder span 1.000 mm = 0.34%-3.37% of the guided wavelength at the 3 measured frequencies",
         "settling_db -43.9 dB (coax drive) / -63.6 dB (msl drive) at N_STEPS=8000"
       ],
       "validated_scope": "NONE -- this is a diagnostic CALCULATION over the already-registered coaxial_port and microstrip_line port families, not a new port primitive and not a validated result. Listed so the matrix does not read as 'a coax<->MSL transition is impossible in rfx'.",
       "caveats": [
         "quote the preflight output and settling_db with any number from this lane",
-        "the reciprocity falsifier is TRIPPED on the one committed fixture -- read the finding, do not treat a future silent pass as evidence of a fix without a new falsifier re-run"
+        "the reciprocity falsifier is TRIPPED on the one committed fixture -- read the finding (probe-ladder instrument scoping, not confirmed junction physics), do not treat a future silent pass as evidence of a fix without a new falsifier re-run",
+        "do not read cond_a alone as a degeneracy witness on this lane -- use cond_a_equilibrated (per-drive amplitude scale dominates raw cond_a on a mixed-family lane)"
       ],
       "ad_traceable": "no",
       "ad_evidence": "not wired to the differentiable forward lane (imperative only); no eps_scale-style channel exists for this leg"

--- a/docs/guides/sparameter_support_matrix.json
+++ b/docs/guides/sparameter_support_matrix.json
@@ -1,6 +1,6 @@
 {
-  "version": 3,
-  "updated": "2026-08-04",
+  "version": 4,
+  "updated": "2026-08-06",
   "result_convention": {
     "full_s_matrix_shape": "(n_ports, n_ports, n_freqs)",
     "frequency_shape": "(n_freqs,)",
@@ -277,7 +277,7 @@
       "supported_configurations": [
         "3d_float32_second_order_uniform_yee_positive_z_cpml_no_periodic_rf_coaxial_line_reflection_exactly_one_top_face_port"
       ],
-      "validation_status": "The one-port TEM-line reflection API has broad analytic validation over termination, impedance, frequency, and mesh axes plus a broad MEEP short/open comparison. It is differentiable through eps_scale. The older single-plane V/I S-matrix API is deprecated and experimental. compute_coaxial_two_port(...) (issue #489 stage 2) is a separate, EXPERIMENTAL two-drive through-line extension — not covered by the 1-port evidence above; see its own known_limits entry and tests/test_coax_two_port_fdtd.py.",
+      "validation_status": "The one-port TEM-line reflection API has broad analytic validation over termination, impedance, frequency, and mesh axes plus a broad MEEP short/open comparison. It is differentiable through eps_scale. The older single-plane V/I S-matrix API is deprecated and experimental. compute_coaxial_two_port(...) (issue #489 stage 2) is a separate, EXPERIMENTAL two-drive through-line extension \u2014 not covered by the 1-port evidence above; see its own known_limits entry and tests/test_coax_two_port_fdtd.py.",
       "known_limits": [
         "compute_coaxial_line_reflection(...) requires exactly one registered coaxial port with face='top' and no mixed port family",
         "compute_coaxial_line_reflection(...) is not a general multi-port coaxial network solver",
@@ -316,7 +316,7 @@
         "matched single-cell resistor fixture is reported separately with max |Gamma| deviation 0.0929",
         "MEEP short/open comparison over 4--12 GHz: max_mag_abs_diff 0.0628 and mean_mag_abs_diff 0.0235",
         "end-to-end eps_scale AD versus finite difference discrepancy 2.6%",
-        "compute_coaxial_two_port single measured run (60 mm / 40 GHz fixture, 4-12 GHz): |S21|,|S12| 0.74-0.96, |S11|,|S22| <= 0.05, reciprocity within 0.3% magnitude / 0.21 degree phase, cond(A) <= 1.11; a post-hoc consistency check found the |S21| deficit matches the matrix-pencil-fitted exp(-Re(gamma)*L12) to within about 2% at every measured frequency (scale-sensitive, referral-blind — see the method docstring)"
+        "compute_coaxial_two_port single measured run (60 mm / 40 GHz fixture, 4-12 GHz): |S21|,|S12| 0.74-0.96, |S11|,|S22| <= 0.05, reciprocity within 0.3% magnitude / 0.21 degree phase, cond(A) <= 1.11; a post-hoc consistency check found the |S21| deficit matches the matrix-pencil-fitted exp(-Re(gamma)*L12) to within about 2% at every measured frequency (scale-sensitive, referral-blind \u2014 see the method docstring)"
       ],
       "validated_scope": "The self-contained TEM coaxial-line model using the documented Simulation, port, and method arguments, in float32 precision on a three-dimensional, second-order uniform Yee grid with positive CPML on both z faces, cpml_axes='z', CPML tokens on all six BoundarySpec faces, no periodic boundary axes, exactly one face='top' coaxial port, at least three requested probe planes that all fit before the source, and the termination, frequency, characteristic-impedance, and mesh ranges in the committed fixtures. Separately registered geometry, sources, monitors, termination helpers, arbitrary launches, face='bottom', mixed port families, and multi-port networks are outside this result.",
       "caveats": [
@@ -325,7 +325,7 @@
         "MEEP covers short/open; resistive cases are covered by the analytic transmission-line fixture"
       ],
       "ad_traceable": "yes",
-      "ad_evidence": "eps_scale -> FDTD -> DFT plane accumulators -> modal voltage -> matrix-pencil reflection -> Gamma; tests/test_coax_end_to_end_ad.py::test_coax_reflection_grad_finite_and_fd_consistent (compute_coaxial_line_reflection). compute_coaxial_s_matrix (deprecated) is NOT traceable — concrete numpy extraction, no eps_scale/traced-input channel wired. compute_coaxial_two_port (issue #489 stage 2, experimental) gained the same eps_scale channel: gate compares float32 AD (as shipped) against a float64-loss central finite difference (scoped enable_x64 around the forward call — the FDTD fields stay float32, same baseline as the MSL f64 referee, but the DFT-accumulator-and-downstream math runs at float64, per rfx/probes/probes.py's jax.config.x64_enabled keying, independent of the precision='float32' pin); measured rel_err 0.51% at h=2e-3 against a 2% gate (tests/test_coax_two_port_ad.py::test_compute_coaxial_two_port_ad_grad_finite_and_fd_consistent; regenerate/extend via scripts/coax_two_port_ad_fd_f64_referee.py), owner-platform (GPU) re-measurement pending. See tests/test_ad_surface_contract.py::AD_CLASSIFICATION for the per-calculator classification this family-level field cannot express."
+      "ad_evidence": "eps_scale -> FDTD -> DFT plane accumulators -> modal voltage -> matrix-pencil reflection -> Gamma; tests/test_coax_end_to_end_ad.py::test_coax_reflection_grad_finite_and_fd_consistent (compute_coaxial_line_reflection). compute_coaxial_s_matrix (deprecated) is NOT traceable \u2014 concrete numpy extraction, no eps_scale/traced-input channel wired. compute_coaxial_two_port (issue #489 stage 2, experimental) gained the same eps_scale channel: gate compares float32 AD (as shipped) against a float64-loss central finite difference (scoped enable_x64 around the forward call \u2014 the FDTD fields stay float32, same baseline as the MSL f64 referee, but the DFT-accumulator-and-downstream math runs at float64, per rfx/probes/probes.py's jax.config.x64_enabled keying, independent of the precision='float32' pin); measured rel_err 0.51% at h=2e-3 against a 2% gate (tests/test_coax_two_port_ad.py::test_compute_coaxial_two_port_ad_grad_finite_and_fd_consistent; regenerate/extend via scripts/coax_two_port_ad_fd_f64_referee.py), owner-platform (GPU) re-measurement pending. See tests/test_ad_surface_contract.py::AD_CLASSIFICATION for the per-calculator classification this family-level field cannot express."
     },
     {
       "primitive": "add_floquet_port(...)",
@@ -489,8 +489,8 @@
       ],
       "validation_status": "EXPERIMENTAL. Diagonals come from the per-family extractors but are NOT verified on this lane (both the wire port-cell V*I accounting and the MSL analytic-Z0 anchor are open), and the shipped values are additionally rewritten by the passivity projection when the raw matrix is non-passive. off-diagonal MAGNITUDES come from Poynting flux with the incident power normalized as P_net/(1-|S_jj|^2). Internal reciprocity witness measured 9% on the probe-fed MSL fixture (the wave channel measured 55% on the same fixture). NO external-solver referee has been run, so ABSOLUTE magnitude is NOT validated. Off-diagonal PHASE mixes two reference-plane conventions and is provisional. Do not cite this family as validation.",
       "known_limits": [
-        "absolute |S| unvalidated — openEMS referee pending",
-        "with enforce_passivity=True (default) the returned diagonal is a JOINT SVD-projected value, not the raw per-family measurement — measured ~4x its unprojected value on the committed test fixture; read S_raw/passivity_correction for what was measured",
+        "absolute |S| unvalidated \u2014 openEMS referee pending",
+        "with enforce_passivity=True (default) the returned diagonal is a JOINT SVD-projected value, not the raw per-family measurement \u2014 measured ~4x its unprojected value on the committed test fixture; read S_raw/passivity_correction for what was measured",
         "off-diagonal phase provisional (cross-family reference-plane mismatch)",
         "per-column power is an ALGEBRAIC IDENTITY on the flux channel and is not a passivity check; reciprocity is the only independent internal witness",
         "residual reciprocity disagreement traced to a driven-port diagonal; which diagonal is open (issue #313 wire port-cell vs the MSL analytic Z0 anchor)",
@@ -509,13 +509,62 @@
         "reciprocity deviation 9.0% (flux channel) vs 55% (wave channel), probe-fed MSL fixture, dx=63.5um, settling -101/-100 dB",
         "reciprocity witness default tolerance 0.06, set BELOW the 9% reference-fixture residual so that fixture warns rather than passing silently"
       ],
-      "validated_scope": "NONE — this is a diagnostic CALCULATION over the already-registered lumped/wire and microstrip_line port families, not a new port primitive and not a validated result. It is listed so the matrix does not read as 'mixed families are impossible in rfx', which the per-extractor limits elsewhere in this document would otherwise imply. Those per-extractor statements remain accurate: compute_msl_s_matrix, the lumped/wire scan driver, and the coaxial calculators each still reject foreign port families.",
+      "validated_scope": "NONE \u2014 this is a diagnostic CALCULATION over the already-registered lumped/wire and microstrip_line port families, not a new port primitive and not a validated result. It is listed so the matrix does not read as 'mixed families are impossible in rfx', which the per-extractor limits elsewhere in this document would otherwise imply. Those per-extractor statements remain accurate: compute_msl_s_matrix, the lumped/wire scan driver, and the coaxial calculators each still reject foreign port families.",
       "caveats": [
         "quote the preflight output and settling_db with any number from this lane",
         "a green passivity/column-power result here is structurally uninformative"
       ],
       "ad_traceable": "no",
       "ad_evidence": "not wired to the differentiable forward lane (imperative only)"
+    },
+    {
+      "primitive": "add_coaxial_port(...) + add_msl_port(...) driven by compute_coax_msl_transition(...)",
+      "family": "coax_msl_transition",
+      "is_port": false,
+      "support_status": "experimental_diagnostic_not_in_validated_set",
+      "calculation_api": [
+        "Simulation.compute_coax_msl_transition(...)"
+      ],
+      "result_type": "CoaxMSLTransitionResult",
+      "supported_configurations": [
+        "uniform second-order Yee mesh only, float32, boundary='cpml' on all six faces (cpml_axes='xyz')",
+        "exactly one add_coaxial_port(face='bottom') plus exactly one add_msl_port(...)",
+        "the coax stub (source, matched annular-resistor feed, probe array) is built internally, mirroring compute_coaxial_two_port's own single-ended stub",
+        "the junction geometry (ground plane, clearance hole, pin-to-trace post, substrate, trace) is the caller's own registered Box/Cylinder geometry, mirroring compute_mixed_s_matrix's own MSL-DUT delegation",
+        "imperative forward path only (no AD channel for this leg)"
+      ],
+      "validation_status": "EXPERIMENTAL, DIAGNOSTIC-ONLY. The power-wave cross-family normalization (per-port sqrt(Z0) division before the two-drive solve) is validated by planted-voltage unit tests under UNEQUAL port impedances, independent of any FDTD run. The one committed FDTD fixture is internally self-consistent (finite, deterministic, settles below -40 dB) but trips its own pre-declared reciprocity falsifier: |S12| vs |S21| disagree by 94-100% across the three measured frequencies, with the two-drive solve's cond_a in the 1e3-1e7 range at every bin -- root-caused to near-degenerate two-drive amplification (both ports strongly reflecting their own port), not to the assembler (ruled out by the planted-voltage tests) or a missing-PEC defect (ruled out by direct pec_mask inspection during construction). Do not cite this family as a validated transition.",
+      "known_limits": [
+        "reciprocity falsifier TRIPPED on the one committed fixture (94-100% deviation) -- locked as a regression/reproducibility witness in tests/test_coax_msl_transition.py, not as a passing accuracy gate",
+        "off-diagonal magnitude on the one fixture is near-zero and unreliable (consistent with the ill-conditioned two-drive solve, see cond_a)",
+        "the MSL side is extracted via the coax matrix-pencil fit (coaxial_line_reflection_from_plane_voltages) rather than the mixed lane's own N-probe fit, a deliberate deviation made because the coax fit deterministically pins the propagation-constant branch while the N-probe fit's sign is documented as unstable",
+        "preflight on the committed fixture independently flags the same resolution class as the finding: pin-post diameter under the 5-cell PEC-volume floor, 3-cell substrate flagged for >5% Z0 staircase bias, and the substrate gap itself flagged 'coupling may be under-resolved'",
+        "no external-solver referee has been run",
+        "AD is out of scope for this leg (no eps_scale-style channel)",
+        "waveguide, Floquet, TFSF, lumped RLC, and any second coaxial or MSL port are all rejected loudly"
+      ],
+      "evidence_level": "experimental/diagnostic-single-fixture",
+      "validation_gaps": [
+        "no external-solver cross-check",
+        "no mesh-convergence study",
+        "single fixture class (vertical coax landing on a grounded substrate edge, thin unmatched pin-to-trace post, no matching structure)",
+        "the one fixture's own reciprocity falsifier is tripped, not passing"
+      ],
+      "evidence_artifacts": [
+        "tests/test_coax_msl_transition.py"
+      ],
+      "numeric_metrics": [
+        "reciprocity deviation 94-100% across 3 frequencies (0.6/3.3/6.0 GHz), one committed fixture, dx=100um",
+        "cond_a 7.0e4 / 4.6e3 / 4.3e7 at the same 3 frequencies (two-drive solve degeneracy witness)",
+        "settling_db -43.9 dB (coax drive) / -63.6 dB (msl drive) at N_STEPS=8000"
+      ],
+      "validated_scope": "NONE -- this is a diagnostic CALCULATION over the already-registered coaxial_port and microstrip_line port families, not a new port primitive and not a validated result. Listed so the matrix does not read as 'a coax<->MSL transition is impossible in rfx'.",
+      "caveats": [
+        "quote the preflight output and settling_db with any number from this lane",
+        "the reciprocity falsifier is TRIPPED on the one committed fixture -- read the finding, do not treat a future silent pass as evidence of a fix without a new falsifier re-run"
+      ],
+      "ad_traceable": "no",
+      "ad_evidence": "not wired to the differentiable forward lane (imperative only); no eps_scale-style channel exists for this leg"
     }
   ],
   "physics_evidence_rule": "docs/guides/physics_validation_evidence_rule.md",

--- a/docs/guides/sparameter_support_matrix.md
+++ b/docs/guides/sparameter_support_matrix.md
@@ -48,6 +48,7 @@ guard. An absent warning therefore cannot be compared across port families.
 | `add_coaxial_port(...)` | `compute_coaxial_line_reflection(...)` | `CoaxialLineReflectionResult` | **limited** — exactly one `face="top"` port; broad-E5 analytic and broad-E4 MEEP evidence for the documented TEM-line result |
 | `add_coaxial_port(...)` | `compute_coaxial_s_matrix(...)` | `CoaxialSMatrixResult` | **experimental and deprecated** — older single-plane V/I path; can produce non-physical `\|S11\| > 1` for a lossless short |
 | `add_coaxial_port(...)` | `compute_coaxial_two_port(...)` | `CoaxialTwoPortResult` | **experimental** (issue #489 stage 2) — two-drive through-line 2-port solve; every DUT it can currently gate against is azimuthally symmetric (TM0n only); an external openEMS referee is now REGISTERED (`validation/crossval/21_coax_two_port_referee.py`, promoted 2026-08-04) bracketing the through-line class — it builds and runs its own independent openEMS model offline and does not execute rfx in-process; EXPERIMENTAL status stands until the transition/AD legs close; no phase claim |
+| `add_coaxial_port(...)` + `add_msl_port(...)` | `compute_coax_msl_transition(...)` | `CoaxMSLTransitionResult` | **experimental, diagnostic-only** (issue #489 leg 4) — coax-to-microstrip transition, two-drive; one committed fixture, and it trips its own reciprocity falsifier (see the section below) — do not treat as a validated transition |
 | `add_floquet_port(...)` | no documented high-level S-parameter API | none | **experimental** — broadside diagnostic helpers only; no calibrated Floquet-port result |
 | Sources, TFSF, probes, DFT planes, flux monitors | none | field, resonance, or flux results | **not a port** — no impedance or S-matrix reference plane |
 
@@ -644,3 +645,73 @@ Two further cautions on this lane, both measured rather than anticipated:
   any entry is non-passive it rewrites others as a side effect. On the committed test
   fixture the shipped MSL diagonal came out ~4× its unprojected value. Read `S_raw` and
   `passivity_correction` for what was actually measured.
+
+## Coax<->MSL transition — EXPERIMENTAL, diagnostic-only (issue #489 leg 4)
+
+```python
+res = sim.compute_coax_msl_transition(junction_x=..., eps_r_sub=...)
+```
+
+Generalizes the mixed-family idea above to a coax<->microstrip launch instead
+of lumped/wire<->MSL, but by a DIFFERENT route: rather than extending
+`compute_mixed_s_matrix`'s own machinery (which is deeply specific to the
+lumped/wire family — flux-box geometry, port-cell V·I, the analytic
+Hammerstad-Jensen anchor baked into its guards), this method combines the
+LESS-INVASIVE half of each existing family's own validated machinery
+unchanged: the coax side is built exactly like `compute_coaxial_two_port`'s
+own single-ended stub (TEM source, matched annular-resistor feed, probe
+array — reused verbatim, just one end instead of two); the MSL side is
+consumed exactly like `compute_mixed_s_matrix` consumes its own MSL ports
+(arbitrary caller-registered substrate/trace/ground-plane/pin-post geometry
+via ordinary `sim.add(Box(...)/Cylinder(...), material=...)`). Both ports'
+forward/backward wave amplitudes come from the SAME extractor,
+`coaxial_line_reflection_from_plane_voltages` (a Z0-free matrix-pencil fit) —
+applied to the coax probe ladder AND, deliberately, to the MSL probe ladder
+too, in place of the mixed lane's own N-probe SVD fit (`extract_msl_nprobe`),
+which that lane's own docstring documents as diagnostic-only with an
+unresolved branch-sign instability. Each port's raw modal-voltage wave is
+converted to a POWER wave via `a = V+ / sqrt(Re(Z0))` (coax: analytic TEM
+Z0; MSL: analytic Hammerstad-Jensen Zc) before the same two-drive solve
+`compute_coaxial_two_port` uses (`solve_two_port_from_wave_amplitudes`) —
+this per-port `sqrt(Z0)` step is the fix for the "impedance-convention
+mismatch" failure mode anticipated for this leg: solving directly on raw
+(un-normalized) volt-wave amplitudes leaves the diagonal correct but scales
+each off-diagonal entry by `sqrt(Z0_i/Z0_j)`, invisible on a coax-coax
+through line (equal Z0 cancels) but not invisible here. This normalization is
+independently unit-tested against a PLANTED, analytically known S-matrix
+under UNEQUAL port impedances (`tests/test_coax_msl_transition.py`), including
+a dedicated regression test that reproduces the exact defect the fix
+prevents.
+
+**One fixture has been run, and it is diagnostic, not validated.** The
+committed fixture (a vertical coax landing on a grounded substrate edge via a
+thin, unmatched pin-to-trace post — "no intermediate matching structure", per
+the leg's own scoping) is internally self-consistent (finite, deterministic,
+settles below −40 dB) but trips its own pre-declared reciprocity falsifier
+badly: `|S12|` vs `|S21|` disagree by 94-100% across the three measured
+frequencies, with the two-drive solve's condition number `cond_a` in the
+1e3-1e7 range at every bin. Per the falsifier's own predeclared discriminant,
+this points at near-degenerate two-drive amplification (both ports strongly
+reflecting their own port, so the two drives' incident-wave columns are
+nearly parallel — `solve_two_port_from_wave_amplitudes`'s own docstring notes
+`cond(A)` "multiplies whatever noise is on the measured amplitudes"), not an
+assembler defect (independently ruled out by the planted-voltage tests above)
+and not a missing-PEC defect (independently ruled out by direct `pec_mask`
+inspection during construction). `sim.preflight()` on this fixture
+independently flags the same resolution class: the pin post's 4-cell
+diameter is under the ≥5-cell PEC-volume floor, the 3-cell substrate is
+flagged for >5% Z0 staircase bias, and the substrate gap itself is flagged
+"coupling may be under-resolved" — consistent with a via-dominated series
+discontinuity at this specific fixture's thin, unmatched dimensions.
+
+| aspect | status |
+|---|---|
+| reciprocity | **FALSIFIER TRIPPED** — 94-100% deviation on the one committed fixture; root-caused to ill-conditioning (`cond_a` 1e3-1e7), not the assembler |
+| off-diagonal magnitude | not validated — the one fixture measured near-zero, unreliable transmission |
+| power-wave normalization (`sqrt(Z0)` step) | validated by planted-voltage unit tests, independent of any FDTD run |
+| AD | out of scope for this leg (no `eps_scale`-style channel) |
+
+Do not extend this lane's gates to "pass" without a NEW pre-declared falsifier
+or an identified implementation defect in this fixture (repo R2 rule) — the
+next attempt needs a redesigned junction (e.g. an intentional matching
+structure, or a wider/shorter via), not a parameter tweak on this one.

--- a/docs/guides/sparameter_support_matrix.md
+++ b/docs/guides/sparameter_support_matrix.md
@@ -670,7 +670,8 @@ applied to the coax probe ladder AND, deliberately, to the MSL probe ladder
 too, in place of the mixed lane's own N-probe SVD fit (`extract_msl_nprobe`),
 which that lane's own docstring documents as diagnostic-only with an
 unresolved branch-sign instability. Each port's raw modal-voltage wave is
-converted to a POWER wave via `a = V+ / sqrt(Re(Z0))` (coax: analytic TEM
+converted to a POWER wave via `a = V+ / sqrt(Z0)` (Z0 is already a real
+analytic value on both sides, so no `Re()` is taken anywhere; coax: analytic TEM
 Z0; MSL: analytic Hammerstad-Jensen Zc) before the same two-drive solve
 `compute_coaxial_two_port` uses (`solve_two_port_from_wave_amplitudes`) —
 this per-port `sqrt(Z0)` step is the fix for the "impedance-convention
@@ -689,29 +690,63 @@ thin, unmatched pin-to-trace post — "no intermediate matching structure", per
 the leg's own scoping) is internally self-consistent (finite, deterministic,
 settles below −40 dB) but trips its own pre-declared reciprocity falsifier
 badly: `|S12|` vs `|S21|` disagree by 94-100% across the three measured
-frequencies, with the two-drive solve's condition number `cond_a` in the
-1e3-1e7 range at every bin. Per the falsifier's own predeclared discriminant,
-this points at near-degenerate two-drive amplification (both ports strongly
-reflecting their own port, so the two drives' incident-wave columns are
-nearly parallel — `solve_two_port_from_wave_amplitudes`'s own docstring notes
-`cond(A)` "multiplies whatever noise is on the measured amplitudes"), not an
-assembler defect (independently ruled out by the planted-voltage tests above)
-and not a missing-PEC defect (independently ruled out by direct `pec_mask`
-inspection during construction). `sim.preflight()` on this fixture
-independently flags the same resolution class: the pin post's 4-cell
-diameter is under the ≥5-cell PEC-volume floor, the 3-cell substrate is
-flagged for >5% Z0 staircase bias, and the substrate gap itself is flagged
-"coupling may be under-resolved" — consistent with a via-dominated series
-discontinuity at this specific fixture's thin, unmatched dimensions.
+frequencies, with the two-drive solve's raw condition number `cond_a` in the
+1e3-1e7 range at every bin.
+
+**Attribution (corrected after adversarial PR review; see PR #581 review
+findings B2/B3).** The first attribution written for this finding —
+"near-degenerate two-drive amplification from strong junction reflection" —
+did not survive its own data and was retracted. Three checks on this
+fixture's own numbers refute it: (i) `cond_a` is almost entirely a per-drive
+amplitude SCALE artifact — after per-column equilibration,
+`cond_a_equilibrated` is 1.0004/1.0001/1.0040 (near 1) and the two drives'
+incident-wave columns are near-ORTHOGONAL (normalized overlap ~1e-4 to
+~4e-3), the opposite of "nearly parallel"; (ii) the "both ports strongly
+reflecting" premise fails on this fixture's own measured `|S22|`
+(0.000/0.000/0.500 — not uniformly near 1); (iii) the signature that DOES
+match is a drive-amplitude mismatch between the two unrelated source
+constructions (the MSL drive's own incident amplitude is 5-9 orders of
+magnitude smaller than the coax drive's), exactly the second branch of the
+two-drive solve's own warning ("one drive that failed to excite"), not the
+first ("nearly linearly dependent" in the geometric sense). The PREDECLARED
+alternative explanation — an MSL wave-extraction instrument-scoping limit,
+not junction physics — is positively supported instead: the MSL probe
+ladder on this fixture spans only 0.34%-3.37% of the guided wavelength
+across the three measured frequencies, and the fitted propagation constant
+on the MSL array does not track the analytic Hammerstad-Jensen beta
+(21.2/116.4/211.7 rad/m) at all — the coax-driven fit gives
+673.0/853.6/885.0 rad/m (4-32x too high and nearly frequency-flat, where
+the true beta is not), and the MSL's own-drive fit gives 4.5/36.2/2881.3
+rad/m with an implied decay length near one grid cell (not a real
+propagating/decaying wave). Both discriminants are locked as test
+assertions, not just prose (`tests/test_coax_msl_transition.py`). Whether
+the junction's own physical reflection also contributes is genuinely
+UNRESOLVED by this one fixture — `sim.preflight()` on the same fixture
+independently names a THIRD, also-unruled-out candidate mechanism (the MSL
+port sits only 200um from its own x-CPML face, "recommended 600um... source-
+side CPML reflection may inflate |S11|") — but the extraction-class
+explanation is the better-supported one, and it NAMES the implementation
+defect (probe ladder far shorter than any reasonable fraction of a guided
+wavelength) that would justify a future, separately pre-declared retry (a
+longer MSL probe ladder, e.g. >= 0.25 lambda_g) — not attempted in this PR.
+`sim.preflight()` on this fixture also independently flags the same general
+resolution class from a different angle: the pin post's 4-cell diameter is
+under the ≥5-cell PEC-volume floor, and the 3-cell substrate is flagged for
+>5% Z0 staircase bias.
 
 | aspect | status |
 |---|---|
-| reciprocity | **FALSIFIER TRIPPED** — 94-100% deviation on the one committed fixture; root-caused to ill-conditioning (`cond_a` 1e3-1e7), not the assembler |
+| reciprocity | **FALSIFIER TRIPPED** — 94-100% deviation on the one committed fixture; root-caused to the MSL probe ladder being far too short for the matrix-pencil wave split (instrument scoping), not the assembler, not a missing-PEC defect, and not confirmed junction physics |
 | off-diagonal magnitude | not validated — the one fixture measured near-zero, unreliable transmission |
 | power-wave normalization (`sqrt(Z0)` step) | validated by planted-voltage unit tests, independent of any FDTD run |
 | AD | out of scope for this leg (no `eps_scale`-style channel) |
 
 Do not extend this lane's gates to "pass" without a NEW pre-declared falsifier
-or an identified implementation defect in this fixture (repo R2 rule) — the
-next attempt needs a redesigned junction (e.g. an intentional matching
-structure, or a wider/shorter via), not a parameter tweak on this one.
+or an identified implementation defect in this fixture (repo R2 rule). This
+finding DOES name such a defect (the MSL probe ladder's length, per the
+attribution above), which is R2's own written escape clause for a second
+attempt: a future retry should lengthen the MSL probe ladder (e.g. to
+>= 0.25 lambda_g at the lowest measured frequency) BEFORE touching the
+junction geometry itself — the junction's own physical dimensions (matching
+structure, via width/length) remain a separate, still-open question this
+fixture cannot yet speak to.

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -40,6 +40,7 @@ from rfx.api._spec import (
     CoaxialTwoPortResult,
     MSLSMatrixResult,
     MixedSMatrixResult,
+    CoaxMSLTransitionResult,
     _WaveguidePortEntry,
     _MSLPortEntry,
 )
@@ -1365,6 +1366,135 @@ def _assemble_coaxial_two_port_from_voltages(
             fit_resid[1, drive_idx, fi] = out_bot.fit_residual
             gamma[0, drive_idx, fi] = out_top.gamma
             gamma[1, drive_idx, fi] = out_bot.gamma
+
+    solve = solve_two_port_from_wave_amplitudes(a_inc, b_out, cond_warn=float(cond_warn))
+    return solve.s_params, solve.cond_a, rec_resid, fit_resid, gamma
+
+
+def _assemble_coax_msl_transition_from_voltages(
+    *,
+    z_coax_planes_m,
+    x_msl_planes_m,
+    ref_coax_m: float,
+    ref_msl_m: float,
+    v_coax_by_drive,
+    v_msl_by_drive,
+    z0_coax: float,
+    z0_msl: float,
+    cond_warn: float = 1.0e3,
+):
+    """Pure post-FDTD assembly: coax + MSL modal-voltage ladders -> power-wave 2x2 S (#489 leg 4).
+
+    Isolated from :meth:`_SparamMixin.compute_coax_msl_transition` so the
+    cross-family normalization can be exercised with PLANTED analytic
+    voltages (no FDTD) — see
+    ``tests/test_coax_msl_transition.py::test_planted_voltages_recover_known_s_matrix``.
+    Concrete NumPy only (no jnp/traced branch): AD is explicitly out of
+    scope for this leg (see :class:`~rfx.api._spec.CoaxMSLTransitionResult`'s
+    class docstring).
+
+    Both ports' forward/backward modal-voltage wave amplitudes come from
+    the SAME extractor,
+    :func:`rfx.sources.coaxial_port.coaxial_line_reflection_from_plane_voltages`
+    (a Z0-free matrix-pencil fit over >=3 equally spaced planes) — applied to
+    the coax port's z-axis probe ladder AND, in place of the MSL lane's own
+    diagnostic-only N-probe SVD fit, to the MSL port's x-axis probe ladder
+    too (see the class docstring for why). That extractor returns RAW modal
+    VOLTAGE wave amplitudes (volts, ``V(x)=A*exp(-gamma*x)+B*exp(+gamma*x)``
+    Z0-free by construction) — each is converted to a POWER wave via
+    ``a = V+ / sqrt(Re(Z0))``, ``b = V- / sqrt(Re(Z0))`` (the standard
+    real-Z0 Kurokawa identity, using each port's OWN reference impedance)
+    before the two-drive solve. This division is the load-bearing fix for
+    the pre-declared "impedance-convention mismatch" failure mode: solving
+    directly on the raw volt-wave amplitudes would leave the diagonal
+    correct but scale each off-diagonal entry by ``sqrt(Z0_i/Z0_j)`` — see
+    :func:`rfx.sources.coaxial_port.solve_two_port_from_wave_amplitudes`'s
+    own docstring for the generic two-drive solve this feeds.
+
+    Parameters
+    ----------
+    z_coax_planes_m, x_msl_planes_m : (n_coax,), (n_msl,) float
+        Equally spaced axial probe-plane positions (metres) for the coax
+        port (port array 0, along z) and the MSL port (port array 1, along
+        x). Each family's own axis — these are NOT on a shared coordinate.
+    ref_coax_m, ref_msl_m : float
+        Each port's own reference plane, in that port's own axis. Chosen by
+        the caller to sit AT the physical coax<->MSL launch discontinuity
+        (minimizing the reference-plane-mismatch failure mode by
+        construction — see :meth:`_SparamMixin.compute_coax_msl_transition`).
+    v_coax_by_drive, v_msl_by_drive : (2, n_coax, n_freqs), (2, n_msl, n_freqs) complex
+        Modal voltage at every probe plane, per drive (index 0 = coax port
+        driven, index 1 = MSL port driven) and frequency.
+    z0_coax, z0_msl : float
+        Real reference impedance (ohm) for the power-wave normalization:
+        analytic coax TEM Z0 and analytic Hammerstad-Jensen microstrip Zc.
+    cond_warn : float
+        Forwarded to :func:`solve_two_port_from_wave_amplitudes`.
+
+    Returns
+    -------
+    s_params, cond_a, recurrence_residual, fit_residual, gamma
+        ``s_params`` is ``(2, 2, n_freqs)``, port order ``(coax, msl)``.
+        The other four are ``(2, 2, n_freqs)`` indexed
+        ``[port_array, drive, freq]`` (port array 0 = coax, 1 = msl), same
+        meaning as :func:`_assemble_coaxial_two_port_from_voltages`'s own
+        return values.
+    """
+    from rfx.sources.coaxial_port import (
+        coaxial_line_reflection_from_plane_voltages,
+        solve_two_port_from_wave_amplitudes,
+    )
+
+    z_coax = np.asarray(z_coax_planes_m, dtype=np.float64)
+    x_msl = np.asarray(x_msl_planes_m, dtype=np.float64)
+    v_coax_by_drive = np.asarray(v_coax_by_drive, dtype=np.complex128)
+    v_msl_by_drive = np.asarray(v_msl_by_drive, dtype=np.complex128)
+    if v_coax_by_drive.shape[0] != 2 or v_msl_by_drive.shape[0] != 2:
+        raise ValueError(
+            "v_coax_by_drive / v_msl_by_drive must have a leading axis of "
+            f"size 2 (one per drive); got {v_coax_by_drive.shape} / "
+            f"{v_msl_by_drive.shape}."
+        )
+    n_f = int(v_coax_by_drive.shape[-1])
+    if int(v_msl_by_drive.shape[-1]) != n_f:
+        raise ValueError(
+            "v_coax_by_drive and v_msl_by_drive must share the same "
+            f"trailing frequency axis; got {v_coax_by_drive.shape[-1]} vs "
+            f"{v_msl_by_drive.shape[-1]}."
+        )
+    if not (np.isfinite(z0_coax) and z0_coax > 0.0):
+        raise ValueError(f"z0_coax must be positive finite, got {z0_coax}")
+    if not (np.isfinite(z0_msl) and z0_msl > 0.0):
+        raise ValueError(f"z0_msl must be positive finite, got {z0_msl}")
+    sqrt_z0 = np.array([np.sqrt(float(z0_coax)), np.sqrt(float(z0_msl))])
+
+    a_inc = np.zeros((2, 2, n_f), dtype=np.complex128)
+    b_out = np.zeros((2, 2, n_f), dtype=np.complex128)
+    rec_resid = np.zeros((2, 2, n_f), dtype=np.float64)
+    fit_resid = np.zeros((2, 2, n_f), dtype=np.float64)
+    gamma = np.zeros((2, 2, n_f), dtype=np.complex128)
+
+    for drive_idx in range(2):
+        for fi in range(n_f):
+            out_coax = coaxial_line_reflection_from_plane_voltages(
+                z_coax, v_coax_by_drive[drive_idx, :, fi],
+                reference_plane_m=float(ref_coax_m),
+            )
+            out_msl = coaxial_line_reflection_from_plane_voltages(
+                x_msl, v_msl_by_drive[drive_idx, :, fi],
+                reference_plane_m=float(ref_msl_m),
+            )
+            # Raw modal-voltage waves (volts, Z0-free) -> power waves.
+            a_inc[0, drive_idx, fi] = out_coax.backward_amp / sqrt_z0[0]
+            b_out[0, drive_idx, fi] = out_coax.forward_amp / sqrt_z0[0]
+            a_inc[1, drive_idx, fi] = out_msl.backward_amp / sqrt_z0[1]
+            b_out[1, drive_idx, fi] = out_msl.forward_amp / sqrt_z0[1]
+            rec_resid[0, drive_idx, fi] = out_coax.recurrence_residual
+            fit_resid[0, drive_idx, fi] = out_coax.fit_residual
+            gamma[0, drive_idx, fi] = out_coax.gamma
+            rec_resid[1, drive_idx, fi] = out_msl.recurrence_residual
+            fit_resid[1, drive_idx, fi] = out_msl.fit_residual
+            gamma[1, drive_idx, fi] = out_msl.gamma
 
     solve = solve_two_port_from_wave_amplitudes(a_inc, b_out, cond_warn=float(cond_warn))
     return solve.s_params, solve.cond_a, rec_resid, fit_resid, gamma
@@ -5337,6 +5467,586 @@ class _SparamMixin:
         return _finalize_sparam_result(
             result_obj,
             extractor="compute_coaxial_two_port",
+            strict=strict_passivity,
+        )
+
+    def compute_coax_msl_transition(
+        self,
+        *,
+        junction_x: float,
+        eps_r_sub: float | None = None,
+        n_steps: int | None = None,
+        num_periods: float = 30.0,
+        freqs: "jnp.ndarray | None" = None,
+        n_freqs: int = 11,
+        field_scale: float = 1.0e4,
+        probe_count: int = 8,
+        probe_start_cells: int = 6,
+        probe_spacing_cells: int = 3,
+        feed_impedance: float | None = None,
+        cond_warn: float = 1.0e3,
+        strict_passivity: bool = False,
+        skip_preflight: bool = False,
+    ) -> "CoaxMSLTransitionResult":
+        """EXPERIMENTAL coax<->microstrip transition 2-port S-parameters (issue #489 leg 4).
+
+        .. warning::
+            **EXPERIMENTAL — not in the validated set**
+            (``docs/guides/sparameter_support_matrix.md`` / ``.json``). One
+            pre-declared fixture has been run against this method; see that
+            fixture's own predeclaration
+            (``tests/test_coax_msl_transition.py``) for the measured
+            envelope. NOT_TRACEABLE (see :class:`~rfx.api._spec.
+            CoaxMSLTransitionResult`'s class docstring for the full honesty
+            contract, including why the MSL side is extracted via the coax
+            matrix-pencil fit rather than the diagnostic-only N-probe fit
+            #488 uses).
+
+        Generalizes issue #488's mixed lumped/wire<->MSL assembler
+        (:meth:`compute_mixed_s_matrix`) to a coax<->MSL pair by combining,
+        UNCHANGED, the less-invasive half of each family's own validated
+        machinery instead of writing a new geometry-specific extractor:
+
+        * The **coax side** is built exactly like :meth:`compute_coaxial_two_port`'s
+          own single-ended stub (CPML, TEM TFSF source, matched annular-
+          resistor feed, then a probe array), reusing
+          :func:`~rfx.sources.coaxial_port.stamp_coaxial_line`,
+          :func:`~rfx.sources.coaxial_port.stamp_coaxial_annular_resistor`,
+          and :func:`~rfx.sources.coaxial_port.build_coaxial_tem_plane_source_specs`
+          verbatim — but only ONE end (this method has no second coax port).
+        * The **MSL side** is consumed exactly like :meth:`compute_mixed_s_matrix`
+          consumes its MSL ports: the caller registers arbitrary DUT
+          geometry (substrate, trace, ground plane, and — unique to this
+          transition — the ground-plane clearance hole and the vertical
+          pin-to-trace post that connects the two families) via the
+          ordinary ``sim.add(Box(...)/Cylinder(...), material=...)`` API,
+          and this method reuses :func:`~rfx.sources.msl_port.compute_msl_mode_profile`,
+          :func:`~rfx.sources.msl_port.setup_msl_port`, and
+          :func:`~rfx.sources.msl_port.make_msl_port_sources` verbatim for
+          the MSL port's own termination/excitation.
+
+        This method does NOT build the junction geometry itself (the ground
+        plane, its clearance hole, or the pin-to-trace post) — those are
+        DUT-specific and belong to the caller's own registered geometry,
+        exactly as :meth:`compute_mixed_s_matrix` never builds its own
+        substrate/trace. What this method DOES fix, by construction, is
+        WHERE each port's own S-parameter reference plane sits: both are
+        placed AT the physical launch discontinuity (see ``junction_x``
+        below and ``port.position[2]`` on the registered
+        :meth:`add_coaxial_port`), specifically to minimize the
+        pre-declared "reference-plane mismatch" failure mode (the coax's
+        axial z-feed-plane convention has no direct analogue in the MSL's
+        along-trace x reference plane — these are different geometric axes
+        entirely).
+
+        Registration contract
+        ----------------------
+        Exactly one :meth:`add_coaxial_port` (``face='bottom'`` — the
+        physical convention this method assumes: the coax stub is built
+        FROM the domain's low-z CPML face UP TO ``position[2]`` (rounded to
+        the nearest grid z-node, :meth:`~rfx.grid.Grid.position_to_index`'s
+        own convention), where ``position[0], position[1]`` is the coax
+        axis centre (x, y) and ``position[2]`` is the physical height of
+        the caller's OWN registered ground-plane conductor — i.e. this is
+        the ONE parameter that ties this method's auto-built coax stub to
+        the caller's own junction geometry; get it wrong and the pin will
+        either dangle in a gap or overlap the caller's own PEC). Exactly
+        one :meth:`add_msl_port`, whose ``position[2]`` (substrate bottom /
+        ground height) MUST equal the coax port's ``position[2]`` to within
+        one grid cell — both refer to the SAME physical ground plane. No
+        other ports (lumped/wire/waveguide/Floquet), no TFSF, no lumped
+        RLC, no pre-registered probes/DFT planes/flux monitors/NTFF (this
+        method builds its own). ``self._geometry`` must be non-empty (the
+        caller's substrate/trace/ground-plane/pin-post Boxes and
+        Cylinders) — arbitrary, not validated here, same delegation
+        :meth:`compute_mixed_s_matrix` uses for its own MSL DUT geometry.
+        Same solver/precision/boundary contract as
+        :meth:`compute_coaxial_two_port` (float32, 3D uniform Yee,
+        ``boundary='cpml'`` with positive CPML on all six faces) EXCEPT
+        this method needs absorption on all three axes (``cpml_axes="xyz"``,
+        not ``"z"``): the coax's own far end needs an absorbing z face
+        exactly like the coax lane, but the MSL trace radiates in x/y too,
+        and the caller's own ground plane is an INTERNAL stamped/registered
+        PEC layer rather than the domain's z boundary — this is also WHY
+        this method cannot reuse a PEC ``z_lo`` domain boundary as the MSL
+        ground reference the way :meth:`compute_mixed_s_matrix`'s
+        ``magnitude_channel="flux"`` fixtures do (that would conflict with
+        the coax's own need for an absorbing z_lo face).
+
+        Two-drive extraction (never a naive single-ratio)
+        ---------------------------------------------------
+        Drives the coax source, then the MSL source, in two separate FDTD
+        runs (never assuming the non-driven port sees zero incident wave —
+        the terminator-floor problem :meth:`compute_coaxial_two_port`
+        already solved for symmetric coax applies here too, and likely
+        worse, since the coax feed resistor and the MSL Hammerstad-Jensen
+        termination have no reason to share a termination quality). Each
+        port's own forward/backward wave amplitudes are recovered from its
+        own probe ladder via :func:`~rfx.sources.coaxial_port.
+        coaxial_line_reflection_from_plane_voltages` (Z0-free matrix-pencil
+        fit — see :class:`~rfx.api._spec.CoaxMSLTransitionResult` for why
+        this is used for the MSL side too, not the lane's own N-probe fit),
+        converted to POWER waves via each port's own analytic reference
+        impedance, and assembled by
+        :func:`~rfx.sources.coaxial_port.solve_two_port_from_wave_amplitudes`
+        (the same generic two-drive solve :meth:`compute_coaxial_two_port`
+        uses). See :func:`_assemble_coax_msl_transition_from_voltages` for
+        the full pure-assembly derivation.
+
+        Parameters
+        ----------
+        junction_x : float
+            Physical x-coordinate (metres) of the coax-to-trace launch
+            discontinuity — the MSL side's own S-parameter reference plane.
+            Must match wherever the caller's own registered pin-to-trace
+            post / trace Box actually begins; this method does not infer it
+            from geometry (mirrors the coax side's own reference plane
+            being the registered port's ``position[2]``, not inferred).
+        eps_r_sub : float, optional
+            Substrate relative permittivity. If ``None``, taken from the
+            registered :meth:`add_msl_port`'s own ``eps_r_sub`` (which must
+            then be set explicitly — this method does not attempt the
+            geometry-bounding-box auto-detection :meth:`add_msl_port`
+            itself offers, to keep the eps anchor unambiguous for the
+            Hammerstad-Jensen Z0 used in the power-wave normalization).
+
+        Returns
+        -------
+        CoaxMSLTransitionResult
+        """
+        from rfx.sources.coaxial_port import (
+            CoaxialPort as _CoaxPort,
+            build_coaxial_tem_plane_source_specs,
+            coaxial_line_plane_voltage,
+            coaxial_tem_characteristic_impedance,
+            stamp_coaxial_line,
+            stamp_coaxial_annular_resistor,
+        )
+        from rfx.sources.msl_eigenmode import hammerstad_jensen_z0_eps_eff
+        from rfx.sources.msl_port import (
+            MSLPort as _MSLPortLL,
+            _msl_yz_cells,
+            compute_msl_mode_profile,
+            setup_msl_port,
+            make_msl_port_sources,
+            msl_probe_x_coords_n,
+        )
+        from rfx.probes.probes import init_dft_plane_probe
+        from rfx.simulation import run as _run, ProbeSpec
+
+        # ---- Registration guards ----------------------------------------
+        if self._boundary != "cpml" or self._cpml_layers <= 0:
+            raise ValueError(
+                "compute_coax_msl_transition() requires boundary='cpml' "
+                "with cpml_layers > 0."
+            )
+        if any(token != "cpml" for _, _, token in self._boundary_spec.faces()):
+            raise ValueError(
+                "compute_coax_msl_transition() requires CPML tokens on all "
+                "six boundary faces; mixed BoundarySpec faces are not "
+                "supported (the coax stub needs an absorbing z_lo face and "
+                "the MSL trace needs absorbing x/y faces; the ground plane "
+                "is an internal registered/stamped PEC layer, not a domain "
+                "boundary)."
+            )
+        if self._periodic_axes:
+            raise ValueError(
+                "compute_coax_msl_transition() does not support periodic "
+                "boundary axes."
+            )
+        if self._mode != "3d":
+            raise ValueError("compute_coax_msl_transition() requires mode='3d'.")
+        if self._solver != "yee":
+            raise ValueError(
+                "compute_coax_msl_transition() supports solver='yee' only."
+            )
+        if self._precision != "float32":
+            raise ValueError(
+                "compute_coax_msl_transition() requires precision='float32'."
+            )
+        if self._stencil_order != 2:
+            raise ValueError(
+                "compute_coax_msl_transition() requires stencil_order=2."
+            )
+        if self._tfsf is not None:
+            raise ValueError(
+                "compute_coax_msl_transition() creates its own coax TEM "
+                "source and does not accept an existing TFSF source."
+            )
+        if (
+            self._dz_profile is not None
+            or self._dx_profile is not None
+            or self._dy_profile is not None
+        ):
+            raise ValueError(
+                "compute_coax_msl_transition() supports only a uniform "
+                "Yee grid; dx_profile/dy_profile/dz_profile are not "
+                "supported."
+            )
+        if self._refinement is not None:
+            raise ValueError(
+                "compute_coax_msl_transition() does not support SBP-SAT "
+                "refinement."
+            )
+        if self._lumped_rlc:
+            raise ValueError(
+                "compute_coax_msl_transition() does not support registered "
+                "lumped RLC elements."
+            )
+        if self._probes or self._dft_planes or self._flux_monitors or self._ntff:
+            raise ValueError(
+                "compute_coax_msl_transition() does not consume registered "
+                "probes, DFT planes, flux monitors, or NTFF boxes (it "
+                "builds its own)."
+            )
+        if (
+            self._coaxial_terminations
+            or self._coaxial_open_terminations
+            or self._coaxial_pec_end_caps
+        ):
+            raise ValueError(
+                "compute_coax_msl_transition() does not consume registered "
+                "add_coaxial_* termination helpers; use feed_impedance= "
+                "instead."
+            )
+        if len(self._coaxial_ports) != 1:
+            raise ValueError(
+                "compute_coax_msl_transition() is built from exactly one "
+                "add_coaxial_port()."
+            )
+        if len(self._msl_ports) != 1:
+            raise ValueError(
+                "compute_coax_msl_transition() is built from exactly one "
+                "add_msl_port()."
+            )
+        if self._ports or self._waveguide_ports or self._floquet_ports:
+            raise NotImplementedError(
+                "compute_coax_msl_transition() is defined only for a "
+                "coax + MSL port pair; no other port families."
+            )
+        if not self._geometry:
+            raise ValueError(
+                "compute_coax_msl_transition() consumes the caller's own "
+                "registered DUT geometry (substrate, trace, ground plane, "
+                "clearance hole, pin-to-trace post) — none is registered. "
+                "This method builds only the coax stub; register the "
+                "junction geometry via sim.add(...) first."
+            )
+        port = self._coaxial_ports[0]
+        if port.face != "bottom":
+            raise NotImplementedError(
+                "compute_coax_msl_transition() currently requires the "
+                "registered coax port's face='bottom' (the coax stub is "
+                "built from the domain's low-z CPML face up to "
+                "position[2])."
+            )
+        msl_pe = self._msl_ports[0]
+        # The coax stub's own top face stops AT port.position[2] (rounded to
+        # the nearest grid node); the caller's own registered ground-plane
+        # conductor is expected to occupy that node and MSL's substrate
+        # (msl_pe.position[2], its own z_lo / substrate-bottom convention)
+        # to begin at or above it -- the exact gap is the caller's own
+        # ground-plane thickness (fixture-specific, not knowable here), so
+        # this only guards the ORDER and catches a grossly misaligned
+        # ground reference (e.g. forgetting to raise msl_z_lo at all).
+        if float(msl_pe.position[2]) < float(port.position[2]) - 1.5e-9:
+            raise ValueError(
+                "compute_coax_msl_transition(): the registered MSL port's "
+                f"substrate-bottom height ({msl_pe.position[2]:.6g} m) sits "
+                f"BELOW the coax port's own junction height "
+                f"({port.position[2]:.6g} m) — both must reference the SAME "
+                "physical ground plane, with the MSL substrate at or above "
+                "it."
+            )
+        eps_r_sub_resolved = (
+            float(eps_r_sub) if eps_r_sub is not None
+            else (float(msl_pe.eps_r_sub) if msl_pe.eps_r_sub is not None else None)
+        )
+        if eps_r_sub_resolved is None:
+            raise ValueError(
+                "compute_coax_msl_transition() needs eps_r_sub, either "
+                "passed directly or set on the registered add_msl_port() "
+                "(this method does not auto-detect it from geometry)."
+            )
+
+        grid = self._build_grid()
+        dz = float(grid.dx)
+        _junction_gap_cells = (float(msl_pe.position[2]) - float(port.position[2])) / dz
+        if _junction_gap_cells > 8.0:
+            raise ValueError(
+                "compute_coax_msl_transition(): the registered MSL port's "
+                f"substrate-bottom height is {_junction_gap_cells:.1f} cells "
+                f"above the coax port's junction height ({port.position[2]:.6g} "
+                "m) — that is implausibly large for a single ground-plane "
+                "layer; check both registrations reference the SAME "
+                "physical ground plane."
+            )
+        materials, debye_spec, lorentz_spec, pec_mask, _, _, _ = \
+            self._assemble_materials(grid)
+
+        if freqs is None:
+            freqs_arr = np.asarray(
+                jnp.linspace(self._freq_max / 10, self._freq_max, n_freqs)
+            )
+        else:
+            freqs_arr = np.asarray(freqs)
+        n_f = int(freqs_arr.shape[0])
+        if n_steps is None:
+            n_steps = grid.num_timesteps(num_periods=num_periods)
+        freqs_jnp = jnp.asarray(freqs_arr, dtype=jnp.float32)
+
+        # ---- Coax stub (mirrors compute_coaxial_two_port's single end) --
+        center_xy = (float(port.position[0]), float(port.position[1]))
+        a, b = float(port.pin_radius), float(port.outer_radius)
+        z_junction_idx = int(grid.position_to_index(port.position)[2])
+        z_stub_lo = int(grid.pad_z_lo) + 2
+        z_feed = z_stub_lo + 1
+        z_src = z_stub_lo + 3
+        z_stub_hi = z_junction_idx - 1
+        if z_stub_hi <= z_src:
+            raise ValueError(
+                "compute_coax_msl_transition(): domain too short between "
+                "the low-z CPML and the junction height for the coax "
+                "stub's source/feed/probe layout; increase the z domain or "
+                "lower position[2]."
+            )
+        probes_coax = sorted(
+            z_src + int(probe_start_cells) + int(probe_spacing_cells) * k
+            for k in range(int(probe_count))
+        )
+        if probes_coax[-1] >= z_stub_hi:
+            raise ValueError(
+                "compute_coax_msl_transition(): the coax probe array "
+                f"reaches index {probes_coax[-1]}, at or past the junction "
+                f"({z_stub_hi}); increase the z domain or reduce "
+                "probe_count/probe_start_cells/probe_spacing_cells."
+            )
+
+        z_tem = coaxial_tem_characteristic_impedance(a, b)
+        r_feed = float(feed_impedance) if feed_impedance is not None else float(z_tem)
+        materials, shell_inner = stamp_coaxial_line(
+            grid, materials, center_xy=center_xy, z_lo_index=z_stub_lo,
+            z_hi_index=z_stub_hi, pin_radius=a, outer_radius=b,
+        )
+        materials = stamp_coaxial_annular_resistor(
+            grid, materials, center_xy=center_xy, z_index=z_feed,
+            pin_radius=a, outer_radius=b, target_impedance=r_feed,
+            shell_inner_radius=shell_inner,
+        )
+
+        src_port = _CoaxPort(
+            position=(center_xy[0], center_xy[1], (z_src - grid.pad_z_lo) * dz),
+            face="bottom", pin_length=dz, pin_radius=a, outer_radius=b,
+            impedance=port.impedance, excitation=port.excitation,
+        )
+        spec_coax = build_coaxial_tem_plane_source_specs(
+            grid=grid, port=src_port, n_steps=int(n_steps),
+            field_scale=float(field_scale), magnetic_ratio=1.0,
+        )
+        ref_coax_m = (z_junction_idx - grid.pad_z_lo) * dz
+        z_planes_coax_m = np.array(
+            [(z - grid.pad_z_lo) * dz for z in probes_coax], dtype=np.float64
+        )
+        annulus_cells = float((b - a) / dz)
+        if annulus_cells < 3.5:
+            import warnings as _wa
+            _wa.warn(
+                f"compute_coax_msl_transition(): coax annulus resolution "
+                f"{annulus_cells:.2f} cells is below the documented "
+                "under-resolved threshold (3.5 cells, same convention as "
+                "compute_coaxial_line_reflection/compute_coaxial_two_port) "
+                "— reflection accuracy degrades at high frequency.",
+                stacklevel=2,
+            )
+
+        # ---- MSL side (mirrors compute_mixed_s_matrix's MSL consumption) ---
+        x_feed, y_centre, msl_z_lo = (float(c) for c in msl_pe.position)
+        msl_port_base = _MSLPortLL(
+            feed_x=x_feed,
+            y_lo=y_centre - msl_pe.width / 2, y_hi=y_centre + msl_pe.width / 2,
+            z_lo=msl_z_lo, z_hi=msl_z_lo + msl_pe.height,
+            direction=msl_pe.direction, impedance=msl_pe.impedance,
+            excitation=None,
+        )
+        mode_profile = compute_msl_mode_profile(grid, msl_port_base, eps_r_sub_resolved)
+        materials = setup_msl_port(grid, msl_port_base, materials, mode_profile=mode_profile)
+        z0_msl, eps_eff_msl = hammerstad_jensen_z0_eps_eff(
+            msl_pe.width, msl_pe.height, eps_r_sub_resolved
+        )
+
+        probe_xs = msl_probe_x_coords_n(
+            grid, msl_port_base, n_probes=int(probe_count),
+            n_offset_cells=int(probe_start_cells),
+            n_spacing_cells=int(probe_spacing_cells),
+        )
+        xs_ladder = [float(x) for x in probe_xs]
+        lx_dom = float(self._domain[0])
+        mono = all(
+            (xs_ladder[q + 1] - xs_ladder[q]) * (1 if msl_pe.direction == "+x" else -1)
+            > 0.5 * dz
+            for q in range(len(xs_ladder) - 1)
+        )
+        if (not mono) or min(xs_ladder) <= 0.0 or max(xs_ladder) >= lx_dom:
+            raise ValueError(
+                "compute_coax_msl_transition(): the MSL probe ladder "
+                f"({', '.join(f'{x * 1e3:.2f}' for x in xs_ladder)} mm) "
+                f"leaves the declared x-domain (0, {lx_dom * 1e3:.2f}) mm "
+                "or was clamped at its edge. Face the port toward the "
+                "junction (direction), reduce n_probe_offset/spacing, or "
+                "enlarge the domain."
+            )
+        # coaxial_line_reflection_from_plane_voltages requires STRICTLY
+        # INCREASING plane positions; a "-x"-facing port's own ladder comes
+        # back decreasing in x (probe n steps AWAY from feed_x, toward the
+        # junction). Sort once here and use this order everywhere below so
+        # DFT-plane construction and the voltage array stay index-consistent.
+        xs_sorted = sorted(xs_ladder)
+
+        pec_mask_np = None if pec_mask is None else np.asarray(pec_mask)
+        cells = _msl_yz_cells(grid, msl_port_base)
+        j_set = sorted({c[1] for c in cells})
+        k_set = sorted({c[2] for c in cells})
+        j_lo_msl, j_hi_msl = j_set[0], j_set[-1]
+        k_lo_msl, k_hi_msl = k_set[0], k_set[-1]
+        j_centre_msl = (j_lo_msl + j_hi_msl) // 2
+        i_feed_msl = cells[0][0]
+        if pec_mask_np is None:
+            raise RuntimeError(
+                "compute_coax_msl_transition(): no PEC geometry registered "
+                "— the MSL trace conductor must be a registered PEC Box "
+                "(pec_mask came back None)."
+            )
+        col = pec_mask_np[i_feed_msl, j_centre_msl, k_hi_msl:]
+        k_pec = np.where(col)[0]
+        if k_pec.size == 0:
+            raise RuntimeError(
+                "compute_coax_msl_transition(): no PEC trace conductor "
+                "found above the substrate top at the registered MSL "
+                "port's own feed plane; add the microstrip trace as a "
+                "Box(material='pec')."
+            )
+        k_trace_lo = int(k_hi_msl + int(k_pec.min()))
+        dz_arr = _msl_cell_profile(grid, "z", grid.nz)
+        _complex_dtype = jnp.complex128 if jax.config.x64_enabled else jnp.complex64
+
+        # ---- Two-drive FDTD run -------------------------------------------
+        msl_waveform = (
+            msl_pe.waveform if msl_pe.waveform is not None
+            else GaussianPulse(f0=self._freq_max / 2, bandwidth=0.8)
+        )
+        import dataclasses as _dc
+        msl_port_driven = _dc.replace(msl_port_base, excitation=msl_waveform)
+
+        v_coax_by_drive = np.zeros((2, len(probes_coax), n_f), dtype=np.complex128)
+        v_msl_by_drive = np.zeros((2, len(xs_sorted), n_f), dtype=np.complex128)
+        settling_db = np.full(2, np.nan, dtype=np.float64)
+
+        x_mid_coax = center_xy[0] + 0.5 * (a + b)
+        i_probe_coax = int(round(x_mid_coax / dz)) + int(grid.pad_x_lo)
+        j_probe_coax = int(grid.pad_y_lo) + int(round(center_xy[1] / dz))
+        i_probe_msl = int(grid.position_to_index(
+            (xs_sorted[len(xs_sorted) // 2], y_centre, msl_z_lo + msl_pe.height * 0.5)
+        )[0])
+        j_probe_msl = int(grid.pad_y_lo) + int(round(y_centre / dz))
+        k_probe_msl = int(round((msl_z_lo + 0.5 * msl_pe.height) / dz)) + int(grid.pad_z_lo)
+
+        # drive_idx 0 drives the coax port; drive_idx 1 drives the MSL port.
+        for drive_idx in range(2):
+            if drive_idx == 0:
+                sources = list(spec_coax.electric_sources)
+                mag_sources = list(spec_coax.magnetic_sources)
+            else:
+                sources = make_msl_port_sources(
+                    grid, msl_port_driven, materials, int(n_steps),
+                    mode_profile=mode_profile,
+                )
+                mag_sources = []
+
+            planes = []
+            for z in probes_coax:
+                for comp in ("ex", "ey"):
+                    planes.append(init_dft_plane_probe(
+                        axis=2, index=int(z), component=comp, freqs=freqs_jnp,
+                        grid_shape=grid.shape, dft_total_steps=int(n_steps),
+                    ))
+            n_coax_planes = len(planes)
+            for x in xs_sorted:
+                i_x = int(grid.position_to_index((x, y_centre, msl_z_lo))[0])
+                planes.append(init_dft_plane_probe(
+                    axis=0, index=i_x, component="ez", freqs=freqs_jnp,
+                    grid_shape=grid.shape, dft_total_steps=int(n_steps),
+                ))
+
+            witness_probes = [
+                ProbeSpec(i=i_probe_coax, j=j_probe_coax,
+                          k=int(probes_coax[len(probes_coax) // 2]), component="ex"),
+                ProbeSpec(i=i_probe_msl, j=j_probe_msl, k=k_probe_msl, component="ez"),
+            ]
+
+            result = _run(
+                grid, materials, int(n_steps), boundary="cpml", cpml_axes="xyz",
+                sources=sources, mag_sources=mag_sources, probes=witness_probes,
+                dft_planes=planes, pec_mask=pec_mask, return_state=False,
+            )
+            if result.dft_planes is None:
+                raise RuntimeError(
+                    "compute_coax_msl_transition(): runner returned no DFT "
+                    "planes"
+                )
+
+            for pi, z in enumerate(probes_coax):
+                v_coax_by_drive[drive_idx, pi, :] = np.asarray(
+                    coaxial_line_plane_voltage(
+                        grid, result.dft_planes[pi * 2 + 0].accumulator,
+                        result.dft_planes[pi * 2 + 1].accumulator,
+                        center_xy=center_xy, pin_radius=a, outer_radius=b,
+                    )
+                )
+            for pi in range(len(xs_sorted)):
+                ez_plane = jnp.asarray(result.dft_planes[n_coax_planes + pi].accumulator)
+                v_q = msl_modal_voltage(
+                    ez_plane, j_centre=j_centre_msl, k_lo=k_lo_msl,
+                    k_hi=k_trace_lo, dz_arr=dz_arr, dtype=_complex_dtype,
+                )
+                v_msl_by_drive[drive_idx, pi, :] = np.asarray(v_q)
+
+            ts = np.asarray(result.time_series, dtype=float)
+            if ts.ndim == 2 and ts.shape[0] >= 10 and ts.shape[1] == len(witness_probes):
+                power = ts ** 2
+                tail = max(1, power.shape[0] // 10)
+                end = power[-tail:, :].mean(axis=0)
+                peak = power.max(axis=0)
+                tiny = np.finfo(float).tiny
+                settling_db[drive_idx] = float(np.max(
+                    10.0 * np.log10((end + tiny) / (peak + tiny))
+                ))
+
+        s_params, cond_a, rec_resid, fit_resid, gamma = \
+            _assemble_coax_msl_transition_from_voltages(
+                z_coax_planes_m=z_planes_coax_m, x_msl_planes_m=np.asarray(xs_sorted),
+                ref_coax_m=ref_coax_m, ref_msl_m=float(junction_x),
+                v_coax_by_drive=v_coax_by_drive, v_msl_by_drive=v_msl_by_drive,
+                z0_coax=float(z_tem), z0_msl=float(z0_msl), cond_warn=float(cond_warn),
+            )
+
+        reference_planes = np.asarray([ref_coax_m, float(junction_x)], dtype=float)
+        z0_ref = np.asarray([float(z_tem), float(z0_msl)], dtype=float)
+        result_obj = CoaxMSLTransitionResult(
+            s_params=s_params,
+            freqs=np.asarray(freqs_arr, dtype=float),
+            port_names=("coax", "msl"),
+            reference_planes=reference_planes,
+            z0_ref=z0_ref,
+            cond_a=cond_a,
+            recurrence_residual=rec_resid,
+            fit_residual=fit_resid,
+            gamma=gamma,
+            settling_db=settling_db,
+            status="experimental",
+        )
+        return _finalize_sparam_result(
+            result_obj,
+            extractor="compute_coax_msl_transition",
             strict=strict_passivity,
         )
 

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -1388,7 +1388,7 @@ def _assemble_coax_msl_transition_from_voltages(
     Isolated from :meth:`_SparamMixin.compute_coax_msl_transition` so the
     cross-family normalization can be exercised with PLANTED analytic
     voltages (no FDTD) — see
-    ``tests/test_coax_msl_transition.py::test_planted_voltages_recover_known_s_matrix``.
+    ``tests/test_coax_msl_transition.py::test_planted_voltages_recover_known_s_matrix_with_unequal_z0``.
     Concrete NumPy only (no jnp/traced branch): AD is explicitly out of
     scope for this leg (see :class:`~rfx.api._spec.CoaxMSLTransitionResult`'s
     class docstring).
@@ -1402,14 +1402,38 @@ def _assemble_coax_msl_transition_from_voltages(
     too (see the class docstring for why). That extractor returns RAW modal
     VOLTAGE wave amplitudes (volts, ``V(x)=A*exp(-gamma*x)+B*exp(+gamma*x)``
     Z0-free by construction) — each is converted to a POWER wave via
-    ``a = V+ / sqrt(Re(Z0))``, ``b = V- / sqrt(Re(Z0))`` (the standard
-    real-Z0 Kurokawa identity, using each port's OWN reference impedance)
-    before the two-drive solve. This division is the load-bearing fix for
-    the pre-declared "impedance-convention mismatch" failure mode: solving
-    directly on the raw volt-wave amplitudes would leave the diagonal
-    correct but scale each off-diagonal entry by ``sqrt(Z0_i/Z0_j)`` — see
+    ``a = V+ / sqrt(Z0)``, ``b = V- / sqrt(Z0)`` (the standard real-Z0
+    Kurokawa identity, using each port's OWN reference impedance — ``Z0`` is
+    already a real float here, both callers pass an analytic real
+    impedance, so no ``Re()`` is taken anywhere in this function; a complex
+    reference impedance is out of scope) before the two-drive solve. This
+    division is the load-bearing fix for the pre-declared
+    "impedance-convention mismatch" failure mode: solving directly on the
+    raw volt-wave amplitudes would leave the diagonal correct but scale
+    each off-diagonal entry by ``sqrt(Z0_i/Z0_j)`` — see
     :func:`rfx.sources.coaxial_port.solve_two_port_from_wave_amplitudes`'s
     own docstring for the generic two-drive solve this feeds.
+
+    ``cond_a`` vs ``cond_a_equilibrated`` (issue #581 review, finding B2)
+    -----------------------------------------------------------------------
+    ``solve_two_port_from_wave_amplitudes``'s own ``cond_a`` is the RAW
+    condition number of the 2x2 incident-wave matrix ``A``. On the coax-coax
+    stage-2 lane that matrix's two columns are naturally comparable in scale
+    (same TEM source construction, same ``field_scale``, both drives), so a
+    large raw ``cond_a`` there really does mean "the two drives' incident
+    waves are nearly parallel in port-space" (near-degenerate). On THIS
+    mixed-family lane the two drives are built by unrelated source
+    constructions with no reason to share an amplitude (a coax TEM plane
+    source vs an MSL Ez injection) — measured on the committed fixture, the
+    two columns differ by 5-9 orders of magnitude in norm, which alone
+    inflates ``cond_a`` into the 1e3-1e7 range with NO implication about the
+    two incident-wave DIRECTIONS. ``cond_a_equilibrated`` divides each
+    column of ``A`` by its own norm before taking ``cond`` — invariant to
+    the per-drive scale, so it isolates genuine geometric near-parallelism.
+    Column equilibration does not change ``s_params`` (``S = B @ inv(A)`` is
+    invariant under any per-column rescaling of ``(a_inc, b_out)`` pairs,
+    since both matrices pick up the identical column scale factor and it
+    cancels in ``B @ inv(A)``); it is a diagnostic-only recomputation.
 
     Parameters
     ----------
@@ -1433,12 +1457,15 @@ def _assemble_coax_msl_transition_from_voltages(
 
     Returns
     -------
-    s_params, cond_a, recurrence_residual, fit_residual, gamma
+    s_params, cond_a, cond_a_equilibrated, recurrence_residual, fit_residual, gamma, a_inc, b_out
         ``s_params`` is ``(2, 2, n_freqs)``, port order ``(coax, msl)``.
-        The other four are ``(2, 2, n_freqs)`` indexed
-        ``[port_array, drive, freq]`` (port array 0 = coax, 1 = msl), same
-        meaning as :func:`_assemble_coaxial_two_port_from_voltages`'s own
-        return values.
+        ``cond_a`` / ``cond_a_equilibrated`` are ``(n_freqs,)`` (see above).
+        ``recurrence_residual`` / ``fit_residual`` / ``gamma`` / ``a_inc`` /
+        ``b_out`` are ``(2, 2, n_freqs)`` indexed ``[port_array, drive,
+        freq]`` (port array 0 = coax, 1 = msl) — ``a_inc``/``b_out`` are the
+        POWER-wave amplitudes actually fed to the two-drive solve (post
+        ``sqrt(Z0)`` division), exposed for audit per issue #581 review
+        finding B2.
     """
     from rfx.sources.coaxial_port import (
         coaxial_line_reflection_from_plane_voltages,
@@ -1497,7 +1524,23 @@ def _assemble_coax_msl_transition_from_voltages(
             gamma[1, drive_idx, fi] = out_msl.gamma
 
     solve = solve_two_port_from_wave_amplitudes(a_inc, b_out, cond_warn=float(cond_warn))
-    return solve.s_params, solve.cond_a, rec_resid, fit_resid, gamma
+
+    # Column-equilibrated condition number (issue #581 review, finding B2):
+    # divide each drive's own incident-wave column by its own norm before
+    # taking cond() so a per-drive amplitude-scale mismatch (routine on a
+    # mixed-family lane, see the docstring above) cannot masquerade as
+    # geometric near-parallelism. Does not touch s_params.
+    cond_a_equilibrated = np.full(n_f, np.nan, dtype=np.float64)
+    for fi in range(n_f):
+        col_norms = np.linalg.norm(a_inc[:, :, fi], axis=0)
+        safe_norms = np.where(col_norms > 0.0, col_norms, 1.0)
+        a_eq = a_inc[:, :, fi] / safe_norms[None, :]
+        cond_a_equilibrated[fi] = float(np.linalg.cond(a_eq))
+
+    return (
+        solve.s_params, solve.cond_a, cond_a_equilibrated,
+        rec_resid, fit_resid, gamma, a_inc, b_out,
+    )
 
 
 class _SparamMixin:
@@ -5874,6 +5917,40 @@ class _SparamMixin:
             msl_pe.width, msl_pe.height, eps_r_sub_resolved
         )
 
+        # Registered impedance= divergence advisory (issue #581 review N2):
+        # add_coaxial_port(impedance=...) / add_msl_port(impedance=...) size
+        # the feed resistor / termination sigma and (for coax) the TEM
+        # source amplitude calibration — but the POWER-WAVE NORMALIZATION
+        # (z0_ref, feeding sqrt(Z0) in the assembler) always uses the
+        # ANALYTIC z_tem / z0_msl computed here, never the registered
+        # impedance. A large silent divergence between the two is a
+        # footgun: the source/termination is calibrated for one Z0 while
+        # the extraction is normalized against another.
+        for _label, _registered, _analytic in (
+            ("coax", float(port.impedance), float(z_tem)),
+            ("msl", float(msl_pe.impedance), float(z0_msl)),
+        ):
+            if _analytic > 0.0:
+                _rel_dev = abs(_registered - _analytic) / _analytic
+                if _rel_dev > 0.05:
+                    import warnings as _wz
+                    _wz.warn(
+                        f"compute_coax_msl_transition(): the registered "
+                        f"{_label} port impedance ({_registered:.2f} ohm) "
+                        f"diverges {_rel_dev * 100:.1f}% from the analytic "
+                        f"{_label} Z0 ({_analytic:.2f} ohm) this method "
+                        "actually uses for the power-wave normalization "
+                        "(z0_ref) and for sizing the feed resistor / "
+                        "termination. The registered impedance= is NOT "
+                        "the reference impedance of the returned "
+                        "s_params; it only affects source/termination "
+                        "sizing. Pass a matching pin_radius/outer_radius "
+                        "(coax) or width/height/eps_r_sub (msl), or "
+                        "reconcile the mismatch, before trusting a "
+                        "specific reference-impedance interpretation.",
+                        stacklevel=2,
+                    )
+
         probe_xs = msl_probe_x_coords_n(
             grid, msl_port_base, n_probes=int(probe_count),
             n_offset_cells=int(probe_start_cells),
@@ -6021,7 +6098,7 @@ class _SparamMixin:
                     10.0 * np.log10((end + tiny) / (peak + tiny))
                 ))
 
-        s_params, cond_a, rec_resid, fit_resid, gamma = \
+        s_params, cond_a, cond_a_equilibrated, rec_resid, fit_resid, gamma, a_inc, b_out = \
             _assemble_coax_msl_transition_from_voltages(
                 z_coax_planes_m=z_planes_coax_m, x_msl_planes_m=np.asarray(xs_sorted),
                 ref_coax_m=ref_coax_m, ref_msl_m=float(junction_x),
@@ -6038,9 +6115,12 @@ class _SparamMixin:
             reference_planes=reference_planes,
             z0_ref=z0_ref,
             cond_a=cond_a,
+            cond_a_equilibrated=cond_a_equilibrated,
             recurrence_residual=rec_resid,
             fit_residual=fit_resid,
             gamma=gamma,
+            a_inc=a_inc,
+            b_out=b_out,
             settling_db=settling_db,
             status="experimental",
         )

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -1571,6 +1571,114 @@ class MixedSMatrixResult:
     magnitude_channel: str = "wave"
 
 
+@dataclass
+class CoaxMSLTransitionResult:
+    """EXPERIMENTAL two-drive coax<->microstrip transition S-parameters (issue #489 leg 4).
+
+    STATUS: **EXPERIMENTAL — not in the validated set**
+    (``docs/guides/sparameter_support_matrix.md`` / ``.json``). This is the
+    coax<->planar generalization of the #488 mixed-family lane
+    (:class:`MixedSMatrixResult`) and reuses the #489 stage-2 coax two-port
+    machinery's per-port wave extraction
+    (:func:`rfx.sources.coaxial_port.coaxial_line_reflection_from_plane_voltages`)
+    for BOTH ports — including the MSL side, in place of the diagnostic-only,
+    sign-unstable N-probe SVD fit (``extract_msl_nprobe``; see its own
+    docstring and :meth:`_SparamMixin.compute_mixed_s_matrix`'s "N-probe line
+    Zc: DIAGNOSTIC ONLY" comment for the documented branch-sign instability
+    this sidesteps) — a deliberate deviation from imitating the #488 lane's
+    own MSL extractor choice, made because the coax matrix-pencil fit
+    deterministically pins the propagation-constant branch
+    (``beta = Im(gamma) > 0``) while the N-probe fit does not.
+
+    Like :class:`MixedSMatrixResult`, ``s_params`` is in the **Kurokawa
+    power-wave convention**: each port's raw modal-voltage wave amplitude
+    (``forward_amp``/``backward_amp``, both in **volts** — the matrix-pencil
+    fit is Z0-free) is divided by ``sqrt(Re(z0_ref))`` of that port's OWN
+    reference impedance BEFORE the two-drive solve
+    (:func:`rfx.sources.coaxial_port.solve_two_port_from_wave_amplitudes`).
+    This step is load-bearing here in a way it was not for the coax-coax
+    two-port lane: solving directly on RAW (un-normalized) volt-wave
+    amplitudes leaves S_ii (diagonal) exactly correct but scales each
+    off-diagonal S_ij (i != j) by ``sqrt(Z0_i/Z0_j)`` relative to the true
+    power-wave value — invisible on a coax-coax through line (equal Z0
+    cancels) but NOT invisible here, since the coax port's analytic TEM Z0
+    and the MSL port's Hammerstad-Jensen Zc are generally different. This is
+    the pre-declared "impedance-convention mismatch" failure mode: getting
+    this normalization wrong presents as spurious reflection/transmission
+    error even on an ideal, lossless transition.
+
+    Reference planes sit at the physical launch discontinuity on BOTH sides
+    by construction (``junction_z`` on the coax's own z axis, ``junction_x``
+    on the MSL's own x axis — see ``reference_planes``), specifically to
+    minimize the OTHER pre-declared failure mode ("reference-plane
+    mismatch": the coax's axial z-feed-plane convention has no direct
+    analogue in the MSL's along-trace x reference plane — these are
+    different geometric axes). Off-diagonal PHASE nonetheless mixes two
+    different transverse-mode conventions (coax TEM radial E-integral vs MSL
+    quasi-TEM z line-integral) and inherits #488's own caveat: magnitude is
+    the validated observable, phase is provisional.
+
+    NOT_TRACEABLE (inherits #488's AD scope): both this result's own
+    assembly and the underlying two extractors it composes
+    (:meth:`_SparamMixin.compute_coax_msl_transition`'s coax stub +
+    :func:`rfx.sources.msl_port.make_msl_port_sources`) run a concrete NumPy
+    path only. AD is explicitly out of scope for this leg (unlike stage-2
+    coax-coax, which grew an ``eps_scale`` channel in PR #572 — no
+    equivalent channel exists here).
+
+    Attributes
+    ----------
+    s_params : (2, 2, n_freqs) complex
+        ``s_params[j, i, :]`` = response at port *j* driving port *i*.
+        Port order is ALWAYS ``("coax", "msl")`` — port 0 = coax, port 1 =
+        MSL (see ``port_names``).
+    freqs : (n_freqs,) float
+    port_names : tuple of str
+        Always ``("coax", "msl")``.
+    reference_planes : (2,) float
+        ``[junction_z_m, junction_x_m]`` — the coax port's own z reference
+        plane and the MSL port's own x reference plane. Both are placed AT
+        the physical launch discontinuity (see class docstring); they are
+        NOT on a shared axis and must not be subtracted from one another.
+    z0_ref : (2,) float
+        ``[z0_coax_ohm, z0_msl_ohm]`` — the power-wave reference impedance
+        used for each port: analytic coax TEM Z0
+        (:func:`rfx.sources.coaxial_port.coaxial_tem_characteristic_impedance`)
+        and analytic Hammerstad-Jensen microstrip Zc
+        (:func:`rfx.sources.msl_eigenmode.hammerstad_jensen_z0_eps_eff`).
+    cond_a : (n_freqs,) float
+        Per-frequency condition number of the two-drive incident-wave
+        matrix (degeneracy bound only, not an accuracy score — same
+        contract as :class:`CoaxialTwoPortResult`).
+    recurrence_residual, fit_residual, gamma : (2, 2, n_freqs)
+        Per (port array, drive, freq), same convention and meaning as
+        :class:`CoaxialTwoPortResult` (0 = clean single-mode field; the MSL
+        array's own numbers are the SAME diagnostics applied to the MSL
+        probe ladder rather than a coax probe ladder).
+    settling_db : (2,) float
+        Ring-down settling witness per drive (worst end/peak field-energy
+        ratio, dB; above -40 dB = truncation suspect — see repo ring-down
+        convention).
+    status : str
+        ``"experimental"`` always (this lane makes no pass/fail physics
+        claim beyond what the calling test's own predeclared gate states;
+        unlike :class:`CoaxialTwoPortResult` there is no committed accuracy
+        battery to derive "passed"/"contaminated" from yet).
+    """
+
+    s_params: np.ndarray
+    freqs: np.ndarray
+    port_names: tuple[str, ...]
+    reference_planes: np.ndarray
+    z0_ref: np.ndarray
+    cond_a: np.ndarray
+    recurrence_residual: np.ndarray
+    fit_residual: np.ndarray
+    gamma: np.ndarray
+    settling_db: np.ndarray
+    status: str = "experimental"
+
+
 __all__ = [
     "MATERIAL_LIBRARY",
     "AD_MemoryEstimate",
@@ -1600,4 +1708,5 @@ __all__ = [
     "_MSLPortEntry",
     "MSLSMatrixResult",
     "MixedSMatrixResult",
+    "CoaxMSLTransitionResult",
 ]

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -1593,8 +1593,11 @@ class CoaxMSLTransitionResult:
     Like :class:`MixedSMatrixResult`, ``s_params`` is in the **Kurokawa
     power-wave convention**: each port's raw modal-voltage wave amplitude
     (``forward_amp``/``backward_amp``, both in **volts** — the matrix-pencil
-    fit is Z0-free) is divided by ``sqrt(Re(z0_ref))`` of that port's OWN
-    reference impedance BEFORE the two-drive solve
+    fit is Z0-free) is divided by ``sqrt(z0_ref)`` of that port's OWN
+    reference impedance (real reference impedances only — no ``Re()`` is
+    taken anywhere in this lane's assembly; see
+    :func:`_assemble_coax_msl_transition_from_voltages`) BEFORE the
+    two-drive solve
     (:func:`rfx.sources.coaxial_port.solve_two_port_from_wave_amplitudes`).
     This step is load-bearing here in a way it was not for the coax-coax
     two-port lane: solving directly on RAW (un-normalized) volt-wave
@@ -1626,6 +1629,43 @@ class CoaxMSLTransitionResult:
     coax-coax, which grew an ``eps_scale`` channel in PR #572 — no
     equivalent channel exists here).
 
+    On the one committed fixture (issue #581 adversarial review, findings
+    B2/B3): reciprocity and the two-drive solve's raw ``cond_a`` are badly
+    degenerate. The ORIGINAL attribution written for this fixture —
+    "near-degenerate two-drive amplification from strong junction
+    reflection" — did not survive its own data and was retracted. Three
+    independent checks on this fixture refute it: (i) ``cond_a`` is almost
+    entirely a per-drive amplitude SCALE artifact, not geometric
+    near-parallelism — after per-column equilibration (see
+    ``cond_a_equilibrated`` below) the two drives' incident-wave columns
+    are near-ORTHOGONAL, not nearly parallel; (ii) the "both ports strongly
+    reflecting" premise fails on this fixture's own measured ``|S22|``
+    (near 0 at two of three bins, not near 1); (iii) the signature that
+    DOES match is a drive-amplitude mismatch between the two unrelated
+    source constructions (coax TEM plane source vs MSL Ez injection) —
+    5-9 orders of magnitude apart on this fixture, visible directly in
+    ``a_inc`` (see below). The PREDECLARED alternative — an MSL wave-
+    extraction instrument-scoping limit, not junction physics — is
+    positively supported instead: the MSL probe ladder on this fixture
+    spans only 0.34%-3.37% of the guided wavelength across the three
+    measured frequencies, and the fitted ``gamma`` on the MSL array does
+    not track the analytic Hammerstad-Jensen propagation constant at all
+    (off by a factor of 4-32x, and the two drives' own independent fits of
+    the SAME array disagree with each other by 1-2 orders of magnitude —
+    see ``tests/test_coax_msl_transition.py``'s
+    ``test_coax_msl_transition_first_fixture_diagnostic`` for the locked
+    assertions and
+    ``test_post_review_discriminant_msl_ladder_too_short_for_pencil_fit``
+    for the pure-geometry version of the same check). Whether the
+    junction's own physical reflection ALSO contributes is genuinely
+    UNRESOLVED by this one fixture — a preflight advisory on the same
+    fixture (MSL port too close to its own x-CPML face) names a third,
+    also-unruled-out candidate mechanism — but the extraction-class
+    explanation is the better-supported one and is what a future retry
+    (a longer MSL probe ladder, not attempted in this PR) would target.
+    Do not read the reciprocity/degeneracy numbers on this result as
+    evidence about coax<->MSL launch physics in general.
+
     Attributes
     ----------
     s_params : (2, 2, n_freqs) complex
@@ -1646,15 +1686,42 @@ class CoaxMSLTransitionResult:
         (:func:`rfx.sources.coaxial_port.coaxial_tem_characteristic_impedance`)
         and analytic Hammerstad-Jensen microstrip Zc
         (:func:`rfx.sources.msl_eigenmode.hammerstad_jensen_z0_eps_eff`).
+        NOTE: the registered ``add_coaxial_port(impedance=...)`` /
+        ``add_msl_port(impedance=...)`` values are NOT used here (they only
+        size the feed resistor / termination and, for coax, the source
+        amplitude calibration) — :meth:`_SparamMixin.compute_coax_msl_transition`
+        warns when a registered impedance diverges from the analytic value
+        actually used by more than 5%.
     cond_a : (n_freqs,) float
         Per-frequency condition number of the two-drive incident-wave
-        matrix (degeneracy bound only, not an accuracy score — same
-        contract as :class:`CoaxialTwoPortResult`).
+        matrix, RAW (same contract as :class:`CoaxialTwoPortResult`'s own
+        ``cond_a``). On a mixed-family lane this is dominated by the two
+        drives' unrelated source-amplitude SCALES (see the finding above)
+        and is NOT a reliable geometric-degeneracy discriminant here —
+        use ``cond_a_equilibrated`` for that.
+    cond_a_equilibrated : (n_freqs,) float
+        Condition number of the SAME incident-wave matrix after dividing
+        each drive's own column by its own norm — invariant to per-drive
+        amplitude scale, so it isolates genuine geometric near-parallelism
+        between the two drives' incident waves. Does not affect
+        ``s_params`` (column equilibration leaves ``S = B @ inv(A)``
+        unchanged). Added in response to issue #581 review finding B2.
     recurrence_residual, fit_residual, gamma : (2, 2, n_freqs)
         Per (port array, drive, freq), same convention and meaning as
         :class:`CoaxialTwoPortResult` (0 = clean single-mode field; the MSL
         array's own numbers are the SAME diagnostics applied to the MSL
-        probe ladder rather than a coax probe ladder).
+        probe ladder rather than a coax probe ladder). On the one committed
+        fixture the MSL array's ``fit_residual`` crosses the predeclared
+        "large = unreliable" line at two of six (array, drive, freq)
+        entries, and its ``gamma`` does not track the analytic beta (see
+        the finding above) — inspect these before trusting any MSL-side
+        number from a new fixture.
+    a_inc, b_out : (2, 2, n_freqs) complex
+        The POWER-wave incident/outgoing amplitudes actually fed to the
+        two-drive solve (after the ``sqrt(Z0)`` division), exposed for
+        audit (issue #581 review finding B2) — e.g. to check each drive's
+        own excitation actually reached a comparable amplitude before
+        trusting ``cond_a``/``cond_a_equilibrated``.
     settling_db : (2,) float
         Ring-down settling witness per drive (worst end/peak field-energy
         ratio, dB; above -40 dB = truncation suspect — see repo ring-down
@@ -1672,9 +1739,12 @@ class CoaxMSLTransitionResult:
     reference_planes: np.ndarray
     z0_ref: np.ndarray
     cond_a: np.ndarray
+    cond_a_equilibrated: np.ndarray
     recurrence_residual: np.ndarray
     fit_residual: np.ndarray
     gamma: np.ndarray
+    a_inc: np.ndarray
+    b_out: np.ndarray
     settling_db: np.ndarray
     status: str = "experimental"
 

--- a/tests/test_ad_surface_contract.py
+++ b/tests/test_ad_surface_contract.py
@@ -93,6 +93,15 @@ AD_CLASSIFICATION = {
         "tests/test_coax_two_port_ad.py::"
         "test_compute_coaxial_two_port_ad_grad_finite_and_fd_consistent.",
     ),
+    "Simulation.compute_coax_msl_transition": (
+        NOT_TRACEABLE,
+        "issue #489 leg 4: concrete numpy path throughout — "
+        "_assemble_coax_msl_transition_from_voltages calls the concrete "
+        "branch of coaxial_line_reflection_from_plane_voltages and "
+        "solve_two_port_from_wave_amplitudes directly (no _prefer_jnp / "
+        "tracer dispatch, unlike compute_coaxial_two_port); no eps_scale "
+        "or other design channel is wired for this leg",
+    ),
     # --- top-level exports --------------------------------------------------
     "compute_error_indicator": (
         NOT_TRACEABLE,

--- a/tests/test_coax_msl_transition.py
+++ b/tests/test_coax_msl_transition.py
@@ -1,0 +1,586 @@
+"""Tests for ``compute_coax_msl_transition`` (issue #489 leg 4).
+
+Structure (mirrors ``tests/test_coax_two_port_fdtd.py`` and
+``tests/test_coax_two_port_referee_header.py``, the two closest
+precedents):
+
+1. Pure-assembly tests (no FDTD) for
+   :func:`rfx.api._sparams._assemble_coax_msl_transition_from_voltages` —
+   PLANTED analytic voltages recover a KNOWN S-matrix, and a dedicated
+   regression test proves the per-port ``sqrt(Z0)`` power-wave
+   normalization is load-bearing (the pre-declared "impedance-convention
+   mismatch" failure mode: skipping it silently corrupts the off-diagonal
+   when the two ports' reference impedances differ).
+2. A PREDECLARATION fill-contract test (UNRUN <=> no numbers, mirrors
+   ``test_coax_two_port_referee_header.py``'s
+   ``REPRODUCE_GATE_RECORD`` pattern) for the one committed FDTD fixture.
+3. The FDTD fixture itself (``@pytest.mark.slow_physics``), asserting the
+   predeclared witnesses at DIAGNOSTIC honesty level — this gate pins the
+   MEASURED envelope of THIS fixture only, no claim beyond it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rfx.api._sparams import (
+    _assemble_coax_msl_transition_from_voltages,
+    _mixed_reciprocity_deviation,
+)
+from tests._gate_policy import gate_from_envelope
+
+
+# ---------------------------------------------------------------------------
+# Part 1 -- pure assembly (no FDTD)
+# ---------------------------------------------------------------------------
+
+
+def _plant_ab_power_wave(s_true, gamma_t, n_f):
+    """Power-wave a/b at both ports for both drives, terminator ``gamma_t``.
+
+    Identical signal-flow construction to
+    ``tests/test_coax_two_port_fdtd.py::_plant_ab`` / the underlying
+    ``tests/test_coax_two_port_solve.py::_plant`` (``a[j, i]`` / ``b[j, i]``
+    indexed [measured_port, driven_port, freq]). Because this is a pure
+    signal-flow identity with no Z0 anywhere, the resulting ``a``/``b`` are
+    already POWER waves for ANY consistent choice of per-port reference
+    impedance -- unlike the coax-coax precedent, this test needs that
+    distinction because port 0 (coax) and port 1 (msl) get DIFFERENT
+    reference impedances below.
+    """
+    s11, s12, s21, s22 = s_true
+    a = np.zeros((2, 2, n_f), dtype=np.complex128)
+    b = np.zeros((2, 2, n_f), dtype=np.complex128)
+    b2 = s21 / (1.0 - s22 * gamma_t)
+    a[0, 0], a[1, 0] = 1.0, gamma_t * b2
+    b[1, 0], b[0, 0] = b2, s11 + s12 * (gamma_t * b2)
+    b1 = s12 / (1.0 - s11 * gamma_t)
+    a[1, 1], a[0, 1] = 1.0, gamma_t * b1
+    b[0, 1], b[1, 1] = b1, s22 + s21 * (gamma_t * b1)
+    return a, b
+
+
+def _voltages_from_ab(a, b, *, gamma, planes_m, ref_m, load_below):
+    """Invert the extractor's own extrapolation to build V(axis) from known a/b.
+
+    Exact copy of ``tests/test_coax_two_port_fdtd.py::_voltages_from_ab``'s
+    algebra (see that function's docstring for the derivation) -- kept as a
+    local, self-contained copy rather than a cross-module import so this
+    test file does not depend on another test file's internals staying
+    stable. ``a``/``b`` here must already be VOLT-wave amplitudes (the
+    ``coaxial_line_reflection_from_plane_voltages`` convention), not power
+    waves -- callers multiply by ``sqrt(Z0)`` before calling this.
+    """
+    planes_m = np.asarray(planes_m, dtype=np.float64)
+    a = np.atleast_1d(np.asarray(a, dtype=np.complex128))
+    b = np.atleast_1d(np.asarray(b, dtype=np.complex128))
+    gamma = np.broadcast_to(np.asarray(gamma, dtype=np.complex128), a.shape)
+    p0 = float(planes_m.mean())
+    pr = ref_m - p0
+    if load_below:
+        A = b * np.exp(-gamma * pr)
+        B = a * np.exp(+gamma * pr)
+    else:
+        A = a * np.exp(-gamma * pr)
+        B = b * np.exp(+gamma * pr)
+    pc = planes_m - p0
+    return (
+        np.exp(np.multiply.outer(pc, gamma)) * A[None, :]
+        + np.exp(-np.multiply.outer(pc, gamma)) * B[None, :]
+    )
+
+
+# A deliberately ASYMMETRIC (S11 != S22), reciprocal (S12 == S21) truth --
+# same reasoning as the coax-coax precedent: a symmetric fixture cannot
+# discriminate a systematic a/b mislabel, and per-frequency-varying values
+# catch a fixed/transposed frequency-index bug in the assembly loop.
+_S_TRUE = (
+    np.array([0.12 - 0.04j, 0.18 + 0.02j, -0.03 - 0.09j]),   # S11 (coax)
+    np.array([0.62 + 0.18j, 0.55 - 0.25j, 0.48 + 0.30j]),    # S12
+    np.array([0.62 + 0.18j, 0.55 - 0.25j, 0.48 + 0.30j]),    # S21 == S12
+    np.array([-0.08 - 0.05j, 0.06 + 0.10j, 0.11 - 0.02j]),   # S22 (msl)
+)
+_N_F = 3
+_GAMMA_T = 0.05
+_GAMMA_LINE = 1j * np.array([35.0, 47.0, 61.0])   # distinct per-frequency beta
+_Z0_COAX = 50.0
+_Z0_MSL = 74.3   # deliberately far from 50 ohm (Hammerstad-Jensen microstrip range)
+
+
+def _s_matrix_per_freq(s_true, n_f):
+    return [
+        np.array([[s_true[0][fi], s_true[1][fi]], [s_true[2][fi], s_true[3][fi]]])
+        for fi in range(n_f)
+    ]
+
+
+def _build_planted_fixture(z0_coax, z0_msl):
+    """Common planted geometry shared by the tests below.
+
+    Coax reference plane sits ABOVE the coax probe centroid (load_below=False,
+    mirrors the ``ref_top_m`` case in the coax-coax precedent -- the coax
+    stub's own junction reference plane sits past the end of its probe
+    array, toward the DUT). The MSL reference plane sits BELOW the MSL probe
+    centroid (load_below=True -- the junction is on the near side of the
+    probe ladder, which steps away from the port's own feed toward the
+    junction).
+    """
+    a_pow, b_pow = _plant_ab_power_wave(_S_TRUE, _GAMMA_T, _N_F)
+    sqrt_z0 = np.array([np.sqrt(z0_coax), np.sqrt(z0_msl)])
+    a_volt = a_pow * sqrt_z0[:, None, None]
+    b_volt = b_pow * sqrt_z0[:, None, None]
+
+    z_coax_planes_m = np.array([0.00, 0.01, 0.02, 0.03, 0.04, 0.05])
+    ref_coax_m = 0.07  # above the probe centroid -> load_below=False
+    # Strictly increasing, as coaxial_line_reflection_from_plane_voltages
+    # requires -- compute_coax_msl_transition sorts its own MSL probe
+    # ladder into this order before calling the extractor (a "-x"-facing
+    # port's own ladder comes back DECREASING in x from
+    # msl_probe_x_coords_n; see the sort in the real method).
+    x_msl_planes_m = np.array([0.15, 0.16, 0.17, 0.18, 0.19, 0.20])
+    ref_msl_m = 0.13   # below the probe centroid -> load_below=True
+
+    v_coax_by_drive = np.stack([
+        _voltages_from_ab(
+            a_volt[0, drive], b_volt[0, drive], gamma=_GAMMA_LINE,
+            planes_m=z_coax_planes_m, ref_m=ref_coax_m, load_below=False,
+        )
+        for drive in range(2)
+    ], axis=0)
+    v_msl_by_drive = np.stack([
+        _voltages_from_ab(
+            a_volt[1, drive], b_volt[1, drive], gamma=_GAMMA_LINE,
+            planes_m=x_msl_planes_m, ref_m=ref_msl_m, load_below=True,
+        )
+        for drive in range(2)
+    ], axis=0)
+    return dict(
+        z_coax_planes_m=z_coax_planes_m, x_msl_planes_m=x_msl_planes_m,
+        ref_coax_m=ref_coax_m, ref_msl_m=ref_msl_m,
+        v_coax_by_drive=v_coax_by_drive, v_msl_by_drive=v_msl_by_drive,
+    )
+
+
+def test_planted_voltages_recover_known_s_matrix_with_unequal_z0():
+    """Full pure-assembly recovers the KNOWN S-matrix under UNEQUAL port Z0.
+
+    This is the primary correctness witness for the "impedance-convention
+    mismatch" pre-declared failure mode: port 0 (coax, 50 ohm) and port 1
+    (msl, 74.3 ohm) have DIFFERENT reference impedances, so a correct
+    power-wave assembly is required to recover ``_S_TRUE`` exactly on this
+    noise-free synthetic field.
+    """
+    fx = _build_planted_fixture(_Z0_COAX, _Z0_MSL)
+    s_params, cond_a, rec_resid, fit_resid, gamma_fit = (
+        _assemble_coax_msl_transition_from_voltages(
+            **fx, z0_coax=_Z0_COAX, z0_msl=_Z0_MSL,
+        )
+    )
+    s_mat_per_freq = _s_matrix_per_freq(_S_TRUE, _N_F)
+    for fi in range(_N_F):
+        np.testing.assert_allclose(s_params[:, :, fi], s_mat_per_freq[fi], atol=1e-9)
+    assert np.all(np.isfinite(rec_resid)) and np.all(rec_resid < 1e-9)
+    assert np.all(np.isfinite(fit_resid)) and np.all(fit_resid < 1e-9)
+    assert np.all(cond_a < 3.0)
+    np.testing.assert_allclose(
+        gamma_fit, np.broadcast_to(_GAMMA_LINE, gamma_fit.shape), atol=1e-6
+    )
+
+
+def test_unequal_z0_normalization_is_required_off_diagonal_only():
+    """Regression witness: skipping the ``sqrt(Z0)`` step corrupts S12/S21 ONLY.
+
+    Directly operationalizes the algebra in
+    :func:`rfx.api._sparams._assemble_coax_msl_transition_from_voltages`'s
+    own docstring: solving on RAW (un-normalized) volt-wave amplitudes
+    leaves each diagonal entry exactly correct (``sqrt(Zi/Zi) = 1``) but
+    scales each off-diagonal entry by ``sqrt(Zi/Zj)`` relative to the true
+    power-wave value. This test calls the extractor's own two building
+    blocks directly (bypassing the ``sqrt(Z0)`` division the function under
+    test performs) to reproduce that DEFECT on the same planted fixture,
+    and confirms: (a) it actually differs from the true S, (b) by the
+    predicted closed-form factor, (c) the diagonal is untouched.
+    """
+    from rfx.sources.coaxial_port import (
+        coaxial_line_reflection_from_plane_voltages,
+        solve_two_port_from_wave_amplitudes,
+    )
+
+    fx = _build_planted_fixture(_Z0_COAX, _Z0_MSL)
+    n_f = _N_F
+    a_raw = np.zeros((2, 2, n_f), dtype=np.complex128)
+    b_raw = np.zeros((2, 2, n_f), dtype=np.complex128)
+    for drive_idx in range(2):
+        for fi in range(n_f):
+            out_c = coaxial_line_reflection_from_plane_voltages(
+                fx["z_coax_planes_m"], fx["v_coax_by_drive"][drive_idx, :, fi],
+                reference_plane_m=fx["ref_coax_m"],
+            )
+            out_m = coaxial_line_reflection_from_plane_voltages(
+                fx["x_msl_planes_m"], fx["v_msl_by_drive"][drive_idx, :, fi],
+                reference_plane_m=fx["ref_msl_m"],
+            )
+            a_raw[0, drive_idx, fi] = out_c.backward_amp   # NO sqrt(Z0) division
+            b_raw[0, drive_idx, fi] = out_c.forward_amp
+            a_raw[1, drive_idx, fi] = out_m.backward_amp
+            b_raw[1, drive_idx, fi] = out_m.forward_amp
+
+    solve = solve_two_port_from_wave_amplitudes(a_raw, b_raw)
+    s_wrong = solve.s_params
+    s_mat_per_freq = _s_matrix_per_freq(_S_TRUE, n_f)
+
+    ratio = np.sqrt(_Z0_COAX / _Z0_MSL)  # predicted S'_01 = S_01 * sqrt(Z0/Z1)
+    for fi in range(n_f):
+        true = s_mat_per_freq[fi]
+        # Diagonal: untouched by the missing normalization.
+        np.testing.assert_allclose(s_wrong[0, 0, fi], true[0, 0], atol=1e-9)
+        np.testing.assert_allclose(s_wrong[1, 1, fi], true[1, 1], atol=1e-9)
+        # Off-diagonal: WRONG, and wrong by exactly the predicted factor.
+        assert abs(s_wrong[0, 1, fi] - true[0, 1]) > 1e-3
+        assert abs(s_wrong[1, 0, fi] - true[1, 0]) > 1e-3
+        np.testing.assert_allclose(s_wrong[0, 1, fi], true[0, 1] * ratio, atol=1e-9)
+        np.testing.assert_allclose(s_wrong[1, 0, fi], true[1, 0] / ratio, atol=1e-9)
+
+
+def test_equal_z0_makes_normalization_a_no_op():
+    """Sanity cross-check: when both ports share one Z0, the fix is inert.
+
+    Confirms the ``sqrt(Z0)`` division degenerates to a no-op common-scale
+    factor when the two families happen to share a reference impedance --
+    exactly why the coax-coax two-port lane never needed this step.
+    """
+    fx = _build_planted_fixture(50.0, 50.0)
+    s_params, *_ = _assemble_coax_msl_transition_from_voltages(
+        **fx, z0_coax=50.0, z0_msl=50.0,
+    )
+    s_mat_per_freq = _s_matrix_per_freq(_S_TRUE, _N_F)
+    for fi in range(_N_F):
+        np.testing.assert_allclose(s_params[:, :, fi], s_mat_per_freq[fi], atol=1e-9)
+
+
+def test_rejects_mismatched_frequency_axes():
+    fx = _build_planted_fixture(_Z0_COAX, _Z0_MSL)
+    fx["v_msl_by_drive"] = fx["v_msl_by_drive"][:, :, :-1]
+    with pytest.raises(ValueError, match="frequency axis"):
+        _assemble_coax_msl_transition_from_voltages(**fx, z0_coax=_Z0_COAX, z0_msl=_Z0_MSL)
+
+
+def test_rejects_missing_drive_axis():
+    fx = _build_planted_fixture(_Z0_COAX, _Z0_MSL)
+    fx["v_coax_by_drive"] = fx["v_coax_by_drive"][0]
+    with pytest.raises(ValueError, match="leading axis"):
+        _assemble_coax_msl_transition_from_voltages(**fx, z0_coax=_Z0_COAX, z0_msl=_Z0_MSL)
+
+
+@pytest.mark.parametrize("bad_z0", [0.0, -50.0, float("nan"), float("inf")])
+def test_rejects_non_positive_finite_z0(bad_z0):
+    fx = _build_planted_fixture(_Z0_COAX, _Z0_MSL)
+    with pytest.raises(ValueError):
+        _assemble_coax_msl_transition_from_voltages(**fx, z0_coax=bad_z0, z0_msl=_Z0_MSL)
+    with pytest.raises(ValueError):
+        _assemble_coax_msl_transition_from_voltages(**fx, z0_coax=_Z0_COAX, z0_msl=bad_z0)
+
+
+# ---------------------------------------------------------------------------
+# Part 2 -- PREDECLARATION (fill-contract; committed BEFORE the reported run)
+# ---------------------------------------------------------------------------
+
+PREDECLARATION = {
+    "leg": "issue #489 leg 4 (coax<->MSL transition), first fixture",
+    "fixture_choice": (
+        "VERTICAL launch (coax axis along z, landing on a grounded "
+        "substrate edge; MSL trace along x), NOT an in-plane collinear "
+        "launch. Justification (rasterization arithmetic, decided BEFORE "
+        "running): every coax 'line' primitive this method reuses "
+        "(stamp_coaxial_line, build_coaxial_tem_plane_source_specs, "
+        "coaxial_line_plane_voltage) is hardcoded to a z-propagation axis "
+        "(circular cross-section in x-y, verified by reading "
+        "rfx/sources/coaxial_port.py: no axis parameter exists, and "
+        "build_coaxial_tem_plane_source_specs raises NotImplementedError "
+        "for axis != 'z'). An in-plane (both-along-x) launch would need "
+        "NEW x-axis analogues of all three -- more invasive, and violates "
+        "the repo's 'imitate the canonical example' rule (there is no "
+        "existing x-axis coax primitive to imitate). The vertical launch "
+        "reuses every coax primitive UNCHANGED (mirrors "
+        "compute_coaxial_two_port's own single-ended stub verbatim) and "
+        "every MSL primitive UNCHANGED (ordinary Box/Cylinder geometry + "
+        "add_msl_port, mirrors compute_mixed_s_matrix's own MSL "
+        "consumption) -- the only NEW code this leg needed was the "
+        "power-wave cross-family normalization "
+        "(_assemble_coax_msl_transition_from_voltages) and the junction "
+        "geometry itself (ground plane, clearance hole, pin-to-trace "
+        "post), which the caller owns via ordinary sim.add(...) calls."
+    ),
+    "geometry_summary": (
+        "dx=100um throughout (one grid, both families). Coax: pin=0.2mm, "
+        "outer=0.6mm (PTFE eps_r=2.1 default) -> annulus 4.0 cells (above "
+        "the 3.5-cell under-resolved floor). Ground plane: 1-cell PEC "
+        "layer at node N_GND=25 (z=2.5mm), full x-y extent, with a "
+        "clearance disk (radius = pin + 2 cells) carved around the pin "
+        "axis. Substrate: RO4350B-like eps_r=3.66, 3 cells (300um) above "
+        "the ground node. Trace: 1-cell PEC, width 600um, starting at "
+        "junction_x=1.0mm and running to feed_x=4.0mm where the MSL port "
+        "sits (direction='-x', facing back toward the junction, mirrors "
+        "the #488 mixed-lane fixture's own convention). Pin-to-trace "
+        "post: a PEC Cylinder (radius = pin radius) connecting the "
+        "ground node through the substrate to the trace node. All Box/"
+        "Cylinder z-boundaries are placed on CELL MIDPOINTS "
+        "((n +/- 0.5)*dx / stamp_coaxial_line-style +2*dz margin), not "
+        "exact node multiples -- see the module docstring note below on "
+        "why exact multiples are unsafe on this grid."
+    ),
+    "healthy_envelope_predeclared": (
+        "|S11| (coax) well below 1 (reflection, not total block); |S21| "
+        "passivity-bounded (<=1 with the documented Yee/extraction "
+        "envelope); reciprocity |S12-S21| within an envelope informed by "
+        "#488's own measured 9-30% class on ITS mixed fixture (this "
+        "fixture, with NO matching structure and a bare via-style post, "
+        "was explicitly flagged in the task scoping as likely WORSE)."
+    ),
+    "falsifiers_predeclared": {
+        "amplitude": (
+            "|S| > 1 beyond the documented single-run Yee/near-cutoff "
+            "envelope (test_sparam_passivity_guard's ~1.05-1.1 tight-path "
+            "convention) = extraction defect (current sign/scale or "
+            "reference plane) -- discriminate by inspecting recurrence_"
+            "residual/fit_residual (large = the matrix-pencil fit itself "
+            "is unreliable, e.g. multi-mode contamination near a source) "
+            "and cond_a (large = the two-drive SYSTEM is ill-conditioned, "
+            "independent of whether the fit itself is clean)."
+        ),
+        "reciprocity": (
+            "|S12| vs |S21| disagreeing far outside the #488-informed "
+            "envelope = reference-plane/normalization defect -- "
+            "discriminate via cond_a: the two-drive solve's own docstring "
+            "states cond(A) 'multiplies whatever noise is on the measured "
+            "amplitudes', so a reciprocity blowout ACCOMPANIED BY cond_a "
+            ">> 1000 points at near-degenerate drives (both ports seeing "
+            "almost the same field -- e.g. both strongly reflecting their "
+            "own port, so the two drives' incident-wave columns are "
+            "nearly parallel), NOT a sign/normalization bug in the "
+            "assembler itself (which is independently verified correct "
+            "by Part 1's planted-voltage tests above)."
+        ),
+    },
+    "status": "RUN",
+}
+
+
+def test_predeclaration_has_required_fields():
+    required = {
+        "leg", "fixture_choice", "geometry_summary",
+        "healthy_envelope_predeclared", "falsifiers_predeclared", "status",
+    }
+    missing = required - set(PREDECLARATION.keys())
+    assert not missing, f"PREDECLARATION missing fields: {missing}"
+    assert set(PREDECLARATION["falsifiers_predeclared"].keys()) == {
+        "amplitude", "reciprocity",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Part 3 -- the one committed FDTD fixture (@pytest.mark.slow_physics)
+# ---------------------------------------------------------------------------
+#
+# R3 self-audit / R2 accounting for this fixture (see PR body for the full
+# form): ONE pre-declared physics attempt was spent. Two CONSTRUCTION
+# defects were found and fixed before the declared attempt was read as a
+# result (both are plumbing, not a mechanism-hypothesis loop, per the
+# repo's own R2 distinction): (1) a missing z-layer of PEC connectivity
+# between the coax stub and the ground-plane/pin-post geometry (an
+# off-by-one in the original z-index bookkeeping), and (2) exact-multiple-
+# of-dx Box/Cylinder corners tripping the float32 rasterization "knife
+# edge" documented in rfx/geometry/csg.py's Box docstring (every boundary
+# in this fixture happened to land exactly on a node plane -- the
+# docstring's own worked recipe, cell-midpoint corners, is what fixed it).
+# Neither fix changed the fixture's PHYSICAL dimensions or the intended
+# junction topology; both are the kind of bug a green construction check
+# would have caught before spending any FDTD time, and are recorded here
+# only because they were found by actually running it, not by review.
+#
+# THE DECLARED RESULT: the fixture runs, is internally self-consistent
+# (finite, deterministic, settles below -40 dB), but the RECIPROCITY
+# falsifier fires -- badly (|S12| vs |S21| disagree by 94-100% across the
+# three measured frequencies) -- with cond_a in the 1e3-1e7 range at every
+# bin. Per the falsifier's own discriminant (predeclared above): this
+# points at near-degenerate two-drive amplification, not an assembler
+# defect (Part 1's planted-voltage tests independently confirm the
+# assembler's power-wave normalization is correct) and not a missing-PEC
+# defect (independently confirmed by direct pec_mask inspection during
+# construction debugging). The coax side reflects strongly (|S11| ~
+# 0.81-0.99) while the MSL side's own reflection is small at low/mid
+# frequency and rises at the top of the band -- consistent with a
+# via-dominated series discontinuity at this SPECIFIC fixture's thin
+# (200um radius, ~700um long) unmatched pin-to-trace post, which the task
+# scoping explicitly anticipated ("no intermediate matching structure").
+#
+# Per R2, this STOPS here: no second geometry attempt in this session.
+# This is reported as an honest FIRST diagnostic measurement of a
+# deliberately unmatched junction, not a validated transition -- the test
+# below locks the measured (bad) reciprocity and passivity numbers as a
+# reproducibility witness, not as an accuracy claim.
+
+DX = 100e-6
+PIN_R = 0.2e-3
+OUTER_R = 0.6e-3
+EPS_COAX = 2.1
+H_SUB = 300e-6
+EPS_SUB = 3.66
+W_TRACE = 600e-6
+JUNCTION_X = 1.0e-3
+FEED_X = 4.0e-3
+LY = 3.4e-3
+Y_C = LY / 2.0
+N_GND, N_SUB_LO, N_SUB_HI, N_TRACE = 25, 26, 28, 29
+JUNCTION_Z = N_GND * DX
+LZ = JUNCTION_Z + H_SUB + DX + 1.0e-3
+LX = FEED_X + 1.0e-3
+FREQ_MAX = 6.0e9
+CLEAR_R = PIN_R + 2 * DX
+N_STEPS = 8000
+
+
+def _half_cell_box_z(n_lo, n_hi):
+    """z=(lo, hi) that rasterizes to EXACTLY grid nodes [n_lo, n_hi].
+
+    Recipe from rfx/geometry/csg.py's ``Box`` docstring ("Rasterization
+    convention"): interior corners belong on cell MIDPOINTS, ``(j+0.5)*dx``
+    -- a corner placed exactly ON a node plane (the float32 double-
+    rounding "knife edge" that docstring documents at length) has
+    UNPREDICTABLE occupancy. Every boundary in this fixture is a clean
+    multiple of ``dx`` before this correction (the obvious-looking
+    choice), which is precisely the case the docstring warns is
+    undecidable -- it silently dropped the ground-plane/pin-post
+    connection's own z-layer on the first construction pass here (see the
+    module-level comment above this fixture).
+    """
+    return (n_lo - 0.5) * DX, (n_hi + 0.5) * DX
+
+
+def _margin_cylinder_z(n_lo, n_hi):
+    """(center_z, height) covering nodes [n_lo, n_hi], one extra cell of
+    margin per side -- mirrors ``stamp_coaxial_line``'s own
+    ``height = (z_hi - z_lo) + 2*dz`` convention, applied here because
+    ``Cylinder``'s inclusive (``<=``) height check has the identical
+    node-plane knife-edge risk as ``Box``'s half-open check.
+    """
+    z_lo, z_hi = n_lo * DX, n_hi * DX
+    return 0.5 * (z_lo + z_hi), (z_hi - z_lo) + 2 * DX
+
+
+def _build_coax_msl_transition_sim():
+    from rfx.api import Simulation
+    from rfx.boundaries.spec import BoundarySpec
+    from rfx.geometry.csg import Box, Cylinder
+
+    sim = Simulation(
+        freq_max=FREQ_MAX, domain=(LX, LY, LZ), dx=DX, cpml_layers=8,
+        boundary=BoundarySpec(x="cpml", y="cpml", z="cpml"),
+    )
+    sim.add_material("sub", eps_r=EPS_SUB)
+    sim.add_material("ptfe", eps_r=EPS_COAX)
+
+    gnd_lo, gnd_hi = _half_cell_box_z(N_GND, N_GND)
+    sim.add(Box((0.0, 0.0, gnd_lo), (LX, LY, gnd_hi)), material="pec")
+    clr_c, clr_h = _margin_cylinder_z(N_GND, N_SUB_LO)
+    sim.add(
+        Cylinder(center=(JUNCTION_X, Y_C, clr_c), radius=CLEAR_R, height=clr_h, axis="z"),
+        material="ptfe",
+    )
+    sub_lo, sub_hi = _half_cell_box_z(N_SUB_LO, N_SUB_HI)
+    sim.add(Box((0.0, 0.0, sub_lo), (LX, LY, sub_hi)), material="sub")
+    trc_lo, trc_hi = _half_cell_box_z(N_TRACE, N_TRACE)
+    sim.add(
+        Box((JUNCTION_X, Y_C - W_TRACE / 2, trc_lo), (LX, Y_C + W_TRACE / 2, trc_hi)),
+        material="pec",
+    )
+    pin_c, pin_h = _margin_cylinder_z(N_GND, N_TRACE)
+    sim.add(
+        Cylinder(center=(JUNCTION_X, Y_C, pin_c), radius=PIN_R, height=pin_h, axis="z"),
+        material="pec",
+    )
+
+    sim.add_coaxial_port(
+        position=(JUNCTION_X, Y_C, N_GND * DX), face="bottom",
+        pin_radius=PIN_R, outer_radius=OUTER_R, impedance=50.0,
+    )
+    sim.add_msl_port(
+        position=(FEED_X, Y_C, N_SUB_LO * DX), width=W_TRACE, height=H_SUB,
+        direction="-x", impedance=50.0, eps_r_sub=EPS_SUB,
+    )
+    return sim
+
+
+@pytest.mark.slow_physics
+def test_coax_msl_transition_first_fixture_diagnostic():
+    """The one committed #489-leg-4 fixture -- DIAGNOSTIC honesty level.
+
+    See ``PREDECLARATION`` above and the module-level comment immediately
+    preceding this test for the full R2/R3 accounting. This test asserts
+    exactly what was measured: self-consistency (finite, settled) passes;
+    the reciprocity/passivity falsifier fires and is LOCKED as a
+    reproducibility witness, not papered over. Runtime ~110s (two FDTD
+    drives on a (67, 51, 56)-cell grid, 8000 steps each).
+    """
+    assert PREDECLARATION["status"] == "RUN"
+
+    sim = _build_coax_msl_transition_sim()
+    result = sim.compute_coax_msl_transition(
+        junction_x=JUNCTION_X, eps_r_sub=EPS_SUB, n_steps=N_STEPS,
+        n_freqs=3, probe_count=6, probe_start_cells=4, probe_spacing_cells=2,
+        skip_preflight=True,
+    )
+
+    assert result.s_params.shape == (2, 2, 3)
+    assert np.all(np.isfinite(result.s_params))
+    assert result.port_names == ("coax", "msl")
+
+    # Settling: both drives clear the -40 dB ring-down rule (this fixture
+    # measured -43.9 / -63.6 dB at N_STEPS=8000; a shorter, 1500-step
+    # smoke run measured only -1.0 / -0.2 dB -- the record was genuinely
+    # under-settled there, not a construction defect).
+    assert np.all(np.asarray(result.settling_db) < -40.0), (
+        f"settling_db {result.settling_db} did not clear -40 dB; the "
+        "8000-step record may need lengthening."
+    )
+
+    # Amplitude falsifier: pin the MEASURED envelope with the repo's
+    # standard 1.5x margin (tests/_gate_policy.py) rather than a fixed
+    # a-priori threshold -- this fixture's own diagonal peaks near 1
+    # (strong coax-side reflection; see the module comment) but must not
+    # cross the passivity-violation floor by more than extraction noise.
+    max_abs_s = float(np.max(np.abs(result.s_params)))
+    gate = gate_from_envelope(max_abs_s, quantum=100)
+    assert max_abs_s <= gate, (
+        f"max|S| {max_abs_s:.4f} exceeds its own {gate:.4f} envelope gate "
+        "-- a NEW amplitude excursion beyond what was measured when this "
+        "test was written; re-run the falsifier diagnostic (recurrence_"
+        "residual / fit_residual / cond_a) before trusting the change."
+    )
+
+    # Degeneracy witness: cond_a stays large (the predeclared discriminant
+    # for the reciprocity falsifier below). A LOW cond_a here without the
+    # matching reciprocity fix would itself be suspicious (the two
+    # findings should move together).
+    assert np.all(np.asarray(result.cond_a) > 1.0e3), (
+        f"cond_a {result.cond_a} dropped below the degenerate-drive floor "
+        "this fixture measured -- the ill-conditioning finding may no "
+        "longer apply; re-evaluate the reciprocity assertion below too."
+    )
+
+    # Reciprocity falsifier -- LOCKED, not silently accepted: this
+    # fixture's own measured deviation is ~94-100% (see module comment).
+    # Regression-lock the FINDING (it stays badly non-reciprocal) so a
+    # future change that quietly "fixes" this number gets flagged for
+    # review rather than assumed correct -- the fix would need its own
+    # falsifier re-run (a NEW fixture geometry, e.g. adding a matching
+    # structure or a wider/shorter via), not a silent gate change here.
+    pair, worst_dev = _mixed_reciprocity_deviation(result.s_params)
+    assert worst_dev > 0.5, (
+        f"reciprocity deviation dropped to {worst_dev:.3f} between ports "
+        f"{pair} -- the pre-declared falsifier no longer fires. Either "
+        "the fixture's physics changed (re-derive the finding) or the "
+        "assembler changed (re-run Part 1's planted-voltage tests, which "
+        "independently pin the correct answer)."
+    )

--- a/tests/test_coax_msl_transition.py
+++ b/tests/test_coax_msl_transition.py
@@ -172,7 +172,7 @@ def test_planted_voltages_recover_known_s_matrix_with_unequal_z0():
     noise-free synthetic field.
     """
     fx = _build_planted_fixture(_Z0_COAX, _Z0_MSL)
-    s_params, cond_a, rec_resid, fit_resid, gamma_fit = (
+    s_params, cond_a, cond_a_eq, rec_resid, fit_resid, gamma_fit, a_inc, b_out = (
         _assemble_coax_msl_transition_from_voltages(
             **fx, z0_coax=_Z0_COAX, z0_msl=_Z0_MSL,
         )
@@ -183,6 +183,8 @@ def test_planted_voltages_recover_known_s_matrix_with_unequal_z0():
     assert np.all(np.isfinite(rec_resid)) and np.all(rec_resid < 1e-9)
     assert np.all(np.isfinite(fit_resid)) and np.all(fit_resid < 1e-9)
     assert np.all(cond_a < 3.0)
+    assert np.all(cond_a_eq < 3.0)
+    assert a_inc.shape == (2, 2, _N_F) and b_out.shape == (2, 2, _N_F)
     np.testing.assert_allclose(
         gamma_fit, np.broadcast_to(_GAMMA_LINE, gamma_fit.shape), atol=1e-6
     )
@@ -324,11 +326,16 @@ PREDECLARATION = {
         "sits (direction='-x', facing back toward the junction, mirrors "
         "the #488 mixed-lane fixture's own convention). Pin-to-trace "
         "post: a PEC Cylinder (radius = pin radius) connecting the "
-        "ground node through the substrate to the trace node. All Box/"
-        "Cylinder z-boundaries are placed on CELL MIDPOINTS "
-        "((n +/- 0.5)*dx / stamp_coaxial_line-style +2*dz margin), not "
-        "exact node multiples -- see the module docstring note below on "
-        "why exact multiples are unsafe on this grid."
+        "ground node through the substrate to the trace node. No z-"
+        "boundary is placed on an exact node multiple -- Box corners use "
+        "the CELL-MIDPOINT convention ((n +/- 0.5)*dx, per rfx/geometry/"
+        "csg.py's own Box docstring); Cylinder heights use a DIFFERENT "
+        "mechanism, a full stamp_coaxial_line-style +2*dz margin on each "
+        "side (Cylinder's inclusive <= height check has the same knife-"
+        "edge risk but is not corner-based, so the midpoint recipe does "
+        "not literally apply -- margin is the analogous fix). See the "
+        "module docstring note below on why exact multiples are unsafe "
+        "on this grid."
     ),
     "healthy_envelope_predeclared": (
         "|S11| (coax) well below 1 (reflection, not total block); |S21| "
@@ -364,7 +371,74 @@ PREDECLARATION = {
         ),
     },
     "status": "RUN",
+    "post_review_correction": (
+        "PR #581 adversarial review (finding B2) refuted the reciprocity "
+        "discriminant's mechanism above by three independent checks on "
+        "this fixture's own data: (i) cond_a is almost ENTIRELY column-"
+        "norm ratio, not near-parallel columns -- after per-column "
+        "equilibration cond_a_equilibrated = 1.0004/1.0001/1.0040 and the "
+        "two incident-wave columns are near-ORTHOGONAL (normalized "
+        "overlap 4e-4/7e-5/4e-3), the opposite of 'nearly parallel'; (ii) "
+        "the 'both ports strongly reflecting' premise fails on this "
+        "fixture's own |S22| = 0.000/0.000/0.500 (the MSL side is NOT "
+        "strongly reflecting at the two lower bins); (iii) the signature "
+        "that DOES match is the two-drive solve's OWN warning's second "
+        "branch, 'one drive that failed to excite': the MSL drive's own "
+        "incident amplitude a_inc[1,1,:] is 8.2e-14/1.3e-11/7.1e-17 "
+        "against the coax drive's a_inc[0,0,:] of 5.8e-9/5.8e-8/3.0e-9 -- "
+        "5 to 9 orders of magnitude apart. Superseded by "
+        "POST_REVIEW_DISCRIMINANT below, which independently confirms the "
+        "PREDECLARED extraction-class failure mode (not junction physics) "
+        "is the better-supported explanation: the MSL ladder spans only "
+        "0.34%-3.37% of the guided wavelength at these three frequencies, "
+        "and the fitted Im(gamma) on the MSL array does not track the "
+        "analytic Hammerstad-Jensen beta at all (ratios 4x-32x off, "
+        "non-monotonic with frequency -- see the discriminant below and "
+        "the class docstring on CoaxMSLTransitionResult)."
+    ),
 }
+
+
+def _msl_guided_beta_and_ladder_fraction(freqs_hz, *, ladder_span_m):
+    """Analytic Hammerstad-Jensen beta and ladder-span/lambda_g fraction.
+
+    Pure function (no FDTD) -- the B3 discriminant computed from the SAME
+    committed fixture's own geometry constants, independent of any run.
+    """
+    from rfx.sources.msl_eigenmode import hammerstad_jensen_z0_eps_eff
+    from rfx.core.yee import EPS_0, MU_0
+
+    c0 = 1.0 / np.sqrt(MU_0 * EPS_0)
+    _, eps_eff_hj = hammerstad_jensen_z0_eps_eff(W_TRACE, H_SUB, EPS_SUB)
+    beta = 2.0 * np.pi * np.asarray(freqs_hz) * np.sqrt(eps_eff_hj) / c0
+    lambda_g = 2.0 * np.pi / beta
+    return beta, ladder_span_m / lambda_g
+
+
+def test_post_review_discriminant_msl_ladder_too_short_for_pencil_fit():
+    """B3 discriminant (issue #581 review) -- no FDTD, pure geometry/analytic.
+
+    The committed fixture's MSL probe ladder (probe_spacing_cells=2,
+    probe_count=6 -> span = 2*5 = 10 cells = 1.000 mm) spans a tiny, and
+    FREQUENCY-DEPENDENT, fraction of the guided wavelength at each measured
+    bin. A matrix-pencil forward/backward decomposition needs the span to
+    resolve a meaningful fraction of a cycle; this locks in that it does
+    not, at any of the three measured frequencies -- independent evidence
+    (alongside POST_REVIEW_DISCRIMINANT's fitted-gamma-vs-analytic-beta
+    comparison, which needs the FDTD result and is reported in the PR body
+    /the slow_physics test below) that the reciprocity/degeneracy finding
+    is an MSL wave-extraction instrument-scoping limit, not a claim about
+    the ladder span at published frequencies elsewhere in this file.
+    """
+    freqs = np.array([0.6e9, 3.3e9, 6.0e9])
+    ladder_span_m = 2 * (6 - 1) * DX  # probe_spacing_cells * (probe_count-1) * dx
+    beta, frac = _msl_guided_beta_and_ladder_fraction(freqs, ladder_span_m=ladder_span_m)
+    assert np.all(frac < 0.05), (
+        f"MSL ladder now spans {frac} of lambda_g at {freqs/1e9} GHz -- if "
+        "this rises above the ~5% floor a matrix-pencil fit needs, the "
+        "instrument-scoping finding may no longer apply; re-derive it "
+        "before trusting a passing reciprocity assertion elsewhere."
+    )
 
 
 def test_predeclaration_has_required_fields():
@@ -402,24 +476,82 @@ def test_predeclaration_has_required_fields():
 # THE DECLARED RESULT: the fixture runs, is internally self-consistent
 # (finite, deterministic, settles below -40 dB), but the RECIPROCITY
 # falsifier fires -- badly (|S12| vs |S21| disagree by 94-100% across the
-# three measured frequencies) -- with cond_a in the 1e3-1e7 range at every
-# bin. Per the falsifier's own discriminant (predeclared above): this
-# points at near-degenerate two-drive amplification, not an assembler
-# defect (Part 1's planted-voltage tests independently confirm the
-# assembler's power-wave normalization is correct) and not a missing-PEC
-# defect (independently confirmed by direct pec_mask inspection during
-# construction debugging). The coax side reflects strongly (|S11| ~
-# 0.81-0.99) while the MSL side's own reflection is small at low/mid
-# frequency and rises at the top of the band -- consistent with a
-# via-dominated series discontinuity at this SPECIFIC fixture's thin
-# (200um radius, ~700um long) unmatched pin-to-trace post, which the task
-# scoping explicitly anticipated ("no intermediate matching structure").
+# three measured frequencies), with raw cond_a in the 1e3-1e7 range at
+# every bin.
 #
-# Per R2, this STOPS here: no second geometry attempt in this session.
-# This is reported as an honest FIRST diagnostic measurement of a
-# deliberately unmatched junction, not a validated transition -- the test
-# below locks the measured (bad) reciprocity and passivity numbers as a
-# reproducibility witness, not as an accuracy claim.
+# ATTRIBUTION (CORRECTED after PR #581 adversarial review, findings B2/B3
+# -- the ORIGINAL attribution in this comment, "near-degenerate two-drive
+# amplification from strong junction reflection", was WRONG and is
+# preserved only in PREDECLARATION["post_review_correction"] above as the
+# historical record of what was first written and why it did not survive
+# its own data):
+#
+# B2: raw cond_a is almost entirely a column-NORM-ratio artifact, not
+# geometric near-parallelism. After per-column equilibration,
+# cond_a_equilibrated = 1.0004/1.0001/1.0040 (see the assembler's own
+# docstring) and the two incident-wave columns are near-ORTHOGONAL
+# (normalized overlap 4e-4/7e-5/4e-3) -- the OPPOSITE of "nearly
+# parallel". The "both ports strongly reflecting" premise also fails on
+# this fixture's own |S22| = 0.000/0.000/0.500 (not uniformly near 1).
+# What DOES match is the two-drive solve's own warning's SECOND branch,
+# "one drive that failed to excite": a_inc[1,1,:] (MSL's own incident
+# wave when MSL drives) is 8.2e-14/1.3e-11/7.1e-17 against
+# a_inc[0,0,:] (coax's own incident wave when coax drives) of
+# 5.8e-9/5.8e-8/3.0e-9 -- 5 to 9 orders of magnitude apart. This is a
+# drive-AMPLITUDE mismatch between the two unrelated source
+# constructions (coax TEM plane source vs MSL Ez injection), not
+# evidence of near-degenerate DIRECTIONS.
+#
+# B3: the PREDECLARED extraction-class failure mode (not junction
+# physics) is positively supported, not ruled out, by this fixture's own
+# numbers. The MSL probe ladder spans only 1.000 mm = 0.34%-3.37% of the
+# guided wavelength across the 3 measured frequencies (locked in by
+# test_post_review_discriminant_msl_ladder_too_short_for_pencil_fit,
+# analytic/no-FDTD) -- far too short for a matrix-pencil forward/backward
+# split to resolve. The fitted Im(gamma) on the MSL array does not track
+# analytic Hammerstad-Jensen beta (21.2/116.4/211.7 rad/m) at all: the
+# coax-driven fit gives 673.0/853.6/885.0 rad/m (4-32x too high, and
+# nearly FREQUENCY-FLAT across a 10x frequency span where the true beta
+# is not -- "locked onto a spatial feature" of the fixed probe spacing,
+# not the guided mode), and the msl-own-drive fit gives
+# 4.5/36.2/2881.3 rad/m with Re(gamma) = 5619/5964/139 rad/m -- a decay
+# length near 1 cell, i.e. not a propagating/decaying wave at all. Two of
+# this array's own fit_residual values (0.0313, 0.0348) already cross the
+# PREDECLARED "large = fit unreliable" line, and |S22| = 0.00000 at bins
+# 0-1 is a b/a ratio of 1e-8 to 1e-11 -- below float32 relative precision,
+# a degenerate split, which directly CONTRADICTS the via-reflector story
+# (that story demands |S22| -> 1, a real near-total reflection, not a
+# numerically-degenerate near-zero ratio). test_coax_msl_transition_
+# first_fixture_diagnostic (below) locks this comparison in as an
+# assertion, not just prose.
+#
+# HONEST STATEMENT (per review): degeneracy is observed. Whether the
+# junction's own physical reflection or the MSL wave-extraction's own
+# instrument-scoping limit (the PREDECLARED failure class) is the
+# dominant cause is UNRESOLVED by this one fixture alone -- but the
+# discriminant above POSITIVELY SUPPORTS the extraction-class
+# explanation and does not support the junction-reflection story, so
+# that is the better-supported reading, not a coin flip. This also NAMES
+# the implementation defect that would justify a future SECOND R2
+# attempt (a longer MSL probe ladder, >= 0.25 lambda_g at the lowest
+# measured frequency -- NOT run in this PR).
+#
+# A NAMED THIRD candidate mechanism, not ruled out either (issue #581
+# review B4): preflight's own x-CPML clearance warning on this fixture
+# ("distance to nearest x-CPML = 200um < recommended 600um... Source-side
+# CPML reflection may inflate |S11|") means the MSL port's own near-field
+# measurement sits close enough to its absorbing boundary that CPML
+# reflection could also be contaminating the MSL-side extraction,
+# independent of the ladder-length limit above. Not disentangled from
+# the ladder-length finding in this PR.
+#
+# Per R2, this STOPS here: no second geometry/probe-ladder attempt in
+# this session -- the numeric re-derivations above are instruments on
+# the ALREADY-COLLECTED run (same geometry, same n_steps; no new FDTD),
+# not a second physics attempt. This is reported as an honest FIRST
+# diagnostic measurement, not a validated transition -- the test below
+# locks the measured (bad) reciprocity/passivity/discriminant numbers as
+# a reproducibility witness, not as an accuracy claim.
 
 DX = 100e-6
 PIN_R = 0.2e-3
@@ -512,16 +644,91 @@ def _build_coax_msl_transition_sim():
     return sim
 
 
+def test_pin_axis_pec_connectivity_is_continuous():
+    """Non-FDTD (~1s) connectivity check -- the claim behind N5/the module
+    comment's "missing PEC z-layer" fix, committed as an artifact instead of
+    living only in throwaway debugging output (issue #581 review N1).
+
+    Reproduces exactly what compute_coax_msl_transition builds on the pin
+    axis (registered geometry via _assemble_materials, THEN the coax stub's
+    own stamp_coaxial_line, mirroring the method's own ordering) and asserts
+    there is no gap: every z-index from the coax stub's near-source end
+    through the trace's own layer is either registered PEC (pec_mask) or
+    coax-stamped PEC-conductivity (sigma >= PEC_SIGMA/2), with no break.
+    """
+    from rfx.sources.coaxial_port import stamp_coaxial_line, PEC_SIGMA
+
+    sim = _build_coax_msl_transition_sim()
+    grid = sim._build_grid()
+    materials, _, _, pec_mask, _, _, _ = sim._assemble_materials(grid)
+    pec = np.asarray(pec_mask)
+
+    port = sim._coaxial_ports[0]
+    center_xy = (float(port.position[0]), float(port.position[1]))
+    z_junction_idx = int(grid.position_to_index(port.position)[2])
+    z_stub_lo = int(grid.pad_z_lo) + 2
+    z_stub_hi = z_junction_idx - 1
+
+    materials, _ = stamp_coaxial_line(
+        grid, materials, center_xy=center_xy, z_lo_index=z_stub_lo,
+        z_hi_index=z_stub_hi, pin_radius=PIN_R, outer_radius=OUTER_R,
+    )
+    sigma = np.asarray(materials.sigma)
+
+    i0, j0 = grid.position_to_index((JUNCTION_X, Y_C, 0.0))[:2]
+    trace_idx = int(grid.position_to_index((JUNCTION_X, Y_C, N_TRACE * DX))[2])
+
+    registered_pec = pec[i0, j0, :]
+    stamped_pec = sigma[i0, j0, :] >= 0.5 * PEC_SIGMA
+    combined = registered_pec | stamped_pec
+
+    span = combined[z_stub_lo:trace_idx + 1]
+    assert np.all(span), (
+        f"gap in pin-axis PEC/sigma connectivity between the coax stub "
+        f"(z_stub_lo={z_stub_lo}) and the trace (idx={trace_idx}): missing "
+        f"indices {z_stub_lo + np.where(~span)[0]}"
+    )
+
+
+# Pinned from gate_from_envelope(0.9928, quantum=100) = 1.49, computed ONCE
+# from the max|S| measured when this test was last written/reviewed (issue
+# #581 review B5): a gate computed LIVE from the value it bounds
+# (``gate_from_envelope(max_abs_s)``) can never fail by construction, so it
+# is frozen here as a literal instead, and capped at the PREDECLARED 1.10
+# passivity floor (1.49 alone is ~40% above that floor and would provide no
+# real protection).
+PINNED_MEASURED_GATE = 1.49
+
+
+def test_pinned_measured_gate_provenance():
+    """PINNED_MEASURED_GATE's own derivation, kept checkable (issue #581
+    review B5): frozen as a literal so the amplitude gate below cannot be
+    tautological, but the literal's provenance (gate_from_envelope applied
+    to the max|S| measured when it was pinned) stays self-verifying rather
+    than a comment-only claim.
+    """
+    assert gate_from_envelope(0.9928, quantum=100) == PINNED_MEASURED_GATE
+
+
 @pytest.mark.slow_physics
 def test_coax_msl_transition_first_fixture_diagnostic():
     """The one committed #489-leg-4 fixture -- DIAGNOSTIC honesty level.
 
     See ``PREDECLARATION`` above and the module-level comment immediately
-    preceding this test for the full R2/R3 accounting. This test asserts
-    exactly what was measured: self-consistency (finite, settled) passes;
-    the reciprocity/passivity falsifier fires and is LOCKED as a
-    reproducibility witness, not papered over. Runtime ~110s (two FDTD
-    drives on a (67, 51, 56)-cell grid, 8000 steps each).
+    preceding this test for the full R2/R3 accounting, INCLUDING THE
+    POST-REVIEW ATTRIBUTION CORRECTION (issue #581 review B2/B3): the
+    degeneracy this test locks in is NOT attributed to "near-degenerate
+    two-drive amplification from junction reflection" (the original,
+    refuted claim) -- it is better explained by the MSL probe ladder being
+    far too short (0.34%-3.37% of a guided wavelength) for the matrix-pencil
+    wave split to resolve, an instrument-scoping limit of THIS fixture's
+    probe geometry, not a claim about the junction's own physics. This test
+    asserts exactly what was (re-)measured: self-consistency (finite,
+    settled) passes; the reciprocity/passivity/degeneracy findings are
+    LOCKED as a reproducibility witness, not papered over; the corrected
+    discriminants (column-equilibrated cond_a, fitted gamma vs analytic
+    beta) are asserted too, not just claimed in prose. Runtime ~110s (two
+    FDTD drives on a (67, 51, 56)-cell grid, 8000 steps each).
     """
     assert PREDECLARATION["status"] == "RUN"
 
@@ -529,12 +736,13 @@ def test_coax_msl_transition_first_fixture_diagnostic():
     result = sim.compute_coax_msl_transition(
         junction_x=JUNCTION_X, eps_r_sub=EPS_SUB, n_steps=N_STEPS,
         n_freqs=3, probe_count=6, probe_start_cells=4, probe_spacing_cells=2,
-        skip_preflight=True,
+        skip_preflight=True, strict_passivity=True,
     )
 
     assert result.s_params.shape == (2, 2, 3)
     assert np.all(np.isfinite(result.s_params))
     assert result.port_names == ("coax", "msl")
+    assert result.a_inc.shape == (2, 2, 3) and result.b_out.shape == (2, 2, 3)
 
     # Settling: both drives clear the -40 dB ring-down rule (this fixture
     # measured -43.9 / -63.6 dB at N_STEPS=8000; a shorter, 1500-step
@@ -545,37 +753,85 @@ def test_coax_msl_transition_first_fixture_diagnostic():
         "8000-step record may need lengthening."
     )
 
-    # Amplitude falsifier: pin the MEASURED envelope with the repo's
-    # standard 1.5x margin (tests/_gate_policy.py) rather than a fixed
-    # a-priori threshold -- this fixture's own diagonal peaks near 1
-    # (strong coax-side reflection; see the module comment) but must not
+    # Amplitude falsifier: pinned literal (see PINNED_MEASURED_GATE above),
+    # capped at the predeclared 1.10 passivity floor -- this fixture's own
+    # diagonal peaks near 1 (strong coax-side reflection) but must not
     # cross the passivity-violation floor by more than extraction noise.
+    # strict_passivity=True above additionally makes the hard
+    # passivity/finiteness self-check RAISE (not warn) if this fixture's
+    # own extraction ever crosses that check's tol=0.10 bound.
     max_abs_s = float(np.max(np.abs(result.s_params)))
-    gate = gate_from_envelope(max_abs_s, quantum=100)
+    gate = min(PINNED_MEASURED_GATE, 1.10)
     assert max_abs_s <= gate, (
-        f"max|S| {max_abs_s:.4f} exceeds its own {gate:.4f} envelope gate "
-        "-- a NEW amplitude excursion beyond what was measured when this "
-        "test was written; re-run the falsifier diagnostic (recurrence_"
-        "residual / fit_residual / cond_a) before trusting the change."
+        f"max|S| {max_abs_s:.4f} exceeds the pinned gate {gate:.4f} -- a "
+        "NEW amplitude excursion beyond what was measured when this test "
+        "was written; re-run the falsifier diagnostic (recurrence_"
+        "residual / fit_residual / cond_a_equilibrated) before trusting "
+        "the change."
     )
 
-    # Degeneracy witness: cond_a stays large (the predeclared discriminant
-    # for the reciprocity falsifier below). A LOW cond_a here without the
-    # matching reciprocity fix would itself be suspicious (the two
-    # findings should move together).
+    # Degeneracy witness -- CORRECTED (issue #581 review B2): raw cond_a
+    # stays large (scale-mismatch artifact, see module comment), but the
+    # column-EQUILIBRATED cond_a -- the one that actually discriminates
+    # geometric near-parallelism on a mixed-family lane -- stays near 1,
+    # confirming the two drives are NOT geometrically near-degenerate.
     assert np.all(np.asarray(result.cond_a) > 1.0e3), (
-        f"cond_a {result.cond_a} dropped below the degenerate-drive floor "
-        "this fixture measured -- the ill-conditioning finding may no "
-        "longer apply; re-evaluate the reciprocity assertion below too."
+        f"cond_a {result.cond_a} dropped below the scale-mismatch floor "
+        "this fixture measured -- re-evaluate the attribution."
+    )
+    assert np.all(np.asarray(result.cond_a_equilibrated) < 1.5), (
+        f"cond_a_equilibrated {result.cond_a_equilibrated} rose above the "
+        "near-unity floor this fixture measured -- the two drives may have "
+        "become genuinely geometrically near-degenerate, which would "
+        "revive (not refute) the original junction-reflection attribution; "
+        "re-derive the finding before trusting either story."
+    )
+
+    # B3 discriminant, asserted (not just claimed in the PR body): the
+    # fitted Im(gamma) on the MSL array does not track the analytic
+    # Hammerstad-Jensen beta -- confirms the extraction-class (ladder too
+    # short) explanation over the junction-physics one, per the module
+    # comment. Checked both drives' own fits (they disagree with EACH
+    # OTHER by 1-2 orders of magnitude too -- a second, independent
+    # symptom of an unreliable split, not just a mismatch vs the analytic
+    # value).
+    freqs = np.asarray(result.freqs)
+    ladder_span_m = 2 * (6 - 1) * DX
+    beta_analytic, ladder_frac = _msl_guided_beta_and_ladder_fraction(
+        freqs, ladder_span_m=ladder_span_m,
+    )
+    im_gamma_coax_driven = np.abs(result.gamma[1, 0, :].imag)
+    im_gamma_msl_owndrive = np.abs(result.gamma[1, 1, :].imag)
+    ratio_coax_driven = im_gamma_coax_driven / beta_analytic
+    assert np.all(ratio_coax_driven > 3.0), (
+        f"fitted Im(gamma) (coax-driven) / analytic beta = "
+        f"{ratio_coax_driven} dropped near 1 -- the MSL matrix-pencil fit "
+        "may have started tracking the true guided mode; re-derive the "
+        "instrument-scoping attribution before trusting it."
+    )
+    # The two drives' own fits should still disagree by >1 order of
+    # magnitude at at least one bin (measured: bin 0 gives 673.0 vs 4.5 --
+    # ratio ~150x) -- an internal cross-check that neither fit is simply
+    # "the right answer measured twice".
+    cross_drive_ratio = np.maximum(
+        im_gamma_coax_driven / np.maximum(im_gamma_msl_owndrive, 1e-30),
+        im_gamma_msl_owndrive / np.maximum(im_gamma_coax_driven, 1e-30),
+    )
+    assert np.any(cross_drive_ratio > 10.0), (
+        f"coax-driven vs msl-own-drive Im(gamma) ratios {cross_drive_ratio} "
+        "no longer disagree by >10x anywhere -- the two independent fits "
+        "may have converged, which would weaken the instrument-scoping "
+        "finding; re-derive it."
     )
 
     # Reciprocity falsifier -- LOCKED, not silently accepted: this
-    # fixture's own measured deviation is ~94-100% (see module comment).
-    # Regression-lock the FINDING (it stays badly non-reciprocal) so a
-    # future change that quietly "fixes" this number gets flagged for
-    # review rather than assumed correct -- the fix would need its own
-    # falsifier re-run (a NEW fixture geometry, e.g. adding a matching
-    # structure or a wider/shorter via), not a silent gate change here.
+    # fixture's own measured deviation is ~94-100% (see module comment for
+    # the corrected attribution). Regression-lock the FINDING (it stays
+    # badly non-reciprocal) so a future change that quietly "fixes" this
+    # number gets flagged for review rather than assumed correct -- the
+    # fix would need its own falsifier re-run (e.g. a longer MSL probe
+    # ladder, >= 0.25 lambda_g -- a NEW, separately pre-declared R2
+    # attempt, NOT run in this PR), not a silent gate change here.
     pair, worst_dev = _mixed_reciprocity_deviation(result.s_params)
     assert worst_dev > 0.5, (
         f"reciprocity deviation dropped to {worst_dev:.3f} between ports "


### PR DESCRIPTION
## Summary

Implements issue #489's "leg 4" (coax<->planar transition), scoped in PR #561's leg-4 paragraph. Adds `Simulation.compute_coax_msl_transition(...)` + `CoaxMSLTransitionResult`, **EXPERIMENTAL, diagnostic-only from birth**, plus one committed FDTD fixture and its predeclaration.

**This revision responds to an adversarial review of the first version (5 blocking findings, all addressed in this commit; no second FDTD run required — every fix below is a claim/instrument correction on the SAME already-collected run).** The engineering (power-wave normalization, R2-STOP discipline, honesty scaffolding) was judged sound; the bug was in my OWN attribution of *why* the committed fixture is degenerate. That attribution is corrected throughout this revision — see "Attribution correction" below, which is the most important section of this PR body.

## Design choice: new function, not a generalized `compute_mixed_s_matrix`

`compute_mixed_s_matrix` (#488) is deeply lumped/wire-specific (flux-box geometry, PEC-z_lo-boundary guard, per-family diagonals); threading a third port family through it would touch nearly every guard. Instead `compute_coax_msl_transition` combines the less-invasive half of each existing family's own validated machinery, unchanged:
- **Coax side**: reuses `stamp_coaxial_line` / `stamp_coaxial_annular_resistor` / `build_coaxial_tem_plane_source_specs` verbatim, mirroring `compute_coaxial_two_port`'s own single-ended stub — just one end instead of two.
- **MSL side**: consumed exactly like `compute_mixed_s_matrix` consumes its MSL ports — the caller registers arbitrary junction geometry (substrate, trace, ground plane, clearance hole, pin-to-trace post) via ordinary `sim.add(Box(...)/Cylinder(...), material=...)`, and the method reuses `compute_msl_mode_profile` / `setup_msl_port` / `make_msl_port_sources` verbatim.

No existing extractor's guard rails were touched.

## Power-wave normalization (the pre-declared "impedance-convention mismatch" failure mode)

Both ports' forward/backward wave amplitudes come from the same extractor, `coaxial_line_reflection_from_plane_voltages` (a Z0-free matrix-pencil fit) — applied to the coax probe ladder **and, deliberately, to the MSL probe ladder too**, in place of the #488 lane's own N-probe SVD fit (`extract_msl_nprobe`), whose sign instability is documented in `compute_mixed_s_matrix`'s own source.

Each port's raw modal-voltage wave (volts, Z0-free) is converted to a power wave via `a = V+ / sqrt(Z0)` (real Z0 only — no `Re()` is taken anywhere) — coax: analytic TEM Z0; MSL: analytic Hammerstad-Jensen Zc — **before** the shared two-drive solve. This division is new and load-bearing here in a way it wasn't for #489 stage-2 coax-coax: solving directly on raw volt-wave amplitudes leaves the diagonal exactly correct but scales each off-diagonal entry by `sqrt(Zi/Zj)` — invisible on a coax-coax through line (equal Z0 cancels) but not invisible when Z0_coax != Z0_msl.

Independently unit-tested with **planted, analytically known voltages under deliberately unequal Z0** (50 ohm coax vs 74.3 ohm MSL) — `tests/test_coax_msl_transition.py`:
- `test_planted_voltages_recover_known_s_matrix_with_unequal_z0` — the fix recovers the known S-matrix exactly (atol 1e-9).
- `test_unequal_z0_normalization_is_required_off_diagonal_only` — a dedicated regression test reproducing the exact defect the fix prevents.
- `test_equal_z0_makes_normalization_a_no_op` — sanity cross-check.

This piece of the review — the normalization math itself — was reviewed and judged sound and mutation-verified; it is unchanged in this revision.

## Attribution correction (this revision's main content — review findings B2, B3)

The first version of this PR attributed the committed fixture's badly-broken reciprocity (94-100% `|S12|` vs `|S21|` deviation) to **"near-degenerate two-drive amplification from strong junction reflection."** That attribution is **wrong** and is retracted. Three independent checks on the fixture's own numbers refute it, and a fourth positively supports the alternative the task itself pre-declared as a candidate failure class.

### B2 — `cond_a` was measuring drive-amplitude scale, not geometric degeneracy

Raw `cond_a` (1e3-1e7 across the 3 bins) is **almost entirely a column-norm-ratio artifact**. After per-column equilibration (new `cond_a_equilibrated` field, added this revision):

```
cond_a (raw):          7.05e+04   4.59e+03   4.27e+07
cond_a_equilibrated:   1.00042    1.00007    1.00400
```

The two incident-wave columns are near-**orthogonal**, not nearly parallel (normalized overlap 4.18e-4 / 6.74e-5 / 3.99e-3). Joint column scaling leaves `S = B @ inv(A)` invariant (verified: a planted known-S case at `cond(A)=1e7` recovers with 0 error after equilibration — see the new field's docstring derivation), so this is diagnostic-only and does not change `s_params`.

The "both ports strongly reflecting" premise also fails on this fixture's own `|S22|` = 0.000 / 0.000 / 0.500 (not uniformly near 1). What DOES match is the two-drive solve's own warning's **second branch** — "one drive that failed to excite" — not the first ("nearly linearly dependent" in the geometric sense): the MSL drive's own incident amplitude is many orders of magnitude smaller than the coax drive's:

```
a_inc[coax, own drive]:  5.81e-09   5.79e-08   3.03e-09
a_inc[msl,  own drive]:  8.24e-14   1.26e-11   7.10e-17
```

`a_inc`/`b_out` (the power-wave amplitudes actually fed to the two-drive solve) are now exposed on `CoaxMSLTransitionResult` so this is auditable, not just claimed.

### B3 — the PREDECLARED extraction-class failure mode is positively supported, not ruled out

The MSL probe ladder on this fixture spans 1.000 mm. Compared against the analytic Hammerstad-Jensen guided wavelength at the three measured frequencies:

```
freq (GHz):        0.60      3.30      6.00
beta_analytic:      21.2     116.4     211.7   rad/m
lambda_g:         296.9mm    54.0mm    29.7mm
ladder/lambda_g:   0.34%     1.85%     3.37%
```

A matrix-pencil forward/backward split over <4% of a wavelength cannot reliably separate the two waves. The fitted `Im(gamma)` on the MSL array confirms this — it does not track the analytic beta at all:

```
                     0.60 GHz    3.30 GHz    6.00 GHz
beta_analytic          21.2       116.4       211.7   rad/m
Im(gamma) [coax-driven] 673.0      853.6       885.0   rad/m   (4-32x too high, nearly frequency-FLAT)
Im(gamma) [msl-own-drive] 4.5       36.2      2881.3   rad/m
Re(gamma) [msl-own-drive] 5619.2   5964.0      139.3   rad/m   (decay length ~1 cell -- not a real propagating wave)
```

The "coax-driven" fit is nearly frequency-flat across a 10x frequency span where the true beta is not — consistent with the fit locking onto a spatial feature of the fixed probe spacing rather than the guided mode. The "own-drive" fit's `Re(gamma)` in the thousands rad/m implies a decay length near one grid cell, not physical propagation/decay. Two of this array's own `fit_residual` values (0.0313, 0.0348) already cross the fixture's own predeclared "large = fit unreliable" line, and `|S22|=0.00000` at bins 0-1 is a `b/a` ratio of 1e-8 to 1e-11 — below float32 relative precision, a numerically degenerate split, which directly **contradicts** the via-reflector story (that story demands `|S22| -> 1`, a real near-total reflection).

Both discriminants (ladder-length-vs-lambda_g, fitted-gamma-vs-analytic-beta) are now **locked as test assertions**, not just PR-body prose — `tests/test_coax_msl_transition.py::test_post_review_discriminant_msl_ladder_too_short_for_pencil_fit` (pure geometry, no FDTD) and the corresponding assertions inside `test_coax_msl_transition_first_fixture_diagnostic`.

### Honest statement (adopted in all carriers: PR body, `CoaxMSLTransitionResult` docstring, support-matrix md+json, ledger snippet below)

**Degeneracy is observed. Whether the junction's own physical reflection or the MSL wave-extraction's own instrument-scoping limit (the PREDECLARED failure class) is the dominant cause is UNRESOLVED by this one fixture alone — but the discriminant above positively supports the extraction-class explanation and does not support the junction-reflection story, so that is the better-supported reading, not a coin flip.** This also **names the implementation defect** that would justify a future, separately pre-declared second R2 attempt: a longer MSL probe ladder (>= 0.25 lambda_g at the lowest measured frequency). **That second attempt is NOT run in this PR** — per instruction and per R2, this stops at one physics attempt; the corrected attribution above is entirely re-derived from the existing run's data (no new FDTD).

**A third, named candidate mechanism, also not ruled out** (review finding B4): preflight's own x-CPML clearance warning on this exact fixture reads "distance to nearest x-CPML = 200um... < recommended 600um... **Source-side CPML reflection may inflate |S11|**." The MSL port sits close enough to its own absorbing boundary that CPML reflection could independently contaminate the MSL-side near-field measurement, on top of (or instead of) the ladder-length limit. Not disentangled from the ladder-length finding in this PR.

## What I found while building this (2 construction defects, both plumbing per the repo's own R2 distinction — fixed before the declared measurement, not counted as physics attempts)

1. **Missing PEC z-layer**: my first z-index bookkeeping left a 1-cell gap between the coax stub's own top and the caller's ground-plane/pin-post geometry. Found by direct `pec_mask` inspection during construction, fixed by correcting the junction-height consistency check in `compute_coax_msl_transition` itself. **Now committed as an artifact, not just claimed**: `tests/test_coax_msl_transition.py::test_pin_axis_pec_connectivity_is_continuous` (non-FDTD, ~1s) reproduces the exact check and locks the TRUE result (review finding N1).
2. **Float32 rasterization "knife edge"**: every boundary in my first fixture draft landed on an exact multiple of `dx` — precisely the case `rfx/geometry/csg.py`'s own `Box` docstring warns is undecidable under float32 double-rounding. Fixed using that docstring's own documented recipe (cell-midpoint corners for `Box`; a `stamp_coaxial_line`-style `+2*dz` margin for `Cylinder`, which is a DIFFERENT mechanism since `Cylinder`'s inclusive height check is not corner-based — review finding N5, wording clarified in the predeclaration).

## Preflight output — ALL NINE lines, verbatim (R5; review finding B4)

```
[PREFLIGHT] 'pec' z-extent 100µm = 1.0 cells — below 1 cell resolution. A conductor thinner than a cell is modelled as a one-cell PEC surface — tangential E is zeroed on it and the normal component survives as surface charge. That is usually what you want for metal many skin depths thick, and switching to add_thin_conductor() would not change it; but it means the sheet carries no conductor loss and its thickness is not modelled.
[PREFLIGHT] PEC 'pec' x-extent 400µm = 4.0 cells — volume under-resolved (PEC volume needs ≥5 cells; thin sheets <3 cells are fine).
[PREFLIGHT] PEC 'pec' y-extent 400µm = 4.0 cells — volume under-resolved (PEC volume needs ≥5 cells; thin sheets <3 cells are fine).
[PREFLIGHT] Gap between PEC structures: 300µm = 3.0 cells along z — coupling may be under-resolved.
[PREFLIGHT] all dielectric(s) ['ptfe', 'sub'] are perfectly lossless in an open (CPML) domain. If you are measuring Q / resonance, this gives an ARTIFICIALLY infinite Q (design-guide Anti-Pattern #1, an R5 surface-metric trap) — add loss, e.g. sigma = 2*pi*f*eps0*eps_r*tan_delta. (Harmless if you are not measuring Q.)
[PREFLIGHT] MSL port 'msl_0' (trace W=600µm, h_sub=300µm): lateral clearance to +y absorbing boundary = 600µm (domain edge + 800µm calibrated CPML buffer) < recommended 600µm (= 2·h_sub). Fringing field will be clipped → Z0 may be biased HIGH by ~0%, mesh-conv may diverge. Increase domain y-extent OR move port further from sidewall.
[PREFLIGHT] MSL port 'msl_0': only 3 substrate cell(s) in z (h_sub=300µm, dx=100µm). Yee staircase at dielectric interface is O(dx) — Z0 staircase error >5% expected. Refine to dx ≤ 75µm (4+ substrate cells) AND keep h_sub/dx an integer (aligned) for <5% Z0 bias — measured post-#511/#507 at -3.8%/-1.2%/+0.7% for h_sub/4, h_sub/5, h_sub/6 (scripts/diagnostics/msl_z0_bias_floor_sweep.py). Refining WITHOUT alignment does not reach that: a mixed-cell mesh at a similar cell count measured +11% (h_sub/dx=4.233) — see the mixed-cell-danger-zone check below.
[PREFLIGHT] MSL port 'msl_0' at x=4.00mm, direction='-x': distance to nearest x-CPML = 200µm (domain edge + 800µm calibrated CPML buffer) < recommended 600µm (= 2·h_sub). Source-side CPML reflection may inflate |S11|. Move port further from boundary OR increase domain x-extent.
[PREFLIGHT] MSL port 'msl_0' (direction='-x'): probe 4 (deepest, x=-0.80mm) is past the domain edge (domain x-extent [0, 5.00]mm) — inside the CPML absorbing region. The N-probe extractor's clean-travelling-wave assumption is void there: signal is attenuated and the fitted Z0/S11 are corrupted. no compliant n_probe_offset exists on this feed length (interval empty).
```

Lines 2/3/4/7 are the same under-resolution class the B3 discriminant confirms independently (pin-post diameter, substrate thickness, ground-to-trace gap). **Line 8 (the x-CPML clearance line) is the named third mechanism** discussed above — addressed explicitly, not silently dropped this time. Line 9 is the known caveat, verified correct in the first review pass: preflight's own generic MSL probe-ladder advisory evaluates against the registered port's *default* `n_probe_offset`/`n_probe_spacing` fields, which `compute_coax_msl_transition` does not consume (it takes its own `probe_start_cells`/`probe_spacing_cells` parameters, separately guarded) — that specific advisory line is a known mismatch, not a defect in this method's own probe ladder.

## Other review findings addressed this revision

- **B1 (hard blocker, CI-red)**: `tests/test_ad_surface_contract.py::test_every_sparam_entry_point_is_ad_classified` was failing — added `"Simulation.compute_coax_msl_transition": (NOT_TRACEABLE, "...")` to `AD_CLASSIFICATION`. Now passes (5/5 in that file).
- **B5**: the amplitude gate was self-referential (`gate_from_envelope(max_abs_s)` computed from the value it bounds — could never fail). Fixed: `PINNED_MEASURED_GATE = 1.49` is now a frozen literal (provenance kept checkable by a dedicated `test_pinned_measured_gate_provenance`), and the actual assertion is `max_abs_s <= min(PINNED_MEASURED_GATE, 1.10)` — the predeclared passivity floor. Also added `strict_passivity=True` to the fixture's own call (verified: does not raise, since `max|S|=0.993 < 1.10`).
- **N2**: added a warning when a registered `add_coaxial_port(impedance=...)` / `add_msl_port(impedance=...)` diverges >5% from the analytic Z0 this method actually uses for the power-wave normalization (previously silently ignored beyond source/termination sizing). Fires on the committed fixture itself (coax: registered 50 ohm vs analytic 45.46 ohm, 10.0%; msl: registered 50 ohm vs analytic 53.11 ohm, 5.8%) — verified via the slow_physics test's own captured warnings.
- **N4**: corrected the residual claim — two `fit_residual` values exceed 0.02 (0.0313, 0.0348), not zero as the first PR body implied; now stated correctly and used as part of the B3 discriminant above.
- **N6**: `json.dump(..., ensure_ascii=False)` — the first revision's plain `json.dump` re-escaped pre-existing non-ASCII characters (em-dashes) in four UNRELATED entries, showing as spurious diff churn. Fixed; the JSON diff is now scoped to the actual new/changed entry only.
- **n1**: fixed a stale test-name citation in `_assemble_coax_msl_transition_from_voltages`'s own docstring (cited `test_planted_voltages_recover_known_s_matrix`, the real name has a `_with_unequal_z0` suffix).
- **n2**: reworded "sqrt(Re(Z0))" to "sqrt(Z0)" + an explicit "real reference impedances only, no `Re()` is taken" note, in every carrier (assembler docstring, result docstring, support-matrix md) — the code never actually calls `Re()`.

## Deliverable checklist

1. `compute_coax_msl_transition` (new function; less invasive than generalizing `compute_mixed_s_matrix`) — EXPERIMENTAL from birth, NOT_TRACEABLE (AD-classified, see B1 fix), two-drive, per-family extraction reusing validated primitives, per-port reference impedances + planes documented in the docstring, now including `cond_a_equilibrated`/`a_inc`/`b_out` for auditability and an impedance-divergence advisory.
2. First fixture as a test (`tests/test_coax_msl_transition.py`, ~110s, `slow_physics`-marked): predeclaration + witnesses asserted at DIAGNOSTIC honesty level — the amplitude gate is now a pinned literal (not self-referential), the reciprocity/degeneracy finding is locked with the CORRECTED attribution, and the B3 discriminant is a real assertion, not prose. Plus a fast (~1s) non-FDTD connectivity test and a fast (<1s) pure-geometry ladder-length discriminant test.
3. Support-matrix row (md+json, matching phrasing, corrected attribution) — `docs/guides/sparameter_support_matrix.md`'s "Coax<->MSL transition" section, the `coax_msl_transition` entry in `.json` (version 3->4), the API-summary table row, and `docs/agent/repo-map.mdx`'s grep-map line + caveat paragraph.
4. Ledger-ready snippet for the gitignored ledger (paste at merge — reworded per review finding N3, this is now R1-load-bearing memory for future sessions and must not repeat the retracted attribution):

> **#489 leg 4 (coax<->MSL transition) — EXPERIMENTAL, diagnostic-only, PR #581.** `compute_coax_msl_transition` generalizes #488's mixed-family idea by combining the coax two-port stub (unchanged) with #488's own MSL-DUT delegation (unchanged); both ports extracted via the coax matrix-pencil fit (not #488's N-probe fit, whose sign instability is documented in `compute_mixed_s_matrix`'s own source), power-wave normalized via each port's analytic Z0 — independently regression-tested against planted unequal-Z0 voltages (this part is sound, mutation-verified). One committed FDTD fixture (vertical launch, thin unmatched via) is self-consistent but TRIPS its own reciprocity falsifier (94-100% deviation). **Do NOT attribute this to "junction reflection" or "near-degenerate two-drive amplification"** — that attribution was checked against the fixture's own `cond_a_equilibrated` (near 1), column overlap (near-orthogonal), and `|S22|` (near 0 at 2/3 bins) and REFUTED. The better-supported explanation (not yet fully confirmed) is that the MSL probe ladder (0.34%-3.37% of lambda_g) is too short for the matrix-pencil wave split to resolve — an instrument-scoping limit, not a junction-physics finding. A third candidate (MSL port too close to its own x-CPML face) is also unruled out. R2-STOP after one attempt. **Next attempt: lengthen the MSL probe ladder (>= 0.25 lambda_g) FIRST, before touching the junction geometry** — a new, separately pre-declared R2 attempt, not yet run.

## R3 pre-commit self-audit

1. **Contradicted by a known memory/feedback entry?** None found after grep (primary checkout `docs/agent-memory/rfx-known-issues.md`, `port_primitives_inventory.md`, `sparameter_support_matrix.md`; also newly consistent with `feedback_agreement_is_not_independence.md` — the coax-fit-for-both-ports choice is one extractor family, disclosed as such, not treated as two independent witnesses — and directly operationalizes `feedback_gate_can_bind_artifact.md`'s falsifier-re-run mandate, this time correctly: the B2/B3 re-derivation IS the falsifier re-run this rule requires before trusting a strengthened claim, and it changed the claim).
2. **R2 tripped?** No. One physics attempt. The B2/B3 corrections in this revision are instruments/re-derivations on the SAME already-collected run (no new FDTD, same geometry, same n_steps) — not a second attempt. Two construction-debugging fixes preceded the declared run (a missing PEC layer, a rasterization knife-edge), both plumbing, both now committed as fast non-FDTD tests (N1) rather than living only in throwaway debug output.
3. **What would falsify this?** Re-run `pytest -m slow_physics tests/test_coax_msl_transition.py` — `cond_a_equilibrated` should stay near 1, the fitted-gamma-vs-beta ratio should stay >3x, and reciprocity deviation should stay >0.5; if any of those move, the attribution needs re-review. `pytest -m "not slow_physics" tests/test_coax_msl_transition.py` (14 tests) re-proves the assembler's power-wave normalization AND the pure-geometry ladder-length discriminant, no FDTD, <3s.

## Verification

- Touched-file pytest: `tests/test_coax_msl_transition.py` — 13/13 fast + 1/1 `slow_physics` (~115s), all pass.
- AD-surface contract (review B1, now passing): `tests/test_ad_surface_contract.py` — 5/5.
- Coax-family regression (PR #572's AD work, unaffected): `tests/test_coax_two_port_ad.py` — 5/5 (3 fast + 2 `slow_physics`).
- Contract/API-reference gates: `tests/test_sparameter_support_contract.py` (19/19), `tests/test_api_private_surface_guard.py` (5/5).
- `ruff check rfx/api/_sparams.py rfx/api/_spec.py tests/test_coax_msl_transition.py tests/test_ad_surface_contract.py --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402` — clean.
- JSON validity + scoped diff (review N6): `docs/guides/sparameter_support_matrix.json` parses, and the diff against main no longer touches unrelated entries.
- `rfx/api/_preflight.py` untouched (no Studio-suite obligation).
- Never `jax.config.update('jax_enable_x64', True)` at module level — not used anywhere in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
