### PR TITLE
feat(material-fit): magnitude-preserving reference_probe loss mode (#580)

### DIFF
--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -767,7 +767,9 @@
         "weight_mag",
         "weight_phase",
         "checkpoint",
-        "verbose"
+        "verbose",
+        "normalization",
+        "reference_probe"
       ]
     },
     "directivity": {

--- a/rfx/differentiable_material_fit.py
+++ b/rfx/differentiable_material_fit.py
@@ -5,13 +5,28 @@ this module differentiates through the full FDTD simulation to fit
 dispersive material models.  No de-embedding is needed because the fixture
 geometry is included in the simulation.
 
-ACCURACY CAVEAT — despite the name, the current loss does NOT fit true
-S-parameters. The extraction self-normalizes each probe spectrum by its own
-per-probe maximum magnitude (see ~L470-477), which discards magnitude
-information; the loss therefore matches only the *shape* of a self-normalized
-probe spectrum, not S-parameter magnitude and phase. The code calls this an
-"S-param proxy" internally. A real S-parameter fit is planned (the
-review-remediation plan, Stage 3.5a).
+ACCURACY CAVEAT — despite the name, neither loss mode fits true 2-port
+S-parameters; both build a diagonal per-probe proxy. The difference between
+the two ``normalization=`` modes is what the proxy preserves (issue #580):
+
+* ``"per_probe_max"`` (default, legacy): each probe spectrum is divided by
+  its own maximum magnitude. This matches only the *shape* of each probe's
+  spectrum — it is invariant to ANY frequency-independent field scaling,
+  including the physical magnitude changes that loss tangent and
+  conductivity produce, so a fit can look converged while the absolute
+  level is wrong. Appropriate only when magnitude is genuinely
+  uncalibrated (unknown drive, uncalibrated measurement chain).
+* ``"reference_probe"``: every probe spectrum is divided, complex and
+  per-frequency, by ONE designated reference probe's spectrum (typically a
+  probe recording the incident wave). Relative level between probes and
+  the response-vs-reference level both enter the loss, so magnitude-acting
+  parameters (conductivity-like Debye loss) are identifiable; the ratio is
+  still invariant to the shared drive amplitude, which is the calibration
+  you want. Appropriate whenever the fixture can afford one probe on the
+  incident side.
+
+A real S-parameter fit (off-diagonal terms, port de-embedding) remains
+planned (the review-remediation plan, Stage 3.5a).
 
 The gradient path is::
 
@@ -271,6 +286,55 @@ def _adam_step(
 # Main fitting function
 # ---------------------------------------------------------------------------
 
+def _normalize_probe_spectra(
+    s_raw: "jnp.ndarray",
+    n_ports: int,
+    target_shape: tuple,
+    *,
+    normalization: str = "per_probe_max",
+    reference_probe: "int | None" = None,
+) -> "jnp.ndarray":
+    """Probe DFT spectra -> diagonal S-proxy, under the selected mode.
+
+    Pure function (unit-tested directly, issue #580). ``s_raw`` is
+    (n_probes, n_freqs) complex; returns ``target_shape`` complex
+    ((n_ports, n_ports, n_freqs)) with only the diagonal populated.
+
+    ``per_probe_max``: probe i divided by max|probe i| — shape-only, blind
+    to any frequency-independent magnitude change (the legacy proxy).
+    ``reference_probe``: probe i divided complex-per-frequency by the
+    designated reference probe's spectrum — preserves relative and
+    response-vs-reference magnitude and phase; invariant to the shared
+    drive amplitude.
+    """
+    n_probes = s_raw.shape[0]
+    s_sim = jnp.zeros(target_shape, dtype=jnp.complex64)
+    if normalization == "per_probe_max":
+        if n_probes >= n_ports:
+            for i in range(min(n_ports, n_probes)):
+                mag = jnp.abs(s_raw[i])
+                safe_max = jnp.maximum(jnp.max(mag), 1e-30)
+                s_sim = s_sim.at[i, i, :].set(s_raw[i] / safe_max)
+        else:
+            mag = jnp.abs(s_raw[0])
+            safe_max = jnp.maximum(jnp.max(mag), 1e-30)
+            s_sim = (s_raw[0] / safe_max).reshape(target_shape)
+        return s_sim
+    if normalization == "reference_probe":
+        ref = s_raw[reference_probe]
+        # complex per-frequency division; floor |ref| to avoid 0/0 at band
+        # edges where the reference has no energy
+        ref_safe = jnp.where(jnp.abs(ref) > 1e-30, ref,
+                             jnp.asarray(1e-30, dtype=ref.dtype))
+        for i in range(min(n_ports, n_probes)):
+            s_sim = s_sim.at[i, i, :].set(s_raw[i] / ref_safe)
+        return s_sim
+    raise ValueError(
+        f"normalization must be 'per_probe_max' or 'reference_probe', "
+        f"got {normalization!r}"
+    )
+
+
 def differentiable_material_fit(
     sim_factory: Callable,
     s_measured: np.ndarray,
@@ -285,6 +349,8 @@ def differentiable_material_fit(
     weight_phase: float = 0.1,
     checkpoint: bool = True,
     verbose: bool = True,
+    normalization: str = "per_probe_max",
+    reference_probe: "int | None" = None,
 ) -> MaterialFitResult:
     """Fit dispersive material poles to S-parameter data via jax.grad through FDTD.
 
@@ -317,10 +383,29 @@ def differentiable_material_fit(
         Use ``jax.checkpoint`` in the FDTD loop (recommended).
     verbose : bool
         Print progress.
+    normalization : {"per_probe_max", "reference_probe"}
+        Loss-proxy normalization mode (issue #580; see the module
+        docstring's ACCURACY CAVEAT for when each is appropriate).
+        ``"per_probe_max"`` (default, legacy) is shape-only and BLIND to
+        magnitude-acting parameters such as conductivity;
+        ``"reference_probe"`` divides every probe spectrum, complex and
+        per-frequency, by the designated reference probe's spectrum, so
+        magnitude and inter-probe level enter the loss while the shared
+        drive amplitude cancels.
+    reference_probe : int or None
+        Required (and only used) with ``normalization="reference_probe"``:
+        index into the fixture's registered probe list of the probe that
+        records the reference (incident-side) signal. Must not be one of
+        the first ``n_ports`` probes — those are the response probes the
+        proxy is built from, and self-referencing would reintroduce the
+        degeneracy this mode exists to remove.
 
     Returns
     -------
     MaterialFitResult
+        ``final_s_params`` carries the LAST iteration's model-side proxy
+        spectrum (same normalization as the loss) — previously this field
+        was always ``None``.
     """
     from rfx.simulation import run as sim_run, make_port_source, make_probe
     from rfx.sources.sources import LumpedPort, setup_lumped_port
@@ -375,6 +460,45 @@ def differentiable_material_fit(
     grid = dummy_sim._build_grid()
     dt = grid.dt
     n_steps = grid.num_timesteps(num_periods=20.0)
+
+    # ---- normalization-mode validation (issue #580), fail-loud up front --
+    if normalization not in ("per_probe_max", "reference_probe"):
+        raise ValueError(
+            f"normalization must be 'per_probe_max' or 'reference_probe', "
+            f"got {normalization!r}"
+        )
+    _n_ports_meas = int(s_measured.shape[0])
+    _n_fixture_probes = len(dummy_sim._probes)
+    if normalization == "reference_probe":
+        if reference_probe is None:
+            raise ValueError(
+                "normalization='reference_probe' requires reference_probe= "
+                "(index into the fixture's registered probe list of the "
+                "incident-side reference probe)."
+            )
+        _ref = int(reference_probe)
+        if not (-_n_fixture_probes <= _ref < _n_fixture_probes):
+            raise ValueError(
+                f"reference_probe={reference_probe} is outside the fixture's "
+                f"probe list (n_probes={_n_fixture_probes})."
+            )
+        _ref_pos = _ref % _n_fixture_probes
+        if _ref_pos < _n_ports_meas:
+            raise ValueError(
+                f"reference_probe={reference_probe} indexes one of the first "
+                f"n_ports={_n_ports_meas} probes, which are the response "
+                "probes the proxy is built from — self-referencing "
+                "reintroduces the magnitude degeneracy this mode removes. "
+                "Register a dedicated incident-side probe and point at it."
+            )
+        if _n_fixture_probes < _n_ports_meas + 1:
+            raise ValueError(
+                "normalization='reference_probe' needs at least "
+                f"n_ports+1={_n_ports_meas + 1} registered probes "
+                f"(response probes + the reference); fixture has "
+                f"{_n_fixture_probes}."
+            )
+        reference_probe = _ref_pos
 
     # ------------------------------------------------------------------
     # Forward function (called inside jax.value_and_grad)
@@ -448,8 +572,6 @@ def differentiable_material_fit(
         # Extract S-params from time series via DFT
         # Use probe time series and compute S-params from voltage/current DFTs
         ts = result.time_series  # (n_steps, n_probes)
-        n_probes = ts.shape[1] if ts.ndim > 1 else 1
-        len(freqs)
 
         # Compute DFT of probe time series at target frequencies
         times = jnp.arange(n_steps) * dt
@@ -464,43 +586,35 @@ def differentiable_material_fit(
         # S_raw ~ DFT of probe signals, shape (n_probes, n_freqs) complex
         s_raw = jnp.dot(ts.T.astype(jnp.complex64), phase_matrix)
 
-        # Normalize: S_ij ~ response_i / excitation_j
-        # For a simple proxy: normalize by the first port's self-response
-        # and form an S-matrix-like quantity
+        # Probe spectra -> diagonal S-proxy under the selected mode
+        # (issue #580; the pure helper carries the unit-tested arithmetic)
         n_ports = s_meas_jnp.shape[0]
+        s_sim = _normalize_probe_spectra(
+            s_raw, n_ports, s_meas_jnp.shape,
+            normalization=normalization, reference_probe=reference_probe,
+        )
 
-        # Build a simplified S-param proxy from probe frequency content
-        # Use probe signals to form S11-like reflection coefficients
-        if n_probes >= n_ports:
-            s_sim = jnp.zeros_like(s_meas_jnp)
-            for i in range(min(n_ports, n_probes)):
-                mag = jnp.abs(s_raw[i])
-                safe_max = jnp.maximum(jnp.max(mag), 1e-30)
-                s_sim = s_sim.at[i, i, :].set(s_raw[i] / safe_max)
-        else:
-            # Single probe: use as S11
-            mag = jnp.abs(s_raw[0])
-            safe_max = jnp.maximum(jnp.max(mag), 1e-30)
-            s_sim = (s_raw[0] / safe_max).reshape(s_meas_jnp.shape)
-
-        return sparam_loss(
+        loss = sparam_loss(
             s_sim, s_meas_jnp,
             weight_mag=weight_mag, weight_phase=weight_phase,
         )
+        return loss, s_sim
 
     # ------------------------------------------------------------------
     # Optimization loop (Adam)
     # ------------------------------------------------------------------
-    grad_fn = jax.value_and_grad(forward)
+    grad_fn = jax.value_and_grad(forward, has_aux=True)
 
     m = jnp.zeros_like(params)
     v = jnp.zeros_like(params)
     loss_history = []
+    last_s_sim = None
 
     for it in range(n_iterations):
-        loss_val, grad = grad_fn(params)
+        (loss_val, s_sim_aux), grad = grad_fn(params)
         loss_val = float(loss_val)
         loss_history.append(loss_val)
+        last_s_sim = s_sim_aux
 
         params, m, v = _adam_step(
             params, grad, m, v, it, learning_rate,
@@ -541,7 +655,8 @@ def differentiable_material_fit(
         debye_poles=debye_out,
         lorentz_poles=lorentz_out,
         loss_history=loss_history,
-        final_s_params=None,
+        final_s_params=(None if last_s_sim is None
+                        else np.asarray(last_s_sim)),
         freqs=freqs,
         converged=converged,
     )

--- a/tests/test_differentiable_material_fit.py
+++ b/tests/test_differentiable_material_fit.py
@@ -347,3 +347,102 @@ def test_recover_known_debye():
     # The error should have decreased (we moved toward the truth)
     assert de_err_final < de_err_init, \
         f"delta_eps error did not decrease: {de_err_final:.2%} >= {de_err_init:.2%}"
+
+
+# ---------------------------------------------------------------------------
+# #580: recovery through the PUBLIC entry with the magnitude-preserving
+# reference_probe mode (acceptance criterion 1). The measurement-harvest
+# trick: n_iterations=1 with learning_rate=0.0 leaves params untouched, so
+# MaterialFitResult.final_s_params IS the model observation at the given
+# initial_guess — used to generate a self-consistent synthetic
+# "measurement" at the truth parameters through the identical pipeline.
+# ---------------------------------------------------------------------------
+
+def _i580_factory():
+    from rfx.api import Simulation
+    from rfx.geometry.csg import Box
+    from rfx.sources.sources import GaussianPulse as _GP
+
+    def factory(eps_inf, debye_poles, lorentz_poles):
+        sim = Simulation(freq_max=5e9, domain=(0.024, 0.009, 0.009))
+        sim.add_material("dut", eps_r=eps_inf, debye_poles=debye_poles)
+        sim.add(Box((0.010, 0.0, 0.0), (0.016, 0.009, 0.009)), material="dut")
+        sim.add_port((0.003, 0.0045, 0.0045), "ez",
+                     waveform=_GP(f0=3e9, bandwidth=0.5))
+        # probe 0 = response (behind the slab, transmission-sensitive);
+        # probe 1 = reference (incident side, between port and slab)
+        sim.add_probe((0.020, 0.0045, 0.0045), component="ez")
+        sim.add_probe((0.007, 0.0045, 0.0045), component="ez")
+        return sim
+
+    return factory
+
+
+def test_recover_debye_reference_mode_public_entry():
+    """#580 acceptance: a known (eps_inf, lossy Debye pole) is recovered
+    through the public differentiable_material_fit entry under
+    normalization='reference_probe', and the per_probe_max proxy's
+    structural magnitude blindness is witnessed on the same data."""
+    from rfx.material_fit import DebyeFitResult
+    from rfx.differentiable_material_fit import differentiable_material_fit
+
+    factory = _i580_factory()
+    freqs = np.linspace(2.0e9, 4.0e9, 5)
+    true_de, true_tau, true_eps_inf = 3.0, 50.0e-12, 2.0  # tau relaxation ~3.2 GHz = IN the 2-4 GHz band (identifiability; 8 ps put it at ~20 GHz, out of band, and tau drifted)
+    truth = DebyeFitResult(
+        eps_inf=true_eps_inf,
+        poles=[DebyePole(delta_eps=true_de, tau=true_tau)],
+        fit_error=0.0,
+    )
+
+    # harvest the truth observation through the identical pipeline
+    obs = differentiable_material_fit(
+        factory, np.zeros((1, 1, 5), complex), freqs, n_debye_poles=1,
+        n_iterations=1, learning_rate=0.0, initial_guess=truth,
+        verbose=False, normalization="reference_probe", reference_probe=1,
+    )
+    s_meas = obs.final_s_params
+    assert s_meas is not None and np.all(np.isfinite(s_meas))
+    # magnitude information present: NOT pinned to a unit peak
+    assert abs(float(np.max(np.abs(s_meas))) - 1.0) > 1e-3
+
+    # fit from a perturbed guess (2x both pole parameters)
+    guess = DebyeFitResult(
+        eps_inf=true_eps_inf,
+        poles=[DebyePole(delta_eps=true_de * 2.0, tau=true_tau * 2.0)],
+        fit_error=0.0,
+    )
+    fit = differentiable_material_fit(
+        factory, s_meas, freqs, n_debye_poles=1,
+        n_iterations=25, learning_rate=0.05, initial_guess=guess,
+        verbose=False, normalization="reference_probe", reference_probe=1,
+    )
+    rec_de = float(fit.debye_poles[0].delta_eps)
+    rec_tau = float(fit.debye_poles[0].tau)
+    print(f"\n#580 recovery: de {true_de*2:.2f}->{rec_de:.3f} (true {true_de}), "
+          f"tau {true_tau*2:.2e}->{rec_tau:.2e} (true {true_tau:.1e}), "
+          f"loss {fit.loss_history[0]:.3e}->{fit.loss_history[-1]:.3e}")
+
+    assert fit.loss_history[-1] < fit.loss_history[0]
+    # moved toward truth from the 2x start on both parameters
+    assert abs(rec_de - true_de) < abs(true_de * 2.0 - true_de)
+    assert abs(rec_tau - true_tau) < abs(true_tau * 2.0 - true_tau)
+    # documented recovery tolerance (issue #580 acceptance), pinned from the
+    # 2026-08-07 CPU measurement: de 6.00->3.331 (11% rel err, gate 20%),
+    # tau 1.00e-10->5.29e-11 (5.8% rel err, gate 15%), loss 1.44e-4->8.40e-6
+    # (25 Adam iterations, lr=0.05). Gates carry ~1.8x/2.6x margin over the
+    # measured errors, same envelope-with-margin convention as the repo's
+    # gate_from_envelope policy.
+    assert abs(rec_de - true_de) / true_de < 0.20
+    assert abs(rec_tau - true_tau) / true_tau < 0.15
+
+    # structural-blindness witness: the legacy proxy's model spectrum is
+    # pinned to a unit peak REGARDLESS of the material, so it cannot carry
+    # the magnitude information the measurement contains
+    legacy = differentiable_material_fit(
+        factory, s_meas, freqs, n_debye_poles=1,
+        n_iterations=1, learning_rate=0.0, initial_guess=truth,
+        verbose=False, normalization="per_probe_max",
+    )
+    assert np.isclose(float(np.max(np.abs(legacy.final_s_params))), 1.0,
+                      atol=1e-5)

--- a/tests/test_differentiable_material_fit_normalization.py
+++ b/tests/test_differentiable_material_fit_normalization.py
@@ -1,0 +1,127 @@
+"""#580: the magnitude-preserving reference_probe loss mode.
+
+Acceptance criterion 2 lives here at the arithmetic level, where it is
+deterministic and cheap: a pure magnitude change on the RESPONSE side is
+invisible to the legacy per-probe-max proxy (the documented blindness that
+made loss/conductivity fits near-degenerate) and visible to the
+reference-probe proxy — while a shared drive-amplitude change cancels in
+the reference mode (that invariance is the desired calibration, not a
+defect). The FDTD-in-the-loop recovery test (acceptance criterion 1) is
+test_differentiable_material_fit.py::test_recover_debye_reference_mode_public_entry
+(gpu lane, same file as the other FDTD fit tests).
+"""
+import numpy as np
+import jax.numpy as jnp
+import pytest
+
+from rfx.differentiable_material_fit import (
+    _normalize_probe_spectra,
+    differentiable_material_fit,
+)
+
+
+def _synthetic_raw(seed=7, n_probes=3, n_freqs=8):
+    rng = np.random.default_rng(seed)
+    return jnp.asarray(
+        rng.normal(size=(n_probes, n_freqs))
+        + 1j * rng.normal(size=(n_probes, n_freqs)),
+        dtype=jnp.complex64,
+    )
+
+
+def test_per_probe_max_is_blind_to_response_magnitude():
+    """The legacy proxy is INVARIANT to scaling a response probe — the
+    exact blindness #580 reports (conductivity acts on magnitude)."""
+    s_raw = _synthetic_raw()
+    scaled = s_raw.at[0].multiply(0.37)
+    a = _normalize_probe_spectra(s_raw, 1, (1, 1, 8))
+    b = _normalize_probe_spectra(scaled, 1, (1, 1, 8))
+    np.testing.assert_allclose(np.asarray(a), np.asarray(b),
+                               rtol=1e-6, atol=1e-7)
+
+
+def test_reference_probe_sees_response_magnitude():
+    """The reference mode scales with a response-side magnitude change —
+    the discriminating case (pure magnitude offset) from the issue."""
+    s_raw = _synthetic_raw()
+    scaled = s_raw.at[0].multiply(0.37)
+    kw = dict(normalization="reference_probe", reference_probe=2)
+    a = np.asarray(_normalize_probe_spectra(s_raw, 1, (1, 1, 8), **kw))
+    b = np.asarray(_normalize_probe_spectra(scaled, 1, (1, 1, 8), **kw))
+    np.testing.assert_allclose(b[0, 0], 0.37 * a[0, 0], rtol=1e-5)
+    assert not np.allclose(a, b, rtol=1e-3)
+
+
+def test_reference_probe_cancels_shared_drive_amplitude():
+    """Scaling ALL probes together (drive amplitude) cancels in the
+    reference mode — that invariance is the calibration, kept by design."""
+    s_raw = _synthetic_raw()
+    kw = dict(normalization="reference_probe", reference_probe=2)
+    a = np.asarray(_normalize_probe_spectra(s_raw, 1, (1, 1, 8), **kw))
+    b = np.asarray(_normalize_probe_spectra(2.9 * s_raw, 1, (1, 1, 8), **kw))
+    np.testing.assert_allclose(a, b, rtol=1e-5)
+
+
+def test_reference_probe_preserves_phase():
+    """Complex per-frequency division: a phase ramp applied to the
+    response probe appears in the proxy (per-probe-max keeps it too, but
+    reference mode must not lose it while fixing magnitude)."""
+    s_raw = _synthetic_raw()
+    ramp = jnp.exp(1j * jnp.linspace(0.0, 1.2, 8)).astype(jnp.complex64)
+    kw = dict(normalization="reference_probe", reference_probe=2)
+    a = np.asarray(_normalize_probe_spectra(s_raw, 1, (1, 1, 8), **kw))
+    b = np.asarray(_normalize_probe_spectra(s_raw.at[0].multiply(ramp),
+                                            1, (1, 1, 8), **kw))
+    np.testing.assert_allclose(np.angle(b[0, 0] / a[0, 0]),
+                               np.linspace(0.0, 1.2, 8), atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Public-entry validation (no FDTD reached: the mode checks raise before
+# the optimization loop; only a tiny grid build runs)
+# ---------------------------------------------------------------------------
+
+def _tiny_factory(n_probes):
+    from rfx.api import Simulation
+    from rfx import GaussianPulse
+
+    def factory(eps_inf, debye_poles, lorentz_poles):
+        sim = Simulation(freq_max=5e9, domain=(0.012, 0.012, 0.012))
+        sim.add_material("dut", eps_r=eps_inf, debye_poles=debye_poles)
+        sim.add_port((0.003, 0.006, 0.006), "ez",
+                     waveform=GaussianPulse(f0=3e9, bandwidth=0.5))
+        xs = np.linspace(0.006, 0.010, n_probes)
+        for x in xs:
+            sim.add_probe((float(x), 0.006, 0.006), component="ez")
+        return sim
+
+    return factory
+
+
+def _call(n_probes, **kw):
+    freqs = np.linspace(2e9, 4e9, 4)
+    s_meas = np.zeros((1, 1, 4), dtype=complex)
+    return differentiable_material_fit(
+        _tiny_factory(n_probes), s_meas, freqs, n_debye_poles=1,
+        n_iterations=1, verbose=False, **kw,
+    )
+
+
+def test_validation_bad_mode_name():
+    with pytest.raises(ValueError, match="per_probe_max"):
+        _call(2, normalization="typo_mode")
+
+
+def test_validation_reference_mode_requires_index():
+    with pytest.raises(ValueError, match="requires reference_probe"):
+        _call(2, normalization="reference_probe")
+
+
+def test_validation_reference_must_not_be_response_probe():
+    with pytest.raises(ValueError, match="response"):
+        _call(2, normalization="reference_probe", reference_probe=0)
+
+
+def test_validation_reference_out_of_range():
+    with pytest.raises(ValueError, match="outside"):
+        _call(2, normalization="reference_probe", reference_probe=5)


### PR DESCRIPTION
Closes #580 (all three acceptance criteria, each measured before commit).

## What changed

- **`normalization="reference_probe"` + `reference_probe=`** on `differentiable_material_fit`: every probe spectrum is divided, complex and per-frequency, by one designated incident-side reference probe's spectrum — magnitude and inter-probe level enter the loss, the shared drive amplitude cancels (that invariance is the calibration you want). The default `"per_probe_max"` stays byte-identical legacy behavior; the module's ACCURACY CAVEAT is rewritten as a mode-selection guide.
- The proxy arithmetic moved to a pure helper (`_normalize_probe_spectra`) so the acceptance discriminators are unit-testable; fail-loud validation for bad mode / missing / out-of-range / self-referencing reference index / too-few-probes.
- `MaterialFitResult.final_s_params` is now **populated** (previously always `None`) via `value_and_grad(has_aux=True)` — the last iteration's model-side proxy, which is also what makes the self-consistent recovery protocol possible.

## Acceptance, measured

1. **Ground-truth recovery through the public entry** (new gpu-lane test): truth `(eps_inf=2.0, Δε=3.0, τ=50 ps)` — relaxation IN the 2–4 GHz band — recovered from a 2× perturbed start in 25 Adam iterations: **Δε 6.00→3.331 (11% rel err, gate 20%), τ 100 ps→52.9 ps (5.8% rel err, gate 15%)**, loss 1.44e-4→8.40e-6. Gates pinned with ~1.8×/2.6× margin over measured; falsifier re-run green with the pinned gates. (The first fixture draft used τ=8 ps, whose relaxation sits at ~20 GHz — out of band; τ drifted and the test failed. The fix was **identifiability** — moving the pole in-band — not a tolerance widening.)
2. **A test that fails under the self-normalized loss and passes under the new one**: at the arithmetic level, deterministic and in the fast lane — scaling a response probe by 0.37 leaves the per-probe-max proxy bit-unchanged (the blindness) while the reference-mode proxy scales by exactly 0.37; plus shared-amplitude cancellation, phase preservation, and 4 validation-error tests (8 new fast tests, no FDTD, 2.8 s). The structural blindness is also witnessed at the fit level: the legacy mode's `final_s_params` peak is pinned to 1.0 regardless of material.
3. **Docstring caveat updated** with when each mode is appropriate.

api_symbol_inventory regenerated; ruff clean.

R3: memory=root-cause-before-gate-change (in-band fix, not tolerance) + gate-binds-artifact (falsifier re-run after pinning) | R2-attempts=0 | falsifier=unit discriminators + pinned-gate re-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)