### PR TITLE
feat(vmap): batch DFT plane accumulators on the vmap fast path (#578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,69 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Added — `vmap_material_sweep()` batches DFT plane accumulators on the fast path (#578)
+
+- `add_dft_plane_probe` planes now accumulate inside the `jax.vmap`-batched
+  scan carry, inlining `Simulation.run()`'s rect-window DFT kernel exactly
+  (same `init_dft_plane_probe` call, same `t = state.step * dt` phase
+  reference — using the scan's own step-index instead would be an
+  off-by-one, per-bin phase-error class bug). `VmapSweepResult` gains a
+  new field, `dft_planes: dict[str, ndarray] | None`, with a leading
+  batch axis (`n_batch, n_freqs, n1, n2` complex) — the SAME accessor
+  key each plane's `add_dft_plane_probe(name=...)` uses for a single
+  `Result.dft_planes[name]`. The sequential fallback also populates this
+  field now (by stacking each swept value's `Result.dft_planes`
+  accumulator), so a registered DFT plane returns data through
+  `vmap_material_sweep()` regardless of which internal path a given
+  `Simulation` takes — previously flux monitors and DFT planes both
+  forced the sequential fallback and neither path's output carried any
+  frequency-domain data at all (`VmapSweepResult` had no such field).
+  Verified against `Simulation.run()` per swept element with a predeclared
+  tolerance and a one-sided falsifier (a deliberate DFT-kernel sign flip
+  turns the equivalence gate red on every frequency bin); see
+  `tests/test_vmap_sweep_dft_planes.py`.
+- Measured speedup (batched vmap fast path vs. the sequential fallback,
+  same machine, same config: CPML dielectric slab + one DFT plane,
+  `n_steps=300`, CPU backend, JAX 0.10.2, AMD EPYC 9654 96-core, no
+  GPU available in this environment): **1.2x at `n_batch=8`, 2.0x at
+  `n_batch=16`, 4.7x at `n_batch=32`** — the fast path pays one XLA
+  compile amortized over the whole batch while the fallback recompiles
+  per swept value, so the speedup grows with batch size in the
+  documented "moderate batch sizes (5-50 values)" regime; a GPU is
+  expected to widen this further via genuine parallel kernel execution
+  (untested here — no GPU device in this environment).
+- **BREAKING (fail-loud, not a numerics change)**: `vmap_material_sweep(...,
+  return_fields=True)` now raises `ValueError` instead of silently
+  returning `VmapSweepResult.final_fields=None`. `return_fields` was
+  documented since this function's introduction but never implemented on
+  either the fast path or the sequential fallback — `final_fields` was
+  always `None` regardless of the flag. Use `sim.run()`/`sim.forward()`
+  for a final-field snapshot, or `parametric_sweep()` for full per-value
+  `Result` objects.
+- New eligibility guards route simulations carrying MSL (`_msl_ports`),
+  Floquet (`_floquet_ports`), or coaxial (`_coaxial_ports`) ports to the
+  sequential fallback instead of the vmap fast path. MSL/Floquet ports
+  were a genuine silent-drop gap (the fast-path scan bodies never
+  launched or recorded them, so a swept sim carrying one previously ran
+  the fast path missing that physics with no warning). Coaxial ports are
+  not consumed by plain `Simulation.run()` at all today; this guard makes
+  that failure loud (the fallback now surfaces `run()`'s existing
+  `NotImplementedError` for `add_coaxial_port`) instead of silently
+  taking the fast path and ignoring the port.
+- Fixed a drifted module-docstring inversion (`rfx/vmap_sweep.py`
+  Limitations section used to claim ports/TFSF/dispersion/waveguide
+  ports/NTFF/RLC elements were "fully supported" — the opposite
+  of the function docstring and the code guards, which always correctly
+  listed them as fallback-triggering).
+- Angle-batched TFSF sweeps remain out of scope for `vmap_material_sweep`
+  — documented as a structural limitation, not a missing feature (the
+  TFSF incident field is itself an in-scan auxiliary FDTD solution,
+  Method B's auxiliary grid size is angle-dependent, and rfx cannot
+  express a general incidence triple today). `parametric_sweep()` is the
+  documented route for illumination/angle sweeps, with the pre-existing
+  oblique-Bloch-TFSF-plus-DFT-planes `NotImplementedError` noted as a
+  caveat there.
+
 ### Added — `rfx.observables`: differentiable DFT-plane accessor + objectives (#579)
 
 - New `rfx.observables` module (flat-exported at top level and in the

--- a/docs/agent/recipe-parameter-sweeps.mdx
+++ b/docs/agent/recipe-parameter-sweeps.mdx
@@ -20,14 +20,17 @@ points, not by what is convenient to write.
    or scoped to one material as `"substrate.eps_r"`) →
    `vmap_material_sweep`. The entire FDTD time loop is `jax.vmap`-ed into
    a single fused kernel — typically the fastest option on GPU, with
-   memory scaling as `n_batch × grid_size`.
+   memory scaling as `n_batch × grid_size` plus `n_batch × n_planes ×
+   n_freqs × n1 × n2` complex for any registered DFT plane accumulators.
    - The vmap fast path supports **only**: PEC/periodic walls, CPML
-     absorbing boundaries, soft sources, and point probes.
-   - Simulations using UPML, lumped RLC elements, TFSF, material
-     dispersion, waveguide ports, DFT planes, flux monitors, NTFF, or a
+     absorbing boundaries, soft sources, point probes, and DFT plane
+     probes (`add_dft_plane_probe`).
+   - Simulations using UPML, lumped/MSL/coaxial/floquet ports, TFSF,
+     material dispersion, waveguide ports, flux monitors, NTFF, or a
      non-uniform mesh take a **sequential fallback** — same results,
      without the fused-kernel speedup. The fallback carries the full
-     material specification (including Kerr χ³).
+     material specification (including Kerr χ³) and also returns DFT
+     plane accumulators, so a registered plane works on either path.
 3. **Far-field over many frequencies** where the NTFF accumulator
    dominates memory → `ntff_sweep(sim, freqs, batch_size=…)`. Requires
    `add_ntff_box(...)` on the simulation; accumulates in memory-bounded

--- a/docs/agent/recipe-parameter-sweeps.mdx
+++ b/docs/agent/recipe-parameter-sweeps.mdx
@@ -25,9 +25,9 @@ points, not by what is convenient to write.
    - The vmap fast path supports **only**: PEC/periodic walls, CPML
      absorbing boundaries, soft sources, point probes, and DFT plane
      probes (`add_dft_plane_probe`).
-   - Simulations using UPML, lumped/MSL/coaxial/floquet ports, TFSF,
-     material dispersion, waveguide ports, flux monitors, NTFF, or a
-     non-uniform mesh take a **sequential fallback** — same results,
+   - Simulations using UPML, lumped RLC elements, lumped/MSL/coaxial/floquet
+     ports, TFSF, material dispersion, waveguide ports, flux monitors, NTFF,
+     or a non-uniform mesh take a **sequential fallback** — same results,
      without the fused-kernel speedup. The fallback carries the full
      material specification (including Kerr χ³) and also returns DFT
      plane accumulators, so a registered plane works on either path.

--- a/rfx/vmap_sweep.py
+++ b/rfx/vmap_sweep.py
@@ -17,9 +17,16 @@ Limitations
 - Only material parameters (``eps_r``, ``sigma``, ``mu_r``) can be swept.
   For geometry sweeps (different shapes/sizes) use ``parametric_sweep()``.
 - ``until_decay`` is not supported (requires Python-level control flow).
-- Ports, TFSF, CPML, dispersion, waveguide ports, NTFF, DFT planes,
-  snapshots, and RLC elements are fully supported because they use the
-  same grid topology.
+- CPML and DFT plane probes (``add_dft_plane_probe``, #578) ARE supported on
+  the fast path because they use the same grid topology as PEC/periodic
+  walls. This bullet used to claim the WHOLE feature list below it was
+  "fully supported" — that was a drifted inversion of the true limitation
+  (the function docstring below and the code guards always disagreed with
+  it). Lumped/MSL/coaxial/floquet ports, TFSF, dispersion, waveguide ports,
+  flux monitors, NTFF, snapshots, and RLC elements are NOT wired into the
+  fast-path scan bodies and trigger the sequential fallback instead (still
+  correct, just slower — and, as of #578, that fallback also carries DFT
+  plane accumulators, so no feature silently vanishes on either path).
 """
 
 from __future__ import annotations
@@ -31,6 +38,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from rfx.core.yee import MaterialArrays, init_state, update_e, update_h, EPS_0
+from rfx.probes.probes import DFTPlaneProbe, init_dft_plane_probe
 from rfx.simulation import (
     SourceSpec,
     ProbeSpec,
@@ -56,12 +64,26 @@ class VmapSweepResult:
         Name of the swept parameter.
     param_values : ndarray, shape (n_batch,)
         The parameter values that were swept.
+    dft_planes : dict[str, ndarray] or None
+        DFT plane accumulators, keyed by the ``add_dft_plane_probe`` name,
+        each shaped ``(n_batch, n_freqs, n1, n2)`` complex — a leading
+        batch axis over the same accumulator ``Result.dft_planes[name]``
+        exposes for a single run (#578). Populated on BOTH the vmap fast
+        path and the sequential fallback (the fallback stacks each
+        swept-value ``Result.dft_planes[name].accumulator``), so the field
+        is uniform regardless of which path a given ``Simulation`` takes.
+        ``None`` if no ``add_dft_plane_probe`` was registered.
     final_fields : dict or None
-        If requested, dict mapping component name to (n_batch, Nx, Ny, Nz).
+        Never populated (``return_fields=True`` raises ``ValueError``
+        instead of silently returning ``None`` here — see
+        ``vmap_material_sweep``). Reserved for a future final-field-state
+        implementation; use ``sim.run()``/``sim.forward()`` or
+        ``parametric_sweep()`` for final fields today.
     """
     time_series: np.ndarray
     param_name: str
     param_values: np.ndarray
+    dft_planes: dict | None = None
     final_fields: dict | None = None
 
     def peak_field(self) -> np.ndarray:
@@ -222,14 +244,16 @@ def _build_vmap_scan_fn(
     cpml_axes: str = "xyz",
     pec_axes: str = "xyz",
     pec_mask=None,
+    dft_probes: list[DFTPlaneProbe] | None = None,
 ):
-    """Build a pure function ``f(materials) -> time_series`` suitable for vmap.
+    """Build a pure function ``f(materials) -> (time_series, dft_accs)``
+    suitable for vmap.
 
     Constructs a minimal FDTD loop (H update -> [CPML H] -> E update ->
-    [CPML E] -> PEC -> sources -> probes) without dispersion, TFSF, DFT
-    planes, or waveguide ports.  For the common material-sweep use case
-    (PEC cavity, CPML absorber, or simple probe measurement) this covers the
-    needed physics.
+    [CPML E] -> PEC -> sources -> DFT-plane accumulation -> probes) without
+    dispersion, TFSF, or waveguide ports.  For the common material-sweep use
+    case (PEC cavity, CPML absorber, DFT-plane probe, or simple probe
+    measurement) this covers the needed physics.
 
     Parameters
     ----------
@@ -242,14 +266,33 @@ def _build_vmap_scan_fn(
         soft sources on any boundary.  Raw (un-Cb-normalized) J-source
         waveforms + cell indices so Cb can be computed dynamically inside the
         vmapped function from the actual material arrays.
+    dft_probes : list of DFTPlaneProbe or None
+        Zero-initialized DFT plane probes (from ``init_dft_plane_probe``,
+        the SAME helper ``run()`` uses — rfx/runners/uniform.py:489-497).
+        Their ``.accumulator`` seeds the scan-carry accumulator for that
+        plane; ``.component``/``.axis``/``.index``/``.freqs`` drive the
+        per-step kernel, inlined here to match ``Simulation.run()``'s rect
+        kernel exactly (rfx/simulation.py:1512-1526): ``t = st.step * dt``
+        (the STATE's step counter, NOT the scan's ``xs`` step index — using
+        the latter is an off-step, per-bin-phase-error class bug, #404).
+        The returned ``run_one`` always returns a 2-tuple
+        ``(time_series, dft_accs)`` where ``dft_accs`` is a tuple of final
+        accumulators in the SAME order as ``dft_probes`` (empty tuple if
+        no planes were registered).
     """
     dt = grid.dt
     dx = grid.dx
     sources = sources or []
     j_source_raw_info = j_source_raw_info or []
     probes = probes or []
+    dft_probes = dft_probes or []
 
     use_pec_mask = pec_mask is not None
+    use_dft = len(dft_probes) > 0
+    dft_meta = tuple(
+        (p.component, p.axis, p.index, p.freqs) for p in dft_probes
+    )
+    dft_acc_init = tuple(p.accumulator for p in dft_probes)
 
     if use_cpml:
         from rfx.boundaries.cpml import init_cpml, apply_cpml_e, apply_cpml_h
@@ -278,10 +321,13 @@ def _build_vmap_scan_fn(
     if use_cpml:
         cpml_params, cpml_state_init = init_cpml(grid)
 
-    def run_one(materials: MaterialArrays) -> jnp.ndarray:
+    def run_one(materials: MaterialArrays) -> tuple[jnp.ndarray, tuple]:
         """Run a single FDTD simulation with the given materials.
 
-        Returns time_series of shape (n_steps, n_probes).
+        Returns ``(time_series, dft_accs)``: time_series shaped
+        ``(n_steps, n_probes)``; dft_accs a tuple of final ``(n_freqs, n1,
+        n2)`` complex accumulators, one per registered DFT plane (empty
+        tuple if none).
         """
         fdtd = init_state(grid.shape)
 
@@ -305,9 +351,9 @@ def _build_vmap_scan_fn(
         def step_fn(carry, xs):
             _step_idx, src_vals, j_src_vals = xs
             if use_cpml:
-                st, cpml_st = carry
+                st, cpml_st, dft_accs = carry
             else:
-                st = carry
+                st, dft_accs = carry
 
             # H update
             st = update_h(st, materials, dt, dx, periodic=periodic)
@@ -352,14 +398,34 @@ def _build_vmap_scan_fn(
                 field = field.at[si, sj, sk].add(j_src_vals[idx_j])
                 st = st._replace(**{sc: field})
 
+            # DFT-plane accumulation (rect window always — matches
+            # Simulation.run()'s inline kernel, rfx/simulation.py:1512-1526).
+            # ``t`` is derived from the STATE's own step counter, not the
+            # scan xs step index, so it matches run() bit-for-bit under vmap.
+            if use_dft:
+                t_plane = st.step * dt
+                new_dft_accs = []
+                for acc, (component, axis, index, freqs) in zip(dft_accs, dft_meta):
+                    field = getattr(st, component)
+                    if axis == 0:
+                        plane = field[index, :, :]
+                    elif axis == 1:
+                        plane = field[:, index, :]
+                    else:
+                        plane = field[:, :, index]
+                    phase = jnp.exp(-1j * 2.0 * jnp.pi * freqs * t_plane)
+                    new_dft_accs.append(
+                        acc + plane[None, :, :] * phase[:, None, None] * dt)
+                dft_accs = tuple(new_dft_accs)
+
             # Probe samples
             samples = [getattr(st, pc)[pi, pj, pk]
                        for pi, pj, pk, pc in prb_meta]
             probe_out = jnp.stack(samples) if samples else jnp.zeros(0)
 
             if use_cpml:
-                return (st, cpml_st), probe_out
-            return st, probe_out
+                return (st, cpml_st, dft_accs), probe_out
+            return (st, dft_accs), probe_out
 
         xs = (
             jnp.arange(n_steps, dtype=jnp.int32),
@@ -367,11 +433,12 @@ def _build_vmap_scan_fn(
             j_src_waveforms,
         )
         if use_cpml:
-            init_carry = (fdtd, cpml_state_init)
+            init_carry = (fdtd, cpml_state_init, dft_acc_init)
         else:
-            init_carry = fdtd
-        _, time_series = jax.lax.scan(step_fn, init_carry, xs)
-        return time_series
+            init_carry = (fdtd, dft_acc_init)
+        final_carry, time_series = jax.lax.scan(step_fn, init_carry, xs)
+        final_dft_accs = final_carry[-1]
+        return time_series, final_dft_accs
 
     return run_one
 
@@ -386,8 +453,10 @@ def _build_full_scan_fn(
     lorentz_spec=None,
     pec_mask=None,
 ):
-    """Build a function ``f(materials) -> time_series`` that uses the full
-    simulation runner (including CPML, dispersion, etc.).
+    """Build ``(f, dft_names)`` where ``f(materials) -> (time_series,
+    dft_accs)`` uses the full simulation runner (including CPML,
+    dispersion, etc.), or ``(None, None)`` if this simulation must take the
+    sequential fallback instead.
 
     This wraps ``simulation.run()`` into a vmappable form by making
     ``materials`` an explicit argument rather than a closure capture.
@@ -399,30 +468,41 @@ def _build_full_scan_fn(
     has_tfsf = sim._tfsf is not None
     has_waveguide = len(sim._waveguide_ports) > 0
     has_dispersion = debye_spec is not None or lorentz_spec is not None
+    # MSL/floquet ports are genuine run()-consumed silent drops if allowed
+    # onto the fast path (neither scan body launches/records them); coaxial
+    # ports are NOT consumed by plain run() at all today, so this guard is
+    # added for honesty/uniformity with the other port families rather than
+    # because the fast path would corrupt anything (#578 design v2 PR B.3).
+    has_msl_ports = len(getattr(sim, "_msl_ports", []) or []) > 0
+    has_floquet_ports = len(getattr(sim, "_floquet_ports", []) or []) > 0
+    has_coaxial_ports = len(getattr(sim, "_coaxial_ports", []) or []) > 0
 
     # Allowlist guard: the vmap scan bodies implement ONLY pec/periodic
-    # walls and CPML. Anything below must take the sequential fallback
-    # (return None) or it would be SILENTLY DROPPED from the swept runs:
+    # walls, CPML, and (as of #578) DFT plane probes. Anything below must
+    # take the sequential fallback (return None) or it would be SILENTLY
+    # DROPPED from the swept runs:
     #   - boundary='upml': neither scan body applies a UPML step, so the
     #     fast path would run with no absorber at all;
     #   - lumped RLC elements: not wired into either scan body;
-    #   - flux monitors / DFT planes / NTFF: frequency-domain accumulators
-    #     exist only in the canonical Simulation.run() loop;
+    #   - flux monitors / NTFF: frequency-domain accumulators exist only in
+    #     the canonical Simulation.run() loop (DFT PLANE probes are the
+    #     #578 exception — built into ``dft_probes`` below and threaded
+    #     into the fast-path scan body);
     #   - non-uniform mesh profiles: scan bodies assume a uniform grid.
     if boundary == "upml":
-        return None
+        return None, None
     if getattr(sim, "_lumped_rlc", None):
-        return None
-    if getattr(sim, "_flux_monitors", None) or getattr(sim, "_dft_planes", None):
-        return None
+        return None, None
+    if getattr(sim, "_flux_monitors", None):
+        return None, None
     if getattr(sim, "_ntff", None) is not None:
-        return None
+        return None, None
     if (
         getattr(sim, "_dx_profile", None) is not None
         or getattr(sim, "_dy_profile", None) is not None
         or getattr(sim, "_dz_profile", None) is not None
     ):
-        return None
+        return None, None
 
     # Build sources and probes from the simulation.
     # For CPML J-sources the Cb coefficient depends on material properties
@@ -473,9 +553,55 @@ def _build_full_scan_fn(
     for pe in sim._probes:
         probes.append(make_probe(grid, pe.position, pe.component))
 
-    # For the simple (no-port, no-dispersion, no-TFSF) case, use the
-    # lightweight scan function that can be cleanly vmapped.
-    if not has_ports and not has_tfsf and not has_waveguide and not has_dispersion:
+    # DFT plane probes (#578): mirrors rfx/runners/uniform.py:478-498
+    # exactly, including calling the SAME init_dft_plane_probe helper, so
+    # the accumulator dtype/shape/init state is identical to run()'s by
+    # construction (the #477/#484 x64-contract pin below is therefore a
+    # sanity assertion, not a computed correction).
+    axis_to_index = {"x": 0, "y": 1, "z": 2}
+    dft_probes: list[DFTPlaneProbe] = []
+    dft_names: list[str] = []
+    for pe in getattr(sim, "_dft_planes", []) or []:
+        axis_idx = axis_to_index[pe.axis]
+        plane_pos = [0.0, 0.0, 0.0]
+        plane_pos[axis_idx] = pe.coordinate
+        grid_index = grid.position_to_index(tuple(plane_pos))[axis_idx]
+        freqs_arr = (
+            pe.freqs
+            if pe.freqs is not None
+            else jnp.linspace(sim._freq_max / 10, sim._freq_max, pe.n_freqs)
+        )
+        dft_probes.append(
+            init_dft_plane_probe(
+                axis=axis_idx,
+                index=grid_index,
+                component=pe.component,
+                freqs=freqs_arr,
+                grid_shape=grid.shape,
+                dft_total_steps=n_steps,
+            )
+        )
+        dft_names.append(pe.name)
+
+    if dft_probes:
+        _expected_dtype = (
+            jnp.complex128 if jax.config.x64_enabled else jnp.complex64)
+        for _probe in dft_probes:
+            assert _probe.accumulator.dtype == _expected_dtype, (
+                f"vmap DFT accumulator dtype {_probe.accumulator.dtype} != "
+                f"run()'s {_expected_dtype} "
+                f"(x64_enabled={jax.config.x64_enabled}) — #477/#484 "
+                "x64-contract pin violated"
+            )
+
+    # For the simple (no-port, no-dispersion, no-TFSF, no-MSL/floquet/coax
+    # port) case, use the lightweight scan function that can be cleanly
+    # vmapped.
+    if (
+        not has_ports and not has_tfsf and not has_waveguide
+        and not has_dispersion and not has_msl_ports
+        and not has_floquet_ports and not has_coaxial_ports
+    ):
         periodic = (False, False, False)
         if sim._periodic_axes:
             periodic = tuple(axis in sim._periodic_axes for axis in "xyz")
@@ -495,7 +621,7 @@ def _build_full_scan_fn(
         if boundary == "cpml":
             # CPML requires its own state management.  For the vmapped path,
             # we build a scan function that includes CPML handling.
-            return _build_vmap_scan_fn(
+            run_one_fn = _build_vmap_scan_fn(
                 grid, n_steps,
                 use_cpml=True,
                 sources=sources,
@@ -505,9 +631,10 @@ def _build_full_scan_fn(
                 cpml_axes=cpml_axes,
                 pec_axes=pec_axes,
                 pec_mask=pec_mask,
+                dft_probes=dft_probes,
             )
         else:
-            return _build_vmap_scan_fn(
+            run_one_fn = _build_vmap_scan_fn(
                 grid, n_steps,
                 use_cpml=False,
                 sources=sources,
@@ -520,10 +647,12 @@ def _build_full_scan_fn(
                 periodic=periodic,
                 pec_axes=pec_axes,
                 pec_mask=pec_mask,
+                dft_probes=dft_probes,
             )
+        return run_one_fn, dft_names
 
     # Fallback: for complex sims, run sequentially (not vmapped)
-    return None
+    return None, None
 
 
 # ---------------------------------------------------------------------------
@@ -559,25 +688,88 @@ def vmap_material_sweep(
     num_periods : float
         Periods at freq_max for auto timestep count (default 20).
     return_fields : bool
-        If True, also return final E-field snapshots per batch element.
+        Must be False (the default). ``return_fields=True`` was documented
+        here since this function's introduction but never implemented —
+        neither the fast path nor the sequential fallback ever populated
+        ``VmapSweepResult.final_fields``, so it silently returned ``None``
+        instead of the promised snapshot. Passing ``True`` now raises
+        ``ValueError`` (fail loud beats silent ``None``, #578). Use
+        ``sim.run()``/``sim.forward()`` for a final-field snapshot of one
+        configuration, or ``parametric_sweep()`` for full per-value
+        ``Result`` objects across a swept parameter.
 
     Returns
     -------
     VmapSweepResult
-        Result with ``.time_series`` of shape ``(n_batch, n_steps, n_probes)``
-        and ``.param_values``.
+        Result with ``.time_series`` of shape
+        ``(n_batch, n_steps, n_probes)``, ``.dft_planes`` (dict of
+        ``(n_batch, n_freqs, n1, n2)`` complex arrays keyed by
+        ``add_dft_plane_probe`` name, or ``None`` if no plane was
+        registered), and ``.param_values``.
 
     Notes
     -----
     The entire FDTD time loop is vmapped so all simulations execute in a
-    single fused GPU kernel.  Memory scales as ``n_batch * grid_size``.
-    For large grids, reduce batch size to avoid OOM.
+    single fused GPU kernel. Memory scales as
+    ``n_batch * grid_size + n_batch * sum(n_freqs_p * n1_p * n2_p for each
+    registered DFT plane p)`` (complex accumulators; no remat on this
+    path). For large grids/plane counts, reduce batch size or plane
+    frequency count to avoid OOM.
 
     Features supported in vmap path: PEC boundaries, CPML absorbing
-    boundaries, soft sources, point probes.  Lumped ports, TFSF,
-    dispersion, waveguide ports, DFT planes, and NTFF are **not**
-    supported in the vmap fast path and will trigger a sequential fallback.
+    boundaries, soft sources (incl. ``amplitude_kind='current'``, #571),
+    point probes, and DFT plane probes (``add_dft_plane_probe``, #578).
+    Lumped ports, MSL/coaxial/floquet ports, TFSF, dispersion, waveguide
+    ports, flux monitors, and NTFF are **not** supported in the vmap fast
+    path and trigger a sequential fallback. As of #578 that fallback also
+    populates ``.dft_planes`` (by stacking each swept value's
+    ``Result.dft_planes`` accumulators), so registering a DFT plane never
+    silently loses data on either path — it is only the FAST path that is
+    conditional on eligibility, not the DFT-plane *output*.
+
+    TFSF sweeps — angle batching is intentionally out of scope, not just
+    unimplemented: it is a structural mismatch with this function's
+    material-only batching model, not a missing feature. The TFSF incident
+    field is itself an auxiliary FDTD solution advanced *inside* the scan
+    (not closed-form); Method B's auxiliary-grid size is angle-dependent
+    (a batch of angles would need a batch of scan shapes, which
+    ``jax.vmap`` cannot express); and the oblique 2D-aux Bloch path
+    concretizes its transverse phase factors from ``angle_deg`` at trace
+    time (rfx/sources/tfsf_2d.py). More basically, rfx cannot even
+    *express* a general incidence triple ``(theta, phi, psi)`` today — only
+    ``angle_deg`` + a binary ``direction`` + a two-way ``polarization``
+    choice — so there is no batchable angle parameter to expose in the
+    first place. Route illumination/angle sweeps to ``parametric_sweep()``
+    instead: it already returns full ``Result`` objects including
+    ``dft_planes`` for each swept value. Caveat there too: oblique-Bloch
+    TFSF (``angle_deg != 0``, ``method='bloch'``, the default) combined
+    with DFT planes/flux monitors/NTFF raises ``NotImplementedError`` by
+    design (rfx/simulation.py:728-745) because the accumulated envelope is
+    not the physical spectrum — DFT-plane tensors from a TFSF-illuminated
+    ``parametric_sweep`` are obtainable only at normal incidence
+    (``angle_deg=0``) or with ``method='methodB'`` (open-domain, real
+    fields). A MATERIAL sweep on a sim carrying a FIXED (non-swept) TFSF
+    source still benefits from #578: it takes this function's sequential
+    fallback (TFSF is not fast-path-eligible) but that fallback now
+    carries ``dft_planes`` through, so per-material DFT tensors at fixed
+    incidence ARE obtainable via ``vmap_material_sweep`` today.
+
+    Point-frequency-domain probes are not a separate case here: rfx has no
+    public builder for a point DFT probe (only plane DFT probes and flux
+    monitors), and point *time series* — the actual point-probe primitive
+    — are already fully batched via ``add_probe`` + ``.time_series`` on
+    both paths.
     """
+    if return_fields:
+        raise ValueError(
+            "return_fields=True is not implemented on vmap_material_sweep "
+            "— it was accepted since this function's introduction but "
+            "silently ignored (VmapSweepResult.final_fields was never "
+            "populated on either the fast path or the sequential "
+            "fallback). Use sim.run()/sim.forward() for a final-field "
+            "snapshot, or parametric_sweep() for full per-value Result "
+            "objects."
+        )
     param_values = np.asarray(param_values, dtype=np.float32).ravel()
     if len(param_values) == 0:
         raise ValueError("param_values must not be empty")
@@ -593,7 +785,7 @@ def vmap_material_sweep(
         n_steps = grid.num_timesteps(num_periods=num_periods)
 
     # Build the vmappable scan function
-    run_one_fn = _build_full_scan_fn(
+    run_one_fn, dft_names = _build_full_scan_fn(
         sim, grid, base_materials, n_steps,
         debye_spec=debye_spec,
         lorentz_spec=lorentz_spec,
@@ -614,17 +806,25 @@ def vmap_material_sweep(
             return run_one_fn(mats)
 
         batched_run = jax.vmap(run_one_from_materials)
-        time_series = batched_run(
+        time_series, dft_accs = batched_run(
             batched_materials.eps_r,
             batched_materials.sigma,
             batched_materials.mu_r,
         )
         time_series_np = np.asarray(time_series)
 
+        dft_planes_out = None
+        if dft_names:
+            dft_planes_out = {
+                name: np.asarray(acc)
+                for name, acc in zip(dft_names, dft_accs)
+            }
+
         return VmapSweepResult(
             time_series=time_series_np,
             param_name=param_name,
             param_values=param_values,
+            dft_planes=dft_planes_out,
         )
     else:
         # Fallback: sequential execution for complex simulations
@@ -632,8 +832,10 @@ def vmap_material_sweep(
         import warnings
         warnings.warn(
             "Simulation uses features not supported by vmap fast path "
-            "(ports/TFSF/dispersion/waveguide). Falling back to sequential "
-            "execution. Use parametric_sweep() for better sequential support.",
+            "(ports incl. MSL/coaxial/floquet, TFSF, dispersion, "
+            "waveguide, flux monitors, NTFF). Falling back to sequential "
+            "execution. Use parametric_sweep() for better sequential "
+            "support.",
             stacklevel=2,
         )
         return _sequential_fallback(
@@ -648,10 +850,21 @@ def _sequential_fallback(
     *,
     n_steps: int,
 ) -> VmapSweepResult:
-    """Sequential fallback when vmap is not possible."""
+    """Sequential fallback when vmap is not possible.
+
+    #578: also populates ``VmapSweepResult.dft_planes`` by stacking each
+    swept value's ``Result.dft_planes[name].accumulator`` — the SAME
+    carrier the fast path populates (dict[str, ndarray] with a leading
+    batch axis), so a DFT plane registered on a simulation that must take
+    this fallback (TFSF, lumped/MSL/coaxial/floquet ports, dispersion,
+    waveguide ports, ...) still comes back through
+    ``vmap_material_sweep()`` instead of only being reachable via
+    ``parametric_sweep()``.
+    """
     mat_name, field = _parse_param_name(param_name)
 
     all_ts = []
+    dft_acc_lists: dict[str, list] = {}
     for _i, val in enumerate(param_values):
         # Clone the simulation and modify the material
         import copy
@@ -678,10 +891,24 @@ def _sequential_fallback(
         result = sim_copy.run(n_steps=n_steps, skip_preflight=_i > 0)
         all_ts.append(np.asarray(result.time_series))
 
+        if result.dft_planes:
+            for name, probe in result.dft_planes.items():
+                dft_acc_lists.setdefault(name, []).append(
+                    np.asarray(probe.accumulator))
+
     # Stack into (n_batch, n_steps, n_probes)
     time_series = np.stack(all_ts, axis=0)
+
+    dft_planes_out = None
+    if dft_acc_lists:
+        dft_planes_out = {
+            name: np.stack(accs, axis=0)
+            for name, accs in dft_acc_lists.items()
+        }
+
     return VmapSweepResult(
         time_series=time_series,
         param_name=param_name,
         param_values=param_values,
+        dft_planes=dft_planes_out,
     )

--- a/rfx/vmap_sweep.py
+++ b/rfx/vmap_sweep.py
@@ -23,7 +23,7 @@ Limitations
   "fully supported" — that was a drifted inversion of the true limitation
   (the function docstring below and the code guards always disagreed with
   it). Lumped/MSL/coaxial/floquet ports, TFSF, dispersion, waveguide ports,
-  flux monitors, NTFF, snapshots, and RLC elements are NOT wired into the
+  flux monitors, NTFF, and RLC elements are NOT wired into the
   fast-path scan bodies and trigger the sequential fallback instead (still
   correct, just slower — and, as of #578, that fallback also carries DFT
   plane accumulators, so no feature silently vanishes on either path).
@@ -64,6 +64,12 @@ class VmapSweepResult:
         Name of the swept parameter.
     param_values : ndarray, shape (n_batch,)
         The parameter values that were swept.
+    final_fields : dict or None
+        Never populated (``return_fields=True`` raises ``ValueError``
+        instead of silently returning ``None`` here — see
+        ``vmap_material_sweep``). Reserved for a future final-field-state
+        implementation; use ``sim.run()``/``sim.forward()`` or
+        ``parametric_sweep()`` for final fields today.
     dft_planes : dict[str, ndarray] or None
         DFT plane accumulators, keyed by the ``add_dft_plane_probe`` name,
         each shaped ``(n_batch, n_freqs, n1, n2)`` complex — a leading
@@ -72,19 +78,16 @@ class VmapSweepResult:
         path and the sequential fallback (the fallback stacks each
         swept-value ``Result.dft_planes[name].accumulator``), so the field
         is uniform regardless of which path a given ``Simulation`` takes.
-        ``None`` if no ``add_dft_plane_probe`` was registered.
-    final_fields : dict or None
-        Never populated (``return_fields=True`` raises ``ValueError``
-        instead of silently returning ``None`` here — see
-        ``vmap_material_sweep``). Reserved for a future final-field-state
-        implementation; use ``sim.run()``/``sim.forward()`` or
-        ``parametric_sweep()`` for final fields today.
+        ``None`` if no ``add_dft_plane_probe`` was registered. Appended
+        AFTER ``final_fields`` (not inserted before it) to preserve the
+        positional-construction meaning of this publicly exported
+        dataclass for any existing caller using positional args.
     """
     time_series: np.ndarray
     param_name: str
     param_values: np.ndarray
-    dft_planes: dict | None = None
     final_fields: dict | None = None
+    dft_planes: dict | None = None
 
     def peak_field(self) -> np.ndarray:
         """Return peak |probe value| per batch element."""

--- a/tests/test_vmap_sweep_dft_planes.py
+++ b/tests/test_vmap_sweep_dft_planes.py
@@ -5,17 +5,33 @@ CPU-runnable on tiny grids (intentionally not gpu-marked, matching
 
 Comparator-class work (rfx-known-issues.md case ledger; workspace R5): the
 equivalence tests below carry a predeclared tolerance derived from an
-inspected per-bin dump (not asserted blind), and the falsifier ritual — a
-one-sided deliberate sign flip in the vmap DFT kernel that must turn the
-equivalence check red — was run manually against a throwaway edit before
-this file was written; see
-``i578_falsifier_red.txt``/``i578_perbin_dump.txt`` in the session
-scratchpad for the artifacts. The observed agreement floor at the chosen
-geometry/step count is ~5e-4 relative (float32 accumulation roundoff
-between the two independently-coded scan bodies); a genuine phase/sign
-defect produces O(1) relative error uniformly (demonstrated by the
-falsifier run), so the gates here use rtol with a comfortable margin above
-the observed floor, not a tight-as-possible bound.
+inspected per-bin dump (not asserted blind), and a one-sided falsifier
+ritual (deliberate sign flip in the vmap DFT kernel, which must turn the
+equivalence check red) was run before this tolerance was trusted.
+
+R5 per-bin dump (batched vmap vs. sequential ``sim.run()``, plane p1 =
+axis=x, coordinate=0.010 m, component=ez, n_freqs=4, eps_r=2.0, n_steps=60
+-- the eps_r=6.0 case measured tighter, 2.6e-4 to 2.8e-4 uniformly, and is
+omitted for brevity):
+
+    freq (Hz)     |run acc|      |vmap acc|     complex maxdiff   rel diff
+    5.0000e+08    4.857830e-12   4.857516e-12   2.500504e-15      5.147e-04
+    2.0000e+09    4.366568e-12   4.366276e-12   2.269723e-15      5.198e-04
+    3.5000e+09    3.554534e-12   3.554285e-12   1.870204e-15      5.261e-04
+    5.0000e+09    2.804546e-12   2.804345e-12   1.480970e-15      5.281e-04
+
+Magnitudes agree to ~5 significant figures at every bin (rel diff 2.6e-4 to
+5.3e-4, uniform across frequency and eps_r) -- consistent with ordinary
+float32 accumulation roundoff between the two independently-coded scan
+bodies, not a systematic phase/sign/off-by-one defect. Falsifier (temporary
+sign flip of the vmap DFT kernel to ``exp(+1j...)``, reverted via ``git
+checkout`` immediately after each run): relative error jumped to 0.11-1.79
+(O(1)) uniformly across every bin, both when run as a standalone script and
+when run against this committed pytest file -- and ONLY the
+``TestVmapDftPlaneFastPath`` tests went red, confirming the falsifier is
+localized to the code path it is meant to catch. So the gates below use
+rtol with a comfortable margin above the observed ~5e-4 floor, not a
+tight-as-possible bound.
 """
 
 from __future__ import annotations
@@ -25,6 +41,11 @@ import warnings
 import numpy as np
 import numpy.testing as npt
 import pytest
+
+try:  # modern JAX: scoped x64 promoted to top-level (experimental removed v0.8.0)
+    from jax import enable_x64 as _enable_x64
+except ImportError:  # older JAX (< ~0.4.31)
+    from tests._x64_compat import enable_x64 as _enable_x64
 
 from rfx import Simulation, GaussianPulse, Box
 from rfx.vmap_sweep import vmap_material_sweep, VmapSweepResult
@@ -73,8 +94,8 @@ def _assert_dft_planes_match(vmap_planes: dict, ref_planes: dict, *,
     precision on the actual signal (discovered building this test: doing
     the elementwise check first gave 27% "mismatched" elements, all at
     |value| ~ 1e-16 next to a ~1e-12 peak). This is the same max-abs-diff
-    / max-abs-reference ratio manually verified and dumped for the R5
-    per-bin artifact (i578_perbin_dump.txt) before this gate was written.
+    / max-abs-reference ratio manually verified and inlined into this
+    module's docstring (the R5 per-bin dump) before this gate was written.
     """
     for name, probe in ref_planes.items():
         ref_acc = np.asarray(probe.accumulator, dtype=np.complex128)
@@ -170,6 +191,38 @@ class TestVmapDftPlaneFastPath:
         res = vmap_material_sweep(sim, "substrate.eps_r", np.array([2.0, 4.0]),
                                    n_steps=20)
         assert res.dft_planes is None
+
+
+class TestVmapDftPlaneX64:
+    """#477/#484 x64-contract pin, scoped (never module-level, per repo
+    rule): under ``jax_enable_x64``, ``init_dft_plane_probe`` (called
+    identically by both the vmap fast path and ``run()``) selects
+    ``complex128`` instead of ``complex64`` (rfx/probes/probes.py:441).
+    This is a separate axis from the default-precision equivalence tests
+    above -- confirm the promoted dtype AND that equivalence still holds
+    (same ~5e-4 relative floor observed at default precision; x64 widens
+    the accumulator's storage precision but the underlying field state is
+    still produced by the same float32-pinned Yee kernels, so the
+    numerical agreement floor does not tighten)."""
+
+    def test_dft_plane_matches_run_cpml_x64(self):
+        eps_values = np.array([2.0, 6.0])
+        n_steps = 60
+
+        with _enable_x64(True):
+            vmap_res = vmap_material_sweep(
+                _dft_sim("cpml", eps_r=4.0), "substrate.eps_r", eps_values,
+                n_steps=n_steps,
+            )
+            assert vmap_res.dft_planes["p1"].dtype == np.complex128
+
+            for idx, ev in enumerate(eps_values):
+                ref = _dft_sim("cpml", eps_r=float(ev)).run(n_steps=n_steps)
+                assert ref.dft_planes["p1"].accumulator.dtype == np.complex128
+                _assert_dft_planes_match(
+                    {"p1": vmap_res.dft_planes["p1"][idx]},
+                    ref.dft_planes, rtol=2e-3, ctx=f"x64 cpml eps_r={ev}",
+                )
 
 
 class TestVmapDftPlaneFallbackCarries:

--- a/tests/test_vmap_sweep_dft_planes.py
+++ b/tests/test_vmap_sweep_dft_planes.py
@@ -1,0 +1,352 @@
+"""Tests for DFT plane accumulators on the vmap fast path (#578).
+
+CPU-runnable on tiny grids (intentionally not gpu-marked, matching
+``test_vmap_sweep_eligibility.py``, so the PR gate exercises this file).
+
+Comparator-class work (rfx-known-issues.md case ledger; workspace R5): the
+equivalence tests below carry a predeclared tolerance derived from an
+inspected per-bin dump (not asserted blind), and the falsifier ritual — a
+one-sided deliberate sign flip in the vmap DFT kernel that must turn the
+equivalence check red — was run manually against a throwaway edit before
+this file was written; see
+``i578_falsifier_red.txt``/``i578_perbin_dump.txt`` in the session
+scratchpad for the artifacts. The observed agreement floor at the chosen
+geometry/step count is ~5e-4 relative (float32 accumulation roundoff
+between the two independently-coded scan bodies); a genuine phase/sign
+defect produces O(1) relative error uniformly (demonstrated by the
+falsifier run), so the gates here use rtol with a comfortable margin above
+the observed floor, not a tight-as-possible bound.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from rfx import Simulation, GaussianPulse, Box
+from rfx.vmap_sweep import vmap_material_sweep, VmapSweepResult
+
+_FALLBACK_MATCH = "Falling back to sequential"
+
+
+def _dft_sim(boundary: str = "cpml", eps_r: float = 4.0,
+             amplitude_kind: str | None = None) -> Simulation:
+    """CPML/PEC dielectric slab with one DFT plane MID-domain (not near a
+    boundary): moving the plane away from the domain edge matters — near
+    the edge the accumulated signal is dominated by roundoff noise (near
+    zero at these short step counts) and a relative-tolerance check would
+    pass vacuously without exercising anything (discovered while building
+    this file: a plane at x=0.016 gave accumulator magnitudes ~1e-15 with
+    no real signal; x=0.010 gives ~1e-12, a genuine non-trivial spectrum).
+    """
+    kwargs = {"cpml_layers": 6} if boundary == "cpml" else {}
+    sim = Simulation(
+        freq_max=5e9, domain=(0.02, 0.02, 0.02), boundary=boundary,
+        dx=0.002, **kwargs,
+    )
+    sim.add_material("substrate", eps_r=eps_r)
+    sim.add(Box((0.005, 0, 0), (0.015, 0.02, 0.02)), material="substrate")
+    sim.add_source((0.01, 0.01, 0.01), "ez", waveform=GaussianPulse(f0=3e9),
+                    amplitude_kind=amplitude_kind)
+    sim.add_probe((0.005, 0.01, 0.01), "ez")
+    sim.add_dft_plane_probe(axis="x", coordinate=0.010, component="ez",
+                             n_freqs=4, name="p1")
+    return sim
+
+
+def _assert_dft_planes_match(vmap_planes: dict, ref_planes: dict, *,
+                              rtol: float, ctx: str) -> None:
+    """Compare dict[str, DFTPlaneProbe] (a Result) against a single batch
+    slice of VmapSweepResult.dft_planes, comparison arithmetic in f64
+    (#527 style: the accumulators are complex64-scale; casting up before
+    diffing avoids a spurious float32-comparator artefact).
+
+    Per-FREQUENCY-BIN relative error, normalized by that bin's own peak
+    magnitude over the plane -- NOT a blind elementwise
+    ``assert_allclose``. A DFT plane has near-zero cells far from the
+    source/trace where the true signal is dominated by roundoff-level
+    cancellation noise; an elementwise rtol check flags those as huge
+    relative mismatches even though both paths agree to within float32
+    precision on the actual signal (discovered building this test: doing
+    the elementwise check first gave 27% "mismatched" elements, all at
+    |value| ~ 1e-16 next to a ~1e-12 peak). This is the same max-abs-diff
+    / max-abs-reference ratio manually verified and dumped for the R5
+    per-bin artifact (i578_perbin_dump.txt) before this gate was written.
+    """
+    for name, probe in ref_planes.items():
+        ref_acc = np.asarray(probe.accumulator, dtype=np.complex128)
+        got_acc = np.asarray(vmap_planes[name], dtype=np.complex128)
+        assert ref_acc.shape == got_acc.shape, (
+            f"DFT plane {name!r} shape mismatch ({ctx}): "
+            f"{got_acc.shape} vs {ref_acc.shape}"
+        )
+        for fi in range(ref_acc.shape[0]):
+            mag_ref = np.max(np.abs(ref_acc[fi]))
+            diff = np.max(np.abs(got_acc[fi] - ref_acc[fi]))
+            assert mag_ref > 0.0, (
+                f"DFT plane {name!r} freq bin {fi} is all-zero in the "
+                f"reference ({ctx}) -- fixture does not exercise signal "
+                "at this bin, tolerance check is meaningless"
+            )
+            rel = diff / mag_ref
+            assert rel < rtol, (
+                f"DFT plane {name!r} freq bin {fi} mismatch ({ctx}): "
+                f"rel={rel:.3e} >= rtol={rtol:.3e} "
+                f"(|ref|_max={mag_ref:.3e}, maxdiff={diff:.3e})"
+            )
+
+
+class TestVmapDftPlaneFastPath:
+    """Fast-path (vmap-batched) DFT accumulator vs. direct sim.run(),
+    per swept element -- the comparator-class equivalence gate."""
+
+    def test_dft_plane_matches_run_cpml(self):
+        eps_values = np.array([2.0, 6.0])
+        n_steps = 60
+
+        vmap_res = vmap_material_sweep(
+            _dft_sim("cpml", eps_r=4.0), "substrate.eps_r", eps_values,
+            n_steps=n_steps,
+        )
+        assert vmap_res.dft_planes is not None
+        assert set(vmap_res.dft_planes.keys()) == {"p1"}
+        # axis="x" plane -> (n1, n2) = (Ny, Nz) INCLUDING CPML padding;
+        # not hand-computed here (grid padding is an implementation detail)
+        # -- cross-checked against the shape run() itself produces below.
+        ref0 = _dft_sim("cpml", eps_r=float(eps_values[0])).run(n_steps=n_steps)
+        expected_shape = (len(eps_values),) + tuple(
+            ref0.dft_planes["p1"].accumulator.shape)
+        assert vmap_res.dft_planes["p1"].shape == expected_shape
+
+        for idx, ev in enumerate(eps_values):
+            ref = _dft_sim("cpml", eps_r=float(ev)).run(n_steps=n_steps)
+            _assert_dft_planes_match(
+                {"p1": vmap_res.dft_planes["p1"][idx]},
+                ref.dft_planes, rtol=2e-3, ctx=f"cpml eps_r={ev}",
+            )
+
+    def test_dft_plane_matches_run_pec(self):
+        """Non-CPML (plain PEC-wall) boundary takes the OTHER
+        ``_build_vmap_scan_fn`` branch (``use_cpml=False``) -- pin it too,
+        it is a structurally different scan body."""
+        eps_values = np.array([2.0, 6.0])
+        n_steps = 60
+
+        vmap_res = vmap_material_sweep(
+            _dft_sim("pec", eps_r=4.0), "substrate.eps_r", eps_values,
+            n_steps=n_steps,
+        )
+        for idx, ev in enumerate(eps_values):
+            ref = _dft_sim("pec", eps_r=float(ev)).run(n_steps=n_steps)
+            _assert_dft_planes_match(
+                {"p1": vmap_res.dft_planes["p1"][idx]},
+                ref.dft_planes, rtol=2e-3, ctx=f"pec eps_r={ev}",
+            )
+
+    def test_dft_plane_dtype_matches_run(self):
+        """#477/#484 x64-contract pin: the vmap accumulator dtype must be
+        the SAME complex dtype run() would produce (complex64 with x64
+        off, the default here)."""
+        vmap_res = vmap_material_sweep(
+            _dft_sim("cpml"), "substrate.eps_r", np.array([2.0, 4.0]),
+            n_steps=20,
+        )
+        ref = _dft_sim("cpml").run(n_steps=20)
+        assert vmap_res.dft_planes["p1"].dtype == ref.dft_planes["p1"].accumulator.dtype
+
+    def test_no_dft_plane_registered_leaves_dft_planes_none(self):
+        """Control: a sim with no add_dft_plane_probe call must NOT
+        fabricate a dft_planes dict."""
+        sim = Simulation(freq_max=5e9, domain=(0.02, 0.02, 0.02),
+                          boundary="cpml", cpml_layers=6, dx=0.002)
+        sim.add_material("substrate", eps_r=4.0)
+        sim.add(Box((0.005, 0, 0), (0.015, 0.02, 0.02)), material="substrate")
+        sim.add_source((0.01, 0.01, 0.01), "ez", waveform=GaussianPulse(f0=3e9))
+        sim.add_probe((0.005, 0.01, 0.01), "ez")
+
+        res = vmap_material_sweep(sim, "substrate.eps_r", np.array([2.0, 4.0]),
+                                   n_steps=20)
+        assert res.dft_planes is None
+
+
+class TestVmapDftPlaneFallbackCarries:
+    """#578: the sequential fallback must ALSO populate ``.dft_planes`` —
+    no path asymmetry (design v2 PR B.1)."""
+
+    def test_upml_fallback_carries_dft_planes(self):
+        """UPML (not fast-path eligible) + a registered DFT plane: the
+        fallback must return the SAME accumulator run() would (exact
+        match expected -- the fallback literally calls sim.run() per
+        swept value, so this is not a numerical-tolerance comparator, it
+        is the same call twice)."""
+        eps_values = np.array([2.0, 6.0])
+        n_steps = 20
+
+        with pytest.warns(UserWarning, match=_FALLBACK_MATCH):
+            res = vmap_material_sweep(
+                _dft_sim("upml", eps_r=4.0), "substrate.eps_r", eps_values,
+                n_steps=n_steps,
+            )
+        assert res.dft_planes is not None
+        assert res.dft_planes["p1"].shape[0] == len(eps_values)
+
+        for idx, ev in enumerate(eps_values):
+            ref = _dft_sim("upml", eps_r=float(ev)).run(n_steps=n_steps)
+            npt.assert_allclose(
+                res.dft_planes["p1"][idx],
+                np.asarray(ref.dft_planes["p1"].accumulator),
+                rtol=1e-10, atol=1e-20,
+                err_msg=f"fallback dft_planes should exactly reproduce "
+                        f"run() at eps_r={ev} (same call)",
+            )
+
+
+class TestVmapPortFamilyEligibility:
+    """MSL/floquet/coaxial ports are separate registries from
+    ``sim._ports`` (lumped/soft-source) and were never consulted by the
+    fast-path eligibility guard before #578 -- a genuine silent-drop gap
+    for MSL/floquet (run()-consumed) and an honesty gap for coaxial (not
+    consumed by plain run() at all). These pins belong here rather than
+    ``test_vmap_sweep_eligibility.py`` because they combine port families
+    with a registered DFT plane to also exercise the fallback-carries-DFT
+    path for a non-UPML fallback reason."""
+
+    def test_floquet_port_takes_sequential_fallback(self):
+        Lx, Ly, Lz = 0.015, 0.015, 0.03
+        sim = Simulation(freq_max=15e9, domain=(Lx, Ly, Lz), boundary="cpml",
+                          cpml_layers=8, dx=0.001)
+        sim.add_material("substrate", eps_r=2.2)
+        sim.add(Box((0, 0, Lz / 2 - 0.001), (Lx, Ly, Lz / 2)), material="substrate")
+        patch_w = 0.008
+        x0 = (Lx - patch_w) / 2
+        y0 = (Ly - patch_w) / 2
+        sim.add(Box((x0, y0, Lz / 2), (x0 + patch_w, y0 + patch_w, Lz / 2 + 0.001)),
+                material="pec")
+        sim.add_floquet_port(Lz * 0.25, axis="z", scan_theta=0.0, scan_phi=0.0,
+                              polarization="te", n_freqs=10)
+        sim.add_probe((Lx / 2, Ly / 2, Lz / 2 + 0.002), component="ex")
+
+        with pytest.warns(UserWarning, match=_FALLBACK_MATCH):
+            res = vmap_material_sweep(
+                sim, "substrate.eps_r", np.array([2.0, 3.0]), n_steps=20,
+            )
+        assert res.time_series.shape[0] == 2
+
+    def test_msl_port_takes_sequential_fallback(self):
+        sim = Simulation(freq_max=5e9, domain=(0.02, 0.01, 0.006),
+                          boundary="cpml", cpml_layers=6, dx=0.001)
+        sim.add_material("sub", eps_r=4.0)
+        sim.add(Box((0, 0, 0), (0.02, 0.01, 0.002)), material="sub")
+        sim.add(Box((0, 0.004, 0.002), (0.02, 0.006, 0.003)), material="pec")
+        sim.add_msl_port(position=(0.003, 0.005, 0.0), width=0.002,
+                          height=0.002, direction="+x", impedance=50.0)
+
+        with pytest.warns(UserWarning, match=_FALLBACK_MATCH):
+            res = vmap_material_sweep(
+                sim, "sub.eps_r", np.array([2.0, 3.0]), n_steps=15,
+            )
+        assert res.time_series.shape[0] == 2
+
+    def test_coaxial_port_takes_sequential_fallback_and_fails_loud(self):
+        """Coaxial ports are not consumed by plain ``sim.run()`` at all
+        (pre-existing NotImplementedError there); before #578 the vmap
+        fast-path eligibility guard did not check ``_coaxial_ports``, so
+        a coax-port sim silently took the fast path and just ignored the
+        port (no error, wrong/incomplete physics). Post-#578 it routes to
+        the sequential fallback, which surfaces run()'s existing honest
+        NotImplementedError instead of a silent no-op -- this is the
+        'honesty claim distinguishes the families' guard from the design
+        doc, verified by an actual raise, not just a routing check."""
+        sim = Simulation(freq_max=10e9, domain=(0.02, 0.02, 0.02),
+                          boundary="pec", dx=0.002)
+        sim.add_material("sub", eps_r=4.0)
+        sim.add(Box((0.005, 0, 0), (0.015, 0.02, 0.02)), material="sub")
+        sim.add_coaxial_port((0.010, 0.010, 0.015), face="top")
+        sim.add_source((0.01, 0.01, 0.005), "ez", waveform=GaussianPulse(f0=3e9))
+        sim.add_probe((0.005, 0.01, 0.01), "ez")
+
+        with pytest.warns(UserWarning, match=_FALLBACK_MATCH):
+            with pytest.raises(NotImplementedError, match="add_coaxial_port"):
+                vmap_material_sweep(
+                    sim, "sub.eps_r", np.array([2.0, 3.0]), n_steps=15,
+                )
+
+
+class TestVmapAmplitudeKindCurrent:
+    """PR #617 (issue #571) added ``amplitude_kind='current'`` soft
+    sources with a dynamic per-batch Cb-normalization path in
+    ``_build_vmap_scan_fn`` (rfx/vmap_sweep.py:450-468) -- until this
+    file, no test exercised it at the ``vmap_material_sweep`` level (the
+    #617 coverage gap named in the #578 design doc). Tolerance is looser
+    than the DFT-plane gate above: at n_steps=20 the observed relative
+    floor between the vmap dynamic-Cb path and run()'s equivalent is
+    ~5e-5 (grows with step count as the dielectric-filled small CPML
+    domain accumulates reflections -- ordinary float32 FDTD chaos, not a
+    phase/sign defect; see the module docstring for the falsifier
+    argument)."""
+
+    def test_amplitude_kind_current_matches_run_cpml(self):
+        eps_values = np.array([2.0, 6.0])
+        n_steps = 20
+
+        vmap_res = vmap_material_sweep(
+            _dft_sim("cpml", eps_r=4.0, amplitude_kind="current"),
+            "substrate.eps_r", eps_values, n_steps=n_steps,
+        )
+        for idx, ev in enumerate(eps_values):
+            ref = _dft_sim(
+                "cpml", eps_r=float(ev), amplitude_kind="current",
+            ).run(n_steps=n_steps)
+            npt.assert_allclose(
+                vmap_res.time_series[idx],
+                np.asarray(ref.time_series, dtype=np.float64),
+                rtol=1e-3, atol=1e-6,
+                err_msg=f"amplitude_kind='current' vmap-vs-run at eps_r={ev}",
+            )
+
+    def test_amplitude_kind_current_matches_run_pec(self):
+        eps_values = np.array([2.0, 6.0])
+        n_steps = 20
+
+        vmap_res = vmap_material_sweep(
+            _dft_sim("pec", eps_r=4.0, amplitude_kind="current"),
+            "substrate.eps_r", eps_values, n_steps=n_steps,
+        )
+        for idx, ev in enumerate(eps_values):
+            ref = _dft_sim(
+                "pec", eps_r=float(ev), amplitude_kind="current",
+            ).run(n_steps=n_steps)
+            npt.assert_allclose(
+                vmap_res.time_series[idx],
+                np.asarray(ref.time_series, dtype=np.float64),
+                rtol=1e-3, atol=1e-6,
+                err_msg=f"amplitude_kind='current' vmap-vs-run (pec) at eps_r={ev}",
+            )
+
+
+class TestVmapReturnFieldsRaise:
+    """#578: return_fields=True was documented-but-never-implemented
+    (VmapSweepResult.final_fields was never populated) -- it now raises
+    ValueError instead of silently returning final_fields=None."""
+
+    def test_return_fields_true_raises(self):
+        sim = _dft_sim("cpml")
+        with pytest.raises(ValueError, match="return_fields=True"):
+            vmap_material_sweep(
+                sim, "substrate.eps_r", np.array([2.0, 4.0]), n_steps=10,
+                return_fields=True,
+            )
+
+    def test_return_fields_false_is_unaffected(self):
+        """Control: the default (False) must not raise and must behave
+        exactly as before."""
+        sim = _dft_sim("cpml")
+        res = vmap_material_sweep(
+            sim, "substrate.eps_r", np.array([2.0, 4.0]), n_steps=10,
+            return_fields=False,
+        )
+        assert isinstance(res, VmapSweepResult)
+        assert res.final_fields is None

--- a/tests/test_vmap_sweep_eligibility.py
+++ b/tests/test_vmap_sweep_eligibility.py
@@ -1,11 +1,24 @@
 """Eligibility guards for the vmap_material_sweep fast path (roadmap W1.2).
 
-The vmap scan bodies implement only pec/periodic walls and CPML. Before
-this guard, a sim with ``boundary='upml'`` was routed to a scan body that
-applies NO absorber at all, and lumped RLC elements / flux monitors /
-DFT planes / NTFF / non-uniform profiles were silently dropped from the
-swept runs. These tests pin the sequential fallback for every such case
-and pin that the supported fast path still does NOT fall back.
+The vmap scan bodies implement only pec/periodic walls, CPML, and (as of
+#578) DFT plane probes. Before the original guard, a sim with
+``boundary='upml'`` was routed to a scan body that applies NO absorber at
+all, and lumped RLC elements / flux monitors / NTFF / non-uniform profiles
+were silently dropped from the swept runs. These tests pin the sequential
+fallback for every such case and pin that the supported fast path still
+does NOT fall back.
+
+#578 added DFT plane probes to the fast-path allowlist (see
+``tests/test_vmap_sweep_dft_planes.py`` for the batched-vs-run()
+equivalence gate, the falsifier ritual, and the fallback-carries-DFT
+pin) and added eligibility guards for the MSL/floquet/coaxial port
+registries (``sim._msl_ports`` / ``_floquet_ports`` / ``_coaxial_ports``),
+which were never consulted here before — a sim carrying one of those took
+the fast path and silently ignored the port. MSL/floquet/coaxial
+fallback pins (combined with a registered DFT plane, to also exercise
+fallback-carries-DFT for a non-UPML fallback reason) live in
+``tests/test_vmap_sweep_dft_planes.py::TestVmapPortFamilyEligibility``
+rather than here.
 
 CPU-runnable on tiny grids (intentionally not gpu-marked so the PR gate
 exercises this file).


### PR DESCRIPTION
## Summary

Implements #578's PR B (design v2, three-lens-reviewed contract), delivering AC2/AC3 and declining AC1 with reasons per the issue's own invitation ("If either is fundamentally incompatible with the vmap path, a note in the docstring explaining *why* would still help").

- **AC2 (delivered)**: `add_dft_plane_probe` planes now accumulate inside the `jax.vmap`-batched scan carry, inlining `Simulation.run()`'s rect-window DFT kernel exactly (same `init_dft_plane_probe` call, same `t = state.step * dt` phase reference — using the scan's own step index instead would be an off-by-one, per-bin phase-error class bug, the #404 comparator precedent). `VmapSweepResult` gains `dft_planes: dict[str, ndarray] | None` with a leading batch axis `(n_batch, n_freqs, n1, n2)`. The sequential fallback (still used for TFSF, lumped/MSL/coaxial/floquet ports, dispersion, waveguide ports, flux monitors, NTFF) now *also* populates this field by stacking each swept value's `Result.dft_planes` accumulator — no path asymmetry, so a registered DFT plane never silently loses data regardless of which internal path a given `Simulation` takes. Previously neither path carried any frequency-domain data at all.
- **AC3 (delivered, docstring stays qualitative per the anti-rot norm, number lives here + CHANGELOG)**: measured speedup, batched vmap fast path vs. sequential fallback, same machine/config (CPML dielectric slab + one DFT plane, `n_steps=300`, CPU backend, JAX 0.10.2, AMD EPYC 9654 96-core — **no GPU available in this environment**, so this undersells the real benefit which comes from genuine parallel kernel execution): **1.2x at n_batch=8, 2.0x at n_batch=16, 4.7x at n_batch=32**. Speedup grows with batch size because the fast path pays one XLA compile amortized over the whole batch while the fallback recompiles per swept value.
- **AC1 (declined with reasons — issue's own escape hatch)**: batching TFSF incidence angle/polarization is a structural mismatch with `vmap_material_sweep`'s material-only batching model, not a missing feature:
  - The TFSF incident field is itself an auxiliary FDTD solution advanced *inside* the scan (not closed-form, contrary to the issue's assumption that "the incident-field evaluation is a closed-form function of the angles").
  - Method B's auxiliary-grid size is angle-dependent (`rfx/sources/tfsf_oblique_open.py`) — a batch of angles would need a batch of scan shapes, which `jax.vmap` cannot express.
  - The oblique 2D-aux Bloch path concretizes its transverse phase factors from `angle_deg` at trace time (`rfx/sources/tfsf_2d.py`).
  - More basically, rfx cannot even *express* a general incidence triple `(theta, phi, psi)` today — only `angle_deg` + a binary `direction` + a two-way `polarization` choice — so there is no batchable angle parameter to expose in the first place.
  - Route: `parametric_sweep()` (`rfx/sweep.py`) already returns full `Result` objects including `dft_planes` per swept value, so illumination/angle sweeps ARE supported there today — with the caveat that oblique-Bloch TFSF (`angle_deg != 0`, `method='bloch'`) combined with DFT planes/flux/NTFF raises `NotImplementedError` by design (`rfx/simulation.py:728-745`, pre-existing, not new): DFT-plane tensors under TFSF illumination are obtainable at normal incidence (`angle_deg=0`) or `method='methodB'` only.
  - A *material* sweep on a sim carrying a *fixed* (non-swept) TFSF source still benefits from this PR: it takes the sequential fallback (TFSF isn't fast-path-eligible) but that fallback now carries `dft_planes` through.

Also in scope (design v2 PR B.3, guard/text fixes on the touched file):
- New eligibility guards for MSL (`_msl_ports`) and Floquet (`_floquet_ports`) ports — genuine silent-drop gaps before this PR (the fast-path scan bodies never launched or recorded them, so a swept sim carrying one ran the fast path silently missing that physics). Coaxial ports (`_coaxial_ports`) get the same guard for honesty/uniformity even though they aren't consumed by plain `run()` at all today — the guard converts a silent no-op into `run()`'s pre-existing `NotImplementedError` instead.
- Fixed a drifted module-docstring inversion (`rfx/vmap_sweep.py` Limitations section claimed ports/TFSF/dispersion/etc. were "fully supported" — the opposite of the function docstring and the code guards, which always correctly listed them as fallback-triggering).
- `return_fields=True` now raises `ValueError` instead of silently returning `final_fields=None` (documented-but-never-implemented since this function's introduction).

## Review fixes (commit `100bb11`, after an independent reviewer pass)

- **B1 (blocking)**: `docs/agent/recipe-parameter-sweeps.mdx` had drifted from the shipped code — DFT planes were still listed under the sequential-fallback bullet (they're fast-path now), the fast-path bullet omitted DFT planes, the new MSL/coaxial/floquet port guards were absent from the fallback list, and the memory-scaling note didn't mention the batched DFT-accumulator term. All four points now match `rfx/vmap_sweep.py`'s module docstring.
- **A1**: this PR body's test tallies were wrong — corrected below (`test_vmap_sweep.py` is 10 not 12; `test_stage2_tier3_guards.py` is 4 not 3).
- **A2**: `tests/test_vmap_sweep_dft_planes.py`'s docstring and this PR body pointed at session-scratchpad artifact paths unreachable outside this session (this is a public repo). The R5 per-bin dump is now inlined directly into the test module's docstring and into this PR body (below) — no external pointer.
- **A3**: dropped "snapshots" from the `rfx/vmap_sweep.py` module docstring's fallback-triggering feature list — there is no snapshot registry on `Simulation`; `snapshot=` is a `run()`-only kwarg the vmap path never receives, so it was never a real guard.
- **A4**: `VmapSweepResult.dft_planes` was inserted before `final_fields` in a publicly exported dataclass; moved to the END (after `final_fields`) to preserve positional-construction meaning. Both construction call sites already use keyword args (verified, unaffected either way); `check_api_reference.py` stays clean.
- **A5**: added `TestVmapDftPlaneX64` — a per-test x64-scoped equivalence case (`tests/_x64_compat` pattern, never module-level) confirming the accumulator promotes to `complex128` on both paths (same `init_dft_plane_probe` call) and equivalence holds at the same ~5e-4 relative floor observed at default precision.
- The DFT kernel arithmetic itself (`rfx/vmap_sweep.py`'s `phase = jnp.exp(-1j * ...)` line) was **not touched** by this fix commit — only docstrings, dataclass field order, one guard-list text item, and the `.mdx` doc changed — so the falsifier evidence from the original commits still applies unchanged.

## R1 memory citations
- Comparator-bug case ledger (workspace rule, `rfx-known-issues.md`): PR B's equivalence test is comparator-class work — it got a one-sided falsifier (deliberate DFT-kernel sign flip) and an R5 per-bin dump before being trusted green (both below).
- #477/#484 x64-contract: the vmap accumulator dtype is asserted equal to `run()`'s (`jax.config.x64_enabled`-derived), by construction since both call the same `init_dft_plane_probe`.
- Primary-checkout `docs/agent-memory/rfx-known-issues.md` grep for "vmap": two unrelated hits (#224 CPML material-aware absorber threading, #107 tuple-unpack fix) — neither concerns DFT-plane accumulation, no contradiction found.

## R2
Single clean implementation pass; the only correction made during development was to the *test's* comparator (see Test plan), not the vmap kernel itself, which passed the falsifier on the first implementation. Attempt count for the mechanism = 1.

## Test plan

Full required set, all run explicitly with `-m ''` (overrides `pyproject.toml`'s default `addopts = "-m 'not gpu and not slow and not slow_physics'"`, which otherwise deselects the gpu-marked file below) — **34/34 pass**:

- [x] `tests/test_vmap_sweep.py` — **10 tests**, gpu-marked (deselected by default addopts; run explicitly with `-m ''`), pre-existing — unchanged, still green (no regression on the legacy fast/fallback paths).
- [x] `tests/test_vmap_cpml_dielectric.py` — **2 tests**, not gpu-marked (runs under the default lane), pre-existing — unchanged, still green.
- [x] `tests/test_vmap_sweep_eligibility.py` — **5 tests** (header updated to point at the new port-family pins) — still green.
- [x] `tests/test_stage2_tier3_guards.py` — **4 tests** — still green.
- [x] `tests/test_vmap_sweep_dft_planes.py` — **13 tests** (new file; 12 from the original commit + `TestVmapDftPlaneX64` added in the review-fix commit) — batched-vs-`run()` DFT equivalence (CPML and PEC scan bodies separately, structurally different code paths), an x64-scoped equivalence case, dtype x64-contract pin, fallback-carries-DFT pin (UPML), MSL/floquet/coaxial fallback pins (coaxial asserts the fallback surfaces `run()`'s pre-existing `NotImplementedError`), `amplitude_kind='current'` vmap-level coverage (closes the #617 gap — no prior test exercised the dynamic-Cb path at the `vmap_material_sweep` level), `return_fields=True` raise.
- [x] **Comparator note**: the equivalence gate uses a per-frequency-bin, magnitude-normalized relative-error check, not a blind elementwise `assert_allclose` — an elementwise check on the first attempt flagged 27% of array elements as "mismatched" purely from cancellation noise in near-zero cells far from the source (both paths agree to ~5e-4 relative on the actual signal). Documented inline in the test file.
- [x] **Falsifier (one-sided, mandatory before trusting green)**: temporarily flipped the vmap DFT kernel to `exp(+1j...)` (throwaway edit, reverted via `git checkout` immediately after each run, confirmed clean via `git status`/`git diff --stat`), ran twice — a standalone script and the actual committed pytest file. Both runs went red on exactly `TestVmapDftPlaneFastPath` (relative error jumped from ~5e-4 to 0.11–1.79, i.e. O(1)) and nothing else (port-eligibility/fallback/amplitude_kind/return_fields tests stayed green), confirming the falsifier is localized to the code path it's supposed to catch. Not re-run after the review-fix commit since that commit did not touch the kernel line (see above).
- [x] **R5 per-bin dump** (inlined here, and in `tests/test_vmap_sweep_dft_planes.py`'s module docstring — no external artifact pointer): plane `p1` = axis=x, coordinate=0.010 m, component=ez, n_freqs=4, `eps_r=2.0`, `n_steps=60` (the `eps_r=6.0` case measured tighter, 2.6e-4 to 2.8e-4 uniformly, omitted here for brevity):

  ```
  freq (Hz)     |run acc|      |vmap acc|     complex maxdiff   rel diff
  5.0000e+08    4.857830e-12   4.857516e-12   2.500504e-15      5.147e-04
  2.0000e+09    4.366568e-12   4.366276e-12   2.269723e-15      5.198e-04
  3.5000e+09    3.554534e-12   3.554285e-12   1.870204e-15      5.261e-04
  5.0000e+09    2.804546e-12   2.804345e-12   1.480970e-15      5.281e-04
  ```

  Magnitudes agree to ~5 significant figures at every bin, uniform across frequency and eps_r — consistent with ordinary float32 accumulation roundoff between the two independently-coded scan bodies, not a systematic phase/sign/off-by-one defect (contrast with the O(1) falsifier numbers above).
- [x] `ruff check rfx/ tests/ --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402` — clean.
- [x] `python scripts/check_api_reference.py` — clean (no public signature drift; `vmap_material_sweep`'s parameters are unchanged, only its return-value dataclass gained a field, and that field was moved to preserve positional-construction order per A4).

## Sequencing
Per the design doc, PR A (#579, `rfx.observables` + fail-loud distributed fences) should land first; this PR does not depend on PR A's code but the design doc treats them as one program. No conflicting files (PR A touches `rfx/observables.py` + `rfx/api/_execute.py` fences; this PR touches only `rfx/vmap_sweep.py` + its tests + `docs/agent/recipe-parameter-sweeps.mdx` + CHANGELOG). **Held open, not merged** pending PR A landing and final reviewer sign-off.

Closes #578.

R3: memory=none-after-grep (see R1 above) | R2-attempts=1 | falsifier=sign-flip the vmap DFT kernel, confirmed red twice (script + pytest gate) — per-bin dump and falsifier numbers now inlined in this PR body and in the test file's own docstring (no scratchpad pointer).

## Second review pass — one-word doc fix (commit `45c0bb9`)

A follow-up spot-check on `100bb11` caught one more micro-drift: the rewritten `docs/agent/recipe-parameter-sweeps.mdx` fallback bullet dropped "lumped RLC elements" while adding MSL/coaxial/floquet ports. `add_lumped_rlc` is a separate registry (`sim._lumped_rlc`, not `sim._ports`) whose guard still forces the fallback (`rfx/vmap_sweep.py:489-491`) — "lumped ports" in the rewritten text didn't cover it. Restored. Docs-only change (no kernel/code touched); re-ran the full 34-test required set + ruff after the fix, still 34/34 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

