### PR TITLE
refactor: finish TAP→T-MTT rename (validation/tmtt_paper) + paper-materials map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Changed — validation/tap_paper/ renamed to validation/tmtt_paper/
+
+- Finishes the TAP -> T-MTT venue rename (#598 relabeled prose only): the
+  paper-support directory and every live reference (bakeoff runner paths,
+  multistart test path, source/test docstrings, validation/README) now say
+  `tmtt_paper`. Historical CHANGELOG entries and dated inventory snapshots
+  keep the old name. The directory README now opens with a five-row map of
+  all paper materials (examples, crossval suite, patch record, raw campaign
+  data, release tag).
+
 ### Changed — MSL AD gate objective replaced: band-mean |S21|^2, not sum_ij|S_ij|^2 (issues #530, #515)
 
 - `test_msl_ad_fd_converged_tight`'s differentiated objective was

--- a/rfx/probes/msl_wave_decomp.py
+++ b/rfx/probes/msl_wave_decomp.py
@@ -332,7 +332,7 @@ def _v_from_plane(fr, plane_name: str, p: MSLPlaneProbeSet) -> jnp.ndarray:
        this.
 
        Callers today: ``tests/test_msl_plane_primitives_smoke.py`` and
-       ``validation/tap_paper/msl_stub_notch_tuning.py`` (whose full-res
+       ``validation/tmtt_paper/msl_stub_notch_tuning.py`` (whose full-res
        headline numbers are projected targets, not committed validation).
     """
     plane = fr.dft_planes[plane_name].accumulator     # (n_freqs, ny, nz)

--- a/rfx/sources/msl_port.py
+++ b/rfx/sources/msl_port.py
@@ -15,7 +15,7 @@ least-squares (issue #80 Fix C), and assembles the S-matrix with the
 multi-drive solve (issue #507). The original 3-probe placement
 (:func:`msl_probe_x_coords`) and the OpenEMS-style 3-probe recurrence it
 was built for are retained as a geometry primitive consumed by
-``validation/tap_paper/msl_stub_notch_tuning.py`` (via
+``validation/tmtt_paper/msl_stub_notch_tuning.py`` (via
 ``rfx.probes.msl_wave_decomp.register_msl_plane_probes``); it is not on
 the production S-matrix path.
 

--- a/scripts/diagnostics/optimizer_bakeoff/run_bakeoff.py
+++ b/scripts/diagnostics/optimizer_bakeoff/run_bakeoff.py
@@ -226,13 +226,13 @@ def _load_msl_coarse(dx_new: str):
     made |S21| flat/garbage there; dx = h_sub and dx = h_sub/2 are the clean
     points, and h_sub is the affordable one.
     """
-    src = (REPO / "validation/tap_paper/msl_stub_notch_tuning.py").read_text()
+    src = (REPO / "validation/tmtt_paper/msl_stub_notch_tuning.py").read_text()
     patched = src.replace("DX = 127e-6", f"DX = {dx_new}", 1)
     if patched == src:
         raise RuntimeError("MSL dx patch did not apply")
     import types
     mod = types.ModuleType("bo_msl_coarse")
-    mod.__file__ = str(REPO / "validation/tap_paper/msl_stub_notch_tuning.py")
+    mod.__file__ = str(REPO / "validation/tmtt_paper/msl_stub_notch_tuning.py")
     sys.modules["bo_msl_coarse"] = mod
     exec(compile(patched, mod.__file__, "exec"), mod.__dict__)
     return mod
@@ -305,7 +305,7 @@ def build_waveguide_taper():
     ``design_layout`` + ``make_eps_builder`` + ``make_objective`` -> ``loss_fn``.
     Init = zeros theta (the example's flat mid-eps block).
     """
-    tp = _load(REPO / "validation/tap_paper/waveguide_dielectric_taper.py", "bo_tp")
+    tp = _load(REPO / "validation/tmtt_paper/waveguide_dielectric_taper.py", "bo_tp")
     sim = tp.build_sim()
     grid = sim._build_grid()
     layout = tp.design_layout(grid)

--- a/tests/test_msl_multistart.py
+++ b/tests/test_msl_multistart.py
@@ -37,7 +37,7 @@ import jax.numpy as jnp
 
 EXAMPLE = (
     pathlib.Path(__file__).resolve().parent.parent
-    / "validation" / "tap_paper" / "msl_stub_notch_tuning.py"
+    / "validation" / "tmtt_paper" / "msl_stub_notch_tuning.py"
 )
 
 

--- a/tests/test_msl_plane_primitives_smoke.py
+++ b/tests/test_msl_plane_primitives_smoke.py
@@ -4,7 +4,7 @@ WI-3 (2026-05-24) deleted `test_msl_plane_extractor_jax.py` along with the
 deprecated plane *extractor* (`extract_msl_s_params_jax_plane`). But the
 plane-probe PRIMITIVES it transitively exercised —
 `register_msl_plane_probes`, `_v_from_plane`, `_i_from_plane` — survive and
-are still consumed by `validation/tap_paper/msl_stub_notch_tuning.py`.
+are still consumed by `validation/tmtt_paper/msl_stub_notch_tuning.py`.
 This file restores minimal regression coverage for those primitives so a
 silent break surfaces here rather than only when the example is run.
 

--- a/tests/test_preflight_false_positives.py
+++ b/tests/test_preflight_false_positives.py
@@ -1,6 +1,6 @@
 """Preflight false-positive refinements (2026-05-06).
 
-The Y2 MSL stub-notch demo (`validation/tap_paper/msl_stub_notch_tuning.py`)
+The Y2 MSL stub-notch demo (`validation/tmtt_paper/msl_stub_notch_tuning.py`)
 exposed three preflight checks that were firing on canonical
 transmission-line geometry while still leaving the original footgun cases
 covered.  These tests pin both halves of each refinement: the FP case must

--- a/validation/README.md
+++ b/validation/README.md
@@ -63,6 +63,6 @@ an applicable comparison.
 - `research/subgrid/13_subgrid_material_validation.py` demonstrates the guarded
   subgrid boundary and checks the same material setup on a uniform mesh.
   SBP-SAT/subgridding is not a supported feature.
-- `tap_paper/` contains paper-support scripts. Values identified there as
+- `tmtt_paper/` contains paper-support scripts. Values identified there as
   targets are experiment goals, not measured results. See
-  `tap_paper/README.md` for the status of each script.
+  `tmtt_paper/README.md` for the status of each script.

--- a/validation/tmtt_paper/README.md
+++ b/validation/tmtt_paper/README.md
@@ -6,6 +6,18 @@ These scripts reproduce the inverse-design results of the paper
 > Engineering**, B. Kim, submitted to *IEEE Transactions on Microwave Theory and
 > Techniques* (T-MTT).
 
+## Paper materials map (start here)
+
+Everything the paper and its response letter reference lives in five places:
+
+| Material | Location |
+|---|---|
+| Worked inverse-design examples (notch, taper, beam steering, gradient check) | this directory |
+| Solver cross-validation suite (openEMS / Palace / Meep comparators, 20+ studies) | [`validation/crossval/`](../crossval/) |
+| Four-solver X-band patch record (geometry + port figure, protocol, results, exclusions) | [`docs/crossval/patch_xband_4solver.md`](../../docs/crossval/patch_xband_4solver.md) |
+| Raw patch-campaign data (CST Touchstone files, falsification ledger, `REPRODUCE.md`) | branch [`research/calibration-inverse`](https://github.com/bk-squared/rfx/tree/research/calibration-inverse/scripts/research/calibration/crossval), `scripts/research/calibration/crossval/` |
+| Release accompanying the paper | tag [`paper-tmtt-2026`](https://github.com/bk-squared/rfx/tree/paper-tmtt-2026) |
+
 Each script is self-contained and runs a real reverse-mode FDTD gradient.
 `SMOKE=1` (the default) verifies the pipeline end to end on CPU in ~1-3 min;
 it does not reproduce the headline numbers. `SMOKE=0` reproduces the paper's
@@ -16,8 +28,8 @@ beam-steering superstrate.
 > `pip install rfx-fdtd[optimization]` (with the repo on `PYTHONPATH`, or an
 > editable install).
 
-> **Notch filter (Example 1) lives elsewhere in the repo**, not duplicated here:
-> `validation/tap_paper/msl_stub_notch_tuning.py` (cross-validation companion:
+> **Notch filter (Example 1)** is `msl_stub_notch_tuning.py` in this directory
+> (cross-validation companion:
 > `validation/crossval/06b_msl_notch_filter_uniform.py`).
 
 > **GPU note.** `SMOKE=0` for the dielectric taper and the beam-steering
@@ -31,7 +43,7 @@ placed at 6 GHz by descending a single stub-length design variable. The
 single-variable descent reaches a -46.1 dB in-band objective, and the validated
 optimized null is -55.7 dB at 5.924 GHz, within 3.1% of the analytic
 quarter-wave length. Not duplicated here; see
-`validation/tap_paper/msl_stub_notch_tuning.py` (cross-validation companion:
+`validation/tmtt_paper/msl_stub_notch_tuning.py` (cross-validation companion:
 `validation/crossval/06b_msl_notch_filter_uniform.py`).
 
 **Example 2 - Waveguide dielectric taper (30 sections).**
@@ -43,8 +55,8 @@ resolution dx = 0.25 mm, versus a discretized Klopfenstein taper of the same
 electrical length at -36.6 dB (dx = 0.25 mm). At a comparable coarse-grid solve
 budget, particle-swarm and genetic search trail the gradient by at least
 11.6 dB. Run:
-`SMOKE=1 JAX_PLATFORMS=cpu python validation/tap_paper/waveguide_dielectric_taper.py`
-(CPU, ~1-3 min); `SMOKE=0 python validation/tap_paper/waveguide_dielectric_taper.py`
+`SMOKE=1 JAX_PLATFORMS=cpu python validation/tmtt_paper/waveguide_dielectric_taper.py`
+(CPU, ~1-3 min); `SMOKE=0 python validation/tmtt_paper/waveguide_dielectric_taper.py`
 (full, GPU).
 
 **Example 3 - Beam-steering superstrate (441-param latent / 2883-cell).**
@@ -57,8 +69,8 @@ superstrate, a +3.6 dB gain over the 5.9 dBi bare plate-backed dipole. A
 laterally uniform slab of the same aperture reaches at most 5.4 dBi toward
 30 deg. An independent openEMS run corroborates the steered direction (8.9 dBi
 toward 30 deg, with the pattern peak near 30 deg). Run:
-`SMOKE=1 JAX_PLATFORMS=cpu python validation/tap_paper/beam_steering_superstrate.py`
-(CPU, ~1-3 min); `SMOKE=0 python validation/tap_paper/beam_steering_superstrate.py`
+`SMOKE=1 JAX_PLATFORMS=cpu python validation/tmtt_paper/beam_steering_superstrate.py`
+(CPU, ~1-3 min); `SMOKE=0 python validation/tmtt_paper/beam_steering_superstrate.py`
 (full, GPU).
 
 ## Gradient verification
@@ -67,7 +79,7 @@ toward 30 deg, with the pattern peak near 30 deg). Run:
 the analytic directional derivative of |S11|^2 (one reverse-mode pass) agrees
 with a central finite difference (two forward passes) to 0.2% over the 24-cell
 design region. Runs on CPU in ~5-10 min (no GPU needed):
-`JAX_PLATFORMS=cpu python validation/tap_paper/lumped_port_gradient_check.py`.
+`JAX_PLATFORMS=cpu python validation/tmtt_paper/lumped_port_gradient_check.py`.
 
 The modal-S gradient check (taper) and the NTFF log-ratio gradient check
 (superstrate) are exercised by their example scripts. AD-vs-FD agreement is

--- a/validation/tmtt_paper/beam_steering_superstrate.py
+++ b/validation/tmtt_paper/beam_steering_superstrate.py
@@ -52,8 +52,8 @@ the simulation, takes a few optimizer steps, and demonstrates the lobe moving
 
 Run
 ---
-    SMOKE=1 JAX_PLATFORMS=cpu python validation/tap_paper/beam_steering_superstrate.py
-    SMOKE=0 python validation/tap_paper/beam_steering_superstrate.py    # paper (GPU)
+    SMOKE=1 JAX_PLATFORMS=cpu python validation/tmtt_paper/beam_steering_superstrate.py
+    SMOKE=0 python validation/tmtt_paper/beam_steering_superstrate.py    # paper (GPU)
 """
 
 from __future__ import annotations

--- a/validation/tmtt_paper/lumped_port_gradient_check.py
+++ b/validation/tmtt_paper/lumped_port_gradient_check.py
@@ -14,7 +14,7 @@ the directional derivative along the gradient, which agrees with central FD to
 0.2% over the 24 design cells (the value reported in the paper).
 
 Run (CPU is fine, ~few minutes):
-    JAX_PLATFORMS=cpu python validation/tap_paper/lumped_port_gradient_check.py
+    JAX_PLATFORMS=cpu python validation/tmtt_paper/lumped_port_gradient_check.py
 """
 import argparse
 import json
@@ -47,7 +47,7 @@ def main():
     ap.add_argument("--eps0", type=float, default=4.0)
     ap.add_argument("--h", type=float, default=1e-3)
     ap.add_argument("--ncheck", type=int, default=0, help="0 = check all cells")
-    ap.add_argument("--out", type=str, default="validation/tap_paper/_out/lumped_port_gradient_check")
+    ap.add_argument("--out", type=str, default="validation/tmtt_paper/_out/lumped_port_gradient_check")
     args = ap.parse_args()
 
     f0 = 3.0e9

--- a/validation/tmtt_paper/msl_stub_notch_tuning.py
+++ b/validation/tmtt_paper/msl_stub_notch_tuning.py
@@ -86,7 +86,7 @@ check, enforced by `sim.preflight()` — see
 5 mm line biases |S11|@notch to ≈ -7 dB instead of the physical 0 dB; this
 geometry avoids that.
 
-Run: ``python validation/tap_paper/msl_stub_notch_tuning.py``
+Run: ``python validation/tmtt_paper/msl_stub_notch_tuning.py``
 """
 
 from __future__ import annotations

--- a/validation/tmtt_paper/waveguide_dielectric_taper.py
+++ b/validation/tmtt_paper/waveguide_dielectric_taper.py
@@ -47,8 +47,8 @@ settings (GPU required in practice for the full-resolution scan).
 
 Run
 ---
-  SMOKE=1 JAX_PLATFORMS=cpu python validation/tap_paper/waveguide_dielectric_taper.py
-  SMOKE=0 python validation/tap_paper/waveguide_dielectric_taper.py   # paper (GPU)
+  SMOKE=1 JAX_PLATFORMS=cpu python validation/tmtt_paper/waveguide_dielectric_taper.py
+  SMOKE=0 python validation/tmtt_paper/waveguide_dielectric_taper.py   # paper (GPU)
 
 Output: initial vs optimized band-averaged |S11| in dB, plus a figure of the
 optimized permittivity profile and the |S11|(f) curves.


### PR DESCRIPTION
Finishes what #598 started: the paper-support directory kept its TAP-era name. Renames `validation/tap_paper/` → `validation/tmtt_paper/`, updates every live reference (bakeoff runner path constants, multistart test path, 2 source docstrings, 2 test docstrings, validation/README, self-references), adds a CHANGELOG entry, and leaves historical records (past CHANGELOG entries, dated scope inventory) untouched.

Also makes `validation/tmtt_paper/README.md` the one-stop map for paper materials — worked examples, crossval suite, the four-solver patch record, the raw campaign-data branch, and the release tag — per PI request that these stop being scattered. Corrects the stale pre-#357 'Example 1 lives elsewhere' note.

Repo-wide `grep tap_paper` now returns only the two historical files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)