### PR TITLE
test(support-matrix): parity gate extension — 3 lanes, API-summary table, transition z0_ref advisory (#586)

### DIFF
--- a/docs/guides/sparameter_support_matrix.json
+++ b/docs/guides/sparameter_support_matrix.json
@@ -1,6 +1,6 @@
 {
   "version": 6,
-  "updated": "2026-08-06",
+  "updated": "2026-08-09",
   "result_convention": {
     "full_s_matrix_shape": "(n_ports, n_ports, n_freqs)",
     "frequency_shape": "(n_freqs,)",
@@ -549,6 +549,7 @@
         "the settled VESSL run (369367252283, n_steps=135000) clears the -40 dB ring-down rule for the first time on this lane; see SETTLED_RUN_RECORD in tests/test_coax_msl_transition.py (status RUN) and the tracked run log/result JSON under scripts/diagnostics/_coax_msl_transition_settled_run_logs/",
         "raw cond_a (1e3-1e7 on both attempts) is dominated by per-drive amplitude scale, not geometric near-degeneracy -- see cond_a_equilibrated (near 1 on both attempts) on CoaxMSLTransitionResult",
         "the MSL side is extracted via the coax matrix-pencil fit (coaxial_line_reflection_from_plane_voltages) rather than the mixed lane's own N-probe fit, a deliberate deviation made because the coax fit deterministically pins the propagation-constant branch while the N-probe fit's sign is documented as unstable",
+        "the registered impedance= on add_coaxial_port(...)/add_msl_port(...) sizes only the feed resistor / termination and (for coax) the TEM source amplitude calibration; the power-wave normalization (z0_ref) always uses the analytic TEM / Hammerstad-Jensen Z0 the method computes itself, so the registered impedance= is NOT the reference impedance of the returned s_params -- the method emits a divergence advisory when either port's registered impedance diverges more than 5% from the analytic Z0 it actually uses (issue #581 review N2)",
         "no external-solver referee has been run",
         "AD is out of scope for both attempts (no eps_scale-style channel)",
         "waveguide, Floquet, TFSF, lumped RLC, and any second coaxial or MSL port are all rejected loudly"

--- a/docs/guides/sparameter_support_matrix.md
+++ b/docs/guides/sparameter_support_matrix.md
@@ -40,15 +40,16 @@ guard. An absent warning therefore cannot be compared across port families.
 |---|---|---|---|
 | Lumped `add_port(..., extent=None)` | `run(compute_s_params=True, s_param_freqs=...)` | `Result.s_params`, `Result.freqs` | **limited** — one-cell impedance model; E2/E3/E4-partial evidence |
 | Lumped `add_port(..., extent=None)` | `forward(port_s11_freqs=...)` | `ForwardResult.s_params`, `.freqs` (S11 vectors) | **limited** — uniform, single-device AD path; inherits the lumped-port RF limits |
-| Wire `add_port(..., extent=...)` | `run(compute_s_params=True, s_param_freqs=...)` | `Result.s_params`, `Result.freqs` | **limited** — multi-cell discrete feed across `extent`; magnitude evidence is stronger than absolute calibration evidence |
+| Wire `add_port(..., extent=...)` | `run(compute_s_params=True, s_param_freqs=...)` | `Result.s_params`, `Result.freqs` | **limited** — multi-cell discrete feed across `extent`; magnitude evidence is stronger than absolute calibration evidence; nonuniform use is experimental |
 | Wire `add_port(..., extent=...)` | `forward(port_s11_freqs=...)` | `ForwardResult.s_params`, `.freqs` (S11 vectors) | **limited** — uniform, single-device AD path |
-| `add_msl_port(...)` | `compute_msl_s_matrix(...)` | `MSLSMatrixResult.S`, `.freqs`, `.Z0`, `.beta`, `.port_names`, `.reliable` | **limited** — E5-narrow / eigenmode-blocked; external notch agreement is characterized, not tight; `eps_override` AD checked against an f64 referee on the band-mean `\|S21\|^2` objective (rel_err 0.0026 at the gate's num_periods=20 fixture, threshold 0.03; issue #530, superseding the pre-#530 `sum\|S_ij\|^2` objective and its 0.0331/0.10 figures) |
-| `add_waveguide_port(...)` | `compute_waveguide_s_matrix(...)` | `WaveguideSMatrixResult.s_params`, `.freqs`, `.port_names`, `.port_directions`, `.reference_planes` | **limited** — broad magnitude evidence for documented uniform single-mode rectangular guides; phase and junction evidence are narrower |
+| `add_msl_port(...)` | `compute_msl_s_matrix(...)` | `MSLSMatrixResult.S`, `.freqs`, `.Z0`, `.beta`, `.port_names`, `.reliable` | **limited** — E5-narrow / eigenmode-blocked; external notch agreement is characterized, not tight; `eps_override` AD checked against an f64 referee on the band-mean `\|S21\|^2` objective (rel_err 0.0026 at the gate's num_periods=20 fixture, threshold 0.03; issue #530, superseding the pre-#530 `sum\|S_ij\|^2` objective and its 0.0331/0.10 figures); nonuniform mode is experimental |
+| `add_waveguide_port(...)` | `compute_waveguide_s_matrix(...)` | `WaveguideSMatrixResult.s_params`, `.freqs`, `.port_names`, `.port_directions`, `.reference_planes` | **limited** — broad magnitude evidence for documented uniform single-mode rectangular guides; phase and junction evidence are narrower; nonuniform configurations outside the passed Palace `normalize=flux` WR-90 cases remain experimental |
 | `add_waveguide_port(...)` | `run(...)` | `Result.waveguide_sparams[name]` | **limited diagnostic** — per-port output, not the full multi-port matrix API |
 | `add_coaxial_port(...)` | `compute_coaxial_line_reflection(...)` | `CoaxialLineReflectionResult` | **limited** — exactly one `face="top"` port; broad-E5 analytic and broad-E4 MEEP evidence for the documented TEM-line result |
 | `add_coaxial_port(...)` | `compute_coaxial_s_matrix(...)` | `CoaxialSMatrixResult` | **experimental and deprecated** — older single-plane V/I path; can produce non-physical `\|S11\| > 1` for a lossless short |
-| `add_coaxial_port(...)` | `compute_coaxial_two_port(...)` | `CoaxialTwoPortResult` | **validated with scope** (issue #489, PI decision 2026-08-06) — two-drive through-line 2-port solve on one coax geometry family; bracketed by an external openEMS referee (`validation/crossval/21_coax_two_port_referee.py`, VESSL run-3 `369367251629` + VESSL `369367252220`) on `\|S21\|` and, via the port's own measured `beta`, phase, plus a mesh-refinement convergence witness (VESSL `369367251845`, `p ~= 1.5`) and a `GRAD_SAFE` `eps_scale` AD gate; every DUT it can currently gate against is still azimuthally symmetric (TM0n only) — coax<->planar transitions stay **EXPERIMENTAL, diagnostic-only** in the separate `compute_coax_msl_transition(...)` lane |
-| `add_coaxial_port(...)` + `add_msl_port(...)` | `compute_coax_msl_transition(...)` | `CoaxMSLTransitionResult` | **experimental, diagnostic-only** (issue #489 leg 4) — coax-to-microstrip transition, two-drive; two committed fixtures plus a settled VESSL run (`369367252283`, `n_steps=135000`) of attempt 2's own fixture. gamma-vs-beta is CONFIRMED (three in-band checkpoints, the last at full settling); reciprocity (91.4% worst deviation) and passivity are now MEASURED/ATTRIBUTED at full settling (the earlier passivity-guard trip was a truncation artifact); the MSL-driven column power is a SHARPENED open question (~99% missing at 6/8 GHz, ~20% at 10 GHz) with a named discriminating check — see the section below — do not treat as a validated transition |
+| `add_coaxial_port(...)` | `compute_coaxial_two_port(...)` | `CoaxialTwoPortResult` | **validated with scope** (issue #489, PI decision 2026-08-06) — two-drive through-line 2-port solve on one coax geometry family; bracketed by an external openEMS referee (`validation/crossval/21_coax_two_port_referee.py`, VESSL run-3 `369367251629` + VESSL `369367252220`) on `\|S21\|` and, via the port's own measured `beta`, phase, plus a mesh-refinement convergence witness (VESSL `369367251845`, `p ~= 1.5`) and a `GRAD_SAFE` `eps_scale` AD gate; every DUT it can currently gate against is still azimuthally symmetric (TM0n only) — coax<->planar transitions are the separate `compute_coax_msl_transition(...)` lane (own row below, own status, unaffected by this promotion) |
+| `add_coaxial_port(...)` + `add_msl_port(...)` | `compute_coax_msl_transition(...)` | `CoaxMSLTransitionResult` | **experimental, diagnostic-only** (issue #489 leg 4) — coax-to-microstrip transition, two-drive; two committed fixtures plus a settled VESSL run (`369367252283`, `n_steps=135000`) of attempt 2's own fixture. gamma-vs-beta is CONFIRMED (three in-band checkpoints, the last at full settling); reciprocity (91.4% worst deviation) and passivity are now MEASURED/ATTRIBUTED at full settling (the earlier passivity-guard trip was a truncation artifact); the MSL-driven column power is a SHARPENED open question (~99% missing at 6/8 GHz, ~20% at 10 GHz) with a named discriminating check, and whether the junction's own physical reflection also contributes is genuinely unresolved — see the section below — do not treat as a validated transition |
+| `add_port(...)` + `add_msl_port(...)` | `compute_mixed_s_matrix(...)` | `MixedSMatrixResult` | **experimental**, diagnostic, not in the validated set — off-diagonal magnitudes from Poynting flux; internal reciprocity witness 9.0% (flux channel) vs 55% (wave channel) on the probe-fed MSL fixture; absolute \|S\| is NOT validated (no external-solver referee has been run); with `enforce_passivity=True` (default) the returned diagonal is a joint SVD-projected value — read `S_raw`/`passivity_correction` for what was measured |
 | `add_floquet_port(...)` | no documented high-level S-parameter API | none | **experimental** — broadside diagnostic helpers only; no calibrated Floquet-port result |
 | Sources, TFSF, probes, DFT planes, flux monitors | none | field, resonance, or flux results | **not a port** — no impedance or S-matrix reference plane |
 
@@ -639,11 +640,17 @@ only gates below 3.5).
 ## Floquet/Bloch and non-port observables
 
 `add_floquet_port(...)` has broadside modal bookkeeping, field-dump replay, and
-analytic empty-space/slab diagnostics. Representative internal differences are
-`max_abs_diff 0.06067` for the empty-space analytic-null check and
-`max_mag_abs_diff 0.06212` for the three-frequency homogeneous-slab magnitude
-check. These are not RCWA or independent full-wave validation, and there is no
-documented high-level Floquet S-parameter API. Treat the result as experimental.
+analytic empty-space/slab diagnostics. The internal differences: the
+empty-space analytic-null check has `max_abs_diff 0.06067` (against `0.07`) and
+`mean_abs_diff 0.05306` (against `0.06`); the homogeneous-slab analytic oracle
+covers 8 cases x 3 frequencies with maximum power-balance error `4.44e-16`; the
+rfx-FDTD homogeneous-slab magnitude check has `max_mag_abs_diff 0.06212`
+(against `0.07`) and `mean_mag_abs_diff 0.03209` (against `0.04`) over 3
+frequencies; the synthetic specular-TE check has S11 difference `2.89e-7`, S21
+difference `6.37e-7`, and power-balance error `1.02e-6`; the real-FDTD Ex/Hy
+DFT-plane replay has maximum S difference `2.23e-7`. These are not RCWA or
+independent full-wave validation, and there is no documented high-level Floquet
+S-parameter API. Treat the result as experimental.
 
 `add_source(...)`, polarized sources, TFSF, point probes, DFT plane probes, and
 flux monitors do not define a port impedance or S-matrix reference. Validate
@@ -696,7 +703,7 @@ What this is and is not:
 
 | aspect | status |
 |---|---|
-| off-diagonal magnitude | experimental; internal reciprocity witness 9% on the probe-fed MSL fixture (55% on the wave channel) |
+| off-diagonal magnitude | experimental; internal reciprocity witness 9.0% on the probe-fed MSL fixture at `dx=63.5um`, settling `-101`/`-100` dB (55% on the wave channel) |
 | absolute magnitude | **NOT validated** — no external-solver referee has been run |
 | off-diagonal phase | provisional (mixes two reference-plane conventions) |
 | per-column power | an algebraic identity on the flux channel — **not** a passivity check |
@@ -704,7 +711,9 @@ What this is and is not:
 Because the flux normalization makes column power identically 1 whenever the
 arriving power equals the net launched power, a green passivity result on this
 lane carries no information. Reciprocity is the only independent internal
-witness, and the method warns when it exceeds `reciprocity_tol`.
+witness, and the method warns when it exceeds `reciprocity_tol` (default
+`0.06`, set below the 9% reference-fixture residual so that fixture warns
+rather than passing silently).
 
 Everything outside the first supported pair is rejected loudly: waveguide,
 Floquet, coaxial and TFSF registrations, bare sources and 0-ohm ports, mixed
@@ -763,6 +772,18 @@ independently unit-tested against a PLANTED, analytically known S-matrix
 under UNEQUAL port impedances (`tests/test_coax_msl_transition.py`), including
 a dedicated regression test that reproduces the exact defect the fix
 prevents.
+
+The registered `impedance=` on either port is NOT the reference impedance of
+the returned `s_params` (issue #581 review N2): `add_coaxial_port(impedance=...)`
+/ `add_msl_port(impedance=...)` size only the feed resistor / termination and
+(for coax) the TEM source amplitude calibration, while the power-wave
+normalization (`z0_ref`, the `sqrt(Z0)` step above) always uses the analytic
+TEM / Hammerstad-Jensen Z0 the method computes itself. When either port's
+registered impedance diverges more than 5% from the analytic Z0 actually used,
+`compute_coax_msl_transition(...)` emits a divergence advisory naming both
+values — pass a matching `pin_radius`/`outer_radius` (coax) or
+`width`/`height`/`eps_r_sub` (msl), or reconcile the mismatch, before trusting
+a specific reference-impedance interpretation.
 
 **One fixture has been run, and it is diagnostic, not validated.** The
 committed fixture (a vertical coax landing on a grounded substrate edge via a

--- a/tests/test_support_matrix_parity.py
+++ b/tests/test_support_matrix_parity.py
@@ -91,12 +91,32 @@ review ran into before landing):
   in neither dict fails ``test_lane_map_is_complete_in_both_directions``
   loudly instead of silently escaping the gate.
 
+- The "## API summary" table is a THIRD in-file copy of the same per-lane
+  status claims (issue #586 item 2), and a demonstrated drift site: one of
+  PR #584's five live-drift fixes was the coax section saying "no external
+  referee" while the summary table's row for the same API already correctly
+  said the referee was registered -- caught only by accident. The third
+  comparison (``test_api_summary_status_cell_agrees_with_section_status``)
+  pairs each mapped lane's summary-table row(s) (``API_SUMMARY_ROW_ANCHORS``,
+  1:1 and in order with ``LANE_STATUS_ANCHORS_MD``) with the section's
+  designated status block and requires STATUS_TOKENS presence-polarity
+  agreement between the row's status cell and that block. The table parser
+  is fail-loud by construction (the #303 "All checks passed with a skipped
+  check family" class): the section, the exact 4-column header row, the
+  4-cell shape of every row, and a nonzero data-row count are all asserted,
+  and every mapped row key must match exactly one row -- a restructured
+  table fails loudly instead of parsing to nothing and passing vacuously.
+  Extending this check exposed live drift on first contact (the #584
+  experience repeating): three rows understating the section's
+  nonuniform-experimental status, the coax two-port row carrying ANOTHER
+  lane's status word inside its own status cell, the transition row missing
+  its section's "unresolved", and the compute_mixed_s_matrix lane having no
+  summary row at all -- all fixed doc-side in the same change.
+
 Not in scope (see the issue, and issue #586 filed from the PR #584 review for
 the deferred items): auto-generating one carrier from the other, byte/full-
-text parity, covering every lane immediately (the map grows incrementally as
-drift surfaces in a given lane), and checking the separate "## API summary"
-table (a second, currently-ungated in-file copy of the same per-primitive
-claims -- issue #586).
+text parity, and covering every lane immediately (the map grows incrementally
+as drift surfaces in a given lane).
 
 Pure text parsing, no FDTD -- joins the contract-test family (same default
 marker/lane as test_sparameter_support_contract.py; no slow/gpu marker).
@@ -122,43 +142,48 @@ MATRIX_MD_PATH = Path("docs/guides/sparameter_support_matrix.md")
 # actually hit (issue #554): MSL (ad_evidence), coax two-port, coax-MSL
 # transition, wire/patch, and the waveguide near-cutoff group-delay figures
 # (NU broad-E4/E5 lives in the same "## Rectangular-waveguide port" section).
+# Issue #586 extended the map to the 3 remaining genuinely mappable lanes
+# (lumped, Floquet, mixed lumped/wire+MSL); mapping them immediately exposed
+# live numeric drift in the Floquet and mixed sections (json numeric_metrics
+# tokens absent from the .md), fixed doc-side from the json in the same
+# change -- the #584 experience repeating on first contact.
 LANE_SECTION_MAP: dict[str, str] = {
+    "add_port(extent=None)": "## Lumped port",
     "add_port(extent=...)": "## Wire port",
     "add_msl_port(...)": "## Microstrip-line port",
     "add_waveguide_port(...)": "## Rectangular-waveguide port",
     "add_coaxial_port(...)": "## Coaxial port",
     "add_coaxial_port(...) + add_msl_port(...) driven by compute_coax_msl_transition(...)":
         "## Coax<->MSL transition — EXPERIMENTAL, diagnostic-only (issue #489 leg 4)",
+    "add_floquet_port(...)": "## Floquet/Bloch and non-port observables",
+    "add_port(...) + add_msl_port(...) driven by compute_mixed_s_matrix(...)":
+        "## Mixed port families — EXPERIMENTAL, not in the validated set",
 }
 
-# json port_families primitives NOT yet mapped above, each with a short
-# reason. Adding a primitive to the json's port_families without adding it to
-# EITHER this dict or LANE_SECTION_MAP fails
+# json port_families primitives NOT mapped above, each with a short reason.
+# Adding a primitive to the json's port_families without adding it to EITHER
+# this dict or LANE_SECTION_MAP fails
 # test_lane_map_is_complete_in_both_directions loudly rather than silently
-# escaping the parity gate. issue #586 (filed from the PR #584 review) tracks
-# promoting the 3 genuinely mappable lanes below (lumped, floquet, mixed) into
-# LANE_SECTION_MAP; the remaining 3 are "not_a_port" families whose
-# numeric_metrics field HOLDS a value -- ``["not an S-parameter calculation"]``
-# -- but that value carries no numeric token to check, which is why they stay
-# deferred rather than mapped.
+# escaping the parity gate. Issue #586 promoted the 3 genuinely mappable
+# lanes (lumped, floquet, mixed) into LANE_SECTION_MAP; the remaining 3 are
+# "not_a_port" families whose numeric_metrics field HOLDS a value --
+# ``["not an S-parameter calculation"]`` -- but that value carries no numeric
+# token to check (the #584-corrected reason: the key exists, its content is
+# non-numeric), which is why they stay deferred rather than mapped.
 UNMAPPED_LANES_TODO: dict[str, str] = {
-    "add_port(extent=None)": "TODO(#586): lumped-port section not yet mapped",
-    "add_floquet_port(...)": "TODO(#586): Floquet section not yet mapped",
     "add_source(...) / add_polarized_source(...)":
-        "TODO(#586): not-a-port family, numeric_metrics carries no numeric tokens",
+        "not_a_port family: numeric_metrics carries no numeric tokens (issue #586 kept it deferred)",
     "add_tfsf_source(...)":
-        "TODO(#586): not-a-port family, numeric_metrics carries no numeric tokens",
+        "not_a_port family: numeric_metrics carries no numeric tokens (issue #586 kept it deferred)",
     "add_probe(...) / add_dft_plane_probe(...) / add_flux_monitor(...)":
-        "TODO(#586): not-a-port family, numeric_metrics carries no numeric tokens",
-    "add_port(...) + add_msl_port(...) driven by compute_mixed_s_matrix(...)":
-        "TODO(#586): mixed lumped/wire+MSL lane not yet mapped",
+        "not_a_port family: numeric_metrics carries no numeric tokens (issue #586 kept it deferred)",
 }
 
 # Lanes explicitly exempt from the "numeric_metrics must extract at least one
 # token" floor in test_json_numeric_claims_appear_in_markdown (PR #584
 # review, L4). Empty on purpose: every currently-mapped lane has real
 # numeric_metrics content: an empty allowlist means the floor is live on all
-# 5 mapped lanes today. Add a primitive here only with a comment naming why
+# 8 mapped lanes today. Add a primitive here only with a comment naming why
 # its numeric_metrics is genuinely number-free (not merely emptied by a
 # careless edit, which is exactly the silent-vacuous-pass class L4 closes).
 NUMBER_FREE_LANES: frozenset[str] = frozenset()
@@ -184,6 +209,13 @@ NUMBER_FREE_LANES: frozenset[str] = frozenset()
 # matching at all (an "anchor not found" error) instead of exercising the
 # intended status-token disagreement path.
 LANE_STATUS_ANCHORS_MD: dict[str, tuple[str, ...]] = {
+    "add_port(extent=None)": (
+        # the Restrictions bullet block -- the lumped lane's only
+        # status-bearing text (json status is "limited", which is not a
+        # tracked token, so this anchor pins "no status tokens on either
+        # side" rather than a specific word's presence)
+        "Analytic extractor and V/I replay checks validate",
+    ),
     "add_port(extent=...)": (
         "The nonuniform wire calculation is",
     ),
@@ -199,6 +231,18 @@ LANE_STATUS_ANCHORS_MD: dict[str, tuple[str, ...]] = {
     ),
     "add_coaxial_port(...) + add_msl_port(...) driven by compute_coax_msl_transition(...)": (
         "the junction's own physical reflection also contributes is genuinely",
+    ),
+    "add_floquet_port(...)": (
+        # the section's opening paragraph, which states the lane's own
+        # status ("Treat the result as experimental") -- prefix chosen
+        # upstream of the status word per this dict's own anchor rule
+        "`add_floquet_port(...)` has broadside modal bookkeeping",
+    ),
+    "add_port(...) + add_msl_port(...) driven by compute_mixed_s_matrix(...)": (
+        # the per-aspect status table block; the lane's loudest status
+        # marker is in the section header ("-- EXPERIMENTAL, not in the
+        # validated set"), which _lane_status_blocks_md includes by design
+        "| off-diagonal magnitude |",
     ),
 }
 
@@ -247,6 +291,59 @@ LANE_STATUS_ANCHORS_JSON: dict[str, tuple[str, ...]] = {
     "add_coaxial_port(...)": (
         "compute_coaxial_s_matrix(...) remains",
         "validation/crossval/21_coax_two_port_referee.py, VESSL run-3 369367251629",
+    ),
+}
+
+# ---------------------------------------------------------------------------
+# "## API summary" table (issue #586 item 2)
+# ---------------------------------------------------------------------------
+
+# The summary table is one row per (primitive, calculation API) pair with its
+# own status cell -- a second, previously ungated in-file copy of the same
+# per-lane status claims the section prose carries (see the module docstring
+# for the demonstrated #584 drift case this closes). Each mapped primitive
+# lists here one row key per LANE_STATUS_ANCHORS_MD anchor, PAIRED 1:1 IN THE
+# SAME ORDER: row key i's status cell is token-compared against md anchor i's
+# designated block. A row key is a substring matched against
+# "<primitive cell> | <calculation API cell>" and must match EXACTLY ONE data
+# row (fail-loud, same discipline as the anchor lookups). Rows without a
+# paired anchor (e.g. the lumped/wire forward(...) rows, the coax
+# line-reflection row, the not-a-port row) are parsed but not compared --
+# coverage grows the same incremental way LANE_SECTION_MAP does.
+#
+# Pairing is per-row, not per-lane-union, for the same reason the json side
+# went per-anchor (PR #588 review, P1): the coax lane's three rows carry two
+# independently evolving sub-API statuses, and a union over them would be
+# constant-True for either token regardless of which sub-API's own cell
+# changed.
+API_SUMMARY_HEADER = "## API summary"
+API_SUMMARY_EXPECTED_COLUMNS = ("Primitive", "Calculation API", "Result", "Current status")
+
+API_SUMMARY_ROW_ANCHORS: dict[str, tuple[str, ...]] = {
+    "add_port(extent=None)": (
+        "Lumped `add_port(..., extent=None)` | `run(",
+    ),
+    "add_port(extent=...)": (
+        "Wire `add_port(..., extent=...)` | `run(",
+    ),
+    "add_msl_port(...)": (
+        "`add_msl_port(...)` | `compute_msl_s_matrix(...)`",
+    ),
+    "add_waveguide_port(...)": (
+        "`add_waveguide_port(...)` | `compute_waveguide_s_matrix(...)`",
+    ),
+    "add_coaxial_port(...)": (
+        "`add_coaxial_port(...)` | `compute_coaxial_s_matrix(...)`",
+        "`add_coaxial_port(...)` | `compute_coaxial_two_port(...)`",
+    ),
+    "add_coaxial_port(...) + add_msl_port(...) driven by compute_coax_msl_transition(...)": (
+        "`add_coaxial_port(...)` + `add_msl_port(...)` | `compute_coax_msl_transition(...)`",
+    ),
+    "add_floquet_port(...)": (
+        "`add_floquet_port(...)` | no documented high-level",
+    ),
+    "add_port(...) + add_msl_port(...) driven by compute_mixed_s_matrix(...)": (
+        "`add_port(...)` + `add_msl_port(...)` | `compute_mixed_s_matrix(...)`",
     ),
 }
 
@@ -454,6 +551,53 @@ def _lane_status_blocks_json(entry: dict, primitive: str) -> list[str] | None:
         )
         result.append(matches[0])
     return result
+
+
+def _api_summary_rows(md_sections: dict[str, str]) -> list[tuple[str, str, str, str]]:
+    """[(primitive_cell, api_cell, result_cell, status_cell), ...] parsed
+    from the "## API summary" table, fail-loud at every stage (issue #586
+    item 2; a parser that silently parses nothing and lets the comparison
+    pass vacuously is the #303 "skipped check family" class):
+
+    - the section itself must exist,
+    - exactly one header row must carry exactly the 4 expected column
+      titles (a renamed/reordered/re-widened table fails here, not by
+      matching zero rows),
+    - every table line must split into exactly 4 cells (split on UNESCAPED
+      pipes only -- status cells legitimately contain ``\\|S21\\|``),
+    - at least one data row must survive.
+    """
+    section = md_sections.get(API_SUMMARY_HEADER)
+    assert section is not None, (
+        f"section {API_SUMMARY_HEADER!r} not found in the .md -- if the table "
+        "moved or was renamed, update API_SUMMARY_HEADER."
+    )
+    header_rows = 0
+    data_rows: list[tuple[str, str, str, str]] = []
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not (stripped.startswith("|") and stripped.endswith("|")):
+            continue
+        cells = [c.strip() for c in re.split(r"(?<!\\)\|", stripped[1:-1])]
+        assert len(cells) == len(API_SUMMARY_EXPECTED_COLUMNS), (
+            f"API summary table row does not have exactly "
+            f"{len(API_SUMMARY_EXPECTED_COLUMNS)} cells (unescaped-pipe "
+            f"split): {stripped!r} -> {cells}"
+        )
+        if all(set(c) <= {"-", ":"} and c for c in cells):
+            continue  # the |---|---| separator row
+        if tuple(cells) == API_SUMMARY_EXPECTED_COLUMNS:
+            header_rows += 1
+            continue
+        data_rows.append((cells[0], cells[1], cells[2], cells[3]))
+    assert header_rows == 1, (
+        f"expected exactly one API summary header row with columns "
+        f"{API_SUMMARY_EXPECTED_COLUMNS}, found {header_rows} -- if the "
+        "table's columns changed, update API_SUMMARY_EXPECTED_COLUMNS and "
+        "re-verify what the status comparison reads."
+    )
+    assert data_rows, "API summary table parsed to zero data rows"
+    return data_rows
 
 
 def _lane_evidence_text(entry: dict) -> str:
@@ -666,6 +810,76 @@ def test_status_token_polarity_agrees(
     assert not disagreements, (
         f"{primitive}: status token polarity disagreement "
         f"(anchor, token, which carrier has it): {disagreements}"
+    )
+
+
+def test_api_summary_row_map_covers_all_mapped_lanes():
+    """API_SUMMARY_ROW_ANCHORS must cover exactly the mapped primitives, with
+    one row key per md status anchor (1:1, same order) -- the same
+    completeness discipline test_json_status_anchors_... applies to the json
+    side. A mapped lane missing here would silently escape the table check;
+    a stale key would silently never run."""
+    assert set(API_SUMMARY_ROW_ANCHORS) == set(LANE_SECTION_MAP), (
+        "API_SUMMARY_ROW_ANCHORS keys must equal LANE_SECTION_MAP keys; "
+        f"missing={set(LANE_SECTION_MAP) - set(API_SUMMARY_ROW_ANCHORS)}, "
+        f"stale={set(API_SUMMARY_ROW_ANCHORS) - set(LANE_SECTION_MAP)}"
+    )
+    mismatched = {
+        primitive: (len(row_keys), len(LANE_STATUS_ANCHORS_MD.get(primitive, ())))
+        for primitive, row_keys in API_SUMMARY_ROW_ANCHORS.items()
+        if len(row_keys) != len(LANE_STATUS_ANCHORS_MD.get(primitive, ()))
+    }
+    assert not mismatched, (
+        f"API_SUMMARY_ROW_ANCHORS/LANE_STATUS_ANCHORS_MD count mismatch "
+        f"(primitive -> (row_key_count, md_anchor_count)): {mismatched}"
+    )
+
+
+@pytest.mark.parametrize("primitive,header", sorted(LANE_SECTION_MAP.items()))
+def test_api_summary_status_cell_agrees_with_section_status(
+    primitive, header, matrix_md_sections
+):
+    """Third comparison (issue #586 item 2), alongside json-vs-md-section
+    numeric parity and status polarity: the "## API summary" table's status
+    cell for each mapped (primitive, calculation API) row must agree with
+    the mapped section's designated status block (LANE_STATUS_ANCHORS_MD) on
+    STATUS_TOKENS presence -- row key i paired with anchor i. Catches the
+    demonstrated #584 drift shape: the summary table and the detailed
+    section, hundreds of lines apart in the SAME file, stating different
+    statuses for the same API. The anchor side includes the section header
+    (same semantics as the json-vs-md check): several lanes carry their
+    loudest status marker there."""
+    rows = _api_summary_rows(matrix_md_sections)
+    row_keys = API_SUMMARY_ROW_ANCHORS[primitive]
+    anchor_blocks = _lane_status_blocks_md(
+        matrix_md_sections[header], header, LANE_STATUS_ANCHORS_MD[primitive]
+    )
+    assert len(row_keys) == len(anchor_blocks), (
+        f"{primitive}: {len(row_keys)} summary row key(s) but "
+        f"{len(anchor_blocks)} md status anchor(s) -- must pair 1:1, same order."
+    )
+
+    disagreements = []
+    for row_key, (anchor, block_text) in zip(row_keys, anchor_blocks):
+        matches = [r for r in rows if row_key in f"{r[0]} | {r[1]}"]
+        assert len(matches) == 1, (
+            f"{primitive}: API summary row key {row_key!r} must match exactly "
+            f"one table row; found {len(matches)}. If the table changed, "
+            "update API_SUMMARY_ROW_ANCHORS."
+        )
+        status_cell = matches[0][3].lower()
+        block_lower = block_text.lower()
+        for token in STATUS_TOKENS:
+            in_table = token in status_cell
+            in_section = token in block_lower
+            if in_table != in_section:
+                disagreements.append(
+                    (row_key, anchor, token, "table-only" if in_table else "section-only")
+                )
+
+    assert not disagreements, (
+        f"{primitive}: API-summary-table vs section status token disagreement "
+        f"(row key, md anchor, token, which side has it): {disagreements}"
     )
 
 


### PR DESCRIPTION
Closes #586. Workflow-built + independent adversarial verify (**APPROVE**). The extension found and fixed **eight live drifts on first contact** — exactly the demonstrated failure class the issue filed:

- **3 lanes mapped** (lumped / floquet / mixed): Floquet's section was missing **10 json numeric tokens**; the mixed section lacked dx=63.5 µm, settling −101/−100 dB, and the 0.06 `reciprocity_tol` default. All fixed doc-side from json.
- **API-summary table now gated** (the #584-demonstrated second-copy drift class): fail-loud parser (named header asserted; a silent parse-nothing pass is structurally impossible) + per-row status anchors. First run redded **6 drifts**: three rows missing nonuniform-experimental qualifiers, the coax two-port row carrying another lane's status word, the transition row missing its "genuinely unresolved" clause, and `compute_mixed_s_matrix` having **no summary row at all**.
- **Transition z0_ref advisory** documented in both carriers from the actual `_sparams.py` warning text (registered `impedance=` is NOT the reference impedance of the returned `s_params`; >5% divergence warns).

Added-gate falsifiers run per the strengthened-gate mandate: flipped status cell → red; renamed header column → loud parser failure; reintroduced other-lane wording → red. Parity file `39 passed, 6 skipped`; sibling consumers green (19 + 61); ruff clean.

R3: memory=gate-can-bind-artifact + #303 fail-loud class | R2-attempts=0 | falsifier=three plants, all red

🤖 Generated with [Claude Code](https://claude.com/claude-code)