### PR TITLE
docs(crossval): geometry + port-model figure for the X-band patch record

### DIFF
--- a/docs/crossval/patch_xband_4solver.md
+++ b/docs/crossval/patch_xband_4solver.md
@@ -12,6 +12,8 @@ without access to the other solvers' setups).
 
 ## 1. Geometry (all dimensions mm)
 
+![Geometry and port models of the cross-validation patch (dimensions in mm). Panel (b) marks the two feed models exercised in the Tier-2 port swap: the guided waveguide/MSL port at the board edge and the lumped V-I discrete port across the substrate gap.](figures/patch_xband_geometry_ports.png)
+
 Substrate: Rogers **RO4003C**, thickness **h = 0.787** (31 mil), nominal
 εr = 3.38, tan δ ≈ 0.0027 @ 10 GHz. 1-oz (35 µm) copper both sides; the
 entire bottom face is ground (no etching).


### PR DESCRIPTION
Docs-only. Adds a two-panel geometry/port visualization (top view with all etched dimensions; feed-centerline section marking the guided waveguide/MSL port vs. the lumped V-I discrete port) to `docs/crossval/patch_xband_4solver.md`, so the record referenced from the T-MTT response letter is verifiable at a glance. Same figure ships in the response letter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)