### PR TITLE
fix(diagnostics): rename tj_farport_test.py so pytest's glob cannot import its module-level argparse (closes #567)

### DIFF
--- a/scripts/diagnostics/finalize_tjunction_farport_artifacts.py
+++ b/scripts/diagnostics/finalize_tjunction_farport_artifacts.py
@@ -3,7 +3,7 @@ data (supersedes the narrow-band near-port finalize_tjunction_artifacts.py, whos
 5.4-6.4 GHz restriction was a port-placement sweet spot, not a convergence limit).
 
 Far-port = de-embedding planes >=5 evanescent decay-lengths from the junction
-(tj_farport_test.py). rfx at dx=2.0 & 1.0 mm; matched far-port MEEP at res=500.
+(tj_farport_diag.py (formerly tj_farport_test.py)). rfx at dx=2.0 & 1.0 mm; matched far-port MEEP at res=500.
 Full single-mode TE10 band 5-7 GHz. Writes the two manifest-referenced artifacts.
 No tolerance loosening: actual metrics are computed and reported as-is.
 """

--- a/scripts/diagnostics/meep_tjunction_farport_reference.py
+++ b/scripts/diagnostics/meep_tjunction_farport_reference.py
@@ -1,5 +1,5 @@
 """Far-port MEEP reference for the H-plane T-junction |S|-matrix, matched to the
-rfx long-arm geometry (scripts/diagnostics/tj_farport_test.py): domain 0.30x0.24,
+rfx long-arm geometry (scripts/diagnostics/tj_farport_diag.py (formerly tj_farport_test.py)): domain 0.30x0.24,
 W=0.04, ports >=5 evanescent decay-lengths from the junction. |S| magnitudes are
 reference-plane independent (only phase rotates), so this is apples-to-apples with
 far-port rfx. FLUX-based (MPB-free; MEEP MPB rejects PEC walls).

--- a/scripts/diagnostics/tj_farport_diag.py
+++ b/scripts/diagnostics/tj_farport_diag.py
@@ -1,4 +1,8 @@
 """DISCRIMINATING TEST: is the T-junction mesh-divergence a SOLVER corner error
+# RENAMED from tj_farport_test.py (issue #567): the old name matched pytest's
+# *_test.py collection glob while the script calls argparse.parse_args() at module
+# level -- an INTERNALERROR landmine if rootdir/testpaths detection ever shifts.
+# Diagnostic scripts must not be named *_test.py.
 (H1/H3) or just PORTS sitting in the junction's evanescent near-field (H2)?
 
 Long-arm T-junction: ports placed >=5 evanescent decay-lengths from the junction

--- a/scripts/diagnostics/tj_farport_geom2.py
+++ b/scripts/diagnostics/tj_farport_geom2.py
@@ -3,7 +3,7 @@
 Second, genuinely different junction geometry demanded by the single-geometry
 honesty locks (tests/test_waveguide_tjunction_e4e5_gates.py): the numeric
 breadth bars require >= 2 junction geometries before any "broad" junction
-claim. Mirrors scripts/diagnostics/tj_farport_test.py (geometry 1, W=0.04)
+claim. Mirrors scripts/diagnostics/tj_farport_diag.py (formerly tj_farport_test.py) (geometry 1, W=0.04)
 with the same far-port discipline on the SAME domain/CPML:
 
   * guide width W = 0.036 m -> TE10 cutoff 4.163 GHz, TE20 cutoff 8.327 GHz;

--- a/scripts/diagnostics/tj_farport_vi.py
+++ b/scripts/diagnostics/tj_farport_vi.py
@@ -2,7 +2,7 @@
 (extract_waveguide_s_matrix). S11 = backward/forward = Gamma_junction, which
 separates the two propagation directions at the port plane and is therefore
 IMMUNE to the source/boundary re-reflection standing wave that ripples the
-flux (power-subtraction) reflection. Same geometry as tj_farport_test.py.
+flux (power-subtraction) reflection. Same geometry as tj_farport_diag.py (formerly tj_farport_test.py).
 Tests whether per-frequency |S11| is clean with V/I separation.
 """
 import sys, argparse; sys.path.insert(0, "/tmp/rfx-tj")


### PR DESCRIPTION
Mechanical rename per #567: the diagnostic matched pytest's `*_test.py` collection pattern while calling `argparse.parse_args()` at module import — a collection INTERNALERROR landmine (tripped live during the PR #566 review when rootdir detection shifted). `git mv` to `tj_farport_diag.py` + a header note + cross-reference updates in the four sibling diagnostics. No code change; `pytest --collect-only` clean.

R3: memory=none-after-grep | R2-attempts=0 | falsifier=pytest --collect-only with a perturbed rootdir no longer imports the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)