### PR TITLE
fix(tests): version-robust scoped-x64 shim (newer JAX removed jax.experimental.enable_x64)

### DIFF
--- a/scripts/coax_two_port_ad_fd_f64_referee.py
+++ b/scripts/coax_two_port_ad_fd_f64_referee.py
@@ -100,7 +100,7 @@ def main() -> int:
     try:
         from jax import enable_x64
     except ImportError:  # older JAX (< ~0.4.31)
-        from jax.experimental import enable_x64
+        from tests._x64_compat import enable_x64
 
     import rfx
     print(f"rfx     : {rfx.__file__}")

--- a/scripts/diagnostics/msl_ad_band_mean_s21_owner_measurement.py
+++ b/scripts/diagnostics/msl_ad_band_mean_s21_owner_measurement.py
@@ -90,7 +90,7 @@ def main() -> int:
 
     import jax
     import jax.numpy as jnp
-    from jax.experimental import enable_x64
+    from tests._x64_compat import enable_x64
 
     import rfx
     print(f"rfx        : {rfx.__file__}")

--- a/scripts/diagnostics/regen_waveguide_smatrix_goldens.py
+++ b/scripts/diagnostics/regen_waveguide_smatrix_goldens.py
@@ -28,7 +28,7 @@ import numpy as np
 try:
     from jax import enable_x64 as _enable_x64
 except ImportError:  # older JAX
-    from jax.experimental import enable_x64 as _enable_x64
+    from tests._x64_compat import enable_x64 as _enable_x64
 
 import jax.numpy as jnp
 from rfx import Simulation

--- a/scripts/msl_ad_fd_f64_referee.py
+++ b/scripts/msl_ad_fd_f64_referee.py
@@ -140,7 +140,7 @@ def main() -> int:
 
     import jax
     import jax.numpy as jnp
-    from jax.experimental import enable_x64
+    from tests._x64_compat import enable_x64
 
     import rfx
     print(f"rfx     : {rfx.__file__}")

--- a/tests/_x64_compat.py
+++ b/tests/_x64_compat.py
@@ -1,0 +1,30 @@
+"""Version-robust scoped-x64 context (local jax-drift class, see ledger).
+
+``jax.experimental.enable_x64`` (the scoped context manager this repo's
+AD/referee tests use per the "never flip x64 at module level" rule) was
+removed in newer JAX releases. CI (python 3.10) still resolves a JAX that
+exports it; a drifted local environment (python 3.11, newer JAX) fails at
+COLLECTION on the bare import, aborting whole-tree ``-k`` runs before a
+single test executes. This shim keeps the upstream context manager when
+it exists and otherwise provides the same semantics the sanctioned way:
+a per-scope flip of ``jax_enable_x64`` with guaranteed restore — exactly
+the "scope x64 per-test (fixture/context)" pattern the repo rule
+prescribes, never a module-level flip.
+"""
+from __future__ import annotations
+
+try:  # JAX still ships the scoped context manager
+    from jax.experimental import enable_x64  # noqa: F401
+except ImportError:  # newer JAX removed it — same semantics, scoped + restored
+    import contextlib
+
+    import jax
+
+    @contextlib.contextmanager
+    def enable_x64():
+        prev = bool(jax.config.read("jax_enable_x64"))
+        jax.config.update("jax_enable_x64", True)
+        try:
+            yield
+        finally:
+            jax.config.update("jax_enable_x64", prev)

--- a/tests/test_coax_two_port_ad.py
+++ b/tests/test_coax_two_port_ad.py
@@ -386,7 +386,7 @@ def test_compute_coaxial_two_port_ad_grad_finite_and_fd_consistent():
     try:
         from jax import enable_x64
     except ImportError:  # older JAX (< ~0.4.31)
-        from jax.experimental import enable_x64
+        from tests._x64_compat import enable_x64
 
     val, g = jax.value_and_grad(_band_mean_s21_sq)(jnp.asarray(1.0, dtype=jnp.float32))
     g_ad = float(g)

--- a/tests/test_decay_flux_convergence.py
+++ b/tests/test_decay_flux_convergence.py
@@ -62,7 +62,7 @@ try:
     # Modern JAX (scoped x64 context manager promoted to top-level).
     from jax import enable_x64 as _enable_x64
 except ImportError:  # older JAX (< ~0.4.31)
-    from jax.experimental import enable_x64 as _enable_x64
+    from tests._x64_compat import enable_x64 as _enable_x64
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_flux_monitor_finite_size.py
+++ b/tests/test_flux_monitor_finite_size.py
@@ -50,7 +50,7 @@ from rfx.sources.sources import ModulatedGaussian
 try:  # jax >= 0.8.0
     from jax import enable_x64
 except ImportError:  # older jax
-    from jax.experimental import enable_x64
+    from tests._x64_compat import enable_x64
 
 C0 = 2.998e8
 

--- a/tests/test_lumped_rlc_ad.py
+++ b/tests/test_lumped_rlc_ad.py
@@ -38,7 +38,7 @@ import pytest
 try:  # modern JAX: scoped x64 promoted to top-level (experimental removed v0.8.0)
     from jax import enable_x64 as _enable_x64
 except ImportError:  # older JAX (< ~0.4.31)
-    from jax.experimental import enable_x64 as _enable_x64
+    from tests._x64_compat import enable_x64 as _enable_x64
 
 from rfx import GaussianPulse, Simulation
 

--- a/tests/test_msl_ad_fd_converged.py
+++ b/tests/test_msl_ad_fd_converged.py
@@ -30,7 +30,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
-from jax.experimental import enable_x64  # SCOPED x64 — never flip it at module level
+from tests._x64_compat import enable_x64  # SCOPED x64 — never flip it at module level
 
 from rfx import Simulation
 from rfx.boundaries.spec import Boundary, BoundarySpec

--- a/tests/test_msl_modal_voltage_and_wave_solve.py
+++ b/tests/test_msl_modal_voltage_and_wave_solve.py
@@ -28,7 +28,7 @@ try:
     # Modern JAX (scoped x64 context manager promoted to top-level).
     from jax import enable_x64
 except ImportError:  # older JAX — jax.experimental.enable_x64 removed in 0.8
-    from jax.experimental import enable_x64
+    from tests._x64_compat import enable_x64
 
 from rfx.api._sparams import msl_modal_voltage, msl_solve_s_from_waves
 

--- a/tests/test_msl_sparam_ad.py
+++ b/tests/test_msl_sparam_ad.py
@@ -134,7 +134,7 @@ def _run_assembly_with_replay(acc_data: dict, freqs_replay: np.ndarray, *,
         # jax.experimental.enable_x64 was removed in v0.8.0.
         from jax import enable_x64
     except ImportError:  # older JAX (< ~0.4.31)
-        from jax.experimental import enable_x64
+        from tests._x64_compat import enable_x64
 
     sim = _build_thru_line_sim()
     freqs_jnp = jnp.asarray(freqs_replay, dtype=jnp.float32)

--- a/tests/test_source_dc_floor_guards.py
+++ b/tests/test_source_dc_floor_guards.py
@@ -84,7 +84,7 @@ def test_cutoff_45_reduces_deposited_dc_by_predicted_factor():
     float32 accumulation would be pure rounding noise. Never enable x64
     at module level — it is process-global at pytest collection.
     """
-    from jax.experimental import enable_x64
+    from tests._x64_compat import enable_x64
 
     with enable_x64():
         t = jnp.arange(50_000, dtype=jnp.float64) * DEMO_DT

--- a/tests/test_subgrid_source_injection_dtype.py
+++ b/tests/test_subgrid_source_injection_dtype.py
@@ -89,7 +89,7 @@ import numpy as np
 try:  # modern JAX: scoped x64 promoted to top-level (experimental removed v0.8.0)
     from jax import enable_x64 as _enable_x64
 except ImportError:  # older JAX (< ~0.4.31)
-    from jax.experimental import enable_x64 as _enable_x64
+    from tests._x64_compat import enable_x64 as _enable_x64
 
 from rfx import GaussianPulse, Simulation
 

--- a/tests/test_waveguide_sparam_ad.py
+++ b/tests/test_waveguide_sparam_ad.py
@@ -35,7 +35,7 @@ try:
     # jax.experimental.enable_x64 was removed in v0.8.0).
     from jax import enable_x64 as _enable_x64
 except ImportError:  # older JAX (< ~0.4.31)
-    from jax.experimental import enable_x64 as _enable_x64
+    from tests._x64_compat import enable_x64 as _enable_x64
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Found by the #556 adversarial verify pass: `from jax.experimental import enable_x64` (14 files) fails at **collection** on a drifted local environment (py3.11 → newer JAX without the symbol), aborting whole-tree `-k` runs before a single test executes. CI (py3.10 → older JAX) never sees it — every lane green while local collection was broken. Known env-drift class.

- **`tests/_x64_compat.py`** (same shared-helper convention as `_gate_policy`): try-import the upstream context manager; on ImportError, provide identical semantics the repo rule already prescribes — a per-scope flip of `jax_enable_x64` with guaranteed restore (never module-level).
- 10 test files + 4 scripts rewired; on CI's JAX the try-import succeeds → zero behavior change there.
- Verified on the drifted venv (fallback path): the 10 files collect **85/90 with zero collection errors** (previously ImportError abort), sample AD file `4 passed`, scripts compile, ruff clean.

R3: memory=env-drift class + scoped-x64 rule | R2-attempts=0 | falsifier=drifted-venv collection + CI unchanged try-import path

🤖 Generated with [Claude Code](https://claude.com/claude-code)