### PR TITLE
feat(api): explicit soft-source amplitude semantics — add_source(..., amplitude_kind=) (#571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Added — explicit soft-source amplitude semantics: `add_source(..., amplitude_kind=)` (#565/#571)
+
+- `add_source` (and `add_polarized_source`) gain `amplitude_kind='field'|'current'|None`.
+  Explicit kinds are boundary- and mesh-independent: `'current'` = amperes,
+  `E += Cb·I/dV` on every path (the non-uniform path's native Meep-style
+  convention, resolution-independent injected power, and the future default);
+  `'field'` = raw E-field increment `E += w(t)` on every path. With
+  `amplitude_kind='current'` the uniform and non-uniform builders produce
+  EQUAL traces — the boundary-dependent cross-path factor table disappears.
+- `None` (the default) keeps the legacy per-path meaning bit-identically for
+  the deprecation window and emits one `DeprecationWarning` per `Simulation`
+  naming this simulation's concrete legacy meaning (uniform+PEC raw add /
+  uniform+CPML/UPML `Cb`-normalized add / non-uniform current). The
+  open-uniform legacy contract is named by NEITHER kind; its exact migration
+  is waveform amplitude ×`dV` with `amplitude_kind='current'`. Plan:
+  `amplitude_kind` required in 1.8, default `'current'` in 1.9.
+- Conversion lives in one module (`rfx/api/_source_semantics.py`); the
+  source-building helpers declare their native coefficient (`make_source`
+  'raw', `make_j_source` 'cb', `make_current_source` 'cb_over_dv') and
+  dispatch on the Python-level kind — never on a possibly-traced scale value,
+  so `jax.grad` paths are unaffected. 2D grids are treated as one cell deep
+  (`dV = dx·dy·dz_one_cell`).
+- The field is design state, so every serialization surface carries it: the
+  design IR records it on `soft_sources` (schema + registry + round-trip
+  test pinned on the non-default value; a lumped entry carrying a non-None
+  `amplitude_kind` is refused at export since `add_port` cannot set it), and
+  the config CLI accepts an optional `amplitude_kind:` key on `type: source`
+  entries.
+
 ### Fixed — reproducibility-audit corrections (independent clean-room walk-through, 2026-08-09)
 
 - `validation/tmtt_paper/README.md` no longer claims a blanket `SMOKE=1`

--- a/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
+++ b/docs/design_notes/schemas/rfx-design-ir-v1.schema.json
@@ -338,14 +338,15 @@
       "properties": {
         "soft_sources": {
           "type": "array",
-          "description": "add_source() entries. Only the three fields add_source can set are recorded: an impedance-0 entry carrying extent / excite / direction / reference_plane_cells was not built through the public API and is refused at export.",
+          "description": "add_source() entries. Only the four fields add_source can set are recorded: an impedance-0 entry carrying extent / excite / direction / reference_plane_cells was not built through the public API and is refused at export.",
           "items": {
             "type": "object",
             "additionalProperties": false,
             "required": [
               "position",
               "component",
-              "waveform"
+              "waveform",
+              "amplitude_kind"
             ],
             "properties": {
               "position": {
@@ -354,6 +355,13 @@
               "component": {
                 "type": "string",
                 "minLength": 1
+              },
+              "amplitude_kind": {
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "description": "What the waveform amplitude means (issue #571): 'current' (amperes, resolution-independent injected power), 'field' (raw E increment), or null for the deprecated per-path legacy meaning. Required despite the builder default because null is itself a meaning (legacy per-path semantics): a codec that defaulted the field away would silently import a current-normalized design with resolution-dependent injected power. The value fence lives in add_source, not here (two-layer policy)."
               },
               "waveform": {
                 "$ref": "#/$defs/waveform_or_null"

--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -1233,7 +1233,8 @@
         "component",
         "waveform_fn",
         "n_steps",
-        "materials"
+        "materials",
+        "amplitude_kind"
       ]
     },
     "make_nonuniform_grid": {
@@ -1283,7 +1284,9 @@
         "position",
         "component",
         "waveform_fn",
-        "n_steps"
+        "n_steps",
+        "materials",
+        "amplitude_kind"
       ]
     },
     "maximize_bandwidth": {
@@ -2345,7 +2348,8 @@
     "add_polarized_source": [
       "position",
       "polarization",
-      "waveform"
+      "waveform",
+      "amplitude_kind"
     ],
     "add_port": [
       "position",
@@ -2372,7 +2376,8 @@
     "add_source": [
       "position",
       "component",
-      "waveform"
+      "waveform",
+      "amplitude_kind"
     ],
     "add_tfsf_source": [
       "f0",

--- a/docs/public/guide/nonuniform-mesh.mdx
+++ b/docs/public/guide/nonuniform-mesh.mdx
@@ -299,4 +299,11 @@ signatures. Use `make_current_source` when constructing the low-level source
 array directly; the high-level `Simulation` path performs its own source
 registration and scaling.
 
+Soft-source amplitude semantics: on this path the `add_source` waveform is
+natively a **current in amperes** (`E += Cb·I/dV`, resolution-independent
+injected power). Pass `add_source(..., amplitude_kind='current')` to say so
+explicitly — the bare per-path default is deprecated (issue #571), and an
+explicit `amplitude_kind` means the same amplitude on the uniform and
+non-uniform builders.
+
 ---

--- a/docs/public/guide/sources-ports.mdx
+++ b/docs/public/guide/sources-ports.mdx
@@ -103,6 +103,16 @@ sim.add_source(
 
 Use `add_source` for resonance characterization (Harminv) where port loading would suppress the ring-down signal.
 
+What the waveform amplitude *means* is controlled by `amplitude_kind`
+(issue #571): `'current'` — amperes, realized as `E += Cb·I/dV` on every
+path and boundary (resolution-independent injected power, the future
+default) — or `'field'` — a raw E-field increment `E += w(t)`. Omitting it
+keeps a deprecated per-path legacy meaning (raw add on uniform+PEC,
+`Cb`-normalized add on uniform+CPML/UPML, current on non-uniform meshes)
+and emits one `DeprecationWarning` per simulation naming which one applies.
+To migrate an open-boundary uniform script exactly, multiply the waveform
+amplitude by the cell volume `dV` and pass `amplitude_kind='current'`.
+
 ---
 
 ## Polarized source (`add_polarized_source`)

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -785,6 +785,7 @@ class Simulation(
         component: str = "ez",
         *,
         waveform=None,
+        amplitude_kind: str | None = None,
     ) -> "Simulation":
         """Add a soft point source (no impedance loading).
 
@@ -796,77 +797,81 @@ class Simulation(
         content, ~1e-4). This prevents static charge accumulation on PEC
         surfaces.
 
-        .. warning::
-           **The waveform amplitude means different physical quantities on the
-           uniform and non-uniform paths**, so absolute field amplitudes are not
-           comparable between them.
-
-           The invariant: **the non-uniform path divides by the cell volume; the
-           uniform path never does.** On a profiled mesh the amplitude is treated
-           as a CURRENT IN AMPERES and converted as ``E += (dt / eps) * I / dV``
-           for resolution-independent injected power
-           (``rfx.nonuniform.make_current_source``, Meep's convention). On the
-           uniform mesh it is a field quantity, and *which* field quantity is
-           BOUNDARY-DEPENDENT (``rfx/runners/uniform.py``): a closed (PEC) domain
-           takes a raw field add, an open (CPML/UPML) domain goes through
-           ``make_j_source`` and is already ``Cb = dt/eps`` normalized.
-
-           So the cross-path amplitude ratio has two values, both measured at
-           dx = 1 mm on an otherwise identical mesh:
-
-           ===================  =========================  ==================
-           uniform boundary     NU / uniform ratio         at dx = 1 mm
-           ===================  =========================  ==================
-           ``pec`` (closed)     ``dt / (eps0 * dV)``       2.15e8
-           ``cpml`` / ``upml``  ``1 / dV``                 1.00e9
-           ===================  =========================  ==================
-
-           An earlier revision of this warning gave only the PEC factor and
-           stated it unconditionally; on an open domain — rfx's more common case
-           — that is wrong by ``dt/eps0``, a measured 4.64x. Either factor is
-           large enough to look like an instability when a script is ported
-           between paths, which is the reading issue #565 recorded.
-
-           Frequencies, S-parameters (normalized by a reference run) and field
-           ratios are unaffected **in the linear regime**; a Kerr (``chi3``)
-           material makes permittivity depend on ``|E|^2``, so there the absolute
-           drive does reach the phase velocity. Absolute probe traces, field
-           snapshots, flux and NTFF outputs are reported as-is and are affected
-           either way.
-
-           Measured cross-path agreement after removing the applicable factor,
-           all four combinations — the fourth is the one to read:
-
-           ==================  =====================  ====================
-           uniform boundary    ``subpixel_smoothing``  agreement (of scale)
-           ==================  =====================  ====================
-           ``pec``             off                    1.5e-5
-           ``pec``             on                     9.5e-6
-           ``cpml``            off                    1.1e-4
-           ``cpml``            **on**                 **1.98e-2**
-           ==================  =====================  ====================
-
-           **The open-boundary + subpixel case does NOT reduce**: a systematic
-           0.18 % amplitude error and 2 % of the waveform, stable across a 4x
-           record length. That is an open defect (issue #582), not a tolerance —
-           so do not read the three good rows as clearance for subpixel
-           smoothing on an open domain, which is the combination issue #565 was
-           about.
-
-           ``tests/test_nonuniform_uniform_end_to_end_reduction.py`` pins all
-           four (the last as ``xfail(strict=True)``, so it announces itself when
-           fixed). See issue #571 for whether to unify the two source
-           conventions.
-
         Parameters
         ----------
         position : (x, y, z) in metres
         component : "ex", "ey", or "ez"
         waveform : excitation pulse
             (default: ``GaussianPulse(f0=freq_max/2, bandwidth=0.8)``)
+        amplitude_kind : 'field' | 'current' | None
+            What the waveform amplitude MEANS — issue #571. Boundary- and
+            mesh-independent once explicit:
+
+            - ``'current'``: the amplitude is a current I(t) in amperes,
+              realized as ``E += Cb * I / dV`` on every path and boundary
+              (``Cb = (dt/eps)/(1 + sigma*dt/(2*eps))`` at the source cell,
+              ``dV`` = local cell volume). Resolution-independent injected
+              power; Meep's convention; the future default.
+            - ``'field'``: the amplitude is a raw E-field increment per
+              step, ``E += w(t)`` on every path and boundary.
+
+            Cell-volume convention: ``dV = dx * dy * dz`` at the source
+            cell; a 2D grid is treated as ONE CELL DEEP (``dz`` one cell,
+            duck-typed to ``dx``), so ``dV = dx**3`` on a cubic 2D grid,
+            not the per-unit-length ``dx**2``
+            (``rfx/api/_source_semantics.py``).
+
+            .. deprecated:: 1.7
+               ``None`` (the current default) keeps the legacy PER-PATH
+               meaning and emits one :class:`DeprecationWarning` per
+               Simulation naming what it resolves to on this simulation:
+               a CURRENT in amperes on a profiled (non-uniform) mesh
+               (identical to ``'current'``); on the uniform mesh a raw
+               field add for ``pec`` (identical to ``'field'``) or a
+               ``Cb``-normalized add for ``cpml``/``upml`` — which is
+               named by NEITHER kind. Cross-path amplitude ratios
+               ``dt/(eps0*dV)`` (pec) and ``1/dV`` (open), measured
+               2.15e8 and 1.00e9 at dx = 1 mm
+               (``tests/test_nonuniform_uniform_end_to_end_reduction.py``
+               pins both). **Exact migration for the open-uniform legacy
+               contract**: multiply your waveform amplitude by the cell
+               volume ``dV`` and pass ``amplitude_kind='current'`` —
+               algebra ``Cb*(w*dV)/dV == Cb*w``, exact up to one float
+               multiply/divide pair (not bit-identical). From 1.8
+               ``amplitude_kind`` is required; from 1.9 the default
+               becomes ``'current'``.
+
+            Route note (pre-existing, unchanged): the ``forward()``
+            uniform route uses the ``Cb``-normalized helper regardless of
+            boundary, so ``None`` there means the ``Cb`` contract even on
+            ``pec``; explicit kinds behave identically on ``run()`` and
+            ``forward()``.
+
+            The open-boundary + ``subpixel_smoothing`` cross-path residual
+            (0.18 % amplitude, issue #582) is a solver defect independent
+            of this parameter.
         """
         if component not in ("ex", "ey", "ez"):
             raise ValueError(f"component must be ex/ey/ez, got {component!r}")
+        from rfx.api._source_semantics import (
+            validate_amplitude_kind, legacy_kind_description)
+        validate_amplitude_kind(amplitude_kind)
+        if amplitude_kind is None and not getattr(
+                self, "_amplitude_kind_warned", False):
+            self._amplitude_kind_warned = True
+            import warnings
+            _is_nu = (self._dx_profile is not None
+                      or self._dy_profile is not None
+                      or self._dz_profile is not None)
+            warnings.warn(
+                "add_source(..., amplitude_kind=None): on this simulation "
+                "the waveform amplitude is "
+                f"{legacy_kind_description(_is_nu, self._boundary)}. "
+                "This per-path default is deprecated (issue #571): pass "
+                "amplitude_kind='current' (amperes, resolution-independent "
+                "power — the future default) or amplitude_kind='field' (raw "
+                "E increment). amplitude_kind becomes required in 1.8.",
+                DeprecationWarning, stacklevel=2)
         if waveform is None:
             waveform = GaussianPulse(f0=self._freq_max / 2, bandwidth=0.8)
 
@@ -875,6 +880,7 @@ class Simulation(
             position=position, component=component,
             impedance=0.0,  # 0 = no port impedance (soft source)
             waveform=waveform, extent=None,
+            amplitude_kind=amplitude_kind,
         ))
         return self
 
@@ -884,6 +890,7 @@ class Simulation(
         *,
         polarization: str | tuple = "ez",
         waveform=None,
+        amplitude_kind: str | None = None,
     ) -> "Simulation":
         """Add a polarized point source.
 
@@ -899,13 +906,18 @@ class Simulation(
               the documented linear-polarization scope
             - "slant45" — 45° linear (Ex = Ey)
         waveform : excitation pulse (default: GaussianPulse)
+        amplitude_kind : 'field' | 'current' | None
+            Threaded through to every internal :meth:`add_source` call —
+            see ``add_source`` for the semantics and the ``None``
+            deprecation (issue #571).
         """
         if waveform is None:
             waveform = GaussianPulse(f0=self._freq_max / 2, bandwidth=0.8)
 
         if isinstance(polarization, str):
             if polarization in ("ex", "ey", "ez"):
-                self.add_source(position, polarization, waveform=waveform)
+                self.add_source(position, polarization, waveform=waveform,
+                                amplitude_kind=amplitude_kind)
                 return self
             pol_map = {
                 "circular": (1.0, 1j),
@@ -940,13 +952,15 @@ class Simulation(
                 wx = GP(f0=waveform.f0, bandwidth=waveform.bandwidth,
                         amplitude=waveform.amplitude * float(jx.real),
                         cutoff=getattr(waveform, 'cutoff', 3.0))
-                self.add_source(position, "ex", waveform=wx)
+                self.add_source(position, "ex", waveform=wx,
+                                amplitude_kind=amplitude_kind)
             if abs(float(jy.real)) > 1e-10:
                 from rfx.sources.sources import GaussianPulse as GP
                 wy = GP(f0=waveform.f0, bandwidth=waveform.bandwidth,
                         amplitude=waveform.amplitude * float(jy.real),
                         cutoff=getattr(waveform, 'cutoff', 3.0))
-                self.add_source(position, "ey", waveform=wy)
+                self.add_source(position, "ey", waveform=wy,
+                                amplitude_kind=amplitude_kind)
         else:
             # Complex Jones — build carrier-modulated components.
             from rfx.sources.sources import ModulatedGaussian as MG
@@ -954,7 +968,8 @@ class Simulation(
             if abs(jx) > 1e-10:
                 wx = MG(f0=waveform.f0, bandwidth=waveform.bandwidth,
                         amplitude=waveform.amplitude * float(abs(jx)))
-                self.add_source(position, "ex", waveform=wx)
+                self.add_source(position, "ex", waveform=wx,
+                                amplitude_kind=amplitude_kind)
             # Ey component (90° phase shift for circular)
             if abs(jy) > 1e-10:
                 # Phase of jy relative to jx
@@ -970,7 +985,8 @@ class Simulation(
                     envelope = _jnp.exp(-((t - t0) / tau)**2)
                     carrier = _jnp.cos(2.0 * _jnp.pi * waveform.f0 * t + float(phase))
                     return amp_y * carrier * envelope
-                self.add_source(position, "ey", waveform=CustomWaveform(func=_ey_func))
+                self.add_source(position, "ey", waveform=CustomWaveform(func=_ey_func),
+                                amplitude_kind=amplitude_kind)
 
         return self
 

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -970,9 +970,13 @@ class _ExecuteMixin:
         for pe in self._ports:
             if pe.impedance == 0.0:
                 from rfx.simulation import make_j_source
+                # forward() uniform route: Cb-normalized helper regardless
+                # of boundary (pre-existing). amplitude_kind (issue #571)
+                # rescales inside the helper; None = legacy bit-identical.
                 sources.append(
                     make_j_source(grid, pe.position, pe.component,
-                                  pe.waveform, n_steps, materials)
+                                  pe.waveform, n_steps, materials,
+                                  amplitude_kind=pe.amplitude_kind)
                 )
                 continue
 
@@ -2040,7 +2044,7 @@ class _ExecuteMixin:
             # both for the source-cell normalisation).
             si, sj, sk, sc, wf = _nu_make_current_source(
                 grid, idx, pe.component, pe.waveform, n_steps,
-                materials_concrete,
+                materials_concrete, amplitude_kind=pe.amplitude_kind,
             )
             sources.append(SourceSpec(
                 i=int(si), j=int(sj), k=int(sk),

--- a/rfx/api/_source_semantics.py
+++ b/rfx/api/_source_semantics.py
@@ -1,0 +1,147 @@
+"""Single home for soft-source amplitude semantics (issue #571, option 4).
+
+Two named, boundary- and mesh-INDEPENDENT amplitude kinds:
+
+``'current'``
+    The waveform is a current I(t) in amperes; realized as
+    ``E += Cb * I / dV`` on every path and boundary
+    (``Cb = (dt/eps) / (1 + sigma*dt/(2*eps))``; ``dV`` = local cell
+    volume). This is the non-uniform path's native convention
+    (Meep-style, resolution-independent injected power) and the future
+    default.
+
+``'field'``
+    The waveform is a raw E-field increment per step; realized as
+    ``E += w(t)`` on every path and boundary. This is the uniform-PEC
+    path's native convention.
+
+The three LEGACY (``amplitude_kind=None``) contracts map onto these exactly:
+
+====================  ====================  =====================================
+path                  legacy native coeff   exact explicit spelling
+====================  ====================  =====================================
+NU (any boundary)     ``Cb/dV`` (current)   ``amplitude_kind='current'``, waveform
+                                            unchanged
+uniform + pec         ``1`` (field)         ``amplitude_kind='field'``, waveform
+                                            unchanged
+uniform + cpml/upml   ``Cb`` (NEITHER —     ``amplitude_kind='current'`` with the
+                      third contract)       waveform amplitude multiplied by dV
+                                            (``Cb*(w*dV)/dV == Cb*w``; exact up to
+                                            one float multiply/divide pair)
+====================  ====================  =====================================
+
+The conversion FORMULA lives here and nowhere else. The source-building
+helpers (``rfx.simulation.make_source`` — native ``'raw'``,
+``rfx.simulation.make_j_source`` — native ``'cb'``,
+``rfx.nonuniform.make_current_source`` — native ``'cb_over_dv'``) each
+declare their native coefficient and, when :func:`needs_scale` says a
+conversion applies, multiply the waveform by
+:func:`source_amplitude_scale`. ``kind=None`` or a kind matching the
+native convention skips the multiply entirely, keeping legacy output
+bit-identical during the deprecation window.
+
+Tracer safety (issue #571 dossier): whether to apply the multiply is
+decided by :func:`needs_scale` on the PYTHON-LEVEL ``(kind, native)``
+string pair — never by comparing the scale VALUE, which may be a JAX
+tracer (``cb``/``dV`` are traced on the differentiable-materials /
+mesh-as-design-variable paths and ``scale != 1.0`` would raise
+``ConcretizationTypeError`` there).
+
+2D-grid convention: a 2D grid is treated as ONE CELL DEEP, so
+``dV = dx * dy * dz_one_cell`` with the missing axes duck-typed to
+``dx`` (``getattr(grid, 'dy', dx)`` pattern, repo engineering
+principle 3) — i.e. ``dV = dx**3`` on a cubic 2D grid, not the
+per-unit-length ``dx**2``.
+"""
+
+from __future__ import annotations
+
+SOURCE_AMPLITUDE_KINDS = ("field", "current")
+
+# Native waveform coefficient of each helper, i.e. what multiplies w(t) in
+# the E update when the helper is fed the waveform unscaled:
+#   'raw'        E += w              (rfx.simulation.make_source)
+#   'cb'         E += Cb * w         (rfx.simulation.make_j_source)
+#   'cb_over_dv' E += Cb * w / dV    (rfx.nonuniform.make_current_source)
+_NATIVES = ("raw", "cb", "cb_over_dv")
+
+# Which named kind each native coefficient already realizes. 'cb' realizes
+# NEITHER kind — it is the legacy open-uniform third contract, reachable
+# only through amplitude_kind=None during the deprecation window.
+_NATIVE_REALIZES = {"raw": "field", "cb": None, "cb_over_dv": "current"}
+
+
+def validate_amplitude_kind(kind) -> None:
+    """Raise ValueError unless ``kind`` is 'field', 'current' or None."""
+    if kind is not None and kind not in SOURCE_AMPLITUDE_KINDS:
+        raise ValueError(
+            f"amplitude_kind must be 'field', 'current' or None, got {kind!r}")
+
+
+def needs_scale(kind, native) -> bool:
+    """Python-level dispatch: does ``kind`` require rescaling ``native``?
+
+    Decides on the ``(kind, native)`` STRING pair only. Callers must gate
+    the waveform multiply on this predicate rather than on the scale value,
+    which may be a JAX tracer (see module docstring, tracer safety).
+    Returns False for ``kind=None`` (legacy: bit-identical no-op) and for a
+    kind the native coefficient already realizes.
+    """
+    if native not in _NATIVES:
+        raise ValueError(f"unknown native coefficient {native!r}")
+    if kind is None:
+        return False
+    validate_amplitude_kind(kind)
+    return _NATIVE_REALIZES[native] != kind
+
+
+def source_amplitude_scale(kind, native, *, cb, dV):
+    """Scalar ``s`` such that <native helper>(s * w) realizes kind ``kind``.
+
+    Parameters
+    ----------
+    kind : 'field' | 'current' | None
+        Requested amplitude semantics. None = legacy = the helper's native
+        convention; returns exactly 1.0.
+    native : 'raw' | 'cb' | 'cb_over_dv'
+        The calling helper's native waveform coefficient (module table).
+    cb : float or jnp scalar
+        ``(dt/eps)/(1 + sigma*dt/(2*eps))`` at the source cell — computed
+        by the CALLER with its existing (tracer-safe) eps/sigma handling,
+        so this module never touches materials and stays jax-agnostic.
+    dV : float or jnp scalar
+        Local cell volume at the source cell (``dx*dy*dz``; one cell deep
+        on 2D grids — module docstring).
+
+    Returns
+    -------
+    Exactly ``1.0`` when :func:`needs_scale` is False (bit-identity
+    guarantee for the deprecation window); otherwise the target/native
+    coefficient ratio: ``field<-cb: 1/Cb``, ``field<-cb_over_dv: dV/Cb``,
+    ``current<-raw: Cb/dV``, ``current<-cb: 1/dV``.
+    """
+    if not needs_scale(kind, native):
+        return 1.0
+    if kind == "field":
+        # native 'cb': 1/Cb;  native 'cb_over_dv': dV/Cb
+        return (1.0 / cb) if native == "cb" else (dV / cb)
+    # kind == 'current': native 'raw': Cb/dV;  native 'cb': 1/dV
+    return (cb / dV) if native == "raw" else (1.0 / dV)
+
+
+def legacy_kind_description(is_nonuniform: bool, boundary: str) -> str:
+    """One-line concrete statement of what ``amplitude_kind=None`` means for
+    THIS simulation's ``run()`` path — used verbatim in the ``add_source``
+    DeprecationWarning. (The ``forward()`` uniform route always uses the
+    Cb-normalized helper regardless of boundary — pre-existing route
+    difference, documented at ``add_source``.)"""
+    if is_nonuniform:
+        return ("a CURRENT in amperes (E += Cb*I/dV; identical to "
+                "amplitude_kind='current')")
+    if boundary in ("cpml", "upml"):
+        return ("a Cb-normalized field add (E += Cb*w; NOT one of the two "
+                "named kinds — to keep today's numbers, multiply your "
+                "waveform amplitude by the cell volume dV and pass "
+                "amplitude_kind='current')")
+    return ("a raw field increment (E += w; identical to "
+            "amplitude_kind='field')")

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -1087,6 +1087,13 @@ class _PortEntry:
     # behaviour, byte-identical. Diagonal S_jj always stays on the legacy
     # path either way.
     reference_plane_cells: int | None = None
+    # Soft-source amplitude semantics (issue #571, option 4):
+    # 'field' | 'current' | None (= legacy per-path default, deprecated).
+    # Only meaningful when impedance == 0.0 (add_source soft sources); port
+    # entries (impedance > 0) keep their own port-normalized waveform
+    # contract and never set this. Defaulted so every non-add_source
+    # _PortEntry construction site is untouched.
+    amplitude_kind: str | None = None
 
 
 @dataclass(frozen=True)

--- a/rfx/config/loader.py
+++ b/rfx/config/loader.py
@@ -206,12 +206,20 @@ def _add_sources(sim: Simulation, sources_cfg) -> None:
         waveform = waveform_from_config(waveform_cfg) if waveform_cfg else None
 
         if stype == "source":
-            extra = set(entry) - {"type", "position", "component", "waveform"}
+            extra = set(entry) - {
+                "type", "position", "component", "waveform", "amplitude_kind",
+            }
             if extra:
                 raise KeyError(
                     f"{ctx}: soft source got unsupported key(s) {sorted(extra)}"
                 )
-            sim.add_source(position, component, waveform=waveform)
+            amplitude_kind = entry.get("amplitude_kind")
+            if amplitude_kind is not None:
+                amplitude_kind = str(amplitude_kind)
+            sim.add_source(
+                position, component, waveform=waveform,
+                amplitude_kind=amplitude_kind,
+            )
             continue
 
         # Lumped port.

--- a/rfx/diagnostics.py
+++ b/rfx/diagnostics.py
@@ -246,6 +246,7 @@ def _check_smoke(report: _Report) -> None:
             (0.01, 0.01, 0.01),
             "ez",
             waveform=GaussianPulse(f0=5e9, bandwidth=0.8),
+            amplitude_kind="field",
         )
         sim.add_probe((0.012, 0.01, 0.01), "ez")
 

--- a/rfx/gpu.py
+++ b/rfx/gpu.py
@@ -77,11 +77,17 @@ def benchmark(
 
         pulse = GaussianPulse(f0=5e9)
         center = tuple(s * dx / 2 for s in shape)
-        src = make_source(grid, center, "ez", pulse, n_steps)
+        # issue #571: benchmark drive is explicitly a raw field add —
+        # 'field' is make_source's native kind (bit-identical no-op), and
+        # being explicit insulates the benchmark from the deprecation-window
+        # default changes.
+        src = make_source(grid, center, "ez", pulse, n_steps,
+                          materials=materials, amplitude_kind="field")
         prb = make_probe(grid, center, "ez")
 
         # Warm up JIT (separate short source to match step count)
-        warmup_src = make_source(grid, center, "ez", pulse, 10)
+        warmup_src = make_source(grid, center, "ez", pulse, 10,
+                                 materials=materials, amplitude_kind="field")
         _ = run(grid, materials, 10, sources=[warmup_src], probes=[prb])
 
         # Timed run

--- a/rfx/interop/_design.py
+++ b/rfx/interop/_design.py
@@ -494,6 +494,10 @@ _SOFT_SOURCE_FIELDS: dict[str, _F] = {
     "position": _vec(3),
     "component": _STR,
     "waveform": _WAVEFORM,
+    # issue #571 option 4: recorded so a design document round-trips the
+    # explicit amplitude semantics; None round-trips as the legacy per-path
+    # meaning (and correctly re-emits the deprecation warning on load).
+    "amplitude_kind": _opt(_STR),
 }
 
 _LUMPED_PORT_FIELDS: dict[str, _F] = {
@@ -1005,7 +1009,10 @@ def _dump_ports(sim: Any) -> tuple[list[dict], list[dict]]:
     never has to re-derive the intent from a sentinel.
     """
     live = set(live_field_names(_PortEntry))
-    unrecorded = live - set(_LUMPED_PORT_FIELDS)
+    # _PortEntry is shared by both families; a field is recorded if EITHER
+    # family's registry knows it (amplitude_kind is soft-source-only — the
+    # lumped branch below refuses a non-None value it cannot rebuild).
+    unrecorded = live - set(_LUMPED_PORT_FIELDS) - set(_SOFT_SOURCE_FIELDS)
     if unrecorded:
         raise _refuse(
             f"_PortEntry carries fields the design document does not record: "
@@ -1038,6 +1045,13 @@ def _dump_ports(sim: Any) -> tuple[list[dict], list[dict]]:
                 }
             )
         else:
+            if getattr(entry, "amplitude_kind", None) is not None:
+                raise _refuse(
+                    f"{what} is a lumped port but carries amplitude_kind="
+                    f"{entry.amplitude_kind!r}; add_port() cannot set that "
+                    f"field, so the entry was not built through the public "
+                    f"API and cannot be rebuilt through it"
+                )
             lumped.append(
                 {
                     name: field.dump(getattr(entry, name), f"{what}.{name}")
@@ -1743,7 +1757,8 @@ def simulation_from_design(document: Any) -> Any:
             what=f"excitations.soft_sources[{index}]",
         )
         sim.add_source(
-            values["position"], values["component"], waveform=values["waveform"]
+            values["position"], values["component"], waveform=values["waveform"],
+            amplitude_kind=values["amplitude_kind"],
         )
 
     for index, payload in enumerate(

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -539,7 +539,7 @@ def make_z_profile(
 
 
 def make_current_source(grid: NonUniformGrid, position_ijk, component,
-                        waveform_fn, n_steps, materials):
+                        waveform_fn, n_steps, materials, amplitude_kind=None):
     """Create a properly normalized current source for non-uniform grid.
 
     The waveform specifies CURRENT (Amperes). The E-field addition is:
@@ -548,6 +548,14 @@ def make_current_source(grid: NonUniformGrid, position_ijk, component,
 
     This gives resolution-independent injected POWER regardless of cell size.
     Same approach as Meep's internal source normalization.
+
+    Native amplitude convention (issue #571): ``'current'`` —
+    ``amplitude_kind`` of None or ``'current'`` is bit-identical to the
+    historical output (no extra multiply). ``amplitude_kind='field'``
+    rescales by ``dV/Cb`` via
+    ``rfx.api._source_semantics.source_amplitude_scale``, computed AFTER
+    the tracer-safe cb/dV resolution below so the GEO-C3
+    differentiable-material path is preserved unchanged.
     """
     import jax
     i, j, k = position_ijk
@@ -592,6 +600,15 @@ def make_current_source(grid: NonUniformGrid, position_ijk, component,
     # This ensures power = ∫(J·E)dV is independent of cell size
     times = jnp.arange(n_steps, dtype=jnp.float32) * grid.dt
     waveform = (cb / dV) * jax.vmap(waveform_fn)(times)
+
+    from rfx.api._source_semantics import needs_scale, source_amplitude_scale
+    if needs_scale(amplitude_kind, "cb_over_dv"):
+        # only 'field' lands here (scale dV/Cb). Python-level dispatch on
+        # the kind string (issue #571 dossier): cb/dV may be tracers on
+        # the GEO-C3 / mesh-as-design-variable paths, so never gate the
+        # multiply on the scale VALUE.
+        waveform = source_amplitude_scale(
+            amplitude_kind, "cb_over_dv", cb=cb, dV=dV) * waveform
 
     waveform_out = waveform if any_traced else np.array(waveform)
     return (i, j, k, component, waveform_out)

--- a/rfx/runners/distributed.py
+++ b/rfx/runners/distributed.py
@@ -1343,12 +1343,16 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
             materials = setup_lumped_port(grid, lp, materials)
             sources.append(make_port_source(grid, lp, materials, n_steps))
         elif pe.impedance == 0.0:
+            # issue #571: thread amplitude_kind; helper stays boundary-selected.
             if sim._boundary == "cpml":
                 sources.append(make_j_source(grid, pe.position, pe.component,
-                                             pe.waveform, n_steps, materials))
+                                             pe.waveform, n_steps, materials,
+                                             amplitude_kind=pe.amplitude_kind))
             else:
                 sources.append(make_source(grid, pe.position, pe.component,
-                                           pe.waveform, n_steps))
+                                           pe.waveform, n_steps,
+                                           materials=materials,
+                                           amplitude_kind=pe.amplitude_kind))
     for pe in sim._probes:
         probes.append(make_probe(grid, pe.position, pe.component))
 

--- a/rfx/runners/distributed_v2.py
+++ b/rfx/runners/distributed_v2.py
@@ -740,7 +740,8 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
             if pe.impedance == 0.0:
                 idx = _nu_pos_to_idx(grid, pe.position)
                 si, sj, sk, sc, wf = _nu_make_current_source(
-                    grid, idx, pe.component, pe.waveform, n_steps, materials)
+                    grid, idx, pe.component, pe.waveform, n_steps, materials,
+                    amplitude_kind=pe.amplitude_kind)
                 sources.append(SourceSpec(
                     i=int(si), j=int(sj), k=int(sk),
                     component=sc, waveform=jnp.asarray(wf),
@@ -761,12 +762,16 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
                 materials = setup_lumped_port(grid, lp, materials)
                 sources.append(make_port_source(grid, lp, materials, n_steps))
             elif pe.impedance == 0.0:
+                # issue #571: thread amplitude_kind; helper stays boundary-selected.
                 if sim._boundary == "cpml":
                     sources.append(make_j_source(grid, pe.position, pe.component,
-                                                 pe.waveform, n_steps, materials))
+                                                 pe.waveform, n_steps, materials,
+                                                 amplitude_kind=pe.amplitude_kind))
                 else:
                     sources.append(make_source(grid, pe.position, pe.component,
-                                               pe.waveform, n_steps))
+                                               pe.waveform, n_steps,
+                                               materials=materials,
+                                               amplitude_kind=pe.amplitude_kind))
         for pe in sim._probes:
             probes.append(make_probe(grid, pe.position, pe.component))
 

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -592,9 +592,11 @@ def run_nonuniform_path(sim, *, n_steps, compute_s_params=None, s_param_freqs=No
     for pe in sim._ports:
         idx = pos_to_nu_index(grid, pe.position)
         if pe.impedance == 0.0:
-            # Current source with dV normalization
+            # Current source with dV normalization; amplitude_kind (issue
+            # #571) threaded — None/'current' are bit-identical no-ops here.
             src = make_current_source(
-                grid, idx, pe.component, pe.waveform, sizing_n, materials_concrete)
+                grid, idx, pe.component, pe.waveform, sizing_n,
+                materials_concrete, amplitude_kind=pe.amplitude_kind)
             sources.append(src)
         elif pe.extent is not None:
             # Wire port on non-uniform grid

--- a/rfx/runners/subgridded.py
+++ b/rfx/runners/subgridded.py
@@ -353,17 +353,30 @@ def _run_subgridded_once(
             # Soft source — normalization depends on boundary type:
             # PEC: raw field add (matches make_source in uniform runner)
             # CPML/UPML: J-source Cb normalized (matches make_j_source)
+            # amplitude_kind (issue #571) rides on top: the native
+            # coefficient stays boundary-selected exactly as before; an
+            # explicit kind only rescales the waveform. kind=None is the
+            # legacy bit-identical no-op (needs_scale dispatches on the
+            # Python-level kind string — never on a scale value).
+            from rfx.api._source_semantics import (
+                needs_scale, source_amplitude_scale)
             idx = _pos_to_fine_idx(pe.position)
             i, j, k = idx
             raw_waveform = jax.vmap(pe.waveform)(times)
-            if sim._boundary in ("cpml", "upml"):
+            native = "cb" if sim._boundary in ("cpml", "upml") else "raw"
+            if native == "cb" or needs_scale(pe.amplitude_kind, native):
                 eps = float(mats_f.eps_r[i, j, k]) * EPS_0
                 sigma_val = float(mats_f.sigma[i, j, k])
                 loss = sigma_val * dt / (2.0 * eps)
                 cb = (dt / eps) / (1.0 + loss)
-                waveform = cb * raw_waveform
             else:
-                waveform = raw_waveform
+                cb = None  # not needed on the raw no-conversion path
+            waveform = cb * raw_waveform if native == "cb" else raw_waveform
+            if needs_scale(pe.amplitude_kind, native):
+                # dV on the fine grid: cubic cells, one cell deep is moot
+                # (3D); dx_f**3 = dx*dy*dz duck convention (#571).
+                waveform = source_amplitude_scale(
+                    pe.amplitude_kind, native, cb=cb, dV=dx_f ** 3) * waveform
             sources_f.append(
                 (
                     i,

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -311,12 +311,19 @@ def run_uniform(
             # Auto-select source type based on boundary conditions:
             # - CPML (open): Cb/dx normalized (prevents DC on PEC surface)
             # - PEC (closed): raw field add (broadband, exact cavity modes)
+            # amplitude_kind (issue #571) rides on top: the helper stays
+            # boundary-selected (its native numerics are deliberate); the
+            # KIND only rescales the waveform inside the helper. kind=None
+            # threads through as a no-op (legacy, bit-identical).
             if sim._boundary in ("cpml", "upml"):
                 sources.append(make_j_source(grid, pe.position, pe.component,
-                                             pe.waveform, n_steps, materials))
+                                             pe.waveform, n_steps, materials,
+                                             amplitude_kind=pe.amplitude_kind))
             else:
                 sources.append(make_source(grid, pe.position, pe.component,
-                                           pe.waveform, n_steps))
+                                           pe.waveform, n_steps,
+                                           materials=materials,
+                                           amplitude_kind=pe.amplitude_kind))
             continue
         if pe.extent is not None:
             # Multi-cell wire port

--- a/rfx/simulation.py
+++ b/rfx/simulation.py
@@ -174,20 +174,66 @@ class SimResult(NamedTuple):
 # Helpers to build source / probe specs
 # ---------------------------------------------------------------------------
 
-def make_source(grid: Grid, position, component, waveform_fn, n_steps):
+def _source_cell_cb(grid: Grid, idx, materials):
+    """Cb = (dt/eps)/(1 + sigma*dt/(2*eps)) at the source cell.
+
+    Single spelling of the coefficient shared by ``make_source`` and
+    ``make_j_source`` (same expression, same operation order, so the
+    ``make_j_source`` output stays bit-identical to its historical value).
+    ``materials.eps_r``/``sigma`` may be JAX tracers (forward/AD path) —
+    no ``float()`` here.
+    """
+    i, j, k = idx
+    eps = materials.eps_r[i, j, k] * EPS_0
+    sigma = materials.sigma[i, j, k]
+    loss = sigma * grid.dt / (2.0 * eps)
+    return (grid.dt / eps) / (1.0 + loss)
+
+
+def _uniform_cell_volume(grid: Grid) -> float:
+    """dV = dx*dy*dz with missing axes duck-typed to dx (engineering
+    principle 3). A 2D grid is treated as ONE CELL DEEP (dz -> dx), so
+    dV = dx**3 there too — the documented #571 convention
+    (``rfx/api/_source_semantics.py``), not per-unit-length dx**2."""
+    return grid.dx * getattr(grid, "dy", grid.dx) * getattr(grid, "dz", grid.dx)
+
+
+def make_source(grid: Grid, position, component, waveform_fn, n_steps,
+                materials=None, amplitude_kind=None):
     """Create a SourceSpec by precomputing a waveform function (raw E-field add).
 
     WARNING: raw field source causes DC accumulation on PEC surfaces.
     Prefer ``make_j_source`` for resonance detection.
+
+    Native amplitude convention (issue #571): ``'field'`` — ``E += w``.
+    ``amplitude_kind='current'`` rescales the waveform by ``Cb/dV`` via
+    ``rfx.api._source_semantics.source_amplitude_scale`` and REQUIRES
+    ``materials`` (for Cb at the source cell). ``amplitude_kind`` of
+    None or ``'field'`` is bit-identical to the historical output (no
+    multiply is applied at all). ``materials`` is accepted and unused in
+    that legacy/native case.
     """
+    from rfx.api._source_semantics import needs_scale, source_amplitude_scale
     idx = grid.position_to_index(position)
     times = jnp.arange(n_steps, dtype=jnp.float32) * grid.dt
     waveform = jax.vmap(waveform_fn)(times)
+    if needs_scale(amplitude_kind, "raw"):
+        # only 'current' lands here
+        if materials is None:
+            raise ValueError(
+                "make_source(amplitude_kind='current') needs materials "
+                "for the Cb normalization at the source cell")
+        scale = source_amplitude_scale(
+            amplitude_kind, "raw",
+            cb=_source_cell_cb(grid, idx, materials),
+            dV=_uniform_cell_volume(grid))
+        waveform = scale * waveform
     return SourceSpec(i=idx[0], j=idx[1], k=idx[2],
                       component=component, waveform=waveform)
 
 
-def make_j_source(grid: Grid, position, component, waveform_fn, n_steps, materials):
+def make_j_source(grid: Grid, position, component, waveform_fn, n_steps, materials,
+                  amplitude_kind=None):
     """Create a SourceSpec using current density injection (J source).
 
     Unlike ``make_source``, the waveform is Cb-normalized so that
@@ -197,10 +243,17 @@ def make_j_source(grid: Grid, position, component, waveform_fn, n_steps, materia
 
     where Cb = dt / (eps * (1 + sigma*dt/2eps)).
 
-    Note: this is a soft *field* source, not a current-density
-    source.  Injected amplitude depends on local material (eps, sigma)
-    but NOT on cell size.  Power coupling varies with resolution;
-    use Harminv/FFT for mode extraction rather than absolute amplitude.
+    Note (scoped to ``amplitude_kind=None``): this is a soft *field*
+    source, not a current-density source. Injected amplitude depends on
+    local material (eps, sigma) but NOT on cell size. Power coupling
+    varies with resolution; use Harminv/FFT for mode extraction rather
+    than absolute amplitude.
+
+    Native amplitude convention (issue #571): ``'cb'`` — ``E += Cb*w`` —
+    which is NEITHER named kind (the legacy open-uniform third contract).
+    ``amplitude_kind='current'`` rescales by ``1/dV``, ``'field'`` by
+    ``1/Cb``, both via ``rfx.api._source_semantics.source_amplitude_scale``.
+    None is bit-identical to the historical output (no multiply applied).
 
     Parameters
     ----------
@@ -210,13 +263,12 @@ def make_j_source(grid: Grid, position, component, waveform_fn, n_steps, materia
     waveform_fn : callable(t) -> value
     n_steps : int
     materials : MaterialArrays (for Cb computation at source cell)
+    amplitude_kind : 'field' | 'current' | None (issue #571, above)
     """
+    from rfx.api._source_semantics import needs_scale, source_amplitude_scale
     idx = grid.position_to_index(position)
     i, j, k = idx
-    eps = materials.eps_r[i, j, k] * EPS_0
-    sigma = materials.sigma[i, j, k]
-    loss = sigma * grid.dt / (2.0 * eps)
-    cb = (grid.dt / eps) / (1.0 + loss)
+    cb = _source_cell_cb(grid, idx, materials)
 
     times = jnp.arange(n_steps, dtype=jnp.float32) * grid.dt
     # Cb normalization: the source enters the update equation through
@@ -226,6 +278,13 @@ def make_j_source(grid: Grid, position, component, waveform_fn, n_steps, materia
     # Power scales as Cb²·dx³ — weaker at fine grids, but Harminv
     # with bandpass filtering reliably extracts modes at all resolutions.
     waveform = cb * jax.vmap(waveform_fn)(times)
+    if needs_scale(amplitude_kind, "cb"):
+        # Python-level dispatch (issue #571 dossier): the scale may be a
+        # tracer ('field' -> 1/Cb with traced materials), so never gate
+        # the multiply on its value.
+        waveform = source_amplitude_scale(
+            amplitude_kind, "cb", cb=cb,
+            dV=_uniform_cell_volume(grid)) * waveform
     return SourceSpec(i=i, j=j, k=k,
                       component=component, waveform=waveform)
 

--- a/rfx/vmap_sweep.py
+++ b/rfx/vmap_sweep.py
@@ -238,7 +238,8 @@ def _build_vmap_scan_fn(
         CPML H/E sub-steps are applied; J-source waveforms are Cb-normalized
         per batch element from the actual material arrays.
     j_source_raw_info : list of (i, j, k, component, raw_waveform)
-        Only used when ``use_cpml``.  Raw (un-Cb-normalized) J-source
+        Populated for legacy CPML J-sources AND for ``amplitude_kind='current'``
+        soft sources on any boundary.  Raw (un-Cb-normalized) J-source
         waveforms + cell indices so Cb can be computed dynamically inside the
         vmapped function from the actual material arrays.
     """
@@ -263,7 +264,8 @@ def _build_vmap_scan_fn(
     prb_meta = [(p.i, p.j, p.k, p.component) for p in probes]
 
     # J-source metadata: cell indices + component + raw (un-Cb-normalized)
-    # waveforms.  Only populated on the CPML path.
+    # waveforms.  Populated for legacy CPML J-sources and for
+    # amplitude_kind='current' soft sources on any boundary.
     j_src_meta = [(i, j, k, comp) for i, j, k, comp, _ in j_source_raw_info]
     if j_source_raw_info:
         j_src_raw_waveforms = jnp.stack(
@@ -343,7 +345,8 @@ def _build_vmap_scan_fn(
                 field = field.at[si, sj, sk].add(src_vals[idx_s])
                 st = st._replace(**{sc: field})
 
-            # J-sources (Cb-normalized, material-dependent); CPML path only
+            # J-sources (Cb-normalized, material-dependent): legacy cpml
+            # route, plus amplitude_kind='current' on any boundary (#571)
             for idx_j, (si, sj, sk, sc) in enumerate(j_src_meta):
                 field = getattr(st, sc)
                 field = field.at[si, sj, sk].add(j_src_vals[idx_j])
@@ -432,11 +435,34 @@ def _build_full_scan_fn(
 
     for pe in sim._ports:
         if pe.impedance == 0.0:
-            if boundary == "cpml":
+            # amplitude_kind (issue #571) routing:
+            #   None      -> legacy per-boundary routing, bit-identical
+            #               (cpml: dynamic-Cb J-source; else raw make_source)
+            #   'field'   -> raw make_source on EVERY boundary (E += w has
+            #               no material dependence, so no dynamic path)
+            #   'current' -> dynamic-Cb J-source on EVERY boundary, with the
+            #               raw waveform prescaled by the static 1/dV part
+            #               (Cb is material-dependent and varies per sweep
+            #               element, so it stays dynamic; dV is geometry)
+            if pe.amplitude_kind == "field":
+                sources.append(make_source(grid, pe.position, pe.component,
+                                           pe.waveform, n_steps))
+            elif pe.amplitude_kind == "current" or (
+                    pe.amplitude_kind is None and boundary == "cpml"):
                 # Store raw waveform + cell info for dynamic Cb computation
                 idx = grid.position_to_index(pe.position)
                 times = jnp.arange(n_steps, dtype=jnp.float32) * grid.dt
                 raw_waveform = jax.vmap(pe.waveform)(times)
+                if pe.amplitude_kind == "current":
+                    from rfx.api._source_semantics import (
+                        source_amplitude_scale)
+                    from rfx.simulation import _uniform_cell_volume
+                    # 'current' <- 'cb': static 1/dV (cb unused on this
+                    # branch); the dynamic per-batch Cb multiply below in
+                    # _build_vmap_scan_fn completes Cb*w/dV.
+                    raw_waveform = source_amplitude_scale(
+                        "current", "cb", cb=None,
+                        dV=_uniform_cell_volume(grid)) * raw_waveform
                 j_source_raw_info.append(
                     (idx[0], idx[1], idx[2], pe.component, raw_waveform)
                 )
@@ -485,6 +511,11 @@ def _build_full_scan_fn(
                 grid, n_steps,
                 use_cpml=False,
                 sources=sources,
+                # non-empty only for amplitude_kind='current' soft sources
+                # on a non-cpml boundary (issue #571): their Cb is material-
+                # dependent and must be computed dynamically per sweep
+                # element, exactly like the legacy cpml J-source path.
+                j_source_raw_info=j_source_raw_info,
                 probes=probes,
                 periodic=periodic,
                 pec_axes=pec_axes,

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -268,6 +268,39 @@ def test_missing_required_key_raises():
         simulation_from_dict({"domain": {"x": 0.01, "y": 0.01, "z": 0.01}})
 
 
+def test_soft_source_amplitude_kind_passthrough():
+    cfg = {
+        "frequency": {"freq_max": 1e10},
+        "domain": {"x": 0.01, "y": 0.01, "z": 0.01},
+        "boundary": "pec",
+        "dx": 0.001,
+        "sources": [
+            {"type": "source", "position": [0.005, 0.005, 0.005],
+             "component": "ez", "amplitude_kind": "current",
+             "waveform": {"type": "gaussian_pulse", "f0": 5e9}},
+        ],
+    }
+    sim = simulation_from_dict(cfg)
+    assert sim._ports[0].amplitude_kind == "current"
+
+
+def test_soft_source_without_amplitude_kind_stays_legacy():
+    cfg = {
+        "frequency": {"freq_max": 1e10},
+        "domain": {"x": 0.01, "y": 0.01, "z": 0.01},
+        "boundary": "pec",
+        "dx": 0.001,
+        "sources": [
+            {"type": "source", "position": [0.005, 0.005, 0.005],
+             "component": "ez",
+             "waveform": {"type": "gaussian_pulse", "f0": 5e9}},
+        ],
+    }
+    with pytest.warns(DeprecationWarning, match="amplitude_kind"):
+        sim = simulation_from_dict(cfg)
+    assert sim._ports[0].amplitude_kind is None
+
+
 # --------------------------------------------------------------------------
 # Full run — slow, opt-in. Confirms YAML run == direct-build run.
 # --------------------------------------------------------------------------

--- a/tests/test_interop_design_document.py
+++ b/tests/test_interop_design_document.py
@@ -549,11 +549,19 @@ def test_record_field_registry_is_pinned(cls, fields):
 
 
 def test_port_entry_registry_is_pinned():
-    """``_PortEntry`` splits across two sections, so it is pinned separately."""
+    """``_PortEntry`` splits across two sections, so it is pinned separately.
+
+    Every live field must be recorded by at least one family's registry.
+    ``amplitude_kind`` is the one soft-source-only field (add_port cannot set
+    it; the exporter refuses a lumped entry carrying a non-None value) — any
+    new asymmetry between the registries must be a deliberate decision here.
+    """
     from rfx.interop._design import _LUMPED_PORT_FIELDS, _SOFT_SOURCE_FIELDS
 
-    assert set(live_field_names(_PortEntry)) == set(_LUMPED_PORT_FIELDS)
-    assert set(_SOFT_SOURCE_FIELDS) <= set(_LUMPED_PORT_FIELDS)
+    assert set(live_field_names(_PortEntry)) == (
+        set(_LUMPED_PORT_FIELDS) | set(_SOFT_SOURCE_FIELDS)
+    )
+    assert set(_SOFT_SOURCE_FIELDS) - set(_LUMPED_PORT_FIELDS) == {"amplitude_kind"}
 
 
 def test_waveform_registry_is_pinned():
@@ -1206,6 +1214,43 @@ def test_round_trip_preserves_the_tfsf_method_lane():
     restored = simulation_from_design(document)
     assert restored._tfsf.method == "methodB"
     assert restored._tfsf.angle_deg == 30.0
+
+
+def test_round_trip_preserves_soft_source_amplitude_kind():
+    """``amplitude_kind`` is design state (issue #571): 'current' means the
+    waveform amplitude is amperes with resolution-independent injected power;
+    null means the deprecated per-path legacy meaning. Pinned on the
+    NON-default value: a codec that defaulted the field away would still
+    round-trip a legacy design cleanly while silently importing a
+    current-normalized design with resolution-dependent injected power."""
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
+    sim.add_source(
+        (0.010, 0.010, 0.010), "ez",
+        waveform=GaussianPulse(f0=5e9), amplitude_kind="current",
+    )
+
+    document = design_to_dict(sim)
+    assert document["excitations"]["soft_sources"][0]["amplitude_kind"] == "current"
+    restored = simulation_from_design(document)
+    assert restored._ports[0].amplitude_kind == "current"
+
+
+def test_refuses_lumped_port_carrying_amplitude_kind():
+    """``add_port`` cannot set ``amplitude_kind``, so a lumped entry carrying
+    one was not built through the public API and cannot be rebuilt through it."""
+    sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02), dx=1e-3, boundary="pec")
+    sim._ports.append(
+        _PortEntry(
+            position=(0.010, 0.010, 0.010),
+            component="ez",
+            impedance=50.0,
+            waveform=GaussianPulse(f0=5e9),
+            amplitude_kind="current",
+        )
+    )
+
+    with pytest.raises(UnsupportedDesignFeature, match="amplitude_kind"):
+        design_to_dict(sim)
 
 
 def test_import_does_not_widen_the_tfsf_boundary_fence():

--- a/tests/test_source_amplitude_kind.py
+++ b/tests/test_source_amplitude_kind.py
@@ -1,0 +1,332 @@
+"""Contract tests for ``add_source(amplitude_kind=)`` — issue #571, option 4.
+
+What this file pins, per the #571 decision dossier:
+
+(a) NON-PERTURBATION: ``amplitude_kind=None`` is bit-identical to the
+    pristine (pre-#571) behavior on all three legacy contracts. The
+    cross-checkout witness was run at the introduction commit (base
+    635433b): the closed-uniform, open-uniform and NU mini-fixture traces
+    below were byte-compared (``np.array_equal``) between pristine main
+    and the patched tree — all three identical. In-repo, this file keeps
+    the executable remnants of that witness: kwarg-omitted vs
+    ``amplitude_kind=None`` full-trace equality, and a helper-level
+    bitwise pin of the ``kind=None`` waveform against an inline spelling
+    of the pristine formula.
+
+(b) THREE-CONTRACT EQUIVALENCE: each legacy ``None`` call equals its
+    exact explicit-kind spelling (closed-uniform = 'field' bitwise;
+    NU = 'current' bitwise; open-uniform = 'current' with waveform
+    amplitude x dV, exact up to one float multiply/divide pair).
+
+(c) THE NEW INVARIANT: with ``amplitude_kind='current'`` the uniform and
+    non-uniform builders produce EQUAL traces (no factor table) on an
+    open boundary. Float tolerance, measured on this fixture: cross-path
+    amplitude scale 1 - 3e-8 (gate rel 1e-5), per-sample residual
+    3.2e-5 of peak (gate 3e-4, the tripwire file's measured cpml
+    envelope class), 1-corr 5e-10 (gate 1e-7).
+
+(d) The ``None`` DeprecationWarning fires exactly ONCE per Simulation,
+    names this simulation's concrete legacy meaning, and never fires for
+    an explicit kind.
+
+(e) AD: ``jax.grad`` flows through an ``amplitude_kind='current'`` (and
+    'field') source on the traced-materials ``forward(eps_override=...)``
+    path — the dossier's ConcretizationTypeError fix (dispatch on the
+    Python-level kind, never on a possibly-traced scale value).
+
+Subpixel smoothing is deliberately NOT used anywhere here (#582: the
+open-boundary + subpixel cross-path residual is a solver defect
+independent of amplitude semantics).
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from rfx import GaussianPulse, Simulation
+from rfx.api._source_semantics import (
+    needs_scale,
+    source_amplitude_scale,
+)
+from rfx.core.yee import EPS_0, init_materials
+from rfx.grid import Grid
+from rfx.simulation import make_j_source, make_source
+
+DX = 1e-3
+NA, NB, NZ = 24, 20, 4
+STEPS = 600
+F0 = 5e9
+DV = DX ** 3
+
+_SRC = (NA * DX / 3, NB * DX / 3, 2 * DX)
+_PRB = (2 * NA * DX / 3, 2 * NB * DX / 3, 2 * DX)
+
+
+def _sim(boundary: str, nonuniform: bool) -> Simulation:
+    profiles = (dict(dx_profile=np.full(NA, DX), dy_profile=np.full(NB, DX))
+                if nonuniform else {})
+    return Simulation(freq_max=1e10, domain=(NA * DX, NB * DX, NZ * DX),
+                      dx=DX, boundary=boundary,
+                      cpml_layers=(0 if boundary == "pec" else 8), **profiles)
+
+
+def _trace(boundary: str, nonuniform: bool, kind, amplitude: float = 1.0,
+           omit_kwarg: bool = False) -> np.ndarray:
+    sim = _sim(boundary, nonuniform)
+    wf = GaussianPulse(f0=F0, bandwidth=0.8, amplitude=amplitude)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        if omit_kwarg:
+            sim.add_source(_SRC, "ez", waveform=wf)
+        else:
+            sim.add_source(_SRC, "ez", waveform=wf, amplitude_kind=kind)
+    sim.add_probe(_PRB, "ez")
+    result = sim.run(n_steps=STEPS, compute_s_params=False,
+                     skip_preflight=True)
+    return np.asarray(result.time_series, dtype=float).ravel()
+
+
+# ---------------------------------------------------------------------------
+# Conversion-table unit contract (the ONE conversion site)
+# ---------------------------------------------------------------------------
+
+def test_conversion_table_and_dispatch():
+    """Full target/native table + the Python-level needs_scale dispatch."""
+    # no-op rows (bit-identity guarantee): None everywhere, kind == native
+    for native in ("raw", "cb", "cb_over_dv"):
+        assert needs_scale(None, native) is False
+        assert source_amplitude_scale(None, native, cb=123.0, dV=456.0) == 1.0
+    assert needs_scale("field", "raw") is False
+    assert needs_scale("current", "cb_over_dv") is False
+    # 'cb' realizes NEITHER kind (legacy open-uniform third contract)
+    assert needs_scale("field", "cb") and needs_scale("current", "cb")
+    # conversion rows
+    assert source_amplitude_scale("field", "cb", cb=4.0, dV=None) == 0.25
+    assert source_amplitude_scale("field", "cb_over_dv", cb=2.0, dV=8.0) == 4.0
+    assert source_amplitude_scale("current", "raw", cb=2.0, dV=8.0) == 0.25
+    assert source_amplitude_scale("current", "cb", cb=None, dV=2.0) == 0.5
+    # validation
+    with pytest.raises(ValueError, match="native"):
+        needs_scale("field", "bogus")
+    with pytest.raises(ValueError, match="amplitude_kind"):
+        needs_scale("volts", "cb")
+
+
+def test_dispatch_is_python_level_and_tracer_safe():
+    """The dossier's ConcretizationTypeError fix: whether to scale is
+    decided on the (kind, native) string pair, so a TRACED cb/dV never
+    reaches a value comparison. Under jit this raises if anyone
+    reintroduces ``if scale != 1.0``-style gating on the value."""
+    @jax.jit
+    def convert(cb, dv):
+        w = jnp.ones(4, dtype=jnp.float32)
+        if needs_scale("field", "cb"):
+            w = source_amplitude_scale("field", "cb", cb=cb, dV=dv) * w
+        if needs_scale("current", "raw"):
+            w = source_amplitude_scale("current", "raw", cb=cb, dV=dv) * w
+        return w
+    out = convert(jnp.float32(2.0), jnp.float32(4.0))
+    # (1/cb) * (cb/dV) = 1/dV = 0.25
+    np.testing.assert_allclose(np.asarray(out), 0.25, rtol=1e-6)
+
+
+def test_add_source_rejects_unknown_kind():
+    sim = _sim("pec", False)
+    with pytest.raises(ValueError, match="amplitude_kind"):
+        sim.add_source(_SRC, "ez", amplitude_kind="volts")
+
+
+# ---------------------------------------------------------------------------
+# (a) Non-perturbation: amplitude_kind=None is the pristine behavior
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("boundary,nonuniform", [
+    pytest.param("pec", False, id="closed-uniform"),
+    pytest.param("cpml", False, id="open-uniform"),
+    pytest.param("cpml", True, id="nonuniform"),
+])
+def test_kind_none_equals_omitting_the_kwarg_bitwise(boundary, nonuniform):
+    """Full-trace byte identity: passing amplitude_kind=None explicitly is
+    the documented spelling of today's default."""
+    t_omit = _trace(boundary, nonuniform, None, omit_kwarg=True)
+    t_none = _trace(boundary, nonuniform, None)
+    assert np.abs(t_omit).max() > 0.0
+    assert np.array_equal(t_omit, t_none)
+
+
+def test_make_j_source_kind_none_bitwise_matches_pristine_formula():
+    """Helper-level pin of the pristine open-uniform waveform: kind=None
+    output of make_j_source is BIT-identical to the pre-#571 formula
+    ``Cb * w(t)`` spelled inline here (same expression, same op order)."""
+    grid = Grid(freq_max=1e10, domain=(NA * DX, NB * DX, NZ * DX),
+                dx=DX, cpml_layers=8)
+    materials = init_materials(grid.shape)
+    pulse = GaussianPulse(f0=F0, bandwidth=0.8)
+    spec = make_j_source(grid, _SRC, "ez", pulse, 64, materials)
+    # inline pristine formula
+    i, j, k = grid.position_to_index(_SRC)
+    eps = materials.eps_r[i, j, k] * EPS_0
+    sigma = materials.sigma[i, j, k]
+    loss = sigma * grid.dt / (2.0 * eps)
+    cb = (grid.dt / eps) / (1.0 + loss)
+    times = jnp.arange(64, dtype=jnp.float32) * grid.dt
+    pristine = cb * jax.vmap(pulse)(times)
+    assert np.array_equal(np.asarray(spec.waveform), np.asarray(pristine))
+
+
+def test_make_source_kind_none_bitwise_matches_pristine_formula():
+    """Helper-level pin of the pristine closed-uniform waveform (raw add)."""
+    grid = Grid(freq_max=1e10, domain=(NA * DX, NB * DX, NZ * DX),
+                dx=DX, cpml_layers=0)
+    pulse = GaussianPulse(f0=F0, bandwidth=0.8)
+    spec = make_source(grid, _SRC, "ez", pulse, 64)
+    times = jnp.arange(64, dtype=jnp.float32) * grid.dt
+    pristine = jax.vmap(pulse)(times)
+    assert np.array_equal(np.asarray(spec.waveform), np.asarray(pristine))
+
+
+# ---------------------------------------------------------------------------
+# (b) Three-contract equivalence: legacy None == exact explicit spelling
+# ---------------------------------------------------------------------------
+
+def test_closed_uniform_none_equals_field_bitwise():
+    """uniform + pec: legacy raw add == amplitude_kind='field', bitwise
+    (both take the no-multiply path through make_source)."""
+    t_none = _trace("pec", False, None)
+    t_field = _trace("pec", False, "field")
+    assert np.abs(t_none).max() > 0.0
+    assert np.array_equal(t_none, t_field)
+
+
+def test_nonuniform_none_equals_current_bitwise():
+    """NU: legacy == amplitude_kind='current', bitwise (both take the
+    no-multiply path through make_current_source)."""
+    t_none = _trace("cpml", True, None)
+    t_curr = _trace("cpml", True, "current")
+    assert np.abs(t_none).max() > 0.0
+    assert np.array_equal(t_none, t_curr)
+
+
+def test_open_uniform_none_equals_current_times_dv():
+    """uniform + cpml: the legacy Cb-normalized contract is named by
+    NEITHER kind; its exact migration is waveform amplitude x dV with
+    kind='current' (algebra Cb*(w*dV)/dV == Cb*w — exact up to ONE float
+    multiply/divide pair, hence a tolerance, not array_equal; measured
+    3.0e-5 of peak on this fixture, gated 2e-4)."""
+    t_none = _trace("cpml", False, None)
+    t_migr = _trace("cpml", False, "current", amplitude=DV)
+    assert np.abs(t_none).max() > 0.0
+    resid = np.abs(t_migr - t_none).max() / np.abs(t_none).max()
+    assert resid < 2e-4, (
+        f"documented open-uniform migration (amplitude x dV, kind='current') "
+        f"deviates by {resid:.3e} of peak from the legacy trace")
+
+
+# ---------------------------------------------------------------------------
+# (c) The NEW invariant: explicit 'current' makes the two builders EQUAL
+# ---------------------------------------------------------------------------
+
+def test_current_kind_makes_uniform_and_nonuniform_traces_equal():
+    """THE observable design win of #571 option 4: under
+    amplitude_kind='current' the uniform and NU builders agree with NO
+    factor table, open boundary (subpixel off — #582 is out of scope).
+
+    Float tolerance, measured on this fixture: scale deviation 3e-8
+    (gate rel 1e-5), residual 3.2e-5 of peak (gate 3e-4), 1-corr 5e-10
+    (gate 1e-7)."""
+    uni = _trace("cpml", False, "current")
+    nu = _trace("cpml", True, "current")
+    assert np.abs(uni).max() > 0.0
+    assert np.corrcoef(uni, nu)[0, 1] > 1 - 1e-7
+    scale = float(np.dot(uni, nu) / np.dot(uni, uni))
+    assert scale == pytest.approx(1.0, rel=1e-5), (
+        f"amplitude_kind='current' promises EQUAL traces on both builders; "
+        f"measured cross-path scale {scale:.6g}")
+    resid = float(np.abs(nu - uni).max() / np.abs(nu).max())
+    assert resid < 3e-4
+
+
+def test_field_kind_makes_uniform_and_nonuniform_traces_equal_pec():
+    """Mirror witness for 'field' on the boundary where it is native on
+    one side (uniform pec) and converted on the other (NU dV/Cb).
+    Measured: scale deviation 1.4e-6 (gate rel 1e-5), residual 1.9e-4
+    (gate 6e-4)."""
+    uni = _trace("pec", False, "field")
+    nu = _trace("pec", True, "field")
+    assert np.abs(uni).max() > 0.0
+    scale = float(np.dot(uni, nu) / np.dot(uni, uni))
+    assert scale == pytest.approx(1.0, rel=1e-5)
+    resid = float(np.abs(nu - uni).max() / np.abs(nu).max())
+    assert resid < 6e-4
+
+
+# ---------------------------------------------------------------------------
+# (d) DeprecationWarning contract
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("boundary,nonuniform,expected_phrase", [
+    pytest.param("pec", False, "raw field increment", id="closed-uniform"),
+    pytest.param("cpml", False, "Cb-normalized field add", id="open-uniform"),
+    pytest.param("cpml", True, "CURRENT in amperes", id="nonuniform"),
+])
+def test_kind_none_warns_once_per_sim_naming_the_concrete_meaning(
+        boundary, nonuniform, expected_phrase):
+    sim = _sim(boundary, nonuniform)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        sim.add_source(_SRC, "ez")
+        sim.add_source(_PRB, "ez")  # second bare call: NO second warning
+    dep = [w for w in rec if issubclass(w.category, DeprecationWarning)
+           and "amplitude_kind" in str(w.message)]
+    assert len(dep) == 1, (
+        f"expected exactly one amplitude_kind DeprecationWarning per "
+        f"Simulation, got {len(dep)}")
+    assert expected_phrase in str(dep[0].message)
+    assert "issue #571" in str(dep[0].message)
+    # a NEW Simulation warns again (per-sim, not per-process)
+    sim2 = _sim(boundary, nonuniform)
+    with pytest.warns(DeprecationWarning, match="amplitude_kind"):
+        sim2.add_source(_SRC, "ez")
+
+
+def test_explicit_kind_is_warning_free():
+    sim = _sim("cpml", False)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        sim.add_source(_SRC, "ez", amplitude_kind="current")
+        sim.add_source(_PRB, "ez", amplitude_kind="field")
+
+
+# ---------------------------------------------------------------------------
+# (e) AD witness: grad flows through explicit kinds on traced materials
+# ---------------------------------------------------------------------------
+
+def test_grad_flows_through_current_kind_on_traced_materials():
+    """forward(eps_override=tracer) with amplitude_kind='current' (and the
+    'field' conversion leg, whose scale 1/Cb IS a tracer): no
+    ConcretizationTypeError, finite nonzero gradient."""
+    for kind in ("current", "field"):
+        sim = _sim("cpml", False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            sim.add_source(_SRC, "ez",
+                           waveform=GaussianPulse(f0=F0, bandwidth=0.8),
+                           amplitude_kind=kind)
+        sim.add_probe(_PRB, "ez")
+        grid = sim._build_grid()
+        base = jnp.ones(grid.shape, dtype=jnp.float32)
+
+        def loss(p):
+            r = sim.forward(eps_override=base * p, n_steps=150,
+                            skip_preflight=True)
+            return jnp.sum(r.time_series ** 2)
+
+        g = jax.grad(loss)(jnp.float32(2.0))
+        g = float(g)
+        assert np.isfinite(g), f"kind={kind}: non-finite grad {g}"
+        assert g != 0.0, f"kind={kind}: gradient is exactly zero"


### PR DESCRIPTION
Closes #571. Follows the option-4 decision posted on the issue (chosen after measuring option 2's blast radius: ~12 scale-anchored tests, zero physics gates).

## Problem

`add_source`'s waveform amplitude means three different things depending on which runner executes it (measured on the issue):

- uniform + PEC: raw field increment `E += w(t)`
- uniform + CPML/UPML: Cb-normalized add (ratio vs raw ≈ 2.15e8 at dx=1mm)
- non-uniform: current in amperes, `E += (dt/ε)·I/dV` (ratio 1/dV = 1e9 at dx=1mm)

Same script, different boundary or mesh → injected power changes by 8–9 orders of magnitude, silently.

## What

- `add_source`/`add_polarized_source` gain `amplitude_kind='field'|'current'|None`.
  - `'current'`: amperes on EVERY path (NU-native Meep-style; resolution-independent injected power; the future default). New invariant: uniform ≡ NU traces under it.
  - `'field'`: raw E increment on EVERY path.
  - `None` (default): legacy per-path meaning, BIT-IDENTICAL, one `DeprecationWarning` per Simulation naming this sim's concrete legacy meaning. Plan: required in 1.8, default `'current'` in 1.9.
- One conversion home: `rfx/api/_source_semantics.py`. Source-building helpers declare their native coefficient (`make_source` 'raw', `make_j_source` 'cb', `make_current_source` 'cb_over_dv'); dispatch is on the Python-string kind, never a possibly-traced scale value, so `jax.grad` paths are unaffected. 2D grids are one cell deep (`dV = dx·dy·dz_one_cell`).
- Threaded through all build sites: uniform/nonuniform/distributed/distributed_v2/subgridded runners, `forward()` + distributed-forward, `vmap_sweep` (kind='current' → dynamic-Cb J-source path on any boundary), `gpu.py` (explicit 'field').
- Serialization surfaces (added after independent review flagged the silent field drop): design IR records `amplitude_kind` on `soft_sources`; config CLI accepts an optional `amplitude_kind:` key on `type: source` entries; diagnostics smoke pins `amplitude_kind='field'` (PEC fixture — bit-identical native).

## Governance deltas (deliberate, stated)

- `test_port_entry_registry_is_pinned` invariant updated: was "soft ⊆ lumped = all `_PortEntry` fields"; now "lumped ∪ soft = all fields, soft−lumped = {amplitude_kind} exactly". The exporter refuses a lumped entry carrying a non-None `amplitude_kind` (`add_port` cannot set it — not reachable through the public API).
- `rfx-design-ir-v1.schema.json` `soft_sources`: +`amplitude_kind` (string|null), required-despite-default per the #472 (b31edfd) precedent — null is itself a meaning (legacy per-path semantics); a codec that defaulted the field away would silently import a current-normalized design with resolution-dependent injected power. Plain string per the two-layer policy (the value fence lives in `add_source`).

## Verification

- `tests/test_source_amplitude_kind.py` (18 tests): three-contract equivalence, byte-identity witnesses on all three legacy paths under `amplitude_kind=None`, uniform≡NU invariant under 'current', warning UX, AD witness.
- Interop/config/diagnostics surfaces after review fixes: 221 passed, 35 skipped — includes 4 new tests (IR round-trip pinned on the non-default value, lumped-refuse, config passthrough, config legacy-warn).
- Full local suite, 8 shards, all green: 141/76/102/315/58/157/135/142 passed (+1 expected xfail; deselections are the default fast-lane marker filter `not gpu and not slow and not slow_physics`; the pre-existing local-env failures observed during the earlier blast-radius measurement did not reproduce in this run (order/env-dependent class) — CI is authoritative).
- ruff clean; api-reference gate green.

R3: memory=project_rf_usability_roadmap_20260728 + feedback_gate_can_bind_artifact | R2-attempts=0 (API/serialization change, no physics loop) | falsifier=byte-identity witness on all three legacy paths with amplitude_kind=None — ran green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
