### PR TITLE
docs: relabel paper references TAP → T-MTT (venue retarget)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -827,7 +827,7 @@ pins the removal version (v2.0) in the warning text and here.
   (matching `farfield.directivity()` / `antenna._total_radiated_power`) rather
   than the upper hemisphere, so the optimized quantity is the true directivity;
   the hemisphere-only integral inflated it (~+3 dB) for any radiator with back
-  radiation. The shipped tap-paper beam-steering example is unaffected (it builds
+  radiation. The shipped T-MTT-paper beam-steering example is unaffected (it builds
   its own full-sphere `4π U/P_rad` objective and never called this function).
 
 ## [1.6.6] - 2026-06-24

--- a/tests/test_extract_s_matrix_pec_mask.py
+++ b/tests/test_extract_s_matrix_pec_mask.py
@@ -5,7 +5,7 @@ Without this, eval simulations lose ground planes / scatterers added
 via ``Box(..., material="pec")``, producing flat |S11| ≈ 0 dB across
 the band — which manifests as a large train/eval disconnect on the
 ``optimize()`` path identical in shape to the time-gating bug
-(rfx-tap paper, ex1_dra; issue #72 follow-up).
+(rfx T-MTT paper, ex1_dra; issue #72 follow-up).
 
 The wire-port counterpart already accepts ``pec_mask`` — the lumped
 path just needed parity.

--- a/tests/test_nonuniform_grad_sparams.py
+++ b/tests/test_nonuniform_grad_sparams.py
@@ -5,7 +5,7 @@ Before the fix: ``rfx/nonuniform.py:1140`` did
 wrapped in ``jax.grad`` and a WirePort with ``extent=`` is registered,
 ``b_j / safe_a_k`` is a JAX tracer, and ``_np.array(tracer)`` raises
 ``TracerArrayConversionError``, blocking differentiable inverse design
-on non-uniform grids (the IEEE TAP paper's ex3_series_fed_array_nu
+on non-uniform grids (the IEEE T-MTT paper's ex3_series_fed_array_nu
 scenario).
 
 After the fix: ``S`` is a jnp array built via

--- a/tests/test_periodic_cpml.py
+++ b/tests/test_periodic_cpml.py
@@ -124,7 +124,7 @@ def test_forward_periodic_xy_cpml_z_runs_without_nan():
     """End-to-end: periodic xy + CPML z forward must produce finite fields.
 
     Before the fix, the conflicting boundary conditions degenerated the
-    simulation (documented as S11 = 0 dB flat on rfx-TAP ex6). The
+    simulation (documented as S11 = 0 dB flat on the T-MTT-paper ex6). The
     minimum smoke criterion here is that the probe time series is finite
     and non-zero after the fix.
     """


### PR DESCRIPTION
The companion differentiable-FDTD paper was submitted to **IEEE T-MTT** (venue retargeted from TAP in 2026-06). This PR updates the four remaining prose references — `CHANGELOG.md` and three test docstrings — from `tap-paper` / `rfx-tap` / `IEEE TAP paper` to T-MTT wording. Comment/doc-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)