### PR TITLE
fix(ci): split weekly slow-tests into shard+highmem lanes, add live RSS sampler (issue #545 step 3)

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -15,25 +15,54 @@ jobs:
   # Weekly run 31103127491 (2026-08-06, first run with both the #566 rebalance
   # AND the RSS reporter live) proved the recurring shard-1/2/3 kills (exit 143,
   # zero assertions/exceptions) are OOM: every killed shard's process had
-  # already crossed 12-15 GB RSS high-water before its own death, 2-2.5x the
-  # ~7 GB hosted-runner-class ceiling. The fatal tests in each case were
-  # memory-heavy (8-24 GB) but TIME-cheap (38-100s); pytest-split's
-  # duration_based_chunks balances on time only, so it freely relocates these
-  # tests between shards on every .test_durations regeneration -- a fresh
-  # durations file is a coin flip for which shards OOM next. The fix is to
-  # pull the 7 confirmed memory-heavy tests (marked `highmem`, see pyproject
-  # markers + issue #545's discriminator-run comment for the per-test
-  # deltas/peaks) out of the time-balanced shard rotation entirely and run
-  # them in their own job, one process at a time, so at most one multi-GB
-  # peak exists on the runner at any instant.
+  # already crossed 12-15 GB RSS high-water before its own death. pytest-split's
+  # duration_based_chunks balances on time only, so it freely relocates the 7
+  # confirmed memory-heavy (3-24 GB, TIME-cheap at 38-100s each) tests between
+  # shards on every .test_durations regeneration -- a fresh durations file is a
+  # coin flip for which shards OOM next. The fix is to pull those 7 tests
+  # (marked `highmem`, see pyproject markers + issue #545's discriminator-run
+  # comment for the per-test deltas/peaks) out of the time-balanced shard
+  # rotation entirely and run them in their own job, one process at a time, so
+  # at most one multi-GB peak exists on the runner at any instant.
+  #
+  # CORRECTED runner ceiling: PR #592 review re-measurement puts the actual
+  # ceiling at ~16 GB, not ~7 GB -- two witnesses: shard 1 SURVIVED past
+  # 14,976 MB (its own entering-state reading, not a death), and the ~8.9 GB
+  # msl-referee highmem test (test_auto_eps_msl_gradient_matches_fd_mini_referee)
+  # passes on ubuntu-latest in the DEFAULT fast lane on every PR. So this is
+  # NOT "several tests each ~2x an ~7 GB ceiling" -- it is ONE test
+  # (test_forward_tfsf_oblique_differentiable, ~24 GB own footprint, ~1.5x the
+  # ~16 GB ceiling) that will not fit under any serialization, plus 6 tests
+  # that do fit under ~16 GB and only needed to stop competing for headroom
+  # with the rest of a 3300-test shard.
+  #
+  # PREDICTION (not yet proven -- this split has not run in CI): the 4-shard
+  # slow-tests job should stop OOMing now that the highmem tests are gone.
+  # slow-tests-highmem will likely still see
+  # test_forward_tfsf_oblique_differentiable exit 143 -- serialization removes
+  # the ~4 GB of accumulated baseline from co-located tests, which is not
+  # enough to fit a ~24 GB single-test footprint under a ~16 GB ceiling. If
+  # that happens, this IS still an improvement (a single named, reproducible
+  # test death is a strictly better signal than "one of ~1500 tests in a
+  # randomly balanced shard died somewhere"), not evidence the split failed.
+  # Next steps per issue #545 item 3, in order of preference: (a) an explicit
+  # checkpoint_segments count for that test's forward, to see whether its ~24
+  # GB tape is compressible; (b) a larger-runner label for slow-tests-highmem
+  # if (a) does not land it under ~16 GB; (c) exclude it from CI entirely and
+  # track it as a manual/local-only regression check.
   #
   # .test_durations interaction: the 4-shard job's selection (`not gpu and
   # not highmem`) now excludes the 7 highmem tests, so duration_based_chunks
-  # balances only over the remaining ~3312 tests. No regeneration of
-  # .test_durations is needed for this split -- pytest-split's
-  # --collect-only entry simply won't see the deselected highmem tests, and
-  # the file's existing per-test duration entries for them (if present) are
-  # just unused by this selection, not stale/wrong.
+  # balances only over the rest of the "not gpu" suite (~3300 tests; the exact
+  # count depends on which optional extras -- e.g. `cad` -- are installed, but
+  # the partition invariant, shard-selection-count + highmem-selection-count
+  # == old not-gpu-selection-count with no overlap, holds regardless: verified
+  # both at 3320 = 3312 + 8 without optional extras and at 3328 = 3320 + 8
+  # with them installed, --collect-only, PR #592). No regeneration of
+  # .test_durations is needed for this split -- pytest-split's --collect-only
+  # entry simply won't see the deselected highmem tests, and the file's
+  # existing per-test duration entries for them (if present) are just unused
+  # by this selection, not stale/wrong.
   slow-tests:
     runs-on: ubuntu-latest
     # 90 not 60: the slowest shard reached ~52 min on 2026-07-27 and the slow
@@ -73,6 +102,19 @@ jobs:
       # kill from a pure infra shutdown if a shard is killed again — no-op
       # elsewhere (fast-suite/pr-tests.yml do not set this).
       #
+      # -s (issue #545 step 3, PR #592 review): REQUIRED for the live sampler's
+      # background-thread prints to survive at all. Measured directly: under
+      # pytest's default fd-level capture (no -s), a completing test's
+      # [rss-live] lines are captured into pytest's internal per-test buffer
+      # and never surface -- 0 lines, even under a `timeout -s KILL` rehearsal
+      # of the exact SIGKILL scenario this sampler exists for, and even with
+      # `--capture=tee-sys`. Only `-s` (`--capture=no`) sends the thread's
+      # writes straight to the real stdout fd, where flush=True can actually
+      # do its job. See
+      # tests/test_weekly_rss_reporter.py::test_live_sampler_line_survives_sigkill_with_dash_s
+      # (and its without-`-s` regression-pin sibling) for the subprocess-level
+      # proof of this property.
+      #
       # "not highmem" (issue #545 step 3): the 7 confirmed memory-heavy tests
       # move to the slow-tests-highmem job below, see the block comment above
       # this job for why.
@@ -80,7 +122,7 @@ jobs:
         env:
           RFX_WEEKLY_RSS: "1"
         run: >
-          pytest -v -ra
+          pytest -v -ra -s
           -m "not gpu and not highmem"
           --splits 4 --group ${{ matrix.group }}
           --ignore=tests/test_meep_crossval.py
@@ -91,11 +133,15 @@ jobs:
   # The 7 `highmem`-marked tests, run SERIALLY in one job (no shard split, no
   # xdist) so only one multi-GB peak exists on the runner at a time -- see the
   # block comment on slow-tests above for the full OOM evidence this responds
-  # to. These tests are individually time-cheap (measured 38-100s each, ~6-8
-  # min total compute across all 7) but memory-heavy (8-24 GB RSS high-water
-  # each per issue #545's discriminator run), so a generous timeout here is
-  # about tolerating a slow/loaded runner, not about the tests' own compute
-  # cost.
+  # to, INCLUDING the prediction that test_forward_tfsf_oblique_differentiable
+  # (~24 GB own footprint) is likely to still exit 143 here even serialized,
+  # since serialization only removes accumulated co-located-test baseline, not
+  # that one test's own footprint, which alone exceeds the corrected ~16 GB
+  # ceiling. These tests are individually time-cheap (measured 38-100s each,
+  # ~6-8 min total compute across all 7) but memory-heavy (3-24 GB RSS
+  # high-water each per issue #545's discriminator run), so a generous
+  # timeout here is about tolerating a slow/loaded runner, not about the
+  # tests' own compute cost.
   slow-tests-highmem:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -112,11 +158,13 @@ jobs:
       - name: Install package with dev dependencies
         run: pip install -e ".[dev]"
 
+      # -s: required for the live sampler's prints to survive a SIGKILL --
+      # see the matching comment on the slow-tests job above.
       - name: Run highmem suite (serial, one multi-GB peak at a time)
         env:
           RFX_WEEKLY_RSS: "1"
         run: >
-          pytest -v -ra
+          pytest -v -ra -s
           -m "highmem and not gpu"
           --ignore=tests/test_meep_crossval.py
           --ignore=tests/test_meep_crossval_dielectric_cavity.py

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -9,18 +9,44 @@ permissions:
   contents: read
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # slow-tests (4-shard) + slow-tests-highmem (serial) split (issue #545 step 3).
+  #
+  # Weekly run 31103127491 (2026-08-06, first run with both the #566 rebalance
+  # AND the RSS reporter live) proved the recurring shard-1/2/3 kills (exit 143,
+  # zero assertions/exceptions) are OOM: every killed shard's process had
+  # already crossed 12-15 GB RSS high-water before its own death, 2-2.5x the
+  # ~7 GB hosted-runner-class ceiling. The fatal tests in each case were
+  # memory-heavy (8-24 GB) but TIME-cheap (38-100s); pytest-split's
+  # duration_based_chunks balances on time only, so it freely relocates these
+  # tests between shards on every .test_durations regeneration -- a fresh
+  # durations file is a coin flip for which shards OOM next. The fix is to
+  # pull the 7 confirmed memory-heavy tests (marked `highmem`, see pyproject
+  # markers + issue #545's discriminator-run comment for the per-test
+  # deltas/peaks) out of the time-balanced shard rotation entirely and run
+  # them in their own job, one process at a time, so at most one multi-GB
+  # peak exists on the runner at any instant.
+  #
+  # .test_durations interaction: the 4-shard job's selection (`not gpu and
+  # not highmem`) now excludes the 7 highmem tests, so duration_based_chunks
+  # balances only over the remaining ~3312 tests. No regeneration of
+  # .test_durations is needed for this split -- pytest-split's
+  # --collect-only entry simply won't see the deselected highmem tests, and
+  # the file's existing per-test duration entries for them (if present) are
+  # just unused by this selection, not stale/wrong.
   slow-tests:
     runs-on: ubuntu-latest
     # 90 not 60: the slowest shard reached ~52 min on 2026-07-27 and the slow
     # suite grows weekly; the 60-min ceiling left <15% headroom.
     timeout-minutes: 90
     strategy:
-      # Shard the full "not gpu" suite across parallel jobs. Each shard is a
-      # FRESH process running its slice serially, so the cumulative JAX/XLA
-      # compilation-cache growth that OOM-killed the single-process full run
-      # (~75%, exit 143 on the 7 GB ubuntu-latest runner) cannot accumulate.
-      # Serial-per-shard also means no xdist (avoids xdist-only false failures);
-      # dropping -x lets every shard report all of its failures.
+      # Shard the full "not gpu and not highmem" suite across parallel jobs.
+      # Each shard is a FRESH process running its slice serially, so the
+      # cumulative JAX/XLA compilation-cache growth that OOM-killed the
+      # single-process full run (~75%, exit 143 on the 7 GB ubuntu-latest
+      # runner) cannot accumulate. Serial-per-shard also means no xdist
+      # (avoids xdist-only false failures); dropping -x lets every shard
+      # report all of its failures.
       fail-fast: false
       matrix:
         group: [1, 2, 3, 4]
@@ -43,16 +69,55 @@ jobs:
       # -q's failure summary prints only at session end and dies with the runner.
       #
       # RFX_WEEKLY_RSS=1 (issue #545 step 2): opt-in per-test RSS high-water
-      # reporter (conftest.py) so the NEXT run of this lane can discriminate
-      # an OOM-adjacent kill from a pure infra shutdown if a shard is killed
-      # again — no-op elsewhere (fast-suite/pr-tests.yml do not set this).
+      # reporter (conftest.py) so this lane can discriminate an OOM-adjacent
+      # kill from a pure infra shutdown if a shard is killed again — no-op
+      # elsewhere (fast-suite/pr-tests.yml do not set this).
+      #
+      # "not highmem" (issue #545 step 3): the 7 confirmed memory-heavy tests
+      # move to the slow-tests-highmem job below, see the block comment above
+      # this job for why.
       - name: Run slow suite — shard ${{ matrix.group }} of 4
         env:
           RFX_WEEKLY_RSS: "1"
         run: >
           pytest -v -ra
-          -m "not gpu"
+          -m "not gpu and not highmem"
           --splits 4 --group ${{ matrix.group }}
+          --ignore=tests/test_meep_crossval.py
+          --ignore=tests/test_meep_crossval_dielectric_cavity.py
+          --ignore=tests/test_openems_crossval.py
+          --ignore=tests/test_crossval_comprehensive.py
+
+  # The 7 `highmem`-marked tests, run SERIALLY in one job (no shard split, no
+  # xdist) so only one multi-GB peak exists on the runner at a time -- see the
+  # block comment on slow-tests above for the full OOM evidence this responds
+  # to. These tests are individually time-cheap (measured 38-100s each, ~6-8
+  # min total compute across all 7) but memory-heavy (8-24 GB RSS high-water
+  # each per issue #545's discriminator run), so a generous timeout here is
+  # about tolerating a slow/loaded runner, not about the tests' own compute
+  # cost.
+  slow-tests-highmem:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install package with dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run highmem suite (serial, one multi-GB peak at a time)
+        env:
+          RFX_WEEKLY_RSS: "1"
+        run: >
+          pytest -v -ra
+          -m "highmem and not gpu"
           --ignore=tests/test_meep_crossval.py
           --ignore=tests/test_meep_crossval_dielectric_cavity.py
           --ignore=tests/test_openems_crossval.py

--- a/conftest.py
+++ b/conftest.py
@@ -25,6 +25,7 @@ import os
 
 os.environ.setdefault("XLA_FLAGS", "--xla_force_host_platform_device_count=2")
 
+import threading  # noqa: E402
 import warnings  # noqa: E402
 
 import jax  # noqa: E402
@@ -82,10 +83,105 @@ def pytest_configure(config):
 # The parse lives inside _maybe_register_rss_reporter, after the enable
 # gate, with a fallback to the 500 MB default on a bad value. See
 # tests/test_weekly_rss_reporter.py::test_malformed_threshold_with_reporter_off_does_not_raise.
+#
+# issue #545 step 3 (2026-08-06 discriminator run 31103127491): this reporter
+# alone left one structural gap disclosed in that run's writeup -- ru_maxrss
+# only updates in the POST-test hook, so the exact RSS at the SIGKILL instant
+# is never captured (the process dies before that hook resumes). _RSSLiveSampler
+# below closes it with an independent background-thread poll of
+# /proc/self/status VmHWM, on its own ~2s clock, printing (flushed
+# immediately) whenever the high-water mark advances past the threshold --
+# see its docstring.
 
 
 def _rss_env_enabled() -> bool:
     return os.environ.get("RFX_WEEKLY_RSS", "").strip().lower() not in ("", "0", "false")
+
+
+def _read_proc_vmhwm_mb() -> "float | None":
+    """Read VmHWM (peak resident set size, all-time high-water) from
+    ``/proc/self/status``, in MB.
+
+    Returns ``None`` -- never raises -- when ``/proc/self/status`` does not
+    exist (any non-Linux platform) or the ``VmHWM`` line is missing or
+    unparsable, so callers treat "no reading" as "skip this sample," not as
+    a crash or a real 0 MB reading. ``/proc`` is a Linux-only kernel
+    interface, so this is the deliberate non-Linux guard for
+    ``_RSSLiveSampler`` below.
+    """
+    try:
+        with open("/proc/self/status") as f:
+            for line in f:
+                if line.startswith("VmHWM:"):
+                    # Typical line: "VmHWM:\t 1234567 kB"
+                    parts = line.split()
+                    return float(parts[1]) / 1024.0
+    except (OSError, IndexError, ValueError):
+        return None
+    return None
+
+
+class _RSSLiveSampler:
+    """Background daemon thread: samples ``/proc/self/status`` VmHWM on its
+    own ~2s clock (independent of any pytest hook) and prints a line the
+    instant the high-water mark has advanced by more than ``threshold_mb``
+    past the last-printed value.
+
+    Closes a gap ``_RSSHighWaterReporter`` below cannot: that reporter's
+    ``pytest_runtest_protocol`` hookwrapper only samples at test
+    boundaries (before/after each test runs), so if the OS SIGKILLs the
+    process mid-test -- the exit-143 kill class issue #545 exists to
+    discriminate -- the RSS at the moment of death is never captured; the
+    process dies before the hookwrapper resumes. This thread samples on its
+    own independent schedule and flushes every print immediately
+    (``flush=True``), so a killed process still leaves its last high-water
+    line in the streamed CI log even though it died mid-test.
+
+    Zero cost when not started: the object can be constructed without ever
+    launching its thread. In this file it is only constructed (via
+    ``_RSSHighWaterReporter.__init__``) when ``_maybe_register_rss_reporter``
+    has already passed the RFX_WEEKLY_RSS enable gate, and only started
+    (via ``_RSSHighWaterReporter.pytest_sessionstart``) once a real pytest
+    session begins -- so a unit test that merely constructs the reporter
+    (e.g. against a ``MagicMock`` config) never spins up a thread.
+    """
+
+    def __init__(self, threshold_mb: float, interval_s: float = 2.0):
+        self.threshold_mb = threshold_mb
+        self.interval_s = interval_s
+        self.current_nodeid = None  # best-effort, updated by a pytest hook
+        self._last_reported_mb = 0.0
+        self._started = False
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run, name="rfx-rss-live-sampler", daemon=True
+        )
+
+    def start(self) -> None:
+        self._started = True
+        self._thread.start()
+
+    def stop(self, timeout: float = 5.0) -> None:
+        self._stop_event.set()
+        if self._started:
+            self._thread.join(timeout=timeout)
+
+    def is_alive(self) -> bool:
+        return self._thread.is_alive()
+
+    def _sample_once(self) -> None:
+        mb = _read_proc_vmhwm_mb()
+        if mb is None:
+            return  # non-Linux, or /proc unreadable -- silently skip
+        if mb - self._last_reported_mb > self.threshold_mb:
+            self._last_reported_mb = mb
+            suffix = f" during {self.current_nodeid}" if self.current_nodeid else ""
+            # flush=True: a SIGKILL must leave this line in the streamed log.
+            print(f"[rss-live] VmHWM {mb:.0f} MB{suffix}", flush=True)
+
+    def _run(self) -> None:
+        while not self._stop_event.wait(self.interval_s):
+            self._sample_once()
 
 
 class _RSSHighWaterReporter:
@@ -105,11 +201,21 @@ class _RSSHighWaterReporter:
     blind spot -- it says the process had reached at least that much RSS by
     the time this test finished, which is what the OOM-vs-infra question
     actually needs. Both numbers are reported per test and in the summary.
+
+    Also owns a background ``_RSSLiveSampler`` thread (issue #545 step 3)
+    that samples VmHWM directly from ``/proc/self/status`` on its own ~2s
+    clock, to capture the high-water mark at the instant of a mid-test
+    SIGKILL that this class's own post-test hook cannot see (see
+    ``_RSSLiveSampler``'s docstring). Started in ``pytest_sessionstart`` and
+    stopped in ``pytest_sessionfinish``, both gated by the same
+    RFX_WEEKLY_RSS enable check as this whole reporter, transitively, via
+    ``_maybe_register_rss_reporter``.
     """
 
     def __init__(self, threshold_mb: float):
         self.threshold_kb = threshold_mb * 1024.0
         self.samples: list = []  # list[tuple[str, float, float]] of (nodeid, delta_mb, peak_mb)
+        self.live_sampler = _RSSLiveSampler(threshold_mb)
 
     @staticmethod
     def _maxrss_kb() -> float:
@@ -117,8 +223,15 @@ class _RSSHighWaterReporter:
 
         return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
 
+    def pytest_sessionstart(self, session):
+        self.live_sampler.start()
+
+    def pytest_sessionfinish(self, session, exitstatus):
+        self.live_sampler.stop()
+
     @pytest.hookimpl(hookwrapper=True)
     def pytest_runtest_protocol(self, item, nextitem):
+        self.live_sampler.current_nodeid = item.nodeid
         start_kb = self._maxrss_kb()
         yield
         end_kb = self._maxrss_kb()

--- a/conftest.py
+++ b/conftest.py
@@ -181,7 +181,21 @@ class _RSSLiveSampler:
 
     def _run(self) -> None:
         while not self._stop_event.wait(self.interval_s):
-            self._sample_once()
+            try:
+                self._sample_once()
+            except (ValueError, OSError):
+                # Narrow teardown-race guard ONLY: if the main thread has
+                # already moved past pytest_sessionfinish / interpreter
+                # shutdown by the time this daemon thread wakes for its next
+                # sample, stdout (or the pipe under it) can already be
+                # closed -- CPython raises ValueError ("I/O operation on
+                # closed file") or OSError/BrokenPipeError in that case.
+                # Deliberately NOT a bare `except Exception`: see
+                # feedback_broad_except_eats_async_timeout (#555), where a
+                # broad except in preflight swallowed a real SIGALRM timeout
+                # and hung the process. A genuine bug in _sample_once should
+                # still crash this thread loudly, not vanish here.
+                return
 
 
 class _RSSHighWaterReporter:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ markers = [
     "gpu: tests that need GPU — too slow on CPU or GPU-specific (select with '-m gpu')",
     "distributed: tests that require multi-device / distributed setup (deselect with '-m not distributed')",
     "slow_physics: release-tag-time physics regression gate (V173-A bit-identity); opt-in with '-m slow_physics'",
-    "highmem: memory-heavy weekly-lane tests (issue #545, 8-24 GB RSS high-water each); run serially in the dedicated weekly slow-tests-highmem job, ADDITIVE to slow/slow_physics/gpu (never excludes from the default fast lane on its own — addopts below only filters not gpu/slow/slow_physics)",
+    "highmem: memory-heavy weekly-lane tests (issue #545, 3-24 GB RSS high-water each); run serially in the dedicated weekly slow-tests-highmem job, ADDITIVE to slow/slow_physics/gpu (never excludes from the default fast lane on its own — addopts above only filters not gpu/slow/slow_physics)",
 ]
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ markers = [
     "gpu: tests that need GPU — too slow on CPU or GPU-specific (select with '-m gpu')",
     "distributed: tests that require multi-device / distributed setup (deselect with '-m not distributed')",
     "slow_physics: release-tag-time physics regression gate (V173-A bit-identity); opt-in with '-m slow_physics'",
+    "highmem: memory-heavy weekly-lane tests (issue #545, 8-24 GB RSS high-water each); run serially in the dedicated weekly slow-tests-highmem job, ADDITIVE to slow/slow_physics/gpu (never excludes from the default fast lane on its own — addopts below only filters not gpu/slow/slow_physics)",
 ]
 
 [tool.mypy]

--- a/tests/test_coax_end_to_end_ad.py
+++ b/tests/test_coax_end_to_end_ad.py
@@ -54,7 +54,10 @@ def _s11_mag2(deps):
     return jnp.abs(res.s11[0]) ** 2
 
 
+# highmem (issue #545): measured +10.8 GB RSS high-water delta in weekly
+# run 31103127491.
 @pytest.mark.slow_physics
+@pytest.mark.highmem
 def test_coax_reflection_grad_finite_and_fd_consistent():
     """Gate: the full-method reflection is differentiable w.r.t. the dielectric and
     the AD gradient matches a finite difference (the AD moat for coaxial_port)."""

--- a/tests/test_forward_tfsf_differentiable.py
+++ b/tests/test_forward_tfsf_differentiable.py
@@ -60,7 +60,11 @@ def test_forward_tfsf_normal_gradient_matches_fd():
     assert rel < 0.05, f"grad {g:.4f} vs FD {fd:.4f} rel_err {rel*100:.1f}% > 5%"
 
 
+# highmem (issue #545): measured peak RSS 23.78 GB locally (taskset -c 0-1);
+# the shard-1 kill in weekly run 31103127491 crossed 14,976 MB high-water on
+# this test, 2x+ the ~7 GB hosted-runner class ceiling.
 @pytest.mark.slow
+@pytest.mark.highmem
 def test_forward_tfsf_oblique_differentiable():
     """forward() couples an OBLIQUE TFSF source (complex Bloch path, auto-activated)
     and produces a finite, nonzero gradient w.r.t. the scatterer eps."""

--- a/tests/test_forward_tfsf_differentiable.py
+++ b/tests/test_forward_tfsf_differentiable.py
@@ -60,9 +60,17 @@ def test_forward_tfsf_normal_gradient_matches_fd():
     assert rel < 0.05, f"grad {g:.4f} vs FD {fd:.4f} rel_err {rel*100:.1f}% > 5%"
 
 
-# highmem (issue #545): measured peak RSS 23.78 GB locally (taskset -c 0-1);
-# the shard-1 kill in weekly run 31103127491 crossed 14,976 MB high-water on
-# this test, 2x+ the ~7 GB hosted-runner class ceiling.
+# highmem (issue #545): this test's own footprint is UNMEASURED in CI --
+# the [rss] post-test hook only prints AFTER a test completes, and this is
+# the test that got killed (shard 1, weekly run 31103127491), so its own
+# hook line never fired. The process was already at 14,976 MB *entering*
+# this test -- that number is the PRECEDING (coax) test's own reading, not
+# this test's. Measured directly instead: 23.78 GB peak locally
+# (taskset -c 0-1), 23,964 MB on independent standalone remeasurement --
+# ~1.5x the corrected ~16 GB runner-class ceiling (see validation.yml's
+# block comment). This test is PREDICTED to still be killed even
+# serialized into its own job; serialization removes accumulated baseline,
+# not this test's own ~24 GB.
 @pytest.mark.slow
 @pytest.mark.highmem
 def test_forward_tfsf_oblique_differentiable():

--- a/tests/test_msl_source_fixture_static.py
+++ b/tests/test_msl_source_fixture_static.py
@@ -25,6 +25,7 @@ import warnings
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 
 from rfx import Box, Simulation
 from rfx.boundaries.spec import Boundary, BoundarySpec
@@ -70,6 +71,12 @@ def _msl_sim_auto_eps():
     return sim
 
 
+# highmem (issue #545): measured +8.1 GB RSS high-water delta in weekly
+# run 31103127491. No prior slow/slow_physics/gpu marker on this test —
+# highmem is additive only (pyproject addopts filters "not slow and not
+# slow_physics", not highmem), so this test stays in the default fast lane
+# unchanged; highmem only pulls it out of the weekly 4-shard rotation.
+@pytest.mark.highmem
 def test_auto_eps_msl_gradient_matches_fd_mini_referee():
     """f32 mini-referee (np=1, h=1e-2) on the auto-eps_r_sub MSL forward:
     AD within 3% of central FD. Measured: pre-#483 main reads 0.126 (the

--- a/tests/test_oblique_fresnel_magnitude.py
+++ b/tests/test_oblique_fresnel_magnitude.py
@@ -91,7 +91,10 @@ def test_oblique_fresnel_magnitude_vs_analytic(theta, tol):
     assert abs(g - ga) / ga < tol, f"|Γ|={g:.3f} vs R_TE={ga:.3f} (θ={theta}, {abs(g-ga)/ga*100:.1f}%)"
 
 
+# highmem (issue #545): the shard-2 kill in weekly run 31103127491 crossed
+# 12,187 MB high-water on this test, ~1.7x the ~7 GB hosted-runner ceiling.
 @pytest.mark.slow
+@pytest.mark.highmem
 def test_oblique_reflection_magnitude_differentiable():
     """d|Γ|/dε flows through the checkpointed oblique forward and matches finite difference."""
     sim, shape, xi, xe, _idx, dt, ns = _build_lean(30.0)  # lean config: AD tape fits GPU memory

--- a/tests/test_oblique_fresnel_magnitude.py
+++ b/tests/test_oblique_fresnel_magnitude.py
@@ -91,8 +91,11 @@ def test_oblique_fresnel_magnitude_vs_analytic(theta, tol):
     assert abs(g - ga) / ga < tol, f"|Γ|={g:.3f} vs R_TE={ga:.3f} (θ={theta}, {abs(g-ga)/ga*100:.1f}%)"
 
 
-# highmem (issue #545): the shard-2 kill in weekly run 31103127491 crossed
-# 12,187 MB high-water on this test, ~1.7x the ~7 GB hosted-runner ceiling.
+# highmem (issue #545): this test's own footprint is UNMEASURED in CI -- it
+# was the test killed in shard 2 (weekly run 31103127491), so its own
+# post-test [rss] hook line never fired (the process died first). The
+# process was already at 12,187 MB *entering* this test -- that number
+# belongs to the PRECEDING msl-referee highmem test, not this one.
 @pytest.mark.slow
 @pytest.mark.highmem
 def test_oblique_reflection_magnitude_differentiable():

--- a/tests/test_oblique_fresnel_phase.py
+++ b/tests/test_oblique_fresnel_phase.py
@@ -145,7 +145,10 @@ def test_oblique_complex_gamma_vs_analytic(theta, magtol):
     assert dph < 20.0, f"∠Γ={np.degrees(np.angle(g)):.1f}° vs 180° (θ={theta}, off {dph:.1f}°)"
 
 
+# highmem (issue #545): measured +10.7 GB RSS high-water delta in weekly
+# run 31103127491.
 @pytest.mark.slow
+@pytest.mark.highmem
 def test_oblique_complex_gamma_differentiable():
     """The complex-target RIS loss |Γ-Γ_target|² is differentiable through oblique forward()."""
     sim, shape, xi, xe, idx, dt, ns = _build_lean(30.0)  # lean config: AD tape fits GPU memory

--- a/tests/test_ram_magnetic_mu_r_design.py
+++ b/tests/test_ram_magnetic_mu_r_design.py
@@ -203,7 +203,10 @@ def test_mu_r_channel_is_live(mag_run):
     assert rel > 1e-3, f"mu_r_override is a no-op (series change {rel:.2e})"
 
 
+# highmem (issue #545): measured +3.3 GB RSS high-water delta in weekly
+# run 31103127491.
 @pytest.mark.slow
+@pytest.mark.highmem
 def test_mu_r_gradient_ad_vs_fd(mag_run):
     """Autodiff SELF-CONSISTENCY (not physics): jax.grad w.r.t. mu_r matches a FD
     step of the same forward. Physical validation is test_mu_r_gradient_vs_analytic_tmm."""

--- a/tests/test_ram_multilayer_inverse_design.py
+++ b/tests/test_ram_multilayer_inverse_design.py
@@ -322,7 +322,12 @@ def test_ram_magnitude_vs_tmm(ram_run):
         f"absorption dip: FDTD {20*np.log10(g_fd[i0]):.1f} dB, TMM {20*np.log10(g_nom[i0]):.1f} dB"
 
 
+# highmem (issue #545): the [sigma-1.0] case was the fatal test in the
+# shard-3 kill in weekly run 31103127491 (14,854 MB high-water); the eps
+# case shares the same checkpointed forward and is marked with it (pytest
+# marks apply per-function, not per-parametrize-case).
 @pytest.mark.slow
+@pytest.mark.highmem
 @pytest.mark.parametrize("var,x0", [("sigma", 1.0), ("eps", 4.0)])
 def test_ram_gradient_ad_vs_fd(ram_run, var, x0):
     """AUTODIFF SELF-CONSISTENCY (not physics): jax.grad through the checkpointed

--- a/tests/test_ram_multilayer_inverse_design.py
+++ b/tests/test_ram_multilayer_inverse_design.py
@@ -322,10 +322,13 @@ def test_ram_magnitude_vs_tmm(ram_run):
         f"absorption dip: FDTD {20*np.log10(g_fd[i0]):.1f} dB, TMM {20*np.log10(g_nom[i0]):.1f} dB"
 
 
-# highmem (issue #545): the [sigma-1.0] case was the fatal test in the
-# shard-3 kill in weekly run 31103127491 (14,854 MB high-water); the eps
-# case shares the same checkpointed forward and is marked with it (pytest
-# marks apply per-function, not per-parametrize-case).
+# highmem (issue #545): the [sigma-1.0] case was the test killed in shard 3
+# (weekly run 31103127491) -- its own footprint is UNMEASURED in CI, since
+# the [rss] post-test hook never fired for it (the process died first). The
+# process was already at 14,854 MB *entering* it -- that number belongs to
+# the PRECEDING mu_r highmem test, not this one. The eps case shares the
+# same checkpointed forward and is marked with it (pytest marks apply
+# per-function, not per-parametrize-case).
 @pytest.mark.slow
 @pytest.mark.highmem
 @pytest.mark.parametrize("var,x0", [("sigma", 1.0), ("eps", 4.0)])

--- a/tests/test_weekly_rss_reporter.py
+++ b/tests/test_weekly_rss_reporter.py
@@ -346,6 +346,7 @@ def test_rss_live_sampler_helper_allocates_and_self_sigkills():
 def _run_sigkill_helper_subprocess(extra_pytest_args):
     root = Path(__file__).resolve().parent.parent
     env = dict(os.environ)
+    env.pop("PYTEST_ADDOPTS", None)  # an ambient -s here would leak into the child and invert the without--s regression pin
     env["RFX_TEST_SIGKILL_HELPER"] = "1"
     env["RFX_WEEKLY_RSS"] = "1"
     env["RFX_WEEKLY_RSS_THRESHOLD_MB"] = "10"  # low so the 60 MB helper alloc trips it

--- a/tests/test_weekly_rss_reporter.py
+++ b/tests/test_weekly_rss_reporter.py
@@ -14,14 +14,29 @@ And issue #545 step 3 (the live sampler, closing the discriminator gap the
 2026-08-06 run 31103127491 writeup disclosed: ru_maxrss only updates in the
 post-test hook, so the RSS at the exact SIGKILL instant is never captured):
   - _read_proc_vmhwm_mb reads a real number on this (Linux) box and returns
-    None -- never raises -- when /proc is unavailable,
+    None -- never raises -- when /proc is unavailable, and agrees with an
+    INDEPENDENT measurement (resource.getrusage's ru_maxrss) to within a
+    generous band, so a kB/MB unit-conversion mutation cannot silently pass,
   - _RSSLiveSampler prints the documented "[rss-live] VmHWM N MB [during
     nodeid]" line only once VmHWM has advanced past the threshold, using
-    synthetic readings (no real GB allocation in a test),
+    synthetic readings (no real GB allocation) for the pure line-format unit
+    tests,
   - the sampler's thread is an actual daemon thread that starts and stops
-    cleanly, and
+    cleanly,
   - _RSSHighWaterReporter.pytest_sessionstart/pytest_sessionfinish start and
-    stop that thread, gated the same way the reporter itself is gated.
+    stop that thread, gated the same way the reporter itself is gated, and
+  - THE property PR #592 review demanded: a background thread's bare
+    ``print()`` is invisible under pytest's own capture unless ``-s`` is
+    passed (measured: 0 [rss-live] lines at -v -ra with default fd-capture,
+    including under a `timeout -s KILL` rehearsal of the exact scenario, and
+    even with --capture=tee-sys; 3 lines with -s). The unit tests above bind
+    the STRING the sampler builds (via capsys, calling _sample_once
+    directly) -- they do NOT prove that string is ever DELIVERED anywhere a
+    human or CI log could see it. Only a real subprocess pytest run, killed
+    with SIGKILL and inspected from OUTSIDE pytest's own capture layer
+    (subprocess.run's stdout pipe), proves delivery. See
+    test_live_sampler_line_survives_sigkill_with_dash_s and its
+    without-`-s` regression-pin sibling below.
 
 conftest.py sits at the repo root and pytest's default "prepend" import mode
 has already loaded it as the top-level module ``conftest`` by the time this
@@ -30,11 +45,14 @@ module object rather than re-executing the file.
 """
 
 import os
+import signal
 import subprocess
 import sys
 import time
 from pathlib import Path
 from unittest.mock import MagicMock
+
+import pytest
 
 import conftest
 
@@ -173,6 +191,26 @@ def test_read_proc_vmhwm_mb_returns_none_when_proc_is_unreadable(monkeypatch):
     assert conftest._read_proc_vmhwm_mb() is None
 
 
+def test_read_proc_vmhwm_mb_agrees_with_independent_ru_maxrss_band():
+    """Cross-check against an INDEPENDENT measurement (resource.getrusage's
+    ru_maxrss, KB on Linux -- the same call _RSSHighWaterReporter._maxrss_kb
+    uses) so a unit-conversion mutation (e.g. dropping the /1024.0, or
+    reading the wrong /proc/self/status field) cannot silently pass: VmHWM
+    and ru_maxrss are two different kernel-accounting paths to the same
+    process's peak RSS, not byte-identical, but they must never be off by
+    an order of magnitude."""
+    vmhwm_mb = conftest._read_proc_vmhwm_mb()
+    assert vmhwm_mb is not None
+    ru_maxrss_mb = conftest._RSSHighWaterReporter._maxrss_kb() / 1024.0
+    assert ru_maxrss_mb > 0.0
+
+    ratio = vmhwm_mb / ru_maxrss_mb
+    assert 0.5 < ratio < 2.0, (
+        f"VmHWM={vmhwm_mb:.1f} MB vs ru_maxrss={ru_maxrss_mb:.1f} MB, "
+        f"ratio={ratio:.2f} outside the expected band -- possible unit-conversion bug"
+    )
+
+
 def test_live_sampler_line_format_with_nodeid(monkeypatch, capsys):
     """Synthetic reading (no real allocation): a delta past the threshold
     prints the documented "[rss-live] VmHWM N MB during <nodeid>" line."""
@@ -267,3 +305,100 @@ def test_reporter_updates_live_sampler_current_nodeid_during_test():
         next(gen)
     except StopIteration:
         pass
+
+
+# ---------------------------------------------------------------------------
+# THE property (PR #592 review, CRITICAL): does an [rss-live] line actually
+# survive a real SIGKILL, observed from OUTSIDE pytest's own capture layer?
+# The tests above bind the sampler's output STRING via capsys; none of them
+# prove DELIVERY through pytest's real stdout capture machinery. Only a
+# subprocess pytest run, killed for real and inspected via subprocess.run's
+# own stdout pipe (a wholly separate capture layer from pytest's internal
+# one), proves that.
+
+
+def test_rss_live_sampler_helper_allocates_and_self_sigkills():
+    """NOT a standalone test -- a subprocess helper for
+    test_live_sampler_line_survives_sigkill_with_dash_s and
+    test_live_sampler_line_lost_without_dash_s below. Skips immediately
+    unless RFX_TEST_SIGKILL_HELPER=1 is set (only those two driver tests set
+    it, in a CHILD subprocess), so this function is inert in every normal
+    run of this file, including this file's own collection in the
+    fast/weekly lanes.
+
+    Allocates ~60 MB (comfortably above the low RFX_WEEKLY_RSS_THRESHOLD_MB
+    the driver sets, and nowhere near "GB" scale), sleeps long enough for
+    the live sampler's REAL ~2s poll cadence (this deliberately does not
+    shorten interval_s -- it exercises the exact production default) to
+    observe the jump and print at least one line, then SIGKILLs its own
+    process -- reproducing the OOM-style hard kill mid-test that issue #545
+    is about, without needing an actual multi-GB allocation.
+    """
+    if os.environ.get("RFX_TEST_SIGKILL_HELPER") != "1":
+        pytest.skip("subprocess-only helper; set RFX_TEST_SIGKILL_HELPER=1 to run it")
+    buf = bytearray(60 * 1024 * 1024)  # 60 MB
+    for i in range(0, len(buf), 4096):
+        buf[i] = 1  # touch every page so it's actually resident, not just reserved
+    time.sleep(3.0)  # >= one full real _RSSLiveSampler interval_s (2.0s default), with margin
+    os.kill(os.getpid(), signal.SIGKILL)
+
+
+def _run_sigkill_helper_subprocess(extra_pytest_args):
+    root = Path(__file__).resolve().parent.parent
+    env = dict(os.environ)
+    env["RFX_TEST_SIGKILL_HELPER"] = "1"
+    env["RFX_WEEKLY_RSS"] = "1"
+    env["RFX_WEEKLY_RSS_THRESHOLD_MB"] = "10"  # low so the 60 MB helper alloc trips it
+    return subprocess.run(
+        [
+            sys.executable, "-m", "pytest", *extra_pytest_args, "-v",
+            "tests/test_weekly_rss_reporter.py::test_rss_live_sampler_helper_allocates_and_self_sigkills",
+        ],
+        cwd=str(root),
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=90,
+    )
+
+
+def test_live_sampler_line_survives_sigkill_with_dash_s():
+    """THE property (PR #592 review, CRITICAL fix): with -s (--capture=no),
+    the live sampler's background-thread prints reach the real stdout fd, so
+    flush=True actually lands the line before a SIGKILL. This is what
+    validation.yml's -s flag (added in this fix) is load-bearing for --
+    without it, this exact scenario prints nothing (see the sibling
+    regression-pin test below)."""
+    result = _run_sigkill_helper_subprocess(extra_pytest_args=["-s"])
+
+    assert result.returncode == -signal.SIGKILL, (
+        f"expected the child to die from SIGKILL, got returncode={result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "[rss-live] VmHWM" in result.stdout, (
+        "expected at least one [rss-live] line to survive the SIGKILL under -s\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+
+
+def test_live_sampler_line_lost_without_dash_s():
+    """Regression pin for WHY -s is required in validation.yml: under
+    pytest's DEFAULT capture (no -s), the identical scenario prints nothing
+    to the outer process's stdout -- pytest's fd-level capture redirects the
+    real stdout fd to its own internal per-test buffer, which is lost (not
+    replayed) on a SIGKILL mid-test. If a future edit drops -s from the
+    workflow, THIS is the silent loss it would reintroduce; if this
+    assertion ever starts failing (i.e. the line DOES show up here), that
+    means pytest's capture behavior changed and validation.yml's -s flag
+    may no longer be load-bearing -- re-verify before removing it."""
+    result = _run_sigkill_helper_subprocess(extra_pytest_args=[])
+
+    assert result.returncode == -signal.SIGKILL, (
+        f"expected the child to die from SIGKILL, got returncode={result.returncode}\n"
+        f"stdout={result.stdout}\nstderr={result.stderr}"
+    )
+    assert "[rss-live] VmHWM" not in result.stdout, (
+        "expected NO [rss-live] line without -s (pytest's default capture "
+        "should swallow it)\n"
+        f"stdout={result.stdout}"
+    )

--- a/tests/test_weekly_rss_reporter.py
+++ b/tests/test_weekly_rss_reporter.py
@@ -10,6 +10,19 @@ Covers the properties issue #545 step 2 requires:
     whether the reporter is on (falls back to the 500 MB default) or off
     (the value is never even parsed).
 
+And issue #545 step 3 (the live sampler, closing the discriminator gap the
+2026-08-06 run 31103127491 writeup disclosed: ru_maxrss only updates in the
+post-test hook, so the RSS at the exact SIGKILL instant is never captured):
+  - _read_proc_vmhwm_mb reads a real number on this (Linux) box and returns
+    None -- never raises -- when /proc is unavailable,
+  - _RSSLiveSampler prints the documented "[rss-live] VmHWM N MB [during
+    nodeid]" line only once VmHWM has advanced past the threshold, using
+    synthetic readings (no real GB allocation in a test),
+  - the sampler's thread is an actual daemon thread that starts and stops
+    cleanly, and
+  - _RSSHighWaterReporter.pytest_sessionstart/pytest_sessionfinish start and
+    stop that thread, gated the same way the reporter itself is gated.
+
 conftest.py sits at the repo root and pytest's default "prepend" import mode
 has already loaded it as the top-level module ``conftest`` by the time this
 test module is imported, so a plain ``import conftest`` reuses that same
@@ -19,6 +32,7 @@ module object rather than re-executing the file.
 import os
 import subprocess
 import sys
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -136,3 +150,120 @@ def test_reporter_flags_nodeid_when_rss_high_water_crosses_threshold():
     assert nodeid == "tests/test_fake.py::test_thing"
     assert delta_mb >= 0.0
     assert peak_mb > 0.0
+
+
+# ---------------------------------------------------------------------------
+# issue #545 step 3: the live sampler (background thread).
+
+
+def test_read_proc_vmhwm_mb_returns_a_positive_number_on_linux():
+    """This test process itself has a nonzero VmHWM by the time it runs."""
+    mb = conftest._read_proc_vmhwm_mb()
+    assert mb is not None, "/proc/self/status should be readable on Linux CI"
+    assert mb > 0.0
+
+
+def test_read_proc_vmhwm_mb_returns_none_when_proc_is_unreadable(monkeypatch):
+    """Non-Linux / unreadable /proc guard: OSError is swallowed, not raised."""
+
+    def _raise_oserror(*args, **kwargs):
+        raise OSError("no such file or directory")
+
+    monkeypatch.setattr("builtins.open", _raise_oserror)
+    assert conftest._read_proc_vmhwm_mb() is None
+
+
+def test_live_sampler_line_format_with_nodeid(monkeypatch, capsys):
+    """Synthetic reading (no real allocation): a delta past the threshold
+    prints the documented "[rss-live] VmHWM N MB during <nodeid>" line."""
+    monkeypatch.setattr(conftest, "_read_proc_vmhwm_mb", lambda: 1500.0)
+    sampler = conftest._RSSLiveSampler(threshold_mb=500.0)
+    sampler.current_nodeid = "tests/test_fake.py::test_thing"
+
+    sampler._sample_once()
+
+    out = capsys.readouterr().out
+    assert out.strip() == "[rss-live] VmHWM 1500 MB during tests/test_fake.py::test_thing"
+
+
+def test_live_sampler_line_format_without_nodeid(monkeypatch, capsys):
+    """When no nodeid is cheaply known yet, the 'during ...' suffix is
+    omitted entirely rather than printed as 'during None'."""
+    monkeypatch.setattr(conftest, "_read_proc_vmhwm_mb", lambda: 1500.0)
+    sampler = conftest._RSSLiveSampler(threshold_mb=500.0)
+    assert sampler.current_nodeid is None
+
+    sampler._sample_once()
+
+    out = capsys.readouterr().out
+    assert out.strip() == "[rss-live] VmHWM 1500 MB"
+
+
+def test_live_sampler_skips_below_threshold_and_when_unavailable(monkeypatch, capsys):
+    """No line at all when the delta is below threshold, or when the VmHWM
+    reading is unavailable (None)."""
+    sampler = conftest._RSSLiveSampler(threshold_mb=500.0)
+
+    monkeypatch.setattr(conftest, "_read_proc_vmhwm_mb", lambda: 100.0)  # +100 MB < 500 MB
+    sampler._sample_once()
+    assert capsys.readouterr().out == ""
+
+    monkeypatch.setattr(conftest, "_read_proc_vmhwm_mb", lambda: None)
+    sampler._sample_once()
+    assert capsys.readouterr().out == ""
+
+
+def test_live_sampler_thread_starts_is_daemon_and_stops_cleanly(monkeypatch):
+    """The thread this sampler owns is a real daemon thread (never blocks
+    process exit) that actually runs on its own clock and stops on demand."""
+    readings = iter([100.0, 100.0, 100.0, 700.0])  # +600 MB on the 4th sample
+    monkeypatch.setattr(conftest, "_read_proc_vmhwm_mb", lambda: next(readings, 700.0))
+    sampler = conftest._RSSLiveSampler(threshold_mb=500.0, interval_s=0.02)
+    sampler.current_nodeid = "tests/test_fake.py::test_thing"
+
+    assert sampler.is_alive() is False
+    sampler.start()
+    try:
+        assert sampler._thread.daemon is True
+        deadline = time.time() + 2.0
+        while time.time() < deadline and sampler._last_reported_mb == 0.0:
+            time.sleep(0.02)
+        assert sampler._last_reported_mb == 700.0, "sampler never observed the synthetic jump"
+        assert sampler.is_alive() is True
+    finally:
+        sampler.stop(timeout=2.0)
+    assert sampler.is_alive() is False
+
+
+def test_reporter_sessionstart_starts_and_sessionfinish_stops_live_sampler(monkeypatch):
+    """_RSSHighWaterReporter wires its live_sampler's lifecycle to the real
+    pytest session, so a killed process is sampling for as long as the
+    session itself runs."""
+    monkeypatch.setattr(conftest, "_read_proc_vmhwm_mb", lambda: 100.0)
+    reporter = conftest._RSSHighWaterReporter(threshold_mb=500.0)
+    reporter.live_sampler.interval_s = 0.02
+
+    assert reporter.live_sampler.is_alive() is False
+    reporter.pytest_sessionstart(session=MagicMock())
+    try:
+        assert reporter.live_sampler.is_alive() is True
+    finally:
+        reporter.pytest_sessionfinish(session=MagicMock(), exitstatus=0)
+    assert reporter.live_sampler.is_alive() is False
+
+
+def test_reporter_updates_live_sampler_current_nodeid_during_test():
+    """The reporter's own hookwrapper feeds the live sampler its "cheaply
+    knowable" current nodeid before the test body runs, so a mid-test kill
+    still has a nodeid to attribute the next live-sampler line to."""
+    reporter = conftest._RSSHighWaterReporter(threshold_mb=1e9)  # never fires the post-test print
+    fake_item = MagicMock()
+    fake_item.nodeid = "tests/test_fake.py::test_other_thing"
+
+    gen = reporter.pytest_runtest_protocol(fake_item, nextitem=None)
+    next(gen)  # run up to the yield
+    assert reporter.live_sampler.current_nodeid == "tests/test_fake.py::test_other_thing"
+    try:
+        next(gen)
+    except StopIteration:
+        pass


### PR DESCRIPTION
## Summary

Implements the 3-part resolution path from issue #545's 2026-08-06 discriminator-run comment (run 31103127491, first run with both the #566 rebalance and the RSS reporter live). That run proved the recurring shard-1/2/3 kills (exit 143, zero assertions/exceptions) are OOM: every killed shard's process had already crossed **12-15 GB RSS high-water** before its own death. The fatal tests were **memory-heavy (3-24 GB) but time-cheap (38-100s)**; pytest-split's `duration_based_chunks` balances on time only, so it freely relocates these tests between shards on every `.test_durations` regeneration — a coin flip for which shards OOM next.

**This is NOT "Closes #545"** — the issue stays open until a green weekly run proves the split actually prevents the OOM kill. See the **predicted partial outcome** below before treating the next run as a refutation either way.

### 1. `highmem` marker (registered in `pyproject.toml`)

Marked the 7 tests confirmed memory-heavy in the discriminator run. **Important provenance caveat, added after review**: the `[rss]` post-test hook only prints *after* a test completes, so for the 3 tests that were themselves the ones killed (no PASSED suffix in the original run), their own footprint was never captured in CI — the number recorded is the *preceding* test's high-water reading, i.e. "the process was already at N MB entering this test."

| test | existing marker(s) | measured |
|---|---|---|
| `test_forward_tfsf_oblique_differentiable` | `slow` | **own footprint unmeasured in CI** (it was shard 1's kill); process already at 14,976 MB entering it (that's the preceding coax test's reading). Measured directly: 23.78 GB peak locally (taskset -c 0-1), 23,964 MB on independent standalone remeasurement |
| `test_oblique_reflection_magnitude_differentiable` | `slow` | **own footprint unmeasured in CI** (shard 2's kill); process already at 12,187 MB entering it (preceding msl-referee test's reading) |
| `test_ram_gradient_ad_vs_fd` (parametrized sigma/eps) | `slow` | `[sigma-1.0]`: **own footprint unmeasured in CI** (shard 3's kill); process already at 14,854 MB entering it (preceding mu_r test's reading). `[eps-4.0]` shares the same checkpointed forward and is marked with it (pytest marks apply per-function, not per-param) |
| `test_coax_reflection_grad_finite_and_fd_consistent` | `slow_physics` | +10.8 GB delta (self-attributed — this test completed normally) |
| `test_auto_eps_msl_gradient_matches_fd_mini_referee` | **none** (no slow/slow_physics/gpu) | +8.1 GB delta (self-attributed); independently remeasured at ~8.9 GB |
| `test_oblique_complex_gamma_differentiable` | `slow` | +10.7 GB delta (self-attributed) |
| `test_mu_r_gradient_ad_vs_fd` | `slow` | +3.3 GB delta (self-attributed) |

`highmem` is **additive only**: `pyproject.toml`'s `addopts` (the line *above* the markers list) still filters `not gpu and not slow and not slow_physics`, untouched. No test's default-fast-lane membership changes — `test_auto_eps_msl_gradient_matches_fd_mini_referee` still runs in the default/PR-gating lane exactly as before; `highmem` only pulls it out of the *weekly* 4-shard rotation. (That test's continued exposure in the fast lane, with no RSS diagnostics there, is filed separately as #594.)

### 2. Weekly workflow split (`.github/workflows/validation.yml`)

- The 4 `slow-tests` shard jobs now select `-m "not gpu and not highmem"`.
- New `slow-tests-highmem` job runs `-m "highmem and not gpu"` **serially** (no shard split, no xdist) so only one multi-GB peak exists on the runner at any instant. Same `RFX_WEEKLY_RSS=1` env, plus `-s` (see step 3). 30-minute timeout.
- **Corrected runner ceiling: ~16 GB, not ~7 GB.** Two witnesses: shard 1 survived past 14,976 MB (an entering-state reading, not a death); the ~8.9 GB msl-referee highmem test passes on `ubuntu-latest` in the default fast lane on every PR.
- **Predicted outcome (not yet proven — this split has not run in CI)**: the 4-shard job should stop OOMing. `slow-tests-highmem` will likely **still** see `test_forward_tfsf_oblique_differentiable` exit 143 — serialization removes only the ~4 GB of accumulated baseline from co-located tests, not that one test's own ~24 GB footprint, which alone exceeds the ~16 GB ceiling. This is *not* "several tests each ~2x a ~7 GB ceiling" — it's "one test ~1.5x a ~16 GB ceiling, the rest fit." If that test alone dies in its own job, that is **still an improvement** (a single named, reproducible test death is a strictly better signal than a random shard death among ~1500 tests) — not a refutation of the split. Next steps per #545 item 3, in order: (a) an explicit `checkpoint_segments` count for that test's forward; (b) a larger-runner label for `slow-tests-highmem`; (c) exclude it from CI and track it as a manual/local-only regression check.
- `.test_durations` needs no regeneration — its now-unused entries for the deselected `highmem` tests are simply not seen by pytest-split's `-m` selection, not stale.

### 3. Live RSS sampler (closes the discriminator gap, `conftest.py`)

The discriminator run's writeup disclosed a remaining gap: `ru_maxrss` only updates in the post-test hook, so the RSS at the exact SIGKILL instant is never captured. Added `_RSSLiveSampler`: a background **daemon thread** (stdlib `threading` only) polling `/proc/self/status` VmHWM every ~2s, printing `[rss-live] VmHWM N MB [during <nodeid>]` (`flush=True`) whenever the high-water mark advances past the threshold.

**Review caught this shipping dead**: pytest's own capture swallows a background thread's bare `print()` even with `flush=True` — measured 0 `[rss-live]` lines at the workflow's exact `-v -ra` flags, 0 under a `timeout -s KILL` rehearsal of the real SIGKILL scenario, 0 even with `--capture=tee-sys`. **Fixed** by adding `-s` (`--capture=no`) to both weekly pytest steps. Proven with a subprocess-level test pair that spawns a real child `pytest`, self-SIGKILLs it mid-test, and inspects stdout from *outside* pytest's own capture layer:

```
# with -s: [rss-live] VmHWM 208 MB during ...test_rss_live_sampler_helper_allocates_and_self_sigkills
#          survives in the streamed stdout; process then Killed (exit 137)
# without -s (identical scenario): zero [rss-live] output
```

Also added: an independent-oracle band check (`_read_proc_vmhwm_mb` vs `resource.getrusage().ru_maxrss`) so a kB/MB unit-conversion mutation can't silently pass, and a narrow `(ValueError, OSError)` guard around `_sample_once` scoped only to the interpreter/pytest-teardown closed-stream race (not a bare `except Exception` — see `feedback_broad_except_eats_async_timeout`, #555, where a broad except swallowed a real SIGALRM timeout and hung a process).

## Verification

- `pytest tests/test_weekly_rss_reporter.py -v`: **18 passed, 1 skipped** (the SIGKILL helper only runs as a subprocess target by design; includes the new independent-oracle band check and the two subprocess SIGKILL-survival tests).
- All 7 `highmem` tests (8 nodeids incl. sigma/eps parametrization) run and **pass functionally**: `8 passed, 2 warnings in 647.23s (0:10:47)`.
- `ruff check --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402` on every touched file: clean.
- **Partition proof** (`--collect-only`; environment-dependent, invariant holds either way):
  - This dev environment (no optional `cad` extras): old `-m "not gpu"` = **3320**; new shard selection `-m "not gpu and not highmem"` = **3312**; new highmem selection `-m "highmem and not gpu"` = **8**. 3312+8=3320, no overlap, no loss.
  - Reviewer's environment (optional extras installed): 3328 = 3320 + 8 — same invariant, different baseline total.
  - Per-shard `--splits 4` breakdown also sums exactly to the shard-selection total, confirming pytest-split runs cleanly against the existing `.test_durations` file with no regeneration.

## Follow-up filed

#594: the ~8.1-8.9 GB `test_auto_eps_msl_gradient_matches_fd_mini_referee` (marked `highmem` here) runs in the default fast lane every PR with no `RFX_WEEKLY_RSS` diagnostics and the same pytest-split shard-reassignment exposure #545 diagnosed in the weekly lane. Proposes either RSS diagnostics on `pr-tests.yml`'s `fast-suite`, or pinning that test's shard assignment. Not fixed in this PR — scoped as a triage issue.

## R3 self-audit

1. Contradicted by known memory/feedback? — none found after grep; `feedback_dont_over_fragment_prs.md` supports landing all 3 resolution steps in one PR; `feedback_broad_except_eats_async_timeout` (#555) directly informed the narrow-except design in `_run`; `feedback_provenance_mismatch_class.md` directly named the 3-comment misattribution bug review caught.
2. R2 diminishing-returns loop? — n/a, CI-plumbing fix responding to an already-diagnosed OOM verdict, not a physics/extractor investigation loop.
3. Falsifier: the next scheduled/manual `validation.yml` run — `slow-tests` (4-shard) should complete without exit 143; `slow-tests-highmem` is **predicted** to still lose `test_forward_tfsf_oblique_differentiable` to exit 143 specifically (not a refutation, see above) while the other 6 highmem tests should pass in-band.

## Test plan

- [x] `pytest tests/test_weekly_rss_reporter.py -v` — 18 passed, 1 skipped
- [x] Run all 7 `highmem`-marked tests directly — 8/8 nodeids passed (647s)
- [x] Subprocess SIGKILL-survival test pair — both pass, manually reproduced
- [x] `--collect-only` partition proof (invariant holds across environments)
- [x] `ruff check` on all touched files — clean
- [x] Filed follow-up issue #594 for the fast-lane structural risk
- [ ] **Falsifier (next weekly run)**: `slow-tests` completes cleanly; `slow-tests-highmem` shows the predicted single-test death (or, better than predicted, none)

🤖 Generated with [Claude Code](https://claude.com/claude-code)