### PR TITLE
fix(probes): flux_spectrum exact_f64= for absolute-scale energy witnesses (#589 C1 iteration 2)

### DIFF
--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -1008,7 +1008,8 @@
     "flux_spectrum": {
       "kind": "function",
       "params": [
-        "mon"
+        "mon",
+        "exact_f64"
       ]
     },
     "front_to_back_ratio": {

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -5533,7 +5533,7 @@ class _SparamMixin:
                 )
             if extra_flux_monitors:
                 flux_by_drive[("port1", "port2")[drive_idx]] = {
-                    entry.name: np.asarray(_flux_spectrum(fm), dtype=np.float64)
+                    entry.name: np.asarray(_flux_spectrum(fm, exact_f64=True), dtype=np.float64)
                     for entry, fm in zip(
                         extra_flux_monitors, result.flux_monitors or ()
                     )
@@ -6275,7 +6275,7 @@ class _SparamMixin:
                 )
             if extra_flux_monitors:
                 flux_by_drive[("coax", "msl")[drive_idx]] = {
-                    entry.name: np.asarray(_flux_spectrum(fm), dtype=np.float64)
+                    entry.name: np.asarray(_flux_spectrum(fm, exact_f64=True), dtype=np.float64)
                     for entry, fm in zip(
                         extra_flux_monitors, result.flux_monitors or ()
                     )

--- a/rfx/probes/probes.py
+++ b/rfx/probes/probes.py
@@ -610,7 +610,7 @@ def update_flux_monitor(
     )
 
 
-def flux_spectrum(mon: FluxMonitor) -> jnp.ndarray:
+def flux_spectrum(mon: FluxMonitor, *, exact_f64: bool = False) -> jnp.ndarray:
     """Compute Poynting flux spectrum from accumulated DFT fields.
 
     Returns
@@ -629,7 +629,32 @@ def flux_spectrum(mon: FluxMonitor) -> jnp.ndarray:
     this readily). Eager calls detect that state with a float64 NumPy
     recompute of the identical sum and emit a UserWarning; under
     jit/grad the check is skipped entirely (tracer-safe, off the AD tape).
+
+    ``exact_f64=True`` performs that float64 NumPy recompute AS the result
+    (eager-only; raises under tracing): the per-cell products and the sum
+    run in complex128 from the (healthy) float32 accumulators, which is
+    the #304 warning's own sanctioned remedy. Absolute-scale energy
+    consumers (the #589 flux-adjudication witness channel) use this path —
+    partial subnormal flushing corrupts small-magnitude sums well before
+    they reach exact zero, so the warning alone is not sufficient there.
+    The default path is unchanged.
     """
+    if exact_f64:
+        import numpy as np
+        import jax as _jax
+        if isinstance(mon.e1_dft, _jax.core.Tracer):
+            raise TypeError(
+                "flux_spectrum(exact_f64=True) is eager-only — it is a "
+                "NumPy float64 post-processing of concrete accumulators "
+                "and cannot run under jit/grad."
+            )
+        e1 = np.asarray(mon.e1_dft, dtype=np.complex128)
+        e2 = np.asarray(mon.e2_dft, dtype=np.complex128)
+        h1 = np.asarray(mon.h1_dft, dtype=np.complex128)
+        h2 = np.asarray(mon.h2_dft, dtype=np.complex128)
+        integrand = e1 * np.conj(h2) - e2 * np.conj(h1)
+        dA = np.asarray(mon.dA, dtype=np.float64)
+        return np.real(np.sum(integrand * dA, axis=(-2, -1)))
     # Poynting: S_n = E1*H2* - E2*H1* (cyclic cross product).
     # mon.dA is the axis-aware area weight (scalar or (n1,n2)).
     integrand = mon.e1_dft * jnp.conj(mon.h2_dft) - mon.e2_dft * jnp.conj(mon.h1_dft)

--- a/scripts/diagnostics/coax_msl_flux_adjudication.py
+++ b/scripts/diagnostics/coax_msl_flux_adjudication.py
@@ -63,6 +63,18 @@ arithmetic indexes the exact FREQS_2 members only.
 
 INSTRUMENT NOTES (measured during implementation, 2026-08-07)
 -------------------------------------------------------------
+* C1 iteration 2 (declared on #589 before resubmission): the first C1 run
+  (VESSL 369367252342, rc=2 by design) read fluxes of ~1e-29 W with a
+  WRONG net-flux sign at planeA — the MSL drive's absolute scale puts the
+  per-cell E x H* products (~1e-33) inside the GPU float32
+  subnormal-flush zone (issue #304 class; S-parameters are ratio-based
+  and immune, an energy witness is not). Remedy: all witness-channel
+  spectra are now computed with flux_spectrum(exact_f64=True) — a float64
+  NumPy recompute from the healthy float32 accumulators; the FDTD run and
+  the S path are byte-identical. C1's default n_steps also rises to the
+  family's settled recipe (135000): the first run measured -22.1 dB at
+  20000 steps, consistent with this launch's slow ring-down recorded
+  across the lane's checkpoints (-10.7 / -17.9 / -44.2 dB).
 * Non-perturbation witness: S bit-identical with/without monitors —
   committed as tests/test_coax_msl_transition.py::
   test_extra_flux_monitors_do_not_perturb_s (slow_physics).
@@ -368,7 +380,7 @@ def run_c1(n_steps, outdir):
                   probes=witness, dft_planes=[], pec_mask=pec_mask,
                   return_state=False, flux_monitors=flux_cfgs)
 
-    spectra = {e.name: np.asarray(flux_spectrum(fm), float)
+    spectra = {e.name: np.asarray(flux_spectrum(fm, exact_f64=True), float)
                for e, fm in zip(entries, result.flux_monitors or ())}
     settling = _settling_from_witness(result.time_series)
     assert float(np.max(np.asarray(result.time_series) ** 2)) > 0.0, \
@@ -663,7 +675,7 @@ def main(argv=None):
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--stage", choices=("c1", "c2", "target", "all"),
                     default="all")
-    ap.add_argument("--n-steps-c1", type=int, default=20000)
+    ap.add_argument("--n-steps-c1", type=int, default=135000)
     ap.add_argument("--n-steps-c2", type=int, default=6000)
     ap.add_argument("--n-steps-target", type=int, default=135000)
     ap.add_argument("--output-dir", type=Path, required=True)

--- a/tests/test_coax_msl_transition.py
+++ b/tests/test_coax_msl_transition.py
@@ -1769,3 +1769,38 @@ def test_extra_flux_monitors_do_not_perturb_s():
         for name, arr in spectra.items():
             assert arr.shape == (len(FREQS_2),), (drive_key, name, arr.shape)
             assert np.all(np.isfinite(arr)), (drive_key, name, arr)
+
+
+def test_flux_spectrum_exact_f64_matches_default_on_healthy_magnitudes():
+    """#589 C1 iteration 2: the exact_f64 path is the same Poynting sum in
+    float64 — on magnitudes far from the float32 subnormal zone the two
+    paths must agree to float32 roundoff; on subnormal-zone magnitudes the
+    default path collapses (issue #304) while exact_f64 keeps the value.
+    Synthetic monitor, no FDTD."""
+    import numpy as np
+    from rfx.probes.probes import FluxMonitor, flux_spectrum
+
+    rng = np.random.default_rng(42)
+    shape = (3, 8, 9)
+
+    def _mon(scale):
+        def c64(s):
+            return (rng.normal(size=shape) * s
+                    + 1j * rng.normal(size=shape) * s).astype(np.complex64)
+        return FluxMonitor(
+            axis=0, index=5,
+            freqs=np.array([6.0e9, 8.0e9, 10.0e9]),
+            e1_dft=c64(scale), e2_dft=c64(scale),
+            h1_dft=c64(scale), h2_dft=c64(scale),
+            dA=np.float32(1.0e-8),
+            total_steps=100, window="rect", window_alpha=0.25,
+        )
+
+    healthy = _mon(1.0)
+    a = np.asarray(flux_spectrum(healthy), dtype=np.float64)
+    b = np.asarray(flux_spectrum(healthy, exact_f64=True), dtype=np.float64)
+    assert np.allclose(a, b, rtol=5e-6, atol=0.0), (a, b)
+
+    tiny = _mon(1.0e-15)  # products ~1e-30: inside the f32 flush zone
+    t64 = np.asarray(flux_spectrum(tiny, exact_f64=True), dtype=np.float64)
+    assert np.all(np.isfinite(t64)) and np.any(t64 != 0.0)


### PR DESCRIPTION
The first C1 control run of the #589 adjudication (VESSL `369367252342`) exited rc=2 **by design** — the control hard-gate failed and the target was skipped, so the lane's one pre-declared attempt was NOT burned. Diagnosis from the persisted per-face dump: fluxes ~1e-29 W with a wrong net-flux sign at planeA — the MSL drive's absolute scale puts per-cell E×H* products (~1e-33) inside the GPU float32 subnormal-flush zone (the **issue #304 class** the `flux_spectrum` warning already documents, together with its remedy). S-parameters are ratios and immune; an absolute-scale energy witness is not.

- `flux_spectrum(exact_f64=True)`: the #304 warning's own sanctioned float64 recompute, from the healthy float32 accumulators, as the returned value. Eager-only (raises under tracing). Default path byte-identical — `run()`/AD lanes untouched, and the #597 bit-identity witness is unaffected (S path untouched).
- Both extractors' witness collection + the driver's C1 collection use it.
- C1 default `n_steps` 20000 → 135000 (measured −22.1 dB vs the −40 dB predeclared gate; consistent with the lane's recorded ring-down checkpoints).
- Contract test: equivalence on healthy magnitudes to f32 roundoff + nonzero-finite in the flush zone (synthetic monitor). `3 passed` with the #597 fast tests.
- This C1 instrument iteration is declared on #589 before any resubmission.

R3: memory=#304 remedy text + f64-referee dtype-follows-accumulator | R2-attempts=n/a (control iteration, pre-declared) | falsifier=synthetic flush-zone + equivalence tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)