### PR TITLE
fix(distributed-nu): place the x-hi face at the real boundary node in the pad_x>0 lane (#622)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — distributed-NU pad-lane hi-x wall displacement (issue #622)
+
+- `rfx.runners.distributed_nu.run_nonuniform_distributed_pec` and the NU
+  branch of `rfx.runners.distributed_v2.run_distributed` (`distributed=True`
+  with a non-uniform `dx`/`dy`/`dz` profile) produced a distributed cavity
+  effectively **one cell wider** than the equivalent single-device run
+  whenever the sharded x-extent needed alignment padding to divide evenly
+  across devices (`sharded_grid.pad_x > 0` — e.g. any even physical cell
+  count on 2 devices, since #564 made the realized node count `N+1`).
+  `_build_sharded_inv_dx_arrays` re-derived the H-update inverse-spacing
+  array from a padded cell-size profile instead of reading the grid's own
+  `inv_dx_h`, which moved the trailing zero coefficient (the one that
+  freezes the real boundary node's H term) from the real face (global
+  node `nx - 1`) to the padded slab end — so the real boundary cell's H
+  term stayed live. The PEC/PMC face appliers and the CPML x-hi window
+  had the matching off-by-`pad_x` bug, acting on the padded slab end
+  instead of the real face. Net effect on the 13 affected 2-device
+  equivalence tests: final-step probe `rel_err` up to 2.0 (gate 5e-5);
+  the Class F analytic-resonance test stayed green-but-degraded (2.0%
+  measured error under its 5% discretisation gate, now 0.02%).
+  Fix: pad cells are now structurally inert (all E/H inverse-spacing
+  coefficients zero in the pad region, preserving the grid's own
+  trailing zero at the real boundary node), and the PEC/PMC/CPML face
+  machinery is shifted by `pad_x` to act on the real face on the last
+  rank. The `pad_x == 0` lane is unchanged in behaviour class;
+  coefficients now come bit-identically from the grid's own arrays. No
+  gate was loosened; the Class F resonance gate (5% discretisation
+  bound) is untouched even though the measured error dropped well
+  under it.
+- Lane visibility: `tests/test_distributed_nu_kernel.py` carried a
+  module-wide `pytest.mark.gpu` from file creation (2026-04-16, for a
+  test-pollution reason superseded the same day by the root conftest's
+  ordered XLA_FLAGS/jax-import sequence) that put its entire 22-test
+  2-device equivalence family in a lane that never ran it: every CPU
+  lane deselects `gpu`, and the 1-GPU-device VESSL pod's `-m gpu` step
+  only creates *virtual* extra devices on the CPU backend, so it always
+  skipped there too. That is why this regression (introduced pre-#564,
+  unmasked by it) shipped undetected. The marker is removed; the file
+  now runs in the same fast-suite/weekly CPU shards as its sibling
+  `test_distributed_nu_composition.py`, which never carried the marker.
+  `scripts/vessl_gpu_suite.yaml`'s stale comment (claiming distributed
+  coverage already ran in the fast suite) is corrected to match.
+  `tests/test_distributed.py` (the uniform-grid distributed family) is
+  in the same runs-nowhere state and is tracked separately.
+
 ### Added — `vmap_material_sweep()` batches DFT plane accumulators on the fast path (#578)
 
 - `add_dft_plane_probe` planes now accumulate inside the `jax.vmap`-batched

--- a/rfx/runners/distributed_nu.py
+++ b/rfx/runners/distributed_nu.py
@@ -56,61 +56,59 @@ from rfx.runners._distributed_common import (
 def _build_sharded_inv_dx_arrays(grid, n_devices, pad_x=0):
     """Build per-device x-axis inverse-spacing slabs for the shard_map runner.
 
-    The caller has already padded the global x-extent by ``pad_x`` cells
-    (to align ``nx`` on ``n_devices``).  We replicate that padding onto
-    the cell-size profile using the boundary cell value (matching how
-    ``make_nonuniform_grid`` pads CPML cells) and rebuild the global
-    ``inv_dx`` and ``inv_dx_h`` from the padded profile, then reshape to
-    per-device slabs.
-
-    The two inverse-spacing arrays are built on the *global* padded
-    profile, so slicing them into per-device slabs (with ghosts) keeps
-    every entry — including the slab-boundary ones — globally correct.
+    The caller has already decided to pad the global x-extent by
+    ``pad_x`` cells (to align ``nx`` on ``n_devices``).  Unlike the
+    pre-#622 version, this does NOT re-derive ``inv_dx``/``inv_dx_h``
+    from a padded cell-size profile — it reads ``grid.inv_dx`` /
+    ``grid.inv_dx_h`` directly (the single-device reference arrays,
+    which already carry the correct trailing H zero at the REAL
+    boundary node ``nx - 1``, see ``nonuniform.py:219``) and appends
+    ``pad_x`` zero coefficients.  The pad region is therefore
+    STRUCTURALLY INERT: with every E and H coefficient zero there, no
+    field evolves in the pad cells regardless of what the PEC-mask
+    padding does, and the wall stays exactly where the single-device
+    grid put it (#622 — the old re-derivation moved the trailing H
+    zero from real node ``nx-1`` to padded index ``nx_padded-1``,
+    leaving the real boundary cell's H term live).
 
     Parameters
     ----------
     grid : NonUniformGrid
     n_devices : int
     pad_x : int
-        Number of PEC-padded cells appended to the high-x end of the
-        domain so that ``(nx + pad_x) % n_devices == 0``.
+        Number of inert cells appended to the high-x end of the domain
+        so that ``(nx + pad_x) % n_devices == 0``.
 
     Returns
     -------
     inv_dx_e_global : (nx_padded,) np.ndarray
         E-update inverse spacing — mean ``2/(d[k-1]+d[k])`` (leading
-        ``1/d[0]``). Consumed by ``_update_e_local_nu``.
+        ``1/d[0]``), zero in the pad region. Consumed by
+        ``_update_e_local_nu``.
     inv_dx_h_global : (nx_padded,) np.ndarray
-        H-update inverse spacing — local ``1/d[k]`` (trailing ``0``).
+        H-update inverse spacing — local ``1/d[k]`` (zero at real
+        boundary node ``nx-1`` AND throughout the pad region).
         Consumed by ``_update_h_local_nu``.
     dx_padded : (nx_padded,) np.ndarray
-        The padded cell-size profile (float32) — useful for diagnostics
-        and the unit test.
+        The cell-size profile (float32), pad region filled with the
+        boundary cell size for diagnostics (e.g. CPML dx_boundary) —
+        this is geometry bookkeeping only; it does NOT feed the E/H
+        inverse-spacing arrays above.
     """
     dx_arr = np.asarray(grid.dx_arr, dtype=np.float64)
+    inv_dx_e = np.asarray(grid.inv_dx, dtype=np.float64)
+    inv_dx_h = np.asarray(grid.inv_dx_h, dtype=np.float64)
     if pad_x > 0:
-        # pad at the high-x end with boundary-cell-size value
         dx_arr = np.concatenate(
             [dx_arr, np.full(pad_x, float(dx_arr[-1]))]
         )
-    nx = dx_arr.shape[0]
+        inv_dx_e = np.concatenate([inv_dx_e, np.zeros(pad_x, dtype=np.float64)])
+        inv_dx_h = np.concatenate([inv_dx_h, np.zeros(pad_x, dtype=np.float64)])
+    nx = inv_dx_e.shape[0]
     if nx % n_devices != 0:
         raise ValueError(
             f"After padding nx={nx} is not divisible by n_devices={n_devices}"
         )
-
-    # CORE-C2: the E update needs the MEAN spacing 2/(d[k-1]+d[k]); the
-    # H update needs the LOCAL cell width 1/d[k]. (Mirrors the
-    # single-device rfx.nonuniform._profile_to_inv_arrays.) Built on the
-    # global padded profile, so each per-device slab is correct after
-    # the P("x") shard — the E-mean seam straddles the lower neighbour
-    # and is resolved here, globally, before sharding.
-    inv_local = 1.0 / dx_arr                          # 1/d[k]
-    inv_mean = 2.0 / (dx_arr[:-1] + dx_arr[1:])       # 2/(d[k]+d[k+1])
-    # First return -> E update: mean of (d[k-1], d[k]); leading 1/d[0].
-    inv_dx_e = np.concatenate([inv_local[:1], inv_mean])
-    # Second return -> H update: local cell width; trailing 0.
-    inv_dx_h = np.concatenate([inv_local[:-1], np.zeros(1, dtype=np.float64)])
 
     return (
         inv_dx_e.astype(np.float32),
@@ -693,7 +691,7 @@ def _exchange_e_ghosts_nu(state: FDTDState, mesh, n_devices: int) -> FDTDState:
 
 
 def _apply_pec_face_nu_shmap(state: FDTDState, mesh, n_devices: int,
-                             nx_local: int) -> FDTDState:
+                             nx_local: int, pad_x: int = 0) -> FDTDState:
     """Apply PEC on physical domain faces (x_lo, x_hi, y, z) using shard_map.
 
     Mirrors ``rfx/runners/distributed_v2.py::_apply_pec_shmap`` exactly:
@@ -701,11 +699,16 @@ def _apply_pec_face_nu_shmap(state: FDTDState, mesh, n_devices: int,
     conditional (only rank 0 zeroes x_lo, only rank N-1 zeroes x_hi).
 
     Critically, the X-face PEC acts on the **first real cell**
-    (``ghost``) and the **last real cell** (``nx_local - 1 - ghost``),
-    NOT on the seam ghost cells (which belong to neighbouring ranks).
-    This is V3 bullet 7 ("Hard PEC only acts on physical boundary or
-    masked cells, not on seam ghosts") and V3 bullet 6 ("Hard PEC does
-    not re-zero interior seam cells of neighbouring ranks").
+    (``ghost``) and the **last real cell** (``nx_local - 1 - ghost -
+    pad_x``), NOT on the seam ghost cells (which belong to
+    neighbouring ranks) and NOT on the alignment-pad cells (which are
+    beyond the real domain face — #622: with ``pad_x > 0`` the last
+    rank's slab carries ``pad_x`` inert cells past global node
+    ``nx - 1``; the physical face stays at that real node, not at the
+    padded slab end). This is V3 bullet 7 ("Hard PEC only acts on
+    physical boundary or masked cells, not on seam ghosts") and V3
+    bullet 6 ("Hard PEC does not re-zero interior seam cells of
+    neighbouring ranks").
     """
     @partial(
         shard_map,
@@ -738,9 +741,10 @@ def _apply_pec_face_nu_shmap(state: FDTDState, mesh, n_devices: int,
         ey = ey.at[ghost, :, :].set(ey_xlo)
         ez = ez.at[ghost, :, :].set(ez_xlo)
 
-        # X-hi PEC: only rank N-1; act on last REAL cell (skip ghost)
+        # X-hi PEC: only rank N-1; act on last REAL cell (skip ghost AND
+        # the alignment pad — #622).
         is_last = (device_idx == n_devices - 1)
-        last_real = nx_local - 1 - ghost
+        last_real = nx_local - 1 - ghost - pad_x
         ey_xhi = jnp.where(is_last, 0.0, ey[last_real, :, :])
         ez_xhi = jnp.where(is_last, 0.0, ez[last_real, :, :])
         ey = ey.at[last_real, :, :].set(ey_xhi)
@@ -753,7 +757,8 @@ def _apply_pec_face_nu_shmap(state: FDTDState, mesh, n_devices: int,
 
 
 def _apply_pmc_face_nu_shmap(state: FDTDState, mesh, n_devices: int,
-                             nx_local: int, pmc_faces: frozenset) -> FDTDState:
+                             nx_local: int, pmc_faces: frozenset,
+                             pad_x: int = 0) -> FDTDState:
     """Apply PMC (``H_tan = 0``) on physical domain faces using shard_map.
 
     Electromagnetic dual of :func:`_apply_pec_face_nu_shmap`: PEC zeroes
@@ -766,7 +771,8 @@ def _apply_pmc_face_nu_shmap(state: FDTDState, mesh, n_devices: int,
     Y- and Z-face PMC is local to every rank; X-face PMC is rank-
     conditional (only rank 0 zeroes x_lo, only rank N-1 zeroes x_hi),
     and acts on the **first real cell** (``ghost``) / **last real cell**
-    (``nx_local - 1 - ghost``) — NOT the seam ghost.
+    (``nx_local - 1 - ghost - pad_x``) — NOT the seam ghost, and NOT
+    the alignment-pad cells (#622, same class as the PEC face fix).
     """
     if not pmc_faces:
         return state
@@ -799,7 +805,7 @@ def _apply_pmc_face_nu_shmap(state: FDTDState, mesh, n_devices: int,
         device_idx = lax.axis_index("x")
         is_first = (device_idx == 0)
         is_last = (device_idx == n_devices - 1)
-        last_real = nx_local - 1 - ghost
+        last_real = nx_local - 1 - ghost - pad_x
         last_inside = last_real - 1
 
         if "x_lo" in pmc_faces:
@@ -1438,7 +1444,7 @@ def _update_e_dispersive_local_nu(
 
 def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
                            n_cpml: int, dt: float, ghost: int,
-                           n_devices: int, eps_r=None):
+                           n_devices: int, eps_r=None, pad_x: int = 0):
     """Per-rank slab-aware CPML E-field correction with NU per-axis dx.
 
     Mirrors :func:`rfx.boundaries.cpml.apply_cpml_e` but operates on a
@@ -1500,7 +1506,12 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
     n = n_cpml
     g = ghost
     xlo = slice(g, g + n)
-    xhi = slice(-(g + n), -g) if g > 0 else slice(-n, None)
+    # #622: on the last rank, pad_x inert alignment cells sit past the
+    # real x-hi face (global node nx-1) — shift the window left by
+    # pad_x so it covers the physical face, matching single-device
+    # cpml.py's [nx-n, nx) (a no-op on other ranks / when pad_x==0).
+    x_hi_edge = g + pad_x
+    xhi = slice(-(x_hi_edge + n), -x_hi_edge) if x_hi_edge > 0 else slice(-n, None)
 
     # Per-face E-coefficient (material-aware when eps_r is supplied, #205).
     # Each face slice broadcasts element-wise against its correction array:
@@ -1697,7 +1708,7 @@ def _apply_cpml_e_local_nu(state: FDTDState, cpml_params, cpml_state,
 
 def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
                            n_cpml: int, dt: float, ghost: int,
-                           n_devices: int, mu_r=None):
+                           n_devices: int, mu_r=None, pad_x: int = 0):
     """Per-rank slab-aware CPML H-field correction with NU per-axis dx.
 
     Mirror of :func:`_apply_cpml_e_local_nu` for the H field.  Same
@@ -1750,7 +1761,9 @@ def _apply_cpml_h_local_nu(state: FDTDState, cpml_params, cpml_state,
     n = n_cpml
     g = ghost
     xlo = slice(g, g + n)
-    xhi = slice(-(g + n), -g) if g > 0 else slice(-n, None)
+    # #622: same alignment-pad shift as the E-field CPML applier above.
+    x_hi_edge = g + pad_x
+    xhi = slice(-(x_hi_edge + n), -x_hi_edge) if x_hi_edge > 0 else slice(-n, None)
 
     # Per-face H-coefficient (material-aware when mu_r is supplied, #205).
     # Same per-face slicing as the E kernel; vacuum scalar dt/mu_0 when
@@ -2689,7 +2702,7 @@ def run_nonuniform_distributed_pec(
             )
             new_st, new_cs = _apply_cpml_h_local_nu(
                 _st, cpml_params, _cs, n_cpml_local, dt, ghost, n_devices,
-                mu_r=mu_r_slab,
+                mu_r=mu_r_slab, pad_x=pad_x,
             )
             return (new_st.hx, new_st.hy, new_st.hz,
                     new_cs.psi_hy_xlo, new_cs.psi_hy_xhi,
@@ -2757,7 +2770,7 @@ def run_nonuniform_distributed_pec(
             )
             new_st, new_cs = _apply_cpml_e_local_nu(
                 _st, cpml_params, _cs, n_cpml_local, dt, ghost, n_devices,
-                eps_r=eps_r_slab,
+                eps_r=eps_r_slab, pad_x=pad_x,
             )
             return (new_st.ex, new_st.ey, new_st.ez,
                     new_cs.psi_ey_xlo, new_cs.psi_ey_xhi,
@@ -2821,7 +2834,7 @@ def run_nonuniform_distributed_pec(
         #     of PEC: PMC must fire before the next E-update reads H via
         #     curl.
         st = _apply_pmc_face_nu_shmap(
-            st, mesh, n_devices, nx_local, pmc_faces)
+            st, mesh, n_devices, nx_local, pmc_faces, pad_x=pad_x)
 
         # 3. Ghost exchange of H so the upcoming E update sees the
         #    neighbour rank's H at the seam.
@@ -2852,7 +2865,7 @@ def run_nonuniform_distributed_pec(
         st = _exchange_e_ghosts_nu(st, mesh, n_devices)
 
         # 8. PEC on physical domain faces (X-faces are rank-conditional).
-        st = _apply_pec_face_nu_shmap(st, mesh, n_devices, nx_local)
+        st = _apply_pec_face_nu_shmap(st, mesh, n_devices, nx_local, pad_x=pad_x)
 
         # 9. PEC mask zeroing (geometry + override union).  No-op when
         #    sharded_pec_mask is None.

--- a/rfx/runners/distributed_v2.py
+++ b/rfx/runners/distributed_v2.py
@@ -145,8 +145,13 @@ def _exchange_e_ghosts_shmap(state: FDTDState, mesh: Mesh, n_devices: int) -> FD
 # ---------------------------------------------------------------------------
 
 def _apply_pec_shmap(state: FDTDState, mesh: Mesh, n_devices: int,
-                     nx_local_with_ghost: int) -> FDTDState:
-    """Apply PEC boundary conditions using shard_map for device identity."""
+                     nx_local_with_ghost: int, pad_x: int = 0) -> FDTDState:
+    """Apply PEC boundary conditions using shard_map for device identity.
+
+    ``pad_x`` (#622): when the last rank's slab carries alignment-pad
+    cells past the real x-hi face (global node ``nx - 1``), the face
+    must act on that real node, not on the padded slab end.
+    """
 
     @partial(
         shard_map,
@@ -187,9 +192,9 @@ def _apply_pec_shmap(state: FDTDState, mesh: Mesh, n_devices: int,
         ey = ey.at[ghost, :, :].set(ey_xlo)
         ez = ez.at[ghost, :, :].set(ez_xlo)
 
-        # X-hi PEC: device N-1 only
+        # X-hi PEC: device N-1 only (skip ghost AND alignment pad, #622)
         is_last = (device_idx == n_devices - 1)
-        last_real = nx_local_with_ghost - 1 - ghost
+        last_real = nx_local_with_ghost - 1 - ghost - pad_x
         ey_xhi = jnp.where(is_last, 0.0, ey[last_real, :, :])
         ez_xhi = jnp.where(is_last, 0.0, ez[last_real, :, :])
         ey = ey.at[last_real, :, :].set(ey_xhi)
@@ -203,7 +208,7 @@ def _apply_pec_shmap(state: FDTDState, mesh: Mesh, n_devices: int,
 
 def _apply_pmc_shmap(state: FDTDState, mesh: Mesh, n_devices: int,
                      nx_local_with_ghost: int,
-                     pmc_faces: frozenset) -> FDTDState:
+                     pmc_faces: frozenset, pad_x: int = 0) -> FDTDState:
     """PMC (``H_tangential = 0``) for the sharded uniform scan body.
 
     Dual of :func:`_apply_pec_shmap`. Hook point is the H-half of the
@@ -213,7 +218,7 @@ def _apply_pmc_shmap(state: FDTDState, mesh: Mesh, n_devices: int,
 
     Y- and Z-face PMC is local to every rank; X-face PMC is rank-
     conditional and acts on the first / last real cell, not the seam
-    ghost.
+    ghost — nor the alignment-pad cells when ``pad_x > 0`` (#622).
     """
     if not pmc_faces:
         return state
@@ -254,7 +259,7 @@ def _apply_pmc_shmap(state: FDTDState, mesh: Mesh, n_devices: int,
         device_idx = lax.axis_index("x")
         is_first = (device_idx == 0)
         is_last = (device_idx == n_devices - 1)
-        last_real = nx_local_with_ghost - 1 - ghost
+        last_real = nx_local_with_ghost - 1 - ghost - pad_x
         last_inside = last_real - 1
 
         if "x_lo" in pmc_faces:
@@ -1275,7 +1280,7 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
         #     OQ9: after H ghost exchange, before E update. PMC must
         #     fire before the next E-update reads H via curl.
         st = _apply_pmc_shmap(
-            st, mesh, n_devices, nx_local, _pmc_faces_frozen)
+            st, mesh, n_devices, nx_local, _pmc_faces_frozen, pad_x=pad_x)
 
         # 4. E update
         st, db_st, lr_st = _update_e_shmap(
@@ -1327,7 +1332,7 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
         # 2b. PMC face (H-tangential = 0) — T8, 2026-04. H-half hook per
         #     OQ9: after H ghost exchange, before E update.
         st = _apply_pmc_shmap(
-            st, mesh, n_devices, nx_local, _pmc_faces_frozen)
+            st, mesh, n_devices, nx_local, _pmc_faces_frozen, pad_x=pad_x)
 
         # 3. E update
         st, db_st, lr_st = _update_e_shmap(
@@ -1344,7 +1349,7 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
         )
 
         # 5. PEC boundaries
-        st = _apply_pec_shmap(st, mesh, n_devices, nx_local)
+        st = _apply_pec_shmap(st, mesh, n_devices, nx_local, pad_x=pad_x)
 
         # 6. Source injection
         st = _inject_sources_shmap(st, src_vals)

--- a/scripts/vessl_gpu_suite.yaml
+++ b/scripts/vessl_gpu_suite.yaml
@@ -31,7 +31,13 @@ run: |-
   # NOTE: the 'distributed' pytest marker is declared but currently has ZERO
   # tests — distributed coverage lives in regular test files that set their
   # own XLA --xla_force_host_platform_device_count sentinel and run in the
-  # fast suite. Re-add a '-m distributed' step here if the marker gains tests.
+  # fast suite (test_distributed_nu_composition.py always did; as of #622
+  # test_distributed_nu_kernel.py's 2-device family joined it there too —
+  # it used to carry the 'gpu' marker below, which meant its 22 two-device
+  # tests ran in NO lane at all: this 1-GPU pod only creates *virtual*
+  # devices on the CPU backend, so '-m gpu' here always skipped them, and
+  # every CPU lane deselects 'gpu'). Re-add a '-m distributed' step here if
+  # the marker gains tests.
   # POSIX-safe rc capture (the VESSL runner shell is busybox-ash:
   # ${PIPESTATUS[0]} is a bashism and died with 'bad substitution' on
   # proof run 369367242339 — pytest itself completed fine).

--- a/tests/test_distributed_nu_kernel.py
+++ b/tests/test_distributed_nu_kernel.py
@@ -1,7 +1,25 @@
 """Unit tests for Phase B distributed_nu kernels.
 
-These are pure-python tests that do NOT require multiple devices — they
-exercise the slab-building helper and the local H update directly.
+Mostly pure-python tests that do NOT require multiple devices — they
+exercise the slab-building helper and the local H update directly — plus
+a 2-device equivalence family gated by ``_PHASE2B_REQUIRES_2DEV``
+(skips cleanly on <2 devices; the root conftest sets 2 virtual CPU
+devices for any run that doesn't already set XLA_FLAGS).
+
+Historical note (#622): this file carried a module-wide
+``pytestmark = pytest.mark.gpu`` from its creation (2026-04-16,
+a317dc4) for a test-POLLUTION reason (module-level XLA_FLAGS set at
+import time), not a genuine GPU requirement — that pollution class was
+superseded the same day by the root conftest's single, ordered
+XLA_FLAGS/jax-import sequence (1c8268d). Because every CPU lane
+deselects ``gpu`` (pyproject addopts) and the GPU pod exposes only 1
+CUDA device (the sentinel only creates *virtual* devices on the CPU
+backend), the marker meant this file's whole 2-device equivalence
+family ran in NO lane at all — the regression this file's tests guard
+against (13 failing tests, PR that closed #622) went undetected for
+that reason. The marker is removed so these run in the same
+fast-suite/weekly CPU shards as the sibling
+``test_distributed_nu_composition.py`` file, which never carried it.
 """
 
 import os
@@ -13,8 +31,6 @@ os.environ.setdefault(
 import numpy as np
 import jax.numpy as jnp
 import pytest
-
-pytestmark = pytest.mark.gpu
 
 from rfx.nonuniform import make_nonuniform_grid
 from rfx.core.yee import FDTDState, MaterialArrays, MU_0, update_h_nu
@@ -385,12 +401,29 @@ def test_build_sharded_nu_grid_pad_trim_for_nondivisible_nx():
     # High-x rank index
     assert sg.rank_has_high_x_pad == n_devices - 1  # rank 1
 
-    # The padded cell in inv_dx_global should equal 1/dx_arr[-1]
-    expected_last_inv = float(1.0 / np.asarray(grid.dx_arr)[-1])
-    got_last_inv = float(sg.inv_dx_global[-1])
-    assert np.isclose(got_last_inv, expected_last_inv, rtol=1e-5), (
-        f"Padded inv_dx last cell {got_last_inv} != 1/dx[-1] {expected_last_inv}"
+    # #622 fix: the pad region is STRUCTURALLY INERT — both the E
+    # (inv_dx_global) and H (inv_dx_h_global) coefficients are exactly
+    # zero at the padded cell, so nothing evolves there regardless of
+    # the PEC-mask padding. Pre-fix this cell carried a LIVE 1/dx[-1]
+    # coefficient (this assertion used to check for that value) — that
+    # was exactly the #622 bug: it kept the real boundary node's H term
+    # live and displaced the hi-x wall by one cell. Asserting the old
+    # nonzero value here would re-encode the bug as expected behaviour.
+    got_last_inv_h = float(sg.inv_dx_h_global[-1])
+    got_last_inv_e = float(sg.inv_dx_global[-1])
+    assert got_last_inv_h == 0.0, (
+        f"Padded inv_dx_h (H) last cell must be inert (0.0), got {got_last_inv_h}"
     )
+    assert got_last_inv_e == 0.0, (
+        f"Padded inv_dx (E) last cell must be inert (0.0), got {got_last_inv_e}"
+    )
+    # The REAL boundary node's H term (global index nx-1 — the grid's
+    # own trailing zero, nonuniform.py:219) must stay AT nx-1, not move
+    # to the padded slab end.
+    assert float(sg.inv_dx_h_global[sg.nx - 1]) == 0.0, (
+        "Real boundary node's H coefficient must be zero at global nx-1"
+    )
+    assert float(grid.inv_dx_h[-1]) == 0.0  # sanity: matches grid's own convention
 
 
 def test_build_sharded_nu_grid_replicates_dt():
@@ -482,6 +515,7 @@ from rfx.nonuniform import (  # noqa: E402
 from rfx.simulation import SourceSpec, ProbeSpec  # noqa: E402
 from tests._distributed_nu_tolerances import (  # noqa: E402
     assert_class_b_parity,
+    RTOL_PROBE_B,
 )
 
 
@@ -620,6 +654,131 @@ def test_distributed_pec_only_2device_matches_single_device():
 
     assert_class_b_parity(ts_single, ts_dist,
                           label="phase2b_pec_only_2device_parity")
+
+
+@_PHASE2B_REQUIRES_2DEV
+def test_distributed_pec_only_pad_lane_final_state_matches_single_device():
+    """#622 regression: on an odd-node (pad_x > 0) fixture, the FULL
+    gathered final state must match single-device everywhere — not just
+    at one probe.
+
+    Pre-fix, the pad lane realized one extra active x cell (the trailing
+    H-coefficient zero moved from the real boundary node ``nx - 1`` to
+    the padded slab end, and the PEC/PMC/CPML face appliers acted on the
+    padded slab end instead of the real face) — the distributed cavity
+    was effectively one cell wider than the single-device one. A single
+    probe can miss that (see the smallest-drift case,
+    ``test_distributed_pec_mask_override_union_semantics``, where a PEC
+    sheet partially shielded the probe); comparing the whole gathered
+    field state cannot.
+
+    Uses a distinct fixture (``nx_physical=20``) from the other pad-lane
+    tests so this is not a duplicate of an existing parity check, and
+    asserts the ``pad_x > 0`` precondition explicitly (gate-can-bind-
+    artifact rule — a future realized-node-count change must not
+    silently stop exercising the pad lane here).
+    """
+    devices = jax.devices()[:2]
+    n_devices = 2
+    n_steps = 60
+
+    grid = _phase2b_build_test_grid(nx_physical=20, ny=8, nz=8, ratio=1.15)
+    materials = _phase2b_make_materials(grid)
+
+    sharded_grid = build_sharded_nu_grid(grid, n_devices=n_devices,
+                                         exchange_interval=1)
+    # Precondition guard: this test exists specifically to exercise the
+    # pad lane (#622). If a future change makes nx_physical=20 realize
+    # an evenly-divisible nx, this fixture stops testing what it claims
+    # to and must be updated, not silently pass on the pad_x==0 lane.
+    assert sharded_grid.pad_x > 0, (
+        f"fixture no longer exercises the pad lane: grid.nx={grid.nx}, "
+        f"pad_x={sharded_grid.pad_x} (expected > 0)"
+    )
+
+    # Structural check on _build_sharded_inv_dx_arrays's own output
+    # (#622 fix site 1). This is deliberately NOT redundant with the
+    # full-state parity run below: empirically, reverting fix site (1)
+    # alone (while sites 2-4, the PEC/PMC/CPML face appliers, stay
+    # fixed) produces NO observable drift in ANY forward or gradient
+    # parity test in this file — the PEC face applier re-zeros E at the
+    # real boundary node every step, and the corrupted H coefficient at
+    # that one node never leaks anywhere else for a hard-PEC unmasked
+    # cavity. So a parity-only test cannot be the F4 falsifier for site
+    # 1; this direct array assertion is what makes it one.
+    assert float(sharded_grid.inv_dx_h_global[sharded_grid.nx - 1]) == 0.0, (
+        "Real boundary node's H coefficient must be zero at global nx-1"
+    )
+    assert float(sharded_grid.inv_dx_h_global[-1]) == 0.0, (
+        "Pad-region H coefficient must be inert (0.0)"
+    )
+    assert float(sharded_grid.inv_dx_global[-1]) == 0.0, (
+        "Pad-region E coefficient must be inert (0.0)"
+    )
+
+    src_idx = (4, 4, 4)
+    prb_idx = (12, 4, 4)
+    src_si, src_sj, src_sk, src_comp, src_wf = _phase2b_make_current_source(
+        grid, src_idx, "ez", _phase2b_gauss_waveform, n_steps, materials,
+    )
+    src_spec = SourceSpec(
+        i=int(src_si), j=int(src_sj), k=int(src_sk),
+        component=src_comp, waveform=jnp.asarray(src_wf),
+    )
+    prb_spec = ProbeSpec(
+        i=int(prb_idx[0]), j=int(prb_idx[1]), k=int(prb_idx[2]),
+        component="ez",
+    )
+
+    single_out = run_nonuniform(
+        grid=grid, materials=materials, n_steps=n_steps,
+        sources=[src_spec], probes=[prb_spec],
+    )
+    single_state = single_out["state"]
+
+    sharded_mat = _phase2b_shard_mat(materials, sharded_grid)
+    dist_out = run_nonuniform_distributed_pec(
+        sharded_grid=sharded_grid,
+        sharded_materials=sharded_mat,
+        sharded_pec_mask=None,
+        n_steps=n_steps,
+        sources=[src_spec],
+        probes=[prb_spec],
+        n_devices=n_devices,
+        devices=devices,
+    )
+    dist_state = dist_out["final_state"]
+
+    # Full-field parity, combined relative L2 norm across all 6
+    # gathered components (the whole domain, not one probe location).
+    # An elementwise max-relative-error is the wrong metric here: this
+    # z-polarised-source geometry drives hz to a near-null field
+    # (norm ~1e-1 vs ~1e5-1e8 for the other 5 components), so per-cell
+    # ratios there are floating-point noise divided by floating-point
+    # noise, not signal. A combined L2 norm — the same sum-of-squares
+    # style as ``assert_class_b_parity``'s time-integrated energy
+    # check, generalised from the probe time series to the full
+    # spatial field — weights each component by its physical energy
+    # share, so a genuinely null component cannot dominate the metric.
+    for comp in ("ex", "ey", "ez", "hx", "hy", "hz"):
+        assert getattr(single_state, comp).shape == getattr(dist_state, comp).shape, (
+            f"{comp} shape mismatch: single={getattr(single_state, comp).shape}, "
+            f"dist={getattr(dist_state, comp).shape}"
+        )
+    sq_diff = sum(
+        float(jnp.sum((jnp.asarray(getattr(dist_state, c))
+                       - jnp.asarray(getattr(single_state, c))) ** 2))
+        for c in ("ex", "ey", "ez", "hx", "hy", "hz")
+    )
+    sq_ref = sum(
+        float(jnp.sum(jnp.asarray(getattr(single_state, c)) ** 2))
+        for c in ("ex", "ey", "ez", "hx", "hy", "hz")
+    )
+    rel_l2 = (sq_diff / sq_ref) ** 0.5
+    assert rel_l2 < RTOL_PROBE_B, (
+        f"#622 pad-lane full-field parity failed: "
+        f"combined relative L2 = {rel_l2:.3e} >= {RTOL_PROBE_B:.3e}"
+    )
 
 
 @_PHASE2B_REQUIRES_2DEV


### PR DESCRIPTION
Closes #622. Follow-up filed as #623 (same-class sites in the uniform lane's CPML appliers + legacy pmap PEC, found by this PR's independent review).

## Defect

With `pad_x > 0` (nx not divisible by n_devices — the COMMON case post-#564, since an even cell request now realizes an odd node count), the distributed-NU runner placed every x-hi face mechanism at the padded slab end (`nx_padded-1`) instead of the physical boundary node (`nx-1`): the trailing `inv_dx_h` zero, the PEC/PMC face appliers, and the CPML x-hi windows. Net effect: the distributed cavity was one cell wider than the single-device one. Latent pre-#564 (the runner never changed at bb61494); #564's N-cells→N+1-nodes flip put every even-cell fixture onto the defective lane, which is why the whole 2-device equivalence family went red at exactly that commit.

Classification before any kernel edit (comparator-first): all 13 failing tests are production-vs-production equivalence with shared inputs — 13/13 real defect, 0 stale premises. R5 trace: bit-level agreement through step ~20, divergence onset at step 21 = the wavefront reaching the displaced hi-x wall, growing to rel 2.0.

## Fix

Pad cells are now structurally inert (all inverse-spacing coefficients zero — `_build_sharded_inv_dx_arrays` reads `grid.inv_dx`/`grid.inv_dx_h` directly instead of re-deriving from a pad-extended profile), and the face machinery targets the real node: PEC/PMC/CPML appliers gained a static `pad_x` shift (distributed_nu.py + the shared distributed_v2 PEC/PMC appliers, which also fixes the latent uniform-grid PEC/PMC case). Seam/ghost logic untouched (measured healthy: pad_x=0 control at 4.7e-7 pre-fix).

## Evidence (author-measured, independently re-measured in review)

- F1: the 13 red tests go green with fixtures and tolerances UNTOUCHED; kernel file 30/30 (reviewer-reproduced: 30 passed, 65.95 s).
- F2: pad_x=0 non-regression — combined-L2 5.14e-07 (base) vs 5.04e-07 (fixed); coefficients now come bit-identically from the grid's own arrays.
- F3 (R5): per-step divergence trace — step-21 onset gone entirely; final rel_err 2.003e+00 → 5.916e-07.
- F4 (one-sided falsifier): a forward/gradient parity check CANNOT catch the `inv_dx` site in isolation — reviewer confirmed by measurement and stencil trace that the x-hi terminal node is an identically-zero fixed point under the unconditional PEC face zeroing (max|hz[nx-1]| exactly 0.0), so NO physics fixture can see it. The new regression test therefore carries a structural inertness assertion, witnessed red with that site reverted alone (`assert 999.99994 == 0.0`), and its parity leg catches the full original bug at rel_l2 2.06e-01 vs the 5e-5 gate (~4000×).
- F5: the analytic-resonance test had been green-but-degraded (2.0019% error hiding under its 5% gate); after the fix: 0.0245%. Gate untouched (no-silent-gate-change; tightening is a separate decision).
- Uniform lane: `tests/test_distributed.py` 30/30 both with base and fixed `distributed_v2` (reviewer, module-injection A/B) — no currently-green uniform test changes status.

## Lane fix (why these tests were invisible)

The kernel file was module-wide `gpu`-marked since one day after its creation — for a JAX-state-pollution reason superseded the same day by the root conftest — so every CPU lane deselected it and the 1-GPU pod skipped its 2-device tests: the family ran in NO lane, ever. The marker is removed; the file now collects under default addopts (30 collected, 62-66 s single-process) and runs in the fast-suite shards on conftest's two virtual CPU devices, like its composition sibling always has. The stale `vessl_gpu_suite.yaml` comment claiming otherwise is corrected. Note for the first post-merge run: this file's peak RSS ~1.93 GiB will likely be the new shard high-water mark (#545 class) — watch the RSS reporter. `tests/test_distributed.py` remains in the runs-nowhere state; its marker decision is bundled into #623.

R3: memory=comparator-first (13/13 classified before kernel edits) + feedback_gate_can_bind_artifact (F4 one-sided falsifier witnessed red; F5 measured, gate untouched) | R2-attempts=1 engineering fix on a measured mechanism | falsifier=F4 revert-red run (excerpt above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)