### PR TITLE
fix(nonuniform): impedance-match the NU-mesh CPML absorber like the uniform path (closes #582)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   uniform-path solve (amplitude off 0.18%, waveform residual 1.98e-2,
   record-length-independent). Root cause was NOT the smoother — a new
   staircase-only (no smoothing) discriminator case already carried ~90% of
-  the divergence (residual 7.8e-3) — it was the missing pad replication,
-  confirmed by three independent witnesses (input-array diff, field dump,
-  causal A/B relocating the slab away from the domain edge).
+  the divergence (residual 7.7261e-3, measured on the pre-fix tree) — it
+  was the missing pad replication, confirmed by three independent
+  witnesses (input-array diff, field dump, causal A/B relocating the slab
+  away from the domain edge).
   Fix: `assemble_materials_nu` now performs the same interior-edge
   replication into the CPML pads, using the NU grid's existing per-face
   `pad_{x,y,z}_{lo,hi}` bookkeeping. Guided-mode / dielectric-waveguide
@@ -33,11 +34,23 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   absorber the uniform path always has. PEC-bounded simulations are
   unaffected (the new step is gated on `cpml_layers > 0`, which
   `Simulation.__init__` forces to 0 for `boundary="pec"`).
+  **Scope**: the fix mirrors the uniform path's replication exactly,
+  including two gaps it inherits from that path (tracked separately in
+  #627, not addressed here): (a) for a `Box` whose upper face coincides
+  with the domain face, the hi-face replication copies a column the
+  rasterizer leaves at vacuum, so only the lo-side pad ends up matched;
+  (b) Debye/Lorentz dispersive poles are rasterized with no pad-extension
+  step, so a dispersive edge-touching material gets its static `eps_r`
+  matched into the pad but not its poles. In short: this closes the gap
+  for non-dispersive media, and — for boxes ending exactly on the domain
+  face — for the lo-side faces.
   `tests/test_nonuniform_uniform_end_to_end_reduction.py`'s
   `subpixel-cpml` case converts from `xfail(strict=True)` to a normal
-  assertion (residual 1.978e-2 -> 1.14e-4); a new `staircase-slab-cpml`
-  case closes the blind spot that hid most of the effect (residual
-  7.80e-3 -> 8.7e-5).
+  assertion (residual 1.9890e-2 pre-fix -> 1.14e-4 post-fix); a new
+  `staircase-slab-cpml` case closes the blind spot that hid most of the
+  effect (residual 7.7261e-3 pre-fix -> 8.7e-5 post-fix). Pre-fix numbers
+  measured on the pre-fix tree (commit 31395e0); post-fix numbers
+  reproduce exactly on both trees.
 
 ### Fixed — distributed-NU pad-lane hi-x wall displacement (issue #622)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — non-uniform-mesh CPML absorber was not impedance-matched (issue #582)
+
+- The uniform-grid material assembler extends the interior-edge
+  `eps_r`/`sigma`/`mu_r` slice outward into the CPML padding so guided
+  modes see an impedance-matched absorber (`rfx/api/_compile.py`,
+  "equivalent to UPML"). The non-uniform-mesh assembler
+  (`assemble_materials_nu`, `rfx/runners/nonuniform.py`) never had this
+  step, so a structure touching the domain's interior edge (e.g. a
+  dielectric slab spanning the transverse extent) saw a **different
+  absorber medium per path**: on the issue's fixture, 736 CPML pad cells
+  carried `eps_r=4.0` on the uniform path and `eps_r=1.0` on the NU path.
+  Found via the uniform-mesh reduction anchor (#562/#568/#570): the
+  `boundary="cpml"` + `subpixel_smoothing=True` combination was the only
+  one of four boundary x smoothing combinations that did not reduce to the
+  uniform-path solve (amplitude off 0.18%, waveform residual 1.98e-2,
+  record-length-independent). Root cause was NOT the smoother — a new
+  staircase-only (no smoothing) discriminator case already carried ~90% of
+  the divergence (residual 7.8e-3) — it was the missing pad replication,
+  confirmed by three independent witnesses (input-array diff, field dump,
+  causal A/B relocating the slab away from the domain edge).
+  Fix: `assemble_materials_nu` now performs the same interior-edge
+  replication into the CPML pads, using the NU grid's existing per-face
+  `pad_{x,y,z}_{lo,hi}` bookkeeping. Guided-mode / dielectric-waveguide
+  structures on a non-uniform mesh now see the same impedance-matched
+  absorber the uniform path always has. PEC-bounded simulations are
+  unaffected (the new step is gated on `cpml_layers > 0`, which
+  `Simulation.__init__` forces to 0 for `boundary="pec"`).
+  `tests/test_nonuniform_uniform_end_to_end_reduction.py`'s
+  `subpixel-cpml` case converts from `xfail(strict=True)` to a normal
+  assertion (residual 1.978e-2 -> 1.14e-4); a new `staircase-slab-cpml`
+  case closes the blind spot that hid most of the effect (residual
+  7.80e-3 -> 8.7e-5).
+
 ### Fixed — distributed-NU pad-lane hi-x wall displacement (issue #622)
 
 - `rfx.runners.distributed_nu.run_nonuniform_distributed_pec` and the NU

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -83,6 +83,50 @@ def assemble_materials_nu(
     )
     materials, debye_spec, lorentz_spec, pec_mask, _pec_shapes, _kerr_chi3 = result
 
+    # Extend material properties into CPML padding so that guided modes in
+    # dielectric waveguides see an impedance-matched absorber (equivalent to
+    # UPML). Each CPML face copies the interior-edge slice outward, as if
+    # the geometry continued beyond the domain. Mirrors the uniform path's
+    # identical step (rfx/api/_compile.py:188-231) exactly, adapted to the
+    # NU per-face pad bookkeeping (``grid.pad_{axis}_{lo,hi}``, already
+    # zero on PEC/PMC/periodic faces). Before this fix the NU assembler had
+    # NO such step, so an edge-touching structure saw a different absorber
+    # medium per path (#582: measured 736 pad cells eps 4.0-vs-1.0 at the
+    # slab's k=9 layer) and the uniform-mesh reduction anchor diverged
+    # wherever that mismatch interacted with subpixel smoothing.
+    if sim._boundary in ("cpml", "upml") and sim._cpml_layers > 0:
+        plx, phx = grid.pad_x_lo, grid.pad_x_hi
+        ply, phy = grid.pad_y_lo, grid.pad_y_hi
+        plz, phz = grid.pad_z_lo, grid.pad_z_hi
+        eps_r_ext = materials.eps_r
+        sigma_ext = materials.sigma
+        mu_r_ext = materials.mu_r
+        if plx > 0:
+            eps_r_ext = eps_r_ext.at[:plx,:,:].set(eps_r_ext[plx:plx+1,:,:])
+            sigma_ext = sigma_ext.at[:plx,:,:].set(sigma_ext[plx:plx+1,:,:])
+            mu_r_ext = mu_r_ext.at[:plx,:,:].set(mu_r_ext[plx:plx+1,:,:])
+        if phx > 0:
+            eps_r_ext = eps_r_ext.at[-phx:,:,:].set(eps_r_ext[-phx-1:-phx,:,:])
+            sigma_ext = sigma_ext.at[-phx:,:,:].set(sigma_ext[-phx-1:-phx,:,:])
+            mu_r_ext = mu_r_ext.at[-phx:,:,:].set(mu_r_ext[-phx-1:-phx,:,:])
+        if ply > 0:
+            eps_r_ext = eps_r_ext.at[:,:ply,:].set(eps_r_ext[:,ply:ply+1,:])
+            sigma_ext = sigma_ext.at[:,:ply,:].set(sigma_ext[:,ply:ply+1,:])
+            mu_r_ext = mu_r_ext.at[:,:ply,:].set(mu_r_ext[:,ply:ply+1,:])
+        if phy > 0:
+            eps_r_ext = eps_r_ext.at[:,-phy:,:].set(eps_r_ext[:,-phy-1:-phy,:])
+            sigma_ext = sigma_ext.at[:,-phy:,:].set(sigma_ext[:,-phy-1:-phy,:])
+            mu_r_ext = mu_r_ext.at[:,-phy:,:].set(mu_r_ext[:,-phy-1:-phy,:])
+        if plz > 0:
+            eps_r_ext = eps_r_ext.at[:,:,:plz].set(eps_r_ext[:,:,plz:plz+1])
+            sigma_ext = sigma_ext.at[:,:,:plz].set(sigma_ext[:,:,plz:plz+1])
+            mu_r_ext = mu_r_ext.at[:,:,:plz].set(mu_r_ext[:,:,plz:plz+1])
+        if phz > 0:
+            eps_r_ext = eps_r_ext.at[:,:,-phz:].set(eps_r_ext[:,:,-phz-1:-phz])
+            sigma_ext = sigma_ext.at[:,:,-phz:].set(sigma_ext[:,:,-phz-1:-phz])
+            mu_r_ext = mu_r_ext.at[:,:,-phz:].set(mu_r_ext[:,:,-phz-1:-phz])
+        materials = MaterialArrays(eps_r=eps_r_ext, sigma=sigma_ext, mu_r=mu_r_ext)
+
     # Thin conductors (#369): a PEC thin sheet rasterizes on the coords-based
     # mask exactly like geometry PEC — ``mask_on_coords`` resolves fine on
     # non-uniform axes, so the earlier "needs a uniform Grid, skip for now"

--- a/tests/test_nonuniform_uniform_end_to_end_reduction.py
+++ b/tests/test_nonuniform_uniform_end_to_end_reduction.py
@@ -133,9 +133,10 @@ def test_nu_solve_reduces_to_uniform_solve_up_to_source_normalization(
     pad material extension from the smoother (#582 E2): it was never run
     before this fix — the slab used to be added only under ``if
     smoothing:`` — and pre-fix it already carried ~90% of the
-    ``subpixel-cpml`` divergence (residual 7.80e-3 of the 1.978e-2 total),
-    because the missing NU pad replication is a material-assembly gap, not
-    a smoother interaction.
+    ``subpixel-cpml`` divergence (residual 7.7261e-3 of the 1.9890e-2
+    total, both measured on the pre-fix tree, commit 31395e0), because the
+    missing NU pad replication is a material-assembly gap, not a smoother
+    interaction.
     """
     dx = 1e-3
     uni, dt_u = _run(dx, nonuniform=False, smoothing=smoothing, boundary=boundary,
@@ -181,9 +182,10 @@ def test_nu_solve_reduces_to_uniform_solve_up_to_source_normalization(
     # slab therefore saw a different absorber medium per path: 736 pad cells
     # eps 4.0-vs-1.0 at the slab's k=9 layer). Fixed by adding the same pad
     # replication to assemble_materials_nu; post-fix measured 8.7e-5
-    # (staircase-slab-cpml, was 7.80e-3 pre-fix — carried ~90% of the
+    # (staircase-slab-cpml, was 7.7261e-3 pre-fix — carried ~90% of the
     # subpixel-cpml divergence on its own) and 1.1e-4 (subpixel-cpml, was
-    # 1.978e-2 pre-fix, record-length-independent at 600/1200/2400 steps).
+    # 1.9890e-2 pre-fix, record-length-independent at 600/1200/2400 steps).
+    # Pre-fix numbers measured on the pre-fix tree (commit 31395e0).
     assert residual < 3e-4, (
         f"after removing the known source-normalization factor the two paths "
         f"still differ by {residual:.3e} of full scale — the NU solve is not "

--- a/tests/test_nonuniform_uniform_end_to_end_reduction.py
+++ b/tests/test_nonuniform_uniform_end_to_end_reduction.py
@@ -50,9 +50,9 @@ STEPS = 1200
 
 # Deliberately NOT marked slow: the whole point is that this runs in the default
 # lane. An anchor the fast suite deselects would have missed #562's F1 exactly
-# the way the existing suite did. Measured 29.8 s for the five cases here (it
-# was 6.5 s for three before the boundary axis was added) — worth keeping in
-# view against the fast-lane time pressure #545 tracks.
+# the way the existing suite did. Measured 38.6 s for the six cases here (it
+# was 29.8 s for five before staircase-slab-cpml was added, #582 E2) — worth
+# keeping in view against the fast-lane time pressure #545 tracks.
 
 
 def _f110(dx: float) -> float:
@@ -75,16 +75,27 @@ def _expected_factor(boundary: str, dt: float, dx: float) -> float:
     return (dt / (EPS_0 * dV)) if boundary == "pec" else (1.0 / dV)
 
 
-def _run(dx: float, *, nonuniform: bool, smoothing: bool, boundary: str = "pec"):
+def _run(dx: float, *, nonuniform: bool, smoothing: bool, boundary: str = "pec",
+         slab: bool | None = None):
+    """``slab`` defaults to ``smoothing`` (legacy behaviour: the dielectric
+    slab was only ever exercised together with the smoother). Pass it
+    explicitly to decouple the two — the staircase-slab+cpml combo (#582 E2)
+    needs the slab WITHOUT subpixel_smoothing to isolate the CPML pad
+    material extension from the smoother.
+    """
+    if slab is None:
+        slab = smoothing
     f0 = _f110(dx)
     profiles = (dict(dx_profile=np.full(NA, dx), dy_profile=np.full(NB, dx))
                 if nonuniform else {})
     sim = Simulation(freq_max=2.5 * f0, domain=(NA * dx, NB * dx, NZ * dx),
                      dx=dx, boundary=boundary,
                      cpml_layers=(0 if boundary == "pec" else 8), **profiles)
-    if smoothing:
+    if slab:
         sim.add_material("slab", eps_r=4.0)
         # interface deliberately inside a voxel so the smoother engages
+        # (when subpixel_smoothing=True; a no-op when it is False, giving
+        # the plain staircase rasterization of the same geometry)
         sim.add(Box((0.0, 0.0, 0.3 * dx), (NA * dx, NB * dx, 2.0 * dx)),
                 material="slab")
     # z = 3*dx, NOT NZ*dx/2: the latter is EXACTLY the slab's upper face, so the
@@ -100,34 +111,37 @@ def _run(dx: float, *, nonuniform: bool, smoothing: bool, boundary: str = "pec")
 
 
 _CASES = [
-    pytest.param(False, "pec", id="plain-pec"),
-    pytest.param(True, "pec", id="subpixel-pec"),
-    pytest.param(False, "cpml", id="plain-cpml"),
+    pytest.param(False, "pec", False, id="plain-pec"),
+    pytest.param(True, "pec", True, id="subpixel-pec"),
+    pytest.param(False, "cpml", False, id="plain-cpml"),
     pytest.param(
-        True, "cpml", id="subpixel-cpml",
-        marks=pytest.mark.xfail(strict=True, reason=(
-            "NU + subpixel_smoothing does NOT reduce to the uniform path on an "
-            "OPEN boundary (#582). Measured, and record-length "
-            "independent at 600/1200/2400 steps: amplitude factor off by "
-            "0.1804 %, waveform residual 1.978e-02, 1-corr 2.8e-04 — against "
-            "~1e-5 residual for the other three boundary x smoothing "
-            "combinations. strict=True so this XPASSes and hard-fails the suite "
-            "the day it is fixed, rather than silently passing.")),
+        False, "cpml", True, id="staircase-slab-cpml",
     ),
+    pytest.param(True, "cpml", True, id="subpixel-cpml"),
 ]
 
 
-@pytest.mark.parametrize("smoothing,boundary", _CASES)
+@pytest.mark.parametrize("smoothing,boundary,slab", _CASES)
 def test_nu_solve_reduces_to_uniform_solve_up_to_source_normalization(
-        smoothing, boundary):
+        smoothing, boundary, slab):
     """Same mesh, same geometry, both builders: same physics, one known factor.
 
     Run for BOTH boundary conditions, because the uniform path's source
     normalization differs between them and the factor therefore does too.
+
+    ``staircase-slab-cpml`` (slab=True, smoothing=False) isolates the CPML
+    pad material extension from the smoother (#582 E2): it was never run
+    before this fix — the slab used to be added only under ``if
+    smoothing:`` — and pre-fix it already carried ~90% of the
+    ``subpixel-cpml`` divergence (residual 7.80e-3 of the 1.978e-2 total),
+    because the missing NU pad replication is a material-assembly gap, not
+    a smoother interaction.
     """
     dx = 1e-3
-    uni, dt_u = _run(dx, nonuniform=False, smoothing=smoothing, boundary=boundary)
-    nu, dt_n = _run(dx, nonuniform=True, smoothing=smoothing, boundary=boundary)
+    uni, dt_u = _run(dx, nonuniform=False, smoothing=smoothing, boundary=boundary,
+                     slab=slab)
+    nu, dt_n = _run(dx, nonuniform=True, smoothing=smoothing, boundary=boundary,
+                    slab=slab)
 
     assert dt_u == pytest.approx(dt_n, rel=1e-12), (dt_u, dt_n)
     assert np.abs(uni).max() > 1e-6, "uniform leg produced no field"
@@ -158,9 +172,18 @@ def test_nu_solve_reduces_to_uniform_solve_up_to_source_normalization(
         f"choice of make_source (raw add) vs make_j_source (Cb-normalized)")
 
     residual = float(np.abs(nu - scale * uni).max() / np.abs(nu).max())
-    # measured: 1.5e-5 (pec), 8.2e-6 (pec + smoothing), 1.1e-4 (cpml).
-    # cpml + smoothing measures 2.0e-2 and is xfail(strict) above, not covered
-    # by this bound — see _CASES.
+    # measured (post-#582 fix, 1200 steps): 2.0e-5 (pec), 9.5e-6
+    # (pec + smoothing), 1.1e-4 (cpml, no slab). staircase-slab-cpml and
+    # subpixel-cpml used to be untested/xfail (#582: the NU material
+    # assembler never replicated eps/sigma/mu_r into the CPML pads the way
+    # the uniform assembler does, rfx/api/_compile.py:188-231 vs
+    # rfx/runners/nonuniform.py's assemble_materials_nu — an edge-touching
+    # slab therefore saw a different absorber medium per path: 736 pad cells
+    # eps 4.0-vs-1.0 at the slab's k=9 layer). Fixed by adding the same pad
+    # replication to assemble_materials_nu; post-fix measured 8.7e-5
+    # (staircase-slab-cpml, was 7.80e-3 pre-fix — carried ~90% of the
+    # subpixel-cpml divergence on its own) and 1.1e-4 (subpixel-cpml, was
+    # 1.978e-2 pre-fix, record-length-independent at 600/1200/2400 steps).
     assert residual < 3e-4, (
         f"after removing the known source-normalization factor the two paths "
         f"still differ by {residual:.3e} of full scale — the NU solve is not "


### PR DESCRIPTION
Closes #582. Follow-ups filed from this PR's review: #627 (two gaps in pad replication that this PR faithfully inherits from the uniform path), #628 (unrelated test-order pollution found while attributing a failure).

## Defect

`assemble_materials_nu` never replicated interior-edge `eps_r`/`sigma`/`mu_r` into the CPML pads the way the uniform assembler does (`rfx/api/_compile.py:204-227`). An edge-touching structure therefore saw a **different absorber medium on each path** — measured: 736 pad cells at the slab's `k=9` layer holding `eps_r = 4.0` on the uniform path and `1.0` on the NU path. The uniform↔NU reduction anchor (#562/#568/#570) caught it as the one boundary × smoothing combination out of four that did not reduce, at residual 1.9890e-2 against ~1e-4 for the other three.

Diagnosis was comparator-first with three independent witnesses before any code was touched: the input-array diff above; a per-region field dump showing `|E_uniform − E_NU|` peaking in exactly those absorber cells at every snapshot (4.1e-2 vs 1.5e-3 interior) with a smooth leaked interior floor; and a causal A/B — insetting the slab so it never touches an interior-edge slice zeroes the eps disagreement and collapses the red combination to the healthy class (1.98e-2 → 9.4e-5).

## Fix

Mirror `_compile.py`'s replication exactly, using the NU grid's existing per-face `pad_{x,y,z}_{lo,hi}` bookkeeping, gated so PEC runs cannot enter the new path. The review verified the 30 slicing lines are **byte-identical** to the uniform original modulo comments and receiver name, and that the two assemblers now produce bit-identical `eps_r`, `sigma` and `mu_r` (0 mismatched cells of 72,912) for an eps-only slab, for a lossy+magnetic slab, and across all five zero-width-pad layouts.

## Evidence

Pre-declared gates (all six met; the non-closing rule never armed). "Pre-fix" measured on a pristine `git archive 31395e0` tree by the reviewer:

| case | pre-fix | post-fix | gate |
|---|---|---|---|
| subpixel-cpml (the red combination) | 1.9890e-2 | 1.1340e-4 | < 3e-4 |
| staircase-slab-cpml (**new case**) | 7.7261e-3 | 8.6698e-5 | < 3e-4 |
| plain-cpml | 1.0770e-4 | 1.0770e-4 | unchanged |
| plain-pec / subpixel-pec | 2.0407e-5 / 9.3789e-6 | identical, Δ = 0 | unchanged |

The new `staircase-slab-cpml` case closes a real blind spot: the harness only ever added the slab under `if smoothing:`, so no case tested the pad mismatch without the smoother — even though that configuration carried ~90% of the divergence on its own.

**Gate flip honesty.** `subpixel-cpml` moves from `xfail(strict=True)` to a normal assertion. The 3e-4 threshold is not fitted to the result — it is the pre-existing sibling gate the other three cases already used, and the measured 1.1340e-4 sits 2.6× under it. The reviewer diffed every assert and tolerance line between base and head: identical apart from dropping the xfail marker.

**Falsifier (one-sided).** With the replication step neutralized, both cpml-slab cases go red (1.9890e-2 and 7.7261e-3) while the four unaffected cases stay bit-identical. Reproduced independently by the reviewer via module injection against a pristine base tree.

**Independent physics witness beyond the anchor.** On a 4000-step NU run with a lossy `eps_r=9.8, mu_r=2.5` edge-touching slab, absorber tail/peak improves −63.2 dB → −76.7 dB: the absorber is 13.5 dB better and strictly *more* damped. No CFL implication — NU `dt` is the vacuum-speed CFL from cell sizes alone, so replicating `eps_r ≥ 1` or `mu_r ≥ 1` into a pad only increases local margin, and sigma enters through the unconditionally-stable exponentially-damped coefficients.

**Blast radius.** 144/144 on the author's NU suites; the reviewer extended to five more suites (453 tests) and instrumented *which* tests actually see changed material arrays: 98 tests reach the NU assembler, 9 see any change, and only one of those has an envelope gate — `test_two_port_passivity_on_matched_line` moves 0.780314 → 0.783076 against a gate of 1.5, smoothly across all 51 bins. **No committed NU claims-bearing number goes stale**: the WR-90 Palace dielectric-slab comparison (`max_mag_abs_diff = 0.008529` in the support matrix) was checked by rebuilding all three lane geometries — 0 changed cells, since its transverse walls are PEC and the slab never reaches an x pad.

## Scope

The CHANGELOG states this plainly: the fix mirrors the uniform path exactly and therefore inherits two of its gaps, both filed as #627 — hi-face replication is a no-op for a Box whose upper face sits exactly on the domain face (the rasterizer leaves that edge slice at vacuum, so only the lo-side pad matches), and Debye/Lorentz poles have no pad-extension step, so a dispersive material's static `eps_r` is matched but its poles are not.

R3: memory=nu_known_limits #562-#569 arc + comparator-first (three witnesses before any fix) | R2-attempts=1 (one pre-declared attempt, closed cleanly at 1.14e-4 with the non-closing rule unarmed) | falsifier=E4 revert-red, reproduced independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)