### PR TITLE
feat(observables): differentiable DFT-plane accessor + objectives, rfx.observables (#579)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,43 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Added — `rfx.observables`: differentiable DFT-plane accessor + objectives (#579)
+
+- New `rfx.observables` module (flat-exported at top level and in the
+  curated `rfx.__all__`, re-specced 210 -> 213 for this addition):
+  `dft_field(names)` is a result accessor over `result.dft_planes` (a
+  single name returns the raw `(n_freqs, n1, n2)` complex accumulator; a
+  list of names stacks into `(n_names, n_freqs, n1, n2)` when shapes
+  match, else returns a `dict[name] -> array`). `field_energy(names)` and
+  `field_softmax(names, beta=)` are objective factories in the
+  `rfx.optimize_objectives` factory style (`callable(Result) -> scalar`,
+  JAX-differentiable), for `sum(|field|**2)` and a temperature-controlled
+  soft-max over space + frequency respectively. All three are lane-
+  agnostic: they work on `run()`/`forward()` results from both the
+  uniform and non-uniform meshes, since `result.dft_planes` is a
+  name-keyed dict on every one of those four combinations. See the
+  module docstring for the AD-tape contents and an E/H-mixing hazard note
+  (no `h_phase_correction` kwarg — apply `exp(+j*omega*dt/2)` to H-component
+  planes yourself for any E x H* cross-term objective).
+- New example `examples/inverse_design/field_observable_shielding.py`:
+  a normal-incidence TFSF illuminates a multilayer dielectric stack;
+  `field_softmax` pools two internal DFT-plane leakage monitors (the
+  register-N-planes-then-pool pattern, since each plane probe is single-
+  component) into one worst-case-leakage scalar minimized via
+  `jax.grad` descent.
+
+### **BREAKING** — two new fail-loud fences for registered DFT plane probes on distributed lanes (#579)
+
+- `forward(distributed=True)` and `run(devices=[...])` (2+ devices) now
+  raise `NotImplementedError` when any `add_dft_plane_probe(...)` plane is
+  registered, instead of silently dropping it. Neither
+  `rfx.runners.distributed_nu` (the only lane `forward(distributed=True)`
+  currently reaches) nor `rfx.runners.distributed_v2`/`rfx.runners.distributed`
+  accumulates DFT-plane fields — a registered plane's data was previously
+  discarded with no warning. Remediation: drop the DFT plane probe(s), or
+  use the single-device lane (`run()` without `devices=`, or a
+  non-distributed `forward()`).
+
 ### Added — explicit soft-source amplitude semantics: `add_source(..., amplitude_kind=)` (#565/#571)
 
 - `add_source` (and `add_polarized_source`) gain `amplitude_kind='field'|'current'|None`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   `dft_field(names)` is a result accessor over `result.dft_planes` (a
   single name returns the raw `(n_freqs, n1, n2)` complex accumulator; a
   list of names stacks into `(n_names, n_freqs, n1, n2)` when shapes
-  match, else returns a `dict[name] -> array`). `field_energy(names)` and
+  match, else raises `ValueError` pointing at `stack=False`, which opts
+  into a `dict[name] -> array` return instead). `field_energy(names)` and
   `field_softmax(names, beta=)` are objective factories in the
   `rfx.optimize_objectives` factory style (`callable(Result) -> scalar`,
   JAX-differentiable), for `sum(|field|**2)` and a temperature-controlled
@@ -31,7 +32,7 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   component) into one worst-case-leakage scalar minimized via
   `jax.grad` descent.
 
-### **BREAKING** — two new fail-loud fences for registered DFT plane probes on distributed lanes (#579)
+### Changed — two new fail-loud fences for registered DFT plane probes on distributed lanes (**BEHAVIOUR CHANGE**) (#579)
 
 - `forward(distributed=True)` and `run(devices=[...])` (2+ devices) now
   raise `NotImplementedError` when any `add_dft_plane_probe(...)` plane is

--- a/docs/agent/recipe-design-loop.mdx
+++ b/docs/agent/recipe-design-loop.mdx
@@ -71,6 +71,34 @@ explicit in-band `f0`), keep every bin above the mode cutoff, and check
 the final design at 2× `n_steps` (run-length invariance) before trusting
 it. The direct MSL path does not have an equivalent verified design example.
 
+## Direct `jax.grad` through a registered DFT-plane field observable
+
+For an objective defined directly on a frequency-domain FIELD rather than a
+port S-parameter (e.g. "minimize the worst-case field leaking through a
+shield"), register one or more `add_dft_plane_probe(...)` planes and pull
+them off the result with `rfx.observables`:
+
+- `dft_field(names)` -- accessor: single name returns the raw
+  `(n_freqs, n1, n2)` complex accumulator; a list stacks (same-shape planes)
+  or returns a per-name dict.
+- `field_energy(names)` -- `sum(|field|**2)`, a trivially smooth first
+  objective.
+- `field_softmax(names, beta=...)` -- a temperature-controlled soft-max
+  over space + frequency, for a worst-case-bin (not average) objective.
+  **`beta` MUST be scale-matched to your `|field|**2` magnitude** (rfx's
+  DFT-accumulator units commonly sit far from O(1) — see the function's
+  own docstring warning and
+  `examples/inverse_design/field_observable_shielding.py`'s measured
+  `BETA` for a worked example); an unscaled `beta` can make the objective
+  silently dominated by a design-variable-independent constant.
+
+Composition is `lambda p: field_softmax(names)(sim.forward(eps_override=p))`
+— same factory-returns-`callable(Result)` style as `rfx.optimize_objectives`,
+plugging directly into a hand-rolled `jax.grad` descent loop (or `optimize()`
+with a `DesignRegion`). Lane-agnostic: works on `run()`/`forward()` results
+from both the uniform and non-uniform meshes; fenced fail-loud on the two
+distributed lanes (neither sharded runner accumulates DFT planes today).
+
 ## Validate either method
 
 - `rfx.validate_port_smatrix(result)` — passivity/shape verdict. A

--- a/docs/agent/repo-map.mdx
+++ b/docs/agent/repo-map.mdx
@@ -19,6 +19,7 @@ before writing any new simulation code.
 | `rfx/materials/` | Material helpers including Debye, Lorentz, and nonlinear dispersion models |
 | `rfx/boundaries/` | Boundary condition implementations (CPML, UPML, PEC, PMC, Floquet/Bloch) |
 | `rfx/sources/`, `rfx/api/_sparams.py` | Port implementations and S-parameter extraction (production lumped/wire driver: `rfx/probes/sparam_driver.py`) |
+| `rfx/observables.py` | Differentiable accessor/objective factories on registered DFT-plane probes (`dft_field`, `field_energy`, `field_softmax`) — same factory style as `rfx/optimize_objectives.py` |
 | `tests/` | Canonical usage examples for every API surface — start here |
 | `validation/crossval/` | Claims-bearing cases and deliberate diagnostic reporters — roles are pinned in `validation/crossval/manifest.json`; check it before citing any script as validation |
 
@@ -52,6 +53,7 @@ command is verified to return at least one hit on the current tree.
 | Post-processing (flux, Harminv) | `grep "def flux_spectrum\|def harminv" rfx/probes/probes.py rfx/harminv.py` | `rfx/probes/probes.py`, `rfx/harminv.py` |
 | S-parameters and port-family calculators (high-level, use these first) | `grep -rn "def compute_.*_s_matrix\|def compute_coaxial_line_reflection\|def compute_coaxial_two_port\|def compute_coax_msl_transition" rfx/api/` | `rfx/api/_sparams.py`, `rfx/ports/` |
 | S-parameter low-level helpers | `grep "extract_waveguide_s_matrix\|extract_s_matrix\|extract_s11" rfx/api/__init__.py rfx/probes/probes.py` | `rfx/ports/` |
+| DFT-plane observables / objectives (differentiable) | `grep "def dft_field\|def field_energy\|def field_softmax" rfx/observables.py` | `rfx/observables.py` |
 
 ## Current port-family caveat
 

--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -741,6 +741,13 @@
       "kind": "function",
       "params": []
     },
+    "dft_field": {
+      "kind": "function",
+      "params": [
+        "names",
+        "stack"
+      ]
+    },
     "diagnose_ad_saved_residuals": {
       "kind": "function",
       "params": [
@@ -970,6 +977,20 @@
         "i_ref_dft",
         "v_probe_dft",
         "i_probe_dft"
+      ]
+    },
+    "field_energy": {
+      "kind": "function",
+      "params": [
+        "names",
+        "weights"
+      ]
+    },
+    "field_softmax": {
+      "kind": "function",
+      "params": [
+        "names",
+        "beta"
       ]
     },
     "fit_debye": {

--- a/examples/inverse_design/field_observable_shielding.py
+++ b/examples/inverse_design/field_observable_shielding.py
@@ -151,9 +151,11 @@ def _assert_design_region_inside_tfsf_box(grid):
         f"far leakage monitor index {leak_far_idx} too close to TFSF box hi {x_hi_tfsf}"
     )
     print(
-        f"  TFSF total-field box: x in [{x_lo_tfsf}, {x_hi_tfsf}] (grid indices) | "
-        f"shield x in [{shield_lo}, {shield_hi}] | leak_far idx {leak_far_idx} "
-        f"-- design region + both monitors confirmed strictly inside, pad={pad}"
+        f"  TFSF total-field box: x in [{x_lo_tfsf}, {x_hi_tfsf}] (grid indices, "
+        f"inclusive) | shield x in [{shield_lo}, {shield_hi}) (half-open -- "
+        f"{shield_hi - shield_lo} layers, cells {shield_lo}..{shield_hi - 1}) | "
+        f"leak_far idx {leak_far_idx} -- design region + both monitors confirmed "
+        f"strictly inside, pad={pad}"
     )
 
 

--- a/examples/inverse_design/field_observable_shielding.py
+++ b/examples/inverse_design/field_observable_shielding.py
@@ -228,7 +228,8 @@ def main() -> None:
         "descent did not reduce worst-case leakage -- check LR/BETA"
     )
 
-    # ---- PART 4: ring-down settling witness (CLAUDE.md rule) --------------
+    # ---- PART 4: ring-down settling witness (repo convention: quote
+    # end-of-run energy in dB vs post-source peak; -40 dB bar) -----------
     print("\n[4/5] Settling witness on the FINAL design (mandatory before "
           "any frequency-domain number above is trusted) ...")
     final_result = sim.forward(

--- a/examples/inverse_design/field_observable_shielding.py
+++ b/examples/inverse_design/field_observable_shielding.py
@@ -1,0 +1,290 @@
+"""Inverse-design a shielding stack against worst-case leaked field (#579).
+
+Demonstrates ``rfx.observables``: a normal-incidence TFSF plane wave
+illuminates a multilayer dielectric stack; two internal DFT-plane probes
+sit BEHIND the stack at two different depths ("near" and "far" leakage
+monitors). ``field_softmax`` pools BOTH planes (all space + all monitored
+frequencies) into one smooth worst-case-leakage scalar, and
+``jax.grad`` descent shrinks it by reshaping the stack's per-layer
+permittivity.
+
+Why two planes, not one multi-component probe: the original ask (a
+``components=`` argument selecting several field components per probe) is
+NOT how ``add_dft_plane_probe`` works in rfx today -- each plane probe is
+single-component (issue #579 design doc). The register-N-planes-then-pool
+pattern is the workaround: register one plane per physical monitor
+location (or, for a true multi-component leakage measure, one plane per
+component you care about) and pool them together:
+
+    objective = field_softmax(["leak_near", "leak_far"], beta=BETA)
+    loss_fn = lambda p: objective(sim.forward(eps_override=_build_eps(p)))
+
+That composition IS the whole point of this module: an accessor/objective
+factory that plugs directly into ``sim.forward(eps_override=...)`` +
+``jax.grad``, the same way ``rfx.optimize_objectives`` factories plug into
+``result.time_series`` / ``result.s_params``.
+
+Design-region safety note: ``forward()``'s TFSF vacuum-boundary preflight
+check runs on the CONCRETE (baseline, un-perturbed) config, not on
+``eps_override`` -- it cannot see where the design region will end up once
+``p`` moves. This script keeps the design region's INDEX RANGE fixed for
+the whole run (only per-cell permittivity VALUES are trainable), and
+asserts once, before optimizing, that fixed range sits strictly inside the
+TFSF total-field box computed with the same formula
+``rfx/sources/tfsf.py:255-256`` uses internally.
+
+Run: python examples/inverse_design/field_observable_shielding.py
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+import jax
+import jax.numpy as jnp
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+
+from rfx import Simulation
+from rfx.observables import field_softmax
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+# ---------------------------------------------------------------------------
+# Geometry. Normal-incidence TFSF forces periodic y/z + CPML-x internally
+# (rfx/runners/uniform.py, "all other TFSF" branch) regardless of the
+# boundary spec passed at construction, so a thin transverse domain (the
+# same 1D-equivalent trick examples/inverse_design/multilayer_ar_coating.py
+# uses) is valid here too -- it keeps this CPU-fast.
+# ---------------------------------------------------------------------------
+DX = 2.5e-3          # m
+NX_INTERIOR = 60      # requested-domain cell count in x (CPML pads OUTSIDE this)
+NY_INTERIOR = 6
+NZ_INTERIOR = 6
+CPML_LAYERS = 8
+TFSF_MARGIN = 3        # add_tfsf_source(margin=) default, named explicitly below
+F0 = 6.0e9
+BANDWIDTH = 0.5
+FREQ_MAX = 8.0e9
+
+# Shield (design region): a 7-layer dielectric stack, physical x-range.
+SHIELD_X_LO_M = 0.050
+SHIELD_X_HI_M = 0.0675   # 7 layers * DX
+N_LAYERS = 7
+
+# Leakage monitors, both BEHIND the shield, two depths.
+LEAK_NEAR_X_M = 0.080
+LEAK_FAR_X_M = 0.130
+
+EPS_MIN, EPS_MAX = 1.0, 6.0
+# field_softmax sharpness: rfx's TFSF/DFT-accumulator normalization puts
+# raw |field|^2 at this geometry around 1e-22 (the same tiny-absolute-unit
+# convention documented for NTFF power elsewhere in this repo, e.g.
+# maximize_directivity's docstring notes ~1e-27 raw values) -- BETA must
+# scale to THAT, not to an O(1) assumption. Measured empirically
+# (scripts/tune sweep in the #579 PR body): loss/grad converge (the
+# log(count)/beta constant term becomes negligible) by beta ~ 1e24-1e25;
+# 2e24 sits inside that converged plateau with margin.
+BETA = 2.0e24
+N_STEPS = 500
+N_ITERS = 12
+# Gradient descent step: measured |grad|_max ~ 1e-23 at this beta/geometry
+# (same tiny-unit consequence as BETA above) -- LR is sized so a full step
+# moves the most-sensitive layer's eps_r by a fraction of an eps_r unit.
+LR = 1.0e22
+
+
+def _build_sim() -> Simulation:
+    sim = Simulation(
+        freq_max=FREQ_MAX,
+        domain=(NX_INTERIOR * DX, NY_INTERIOR * DX, NZ_INTERIOR * DX),
+        dx=DX,
+        boundary="cpml",
+        cpml_layers=CPML_LAYERS,
+    )
+    sim.add_tfsf_source(
+        f0=F0, bandwidth=BANDWIDTH, polarization="ez", direction="+x",
+        margin=TFSF_MARGIN,
+    )
+    sim.add_dft_plane_probe(
+        axis="x", coordinate=LEAK_NEAR_X_M, component="ez",
+        freqs=jnp.asarray([F0]), name="leak_near",
+    )
+    sim.add_dft_plane_probe(
+        axis="x", coordinate=LEAK_FAR_X_M, component="ez",
+        freqs=jnp.asarray([F0]), name="leak_far",
+    )
+    # Settling-witness-only probe (see PART 4 below) -- the established
+    # single-point envelope-in-dB convention this repo's TFSF/patch
+    # examples use (examples/tutorials/patch_antenna_demo.py), not a
+    # domain-integrated energy (forward() does not expose full-domain
+    # snapshots on the differentiable path).
+    sim.add_probe(position=(LEAK_NEAR_X_M, NY_INTERIOR * DX / 2, NZ_INTERIOR * DX / 2), component="ez")
+    return sim
+
+
+def _shield_index_range(grid):
+    lo = grid.position_to_index((SHIELD_X_LO_M, 0.0, 0.0))[0]
+    hi = grid.position_to_index((SHIELD_X_HI_M, 0.0, 0.0))[0]
+    return lo, hi
+
+
+def _assert_design_region_inside_tfsf_box(grid):
+    """Static, once-before-optimizing check (see module docstring): the
+    TFSF total-field box for normal incidence is
+    [cpml_layers + margin, nx - cpml_layers - margin - 1]
+    (rfx/sources/tfsf.py:255-256, reproduced here since forward()'s own
+    preflight cannot see eps_override-time geometry)."""
+    nx = grid.shape[0]
+    offset = CPML_LAYERS + TFSF_MARGIN
+    x_lo_tfsf, x_hi_tfsf = offset, nx - offset - 1
+    shield_lo, shield_hi = _shield_index_range(grid)
+    leak_far_idx = grid.position_to_index((LEAK_FAR_X_M, 0.0, 0.0))[0]
+    pad = 2  # cells of extra safety clearance beyond the box edge
+    assert x_lo_tfsf + pad < shield_lo, (
+        f"shield lo index {shield_lo} too close to TFSF box lo {x_lo_tfsf}"
+    )
+    assert leak_far_idx + pad < x_hi_tfsf, (
+        f"far leakage monitor index {leak_far_idx} too close to TFSF box hi {x_hi_tfsf}"
+    )
+    print(
+        f"  TFSF total-field box: x in [{x_lo_tfsf}, {x_hi_tfsf}] (grid indices) | "
+        f"shield x in [{shield_lo}, {shield_hi}] | leak_far idx {leak_far_idx} "
+        f"-- design region + both monitors confirmed strictly inside, pad={pad}"
+    )
+
+
+def _build_eps(sim: Simulation, grid, p: jnp.ndarray) -> jnp.ndarray:
+    """p: (N_LAYERS,) eps_r per shield layer -> full eps_override array.
+    Broadcasts uniformly across the (thin, periodic) y/z extent -- a real
+    1D-equivalent multilayer, same convention as multilayer_ar_coating.py."""
+    eps_base = jnp.ones(grid.shape, dtype=jnp.float32)
+    lo, hi = _shield_index_range(grid)
+    return eps_base.at[lo:hi, :, :].set(jnp.clip(p, EPS_MIN, EPS_MAX)[:, None, None])
+
+
+def main() -> None:
+    print("=" * 70)
+    print("Field-observable shielding design (rfx.observables, issue #579)")
+    print("=" * 70)
+
+    sim = _build_sim()
+    print("\n[1/5] Preflight (read every advisory before trusting any number):")
+    report = sim.preflight()
+    print(f"  {len(list(report))} advisory(ies)")
+
+    grid = sim._build_grid()
+    _assert_design_region_inside_tfsf_box(grid)
+
+    objective = field_softmax(["leak_near", "leak_far"], beta=BETA)
+
+    def loss_fn(p):
+        eps = _build_eps(sim, grid, p)
+        result = sim.forward(
+            eps_override=eps, n_steps=N_STEPS, checkpoint=True,
+            skip_preflight=True,
+        )
+        return objective(result)
+
+    # This is the composition the design contract names directly:
+    #   lambda p: field_softmax(["leak_near", "leak_far"], beta=BETA)(
+    #       sim.forward(eps_override=_build_eps(sim, grid, p))
+    #   )
+    # `loss_fn` above is exactly that, spelled out for readability.
+
+    p0 = jnp.full(N_LAYERS, 2.0, dtype=jnp.float32)
+
+    print(f"\n[2/5] Initial forward pass (p0 = {float(p0[0]):.1f} uniform) ...")
+    t0 = time.time()
+    val0 = float(loss_fn(p0))
+    print(f"  field_softmax(leak_near, leak_far) = {val0:.6e}  ({time.time() - t0:.1f}s)")
+    assert np.isfinite(val0) and val0 > 0.0, "objective did not couple to the TFSF source"
+
+    print(f"\n[3/5] Gradient descent, {N_ITERS} iterations ...")
+    p = p0
+    loss_trace = [val0]
+    eps_trace = [np.asarray(p)]
+    for it in range(N_ITERS):
+        t_it = time.time()
+        val, grad = jax.value_and_grad(loss_fn)(p)
+        p = jnp.clip(p - LR * grad, EPS_MIN, EPS_MAX)
+        loss_trace.append(float(val))
+        eps_trace.append(np.asarray(p))
+        print(
+            f"  iter {it + 1:2d}/{N_ITERS}: loss={float(val):.6e}  "
+            f"|grad|_max={float(jnp.max(jnp.abs(grad))):.3e}  "
+            f"eps=[{', '.join(f'{v:.2f}' for v in np.asarray(p))}]  "
+            f"({time.time() - t_it:.1f}s)"
+        )
+
+    print(f"\n  loss: {loss_trace[0]:.6e} -> {loss_trace[-1]:.6e} "
+          f"({100 * (1 - loss_trace[-1] / loss_trace[0]):.1f}% reduction)")
+    assert loss_trace[-1] < loss_trace[0], (
+        "descent did not reduce worst-case leakage -- check LR/BETA"
+    )
+
+    # ---- PART 4: ring-down settling witness (CLAUDE.md rule) --------------
+    print("\n[4/5] Settling witness on the FINAL design (mandatory before "
+          "any frequency-domain number above is trusted) ...")
+    final_result = sim.forward(
+        eps_override=_build_eps(sim, grid, p), n_steps=N_STEPS,
+        checkpoint=False, skip_preflight=True,
+    )
+    ts = np.asarray(final_result.time_series).ravel()
+    dt = float(final_result.grid.dt)
+    envelope = np.abs(ts)
+    peak = float(np.max(envelope))
+    tail = float(np.max(envelope[int(len(envelope) * 0.95):]))
+    end_db = 20 * np.log10(max(tail, 1e-300) / max(peak, 1e-300))
+    settled = end_db < -40.0
+    print(
+        f"  end-of-run envelope {end_db:.1f} dB of the post-source peak "
+        f"(bar: -40 dB, single representative probe at the leak_near plane) "
+        f"-> {'SETTLED' if settled else 'UNDER-SETTLED (raise N_STEPS and rerun)'}"
+    )
+
+    # ---- PART 5: plots ------------------------------------------------------
+    print("\n[5/5] Plotting ...")
+    eps_arr = np.stack(eps_trace)  # (N_ITERS+1, N_LAYERS)
+    fig, axes = plt.subplots(1, 3, figsize=(15, 4))
+
+    axes[0].semilogy(range(len(loss_trace)), loss_trace, "o-", lw=2)
+    axes[0].set_xlabel("Iteration")
+    axes[0].set_ylabel("field_softmax(leak_near, leak_far)")
+    axes[0].set_title("Worst-case leaked |Ez|^2 (soft-max)")
+    axes[0].grid(True, alpha=0.3)
+
+    for li in range(N_LAYERS):
+        axes[1].plot(range(len(eps_trace)), eps_arr[:, li], lw=2, label=f"layer {li + 1}")
+    axes[1].set_xlabel("Iteration")
+    axes[1].set_ylabel("eps_r")
+    axes[1].set_title("Per-layer permittivity trajectory")
+    axes[1].legend(loc="best", fontsize=7)
+    axes[1].grid(True, alpha=0.3)
+
+    t_axis = np.arange(len(ts)) * dt * 1e9
+    axes[2].plot(t_axis, ts, lw=0.7)
+    axes[2].set_xlabel("Time (ns)")
+    axes[2].set_ylabel("Ez at leak_near probe")
+    axes[2].set_title(f"Final-design ring-down (settling: {end_db:.1f} dB)")
+    axes[2].grid(True, alpha=0.3)
+
+    fig.suptitle(
+        f"Shielding design via rfx.observables.field_softmax "
+        f"({N_LAYERS} layers, f0={F0/1e9:.1f} GHz, {N_ITERS} grad-descent steps)",
+        fontsize=12, fontweight="bold",
+    )
+    plt.tight_layout()
+    out_png = os.path.join(SCRIPT_DIR, "field_observable_shielding.png")
+    plt.savefig(out_png, dpi=150, bbox_inches="tight")
+    plt.close()
+    print(f"  plot saved: {out_png}")
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    main()

--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -153,6 +153,7 @@ from rfx.optimize_objectives import (
     maximize_transmitted_energy,
     steer_probe_array,
 )
+from rfx.observables import dft_field, field_energy, field_softmax
 try:
     from rfx.eigenmode import WaveguideMode, solve_waveguide_modes
 except ImportError:
@@ -292,6 +293,7 @@ __all__ = [
     "minimize_s11", "maximize_s21", "target_impedance", "maximize_bandwidth",
     "maximize_directivity", "minimize_reflected_energy",
     "maximize_transmitted_energy", "steer_probe_array",
+    "dft_field", "field_energy", "field_softmax",
     # sweeps / batch
     "parametric_sweep", "SweepResult", "plot_sweep",
     "vmap_material_sweep", "VmapSweepResult",

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -1757,6 +1757,13 @@ class _ExecuteMixin:
                 "add_ntff_box() for far-field observables) or use the "
                 "uniform lane."
             )
+        if self._dft_planes:
+            raise NotImplementedError(
+                "add_dft_plane_probe() is not supported on the distributed "
+                "non-uniform forward path (issue #579); the sharded NU scan "
+                "body does not accumulate DFT-plane fields. Drop DFT plane "
+                "probes or use the uniform lane."
+            )
         import warnings as _w
         from rfx.runners.distributed_nu import (
             build_sharded_nu_grid,
@@ -2858,6 +2865,16 @@ class _ExecuteMixin:
 
         # ---- Distributed multi-device lane ----
         if plan.lane == "run_distributed":
+            if self._dft_planes:
+                raise NotImplementedError(
+                    "add_dft_plane_probe() is not supported on the "
+                    "distributed multi-device run() path (issue #579); "
+                    "neither rfx.runners.distributed_v2 nor "
+                    "rfx.runners.distributed accumulates DFT-plane fields, "
+                    "so a registered plane would be silently dropped. Drop "
+                    "DFT plane probes or omit devices=... (use a "
+                    "single-device run() instead)."
+                )
             self._warn_unsupported_run_kwargs("distributed multi-device", {
                 "subpixel_smoothing": subpixel_smoothing,
                 "checkpoint": checkpoint,

--- a/rfx/observables.py
+++ b/rfx/observables.py
@@ -26,7 +26,10 @@ the uniform AND non-uniform meshes, for both ``run()`` and ``forward()``
 only reads ``result.dft_planes``, so it works unmodified on any of the four
 combinations. The exceptions are the two DISTRIBUTED lanes, which are
 fenced fail-loud (see "Fail-loud fences" below) because neither sharded
-runner accumulates DFT-plane fields.
+runner accumulates DFT-plane fields. The per-name value is duck-typed
+(``.accumulator`` if present, else the value itself), so a name-keyed dict
+of bare arrays (e.g. a vmap-batched sweep result) works too, not just
+``DFTPlaneProbe`` objects.
 
 What stays on the AD tape
 --------------------------
@@ -102,6 +105,12 @@ def _select_planes(result, names, caller: str) -> dict:
     specific missing name(s) when the result has planes but not all of the
     requested ones -- both in the ``optimize_objectives`` error style (name
     the field that's missing and the call that would populate it).
+
+    Duck-types the per-name value: ``DFTPlaneProbe``-like objects (an
+    ``.accumulator`` attribute, from ``run()``/``forward()``) and bare
+    arrays (e.g. a vmap-batched sweep result whose ``dft_planes`` dict
+    carries raw stacked arrays rather than probe objects) are both
+    accepted -- ``getattr(value, "accumulator", value)``.
     """
     planes = getattr(result, "dft_planes", None)
     if not planes:
@@ -124,7 +133,7 @@ def _select_planes(result, names, caller: str) -> dict:
             "passed (or the auto-generated 'component_axis_index' default) to "
             "the matching add_dft_plane_probe(...) call."
         )
-    return {n: jnp.asarray(planes[n].accumulator) for n in name_list}
+    return {n: jnp.asarray(getattr(planes[n], "accumulator", planes[n])) for n in name_list}
 
 
 def dft_field(
@@ -147,9 +156,17 @@ def dft_field(
         but only when every requested plane has the same
         ``(n_freqs, n1, n2)`` shape (planes at different axes/coordinates
         commonly do not, e.g. a yz-plane vs an xz-plane monitor). When the
-        shapes differ, or when ``stack=False``, the accessor instead
-        returns ``dict[name] -> array`` (per-name dict form) so callers with
-        heterogeneous planes are never silently truncated or broadcast.
+        shapes differ, stacking is impossible and the accessor RAISES
+        ``ValueError`` naming the mismatched shapes and pointing at
+        ``stack=False``; it never silently truncates or broadcasts. Pass
+        ``stack=False`` explicitly to opt into the per-name
+        ``dict[name] -> array`` form instead (also the unconditional return
+        form when *names* is a sequence and ``stack=False``, even if the
+        shapes happen to match). Mixed-dtype stacking (e.g. a complex64
+        plane alongside a complex128 one, possible if planes were
+        registered under different ``jax_enable_x64`` states) follows
+        ordinary ``jnp.stack`` dtype promotion -- the result takes the
+        wider dtype.
 
     Returns
     -------
@@ -161,8 +178,8 @@ def dft_field(
     Raises
     ------
     ValueError
-        If *result* carries no ``dft_planes`` at all, or is missing one of
-        the requested *names*, or (list form, ``stack=True``) the requested
+        If *result* carries no ``dft_planes`` at all, is missing one of the
+        requested *names*, or (list form, ``stack=True``) the requested
         planes' shapes do not match -- naming the fix in each case.
     """
     single = isinstance(names, str)
@@ -250,11 +267,41 @@ def field_softmax(
         pattern: register one plane per physical monitor location, then
         soft-max over all of them at once for a single worst-case scalar.
     beta : float
-        Soft-max sharpness (default 1.0). Must be positive.
+        Soft-max sharpness (default 1.0). Must be positive, and MUST be
+        scale-matched to the field magnitude -- see the warning below.
 
-    Returns
-    -------
-    callable(Result) -> scalar (JAX-differentiable)
+    .. warning::
+        **beta must be scale-matched to your |field|**2** magnitude, not
+        left at the default.** ``logsumexp(beta*vals)/beta`` equals
+        ``log(count)/beta + (a term that depends on vals)`` where
+        ``count = n_freqs * n1 * n2`` summed over every requested plane; if
+        ``beta`` is too small for the actual ``|field|**2`` scale, the
+        ``log(count)/beta`` CONSTANT (independent of your design variable)
+        dominates the objective and swallows the real signal -- both the
+        objective value and its gradient measure rounding noise in that
+        constant, not physics, and can coincidentally still pass a single
+        finite-difference check while failing at a different step size
+        (rfx's own DFT-plane accumulators commonly sit around
+        ``|field|**2`` ~1e-10 to 1e-22 depending on geometry/normalization,
+        the same tiny-absolute-unit convention documented elsewhere for
+        NTFF power, e.g. ``maximize_directivity``'s ~1e-27 note -- so
+        ``beta=1.0`` is almost always wrong). Pick beta empirically: measure
+        ``max(|field|**2)`` once (e.g. via :func:`dft_field` +
+        ``jnp.max(jnp.abs(x)**2)``) at a representative design point, and
+        choose beta so ``beta * max(|field|**2)`` is at least a few units
+        (pushes past the ``log(count)`` constant) -- see
+        ``examples/inverse_design/field_observable_shielding.py``'s own
+        ``BETA`` comment for a worked, measured example.
+    .. warning::
+        **Top-end overflow is a real, undocumented-by-JAX failure mode.**
+        ``beta * vals`` is computed as a plain array BEFORE
+        ``jax.nn.logsumexp`` gets to apply its internal max-subtraction
+        stabilization; if ``beta * max(vals)`` itself overflows the
+        working dtype's range (~3.4e38 for float32, ~1.8e308 for float64 --
+        measured: ``beta=1e40`` against ``vals`` ~1e-10 already returns
+        ``nan``, while ``beta=1e30`` on the same ``vals`` is fine), the
+        result is silently ``nan``, not a large-but-finite number. Do not
+        pick beta by "bigger is always safer" -- there is a ceiling.
     """
     if beta <= 0.0:
         raise ValueError(f"field_softmax: beta must be positive, got {beta}")

--- a/rfx/observables.py
+++ b/rfx/observables.py
@@ -1,0 +1,270 @@
+"""Differentiable observables built on registered DFT-plane probes (#579).
+
+``Simulation.add_dft_plane_probe(...)`` registers a frequency-domain plane
+accumulator that ``run()`` and ``forward()`` both populate into a name-keyed
+dict on the result (``Result.dft_planes`` / ``ForwardResult.dft_planes``).
+That accumulator mechanism already existed and is already JAX-traceable
+end-to-end (``rfx/api/_execute.py`` packs it for ``forward()``, and
+``rfx/runners/uniform.py`` / ``rfx/runners/nonuniform.py`` pack it for
+``run()``); this module is the missing public **accessor + objective**
+layer on top of it, in the same "factory returns ``callable(result) ->
+...``" style as :mod:`rfx.optimize_objectives`.
+
+- :func:`dft_field` -- pull one or more named DFT planes off a result as
+  plain ``jax.numpy`` arrays (a result accessor, not an objective).
+- :func:`field_energy` -- ``sum(|field|**2)`` over one or more planes; the
+  simplest possible smooth objective.
+- :func:`field_softmax` -- a temperature-controlled soft-max over
+  space + frequency, for objectives that care about the WORST bin (e.g.
+  "minimize peak leaked field anywhere behind a shield") rather than the
+  average.
+
+Both lanes, both entry points: ``result.dft_planes`` is a name-keyed dict on
+the uniform AND non-uniform meshes, for both ``run()`` and ``forward()``
+(``rfx/runners/uniform.py:859-866``, ``rfx/runners/nonuniform.py:1064-1068``,
+``rfx/api/_execute.py:1579-1596``). Everything here is lane-agnostic: it
+only reads ``result.dft_planes``, so it works unmodified on any of the four
+combinations. The exceptions are the two DISTRIBUTED lanes, which are
+fenced fail-loud (see "Fail-loud fences" below) because neither sharded
+runner accumulates DFT-plane fields.
+
+What stays on the AD tape
+--------------------------
+Each registered plane's accumulator is a single ``(n_freqs, n1, n2)``
+complex array (complex64, or complex128 under ``jax_enable_x64``) living in
+the ``jax.lax.scan`` carry for the whole run (``rfx/simulation.py:857-858,
+1512-1526, 1604-1605``) -- there is no intermediate per-step buffer to
+discard. Reverse-mode AD through :func:`dft_field` / :func:`field_energy` /
+:func:`field_softmax` therefore differentiates through that one carried
+array, not through a stored time series. The window is always the
+rectangular (unweighted) DFT window: ``add_dft_plane_probe`` never exposes
+``dft_window`` / ``dft_window_alpha`` (unlike ``add_flux_monitor``), so
+``DFTPlaneProbe.window`` stays at its ``"rect"`` default on every plane this
+module can see. On the uniform lane, ``forward()`` also always carries the
+full probe time-series tape alongside the DFT accumulators --
+``emit_time_series=False`` is a non-uniform-lane-only option
+(``rfx/api/_execute.py`` forward() docstring); a DFT-only uniform-lane
+objective still pays for the time-series tape today.
+
+E/H mixing hazard
+------------------
+``update_dft_plane_probe`` stamps EVERY component -- electric or magnetic --
+at the same traced time ``t = state.step * dt``
+(``rfx/probes/probes.py:452-460``). Physically, on the Yee leapfrog H lives
+half a step behind E (``H`` at ``t - dt/2``, not ``t``). Magnitude-only
+objectives (``field_energy``, ``field_softmax``, or any other function of
+``|field|`` alone) are UNAFFECTED -- a uniform per-frequency phase rotation
+does not change a magnitude. But composing an E x H* cross term (a Poynting-
+flux-like quantity, or anything computing complex ``Zin = V/I`` from a
+line-integrated E-derived V and H-derived I) needs the same correction the
+production MSL V/I extractor applies: multiply every H-component plane by
+``exp(+j * 2*pi*f * dt/2)`` before combining it with an E-component plane
+(see ``rfx/api/_sparams.py:2975-2995`` for the worked derivation and the
+"``Re(Zin) < 0``" artefact class this omission produces). ``dt`` is not
+carried on ``ForwardResult`` or ``DFTPlaneProbe`` -- it comes from the
+``Simulation`` / ``Grid`` the caller already built (``sim._build_grid().dt``
+or ``result.grid.dt`` when the result carries one), so this module does not
+attempt the correction itself and does not accept an ``h_phase_correction``
+kwarg: it would need a value neither object supplies, and unit-modulus phase
+is invisible to both built-in functionals, so an untested flag would ship.
+Apply the ``exp(+j*omega*dt/2)`` factor to H-component planes yourself, one
+line, if you build an E x H* objective on top of :func:`dft_field`.
+
+Fail-loud fences
+-----------------
+Registering any DFT plane probe and then requesting a distributed run
+raises ``NotImplementedError`` -- on both ``forward(distributed=True)`` and
+``run(devices=[...])`` with ``len(devices) > 1`` -- because neither the
+sharded non-uniform forward runner (``rfx.runners.distributed_nu``) nor the
+sharded ``run()`` runner (``rfx.runners.distributed_v2``) accumulates DFT
+planes at all; before this fence they were silently dropped (CHANGELOG,
+back-compat break). This mirrors the pre-existing
+``add_flux_monitor()``-on-distributed-NU-forward fence
+(``rfx/api/_execute.py``) in both mechanism and wording.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+import jax.numpy as jnp
+from jax.nn import logsumexp
+
+__all__ = ["dft_field", "field_energy", "field_softmax"]
+
+
+def _select_planes(result, names, caller: str) -> dict:
+    """Return ``{name: jnp array}`` for the requested plane name(s).
+
+    Shared by every public function in this module. Raises ``ValueError``
+    naming the producing call (``add_dft_plane_probe`` + ``run()``/
+    ``forward()``) when the result carries no planes at all, and naming the
+    specific missing name(s) when the result has planes but not all of the
+    requested ones -- both in the ``optimize_objectives`` error style (name
+    the field that's missing and the call that would populate it).
+    """
+    planes = getattr(result, "dft_planes", None)
+    if not planes:
+        raise ValueError(
+            f"{caller} requires result.dft_planes, but got {planes!r}. "
+            "DFT-plane observables need Simulation.add_dft_plane_probe(...) "
+            "registered BEFORE run()/forward() -- neither call populates "
+            "dft_planes on its own, and the distributed forward/run lanes "
+            "reject registered planes outright (see rfx.observables module "
+            "docstring, 'Fail-loud fences')."
+        )
+    name_list = [names] if isinstance(names, str) else list(names)
+    if not name_list:
+        raise ValueError(f"{caller}: names must be a non-empty name or list of names.")
+    missing = [n for n in name_list if n not in planes]
+    if missing:
+        raise ValueError(
+            f"{caller}: plane name(s) {missing} not found in result.dft_planes "
+            f"(available: {sorted(planes)}). Check the `name=` argument you "
+            "passed (or the auto-generated 'component_axis_index' default) to "
+            "the matching add_dft_plane_probe(...) call."
+        )
+    return {n: jnp.asarray(planes[n].accumulator) for n in name_list}
+
+
+def dft_field(
+    names: str | Sequence[str], *, stack: bool = True,
+) -> Callable:
+    """Result accessor for one or more registered DFT-plane probes.
+
+    Parameters
+    ----------
+    names : str or sequence of str
+        The ``name=`` (or auto-generated default) given to
+        ``add_dft_plane_probe(...)``. A single name returns the raw
+        ``(n_freqs, n1, n2)`` complex accumulator directly (no dict
+        wrapping -- there is nothing to disambiguate). A sequence of names
+        returns either a stacked array or a dict, controlled by *stack*.
+    stack : bool
+        When *names* is a sequence and ``stack=True`` (default), the
+        accessor stacks all requested planes into one
+        ``(n_names, n_freqs, n1, n2)`` array ALONG A NEW LEADING AXIS --
+        but only when every requested plane has the same
+        ``(n_freqs, n1, n2)`` shape (planes at different axes/coordinates
+        commonly do not, e.g. a yz-plane vs an xz-plane monitor). When the
+        shapes differ, or when ``stack=False``, the accessor instead
+        returns ``dict[name] -> array`` (per-name dict form) so callers with
+        heterogeneous planes are never silently truncated or broadcast.
+
+    Returns
+    -------
+    callable(result) -> jnp.ndarray | dict[str, jnp.ndarray]
+        JAX-differentiable: the returned array(s) are views/stacks of the
+        same accumulator that was carried through the FDTD scan, so
+        ``jax.grad`` flows through them unchanged.
+
+    Raises
+    ------
+    ValueError
+        If *result* carries no ``dft_planes`` at all, or is missing one of
+        the requested *names*, or (list form, ``stack=True``) the requested
+        planes' shapes do not match -- naming the fix in each case.
+    """
+    single = isinstance(names, str)
+    name_list = [names] if single else list(names)
+
+    def accessor(result):
+        arrays = _select_planes(result, name_list, "dft_field")
+        if single:
+            return arrays[names]
+        if stack:
+            shapes = {a.shape for a in arrays.values()}
+            if len(shapes) == 1:
+                return jnp.stack([arrays[n] for n in name_list], axis=0)
+            raise ValueError(
+                f"dft_field({name_list!r}): accumulator shapes differ "
+                f"({ {n: tuple(a.shape) for n, a in arrays.items()} }), so "
+                "they cannot be stacked into one array. Pass stack=False to "
+                "get a dict[name] -> array instead."
+            )
+        return arrays
+
+    return accessor
+
+
+def field_energy(
+    names: str | Sequence[str], *, weights: dict[str, float] | None = None,
+) -> Callable:
+    """Objective factory: ``sum(|field|**2)`` over one or more DFT planes.
+
+    Sums squared magnitude over every element (space AND frequency) of
+    every requested plane. Trivially smooth (a sum of squares is C-infinity
+    in the accumulator), so this is a good first objective to sanity-check
+    a new DFT-plane setup with before reaching for :func:`field_softmax`.
+
+    Parameters
+    ----------
+    names : str or sequence of str
+        Plane name(s) to sum over -- see :func:`dft_field`. Shapes need not
+        match between planes (unlike ``dft_field(..., stack=True)``): each
+        plane's energy is summed independently, so mixing e.g. a yz-plane
+        and an xz-plane monitor is fine.
+    weights : dict[str, float] or None
+        Optional per-plane scalar weight (default 1.0 for every plane not
+        listed), applied before summing -- e.g. to down-weight a monitor
+        plane closer to the source.
+
+    Returns
+    -------
+    callable(Result) -> scalar (JAX-differentiable)
+    """
+    name_list = [names] if isinstance(names, str) else list(names)
+    _weights = weights or {}
+
+    def objective(result) -> jnp.ndarray:
+        arrays = _select_planes(result, name_list, "field_energy")
+        total = jnp.asarray(0.0)
+        for n in name_list:
+            w = _weights.get(n, 1.0)
+            total = total + w * jnp.sum(jnp.abs(arrays[n]) ** 2)
+        return total
+
+    return objective
+
+
+def field_softmax(
+    names: str | Sequence[str], *, beta: float = 1.0,
+) -> Callable:
+    """Objective factory: smooth (soft) max of ``|field|**2`` over space+frequency.
+
+    Uses the standard log-sum-exp soft-max:
+    ``softmax = logsumexp(beta * |field|**2) / beta``, computed with
+    ``jax.nn.logsumexp`` for numerical stability. As ``beta -> infinity``
+    this converges to the true ``max(|field|**2)``; a smaller *beta* trades
+    a looser max approximation for a smoother, better-conditioned gradient
+    (useful early in an optimization run, e.g. the shielding case: minimize
+    the worst-case leaked field anywhere behind a barrier, over all
+    monitored frequencies, rather than the mean leaked field).
+
+    Parameters
+    ----------
+    names : str or sequence of str
+        Plane name(s) to pool over -- see :func:`dft_field`. All requested
+        planes' elements (space AND frequency, across every plane) are
+        pooled into ONE soft-max, so this composes the register-N-planes
+        pattern: register one plane per physical monitor location, then
+        soft-max over all of them at once for a single worst-case scalar.
+    beta : float
+        Soft-max sharpness (default 1.0). Must be positive.
+
+    Returns
+    -------
+    callable(Result) -> scalar (JAX-differentiable)
+    """
+    if beta <= 0.0:
+        raise ValueError(f"field_softmax: beta must be positive, got {beta}")
+    name_list = [names] if isinstance(names, str) else list(names)
+
+    def objective(result) -> jnp.ndarray:
+        arrays = _select_planes(result, name_list, "field_softmax")
+        vals = jnp.concatenate(
+            [jnp.abs(arrays[n]).reshape(-1) ** 2 for n in name_list]
+        )
+        return logsumexp(beta * vals) / beta
+
+    return objective

--- a/tests/test_ad_surface_contract.py
+++ b/tests/test_ad_surface_contract.py
@@ -172,6 +172,32 @@ AD_CLASSIFICATION = {
         UNTESTED,
         "jnp-pure legacy helper, no direct grad smoke test",
     ),
+    # --- rfx.observables (issue #579) ---------------------------------------
+    "observables.dft_field": (
+        GRAD_SAFE,
+        "pure selection/stack of an already-traced DFT-plane accumulator (no "
+        "concretizing op); differentiability is exercised indirectly through "
+        "every field_energy/field_softmax gate below, since both compose "
+        "dft_field internally via the shared _select_planes helper: "
+        "tests/test_observables_dft_field.py::test_field_energy_material_leg_ad_matches_fd, "
+        "tests/test_observables_dft_field.py::test_field_energy_geometry_leg_ad_matches_fd",
+    ),
+    "observables.field_energy": (
+        GRAD_SAFE,
+        "FD-vs-AD gate, both AC legs (material eps_r scalar; one topology-"
+        "density pixel via density_to_material_fields): "
+        "tests/test_observables_dft_field.py::test_field_energy_material_leg_ad_matches_fd, "
+        "tests/test_observables_dft_field.py::test_field_energy_geometry_leg_ad_matches_fd — "
+        "severed-tape falsifier confirmed the gate reads exactly 0.0 AD vs "
+        "finite FD when the accumulator is stop_gradient'd (see the test "
+        "module docstring; red-run artifact in the #579 PR body).",
+    ),
+    "observables.field_softmax": (
+        GRAD_SAFE,
+        "FD-vs-AD gate, both AC legs, same discipline as field_energy: "
+        "tests/test_observables_dft_field.py::test_field_softmax_material_leg_ad_matches_fd, "
+        "tests/test_observables_dft_field.py::test_field_softmax_geometry_leg_ad_matches_fd",
+    ),
 }
 
 
@@ -184,6 +210,18 @@ def _exported_surface() -> set[str]:
     for n, _ in inspect.getmembers(Simulation, predicate=inspect.isfunction):
         if n.startswith("compute_"):
             names.add(f"Simulation.{n}")
+    # #579: rfx.observables' public factories (dft_field/field_energy/
+    # field_softmax) are a new differentiable-observable surface class, not
+    # compute_*/extract_*-shaped, so the prefix scan above never sees them.
+    # The stale-key half of test_every_sparam_entry_point_is_ad_classified
+    # forbids adding AD_CLASSIFICATION entries that aren't in this surface,
+    # so they are enumerated explicitly here (via the module's own
+    # __all__, not a hand-picked list, so a future addition to
+    # rfx/observables.py trips the "missing" half automatically).
+    import rfx.observables as _observables
+    for n in _observables.__all__:
+        if callable(getattr(_observables, n)):
+            names.add(f"observables.{n}")
     return names
 
 

--- a/tests/test_dft_accumulator_dtype.py
+++ b/tests/test_dft_accumulator_dtype.py
@@ -7,13 +7,23 @@ now use the same conditional dtype idiom as compute_msl_s_matrix.
 
 x64 is scoped per-test via a context manager — NEVER flipped at module
 level (process-global; reds every same-process pytest shard).
+
+``jax.experimental.enable_x64`` was removed in newer JAX releases (this
+venv: JAX 0.10.2); the fallback below is the same scoped-flip-with-restore
+shim tests/_x64_compat.py provides, applied inline here (folded pre-
+existing fix, discovered while landing #579's own tests/_x64_compat usage
+— see the #579 PR body).
 """
-import jax
 import jax.numpy as jnp
 import numpy as np
 
 from rfx.grid import Grid
 from rfx.probes.probes import init_dft_probe, init_dft_plane_probe
+
+try:
+    from jax import enable_x64
+except ImportError:  # older JAX (< ~0.4.31) -- see tests/_x64_compat.py
+    from tests._x64_compat import enable_x64
 
 
 def _grid():
@@ -36,7 +46,7 @@ def test_accumulators_are_complex64_by_default():
 def test_accumulators_follow_x64_when_enabled():
     """Under scoped x64 the accumulators must be complex128, so the scan
     carry stays dtype-consistent and an f64 referee can run."""
-    with jax.experimental.enable_x64():
+    with enable_x64():
         g = _grid()
         freqs = jnp.asarray([5e9])
         p = init_dft_probe(g, (0.005, 0.005, 0.005), "ez", freqs)

--- a/tests/test_forward_docstring_contract.py
+++ b/tests/test_forward_docstring_contract.py
@@ -83,8 +83,11 @@ def test_all_is_curated_subset():
     # __all__=204, ratio 0.64 — tighter than the 181/~245=0.74 this gate was
     # written against). Ceiling re-specced 200 -> 210 for that deliberate
     # 23-name expansion; kept tight on purpose so the NEXT surface expansion
-    # trips this gate again and must re-justify itself.
-    assert len(names) < 210, f"rfx.__all__ too large to be curated: {len(names)}"
+    # trips this gate again and must re-justify itself. Re-specced again
+    # 210 -> 213 for the #579 `rfx.observables` factories (`dft_field`,
+    # `field_energy`, `field_softmax`) — a genuinely new differentiable
+    # surface, not incidental growth.
+    assert len(names) < 213, f"rfx.__all__ too large to be curated: {len(names)}"
     missing = [n for n in names if not hasattr(rfx, n)]
     assert not missing, f"rfx.__all__ lists names not on the package: {missing}"
 

--- a/tests/test_observables_dft_field.py
+++ b/tests/test_observables_dft_field.py
@@ -1,0 +1,373 @@
+"""Gate tests for `rfx.observables` (issue #579).
+
+`rfx.observables` is a thin accessor/objective layer over the DFT-plane
+accumulator mechanism that already existed (``Simulation.add_dft_plane_probe``
++ ``result.dft_planes``) and was already end-to-end JAX-differentiable; the
+new surface here is `dft_field` / `field_energy` / `field_softmax`
+(rfx/observables.py) plus two fail-loud distributed fences.
+
+Coverage:
+    (1) FD-vs-AD gates for BOTH acceptance-criteria legs (material eps_r
+        scalar; one topology-density pixel via
+        ``rfx.topology.density_to_material_fields``), for both built-in
+        functionals.
+    (2) A run()-vs-forward() physics witness: the two independent code
+        paths that populate ``result.dft_planes`` (rfx/runners/uniform.py
+        vs rfx/api/_execute.py) must agree on the SAME config -- this
+        catches shared-forward-code defects the FD-vs-AD gate (which only
+        exercises forward()) is blind to.
+    (3) `dft_field` error-path and dict/stack behavior (fast, no FDTD).
+    (4) Regression tests for the two distributed fail-loud fences.
+
+FALSIFIER RITUAL: before trusting the FD-vs-AD gates below, a throwaway
+`jax.lax.stop_gradient` was inserted on the DFT-plane accumulator inside a
+scratch copy of the material-leg objective and the gate was re-run -- AD
+grad collapsed to ~0.0 while the FD reference stayed finite, i.e. the gate
+DOES go red when the tape is actually severed. The red output is saved at
+scratchpad/i579_falsifier_red.txt (not committed here -- see the PR body);
+the throwaway change was reverted immediately after.
+"""
+
+from __future__ import annotations
+
+import types
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from rfx import Simulation
+from rfx.observables import dft_field, field_energy, field_softmax
+from rfx.topology import density_to_material_fields
+
+try:
+    from jax import enable_x64
+except ImportError:  # older JAX (< ~0.4.31) -- see tests/_x64_compat.py
+    from tests._x64_compat import enable_x64
+
+
+# ---------------------------------------------------------------------------
+# Shared small CPU-fast sim: vacuum domain, one soft source, one DFT plane.
+# ---------------------------------------------------------------------------
+
+_DX = 1.0e-3
+_NX, _NY, _NZ = 30, 20, 20
+_PLANE = "probe_plane"
+_FREQS = jnp.asarray([5.0e9])
+# Physical positions (engineering principle #1: physical absolute
+# coordinates, not raw cell-relative indices) — converted to grid indices
+# via Grid.position_to_index() once the actual (CPML-padded) grid.shape is
+# known, since it is larger than (_NX, _NY, _NZ).
+_SLAB_LO_M = (12 * _DX, 0.0, 0.0)  # material-leg design slab
+_SLAB_HI_M = (18 * _DX, _NY * _DX, _NZ * _DX)
+_PIXEL_POS_M = (14 * _DX, 10 * _DX, 10 * _DX)  # geometry-leg single design pixel
+_N_STEPS = 160
+_FD_H = 0.02
+# A single-Yee-cell material perturbation (the geometry/topology leg) has a
+# proportionally tiny effect on a bulk plane-energy sum (~1e-10 measured) —
+# real, FD-matching signal, not noise. The floor only needs to catch an
+# actually-severed tape (which reads exactly/near 0.0), so it sits several
+# orders below that measured single-pixel gradient, not just below the
+# larger material-leg (whole-slab) gradient.
+_GRAD_FLOOR = 1e-14
+
+
+def _build_sim() -> Simulation:
+    sim = Simulation(
+        freq_max=8e9, domain=(_NX * _DX, _NY * _DX, _NZ * _DX), dx=_DX,
+        boundary="cpml", cpml_layers=5,
+    )
+    sim.add_source(
+        position=(8 * _DX, 10 * _DX, 10 * _DX), component="ez",
+        amplitude_kind="current",
+    )
+    sim.add_dft_plane_probe(
+        axis="x", coordinate=20 * _DX, component="ez",
+        freqs=_FREQS, name=_PLANE,
+    )
+    return sim
+
+
+def _grid_and_eps_base(sim: Simulation):
+    """The actual grid is larger than (_NX, _NY, _NZ): CPML padding is
+    added OUTSIDE the requested domain, not carved out of it. Always
+    derive shapes/indices from the built Grid, never from the domain
+    cell counts directly."""
+    grid = sim._build_grid()
+    eps_base = jnp.ones(grid.shape, dtype=jnp.float32)
+    return grid, eps_base
+
+
+def _material_objective(sim, functional):
+    """Material leg: alpha scales eps_r of a dielectric slab between the
+    source and the DFT plane. functional is field_energy(_PLANE) or
+    field_softmax(_PLANE)."""
+    grid, eps_base = _grid_and_eps_base(sim)
+    lo = grid.position_to_index(_SLAB_LO_M)
+    hi = grid.position_to_index(_SLAB_HI_M)
+    slab = (slice(lo[0], hi[0] + 1), slice(None), slice(None))
+
+    def objective(alpha):
+        eps = eps_base.at[slab].set(alpha)
+        result = sim.forward(
+            eps_override=eps, n_steps=_N_STEPS, checkpoint=False,
+            skip_preflight=True,
+        )
+        return functional(result)
+
+    return objective
+
+
+def _geometry_objective(sim, functional, *, eps_bg=1.0, eps_fg=4.0):
+    """Geometry leg: ONE topology-density pixel through
+    density_to_material_fields -> eps_override (topology.py:209-221)."""
+    grid, eps_base = _grid_and_eps_base(sim)
+    i, j, k = grid.position_to_index(_PIXEL_POS_M)
+
+    def objective(rho_scalar):
+        rho = jnp.reshape(rho_scalar, (1, 1, 1))
+        fields = density_to_material_fields(rho, eps_bg, eps_fg)
+        eps = eps_base.at[i, j, k].set(fields.eps[0, 0, 0])
+        result = sim.forward(
+            eps_override=eps, n_steps=_N_STEPS, checkpoint=False,
+            skip_preflight=True,
+        )
+        return functional(result)
+
+    return objective
+
+
+def _central_fd_f64(objective, x0: float, h: float):
+    """Central finite difference with the comparison arithmetic in float64
+    (#527 discipline: the FDTD fields stay float32; only the loss/FD
+    comparison gains precision, scoped via enable_x64()).
+
+    The design-variable input is deliberately kept float32 (its natural
+    dtype, matching eps_base — test_coax_two_port_ad.py established this:
+    forcing the input to float64 is unnecessary AND scatters a float64
+    value into a float32 eps_override array). Under enable_x64() the
+    accumulator/comparison math promotes to float64 on its own (the DFT
+    accumulator dtype follows jax.config.x64_enabled, independent of the
+    FDTD field precision), which is what the dtype assertion below checks.
+    """
+    with enable_x64():
+        fp = objective(jnp.asarray(x0 + h, dtype=jnp.float32))
+        fm = objective(jnp.asarray(x0 - h, dtype=jnp.float32))
+        assert fp.dtype == jnp.float64 and fm.dtype == jnp.float64, (
+            f"FD reference did not run in float64 (got {fp.dtype}); JAX "
+            "truncates a float64 request to float32 when x64 is off."
+        )
+        return (float(fp) - float(fm)) / (2.0 * h)
+
+
+def _assert_ad_matches_fd(g_ad: float, g_fd: float, *, label: str, tol: float = 0.05):
+    assert np.isfinite(g_ad), f"{label}: AD gradient not finite: {g_ad}"
+    assert np.isfinite(g_fd), f"{label}: FD reference not finite: {g_fd}"
+    assert abs(g_ad) > _GRAD_FLOOR, (
+        f"{label}: AD gradient ~0 ({g_ad:.3e}, floor {_GRAD_FLOOR:.0e}) -- "
+        "tape may be severed (see the module docstring falsifier ritual)."
+    )
+    rel = abs(g_ad - g_fd) / max(abs(g_fd), 1e-30)
+    assert rel < tol, (
+        f"{label}: AD grad {g_ad:.6e} vs FD {g_fd:.6e}, rel_err "
+        f"{rel * 100:.2f}% >= {tol * 100:.0f}%"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (1) FD-vs-AD gates: both AC legs x both built-in functionals.
+# ---------------------------------------------------------------------------
+
+def test_field_energy_material_leg_ad_matches_fd():
+    sim = _build_sim()
+    functional = field_energy(_PLANE)
+    obj = _material_objective(sim, functional)
+
+    alpha0 = 2.0
+    val = float(obj(jnp.asarray(alpha0, dtype=jnp.float32)))
+    assert val > 0.0, f"field_energy did not couple to the source (val={val:.3e})"
+
+    g_ad = float(jax.grad(obj)(jnp.asarray(alpha0, dtype=jnp.float32)))
+    g_fd = _central_fd_f64(obj, alpha0, _FD_H)
+    _assert_ad_matches_fd(g_ad, g_fd, label="field_energy material leg")
+
+
+def test_field_energy_geometry_leg_ad_matches_fd():
+    sim = _build_sim()
+    functional = field_energy(_PLANE)
+    obj = _geometry_objective(sim, functional)
+
+    rho0 = 0.5
+    val = float(obj(jnp.asarray(rho0, dtype=jnp.float32)))
+    assert val > 0.0, f"field_energy did not couple to the source (val={val:.3e})"
+
+    g_ad = float(jax.grad(obj)(jnp.asarray(rho0, dtype=jnp.float32)))
+    g_fd = _central_fd_f64(obj, rho0, _FD_H)
+    _assert_ad_matches_fd(g_ad, g_fd, label="field_energy geometry (1-pixel) leg")
+
+
+def test_field_softmax_material_leg_ad_matches_fd():
+    sim = _build_sim()
+    functional = field_softmax(_PLANE, beta=1.0)
+    obj = _material_objective(sim, functional)
+
+    alpha0 = 2.0
+    val = float(obj(jnp.asarray(alpha0, dtype=jnp.float32)))
+    assert np.isfinite(val)
+
+    g_ad = float(jax.grad(obj)(jnp.asarray(alpha0, dtype=jnp.float32)))
+    g_fd = _central_fd_f64(obj, alpha0, _FD_H)
+    _assert_ad_matches_fd(g_ad, g_fd, label="field_softmax material leg")
+
+
+def test_field_softmax_geometry_leg_ad_matches_fd():
+    sim = _build_sim()
+    functional = field_softmax(_PLANE, beta=1.0)
+    obj = _geometry_objective(sim, functional)
+
+    rho0 = 0.5
+    val = float(obj(jnp.asarray(rho0, dtype=jnp.float32)))
+    assert np.isfinite(val)
+
+    g_ad = float(jax.grad(obj)(jnp.asarray(rho0, dtype=jnp.float32)))
+    g_fd = _central_fd_f64(obj, rho0, _FD_H)
+    _assert_ad_matches_fd(g_ad, g_fd, label="field_softmax geometry (1-pixel) leg")
+
+
+# ---------------------------------------------------------------------------
+# (2) Physics witness: run() and forward() must agree on the accumulator.
+# ---------------------------------------------------------------------------
+
+def test_run_forward_dft_plane_parity():
+    """The two independent code paths that populate result.dft_planes
+    (rfx/runners/uniform.py for run(), rfx/api/_execute.py for forward())
+    must produce the SAME accumulator on an identical vacuum config. This
+    is the guard the FD-vs-AD gates above are blind to (they only ever
+    exercise forward())."""
+    sim_run = _build_sim()
+    sim_fwd = _build_sim()
+
+    run_result = sim_run.run(n_steps=_N_STEPS, skip_preflight=True)
+    fwd_result = sim_fwd.forward(n_steps=_N_STEPS, skip_preflight=True)
+
+    assert run_result.dft_planes and _PLANE in run_result.dft_planes
+    assert fwd_result.dft_planes and _PLANE in fwd_result.dft_planes
+
+    run_acc = np.asarray(run_result.dft_planes[_PLANE].accumulator)
+    fwd_acc = np.asarray(fwd_result.dft_planes[_PLANE].accumulator)
+
+    assert run_acc.shape == fwd_acc.shape
+    peak = np.max(np.abs(run_acc)) + 1e-30
+    assert peak > 1e-20, "accumulator is empty -- source did not couple"
+    rel_err = np.max(np.abs(run_acc - fwd_acc)) / peak
+    assert rel_err < 1e-5, (
+        f"run() vs forward() dft_planes accumulator mismatch: rel_err={rel_err:.2e} "
+        f"(run peak={np.max(np.abs(run_acc)):.4e}, forward peak={np.max(np.abs(fwd_acc)):.4e})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (3) dft_field error-path and dict/stack behavior — no FDTD, fake results.
+# ---------------------------------------------------------------------------
+
+def _fake_result(**planes):
+    return types.SimpleNamespace(
+        dft_planes={name: types.SimpleNamespace(accumulator=arr) for name, arr in planes.items()}
+    )
+
+
+def test_dft_field_single_name_returns_array_not_dict():
+    arr = jnp.ones((2, 3, 4), dtype=jnp.complex64)
+    result = _fake_result(p1=arr)
+    out = dft_field("p1")(result)
+    assert isinstance(out, jnp.ndarray)
+    assert out.shape == (2, 3, 4)
+    np.testing.assert_allclose(np.asarray(out), np.asarray(arr))
+
+
+def test_dft_field_list_stacks_when_shapes_match():
+    a = jnp.ones((2, 3, 4), dtype=jnp.complex64)
+    b = jnp.full((2, 3, 4), 2.0, dtype=jnp.complex64)
+    result = _fake_result(a=a, b=b)
+    out = dft_field(["a", "b"])(result)
+    assert out.shape == (2, 2, 3, 4)
+    np.testing.assert_allclose(np.asarray(out[0]), np.asarray(a))
+    np.testing.assert_allclose(np.asarray(out[1]), np.asarray(b))
+
+
+def test_dft_field_mismatched_shapes_raise_with_stack_false_hint():
+    a = jnp.ones((2, 3, 4), dtype=jnp.complex64)
+    b = jnp.ones((2, 3, 5), dtype=jnp.complex64)
+    result = _fake_result(a=a, b=b)
+    with pytest.raises(ValueError, match="stack=False"):
+        dft_field(["a", "b"])(result)
+
+
+def test_dft_field_stack_false_returns_dict():
+    a = jnp.ones((2, 3, 4), dtype=jnp.complex64)
+    b = jnp.ones((2, 3, 5), dtype=jnp.complex64)
+    result = _fake_result(a=a, b=b)
+    out = dft_field(["a", "b"], stack=False)(result)
+    assert set(out) == {"a", "b"}
+    assert out["a"].shape == (2, 3, 4)
+    assert out["b"].shape == (2, 3, 5)
+
+
+def test_dft_field_missing_result_planes_raises():
+    result = types.SimpleNamespace(dft_planes=None)
+    with pytest.raises(ValueError, match="add_dft_plane_probe"):
+        dft_field("p1")(result)
+
+
+def test_dft_field_missing_name_raises():
+    result = _fake_result(p1=jnp.ones((1, 2, 2), dtype=jnp.complex64))
+    with pytest.raises(ValueError, match="not found in result.dft_planes"):
+        dft_field("p2")(result)
+
+
+def test_field_energy_missing_plane_raises_naming_the_call():
+    result = types.SimpleNamespace(dft_planes=None)
+    with pytest.raises(ValueError, match="field_energy"):
+        field_energy("p1")(result)
+
+
+def test_field_softmax_rejects_nonpositive_beta():
+    with pytest.raises(ValueError, match="beta"):
+        field_softmax("p1", beta=0.0)
+
+
+# ---------------------------------------------------------------------------
+# (4) Fail-loud distributed fences (issue #579 item 2) — regression pins.
+# ---------------------------------------------------------------------------
+
+def _nu_sim_with_dft_plane() -> Simulation:
+    nx, ny, nz = 16, 12, 12
+    dx = 1e-3
+    sim = Simulation(
+        freq_max=8e9, domain=(nx * dx, ny * dx, nz * dx), dx=dx,
+        boundary="cpml", cpml_layers=4,
+    )
+    sim._dx_profile = np.full(nx, dx)
+    sim._dy_profile = np.full(ny, dx)
+    sim._dz_profile = np.full(nz, dx)
+    sim.add_source(
+        position=(4e-3, 6e-3, 6e-3), component="ez", amplitude_kind="current",
+    )
+    sim.add_dft_plane_probe(
+        axis="x", coordinate=10e-3, component="ez", freqs=_FREQS,
+    )
+    return sim
+
+
+def test_forward_distributed_nu_dft_planes_fence_raises():
+    sim = _nu_sim_with_dft_plane()
+    with pytest.raises(NotImplementedError, match="add_dft_plane_probe"):
+        sim.forward(distributed=True, n_steps=2, skip_preflight=True)
+
+
+def test_run_distributed_dft_planes_fence_raises():
+    sim = _build_sim()
+    devices = [jax.devices()[0], jax.devices()[0]]
+    with pytest.raises(NotImplementedError, match="add_dft_plane_probe"):
+        sim.run(devices=devices, n_steps=2, skip_preflight=True)

--- a/tests/test_observables_dft_field.py
+++ b/tests/test_observables_dft_field.py
@@ -21,11 +21,17 @@ Coverage:
 
 FALSIFIER RITUAL: before trusting the FD-vs-AD gates below, a throwaway
 `jax.lax.stop_gradient` was inserted on the DFT-plane accumulator inside a
-scratch copy of the material-leg objective and the gate was re-run -- AD
-grad collapsed to ~0.0 while the FD reference stayed finite, i.e. the gate
-DOES go red when the tape is actually severed. The red output is saved at
-scratchpad/i579_falsifier_red.txt (not committed here -- see the PR body);
-the throwaway change was reverted immediately after.
+scratch copy of the material-leg objective (field_energy, alpha0=2.0) and
+the gate was re-run: AD grad went to EXACTLY 0.0 while the FD reference
+stayed finite at -7.7177063137973e-09 -- i.e. the gate DOES go red when
+the tape is actually severed (see the #579 PR body for the full captured
+output). The throwaway change was reverted immediately after and verified
+clean (grep + git status) before this file's tests were trusted green.
+
+BETA CALIBRATION NOTE (the softmax gates below): an initial beta=1.0 on
+these two tests passed by COINCIDENCE, not physics -- see
+`_SOFTMAX_BETA`'s comment for the measured counter-example (h=0.01 read
+18.9% relative error with the AD gradient unchanged) and the fix.
 """
 
 from __future__ import annotations
@@ -64,12 +70,36 @@ _SLAB_HI_M = (18 * _DX, _NY * _DX, _NZ * _DX)
 _PIXEL_POS_M = (14 * _DX, 10 * _DX, 10 * _DX)  # geometry-leg single design pixel
 _N_STEPS = 160
 _FD_H = 0.02
+# field_softmax needs beta scale-matched to the field magnitude (see
+# rfx.observables.field_softmax's docstring warning) -- this sim's
+# max|field|^2 measures ~5e-10 to 5.4e-10 on both legs, with
+# count = n_freqs*n1*n2 = 1*31*31 = 961 elements on the single registered
+# plane, so log(count)/beta ~ 6.87/beta is the CONSTANT (design-variable-
+# independent) floor logsumexp(beta*vals)/beta never drops below. At
+# beta=1.0 that constant totally dominates: the objective sits at
+# ~100.000002% of log(961), both AD and FD differentiate rounding noise in
+# that constant rather than physics, and the two coincidentally agreed at
+# h=0.02 (< 5% rel_err) while DISAGREEING at h=0.01 (18.9% rel_err, same
+# AD value) -- proof the original green was luck, not a real measurement.
+# Measured sweep (geometry leg, h=0.02, same sim): beta=1e9 -> 0.257%,
+# beta=1e10 -> 0.177%, beta=1e11 -> 0.112% rel_err, monotonically
+# tightening as beta pushes past the log(count)/beta regime toward the
+# true max (beta*max(vals) ~ 1e11*5e-10 = 50, comfortably >> log(961)~6.87
+# and comfortably below the ~3.4e38 float32 overflow ceiling the
+# docstring warns about). beta=1e11 is used below, and re-verified across
+# THREE h values (not one) so a future coincidental-rounding regression
+# cannot slip back in unnoticed.
+_SOFTMAX_BETA = 1e11
+_SOFTMAX_FD_H_VALUES = (0.01, 0.02, 0.04)
 # A single-Yee-cell material perturbation (the geometry/topology leg) has a
-# proportionally tiny effect on a bulk plane-energy sum (~1e-10 measured) —
-# real, FD-matching signal, not noise. The floor only needs to catch an
-# actually-severed tape (which reads exactly/near 0.0), so it sits several
-# orders below that measured single-pixel gradient, not just below the
-# larger material-leg (whole-slab) gradient.
+# proportionally tiny effect on a bulk plane-energy sum -- real,
+# FD-matching signal, not noise, but small. The tightest margin measured
+# across all four FD-vs-AD gates is field_softmax's geometry leg at
+# beta=_SOFTMAX_BETA (~4.9e-12) -- about 2.7 orders of magnitude above
+# this floor (field_energy's geometry leg, ~2.1e-10, and both material-leg
+# gradients sit further above it still). The floor only needs to catch an
+# actually-severed tape (which reads exactly/near 0.0), so it sits
+# comfortably below that measured minimum.
 _GRAD_FLOOR = 1e-14
 
 
@@ -209,7 +239,7 @@ def test_field_energy_geometry_leg_ad_matches_fd():
 
 def test_field_softmax_material_leg_ad_matches_fd():
     sim = _build_sim()
-    functional = field_softmax(_PLANE, beta=1.0)
+    functional = field_softmax(_PLANE, beta=_SOFTMAX_BETA)
     obj = _material_objective(sim, functional)
 
     alpha0 = 2.0
@@ -217,13 +247,18 @@ def test_field_softmax_material_leg_ad_matches_fd():
     assert np.isfinite(val)
 
     g_ad = float(jax.grad(obj)(jnp.asarray(alpha0, dtype=jnp.float32)))
-    g_fd = _central_fd_f64(obj, alpha0, _FD_H)
-    _assert_ad_matches_fd(g_ad, g_fd, label="field_softmax material leg")
+    # h-robustness, not a single h: see _SOFTMAX_BETA's comment -- a
+    # coincidental rounding-lattice match does NOT hold consistently
+    # across multiple step sizes, which is exactly what caught the
+    # beta=1.0 false green (18.9% at h=0.01 vs <5% at h=0.02, same g_ad).
+    for h in _SOFTMAX_FD_H_VALUES:
+        g_fd = _central_fd_f64(obj, alpha0, h)
+        _assert_ad_matches_fd(g_ad, g_fd, label=f"field_softmax material leg (h={h})")
 
 
 def test_field_softmax_geometry_leg_ad_matches_fd():
     sim = _build_sim()
-    functional = field_softmax(_PLANE, beta=1.0)
+    functional = field_softmax(_PLANE, beta=_SOFTMAX_BETA)
     obj = _geometry_objective(sim, functional)
 
     rho0 = 0.5
@@ -231,8 +266,11 @@ def test_field_softmax_geometry_leg_ad_matches_fd():
     assert np.isfinite(val)
 
     g_ad = float(jax.grad(obj)(jnp.asarray(rho0, dtype=jnp.float32)))
-    g_fd = _central_fd_f64(obj, rho0, _FD_H)
-    _assert_ad_matches_fd(g_ad, g_fd, label="field_softmax geometry (1-pixel) leg")
+    for h in _SOFTMAX_FD_H_VALUES:
+        g_fd = _central_fd_f64(obj, rho0, h)
+        _assert_ad_matches_fd(
+            g_ad, g_fd, label=f"field_softmax geometry (1-pixel) leg (h={h})"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -335,6 +373,23 @@ def test_field_energy_missing_plane_raises_naming_the_call():
 def test_field_softmax_rejects_nonpositive_beta():
     with pytest.raises(ValueError, match="beta"):
         field_softmax("p1", beta=0.0)
+
+
+def test_dft_field_and_field_energy_accept_raw_array_planes():
+    """Cross-PR robustness (#578): a dft_planes dict may carry BARE arrays
+    instead of DFTPlaneProbe-like objects -- e.g. a vmap-batched sweep
+    result. _select_planes must duck-type (`getattr(v, "accumulator", v)`)
+    rather than assume every value has an `.accumulator` attribute, or this
+    combination crashes AttributeError."""
+    raw = jnp.full((2, 3, 4), 1.5, dtype=jnp.complex64)  # NOT wrapped in a probe-like object
+    result = types.SimpleNamespace(dft_planes={"p1": raw})
+
+    out = dft_field("p1")(result)
+    assert out.shape == (2, 3, 4)
+    np.testing.assert_allclose(np.asarray(out), np.asarray(raw))
+
+    energy = float(field_energy("p1")(result))
+    assert np.isclose(energy, float(jnp.sum(jnp.abs(raw) ** 2)))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds `rfx.observables`: a public accessor/objective layer over the DFT-plane
accumulator mechanism that already existed (`Simulation.add_dft_plane_probe`
+ `result.dft_planes`) and was already end-to-end JAX-differentiable — this
PR is the missing public surface on top of it, in the same
factory-returns-`callable(Result)` style as `rfx.optimize_objectives`.

- `dft_field(names, *, stack=True)` — result accessor. Single name returns
  the raw `(n_freqs, n1, n2)` complex accumulator; a list stacks into
  `(n_names, n_freqs, n1, n2)` when shapes match, else raises `ValueError`
  pointing at `stack=False` (which opts into a `dict[name] -> array` form).
- `field_energy(names, *, weights=None)` — `sum(|field|**2)` objective
  factory, trivially smooth.
- `field_softmax(names, *, beta=1.0)` — temperature-controlled soft-max over
  space + frequency, for worst-case-bin (not average) objectives. **`beta`
  must be scale-matched to the field magnitude** — see below.
- Two fail-loud `NotImplementedError` fences: `forward(distributed=True)`
  and `run(devices=[...2+...])` now reject a registered DFT-plane probe
  instead of silently dropping it (neither sharded runner accumulates DFT
  planes today). **BEHAVIOUR CHANGE**, documented in CHANGELOG.
- `_select_planes` duck-types the per-name value
  (`getattr(v, "accumulator", v)`), so a `dft_planes` dict of bare arrays
  (PR #618's `VmapSweepResult`) works too, not just `DFTPlaneProbe` objects.
- New example `examples/inverse_design/field_observable_shielding.py`: a
  normal-incidence TFSF + 7-layer dielectric stack, two internal DFT-plane
  leakage monitors pooled via `field_softmax` into one worst-case scalar,
  minimized by a hand-rolled `jax.grad` descent loop.

## AC-by-AC accounting (issue #579)

- **AC1** (differentiable field observable, FD-verified): both `field_energy`
  and `field_softmax` are gated FD-vs-AD on BOTH acceptance-criteria legs —
  (a) material `eps_r` scalar via `eps_override`, (b) one topology-density
  pixel via `density_to_material_fields` — central FD, float64 comparison
  arithmetic (#527 discipline), 5% tolerance.
  `field_energy`: material leg rel_err well under tolerance (real signal,
  ~1e-10 to 5e-11 gradient scale); geometry (1-pixel) leg rel_err ~0.3%
  (gradient ~2e-10, matches FD closely despite the tiny single-cell
  perturbation).
  `field_softmax`: required scale-matching `beta` to the field magnitude
  (this repo's DFT-accumulator units sit far from O(1), same tiny-unit class
  documented elsewhere for NTFF power) — see "Independent-review fix" below.
  With `beta=1e11`, both legs pass at THREE step sizes (h=0.01/0.02/0.04):
  material leg 0.000%–0.038% rel_err, geometry leg 0.054%–0.398% rel_err.
- **AC2** (documented AD-tape contents / hazards): `rfx/observables.py`
  module docstring carries "What stays on the AD tape" and "E/H mixing
  hazard" sections; `field_softmax` carries two additional docstring
  warnings (beta scale-matching, top-end overflow). Cross-linked from
  `docs/agent/recipe-design-loop.mdx` (new "Direct `jax.grad` through a
  registered DFT-plane field observable" section) and
  `docs/agent/repo-map.mdx` (new grep-map row).
- **AC3** (worked example): `examples/inverse_design/field_observable_shielding.py`,
  runs end-to-end — 39.5% worst-case-leakage reduction over 12 gradient
  steps, settling witness **-49.5 dB** (bar: -40 dB, SETTLED). PNG generated
  next to the script on each run (not git-added — `**/*.png` is repo-wide
  gitignored with no exception for `examples/inverse_design/`, and the
  existing precedent script `multilayer_ar_coating.png` isn't tracked
  either).

Design-vs-issue deltas (stated per the design contract): the issue's
`components=` ask (multiple field components per probe) is NOT how
`add_dft_plane_probe` works — each plane probe is single-component. The
documented workaround is the register-N-planes-then-pool pattern (register
one plane per component/location you care about, pool with
`field_softmax`/`field_energy`), demonstrated in the example. No
`h_phase_correction` kwarg — neither `ForwardResult` nor `DFTPlaneProbe`
carries `dt`, and magnitude-only objectives are unaffected by the E/H
half-step phase; documented as a one-line user-side fix for anyone building
an E×H* objective.

## Falsifier ritual (executed, not skipped)

Before trusting the FD-vs-AD gates, a throwaway `jax.lax.stop_gradient` was
inserted on the DFT-plane accumulator inside `field_energy`'s objective and
the material-leg gate was re-run. Excerpt:

```
g_ad = 0.0, g_fd = -7.7177063137973e-09

E       AssertionError: field_energy material leg: AD gradient ~0 (0.000e+00, floor 1e-14) --
E       tape may be severed (see the module docstring falsifier ritual).
E       assert 0.0 > 1e-14
E        +  where 0.0 = abs(0.0)
```

AD grad collapsed to EXACTLY 0.0 while the FD reference stayed finite — the
gate goes red when the tape is actually severed. The throwaway edit was
reverted immediately after (verified clean via `git status` + grep before
committing).

## Independent-review fix (this PR also includes)

An independent verify caught that `field_softmax`'s FD-vs-AD gate was green
by coincidence at `beta=1.0`: with this test sim's `count=961` elements per
plane, the objective sat at `~100.000002%` of the constant `log(961)/beta` —
both AD and the FD reference were differentiating rounding noise in that
design-variable-independent constant, not physics. `h=0.01` exposed it at
18.9% relative error with the AD value unchanged (vs <5% at `h=0.02`). Fixed
by scale-matching `beta=1e11` (measured sweep: `beta=1e9`→0.257%,
`1e10`→0.177%, `1e11`→0.112% at `h=0.02`, monotonically tightening toward
the true max) and re-verifying at three step sizes on every run, so a future
coincidental-rounding regression can't slip back in silently. Also folded in
this PR: `field_softmax`'s beta-scale-matching + top-end-overflow docstring
warnings, `dft_field`'s shape-mismatch docstring/CHANGELOG correction (code
raises, doesn't silently return a dict), the `_select_planes` duck-typing
fix + test, and a pre-existing red test
(`test_dft_accumulator_dtype.py::test_accumulators_follow_x64_when_enabled`,
broken by `jax.experimental.enable_x64` removal in newer JAX — same
`tests/_x64_compat` fallback shim this PR's own new test file already uses).

## Test plan

- [x] `tests/test_observables_dft_field.py` — 16 passed (FD-vs-AD both
      legs × both functionals with h-robustness; run()-vs-forward() parity
      witness; dft_field error-path/dict-stack/raw-array behavior; both
      distributed-fence regressions)
- [x] `tests/test_ad_surface_contract.py` — enumeration extended to
      `rfx.observables`' own `__all__`, all GRAD_SAFE with evidence
      pointers
- [x] `tests/test_dft_accumulator_dtype.py` — pre-existing red test fixed
- [x] `tests/test_forward_docstring_contract.py`,
      `tests/test_forward_dft_planes_carry.py` — unaffected, still green
- [x] `ruff check rfx/ tests/ --select E,F,W --ignore E501,F401,E741,E731,E701,E702,E402`
      — clean
- [x] `python scripts/check_api_reference.py` — OK (inventory regenerated
      via `--write`)
- [x] Full-suite `pytest --collect-only` — 3665 tests, 0 import errors
- [x] `examples/inverse_design/field_observable_shielding.py` run
      end-to-end — 39.5% loss reduction, -49.5 dB settling, PNG visually
      inspected

🤖 Generated with [Claude Code](https://claude.com/claude-code)