### PR TITLE
fix(test): rebuild the NU flux-AD eps_override comparator on the production rasterizer (closes #590)

### DIFF
--- a/tests/test_waveguide_nu_checkpoint.py
+++ b/tests/test_waveguide_nu_checkpoint.py
@@ -78,12 +78,44 @@ def test_nu_checkpoint_no_longer_fenced_and_forward_identical():
 
 
 def _eps_override(sim, deps):
-    from rfx.runners.nonuniform import pos_to_nu_index
+    """NU-grid eps override: production-assembled eps + deps inside the slab.
+
+    #590 sibling: mirrors ``test_waveguide_nu_flux_ad.py::_eps_override_for``
+    — derive the baseline from ``assemble_materials_nu`` (the production NU
+    materials-assembly path) and the slab region from the Box's own
+    ``mask_on_coords``, never a hand ``pos_to_nu_index`` nearest-node
+    reconstruction (which went stale under #562's node-coordinate
+    convention change and was silently unprotected here since this test
+    only compares two runs that share the same override, not against a
+    production-default run).
+    """
+    from rfx.runners.nonuniform import assemble_materials_nu
+    from rfx.geometry.rasterize_grid import coords_from_nonuniform_grid
+
     grid = sim._build_nonuniform_grid()
-    eps = jnp.ones(grid.shape, dtype=jnp.float32)
-    i_lo = pos_to_nu_index(grid, (_SLAB_LO, _A / 2, _B / 2))[0]
-    i_hi = pos_to_nu_index(grid, (_SLAB_HI, _A / 2, _B / 2))[0]
-    return eps.at[i_lo:i_hi, :, :].set(_SLAB_EPS + deps)
+    materials, _debye_spec, _lorentz_spec, _pec_mask = assemble_materials_nu(sim, grid)
+    coords = coords_from_nonuniform_grid(grid)
+    slab_entry = next(e for e in sim._geometry if e.material_name == "diel")
+    slab_mask = slab_entry.shape.mask_on_coords(coords.x, coords.y, coords.z)
+    return jnp.where(slab_mask, materials.eps_r + deps, materials.eps_r)
+
+
+def test_eps_override_matches_production_assembly():
+    """#590 sibling regression: lock ``_eps_override`` to the production NU
+    materials assembly (the reduce-to-production pattern PR #564's review
+    used for F1/F2) — an elementwise assertion the helper's deps=0 baseline
+    equals a fresh, independent ``assemble_materials_nu`` call on the
+    identical fixture. Not ``@pytest.mark.slow``: no FDTD run, so it reds
+    in the fast lane if this helper ever drifts back to a hand-rolled
+    index reconstruction.
+    """
+    from rfx.runners.nonuniform import assemble_materials_nu
+
+    sim = _nu_sim()
+    grid = sim._build_nonuniform_grid()
+    materials, _, _, _ = assemble_materials_nu(sim, grid)
+    override = _eps_override(sim, jnp.asarray(0.0, dtype=jnp.float32))
+    np.testing.assert_array_equal(np.asarray(override), np.asarray(materials.eps_r))
 
 
 @pytest.mark.slow

--- a/tests/test_waveguide_nu_checkpoint.py
+++ b/tests/test_waveguide_nu_checkpoint.py
@@ -84,10 +84,22 @@ def _eps_override(sim, deps):
     — derive the baseline from ``assemble_materials_nu`` (the production NU
     materials-assembly path) and the slab region from the Box's own
     ``mask_on_coords``, never a hand ``pos_to_nu_index`` nearest-node
-    reconstruction (which went stale under #562's node-coordinate
-    convention change and was silently unprotected here since this test
-    only compares two runs that share the same override, not against a
-    production-default run).
+    reconstruction.
+
+    Measured correction (PR #591 review): on THIS fixture the OLD
+    (``pos_to_nu_index``) and NEW (``mask_on_coords``) masks occupy the
+    SAME x-planes (28, 29, 30) — the #562 node-coordinate convention shift
+    that broke the sibling ``test_waveguide_nu_flux_ad.py`` fixture does
+    NOT reach this one. The 114 cells that differ are exactly the y=A and
+    z=B hi-face node planes: Box's half-open ``[lo, hi)`` volume rule
+    excludes its own hi face, and this box's y/z extent is the full
+    PEC-walled cross-section, so those planes are the PEC-wall nodes
+    ``pos_to_nu_index`` had no shape-aware reason to exclude. Directly
+    measured: a gradient computed with the OLD mask and one computed with
+    the NEW mask on this fixture are IDENTICAL, ``-2.307174e-02`` both
+    (0.00% difference) — this rewrite is latent-divergence cleanup (the
+    same class of hand-rolled comparator removed before it COULD go stale
+    under a future change), not a fix for a live defect on this fixture.
     """
     from rfx.runners.nonuniform import assemble_materials_nu
     from rfx.geometry.rasterize_grid import coords_from_nonuniform_grid
@@ -101,21 +113,30 @@ def _eps_override(sim, deps):
 
 
 def test_eps_override_matches_production_assembly():
-    """#590 sibling regression: lock ``_eps_override`` to the production NU
-    materials assembly (the reduce-to-production pattern PR #564's review
-    used for F1/F2) — an elementwise assertion the helper's deps=0 baseline
-    equals a fresh, independent ``assemble_materials_nu`` call on the
-    identical fixture. Not ``@pytest.mark.slow``: no FDTD run, so it reds
-    in the fast lane if this helper ever drifts back to a hand-rolled
-    index reconstruction.
+    """#590 sibling / PR #591-review regression: lock ``_eps_override``'s
+    PERTURBATION MASK to the production slab indicator.
+
+    Mirrors ``test_waveguide_nu_flux_ad.py``'s lock — the original
+    deps=0-elementwise-equality version was a TAUTOLOGY in the mask
+    dimension (``jnp.where(mask, eps_r + 0, eps_r) == eps_r`` for ANY
+    mask); the review's witnessed 1-node ``jnp.roll`` mask shift passed it
+    (and every other test in both files) while moving a directly measured
+    gradient 11%. Fixed by perturbing at ``deps != 0`` and checking that
+    the increased cells are exactly the production slab-material cells —
+    a shifted or wrong mask reds this immediately. Not
+    ``@pytest.mark.slow``: no FDTD run.
     """
     from rfx.runners.nonuniform import assemble_materials_nu
 
     sim = _nu_sim()
     grid = sim._build_nonuniform_grid()
     materials, _, _, _ = assemble_materials_nu(sim, grid)
-    override = _eps_override(sim, jnp.asarray(0.0, dtype=jnp.float32))
-    np.testing.assert_array_equal(np.asarray(override), np.asarray(materials.eps_r))
+    deps = jnp.asarray(0.5, dtype=jnp.float32)
+    perturbed = _eps_override(sim, deps)
+    np.testing.assert_array_equal(
+        np.asarray(perturbed) - np.asarray(materials.eps_r) > 0,
+        np.asarray(materials.eps_r) == _SLAB_EPS,
+    )
 
 
 @pytest.mark.slow

--- a/tests/test_waveguide_nu_flux_ad.py
+++ b/tests/test_waveguide_nu_flux_ad.py
@@ -97,7 +97,7 @@ def _wr90_nu_sim():
     return sim, domain_x
 
 
-def _eps_override_for(sim, domain_x, deps):
+def _eps_override_for(sim, deps):
     """NU-grid eps override: production-assembled eps + deps inside the slab.
 
     #590: this used to reconstruct the slab index range by hand via
@@ -130,8 +130,8 @@ def _eps_override_for(sim, domain_x, deps):
 
 
 def _s21_mag2(deps):
-    sim, domain_x = _wr90_nu_sim()
-    eps = _eps_override_for(sim, domain_x, deps)
+    sim, _ = _wr90_nu_sim()
+    eps = _eps_override_for(sim, deps)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         res = sim.compute_waveguide_s_matrix(
@@ -170,8 +170,8 @@ def test_nu_flux_smatrix_forward_matches_untraced():
         warnings.simplefilter("ignore")
         res_a = sim_a.compute_waveguide_s_matrix(
             num_periods=NUM_PERIODS, normalize="flux")
-    sim_b, domain_x_b = _wr90_nu_sim()
-    eps = _eps_override_for(sim_b, domain_x_b, jnp.asarray(0.0, dtype=jnp.float32))
+    sim_b, _ = _wr90_nu_sim()
+    eps = _eps_override_for(sim_b, jnp.asarray(0.0, dtype=jnp.float32))
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         res_b = sim_b.compute_waveguide_s_matrix(
@@ -183,25 +183,36 @@ def test_nu_flux_smatrix_forward_matches_untraced():
 
 
 def test_eps_override_helper_matches_production_assembly():
-    """#590 regression: lock ``_eps_override_for`` to the production NU
-    materials assembly, the reduce-to-production pattern PR #564's review
-    used to close the smoother (F1) and the #325 advisory (F2) — an
-    elementwise assertion the helper's deps=0 baseline equals a fresh,
-    independent ``assemble_materials_nu`` call on the identical fixture.
+    """#590/PR #591-review regression: lock ``_eps_override_for``'s
+    PERTURBATION MASK to the production slab indicator.
 
-    This is deliberately NOT gated behind ``@pytest.mark.slow``: it only
-    builds the grid and rasterizes materials, no FDTD run, so it stays in
-    the fast lane and reds loudly (not just weekly) if this helper ever
-    drifts back to a hand-rolled index reconstruction under a future
-    coordinate-convention change.
+    The first version of this lock asserted elementwise equality at
+    ``deps=0``. That was a TAUTOLOGY in the mask dimension:
+    ``jnp.where(mask, eps_r + 0, eps_r) == eps_r`` for ANY mask, so it
+    could not tell the correct mask apart from a shifted, all-True, or
+    all-False one — the PR review demonstrated a 1-node ``jnp.roll`` of the
+    slab mask passes this assertion (and every other test in this file and
+    the sibling checkpoint file) while moving the measured AD gradient 11%
+    (-1.190e-3 -> -1.059e-3), invisible to the AD/FD gate because both
+    sides of that comparison move together under the same shifted mask.
+
+    Fixed by perturbing at ``deps != 0`` and checking WHERE the increase
+    landed, not just that deps=0 is a no-op: a cell is increased iff it is
+    genuinely slab material (``eps_r == _SLAB_EPS_R``) in the production
+    assembly. A shifted or otherwise wrong mask reds this immediately,
+    because the perturbed set and the true slab-material set diverge.
     """
     from rfx.runners.nonuniform import assemble_materials_nu
 
-    sim, domain_x = _wr90_nu_sim()
+    sim, _ = _wr90_nu_sim()
     grid = sim._build_nonuniform_grid()
     materials, _, _, _ = assemble_materials_nu(sim, grid)
-    override = _eps_override_for(sim, domain_x, jnp.asarray(0.0, dtype=jnp.float32))
-    np.testing.assert_array_equal(np.asarray(override), np.asarray(materials.eps_r))
+    deps = jnp.asarray(0.5, dtype=jnp.float32)
+    perturbed = _eps_override_for(sim, deps)
+    np.testing.assert_array_equal(
+        np.asarray(perturbed) - np.asarray(materials.eps_r) > 0,
+        np.asarray(materials.eps_r) == _SLAB_EPS_R,
+    )
 
 
 def _s11_mag2_at_vacuum(deps):

--- a/tests/test_waveguide_nu_flux_ad.py
+++ b/tests/test_waveguide_nu_flux_ad.py
@@ -98,20 +98,35 @@ def _wr90_nu_sim():
 
 
 def _eps_override_for(sim, domain_x, deps):
-    """NU-grid eps override 1.0 + deps inside the slab region (traced).
+    """NU-grid eps override: production-assembled eps + deps inside the slab.
 
-    Sized to the NU grid the flux extractor builds (``_build_nonuniform_grid``
-    synthesises the same scalar-dx dz_profile and the same x-cpml pad the
-    NU S-matrix path uses, so the shape matches the device materials array).
+    #590: this used to reconstruct the slab index range by hand via
+    ``pos_to_nu_index`` (nearest-E-NODE argmin) — a comparator that agreed
+    with the assembled eps only under the pre-#562 cell-CENTRE coordinate
+    convention. #562/#564 moved ``coords_from_nonuniform_grid`` to E-node
+    coordinates and audited two consumers (the subpixel smoother, the #325
+    rasterization advisory); this helper was a third, unaudited one, and
+    went stale silently (16/16 elements, up to 19.8% rel diff against the
+    production no-override run).
+
+    Fixed the #564-review way: derive the baseline from
+    ``assemble_materials_nu`` (the SAME NU materials-assembly path
+    ``compute_waveguide_s_matrix`` calls internally) and the slab region
+    from the Box's own ``mask_on_coords`` on the production node
+    coordinates — never a hand-rolled index reconstruction.
     """
-    from rfx.runners.nonuniform import pos_to_nu_index
+    from rfx.runners.nonuniform import assemble_materials_nu
+    from rfx.geometry.rasterize_grid import coords_from_nonuniform_grid
+
     grid = sim._build_nonuniform_grid()
-    eps = jnp.ones(grid.shape, dtype=jnp.float32)
-    i_lo = pos_to_nu_index(grid, (_SLAB_X_LO, _A_WG / 2, _B_WG / 2))[0]
-    i_hi = pos_to_nu_index(grid, (_SLAB_X_HI, _A_WG / 2, _B_WG / 2))[0]
-    # Perturb the slab region: base slab eps (=4) + deps so deps=0 is a
-    # no-op vs the assembled materials (gate 3) and deps>0 changes S21.
-    return eps.at[i_lo:i_hi, :, :].set(_SLAB_EPS_R + deps)
+    materials, _debye_spec, _lorentz_spec, _pec_mask = assemble_materials_nu(sim, grid)
+    coords = coords_from_nonuniform_grid(grid)
+    slab_entry = next(e for e in sim._geometry if e.material_name == "diel_slab")
+    slab_mask = slab_entry.shape.mask_on_coords(coords.x, coords.y, coords.z)
+    # Perturb the slab region: base slab eps (=4, from the production
+    # assembly) + deps so deps=0 is a no-op vs the assembled materials
+    # (gate 3) and deps>0 changes S21 (FD gate).
+    return jnp.where(slab_mask, materials.eps_r + deps, materials.eps_r)
 
 
 def _s21_mag2(deps):
@@ -165,6 +180,28 @@ def test_nu_flux_smatrix_forward_matches_untraced():
     sb = np.asarray(res_b.s_params)
     assert np.all(np.isfinite(sa)) and np.all(np.isfinite(sb))
     np.testing.assert_allclose(sb, sa, rtol=1e-5, atol=1e-7)
+
+
+def test_eps_override_helper_matches_production_assembly():
+    """#590 regression: lock ``_eps_override_for`` to the production NU
+    materials assembly, the reduce-to-production pattern PR #564's review
+    used to close the smoother (F1) and the #325 advisory (F2) — an
+    elementwise assertion the helper's deps=0 baseline equals a fresh,
+    independent ``assemble_materials_nu`` call on the identical fixture.
+
+    This is deliberately NOT gated behind ``@pytest.mark.slow``: it only
+    builds the grid and rasterizes materials, no FDTD run, so it stays in
+    the fast lane and reds loudly (not just weekly) if this helper ever
+    drifts back to a hand-rolled index reconstruction under a future
+    coordinate-convention change.
+    """
+    from rfx.runners.nonuniform import assemble_materials_nu
+
+    sim, domain_x = _wr90_nu_sim()
+    grid = sim._build_nonuniform_grid()
+    materials, _, _, _ = assemble_materials_nu(sim, grid)
+    override = _eps_override_for(sim, domain_x, jnp.asarray(0.0, dtype=jnp.float32))
+    np.testing.assert_array_equal(np.asarray(override), np.asarray(materials.eps_r))
 
 
 def _s11_mag2_at_vacuum(deps):


### PR DESCRIPTION
Closes #590.

## The defect

`tests/test_waveguide_nu_flux_ad.py::_eps_override_for` reconstructed the
assembled slab eps by hand via `pos_to_nu_index` (nearest-E-NODE argmin)
instead of calling the production NU materials assembly. That agreed with
the real assembled eps only under the pre-#562 cell-CENTRE coordinate
convention. #562/#564 moved `coords_from_nonuniform_grid` to E-node
coordinates and its review (`b5fe569`) found two other stale consumers (the
subpixel smoother — F1, the #325 rasterization advisory — F2). This
helper was a **third**, unaudited one, and went stale silently.

Reproduced bit-for-bit on this worktree before the fix:
```
Max absolute difference among violations: 0.02200203
Max relative difference among violations: 0.19767725
```
(`test_nu_flux_smatrix_forward_matches_untraced`, 16/16 elements mismatched — matches the issue verbatim.)

## The fix

Fixed the same way #564's review closed F1/F2 — reduce to production, don't
model the rasterizer by hand: `_eps_override_for` now derives the baseline
via `assemble_materials_nu` (the exact NU materials-assembly path
`compute_waveguide_s_matrix` calls internally) and the slab perturbation
region via the Box's own `mask_on_coords`, both evaluated on
`coords_from_nonuniform_grid` — no hand index arithmetic left.

After the fix:
```
test_nu_flux_smatrix_forward_matches_untraced   PASSED
[NU-FLUX-AD] AD=-1.189732e-03 FD=-1.199045e-03 rel=0.0078   (gate: <=0.05)
```

## Sibling sweep

`grep -rn "pos_to_nu_index\|nearest.*node\|argmin.*coord" tests/` turned up
one more hand-reconstruction with the identical pattern:
`tests/test_waveguide_nu_checkpoint.py::_eps_override`. Given the same
treatment (production-assembled baseline + `mask_on_coords`) rather than
left as an unfixed landmine — see "Review round 1" below for the measured
correction to this section's original claim about it.

The other two grep hits (`test_msl_port_preflight.py`,
`test_thin_conductor.py`) are prose comments / genuine production-path
comparisons, not hand reconstructions — no action needed there.

---

## Review round 1 — both items closed in `ac27ec7`

**BLOCKING (mine) — the two new lock tests were tautologies.** At `deps=0`,
`jnp.where(mask, eps_r + 0, eps_r) == eps_r` for **any** mask, so the
original locks (elementwise equality at deps=0 vs. a fresh
`assemble_materials_nu` call) could not tell a correct mask apart from a
shifted, all-True, or all-False one. The reviewer demonstrated a 1-node
`jnp.roll` shift of the slab mask passes every test in both files while
moving a measured AD gradient 11% (`-1.190e-3 -> -1.059e-3`), invisible to
the AD/FD gate because both sides of that comparison move together under
the same shifted mask.

Fixed per the reviewer's prescription: both locks now perturb at
`deps=0.5` and assert that the increased cells are exactly the cells that
are genuine slab material in the production assembly
(`materials.eps_r == _SLAB_EPS_R`), not just that deps=0 is a no-op.
Reproduced the mutation witness myself before pushing — both fixtures red
the new assertion under a 1-node `jnp.roll`:
```
test_waveguide_nu_flux_ad.py fixture:   Mismatched elements: 224 / 14592 (1.54%)
test_waveguide_nu_checkpoint.py fixture: Mismatched elements: 420 / 14880 (2.82%)
```

**MEDIUM — the sibling's "wrong physical location" claim above was FALSE
on that fixture.** Measured independently before writing this correction:
OLD (`pos_to_nu_index`) and NEW (`mask_on_coords`) masks occupy the **same
x-planes** `[28, 29, 30]`. The 114 differing cells are exactly the `y=A` /
`z=B` **hi-face** node planes — `Box.mask_on_coords`'s own half-open
`[lo, hi)` volume rule excluding its own hi face at the box's full-cross-
section extent, not a #562 coordinate-convention artifact (the lo-face
planes `y=0`, `z=0` are included in both OLD and NEW). A gradient computed
with the OLD mask vs. the NEW mask on this fixture is **bit-identical**:
`-0.023071737959980965` both, 0.00% difference. So this rewrite on the
checkpoint sibling is **latent-divergence cleanup** — removing the same
hand-rolled-comparator class before it could go stale under a future
change — not a fix for a live defect on this fixture. The headline
`test_waveguide_nu_flux_ad.py` fixture's diagnosis (genuine extra lo-face
cell from the #562 shift, 19.8% forward mismatch) is untouched and
correct. Both the commit message and `_eps_override`'s docstring now carry
the measured correction.

**LOW — dropped `_eps_override_for`'s dead `domain_x` parameter** (unused
in the function body since before #590) and updated its three call sites.
No signature-parity reason to keep it — the sibling `_eps_override` never
had this parameter.

## Verification (final)

- `pytest tests/test_waveguide_nu_flux_ad.py tests/test_waveguide_nu_checkpoint.py -m "slow or not slow"` → **8 passed**
- 1-node `jnp.roll` mutation witness on both fixtures → **both red** the new mask-shape assertions (shown above)
- `ruff check tests/test_waveguide_nu_flux_ad.py tests/test_waveguide_nu_checkpoint.py --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402` → clean

R3: memory=PR #564's own review reply (`b5fe569`, the reduce-to-production
pattern for F1/F2) reapplied to a third and fourth consumer of the same
convention; this PR's own round-1 review (independently re-verified every
claim — mask x-plane overlap, hi-face-only diff set, bit-identical
OLD/NEW gradient — before acting on it) | R2-attempts=1 per round (single
prescribed fix each time, not a repeated mechanism hypothesis) |
falsifier=the failing-then-passing reproduction (defect) plus the 1-node
`jnp.roll` mutation on both fixtures (lock tests), both reproduced before
pushing

Refs #564, #562

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
