### PR TITLE
feat(validation): #596 producers — z-lane/domain-size scans + stage1 gate 3.5% → 0.03%

### DIFF
--- a/scripts/stage1_nu_cavity_physics_gate.py
+++ b/scripts/stage1_nu_cavity_physics_gate.py
@@ -19,13 +19,13 @@ of f_tm110, so FFT bins span 10% of f and argmax can place the peak only to ±5%
 harminv resolves far below the bin width, exposing the fixture's true ~2.5%
 NU-air-cavity discretization error.
 
-STALE AS OF #562 (2026-08-05): that ~2.5% was dominated by the non-uniform grid
-building every axis one cell short of the requested domain, now fixed. The
-sibling analytic gate this used to cite for corroboration moved from 2.66% @ 4%
-to 0.025% @ 0.04% (#573), and THIS script's own residual measures 0.0144%
-against its unchanged 3.5% gate — 243x loose. Its gate wants the same
-envelope-derived treatment; that is a follow-up, not something to leave
-undocumented here.
+That ~2.5% was #562-era (2026-08-05): the non-uniform grid built every axis one
+cell short of the requested domain, now fixed. The sibling analytic gate this
+used to cite for corroboration moved from 2.66% @ 4% to 0.025% @ 0.04% (#573),
+and this script's gate got the same envelope-derived treatment in #596: the
+residual measures 0.0144% and the enforced gate is 0.03%, derived through the
+shared ``tests/_gate_policy.gate_from_envelope`` (#528/#539) — see the gate
+block in ``run_gate`` for the derivation, falsifier, and invariance evidence.
 
 Run:
     python scripts/stage1_nu_cavity_physics_gate.py
@@ -45,6 +45,15 @@ from rfx import GaussianPulse, Simulation
 from rfx.auto_config import smooth_grading
 from rfx.grid import C0
 from rfx.harminv import harminv
+
+from tests._gate_policy import gate_from_envelope
+
+# Measured residual of THIS script's own configuration, re-measured fresh
+# post-#562 (2026-08-09, single machine, CPU/f32): 0.0144 %. The derivation,
+# what the envelope covers, and the falsifier/invariance evidence live in the
+# gate block inside run_gate().
+_MEASURED_ENVELOPE_PCT = 0.0144
+_GATE_PCT = gate_from_envelope(_MEASURED_ENVELOPE_PCT, quantum=100)  # = 0.03
 
 
 @dataclass(frozen=True)
@@ -144,26 +153,49 @@ def run_gate() -> Stage1NUGateResult:
         raise AssertionError(
             f"cell savings {gate.cell_savings_factor:.2f}x below 40x gate"
         )
-    # Resolution-honest gate. The ~2.54% this comment was written around, and the
-    # "one-cell effective-a registration effect" it attributed it to, were the
-    # #562 grid defect: the NU builder realized every axis one cell short of the
-    # requested domain. Post-fix this script measures 0.0144% against the 3.5%
-    # gate below (243x loose), and the sibling analytic gate moved 2.66% -> 0.025%
-    # with its gate re-derived to 0.04% (#573). Re-deriving THIS gate from a fresh
-    # envelope is the obvious follow-up; the numbers below are kept as the
-    # historical record of what the defect-era measurement was, not as current
-    # values. Corroborated then by zero-padded-FFT + parabolic-peak ~2.55-2.58%
-    # (the exact secondary number is window/pad-factor dependent). The old
-    # "1%" gate was luck: the true 5.433 GHz peak snapped down into the 5.298 GHz
-    # bin (0.03%). 3.5% = measured 2.54% + margin; harminv resolves <0.05% so this
-    # now actually binds a real regression, unlike the ±5% argmax window (#396)
-    # — TRUE WHEN WRITTEN, stale now: post-#562 the measured residual is 0.0144%,
-    # so this 3.5% bound is ~243x loose and binds nothing. Re-deriving it from a
-    # fresh envelope is the follow-up this file promises and does not yet have.
-    if gate.resonance_error_pct > 3.5:
+    # Gate DERIVED from a measured envelope via the shared #528/#539 policy
+    # (envelope x ENVELOPE_GATE_MULTIPLIER, quantized up; quantum=100 in
+    # percent units — the same usage as the #573 sibling gates in
+    # tests/test_nonuniform_xy_cavity_accuracy.py):
+    #
+    #   measured residual, THIS configuration, fresh post-#562 (2026-08-09):
+    #     0.0144 %  (harminv peak 5.300394 GHz vs analytic TM110 5.299632 GHz,
+    #     n_steps=2425; preflight clean: "All checks passed (NTFF advisory
+    #     tier; ...)")
+    #   gate = gate_from_envelope(0.0144, quantum=100) = 0.03 %.
+    #
+    # The envelope covers ONLY this script's own configuration (a=b=40 mm,
+    # dz = 14x1.0 + 8x0.25 + 14x1.0 mm smooth-graded at max_ratio=1.3,
+    # dx=1 mm, PEC closed cavity, num_periods=20, harminv extraction, single
+    # machine, CPU/f32) — the #573 policy: the script only ever runs this one
+    # configuration, so the gate is a regression lock on it, and neighbours
+    # are recorded as evidence rather than folded into the margin. If another
+    # runner reds, re-measure and re-derive with the new datum recorded — do
+    # not blanket-loosen.
+    #
+    # STRENGTHENED-GATE MANDATE evidence (a green gate must be shown to bind
+    # physics, not an artifact; both runs 2026-08-09, this harness):
+    #   * FALSIFIER — the #562-class defect planted in production
+    #     (rfx.nonuniform._append_bounding_node -> identity, interior_cells ->
+    #     the old slice without the -1): residual 2.5196 % (peak 5.433161
+    #     GHz), REJECTED by the 0.03 % gate with 84x margin. The old 3.5 %
+    #     gate ACCEPTED that defect — the exact class this gate exists for.
+    #   * DOMAIN-SIZE INVARIANCE — a=b=50 mm, clean production: residual
+    #     0.0046 % (peak 4.239509 GHz vs analytic 4.239706 GHz, n_steps=3031),
+    #     PASS verdict holds under the same 0.03 % gate.
+    #
+    # History: the pre-#562 defect-era measurement was 2.54 % (corroborated
+    # then by zero-padded-FFT + parabolic-peak ~2.55-2.58 %) and the gate was
+    # 3.5 % = 2.54 % + margin; post-#562 that bound measured 243x loose
+    # (#596 item 1) and is replaced by the derived gate above. The still-older
+    # "1%" gate was rfft-argmax bin-quantization luck: the true 5.433 GHz peak
+    # snapped down into the 5.298 GHz bin (#396). harminv resolves <0.05 %,
+    # so 0.03 % genuinely binds.
+    if gate.resonance_error_pct > _GATE_PCT:
         raise AssertionError(
-            f"resonance error {gate.resonance_error_pct:.3f}% exceeds the "
-            f"resolution-honest 3.5% NU-cavity discretization envelope"
+            f"resonance error {gate.resonance_error_pct:.4f}% exceeds the "
+            f"envelope-derived {_GATE_PCT}% NU-cavity gate "
+            f"(= gate_from_envelope({_MEASURED_ENVELOPE_PCT}, quantum=100))"
         )
     if gate.segmented_ad_gb >= gate.full_ad_gb:
         raise AssertionError(
@@ -179,6 +211,8 @@ def main() -> int:
     print(f"  analytic TM110:       {gate.analytic_freq_hz/1e9:.6f} GHz")
     print(f"  FDTD harminv peak:    {gate.resonance_hz/1e9:.6f} GHz")
     print(f"  resonance error:      {gate.resonance_error_pct:.4f} %")
+    print(f"  gate (derived):       {_GATE_PCT:.2f} % "
+          f"(= gate_from_envelope({_MEASURED_ENVELOPE_PCT}, quantum=100))")
     print(f"  cells:                {gate.cells:,}")
     print(f"  uniform-fine cells:   {gate.uniform_fine_cells:,}")
     print(f"  cell savings:         {gate.cell_savings_factor:.2f}x")

--- a/tests/test_nonuniform_cavity_accuracy.py
+++ b/tests/test_nonuniform_cavity_accuracy.py
@@ -180,9 +180,12 @@ def test_nonuniform_z_graded_cavity_tm111_accuracy():
     #     0.0373 / 0.0306 / 0.0252 / 0.0264 / 0.0213
     #
     # The residual tracks f0, so the gate binds the dispersion floor rather than
-    # a fixture artifact — but the worst case is inside the gate, so the
-    # "do NOT re-parameterize without re-deriving" warning covers cavity SIZE as
-    # well as dx.
+    # a fixture artifact — but the worst case is inside the gate ON THE #573
+    # REVIEWER'S (unrecorded) size grid; the committed producer's documented
+    # grid (validation/research/nu_cavity_gates/nu_cavity_gate_scan.py, #596)
+    # measures its smallest-cavity point ABOVE this gate (0.0715% vs 0.04%) —
+    # direct evidence that the "do NOT re-parameterize without re-deriving"
+    # warning covers cavity SIZE as well as dx.
     #
     # Harminv window sensitivity, same source: over n_steps in {4k, 8k, 12k, 16k}
     # the error spans 0.0071 pt (xy) / 0.0110 pt (z), and the committed 8000-step

--- a/tests/test_nonuniform_xy_cavity_accuracy.py
+++ b/tests/test_nonuniform_xy_cavity_accuracy.py
@@ -240,9 +240,12 @@ def test_nonuniform_xy_graded_cavity_tm110_accuracy():
     #     0.0489 / 0.0390 / 0.0282 / 0.0139 / 0.0203
     #
     # The residual tracks f0, so the gate binds the dispersion floor rather than
-    # a fixture artifact — but the worst case is 97.8% of the gate, so the
-    # "do NOT re-parameterize without re-deriving" warning covers cavity SIZE as
-    # well as dx.
+    # a fixture artifact — but the worst case is 97.8% of the gate ON THE #573
+    # REVIEWER'S (unrecorded) size grid; the committed producer's documented
+    # grid (validation/research/nu_cavity_gates/nu_cavity_gate_scan.py, #596)
+    # measures its smallest-cavity point ABOVE this gate (0.0613% vs 0.05%) —
+    # direct evidence that the "do NOT re-parameterize without re-deriving"
+    # warning covers cavity SIZE as well as dx.
     #
     # Harminv window sensitivity, same source: over n_steps in {4k, 8k, 12k, 16k}
     # the error spans 0.0071 pt (xy) / 0.0110 pt (z), and the committed 8000-step

--- a/validation/research/nu_cavity_gates/nu_cavity_gate_scan.py
+++ b/validation/research/nu_cavity_gates/nu_cavity_gate_scan.py
@@ -2,25 +2,74 @@
 
 The #573 review noted that the scan numbers had become load-bearing in three
 committed files with no committed artifact behind them. This script reproduces
-the xy-lane scans (nine values), so that gate's basis is auditable rather than
-quoted:
+the scans behind BOTH gate lanes (#573 committed the xy lane; #596 added the
+z lane and the domain-size sweeps):
+
+xy lane (tests/test_nonuniform_xy_cavity_accuracy.py, TM110):
 
   * xy resolution / grading scan -> the per-configuration envelope the xy gate
-                                    uses (5 points)
+                                    uses (5 points, committed envelope 0.0282 %)
   * xy harminv window scan       -> that the committed 8000-step point is the
                                     family maximum, so the envelope covers
-                                    estimator scatter by construction (4 points)
+                                    estimator scatter by construction (4 points,
+                                    committed span 0.0071 pt)
   * graded-vs-ungraded at IDENTICAL extents -> the grading term itself
                                     (0.0282% vs 0.0084%, factor 3.35x)
 
-NOT reproduced here (reviewer-measured, no committed producer yet): the
-domain-size sweeps quoted in both gate blocks, and every z-lane number
-(z resolution scan, z harminv span). Issue #596 tracks committing a producer
-for those.
+z lane (tests/test_nonuniform_cavity_accuracy.py, TM111 — the z-graded axis):
+
+  * z resolution / grading scan  -> the committed envelope 0.0252 % plus its
+                                    four neighbours, including the dx = 2.0 mm
+                                    50x warning point (1.2567 %). NOTE: that
+                                    point is reproduced the way the TEST
+                                    constructs it — analytic f from the NOMINAL
+                                    a, b = 40, 35 mm — so at dx = 2.0 mm it
+                                    includes the b = 35 mm dimension-snapping
+                                    offset on top of coarse-mesh dispersion.
+                                    That is the configuration the warning
+                                    fences, so the confound is part of the
+                                    recorded number, not a bug in this script.
+  * z harminv window scan        -> 4 points, committed span 0.0110 pt, 8000
+                                    steps again the family maximum.
+
+domain-size sweeps, BOTH lanes: cavity size swept at fixed dx = 1 mm and fixed
+4:1 grading (xy committed: 0.0489/0.0390/0.0282/0.0139/0.0203; z committed:
+0.0373/0.0306/0.0252/0.0264/0.0213). The #573 reviewer's exact swept sizes
+were NOT recorded anywhere (checked: PR #573 body/reviews/inline comments,
+research notes); this script fixes a documented re-derivation grid so the
+sweep is auditable even though it cannot be bit-identical to the review's:
+scale factors s in {0.6, 0.8, 1.0, 1.2, 1.4} applied to every extent, 3rd
+point = the committed configuration.
+
+  xy lane sizes: graded bands (coarse/fine) = (19/2)*s mm on x, (16/2)*s mm
+                 on y, snapped to whole cells; z fixed at 10 x 1 mm.
+  z  lane sizes: a, b = 40*s, 35*s mm — integer mm at every s, so no
+                 dimension-snapping confound enters the sweep — and z graded
+                 bands (17/2)*s mm, snapped to whole cells.
+
+  MEASURED OUTCOME of this grid (2026-08-09, single machine): the center
+  points reproduce the committed envelopes exactly (0.0282 / 0.0252 %), and
+  the residual still tracks f0 (larger cavity -> generally smaller error) —
+  the finding the committed sweep supports. The OFF-CENTER committed values
+  do NOT reproduce on this grid (largest gap: z s=0.6 measured 0.0715 % vs
+  committed 0.0373 %, ~3x the ~0.011 pt harminv-scatter class), which is the
+  expected signature of a DIFFERENT (unrecorded) size grid, not of a physics
+  change — every same-configuration value in this file reproduces to the last
+  printed digit. The committed off-center numbers therefore remain
+  reviewer-only measurements; this grid is the going-forward reference.
+  Note also: at s=0.6 BOTH lanes measure above their committed gates
+  (xy 0.0613 % > 0.05 %, z 0.0715 % > 0.04 %). The gates bind only the
+  committed configuration, so nothing reds — but this is direct evidence for
+  the in-test warning that cavity SIZE re-parameterization requires gate
+  re-derivation.
 
 Research-lane script: no gate, no fixture. Run it to re-derive, not in CI.
 
-    python validation/research/nu_cavity_gates/nu_cavity_gate_scan.py [--quick]
+    python validation/research/nu_cavity_gates/nu_cavity_gate_scan.py \
+        [--quick] [--only {xy,z,size} ...]
+
+``--quick`` runs the two committed-envelope points only (unchanged from #573).
+``--only`` (repeatable) restricts the full run to the named scan families.
 """
 from __future__ import annotations
 
@@ -66,11 +115,54 @@ def _tm110_error(dx_prof, dy_prof, dz_prof, dx_boundary, steps=8000) -> float:
     return abs(modes[0] - f) / f * 100.0
 
 
+def _tm111_error(a: float, b: float, dz_prof, dx_boundary, steps=8000) -> float:
+    """z-lane leg, imitating tests/test_nonuniform_cavity_accuracy.py: uniform
+    xy from ``domain=(a, b)`` + ``dx``, genuinely graded z from ``dz_profile``,
+    analytic TM111 from NOMINAL a, b and the REALIZED graded z extent d —
+    exactly the quantities the test feeds its closed form."""
+    d = float(np.sum(dz_prof))
+    f = (C0 / 2) * np.sqrt((1 / a) ** 2 + (1 / b) ** 2 + (1 / d) ** 2)
+    sim = Simulation(freq_max=2 * f, domain=(a, b), boundary="pec",
+                     dx=dx_boundary, dz_profile=np.asarray(dz_prof))
+    # ez source/probe at z = d/4 (NOT d/2, a TM111 node), xy at thirds — the
+    # test's own placement.
+    sim.add_source((a / 3, b / 3, d / 4), "ez",
+                   waveform=GaussianPulse(f0=f, bandwidth=0.8))
+    sim.add_probe((2 * a / 3, 2 * b / 3, d / 4), "ez")
+    res = sim.run(n_steps=steps, skip_preflight=True)
+    modes = sorted((m.freq for m in res.find_resonances(
+        freq_range=(0.6 * f, 1.5 * f))), key=lambda v: abs(v - f))
+    if not modes:
+        return float("nan")
+    return abs(modes[0] - f) / f * 100.0
+
+
+# Committed reference values, printed alongside each measurement so a re-run is
+# self-auditing. Sources: the gate blocks of the two tests (do NOT edit those
+# from here — if a re-run deviates beyond the ~0.01 pt harminv-scatter class,
+# that is a finding to surface, not a number to overwrite).
+_XY_RES_COMMITTED = {(1.0, 4): 0.0282, (1.0, 2): 0.0224, (1.0, 1): 0.0108,
+                     (0.5, 4): 0.0458, (2.0, 4): 0.0868}
+_Z_RES_COMMITTED = {(1.0, 4): 0.0252, (1.0, 2): 0.0164, (1.0, 1): 0.0011,
+                    (0.5, 4): 0.0032, (2.0, 4): 1.2567}
+_XY_WIN_COMMITTED_SPAN = 0.0071
+_Z_WIN_COMMITTED_SPAN = 0.0110
+_SIZE_SCALES = (0.6, 0.8, 1.0, 1.2, 1.4)
+_XY_SIZE_COMMITTED = (0.0489, 0.0390, 0.0282, 0.0139, 0.0203)
+_Z_SIZE_COMMITTED = (0.0373, 0.0306, 0.0252, 0.0264, 0.0213)
+
+
 def main(argv=None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--quick", action="store_true",
                     help="the two committed-envelope points only")
+    ap.add_argument("--only", action="append", choices=("xy", "z", "size"),
+                    help="restrict the full run to the named scan families "
+                         "(repeatable; default = all)")
     args = ap.parse_args(argv)
+
+    def _want(fam: str) -> bool:
+        return not args.quick and (args.only is None or fam in args.only)
 
     dx, fine = 1e-3, 0.25e-3
     dxp = _graded(19.0, 2.0, dx, fine)
@@ -95,17 +187,69 @@ def main(argv=None) -> int:
     if args.quick:
         return 0
 
-    print("\nresolution / grading scan (xy):")
-    for dx_mm, ratio in ((1.0, 4), (1.0, 2), (1.0, 1), (0.5, 4), (2.0, 4)):
-        d_ = dx_mm * 1e-3
-        f_ = d_ / ratio if ratio > 1 else d_
-        e = _tm110_error(_graded(19.0, 2.0, d_, f_), _graded(16.0, 2.0, d_, f_),
-                         [d_] * 10, d_)
-        print(f"  dx {dx_mm:.2f} mm, grading {ratio}:1 -> {e:.4f} %")
+    if _want("xy"):
+        print("\nresolution / grading scan (xy):")
+        for dx_mm, ratio in ((1.0, 4), (1.0, 2), (1.0, 1), (0.5, 4), (2.0, 4)):
+            d_ = dx_mm * 1e-3
+            f_ = d_ / ratio if ratio > 1 else d_
+            e = _tm110_error(_graded(19.0, 2.0, d_, f_), _graded(16.0, 2.0, d_, f_),
+                             [d_] * 10, d_)
+            print(f"  dx {dx_mm:.2f} mm, grading {ratio}:1 -> {e:.4f} % "
+                  f"(committed {_XY_RES_COMMITTED[(dx_mm, ratio)]:.4f})")
 
-    print("\nharminv window scan (xy, committed configuration):")
-    for steps in (4000, 8000, 12000, 16000):
-        print(f"  n_steps {steps:6d} -> {_tm110_error(dxp, dyp, dzp, dx, steps):.4f} %")
+        print("\nharminv window scan (xy, committed configuration; "
+              f"committed span {_XY_WIN_COMMITTED_SPAN:.4f} pt, 8000-step point the max):")
+        win = {s: _tm110_error(dxp, dyp, dzp, dx, s) for s in (4000, 8000, 12000, 16000)}
+        for s, e in win.items():
+            print(f"  n_steps {s:6d} -> {e:.4f} %")
+        print(f"  -> span {max(win.values()) - min(win.values()):.4f} pt")
+
+    # z lane: the TM111 z-graded configuration of tests/test_nonuniform_cavity_accuracy.py
+    az, bz = 40e-3, 35e-3
+    dzp_z = _graded(17.0, 2.0, dx, fine)
+
+    if _want("z"):
+        print(f"\nz lane (TM111): a={az * 1e3:.1f} b={bz * 1e3:.1f} mm, "
+              f"graded z d={float(np.sum(dzp_z)) * 1e3:.4f} mm")
+        print("resolution / grading scan (z):")
+        for dx_mm, ratio in ((1.0, 4), (1.0, 2), (1.0, 1), (0.5, 4), (2.0, 4)):
+            d_ = dx_mm * 1e-3
+            f_ = d_ / ratio if ratio > 1 else d_
+            e = _tm111_error(az, bz, _graded(17.0, 2.0, d_, f_), d_)
+            note = "   <- z envelope" if (dx_mm, ratio) == (1.0, 4) else ""
+            if (dx_mm, ratio) == (2.0, 4):
+                note = "   <- 50x warning point (b=35 mm snaps at dx=2 mm)"
+            print(f"  dx {dx_mm:.2f} mm, grading {ratio}:1 -> {e:.4f} % "
+                  f"(committed {_Z_RES_COMMITTED[(dx_mm, ratio)]:.4f}){note}")
+
+        print("\nharminv window scan (z, committed configuration; "
+              f"committed span {_Z_WIN_COMMITTED_SPAN:.4f} pt, 8000-step point the max):")
+        win = {s: _tm111_error(az, bz, dzp_z, dx, s) for s in (4000, 8000, 12000, 16000)}
+        for s, e in win.items():
+            print(f"  n_steps {s:6d} -> {e:.4f} %")
+        print(f"  -> span {max(win.values()) - min(win.values()):.4f} pt")
+
+    if _want("size"):
+        print("\ndomain-size sweep (xy lane, fixed dx=1 mm / 4:1 grading; "
+              "bands (19/2, 16/2) mm x s):")
+        for s, committed in zip(_SIZE_SCALES, _XY_SIZE_COMMITTED):
+            dxp_s = _graded(19.0 * s, 2.0 * s, dx, fine)
+            dyp_s = _graded(16.0 * s, 2.0 * s, dx, fine)
+            a_s, b_s = float(np.sum(dxp_s)), float(np.sum(dyp_s))
+            e = _tm110_error(dxp_s, dyp_s, dzp, dx)
+            note = "   <- committed configuration" if s == 1.0 else ""
+            print(f"  s={s:.1f} (a={a_s * 1e3:.3f} b={b_s * 1e3:.3f} mm) -> "
+                  f"{e:.4f} % (committed {committed:.4f}){note}")
+
+        print("\ndomain-size sweep (z lane, fixed dx=1 mm / 4:1 grading; "
+              "a,b = (40,35) mm x s, z bands (17/2) mm x s):")
+        for s, committed in zip(_SIZE_SCALES, _Z_SIZE_COMMITTED):
+            dzp_s = _graded(17.0 * s, 2.0 * s, dx, fine)
+            e = _tm111_error(40e-3 * s, 35e-3 * s, dzp_s, dx)
+            note = "   <- committed configuration" if s == 1.0 else ""
+            print(f"  s={s:.1f} (a={40 * s:.1f} b={35 * s:.1f} "
+                  f"d={float(np.sum(dzp_s)) * 1e3:.3f} mm) -> "
+                  f"{e:.4f} % (committed {committed:.4f}){note}")
     return 0
 
 


### PR DESCRIPTION
Closes #596. Workflow-built (two build agents + an independent adversarial verifier that re-ran the measurements: **APPROVE**, 2 MINOR both folded in).

## Scan producers (#596 item 2)

`nu_cavity_gate_scan.py` now produces the z-lane and domain-size numbers that were reviewer-only: **twelve same-configuration committed values reproduce to the last digit** — the full z resolution/grading scan including the dx=2 mm `1.2567` warning point *with its construction mechanism* (nominal-b analytic vs snapped realized b), both harminv window spans (0.0110/0.0071 pt, 8000-step = family maximum), and both sweep centers.

**Honest non-reproduction, surfaced not hidden**: the off-center domain-size committed values do not reproduce on the documented grid (largest gap: z s=0.6 measured 0.0715% vs committed 0.0373%, ~3× harminv scatter) — the #573 reviewer's swept sizes were never recorded anywhere. No grid-chasing was attempted (the R2 comparator-parameter-sweep class); the script's documented grid is the going-forward reference, committed off-center values labeled reviewer-only, and the verifier independently confirmed both the exact-center reproductions and the mismatch.

**Consequence now explicit in both gate blocks** (prose only, no gate touched): on the committed grid the smallest-cavity point measures ABOVE each gate (z 0.0715% vs 0.04%, xy 0.0613% vs 0.05%) — direct evidence for the committed "do NOT re-parameterize cavity SIZE without re-deriving" warning.

## stage1 re-derivation (#596 item 1)

The script's twice-promised follow-up, done with the shared `gate_from_envelope` policy: **3.5% → 0.03%** (envelope = fresh own-configuration measurement 0.0144%). Strengthened-gate mandate: the #562-class production-only replant is **REJECTED at 84×** (the old 3.5% gate would have ACCEPTED it — the gate was binding nothing); domain-size invariance holds (a=b=50 mm → 0.0046%, 6.5× under the gate). `test_gate_policy_is_shared`: 25 passed.

R3: memory=gate-can-bind-artifact + root-cause-before-gate-change | R2-attempts=1 per measurement, all closing | falsifier=#562 replant 84× red + 12 exact reproductions

🤖 Generated with [Claude Code](https://claude.com/claude-code)