### PR TITLE
feat(preflight): wire-port end-gap-to-conductor advisory — D5 false-negative class (#556)

### DIFF
--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2948,6 +2948,41 @@ class _PreflightMixin:
             or self._dx_profile is not None
             or self._dy_profile is not None
         )
+
+        def _ensure_pec_entry_masks(grid):
+            # Lazy (issue #544 review item 8): only rasterize per-entry
+            # masks the first time any port actually needs a conductor
+            # NAME -- a dead cell to attribute (#319) or an adjacent-
+            # conductor gap to attribute (#556) -- so the common clean
+            # case (no dead cells, no gap anywhere) never pays for it.
+            # Covers BOTH ``self._geometry`` PEC entries AND
+            # ``self._thin_conductors`` PEC sheets (issue #544 review
+            # item 3: thin conductors also feed the assembled
+            # ``pec_mask`` -- ``rfx/api/_compile.py``:232-238 -- and were
+            # missing here, which produced an empty ``dead_names`` and a
+            # false ``'pec'`` fallback label for a thin-conductor-only
+            # dead cell).
+            nonlocal pec_entry_masks
+            if pec_entry_masks is not None:
+                return pec_entry_masks
+            pec_entry_masks = []
+            for entry in self._geometry:
+                mat = self._resolve_material(entry.material_name)
+                if mat.sigma < self._PEC_SIGMA_THRESHOLD:
+                    continue
+                pec_entry_masks.append(
+                    (entry.material_name,
+                     np.asarray(entry.shape.mask(grid)))
+                )
+            for _tc_i, tc in enumerate(self._thin_conductors):
+                if not tc.is_pec:
+                    continue
+                pec_entry_masks.append(
+                    (f"thin_conductor[{_tc_i}]",
+                     np.asarray(tc.shape.mask(grid)))
+                )
+            return pec_entry_masks
+
         for pe in self._ports:
             if not getattr(pe, "extent", None):
                 continue
@@ -3040,35 +3075,10 @@ class _PreflightMixin:
                     idx for idx, live in enumerate(live_flags) if not live
                 ]
                 if dead_indices:
-                    if pec_entry_masks is None:
-                        # Lazy (issue #544 review item 8): only rasterize
-                        # per-entry masks the first time any port actually
-                        # has a dead cell to name — the common clean case
-                        # (no dead cells anywhere) never pays for it.
-                        # Covers BOTH ``self._geometry`` PEC entries AND
-                        # ``self._thin_conductors`` PEC sheets (issue #544
-                        # review item 3: thin conductors also feed the
-                        # assembled ``pec_mask`` --
-                        # ``rfx/api/_compile.py``:232-238 -- and were
-                        # missing here, which produced an empty
-                        # ``dead_names`` and a false ``'pec'`` fallback
-                        # label for a thin-conductor-only dead cell).
-                        pec_entry_masks = []
-                        for entry in self._geometry:
-                            mat = self._resolve_material(entry.material_name)
-                            if mat.sigma < self._PEC_SIGMA_THRESHOLD:
-                                continue
-                            pec_entry_masks.append(
-                                (entry.material_name,
-                                 np.asarray(entry.shape.mask(grid)))
-                            )
-                        for _tc_i, tc in enumerate(self._thin_conductors):
-                            if not tc.is_pec:
-                                continue
-                            pec_entry_masks.append(
-                                (f"thin_conductor[{_tc_i}]",
-                                 np.asarray(tc.shape.mask(grid)))
-                            )
+                    # Build (or reuse) the per-entry PEC masks -- see
+                    # ``_ensure_pec_entry_masks`` above for the laziness
+                    # and thin-conductor rationale (issue #544).
+                    _ensure_pec_entry_masks(grid)
                     for idx in dead_indices:
                         ci, cj, ck = cells[idx]
                         for name, mask_arr in pec_entry_masks:
@@ -3082,15 +3092,106 @@ class _PreflightMixin:
                         # "unknown" label) rather than silently inventing
                         # a specific, possibly wrong material name.
                         dead_names = ["unknown"]
+
+                # Issue #556 (D5 follow-up, #488 arc): the OPPOSITE
+                # failure mode of the #314/#319 advisories above. There,
+                # a port extent cell lands ON PEC (false contact / dead
+                # cell). Here, the port terminates one cell SHORT of a
+                # rasterized conductor: its own end cell is live (not
+                # PEC), but the cell immediately beyond it along the port
+                # axis IS PEC in the assembled ``pec_mask`` -- read via
+                # the SAME ground-truth arrays the #544 fix reads
+                # (``_wire_port_live_cells`` against the assembled mask;
+                # no geometric re-derivation from shapes). On the D5
+                # "end-fed trace" fixture (dx=80um, h_sub=254um,
+                # h_sub/dx=3.175 in the [0.10,0.40] mixed-cell danger
+                # zone) the trace's rasterization snapped to the node one
+                # full cell above the wire's rasterized top, so the feed
+                # never galvanically reached the conductor and coupled
+                # only capacitively (measured: |S21| RISING with
+                # frequency, docs/research_notes/
+                # 20260728_i488_falsifier_ledger.md, D5). No cell is dead
+                # in that geometry, so #314/#319 are correctly silent --
+                # nothing warned.
+                #
+                # Gating (the mis-gated-guard class the LLM-footgun audit
+                # documents): fire ONLY on the exact one-cell-short-of-
+                # adjacent-PEC signature. A wire port that legitimately
+                # ends in open vacuum (dipole feed, nothing PEC in the
+                # adjacent cell) has no adjacent-PEC hit and stays
+                # silent; a port whose end cell IS on/in PEC has galvanic
+                # contact (and #319 above already flags it as a dead
+                # cell), so the live-end-cell requirement keeps this
+                # silent there. BOTH ends of the extent are candidates
+                # and both are checked (a port can miss a trace at its
+                # far end or a ground plane at its near end). Pure numpy
+                # reads of already-built arrays -- no new exception-prone
+                # calls inside a try (PR #555 lesson: nothing here may
+                # swallow an async worker-timeout exception).
+                if cells and live_flags:
+                    mask_np = np.asarray(pec_mask)
+                    axis_letter = "xyz"[axis]
+                    d_ax = (grid.dx, getattr(grid, "dy", grid.dx),
+                            getattr(grid, "dz", grid.dx))[axis]
+                    for end_idx, step in ((0, -1), (len(cells) - 1, +1)):
+                        # Degenerate 1-cell rasterization: both loop
+                        # iterations share end_idx 0 but probe DIFFERENT
+                        # neighbor cells (nb-1 vs nb+1), so no duplicate
+                        # warning is possible by construction.
+                        if not live_flags[end_idx]:
+                            continue
+                        nb = list(cells[end_idx])
+                        nb[axis] += step
+                        if not (0 <= nb[axis] < mask_np.shape[axis]):
+                            continue
+                        if not bool(mask_np[nb[0], nb[1], nb[2]]):
+                            continue
+                        adj_names = [
+                            name for name, mask_arr
+                            in _ensure_pec_entry_masks(grid)
+                            if bool(mask_arr[nb[0], nb[1], nb[2]])
+                        ] or ["unknown"]
+                        side = ("+" if step > 0 else "-") + axis_letter
+                        _w.warn(
+                            PreflightWarning(
+                                f"Wire port at {pe.position} (extent "
+                                f"{pe.extent}, component {pe.component}): "
+                                f"its {side}-side end cell "
+                                f"{tuple(cells[end_idx])} is live "
+                                f"(vacuum/dielectric), but the cell "
+                                f"immediately beyond it "
+                                f"({tuple(nb)}) is PEC {adj_names} in "
+                                f"the assembled geometry. The port "
+                                f"terminates in vacuum/dielectric one "
+                                f"cell (gap = 1 cell = {d_ax:g} m) short "
+                                f"of a rasterized conductor, so the feed "
+                                f"never galvanically reaches it and "
+                                f"coupling is capacitive only (measured "
+                                f"signature: |S21| rising with "
+                                f"frequency; issue #556, the #488-lane "
+                                f"D5 finding). Remedy: extend the port "
+                                f"extent by one cell so its end lands on "
+                                f"the conductor's rasterized node, or "
+                                f"refine dx so the conductor interface "
+                                f"aligns with a grid node (e.g. dx = h/N "
+                                f"for an interface at height h).",
+                                code="wire_port_end_gap_to_conductor",
+                                source="_validate_cfg_port_inside_pec",
+                            ),
+                            stacklevel=3,
+                        )
             elif classification_unavailable_reason is not None:
                 _w.warn(
                     PreflightWarning(
                         f"Wire port at {pe.position} (extent {pe.extent}): "
                         f"dead-cell classification unavailable "
                         f"({classification_unavailable_reason}). The "
-                        f"#314/#319 PEC-overlap advisories are skipped "
+                        f"#314/#319 PEC-overlap advisories and the #556 "
+                        f"end-gap-to-conductor advisory are skipped "
                         f"for this port -- verify manually that its "
-                        f"rasterized extent does not land on PEC.",
+                        f"rasterized extent does not land on PEC and "
+                        f"does not stop one cell short of a conductor "
+                        f"it is meant to contact.",
                         code="wire_port_dead_cell_classification_unavailable",
                         source="_validate_cfg_port_inside_pec",
                     ),

--- a/tests/test_mixed_port_sparam.py
+++ b/tests/test_mixed_port_sparam.py
@@ -998,3 +998,159 @@ def test_wire_port_advisory_does_not_swallow_a_timeout_signal(monkeypatch):
     monkeypatch.setattr(sim, "_assemble_materials", _raise_cancel)
     with pytest.raises(RuntimeError, match="worker received signal"):
         sim.preflight()
+
+
+# ---------------------------------------------------------------------------
+# Issue #556 (D5 follow-up): wire port terminating one cell SHORT of a
+# rasterized conductor — the false-NEGATIVE sibling of the #544-fixed
+# false-positive class. On the D5 end-fed trace fixture (dx=80um,
+# h_sub=254um, h_sub/dx=3.175 in the [0.10,0.40] mixed-cell danger zone)
+# the trace's rasterization snaps to node k=4, one full cell above the
+# wire's rasterized top cell (k=3): no port cell is dead, so #314/#319
+# are correctly silent, yet the feed never galvanically reaches the
+# conductor and couples only capacitively (measured: |S21| rising with
+# frequency). The new advisory reads the SAME assembled-pec_mask ground
+# truth as the #544 fix and fires ONLY on the exact
+# one-cell-short-of-adjacent-PEC signature.
+# ---------------------------------------------------------------------------
+
+def _d5_gap_ground_truth(sim, position, component, extent, impedance=50.0):
+    """Independent ground-truth premise check for the #556 signature:
+    classify the port's cells with the assembler's own primitive
+    (fresh grid + assembled pec_mask, nothing reused from preflight) and
+    return (end_cell_live, cell_beyond_end_is_pec) for the high-index
+    end of the extent.
+    """
+    grid = sim._build_grid()
+    axis = {"ex": 0, "ey": 1, "ez": 2}[component]
+    end = list(position)
+    end[axis] += extent
+    wp = WirePort(start=tuple(position), end=tuple(end),
+                  component=component, impedance=impedance)
+    _, _, _, pec_mask, _, _, _ = sim._assemble_materials(grid)
+    cells, live_flags, _ = _wire_port_live_cells(grid, wp, pec_mask)
+    mask_np = np.asarray(pec_mask)
+    nb = list(cells[-1])
+    nb[axis] += 1
+    beyond_is_pec = (
+        0 <= nb[axis] < mask_np.shape[axis]
+        and bool(mask_np[nb[0], nb[1], nb[2]])
+    )
+    return bool(live_flags[-1]), beyond_is_pec
+
+
+def test_wire_port_end_gap_advisory_fires_on_d5_end_fed_trace():
+    """POSITIVE (issue #556): the D5 end-fed trace fixture itself.
+
+    dx=80um, h_sub=254um: the wire port's extent nominally reaches the
+    trace bottom (z=254um -> node k=3), but the trace Box (254..334um)
+    rasterizes to node k=4 -- one full cell above the wire's rasterized
+    top. Every port cell is live (the #544 regression lock above pins
+    n_live/n = 4/4), so the #314/#319 dead-cell advisories are correctly
+    silent -- and before #556 NOTHING warned, while the measured physics
+    was capacitive-only coupling (|S21| rising with f, falsifier-ledger
+    D5). The new advisory must fire exactly once, on the +z side.
+    """
+    sim, y_c = _base_sim()
+    _add_feed(sim, y_c, x=2e-3)
+    _add_msl(sim, y_c, x=5.5e-3, n_probe_offset=10, n_probe_spacing=4)
+
+    end_live, beyond_pec = _d5_gap_ground_truth(
+        sim, position=(2e-3, y_c, 0.0), component="ez", extent=_H_SUB)
+    assert (end_live, beyond_pec) == (True, True), (
+        f"ground-truth premise changed (end_live={end_live}, "
+        f"beyond_pec={beyond_pec}) -- the D5 one-cell-gap signature no "
+        "longer holds on this fixture; re-derive the expected preflight "
+        "behaviour before trusting the rest of this test"
+    )
+
+    issues = sim.preflight()
+    hits = [s for s in issues
+            if getattr(s, "code", None) == "wire_port_end_gap_to_conductor"]
+    assert len(hits) == 1, (
+        "expected exactly one #556 end-gap advisory on the D5 fixture: "
+        + "\n".join(str(s) for s in issues)
+    )
+    assert getattr(hits[0], "severity", None) == "warning", (
+        f"#556 advisory must be advisory (warning) severity, got "
+        f"{getattr(hits[0], 'severity', None)!r}"
+    )
+    msg = str(hits[0])
+    for needle in ("+z-side", "gap = 1 cell", "capacitive",
+                   "extend the port extent by one cell", "refine dx"):
+        assert needle in msg, (
+            f"#556 advisory must name the side, the 1-cell gap, the "
+            f"capacitive consequence and both remedies; missing "
+            f"{needle!r} in: {msg}"
+        )
+    # The advisory must not double-fire as a dead-cell finding: no cell
+    # is dead here (#544 regression lock pins 4/4 live).
+    codes = [getattr(s, "code", None) for s in issues]
+    assert "wire_port_dead_extent_cells" not in codes
+    assert "wire_port_midpoint_in_pec" not in codes
+
+
+def test_wire_port_end_gap_advisory_silent_when_extent_reaches_conductor():
+    """SILENT CONTROL 1 (issue #556): same fixture, wire extent extended
+    one cell (extent = h_sub + dx) so the port's top cell lands ON the
+    rasterized trace node -- galvanic contact restored (D5's remedy).
+    The #556 gap advisory must NOT fire; the end cell is now a dead cell
+    ON the conductor, which is exactly the pre-existing #319
+    dead-extent advisory's territory ("verify the extent was MEANT to
+    end on/inside the conductor") -- assert that partition explicitly.
+    """
+    sim, y_c = _base_sim()
+    sim.add_port(position=(2e-3, y_c, 0.0), component="ez",
+                 impedance=50.0, extent=_H_SUB + _DX)
+    _add_msl(sim, y_c, x=5.5e-3, n_probe_offset=10, n_probe_spacing=4)
+
+    end_live, _ = _d5_gap_ground_truth(
+        sim, position=(2e-3, y_c, 0.0), component="ez",
+        extent=_H_SUB + _DX)
+    assert end_live is False, (
+        "ground-truth premise changed: the extended extent's top cell "
+        "should land ON the rasterized trace (dead cell = contact)"
+    )
+
+    issues = sim.preflight()
+    codes = [getattr(s, "code", None) for s in issues]
+    assert "wire_port_end_gap_to_conductor" not in codes, (
+        "#556 advisory must stay silent when the port's end cell is "
+        "on/in the conductor (galvanic contact): "
+        + "\n".join(str(s) for s in issues)
+    )
+    assert "wire_port_dead_extent_cells" in codes, (
+        "the #319 dead-extent advisory owns the extent-ends-on-conductor "
+        "case; its absence means the two advisories no longer partition "
+        "the space: " + "\n".join(str(s) for s in issues)
+    )
+
+
+def test_wire_port_end_gap_advisory_silent_in_open_vacuum():
+    """SILENT CONTROL 2 (issue #556): a wire port ending in genuine open
+    vacuum -- nothing PEC anywhere in the domain (dipole-feed-like
+    situation, mis-gated-guard footgun class). The advisory must stay
+    silent: a port that legitimately ends in open space is not
+    one-cell-short of anything. Geometry mirrors
+    tests/test_inverse_design_preflight.py's _clean_sim (which pins
+    preflight() == [] on it, so this control is double-locked).
+    """
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02),
+                     dx=0.02 / 15, boundary="cpml", cpml_layers=6)
+    sim.add_port(position=(0.0093, 0.0093, 0.0093), component="ez",
+                 impedance=50.0,
+                 waveform=GaussianPulse(f0=5e9, bandwidth=0.9),
+                 extent=0.004)
+
+    issues = sim.preflight()
+    codes = [getattr(s, "code", None) for s in issues]
+    assert "wire_port_end_gap_to_conductor" not in codes, (
+        "#556 advisory fired on a wire port ending in open vacuum -- "
+        "this is the false-positive class the gating must exclude: "
+        + "\n".join(str(s) for s in issues)
+    )
+    assert issues == [], (
+        "open-vacuum wire-port fixture must stay fully clean (it also "
+        "backs test_zero_issue_summary_line_is_honest): "
+        + "\n".join(str(s) for s in issues)
+    )


### PR DESCRIPTION
Closes #556. Workflow-built with an independent adversarial verify pass (**APPROVE**; its one finding is a pre-existing local jax-drift collection error in an unrelated module, routed separately).

## What this adds

The false-NEGATIVE sibling of the #544 fix: `wire_port_end_gap_to_conductor` (advisory tier) fires **only** on the D5 signature — the wire port's extent-end cell is live while the cell immediately beyond it along the port axis is PEC in the **assembled** `pec_mask` (same `_wire_port_live_cells` ground truth; both ends checked; no geometric re-derivation). The message names the port, side, cells, the 1-cell gap in metres, the capacitive-only consequence (D5's measured |S21|-rising-with-f signature), and both remedies (extend the extent / refine dx).

Open-vacuum ports stay **silent** — the signature-only gating is the design center, per the repo's mis-gated-guard footgun audit. The NU/build-failure path now *discloses* that this check is skipped there (#303 class), rather than staying silent about being silent.

## Evidence

- **Positive**: D5 end-fed trace reconstructed from the falsifier ledger (dx=80 µm, h_sub=254 µm, trace sheet snapping one node above the wire top) — fires exactly once, +z side.
- **Silent control 1**: extent extended one cell (galvanic contact) — this advisory silent, and the #319 dead-extent advisory takes over: the two checks partition the space.
- **Silent control 2**: genuine open-vacuum wire port — silent, `preflight() == []` preserved.
- Suites, verbatim: mixed-port file **29 passed**; preflight suites **79 passed**; wire-port-adjacent **35 passed**; PR #555 Studio/worker-timeout lane **8 passed, 1 skipped**; #544 regression battery green; ruff clean.

Disclosures: the committed #488 fixture itself has the D5 gap, so preflighting it now (correctly) emits the advisory — no committed assertion counts warnings there; a symmetric 1-cell dipole-gap feed fires at both ends, which is correct for a galvanic-intent check at advisory tier.

R3: memory=right-guard-MIS-GATED class + PR #555 no-broad-except lesson | R2-attempts=0 | falsifier=two silent controls + #544 battery

🤖 Generated with [Claude Code](https://claude.com/claude-code)