### PR TITLE
feat(sparams): extra_flux_monitors= energy-witness opt-in + the #589 flux-adjudication driver

### DIFF
--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -2434,7 +2434,8 @@
       "feed_impedance",
       "cond_warn",
       "strict_passivity",
-      "skip_preflight"
+      "skip_preflight",
+      "extra_flux_monitors"
     ],
     "compute_coaxial_line_reflection": [
       "termination",
@@ -2473,7 +2474,8 @@
       "feed_impedance",
       "cond_warn",
       "strict_passivity",
-      "eps_scale"
+      "eps_scale",
+      "extra_flux_monitors"
     ],
     "compute_mixed_s_matrix": [
       "n_steps",

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -269,6 +269,52 @@ def _warn_msl_wave_split_unreliable(
 _SETTLING_WITNESS_DB = -40.0
 
 
+def _validate_extra_flux_monitor_entries(entries, domain, fn_name):
+    """Light re-validation of ``extra_flux_monitors=`` entries (#589 opt-in).
+
+    Entries are the objects ``Simulation.add_flux_monitor`` registers,
+    typically built on a scratch ``Simulation`` sharing this sim's domain —
+    ``add_flux_monitor`` already validated them against THAT domain, so this
+    only re-checks the one property that can silently diverge between the
+    two sims (the normal-axis coordinate inside THIS domain). Energy-witness
+    channel only: spectra come back on ``result.flux_monitors``; nothing
+    here feeds the S-parameter math (the registered-monitor guard below is
+    unchanged — this extractor still builds its own DFT planes).
+    """
+    if not entries:
+        return
+    axis_to_index = {"x": 0, "y": 1, "z": 2}
+    seen = set()
+    for pe in entries:
+        for attr in ("name", "axis", "coordinate"):
+            if not hasattr(pe, attr):
+                raise TypeError(
+                    f"{fn_name}(): extra_flux_monitors entries must be the "
+                    "objects Simulation.add_flux_monitor() registers "
+                    f"(missing attribute {attr!r}); build them by calling "
+                    "add_flux_monitor() on a scratch Simulation with the "
+                    "same domain and passing its ._flux_monitors list."
+                )
+        ax = axis_to_index.get(pe.axis)
+        if ax is None:
+            raise ValueError(
+                f"{fn_name}(): extra flux monitor {pe.name!r} has invalid "
+                f"axis {pe.axis!r}."
+            )
+        if not (0.0 <= float(pe.coordinate) <= float(domain[ax])):
+            raise ValueError(
+                f"{fn_name}(): extra flux monitor {pe.name!r} coordinate "
+                f"{pe.coordinate} m is outside this simulation's "
+                f"{pe.axis}-domain [0, {domain[ax]}] m."
+            )
+        if pe.name in seen:
+            raise ValueError(
+                f"{fn_name}(): duplicate extra flux monitor name "
+                f"{pe.name!r} — result spectra are name-keyed."
+            )
+        seen.add(pe.name)
+
+
 def _warn_if_ringdown_truncated(
     settling_db: np.ndarray, port_names: tuple, *, num_periods: float
 ) -> None:
@@ -5057,6 +5103,7 @@ class _SparamMixin:
         cond_warn: float = 1.0e3,
         strict_passivity: bool = False,
         eps_scale: "jnp.ndarray | float | None" = None,
+        extra_flux_monitors: "list | None" = None,
     ) -> "CoaxialTwoPortResult":
         """Two-drive coaxial 2-port S-parameters (#489 stage 2) — VALIDATED WITH SCOPE.
 
@@ -5161,6 +5208,21 @@ class _SparamMixin:
         separate defect; ``cond_a`` is still RETURNED (as a tracer), so a
         caller can inspect it after concretizing the result if degeneracy
         matters to them. The AD gate is ``tests/test_coax_two_port_ad.py``.
+
+        ``extra_flux_monitors`` (issue #589 flux-adjudication instrument):
+        an ENERGY-WITNESS channel, not an extractor change. Pass the entry
+        objects ``Simulation.add_flux_monitor`` registers (build them on a
+        scratch ``Simulation`` with the same domain and hand over its
+        ``._flux_monitors``); each internal drive run then accumulates the
+        requested Poynting-flux planes, and per-drive spectra come back
+        name-keyed on ``result.flux_monitors``
+        (``{port_name: {monitor_name: (n_monitor_freqs,) float64}}``, net
+        flux, positive = +axis). The S-parameter math is untouched — the
+        non-perturbation witness (S bit-identical with and without
+        monitors) is gated in
+        ``tests/test_coax_msl_transition.py::test_extra_flux_monitors_do_not_perturb_s``.
+        The registered-monitor guard is unchanged: monitors registered ON
+        this sim still raise, because this method builds its own probes.
         """
 
         if self._boundary != "cpml" or self._cpml_layers <= 0:
@@ -5289,6 +5351,8 @@ class _SparamMixin:
             )
 
         from rfx.probes.probes import init_dft_plane_probe
+        from rfx.probes.probes import flux_spectrum as _flux_spectrum
+        from rfx.runners.uniform import build_flux_monitor_cfgs
         from rfx.simulation import run as _run, ProbeSpec
         from rfx.sources.coaxial_port import (
             CoaxialPort as _CoaxPort,
@@ -5299,6 +5363,10 @@ class _SparamMixin:
             stamp_coaxial_line,
             stamp_coaxial_annular_resistor,
         )
+        _validate_extra_flux_monitor_entries(
+            extra_flux_monitors, self._domain, "compute_coaxial_two_port"
+        )
+        flux_by_drive: dict = {}
 
         grid = self._build_grid()
         nz = grid.shape[2]
@@ -5445,15 +5513,31 @@ class _SparamMixin:
                             grid_shape=grid.shape, dft_total_steps=int(n_steps),
                         )
                     )
+            # #589 flux-adjudication opt-in: fresh accumulators PER DRIVE
+            # (init_flux_monitor zeroes the DFT carries; sharing cfgs across
+            # drives would co-accumulate both drives into one spectrum).
+            _flux_run_kwargs = (
+                {"flux_monitors": build_flux_monitor_cfgs(
+                    self, grid, int(n_steps), entries=extra_flux_monitors)}
+                if extra_flux_monitors else {}
+            )
             result = _run(
                 grid, materials, int(n_steps), boundary="cpml", cpml_axes=cpml_axes,
                 sources=list(spec.electric_sources), mag_sources=list(spec.magnetic_sources),
                 probes=witness_probes, dft_planes=planes, return_state=False,
+                **_flux_run_kwargs,
             )
             if result.dft_planes is None:
                 raise RuntimeError(
                     "compute_coaxial_two_port(): runner returned no DFT planes"
                 )
+            if extra_flux_monitors:
+                flux_by_drive[("port1", "port2")[drive_idx]] = {
+                    entry.name: np.asarray(_flux_spectrum(fm), dtype=np.float64)
+                    for entry, fm in zip(
+                        extra_flux_monitors, result.flux_monitors or ()
+                    )
+                }
 
             top_off = n_bot * 2
             if _traced_eps:
@@ -5560,6 +5644,7 @@ class _SparamMixin:
             annulus_cells=annulus_cells,
             settling_db=settling_db,
             status=status,
+            flux_monitors=(flux_by_drive if extra_flux_monitors else None),
         )
         return _finalize_sparam_result(
             result_obj,
@@ -5587,6 +5672,7 @@ class _SparamMixin:
         cond_warn: float = 1.0e3,
         strict_passivity: bool = False,
         skip_preflight: bool = False,
+        extra_flux_monitors: "list | None" = None,
     ) -> "CoaxMSLTransitionResult":
         """EXPERIMENTAL coax<->microstrip transition 2-port S-parameters (issue #489 leg 4).
 
@@ -5728,6 +5814,21 @@ class _SparamMixin:
             attempt 1's exact behavior (and its committed fixture's
             numbers) when left unset.
 
+        ``extra_flux_monitors`` (issue #589 flux-adjudication instrument):
+        an ENERGY-WITNESS channel, not an extractor change. Pass the entry
+        objects ``Simulation.add_flux_monitor`` registers (build them on a
+        scratch ``Simulation`` with the same domain and hand over its
+        ``._flux_monitors``); each internal drive run then accumulates the
+        requested Poynting-flux planes, and per-drive spectra come back
+        name-keyed on ``result.flux_monitors``
+        (``{"coax"|"msl": {monitor_name: (n_monitor_freqs,) float64}}``,
+        net flux, positive = +axis). The S-parameter math is untouched —
+        the non-perturbation witness (S bit-identical with and without
+        monitors) is gated in
+        ``tests/test_coax_msl_transition.py::test_extra_flux_monitors_do_not_perturb_s``.
+        The registered-monitor guard is unchanged: monitors registered ON
+        this sim still raise, because this method builds its own probes.
+
         Returns
         -------
         CoaxMSLTransitionResult
@@ -5750,7 +5851,14 @@ class _SparamMixin:
             msl_probe_x_coords_n,
         )
         from rfx.probes.probes import init_dft_plane_probe
+        from rfx.probes.probes import flux_spectrum as _flux_spectrum
+        from rfx.runners.uniform import build_flux_monitor_cfgs
         from rfx.simulation import run as _run, ProbeSpec
+
+        _validate_extra_flux_monitor_entries(
+            extra_flux_monitors, self._domain, "compute_coax_msl_transition"
+        )
+        flux_by_drive: dict = {}
 
         # ---- Registration guards ----------------------------------------
         if self._boundary != "cpml" or self._cpml_layers <= 0:
@@ -6146,16 +6254,32 @@ class _SparamMixin:
                 ProbeSpec(i=i_probe_msl, j=j_probe_msl, k=k_probe_msl, component="ez"),
             ]
 
+            # #589 flux-adjudication opt-in: fresh accumulators PER DRIVE
+            # (init_flux_monitor zeroes the DFT carries; sharing cfgs across
+            # drives would co-accumulate both drives into one spectrum).
+            _flux_run_kwargs = (
+                {"flux_monitors": build_flux_monitor_cfgs(
+                    self, grid, int(n_steps), entries=extra_flux_monitors)}
+                if extra_flux_monitors else {}
+            )
             result = _run(
                 grid, materials, int(n_steps), boundary="cpml", cpml_axes="xyz",
                 sources=sources, mag_sources=mag_sources, probes=witness_probes,
                 dft_planes=planes, pec_mask=pec_mask, return_state=False,
+                **_flux_run_kwargs,
             )
             if result.dft_planes is None:
                 raise RuntimeError(
                     "compute_coax_msl_transition(): runner returned no DFT "
                     "planes"
                 )
+            if extra_flux_monitors:
+                flux_by_drive[("coax", "msl")[drive_idx]] = {
+                    entry.name: np.asarray(_flux_spectrum(fm), dtype=np.float64)
+                    for entry, fm in zip(
+                        extra_flux_monitors, result.flux_monitors or ()
+                    )
+                }
 
             for pi, z in enumerate(probes_coax):
                 v_coax_by_drive[drive_idx, pi, :] = np.asarray(
@@ -6209,6 +6333,7 @@ class _SparamMixin:
             b_out=b_out,
             settling_db=settling_db,
             status="experimental",
+            flux_monitors=(flux_by_drive if extra_flux_monitors else None),
         )
         return _finalize_sparam_result(
             result_obj,

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -1378,6 +1378,7 @@ class CoaxialTwoPortResult:
     annulus_cells: float
     settling_db: np.ndarray
     status: str
+    flux_monitors: dict | None = None
 
 
 @dataclass(frozen=True)
@@ -1772,7 +1773,12 @@ class CoaxMSLTransitionResult:
     extraction misses non-quasi-TEM content near the junction. A named
     discriminating check (not run): a closed-box (PEC-wall, no absorber)
     variant of this fixture — power reappearing in the port accounting
-    would support (a); power still missing would support (b).
+    would support (a); power still missing would support (b). SUPERSEDED
+    as the chosen instrument: the issue #589 pre-declaration (2026-08-07
+    comment) replaces the closed-box variant with face-resolved flux
+    accounting on the settled open fixture (see ``extra_flux_monitors=``
+    and the ``flux_monitors`` attribute below), with the deviation's
+    reasoning recorded there.
 
     Attributes
     ----------
@@ -1855,6 +1861,7 @@ class CoaxMSLTransitionResult:
     b_out: np.ndarray
     settling_db: np.ndarray
     status: str = "experimental"
+    flux_monitors: dict | None = None
 
 
 __all__ = [

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -59,7 +59,7 @@ def _reconstruct_oblique_physical(sim_result, tfsf_cfg, grid, probes):
     return sim_result._replace(state=new_state, time_series=new_ts)
 
 
-def build_flux_monitor_cfgs(sim, grid, n_steps):
+def build_flux_monitor_cfgs(sim, grid, n_steps, entries=None):
     """Materialize ``sim._flux_monitors`` entries into scan monitor configs.
 
     Mechanical extraction of the historical ``run_uniform`` inline block so
@@ -67,10 +67,19 @@ def build_flux_monitor_cfgs(sim, grid, n_steps):
     mixed-family flux magnitude channel) can register the SAME monitors
     the run() lane does. Pure function of (sim registrations, grid,
     n_steps) — keep byte-identical to the pre-extraction block.
+
+    ``entries`` overrides the entry list (same ``_FluxMonitorEntry``
+    objects ``add_flux_monitor`` registers) without touching the sim's
+    own registrations — the ``extra_flux_monitors=`` opt-in on the coax
+    extractors (#589 flux-adjudication instrument) passes caller-built
+    entries here while the registered-monitor guard stays intact. ``sim``
+    is still consulted for ``_freq_max``/``_domain``.
     """
     axis_to_index = {"x": 0, "y": 1, "z": 2}
     flux_monitors = []
-    for pe in getattr(sim, '_flux_monitors', []):
+    if entries is None:
+        entries = getattr(sim, '_flux_monitors', [])
+    for pe in entries:
         axis_idx = axis_to_index[pe.axis]
         plane_pos = [0.0, 0.0, 0.0]
         plane_pos[axis_idx] = pe.coordinate

--- a/scripts/diagnostics/coax_msl_flux_adjudication.py
+++ b/scripts/diagnostics/coax_msl_flux_adjudication.py
@@ -1,0 +1,555 @@
+#!/usr/bin/env python3
+"""#589 item-2 adjudication driver: face-resolved flux accounting (C1/C2/target).
+
+PRE-DECLARATION BINDING
+-----------------------
+This driver implements, verbatim, the decision rule pre-declared on issue
+#589 (comment of 2026-08-07, "PRE-DECLARATION — item 2 adjudication
+attempt"). The rule, witnesses, controls, and floors are NOT restated as
+authority here — the issue comment is the authority; this header carries
+only what that comment delegated to "the driver PR header": the exact face
+coordinates, their shift ranges, and instrument notes measured during
+implementation. Runs: C1 (MSL through-line control), C2 (coax two-port
+control), target (settled attempt-2 fixture + flux box). Controls gate the
+target: if a control hard-gate fails, the target is NOT interpreted
+(rc=2), per the pre-declaration.
+
+FACE COORDINATE TABLE (attempt-2 fixture; DX = 100 um; interior domain
+12.5 x 3.4 x 3.9 mm; CPML = 8 PAD cells OUTSIDE the interior domain)
+---------------------------------------------------------------------
+All coordinates physical metres; "cell" = physical coordinate / DX.
+Outward sign: +1 if +axis flux is outward for that face, else -1.
+
+  face  axis coord(mm) cell  tangential footprint            outward  shifts
+  xp    x    2.2       22    y [0.3,3.1], z [0.9,3.4] mm     +1       +/-2
+  xm    x    0.3        3    y [0.3,3.1], z [0.9,3.4] mm     -1       +/-2
+  yp    y    3.1       31    x [0.3,2.2], z [0.9,3.4] mm     +1       +/-2
+  ym    y    0.3        3    x [0.3,2.2], z [0.9,3.4] mm     -1       +/-2
+  zt    z    3.4       34    x [0.3,2.2], y [0.3,3.1] mm     +1       +/-2
+  zb    z    0.9        9    x [0.3,2.2], y [0.3,3.1] mm     -1       +/-2
+  x2    x    6.0       60    same footprint as xp (2-plane witness)   none
+  xp_aperture (partition of xp, books to the MSL return channel):
+        x    2.2       22    y Y_C+/-0.6 mm, z [2.5,3.2] mm  +1       +/-2
+  xp remainder := xp - xp_aperture (arithmetic; DFT flux is per-cell
+        linear, both monitors sit at the same plane index).
+
+Placement facts checked against the fixture source (they satisfy the
+pre-declaration's constraints — an earlier in-session estimate that the
+fixture could NOT satisfy the >=3-cell absorber clearance was WRONG; it
+mistook the 8 CPML PAD cells for cells inside the interior domain):
+  * every face is >= 3 cells from every interior-domain edge (min: xm and
+    ym/zb at exactly 3);
+  * both resistive elements are OUTSIDE the box: coax annular resistor at
+    z-index pad+3 (z = 0.3 mm) and coax source plane z = 0.5 mm sit BELOW
+    zb = 0.9 mm; the MSL feed (x = 11.0 mm) sits far outside xp = 2.2 mm;
+  * the below-ground coax annulus (x [0.4,1.6], y [1.1,2.3] mm) is FULLY
+    inside the zb face footprint, so R_coax is measured, not bounded;
+  * xp sits between the junction (x = 1.0 mm) and the first MSL ladder
+    probe (x = 2.6 mm), 4 cells clear of the probe plane;
+  * zb shift -2 lands at 0.7 mm, still 2 cells above the coax source
+    plane — the shift member nearest a source; flagged in output.
+
+MONITOR FREQUENCIES: the lane's committed FREQS_2 bins EXACTLY, plus a
+dense 5-11 GHz reporting band (25 points) on the same monitors. Decision
+arithmetic indexes the exact FREQS_2 members only.
+
+INSTRUMENT NOTES (measured during implementation, 2026-08-07)
+-------------------------------------------------------------
+* Non-perturbation witness: S bit-identical with/without monitors —
+  committed as tests/test_coax_msl_transition.py::
+  test_extra_flux_monitors_do_not_perturb_s (slow_physics).
+* Flux sign convention verified live: a top-drive coax two-port run reads
+  NEGATIVE net flux at a mid-line z-plane (power travels -z), so
+  "positive = +axis" holds and the outward multipliers above are correct.
+* kappa(f) = P_inc,flux / |a_inc[msl,msl]|^2 is a RECORDED witness with a
+  soft [0.7, 1.3] range, not a hard C1 gate: the decision rule's flux legs
+  are normalized by flux-measured P_inc throughout, and its |S22|^2 leg is
+  a pencil-unit RATIO, so the analytic-vs-discrete Z0 factor cancels
+  everywhere it could bind. (This resolves the wording tension between the
+  posted C1 bullet and the posted definitions bullet in favor of the
+  definitions — declared here, before any run.)
+
+HAND-PORTED PREFLIGHT-EQUIVALENTS (C1 runs rfx.simulation.run directly,
+which has no preflight): nonzero excitation energy (witness peak > 0),
+the -40 dB ring-down settling witness (same end/peak tail arithmetic as
+compute_coax_msl_transition), and an in-code assert of every monitor
+coordinate against the table above.
+
+Stages:  --stage c1 | c2 | target | all     (all = c1 -> c2 -> gate -> target)
+Exit codes: 0 = ran, gates evaluated (verdict in JSON, incl. NON-CLOSING);
+2 = control hard-gate failed (target skipped / not interpreted); 1 = crash.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("XLA_PYTHON_CLIENT_PREALLOCATE", "false")
+
+import numpy as np
+
+REPO = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(REPO / "tests"))
+
+DX = 100e-6
+FLOOR = 0.02          # pre-declared floor (fraction of P_inc)
+FLOOR_FAIL = 0.05     # pre-declared: control floor above this fails C1
+W_TOL = 0.15          # pre-declared W1/W2/two-plane tolerance
+DENSE_BAND = np.linspace(5.0e9, 11.0e9, 25)
+
+# face: (axis, coordinate_m, size_(t1,t2)_m, center_(t1,t2)_m, outward, shifts)
+# tangential order follows add_flux_monitor: x-normal -> (y, z);
+# y-normal -> (x, z); z-normal -> (x, y).
+FACES = {
+    "xp": ("x", 2.2e-3, (2.8e-3, 2.5e-3), (1.7e-3, 2.15e-3), +1, (-2, +2)),
+    "xm": ("x", 0.3e-3, (2.8e-3, 2.5e-3), (1.7e-3, 2.15e-3), -1, (-2, +2)),
+    "yp": ("y", 3.1e-3, (1.9e-3, 2.5e-3), (1.25e-3, 2.15e-3), +1, (-2, +2)),
+    "ym": ("y", 0.3e-3, (1.9e-3, 2.5e-3), (1.25e-3, 2.15e-3), -1, (-2, +2)),
+    "zt": ("z", 3.4e-3, (1.9e-3, 2.8e-3), (1.25e-3, 1.7e-3), +1, (-2, +2)),
+    "zb": ("z", 0.9e-3, (1.9e-3, 2.8e-3), (1.25e-3, 1.7e-3), -1, (-2, +2)),
+}
+X2_PLANE = ("x", 6.0e-3, (2.8e-3, 2.5e-3), (1.7e-3, 2.15e-3), +1)
+APERTURE = ("x", 2.2e-3, (1.2e-3, 0.7e-3), (1.7e-3, 2.85e-3), +1, (-2, +2))
+
+
+def _monitor_freqs(base):
+    return np.unique(np.concatenate([np.asarray(base, float), DENSE_BAND]))
+
+
+def _bin_index(mfreqs, targets):
+    idx = []
+    for f in np.asarray(targets, float):
+        j = int(np.argmin(np.abs(mfreqs - f)))
+        assert abs(mfreqs[j] - f) < 1.0, (mfreqs[j], f)
+        idx.append(j)
+    return idx
+
+
+def _build_target_entries(freqs_base):
+    """All monitors for the target/C1 box, incl. shifted siblings."""
+    from rfx.api import Simulation
+    from tests.test_coax_msl_transition import LX_2, LY, LZ_2, FREQ_MAX_2
+    mf = _monitor_freqs(freqs_base)
+    scratch = Simulation(freq_max=FREQ_MAX_2, domain=(LX_2, LY, LZ_2), dx=DX,
+                         boundary="cpml")
+    for name, (axis, coord, size, center, _outward, shifts) in FACES.items():
+        scratch.add_flux_monitor(axis=axis, coordinate=coord, freqs=mf,
+                                 size=size, center=center, name=name)
+        for sh in shifts:
+            scratch.add_flux_monitor(
+                axis=axis, coordinate=coord + sh * DX, freqs=mf,
+                size=size, center=center, name=f"{name}_s{sh:+d}",
+            )
+    axis, coord, size, center, _o = X2_PLANE
+    scratch.add_flux_monitor(axis=axis, coordinate=coord, freqs=mf,
+                             size=size, center=center, name="x2")
+    axis, coord, size, center, _o, shifts = APERTURE
+    scratch.add_flux_monitor(axis=axis, coordinate=coord, freqs=mf,
+                             size=size, center=center, name="xp_aperture")
+    for sh in shifts:
+        scratch.add_flux_monitor(
+            axis=axis, coordinate=coord + sh * DX, freqs=mf,
+            size=size, center=center, name=f"xp_aperture_s{sh:+d}",
+        )
+    return scratch._flux_monitors, mf
+
+
+def _outward(name):
+    base = name.split("_s")[0]
+    if base == "xp_aperture":
+        return +1
+    return FACES.get(base, ("", 0, (), (), +1, ()))[4] if base in FACES else +1
+
+
+def _channels(spectra, p_inc, idx):
+    """Pre-declared channel arithmetic at the FREQS_2 bins.
+
+    R_nl books the xp remainder (xp - xp_aperture) plus xm/yp/ym/zt;
+    R_msl_return = 1 + outward aperture flux / P_inc; R_coax from zb.
+    """
+    out = {}
+    def g(name):
+        return np.asarray(spectra[name], float)[idx]
+    ap = +1 * g("xp_aperture")
+    xp_rem = +1 * (g("xp") - g("xp_aperture"))
+    r_nl = (xp_rem
+            + (-1) * g("xm")
+            + (+1) * g("yp")
+            + (-1) * g("ym")
+            + (+1) * g("zt")) / p_inc
+    r_coax = (-1) * g("zb") / p_inc
+    r_msl_return = 1.0 + ap / p_inc
+    w1 = (g("xp") - g("xm") + g("yp") - g("ym") + g("zt") - g("zb"))
+    out.update(
+        R_nl=r_nl, R_coax=r_coax, R_msl_return=r_msl_return,
+        W1_raw_closure=np.abs(w1) / p_inc,
+        W2_channel_identity=np.abs(r_nl + r_coax + r_msl_return - 1.0),
+        two_plane_delta=(+1) * (g("x2") - g("xp")) / p_inc,
+    )
+    return {k: np.asarray(v, float).tolist() for k, v in out.items()}
+
+
+def _shift_table(spectra, p_inc, idx):
+    """Face-shift invariance: rebuild each channel with one face shifted."""
+    base = _channels(spectra, p_inc, idx)
+    rows = {}
+    for name in list(FACES) + ["xp_aperture"]:
+        for sh in (-2, +2):
+            key = f"{name}_s{sh:+d}"
+            if key not in spectra:
+                continue
+            sub = dict(spectra)
+            sub[name] = spectra[key]
+            ch = _channels(sub, p_inc, idx)
+            rows[key] = {
+                k: (np.abs(np.asarray(ch[k]) - np.asarray(base[k]))).tolist()
+                for k in ("R_nl", "R_coax", "R_msl_return")
+            }
+    worst = 0.0
+    for row in rows.values():
+        for v in row.values():
+            worst = max(worst, float(np.max(v)))
+    return {"per_shift_abs_delta": rows, "worst_abs_delta": worst,
+            "gate_lt_floor": bool(worst < FLOOR)}
+
+
+def _settling_from_witness(ts):
+    ts = np.asarray(ts, float)
+    power = ts ** 2
+    tail = max(1, power.shape[0] // 10)
+    end = power[-tail:, :].mean(axis=0)
+    peak = power.max(axis=0)
+    tiny = np.finfo(float).tiny
+    return float(np.max(10.0 * np.log10((end + tiny) / (peak + tiny))))
+
+
+# ---------------------------------------------------------------------------
+# C1 — MSL through-line control (junction removed, trace into the -x absorber)
+# ---------------------------------------------------------------------------
+
+def run_c1(n_steps, outdir):
+    from rfx.api import Simulation
+    from rfx.geometry.csg import Box
+    from rfx.runners.uniform import build_flux_monitor_cfgs
+    from rfx.probes.probes import flux_spectrum
+    from rfx.simulation import run as _run, ProbeSpec
+    from rfx.sources.msl_port import (  # same helpers the extractor imports
+        MSLPort as _MSLPortLL,
+        compute_msl_mode_profile, setup_msl_port, make_msl_port_sources,
+    )
+    from rfx import GaussianPulse
+    import tests.test_coax_msl_transition as T
+
+    sim = Simulation(freq_max=T.FREQ_MAX_2, domain=(T.LX_2, T.LY, T.LZ_2),
+                     dx=DX, cpml_layers=8, boundary="cpml")
+    sim.add_material("sub", eps_r=T.EPS_SUB)
+    gnd_lo, gnd_hi = T._half_cell_box_z(T.N_GND, T.N_GND)
+    sim.add(Box((0.0, 0.0, gnd_lo), (T.LX_2, T.LY, gnd_hi)), material="pec")
+    sub_lo, sub_hi = T._half_cell_box_z(T.N_SUB_LO, T.N_SUB_HI)
+    sim.add(Box((0.0, 0.0, sub_lo), (T.LX_2, T.LY, sub_hi)), material="sub")
+    trc_lo, trc_hi = T._half_cell_box_z(T.N_TRACE, T.N_TRACE)
+    # junction removed: the trace spans the FULL x-domain into both absorbers
+    sim.add(Box((0.0, T.Y_C - T.W_TRACE / 2, trc_lo),
+                (T.LX_2, T.Y_C + T.W_TRACE / 2, trc_hi)), material="pec")
+    sim.add_msl_port(position=(T.FEED_X_2, T.Y_C, T.N_SUB_LO * DX),
+                     width=T.W_TRACE, height=T.H_SUB, direction="-x",
+                     impedance=50.0, eps_r_sub=T.EPS_SUB)
+
+    entries, mf = _build_target_entries(T.FREQS_2)
+    from rfx.api import Simulation as _S
+    plane_scratch = _S(freq_max=T.FREQ_MAX_2, domain=(T.LX_2, T.LY, T.LZ_2),
+                       dx=DX, boundary="cpml")
+    for nm, x in (("planeA", 9.0e-3), ("planeB", 3.0e-3)):
+        plane_scratch.add_flux_monitor(
+            axis="x", coordinate=x, freqs=mf,
+            size=(2.8e-3, 2.5e-3), center=(1.7e-3, 2.15e-3), name=nm)
+    entries = list(entries) + list(plane_scratch._flux_monitors)
+
+    grid = sim._build_grid()
+    materials, _debye, _lorentz, pec_mask, _, _, _ = sim._assemble_materials(grid)
+    msl_pe = sim._msl_ports[0]
+    # mirror the extractor's entry -> low-level MSLPort conversion verbatim
+    x_feed, y_centre, msl_z_lo = (float(c) for c in msl_pe.position)
+    msl_port_base = _MSLPortLL(
+        feed_x=x_feed,
+        y_lo=y_centre - msl_pe.width / 2, y_hi=y_centre + msl_pe.width / 2,
+        z_lo=msl_z_lo, z_hi=msl_z_lo + msl_pe.height,
+        direction=msl_pe.direction, impedance=msl_pe.impedance,
+        excitation=None,
+    )
+    eps_r = float(T.EPS_SUB)
+    mode_profile = compute_msl_mode_profile(grid, msl_port_base, eps_r)
+    materials = setup_msl_port(grid, msl_port_base, materials,
+                               mode_profile=mode_profile)
+    import dataclasses as _dc
+    wf = GaussianPulse(f0=sim._freq_max / 2, bandwidth=0.8)
+    msl_driven = _dc.replace(msl_port_base, excitation=wf)
+    sources = make_msl_port_sources(grid, msl_driven, materials, int(n_steps),
+                                    mode_profile=mode_profile)
+
+    y_c = T.Y_C
+    k_probe = int(round((T.N_SUB_LO * DX + 0.5 * msl_pe.height) / DX)) + int(grid.pad_z_lo)
+    i_probe = int(grid.position_to_index((6.0e-3, y_c, T.N_SUB_LO * DX))[0])
+    j_probe = int(grid.pad_y_lo) + int(round(y_c / DX))
+    witness = [ProbeSpec(i=i_probe, j=j_probe, k=k_probe, component="ez")]
+
+    flux_cfgs = build_flux_monitor_cfgs(sim, grid, int(n_steps), entries=entries)
+    result = _run(grid, materials, int(n_steps), boundary="cpml",
+                  cpml_axes="xyz", sources=sources, mag_sources=[],
+                  probes=witness, dft_planes=[], pec_mask=pec_mask,
+                  return_state=False, flux_monitors=flux_cfgs)
+
+    spectra = {e.name: np.asarray(flux_spectrum(fm), float)
+               for e, fm in zip(entries, result.flux_monitors or ())}
+    settling = _settling_from_witness(result.time_series)
+    assert float(np.max(np.asarray(result.time_series) ** 2)) > 0.0, \
+        "hand-ported preflight: witness saw zero excitation energy"
+
+    idx = _bin_index(mf, T.FREQS_2)
+    phi_a = np.asarray(spectra["planeA"], float)[idx]
+    phi_b = np.asarray(spectra["planeB"], float)[idx]
+    p_inc = -phi_a  # incident travels -x: net flux at planeA = -P_inc (matched)
+    plane_inv = np.abs(phi_a - phi_b) / np.maximum(np.abs(phi_a), 1e-300)
+    ch = _channels(spectra, p_inc, idx)
+    b_nl = np.asarray(ch["R_nl"], float)
+
+    gates = {
+        "settling_db": settling,
+        "settling_gate_le_-40": bool(settling <= -40.0),
+        "p_inc_positive": bool(np.all(p_inc > 0.0)),
+        "plane_invariance": plane_inv.tolist(),
+        "plane_invariance_gate_le_floor": bool(np.max(plane_inv) <= FLOOR_FAIL),
+        "measured_floor": float(np.max(plane_inv)),
+        "launch_spill_B_nl": b_nl.tolist(),
+        "spill_gate_le_0.05": bool(np.max(np.abs(b_nl)) <= 0.05),
+    }
+    gates["c1_pass"] = bool(
+        gates["settling_gate_le_-40"] and gates["p_inc_positive"]
+        and gates["plane_invariance_gate_le_floor"] and gates["spill_gate_le_0.05"]
+    )
+    out = {
+        "stage": "c1", "n_steps": int(n_steps),
+        "monitor_freqs_hz": mf.tolist(), "freqs2_idx": idx,
+        "p_inc_w": p_inc.tolist(), "gates": gates, "channels": ch,
+        "spectra": {k: v.tolist() for k, v in spectra.items()},
+    }
+    (outdir / "c1_result.json").write_text(json.dumps(out, indent=1))
+    print(f"[c1] settling {settling:.2f} dB | plane-inv "
+          f"{np.max(plane_inv):.4f} | spill {np.max(np.abs(b_nl)):.4f} "
+          f"| PASS={gates['c1_pass']}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# C2 — coax two-port control (validated lane, attenuation-model gate)
+# ---------------------------------------------------------------------------
+
+def run_c2(n_steps, outdir):
+    from rfx.api import Simulation
+    from rfx import GaussianPulse
+    import tests.test_coax_two_port_fdtd as T2
+
+    band = T2.BAND
+    mf = _monitor_freqs(band)
+    dom = (0.008, 0.008, 0.060)
+    scratch = Simulation(domain=dom, freq_max=40.0e9, boundary="cpml")
+    z1, z2 = 0.025, 0.035
+    for nm, z in (("c2_z1", z1), ("c2_z2", z2)):
+        scratch.add_flux_monitor(axis="z", coordinate=z, freqs=mf,
+                                 size=(6.0e-3, 6.0e-3), center=(4.0e-3, 4.0e-3),
+                                 name=nm)
+    for nm, ax, c in (("c2_xm", "x", 0.5e-3), ("c2_xp", "x", 7.5e-3),
+                      ("c2_ym", "y", 0.5e-3), ("c2_yp", "y", 7.5e-3)):
+        scratch.add_flux_monitor(axis=ax, coordinate=c, freqs=mf,
+                                 size=(6.0e-3, 10.0e-3), center=(4.0e-3, 30.0e-3),
+                                 name=nm)
+
+    sim = Simulation(domain=dom, freq_max=40.0e9, boundary="cpml")
+    sim.add_coaxial_port((0.004, 0.004, 0.020), face="top", pin_length=5.0e-3,
+                         waveform=GaussianPulse(f0=8.0e9, bandwidth=1.2))
+    res = sim.compute_coaxial_two_port(
+        n_steps=int(n_steps), freqs=band,
+        extra_flux_monitors=scratch._flux_monitors,
+    )
+    idx = _bin_index(mf, band)
+    gamma = np.asarray(res.gamma)
+    re_gamma = np.mean(np.abs(np.real(gamma)).reshape(-1, gamma.shape[-1]), axis=0)
+    d12 = z2 - z1
+    model = np.exp(-2.0 * re_gamma * d12)
+
+    def flux(drive, name):
+        return np.asarray(res.flux_monitors[drive][name], float)[idx]
+
+    # drive port1 = top: power travels -z through both planes (negative net)
+    f1, f2 = flux("port1", "c2_z1"), flux("port1", "c2_z2")
+    # power decays toward -z: |flux| at z1 (farther from top source) is the
+    # attenuated one: |f1| ~= |f2| * exp(-2 Re(gamma) d12)
+    ratio = np.abs(f1) / np.maximum(np.abs(f2), 1e-300)
+    atten_ok = np.abs(ratio / model - 1.0) <= 0.15
+    p_ref = float(np.max(np.abs(f2)))
+    side = max(float(np.max(np.abs(flux("port1", n)))) for n in
+               ("c2_xm", "c2_xp", "c2_ym", "c2_yp"))
+    col = np.sum(np.abs(np.asarray(res.s_params)[:, 0, :]) ** 2, axis=0)
+
+    gates = {
+        "signs_negative_towards_minus_z": bool(np.all(f1 < 0) and np.all(f2 < 0)),
+        "atten_ratio": ratio.tolist(), "atten_model": model.tolist(),
+        "atten_gate_pm15pct": bool(np.all(atten_ok)),
+        "shield_side_over_pref": side / max(p_ref, 1e-300),
+        "shield_gate_le_floor": bool(side <= FLOOR * p_ref),
+        "column_power_port1_drive": col.tolist(),
+        "column_power_committed_range": [0.546, 0.923],
+        "column_power_in_committed_range": bool(
+            np.all((col > 0.50) & (col < 0.97))),
+        "settling_db": np.asarray(res.settling_db, float).tolist(),
+        "settling_gate_le_-40": bool(np.all(np.asarray(res.settling_db) <= -40.0)),
+    }
+    gates["c2_pass"] = bool(
+        gates["atten_gate_pm15pct"] and gates["shield_gate_le_floor"]
+        and gates["settling_gate_le_-40"]
+        and gates["signs_negative_towards_minus_z"]
+    )
+    out = {"stage": "c2", "n_steps": int(n_steps),
+           "monitor_freqs_hz": mf.tolist(), "gates": gates,
+           "flux_monitors": {d: {k: v.tolist() for k, v in s.items()}
+                             for d, s in res.flux_monitors.items()}}
+    (outdir / "c2_result.json").write_text(json.dumps(out, indent=1))
+    print(f"[c2] atten dev {np.max(np.abs(ratio / model - 1.0)):.4f} | shield "
+          f"{gates['shield_side_over_pref']:.2e} | PASS={gates['c2_pass']}")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# target — settled attempt-2 fixture + flux box, pre-declared decision rule
+# ---------------------------------------------------------------------------
+
+def run_target(n_steps, outdir, p_inc_c1, floor_eff=FLOOR):
+    import tests.test_coax_msl_transition as T
+
+    entries, mf = _build_target_entries(T.FREQS_2)
+    sim = T._build_coax_msl_transition_sim_attempt2()
+    res = sim.compute_coax_msl_transition(
+        junction_x=T.JUNCTION_X, eps_r_sub=T.EPS_SUB, n_steps=int(n_steps),
+        freqs=T.FREQS_2,
+        probe_count=6, probe_start_cells=4, probe_spacing_cells=2,
+        msl_probe_count=T.PROBE_COUNT_2, msl_probe_start_cells=T.PROBE_START_2,
+        msl_probe_spacing_cells=T.PROBE_SPACING_2,
+        skip_preflight=True, strict_passivity=False,
+        extra_flux_monitors=entries,
+    )
+    idx = _bin_index(mf, T.FREQS_2)
+    spectra = res.flux_monitors["msl"]
+    p_inc = np.asarray(p_inc_c1, float)
+    S = np.asarray(res.s_params)
+    s22 = np.abs(S[1, 1, :]) ** 2
+    s12 = np.abs(S[0, 1, :]) ** 2
+    deficit = 1.0 - s22 - s12
+
+    ch = _channels(spectra, p_inc, idx)
+    shifts = _shift_table(spectra, p_inc, idx)
+    a_msl = np.abs(np.asarray(res.a_inc)[1, 1, :]) ** 2
+    kappa = (p_inc / np.maximum(a_msl, 1e-300)).tolist()
+
+    r_nl = np.asarray(ch["R_nl"])
+    r_ret = np.asarray(ch["R_msl_return"])
+    w1 = np.asarray(ch["W1_raw_closure"])
+    w2 = np.asarray(ch["W2_channel_identity"])
+    two_plane = np.asarray(ch["two_plane_delta"])
+    settling_ok = bool(np.all(np.asarray(res.settling_db) <= -40.0))
+
+    b0, b1 = 0, 1  # binding bins: 6, 8 GHz; bin 2 (10 GHz) = trend witness
+    shifts["gate_lt_floor"] = bool(shifts["worst_abs_delta"] < floor_eff)
+    witnesses_ok = bool(np.all(w1[[b0, b1]] <= W_TOL)
+                        and np.all(w2[[b0, b1]] <= W_TOL)
+                        and shifts["gate_lt_floor"] and settling_ok)
+    ret_leg_ok = bool(np.all(np.abs(two_plane[[b0, b1]]) <= W_TOL))
+
+    arm_a = bool(
+        np.all(r_nl[[b0, b1]] >= 0.7 * deficit[[b0, b1]])
+        and np.all(r_nl[[b0, b1]] <= 1.3 * deficit[[b0, b1]])
+        and ((not ret_leg_ok) or np.all(
+            (r_ret - s22)[[b0, b1]] <= 0.15))
+    )
+    arm_b = bool(
+        np.all(r_nl[[b0, b1]] <= 0.3 * deficit[[b0, b1]])
+        and ret_leg_ok
+        and np.any((r_ret - s22)[[b0, b1]] >= 0.5 * deficit[[b0, b1]])
+    )
+    if not witnesses_ok:
+        verdict = "NON-CLOSING (witness failure)"
+    elif arm_a and not arm_b:
+        verdict = "SUPPORTS (a) PHYSICAL"
+    elif arm_b and not arm_a:
+        verdict = "SUPPORTS (b) INSTRUMENT"
+    else:
+        verdict = "NON-CLOSING"
+
+    out = {
+        "stage": "target", "n_steps": int(n_steps), "verdict": verdict,
+        "monitor_freqs_hz": mf.tolist(), "freqs2_idx": idx,
+        "p_inc_from_c1_w": p_inc.tolist(), "kappa_witness": kappa,
+        "deficit": deficit.tolist(), "s22_sq": s22.tolist(),
+        "s12_sq": s12.tolist(),
+        "settling_db": np.asarray(res.settling_db, float).tolist(),
+        "channels": ch, "shift_invariance": shifts,
+        "ret_leg_ok_two_plane": ret_leg_ok,
+        "trend_witness_10ghz_R_nl": float(r_nl[2]),
+        "trend_expected_if_a": [0.14, 0.26],
+        "spectra_msl_drive": {k: np.asarray(v).tolist()
+                              for k, v in spectra.items()},
+        "spectra_coax_drive": {k: np.asarray(v).tolist()
+                               for k, v in res.flux_monitors["coax"].items()},
+    }
+    (outdir / "target_result.json").write_text(json.dumps(out, indent=1))
+    print(f"[target] verdict: {verdict}")
+    print(f"  Deficit {deficit.round(4).tolist()}  R_nl {r_nl.round(4).tolist()}")
+    print(f"  R_msl_return-|S22|^2 {(r_ret - s22).round(4).tolist()}  "
+          f"W1 {w1.round(4).tolist()}  W2 {w2.round(4).tolist()}")
+    print(f"  shift worst {shifts['worst_abs_delta']:.4f}  "
+          f"two-plane {two_plane.round(4).tolist()}  kappa {np.round(kappa,3).tolist()}")
+    return out
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--stage", choices=("c1", "c2", "target", "all"),
+                    default="all")
+    ap.add_argument("--n-steps-c1", type=int, default=20000)
+    ap.add_argument("--n-steps-c2", type=int, default=6000)
+    ap.add_argument("--n-steps-target", type=int, default=135000)
+    ap.add_argument("--output-dir", type=Path, required=True)
+    args = ap.parse_args(argv)
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.stage in ("c1", "all"):
+        c1 = run_c1(args.n_steps_c1, args.output_dir)
+        if args.stage == "all" and not c1["gates"]["c1_pass"]:
+            print("[all] C1 hard-gate FAILED -> target skipped (rc=2)")
+            return 2
+    if args.stage in ("c2", "all"):
+        c2 = run_c2(args.n_steps_c2, args.output_dir)
+        if args.stage == "all" and not c2["gates"]["c2_pass"]:
+            print("[all] C2 hard-gate FAILED -> target skipped (rc=2)")
+            return 2
+    if args.stage in ("target", "all"):
+        c1_path = args.output_dir / "c1_result.json"
+        if not c1_path.exists():
+            print("[target] c1_result.json missing — run --stage c1 first "
+                  "(P_inc is flux-measured there, per the pre-declaration)")
+            return 2
+        c1_data = json.loads(c1_path.read_text())
+        p_inc = c1_data["p_inc_w"]
+        # pre-declared: floor = 0.02 unless C1 measured worse (fail > 0.05)
+        floor_eff = min(max(FLOOR, c1_data["gates"]["measured_floor"]),
+                        FLOOR_FAIL)
+        run_target(args.n_steps_target, args.output_dir, p_inc,
+                   floor_eff=floor_eff)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/diagnostics/coax_msl_flux_adjudication.py
+++ b/scripts/diagnostics/coax_msl_flux_adjudication.py
@@ -22,14 +22,22 @@ Outward sign: +1 if +axis flux is outward for that face, else -1.
 
   face  axis coord(mm) cell  tangential footprint            outward  shifts
   xp    x    2.2       22    y [0.3,3.1], z [0.9,3.4] mm     +1       +/-2
-  xm    x    0.3        3    y [0.3,3.1], z [0.9,3.4] mm     -1       +/-2
-  yp    y    3.1       31    x [0.3,2.2], z [0.9,3.4] mm     +1       +/-2
-  ym    y    0.3        3    x [0.3,2.2], z [0.9,3.4] mm     -1       +/-2
+  xm    x    0.3        3    y [0.3,3.1], z [0.9,3.4] mm     -1       +2 only
+  yp    y    3.1       31    x [0.3,2.2], z [0.9,3.4] mm     +1       -2 only
+  ym    y    0.3        3    x [0.3,2.2], z [0.9,3.4] mm     -1       +2 only
   zt    z    3.4       34    x [0.3,2.2], y [0.3,3.1] mm     +1       +/-2
-  zb    z    0.9        9    x [0.3,2.2], y [0.3,3.1] mm     -1       +/-2
+  zb    z    0.9        9    x [0.3,2.2], y [0.3,3.1] mm     -1       +/-2 (see flag)
   x2    x    6.0       60    same footprint as xp (2-plane witness)   none
   xp_aperture (partition of xp, books to the MSL return channel):
         x    2.2       22    y Y_C+/-0.6 mm, z [2.5,3.2] mm  +1       +/-2
+  strip_{xp,xm,yp,ym}: below-ground sub-strips of the side faces
+        (z [0.9,2.5] mm) — coax shell tightness witness, must read ~0.
+
+  One-sided shifts (declared): xm/ym +2 only and yp -2 only — the omitted
+  member would sit 1 cell from the CPML inner edge, where absorber-fringe
+  contamination could trip the invariance gate for a placement reason.
+  zb's -2 member (0.7 mm) sits 2 cells above the coax source plane and is
+  flagged in the output (SHIFT_FLAGS).
   xp remainder := xp - xp_aperture (arithmetic; DFT flux is per-cell
         linear, both monitors sit at the same plane index).
 
@@ -104,13 +112,30 @@ DENSE_BAND = np.linspace(5.0e9, 11.0e9, 25)
 # face: (axis, coordinate_m, size_(t1,t2)_m, center_(t1,t2)_m, outward, shifts)
 # tangential order follows add_flux_monitor: x-normal -> (y, z);
 # y-normal -> (x, z); z-normal -> (x, y).
+# Shift ranges (review finding, declared): xm/ym take +2 only and yp -2
+# only — their other member would land 1 cell from the CPML inner edge,
+# where absorber-fringe contamination could trip the invariance gate for a
+# placement reason rather than an instrument one. zb keeps -2 with an
+# explicit source-proximity flag in the output (2 cells above the coax
+# source plane at its -2 member).
 FACES = {
     "xp": ("x", 2.2e-3, (2.8e-3, 2.5e-3), (1.7e-3, 2.15e-3), +1, (-2, +2)),
-    "xm": ("x", 0.3e-3, (2.8e-3, 2.5e-3), (1.7e-3, 2.15e-3), -1, (-2, +2)),
-    "yp": ("y", 3.1e-3, (1.9e-3, 2.5e-3), (1.25e-3, 2.15e-3), +1, (-2, +2)),
-    "ym": ("y", 0.3e-3, (1.9e-3, 2.5e-3), (1.25e-3, 2.15e-3), -1, (-2, +2)),
+    "xm": ("x", 0.3e-3, (2.8e-3, 2.5e-3), (1.7e-3, 2.15e-3), -1, (+2,)),
+    "yp": ("y", 3.1e-3, (1.9e-3, 2.5e-3), (1.25e-3, 2.15e-3), +1, (-2,)),
+    "ym": ("y", 0.3e-3, (1.9e-3, 2.5e-3), (1.25e-3, 2.15e-3), -1, (+2,)),
     "zt": ("z", 3.4e-3, (1.9e-3, 2.8e-3), (1.25e-3, 1.7e-3), +1, (-2, +2)),
     "zb": ("z", 0.9e-3, (1.9e-3, 2.8e-3), (1.25e-3, 1.7e-3), -1, (-2, +2)),
+}
+SHIFT_FLAGS = {
+    "zb_s-2": "2 cells above the coax source plane (closest shift-to-source)",
+}
+# Below-ground strip witnesses (coax shell tightness): side-face strips
+# z in [0.9, 2.5] mm (below the ground plane) must read ~0.
+STRIPS = {
+    "strip_xp": ("x", 2.2e-3, (2.8e-3, 1.6e-3), (1.7e-3, 1.7e-3)),
+    "strip_xm": ("x", 0.3e-3, (2.8e-3, 1.6e-3), (1.7e-3, 1.7e-3)),
+    "strip_yp": ("y", 3.1e-3, (1.9e-3, 1.6e-3), (1.25e-3, 1.7e-3)),
+    "strip_ym": ("y", 0.3e-3, (1.9e-3, 1.6e-3), (1.25e-3, 1.7e-3)),
 }
 X2_PLANE = ("x", 6.0e-3, (2.8e-3, 2.5e-3), (1.7e-3, 2.15e-3), +1)
 APERTURE = ("x", 2.2e-3, (1.2e-3, 0.7e-3), (1.7e-3, 2.85e-3), +1, (-2, +2))
@@ -155,42 +180,81 @@ def _build_target_entries(freqs_base):
             axis=axis, coordinate=coord + sh * DX, freqs=mf,
             size=size, center=center, name=f"xp_aperture_s{sh:+d}",
         )
+    for name, (axis, coord, size, center) in STRIPS.items():
+        scratch.add_flux_monitor(axis=axis, coordinate=coord, freqs=mf,
+                                 size=size, center=center, name=name)
     return scratch._flux_monitors, mf
 
 
-def _outward(name):
-    base = name.split("_s")[0]
-    if base == "xp_aperture":
-        return +1
-    return FACES.get(base, ("", 0, (), (), +1, ()))[4] if base in FACES else +1
+def _assert_monitor_indices(entries, grid):
+    """Header-table assert (hand-ported preflight): the MATERIALIZED plane
+    index of every monitor must equal round(coordinate/DX) + pad on its
+    normal axis — checked against the actual grid, pads included, so a
+    rasterization surprise fails loudly before any physics is read."""
+    pads = {"x": int(grid.pad_x_lo), "y": int(grid.pad_y_lo),
+            "z": int(grid.pad_z_lo)}
+    for pe in entries:
+        expected = int(round(float(pe.coordinate) / DX)) + pads[pe.axis]
+        axis_idx = {"x": 0, "y": 1, "z": 2}[pe.axis]
+        pos = [0.0, 0.0, 0.0]
+        pos[axis_idx] = pe.coordinate
+        got = int(grid.position_to_index(tuple(pos))[axis_idx])
+        assert got == expected, (
+            f"monitor {pe.name}: materialized plane index {got} != "
+            f"expected {expected} (coord {pe.coordinate} m)")
 
 
-def _channels(spectra, p_inc, idx):
+def _face_terms(spectra, p_inc, idx):
+    """Per-face OUTWARD flux terms / P_inc at the FREQS_2 bins."""
+    def g(name):
+        return np.asarray(spectra[name], float)[idx]
+    return {
+        "xp_rem": +1 * (g("xp") - g("xp_aperture")) / p_inc,
+        "xm": -1 * g("xm") / p_inc,
+        "yp": +1 * g("yp") / p_inc,
+        "ym": -1 * g("ym") / p_inc,
+        "zt": +1 * g("zt") / p_inc,
+        "zb": -1 * g("zb") / p_inc,
+        "xp_aperture": +1 * g("xp_aperture") / p_inc,
+    }, g
+
+
+def _channels(spectra, p_inc, idx, b_nl_subtract=None):
     """Pre-declared channel arithmetic at the FREQS_2 bins.
 
     R_nl books the xp remainder (xp - xp_aperture) plus xm/yp/ym/zt;
     R_msl_return = 1 + outward aperture flux / P_inc; R_coax from zb.
+    ``b_nl_subtract`` (per-bin, from C1) applies the pre-declared
+    launch-spill background subtraction to R_nl; both raw and corrected
+    values are reported, and the decision arms evaluate the corrected one.
+
+    W2 note (review finding, declared): W2 is algebraically identical to
+    W1 given these channel definitions (the aperture terms cancel), so it
+    is reported as a BOOKKEEPING consistency check of the channel
+    arithmetic, not counted as an independent physics witness —
+    witnesses_ok gates on W1 once.
     """
-    out = {}
-    def g(name):
-        return np.asarray(spectra[name], float)[idx]
-    ap = +1 * g("xp_aperture")
-    xp_rem = +1 * (g("xp") - g("xp_aperture"))
-    r_nl = (xp_rem
-            + (-1) * g("xm")
-            + (+1) * g("yp")
-            + (-1) * g("ym")
-            + (+1) * g("zt")) / p_inc
-    r_coax = (-1) * g("zb") / p_inc
-    r_msl_return = 1.0 + ap / p_inc
+    terms, g = _face_terms(spectra, p_inc, idx)
+    r_nl_raw = (terms["xp_rem"] + terms["xm"] + terms["yp"]
+                + terms["ym"] + terms["zt"])
+    r_nl = r_nl_raw if b_nl_subtract is None else (
+        r_nl_raw - np.asarray(b_nl_subtract, float))
+    r_coax = terms["zb"]
+    r_msl_return = 1.0 + terms["xp_aperture"]
     w1 = (g("xp") - g("xm") + g("yp") - g("ym") + g("zt") - g("zb"))
-    out.update(
-        R_nl=r_nl, R_coax=r_coax, R_msl_return=r_msl_return,
+    out = dict(
+        R_nl=r_nl, R_nl_raw=r_nl_raw, R_coax=r_coax,
+        R_msl_return=r_msl_return,
+        per_face_outward=terms,
         W1_raw_closure=np.abs(w1) / p_inc,
-        W2_channel_identity=np.abs(r_nl + r_coax + r_msl_return - 1.0),
+        W2_bookkeeping_check=np.abs(r_nl_raw + r_coax + r_msl_return - 1.0),
         two_plane_delta=(+1) * (g("x2") - g("xp")) / p_inc,
     )
-    return {k: np.asarray(v, float).tolist() for k, v in out.items()}
+    def _ser(v):
+        if isinstance(v, dict):
+            return {k: _ser(x) for k, x in v.items()}
+        return np.asarray(v, float).tolist()
+    return {k: _ser(v) for k, v in out.items()}
 
 
 def _shift_table(spectra, p_inc, idx):
@@ -297,6 +361,7 @@ def run_c1(n_steps, outdir):
     j_probe = int(grid.pad_y_lo) + int(round(y_c / DX))
     witness = [ProbeSpec(i=i_probe, j=j_probe, k=k_probe, component="ez")]
 
+    _assert_monitor_indices(entries, grid)
     flux_cfgs = build_flux_monitor_cfgs(sim, grid, int(n_steps), entries=entries)
     result = _run(grid, materials, int(n_steps), boundary="cpml",
                   cpml_axes="xyz", sources=sources, mag_sources=[],
@@ -315,7 +380,17 @@ def run_c1(n_steps, outdir):
     p_inc = -phi_a  # incident travels -x: net flux at planeA = -P_inc (matched)
     plane_inv = np.abs(phi_a - phi_b) / np.maximum(np.abs(phi_a), 1e-300)
     ch = _channels(spectra, p_inc, idx)
-    b_nl = np.asarray(ch["R_nl"], float)
+    # Launch-spill background (review fix): the through-line trace passes
+    # THROUGH both x-faces, so xm carries the full transmitted power and
+    # must be EXCLUDED — the background covers the faces the target's R_nl
+    # shares minus xm (xm background is unmeasurable on a through line;
+    # disclosed). Composition: xp remainder + yp + ym + zt.
+    terms = {k: np.asarray(v, float)
+             for k, v in ch["per_face_outward"].items()}
+    b_nl = terms["xp_rem"] + terms["yp"] + terms["ym"] + terms["zt"]
+    strips = {k: np.asarray(spectra[k], float)[idx].tolist()
+              for k in STRIPS}
+    strip_max = max(float(np.max(np.abs(np.asarray(v)))) for v in strips.values())
 
     gates = {
         "settling_db": settling,
@@ -325,7 +400,12 @@ def run_c1(n_steps, outdir):
         "plane_invariance_gate_le_floor": bool(np.max(plane_inv) <= FLOOR_FAIL),
         "measured_floor": float(np.max(plane_inv)),
         "launch_spill_B_nl": b_nl.tolist(),
+        "launch_spill_composition": "xp_rem + yp + ym + zt (xm EXCLUDED: "
+                                    "through-line exit face; disclosed)",
         "spill_gate_le_0.05": bool(np.max(np.abs(b_nl)) <= 0.05),
+        "below_ground_strips": strips,
+        "below_ground_strip_max_over_pinc": strip_max / max(
+            float(np.max(np.abs(p_inc))), 1e-300),
     }
     gates["c1_pass"] = bool(
         gates["settling_gate_le_-40"] and gates["p_inc_positive"]
@@ -377,9 +457,25 @@ def run_c2(n_steps, outdir):
     )
     idx = _bin_index(mf, band)
     gamma = np.asarray(res.gamma)
-    re_gamma = np.mean(np.abs(np.real(gamma)).reshape(-1, gamma.shape[-1]), axis=0)
-    d12 = z2 - z1
-    model = np.exp(-2.0 * re_gamma * d12)
+    # Attenuation model (review fix): the committed mechanism-check record
+    # attributes the own/other-drive Re(gamma) split to loss at the
+    # RECEIVING feed, which does not occur between the mid-line planes —
+    # so the bulk ratio is modeled by the OWN-DRIVE gamma pair; the
+    # all-fits mean is recorded alongside for attribution if the gate
+    # trips near the band edge.
+    if gamma.ndim == 3:
+        re_own = np.mean(np.abs(np.real(gamma[(0, 1), (0, 1), :])), axis=0)
+    else:
+        re_own = np.mean(np.abs(np.real(gamma)).reshape(-1, gamma.shape[-1]),
+                         axis=0)
+    re_all = np.mean(np.abs(np.real(gamma)).reshape(-1, gamma.shape[-1]), axis=0)
+    # snapped plane separation from the actual grid indices
+    g2 = sim._build_grid()
+    k1 = int(g2.position_to_index((0.0, 0.0, z1))[2])
+    k2 = int(g2.position_to_index((0.0, 0.0, z2))[2])
+    d12 = (k2 - k1) * float(g2.dx)
+    model = np.exp(-2.0 * re_own * d12)
+    model_allfits = np.exp(-2.0 * re_all * d12)
 
     def flux(drive, name):
         return np.asarray(res.flux_monitors[drive][name], float)[idx]
@@ -390,26 +486,37 @@ def run_c2(n_steps, outdir):
     # attenuated one: |f1| ~= |f2| * exp(-2 Re(gamma) d12)
     ratio = np.abs(f1) / np.maximum(np.abs(f2), 1e-300)
     atten_ok = np.abs(ratio / model - 1.0) <= 0.15
-    p_ref = float(np.max(np.abs(f2)))
-    side = max(float(np.max(np.abs(flux("port1", n)))) for n in
-               ("c2_xm", "c2_xp", "c2_ym", "c2_yp"))
+    # W1 Poynting closure over the closed C2 box (posted gate): outward =
+    # +f2 (z2, +z face) - f1 (z1, -z face) + outward side faces.
+    side_out = (flux("port1", "c2_xp") - flux("port1", "c2_xm")
+                + flux("port1", "c2_yp") - flux("port1", "c2_ym"))
+    w1_c2 = np.abs(f2 - f1 + side_out) / np.maximum(np.abs(f2), 1e-300)
+    # per-bin shield gate (posted: per-bin, floor-scaled)
+    side_abs = np.max(np.stack([np.abs(flux("port1", n)) for n in
+                                ("c2_xm", "c2_xp", "c2_ym", "c2_yp")]), axis=0)
+    shield_ok = side_abs <= FLOOR * np.maximum(np.abs(f2), 1e-300)
     col = np.sum(np.abs(np.asarray(res.s_params)[:, 0, :]) ** 2, axis=0)
 
     gates = {
         "signs_negative_towards_minus_z": bool(np.all(f1 < 0) and np.all(f2 < 0)),
-        "atten_ratio": ratio.tolist(), "atten_model": model.tolist(),
+        "atten_ratio": ratio.tolist(), "atten_model_own_drive": model.tolist(),
+        "atten_model_all_fits": model_allfits.tolist(),
+        "d12_snapped_m": d12,
         "atten_gate_pm15pct": bool(np.all(atten_ok)),
-        "shield_side_over_pref": side / max(p_ref, 1e-300),
-        "shield_gate_le_floor": bool(side <= FLOOR * p_ref),
+        "w1_closure": w1_c2.tolist(),
+        "w1_gate_le_0.15": bool(np.all(w1_c2 <= W_TOL)),
+        "shield_side_over_f2_per_bin": (side_abs / np.maximum(np.abs(f2), 1e-300)).tolist(),
+        "shield_gate_le_floor_per_bin": bool(np.all(shield_ok)),
         "column_power_port1_drive": col.tolist(),
         "column_power_committed_range": [0.546, 0.923],
-        "column_power_in_committed_range": bool(
+        "column_power_in_widened_range_0.50_0.97": bool(
             np.all((col > 0.50) & (col < 0.97))),
         "settling_db": np.asarray(res.settling_db, float).tolist(),
         "settling_gate_le_-40": bool(np.all(np.asarray(res.settling_db) <= -40.0)),
     }
     gates["c2_pass"] = bool(
-        gates["atten_gate_pm15pct"] and gates["shield_gate_le_floor"]
+        gates["atten_gate_pm15pct"] and gates["shield_gate_le_floor_per_bin"]
+        and gates["w1_gate_le_0.15"]
         and gates["settling_gate_le_-40"]
         and gates["signs_negative_towards_minus_z"]
     )
@@ -418,8 +525,10 @@ def run_c2(n_steps, outdir):
            "flux_monitors": {d: {k: v.tolist() for k, v in s.items()}
                              for d, s in res.flux_monitors.items()}}
     (outdir / "c2_result.json").write_text(json.dumps(out, indent=1))
-    print(f"[c2] atten dev {np.max(np.abs(ratio / model - 1.0)):.4f} | shield "
-          f"{gates['shield_side_over_pref']:.2e} | PASS={gates['c2_pass']}")
+    print(f"[c2] atten dev {np.max(np.abs(ratio / model - 1.0)):.4f} | "
+          f"W1 {np.max(w1_c2):.4f} | shield "
+          f"{np.max(side_abs / np.maximum(np.abs(f2), 1e-300)):.2e} | "
+          f"PASS={gates['c2_pass']}")
     return out
 
 
@@ -427,11 +536,14 @@ def run_c2(n_steps, outdir):
 # target — settled attempt-2 fixture + flux box, pre-declared decision rule
 # ---------------------------------------------------------------------------
 
-def run_target(n_steps, outdir, p_inc_c1, floor_eff=FLOOR):
+def run_target(n_steps, outdir, c1_data, floor_eff=FLOOR):
     import tests.test_coax_msl_transition as T
 
+    p_inc_c1 = c1_data["p_inc_w"]
+    b_nl_bg = np.asarray(c1_data["gates"]["launch_spill_B_nl"], float)
     entries, mf = _build_target_entries(T.FREQS_2)
     sim = T._build_coax_msl_transition_sim_attempt2()
+    _assert_monitor_indices(entries, sim._build_grid())
     res = sim.compute_coax_msl_transition(
         junction_x=T.JUNCTION_X, eps_r_sub=T.EPS_SUB, n_steps=int(n_steps),
         freqs=T.FREQS_2,
@@ -449,25 +561,41 @@ def run_target(n_steps, outdir, p_inc_c1, floor_eff=FLOOR):
     s12 = np.abs(S[0, 1, :]) ** 2
     deficit = 1.0 - s22 - s12
 
-    ch = _channels(spectra, p_inc, idx)
+    ch = _channels(spectra, p_inc, idx, b_nl_subtract=b_nl_bg)
     shifts = _shift_table(spectra, p_inc, idx)
     a_msl = np.abs(np.asarray(res.a_inc)[1, 1, :]) ** 2
     kappa = (p_inc / np.maximum(a_msl, 1e-300)).tolist()
+    kappa_in_soft_range = [bool(0.7 <= k <= 1.3) for k in kappa]
+    if not all(kappa_in_soft_range[:2]):
+        print("[target] WARNING: kappa outside soft range [0.7, 1.3] at a "
+              f"binding bin: {np.round(kappa, 3).tolist()} — investigate "
+              "the P_inc normalization before trusting this verdict "
+              "(pre-declared investigate-before-interpret trigger).")
 
+    # spill-corrected R_nl is the DECISION value (posted C1 bullet:
+    # background 'reported and subtracted explicitly'); raw kept alongside.
     r_nl = np.asarray(ch["R_nl"])
     r_ret = np.asarray(ch["R_msl_return"])
     w1 = np.asarray(ch["W1_raw_closure"])
-    w2 = np.asarray(ch["W2_channel_identity"])
+    w2 = np.asarray(ch["W2_bookkeeping_check"])
     two_plane = np.asarray(ch["two_plane_delta"])
     settling_ok = bool(np.all(np.asarray(res.settling_db) <= -40.0))
+    strips = {k: np.asarray(spectra[k], float)[idx].tolist() for k in STRIPS}
+    strip_max_over_pinc = max(
+        float(np.max(np.abs(np.asarray(v) / p_inc))) for v in strips.values())
 
     b0, b1 = 0, 1  # binding bins: 6, 8 GHz; bin 2 (10 GHz) = trend witness
     shifts["gate_lt_floor"] = bool(shifts["worst_abs_delta"] < floor_eff)
+    w1_per_bin_ok = (w1 <= W_TOL).tolist()
+    # W1 gates at the binding bins; W2 is a bookkeeping identity of the
+    # channel arithmetic (== W1 by construction), reported, not counted.
     witnesses_ok = bool(np.all(w1[[b0, b1]] <= W_TOL)
-                        and np.all(w2[[b0, b1]] <= W_TOL)
                         and shifts["gate_lt_floor"] and settling_ok)
     ret_leg_ok = bool(np.all(np.abs(two_plane[[b0, b1]]) <= W_TOL))
 
+    # Contamination rule, symmetric (review fix, matches the posted text
+    # "only R_nl binds"): when the two-plane witness declares the return
+    # leg contaminated, BOTH arms reduce to their R_nl condition.
     arm_a = bool(
         np.all(r_nl[[b0, b1]] >= 0.7 * deficit[[b0, b1]])
         and np.all(r_nl[[b0, b1]] <= 1.3 * deficit[[b0, b1]])
@@ -476,8 +604,8 @@ def run_target(n_steps, outdir, p_inc_c1, floor_eff=FLOOR):
     )
     arm_b = bool(
         np.all(r_nl[[b0, b1]] <= 0.3 * deficit[[b0, b1]])
-        and ret_leg_ok
-        and np.any((r_ret - s22)[[b0, b1]] >= 0.5 * deficit[[b0, b1]])
+        and ((not ret_leg_ok) or np.any(
+            (r_ret - s22)[[b0, b1]] >= 0.5 * deficit[[b0, b1]]))
     )
     if not witnesses_ok:
         verdict = "NON-CLOSING (witness failure)"
@@ -492,18 +620,35 @@ def run_target(n_steps, outdir, p_inc_c1, floor_eff=FLOOR):
         "stage": "target", "n_steps": int(n_steps), "verdict": verdict,
         "monitor_freqs_hz": mf.tolist(), "freqs2_idx": idx,
         "p_inc_from_c1_w": p_inc.tolist(), "kappa_witness": kappa,
+        "kappa_in_soft_range_0.7_1.3": kappa_in_soft_range,
+        "launch_spill_bg_from_c1": b_nl_bg.tolist(),
+        "decision_uses": "R_nl spill-corrected (raw kept in channels.R_nl_raw)",
         "deficit": deficit.tolist(), "s22_sq": s22.tolist(),
         "s12_sq": s12.tolist(),
         "settling_db": np.asarray(res.settling_db, float).tolist(),
         "channels": ch, "shift_invariance": shifts,
+        "shift_member_flags": SHIFT_FLAGS,
+        "below_ground_strips": strips,
+        "below_ground_strip_max_over_pinc": strip_max_over_pinc,
+        "w1_per_bin_ok": w1_per_bin_ok,
         "ret_leg_ok_two_plane": ret_leg_ok,
         "trend_witness_10ghz_R_nl": float(r_nl[2]),
+        "trend_witness_10ghz_w1_ok": bool(w1_per_bin_ok[2]),
         "trend_expected_if_a": [0.14, 0.26],
         "spectra_msl_drive": {k: np.asarray(v).tolist()
                               for k, v in spectra.items()},
         "spectra_coax_drive": {k: np.asarray(v).tolist()
                                for k, v in res.flux_monitors["coax"].items()},
     }
+    if verdict == "SUPPORTS (b) INSTRUMENT":
+        out["predeclared_consequence"] = (
+            "Per the #589 pre-declaration: the follow-up is a Gwarek V-I "
+            "MSL-side extraction check per the repo's port-class fallback "
+            "discipline — flux numbers never become S numbers. NOTE "
+            "(PI decision 2026-08-07): the lane hard-stops after this "
+            "verdict is reported; the Gwarek follow-up is NOT auto-started."
+        )
+        print("[target] predeclared consequence:", out["predeclared_consequence"])
     (outdir / "target_result.json").write_text(json.dumps(out, indent=1))
     print(f"[target] verdict: {verdict}")
     print(f"  Deficit {deficit.round(4).tolist()}  R_nl {r_nl.round(4).tolist()}")
@@ -536,17 +681,26 @@ def main(argv=None):
             print("[all] C2 hard-gate FAILED -> target skipped (rc=2)")
             return 2
     if args.stage in ("target", "all"):
-        c1_path = args.output_dir / "c1_result.json"
-        if not c1_path.exists():
-            print("[target] c1_result.json missing — run --stage c1 first "
-                  "(P_inc is flux-measured there, per the pre-declaration)")
-            return 2
-        c1_data = json.loads(c1_path.read_text())
-        p_inc = c1_data["p_inc_w"]
+        # both controls must EXIST and PASS regardless of invocation path
+        # (review fix: --stage target alone previously skipped the gates)
+        gate_data = {}
+        for st in ("c1", "c2"):
+            p = args.output_dir / f"{st}_result.json"
+            if not p.exists():
+                print(f"[target] {st}_result.json missing — run --stage {st} "
+                      "first (controls gate the target, per the "
+                      "pre-declaration)")
+                return 2
+            gate_data[st] = json.loads(p.read_text())
+            if not gate_data[st]["gates"][f"{st}_pass"]:
+                print(f"[target] {st} hard-gate FAILED in its recorded "
+                      "result — target not interpreted (rc=2)")
+                return 2
+        c1_data = gate_data["c1"]
         # pre-declared: floor = 0.02 unless C1 measured worse (fail > 0.05)
         floor_eff = min(max(FLOOR, c1_data["gates"]["measured_floor"]),
                         FLOOR_FAIL)
-        run_target(args.n_steps_target, args.output_dir, p_inc,
+        run_target(args.n_steps_target, args.output_dir, c1_data,
                    floor_eff=floor_eff)
     return 0
 

--- a/scripts/vessl_coax_msl_flux_adjudication.yaml
+++ b/scripts/vessl_coax_msl_flux_adjudication.yaml
@@ -1,0 +1,43 @@
+name: rfx-coax-msl-flux-adjudication
+description: "#589 item-2 adjudication (pre-declared 2026-08-07 on the issue): face-resolved flux accounting on the settled attempt-2 coax<->MSL fixture, adjudicating whether the MSL-driven 99.3%/98.9% column-power deficit at 6/8 GHz is (a) physically departing power or (b) extraction blindness. Runs scripts/diagnostics/coax_msl_flux_adjudication.py --stage all: C1 (MSL through-line control -- pins the flux-measured P_inc normalizer, plane-invariance, launch-spill background, settling), C2 (coax two-port control -- attenuation-model gate vs the run's own Re(gamma), shield-tightness, settling), then the target settled run (n_steps=135000, same as VESSL 369367252283) with the 6-face flux box + shifted siblings + two-plane witness. Controls HARD-GATE the target (rc=2 skips it), witnesses can force NON-CLOSING; the decision rule is the issue comment's, verbatim, implemented in the driver. USES THE MOUNTED PRIMARY CHECKOUT (imitates scripts/vessl_coax_msl_transition_settled_run.yaml): the driver, the extra_flux_monitors= opt-in, and its bit-identity contract test must all be on main before submission -- DO NOT SUBMIT until the instrument PR has merged."
+tags: [rfx, issue-589, coax-msl-transition, flux-adjudication]
+resources:
+  cluster: remilab-c0
+  preset: gpu-rtx4090
+image: nvcr.io/nvidia/jax:24.10-py3
+env:
+  PYTHONUNBUFFERED: "1"
+  XLA_PYTHON_CLIENT_PREALLOCATE: "false"
+  HDF5_USE_FILE_LOCKING: "FALSE"
+  LANG: "C.UTF-8"
+mount:
+  /root/workspace/: volume://remilab-fs/personal-workspaces/
+run: |-
+  set -euo pipefail
+  cd /root/workspace/byungkwan-workspace/research/rfx
+  git config --global --add safe.directory /root/workspace/byungkwan-workspace/research/rfx || true
+  echo "=== rfx #589 item 2: flux adjudication (C1 -> C2 -> target 135000) ==="
+  echo "=== provenance ==="
+  git rev-parse HEAD || true
+  git status --short || true
+  echo "=== install runtime dependencies (repo path, no editable install) ==="
+  python -m pip install -q "scipy>=1.11" "h5py>=3.8" "matplotlib>=3.7" pytest
+  export RFX_REPO_ROOT="/root/workspace/byungkwan-workspace/research/rfx"
+  export PYTHONPATH="$RFX_REPO_ROOT:${PYTHONPATH:-}"
+  python -c "import jax, rfx; print('probe ok | jax', jax.__version__, '| devices', jax.devices(), '| rfx', getattr(rfx, '__version__', '?'))"
+  echo "=== bit-identity witness must be green on THIS checkout before the physics runs ==="
+  python -m pytest tests/test_coax_msl_transition.py::test_extra_flux_monitors_do_not_perturb_s -m slow_physics -x -q
+  out=".omx/coax-msl-flux-adjudication/$(date -u +%Y%m%dT%H%M%SZ)-$(git rev-parse --short HEAD)"
+  mkdir -p "$out"
+  set +e
+  timeout 14400 python -u scripts/diagnostics/coax_msl_flux_adjudication.py \
+    --stage all \
+    --output-dir "$out" \
+    > "$out/run.log" 2>&1
+  rc=$?
+  set -e
+  tail -n 120 "$out/run.log"
+  echo "$rc" > "$out/run.rc"
+  echo "artifacts persisted to (mounted, survives job teardown): $out"
+  echo "coax_msl_flux_adjudication_rc=$rc"
+  exit "$rc"

--- a/tests/test_coax_msl_transition.py
+++ b/tests/test_coax_msl_transition.py
@@ -1652,3 +1652,120 @@ def test_coax_msl_transition_attempt2_instrument_verification():
         _warn_if_nonpassive_smatrix(
             result, extractor="compute_coax_msl_transition", strict=True,
         )
+
+
+# ---------------------------------------------------------------------------
+# Part 5 -- #589 flux-adjudication instrument: the extra_flux_monitors= opt-in.
+#
+# The issue #589 pre-declaration (2026-08-07 comment) commits this PR to ONE
+# witness before any adjudication run is interpreted: the S output must be
+# BIT-IDENTICAL with and without monitors attached (the opt-in is an
+# energy-witness channel, not an extractor change), and the registered-
+# monitor guard must stay intact. The fast tests below pin the guard and the
+# entry validation; the slow_physics test pins the bit-identity witness on
+# the SAME attempt-2 fixture the adjudication run uses (step count is
+# instrument calibration only -- bit-identity is step-count independent).
+# ---------------------------------------------------------------------------
+
+def _attempt2_kwargs(n_steps):
+    return dict(
+        junction_x=JUNCTION_X, eps_r_sub=EPS_SUB, n_steps=n_steps,
+        freqs=FREQS_2,
+        probe_count=6, probe_start_cells=4, probe_spacing_cells=2,
+        msl_probe_count=PROBE_COUNT_2, msl_probe_start_cells=PROBE_START_2,
+        msl_probe_spacing_cells=PROBE_SPACING_2,
+        skip_preflight=True, strict_passivity=False,
+    )
+
+
+def _attempt2_scratch_flux_entries():
+    """Flux entries built the documented way: a scratch Simulation sharing
+    the attempt-2 domain, handing over its ._flux_monitors list."""
+    from rfx.api import Simulation as _Sim
+    scratch = _Sim(freq_max=FREQ_MAX_2, domain=(LX_2, LY, LZ_2), dx=DX,
+                   boundary="cpml")
+    scratch.add_flux_monitor(
+        axis="x", coordinate=2.2e-3, freqs=FREQS_2,
+        size=(1.2e-3, 0.7e-3), center=(Y_C, 2.8e-3), name="xplane_aperture",
+    )
+    scratch.add_flux_monitor(
+        axis="z", coordinate=3.0e-3, freqs=FREQS_2,
+        size=(1.3e-3, 1.2e-3), center=(2.15e-3, Y_C), name="ztop_patch",
+    )
+    return scratch._flux_monitors
+
+
+def test_extra_flux_monitors_registered_guard_unchanged():
+    """Monitors registered ON the sim still raise -- the opt-in did not
+    loosen the builds-its-own guard."""
+    sim = _build_coax_msl_transition_sim_attempt2()
+    sim.add_flux_monitor(axis="x", coordinate=2.2e-3, freqs=FREQS_2)
+    with pytest.raises(ValueError, match="flux monitors"):
+        sim.compute_coax_msl_transition(**_attempt2_kwargs(1))
+
+
+def test_extra_flux_monitors_entry_validation():
+    """Malformed opt-in entries fail loudly BEFORE any FDTD work."""
+    with pytest.raises(TypeError, match="add_flux_monitor"):
+        _build_coax_msl_transition_sim_attempt2().compute_coax_msl_transition(
+            **_attempt2_kwargs(1), extra_flux_monitors=[{"name": "not_an_entry"}],
+        )
+
+    from rfx.api import Simulation as _Sim
+    off_domain = _Sim(freq_max=FREQ_MAX_2, domain=(50.0e-3, LY, LZ_2), dx=DX,
+                      boundary="cpml")
+    off_domain.add_flux_monitor(axis="x", coordinate=30.0e-3, freqs=FREQS_2,
+                                name="outside_attempt2_x")
+    with pytest.raises(ValueError, match="outside"):
+        _build_coax_msl_transition_sim_attempt2().compute_coax_msl_transition(
+            **_attempt2_kwargs(1),
+            extra_flux_monitors=off_domain._flux_monitors,
+        )
+
+    dup = _Sim(freq_max=FREQ_MAX_2, domain=(LX_2, LY, LZ_2), dx=DX,
+               boundary="cpml")
+    dup.add_flux_monitor(axis="x", coordinate=2.2e-3, freqs=FREQS_2, name="d")
+    dup.add_flux_monitor(axis="x", coordinate=2.3e-3, freqs=FREQS_2, name="d")
+    with pytest.raises(ValueError, match="duplicate"):
+        _build_coax_msl_transition_sim_attempt2().compute_coax_msl_transition(
+            **_attempt2_kwargs(1), extra_flux_monitors=dup._flux_monitors,
+        )
+
+
+@pytest.mark.slow_physics
+def test_extra_flux_monitors_do_not_perturb_s():
+    """The #589 non-perturbation witness: S bit-identical with and without
+    the opt-in monitors, on the attempt-2 fixture itself.
+
+    Bit-identity (not allclose) is deliberate: the monitors add read-only
+    DFT accumulation to the scan carry, and any drift here would mean the
+    instrument perturbs the thing it measures. Measured before commit on
+    CPU (2026-08-07): identical, and off/off repeatability also identical.
+    If a future backend/XLA version reorders the fused field math under the
+    added carry, this test reds -- that is a REAL finding about the witness
+    (re-measure and re-declare on #589 before trusting adjudication runs),
+    not a tolerance to loosen silently.
+    """
+    n_steps = 1000  # bit-identity is step-count independent; keep it cheap
+    r_off = _build_coax_msl_transition_sim_attempt2().compute_coax_msl_transition(
+        **_attempt2_kwargs(n_steps))
+    r_on = _build_coax_msl_transition_sim_attempt2().compute_coax_msl_transition(
+        **_attempt2_kwargs(n_steps),
+        extra_flux_monitors=_attempt2_scratch_flux_entries(),
+    )
+
+    assert r_off.flux_monitors is None
+    assert np.array_equal(np.asarray(r_off.s_params), np.asarray(r_on.s_params)), (
+        "extra_flux_monitors perturbed the S output -- the #589 "
+        "non-perturbation witness failed; do not run the adjudication "
+        "until this is re-declared."
+    )
+    assert np.array_equal(np.asarray(r_off.settling_db),
+                          np.asarray(r_on.settling_db))
+
+    assert set(r_on.flux_monitors) == {"coax", "msl"}
+    for drive_key, spectra in r_on.flux_monitors.items():
+        assert set(spectra) == {"xplane_aperture", "ztop_patch"}
+        for name, arr in spectra.items():
+            assert arr.shape == (len(FREQS_2),), (drive_key, name, arr.shape)
+            assert np.all(np.isfinite(arr)), (drive_key, name, arr)


### PR DESCRIPTION
Implements the instrument half of the **issue #589 pre-declaration** (2026-08-07 comment): face-resolved flux accounting on the settled attempt-2 fixture, to adjudicate the MSL-driven column-power deficit between **(a) physically departing power** and **(b) extraction blindness**. No fixture is promoted, no gate is changed, and **no VESSL run is submitted by this PR** — submission follows the mounted-checkout rule (driver must be on main) and a coordinate-addendum comment on #589 that precedes it.

## What this adds

- **`extra_flux_monitors=` opt-in** on `compute_coax_msl_transition` and `compute_coaxial_two_port`: entries are the objects `add_flux_monitor` registers (built on a scratch `Simulation`, same domain); each internal drive run accumulates the requested Poynting-flux planes with **fresh per-drive accumulators**, and per-drive spectra return name-keyed on `result.flux_monitors`. The registered-monitor guard is **unchanged**, and the internal run call is byte-identical when the opt-in is unset (kwargs added only when present — the existing monkeypatch fake-run test keeps its explicit signature).
- `build_flux_monitor_cfgs(..., entries=)` override (sim still consulted for `_freq_max`/`_domain` only).
- `flux_monitors: dict | None = None` on both result dataclasses; class docstring records that the #589 pre-declaration supersedes the closed-box variant as the chosen instrument.
- **Driver** `scripts/diagnostics/coax_msl_flux_adjudication.py`: C1 (MSL through-line control — flux-measured P_inc, plane-invariance, launch-spill background, settling), C2 (coax two-port control — attenuation-model gate vs the run's own Re(γ), shield tightness), target (settled 135000-step recipe + 6-face box, aperture partition, shifted-sibling monitors for the face-shift gate, two-plane witness). Controls hard-gate the target (rc=2 skips it). The decision rule is the issue comment's, verbatim; the header carries the face coordinate table the pre-declaration delegated to this PR.
- **VESSL YAML** (tracked by the same force-add exception as the settled-run/gpu-suite/crossval YAMLs); it re-runs the bit-identity witness in-job before the physics stages.

## Witnesses — measured, not promised

- **Non-perturbation witness** (`test_extra_flux_monitors_do_not_perturb_s`, slow_physics): S **bit-identical** with and without monitors on the attempt-2 fixture; settling_db identical; spectra finite and name-keyed. Measured pre-commit on CPU: `1 passed in 40.05s`.
- Fast lane: guard + entry-validation tests, `2 passed in 2.14s`.
- Flux sign convention verified live (top-drive two-port reads negative net flux at a mid-line plane → "positive = +axis" holds; the driver's outward multipliers key off it).
- 3-stage driver smoke at toy scale: exit 0; fail-loud paths verified (C1 gate failure blocks the target; missing `c1_result.json` blocks the target; unsettled toy physics returns NON-CLOSING with the witness numbers visibly wrong, as they should be).
- ruff (CI select/ignore set): clean.

R3: memory=ledger leg-4 entries + power-flux fence (witness-not-extractor stated in both docstrings) + rf_core_audit half-step class (face-shift gate is the declared falsifier) + gate-binds-artifact (witness measured) | R2-attempts=0 (instrument build; the lane's one pre-declared attempt fires at run time) | falsifier=bit-identity test green + smoke rc/gate behavior verified pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)