### PR TITLE
feat(observables): batched forward-mode Jacobians — rfx.jacobian_fwd (closes #577)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,101 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Added — `rfx.jacobian_fwd`, a batched forward-mode Jacobian wrapper (issue #577)
+
+- `rfx.observables.jacobian_fwd(sim_fn, params, *, tangents="identity",
+  batch_tangents=True)` (flat-exported as `rfx.jacobian_fwd`) computes
+  `(value, jacobian)` for any JAX-differentiable `sim_fn(params) -> value`
+  (typically `lambda p: dft_field(name)(sim.forward(eps_override=eps(p),
+  ...))`) via `jax.vmap(jax.jvp(...))` over a tangent basis, NOT
+  `jax.linearize`. This is PACKAGING, not new solver capability: forward
+  mode already ran end-to-end through `sim.forward()` ->
+  `rfx.observables` with zero solver changes before this PR — the new
+  surface is tangent-basis construction, primal de-duplication, and four
+  documented fences.
+- **The headline finding is a negative one, and it is the honest
+  deliverable**: the issue's premise that batched forward-mode AD "shares
+  the expensive primal sweep" is TRUE (verified both structurally, via
+  the compiled jaxpr's scan carry, and via a cost-model fit whose
+  intercept lands within a few percent of one plain solve — see
+  `tests/test_jacobian_fwd.py::test_g3_primal_carry_is_independent_of_n_t`
+  and `scripts/benchmark_jacobian_fwd.py`), but the issue's hoped-for
+  economics ("a few times one solve, not N times") is NOT what the
+  current kernel delivers. MEASURED, CPU (`jax.default_backend()=="cpu"`),
+  jax 0.10.2, float32, `n_steps=120`:
+  - grid 35x31x31 = 33,635 cells: wall time at `n_t=10` is **5.9x** one
+    plain solve (batched) / **21.3x** (sequential, `batch_tangents=False`);
+    flops **17.5x**; XLA-reported `temp_bytes` (a *compiler estimate*, not
+    a measured/observed/certified runtime peak — see the honesty-label
+    discipline in `tests/test_estimate_ad_memory.py`) **10.4x**.
+  - grid 59x55x55 = 178,475 cells (5.3x more cells), same `n_steps`: the
+    SAME `n_t=10` batched configuration moves to **7.3x** wall time /
+    **18.6x** flops / **10.4x** `temp_bytes` — flops and `temp_bytes` (both
+    deterministic compiler outputs) land within ~1% of the small-grid
+    ratio, while wall time (subject to machine load) moved from 5.9x to
+    7.3x. The point of quoting two grid sizes is that the ratio is not a
+    fixed constant across problem sizes — re-run
+    `scripts/benchmark_jacobian_fwd.py --grid-scale 24` for the current
+    number on your hardware rather than trusting either one quoted here.
+  - forward-mode `temp_bytes` is measured INDEPENDENT of `n_steps`
+    (`n_steps=120` vs `240` differ by <0.02% — noise, not a real
+    dependency) — this is the actual argument FOR this mode: reverse mode
+    on the same fixture costs `temp_bytes` tens of times one plain solve
+    for a SINGLE scalar output at `n_steps=120` and cannot produce a
+    many-output Jacobian in one pass at all (`jax.jacrev` raises
+    `TypeError` on a complex-dtype output without `holomorphic=True`).
+  - batching beats running the `n_t` tangent directions one at a time:
+    measured wall time ~3x faster and flops ~1.3-1.4x fewer at `n_t=10`
+    than the `batch_tangents=False` sequential control on the same
+    fixture.
+  - Numbers are never pinned as constants in a test or docstring (repo
+    anti-rot rule) — `tests/test_benchmark_jacobian_fwd.py` gates
+    RELATIONS (intercept-vs-plain-solve ratio band, batched-faster-than-
+    sequential, memory-independent-of-n_steps), and
+    `scripts/benchmark_jacobian_fwd.py` is the regenerable source for any
+    number quoted above or in a PR body.
+- Complex-Jacobian convention: for a complex-valued `value` (e.g.
+  `dft_field`'s output), the returned Jacobian is `dy/dx` UNCONJUGATED —
+  it differs by a conjugate from anything derived through `jax.vjp`/
+  `jax.grad` on the same computation. Documented in the function's own
+  docstring; gated by `tests/test_jacobian_fwd.py::test_g2_jacobian_is_unconjugated_dy_dx`.
+- `tangents="identity"` is defined as per-element identity over SCALAR
+  leaves of `params` ONLY, and fails loud (`ValueError`) on any non-scalar
+  or non-floating leaf — a naive per-leaf identity on a multi-element leaf
+  silently sums that leaf's Jacobian entries instead of isolating one
+  column of them. An explicit tangent pytree/matrix (params' structure
+  with a leading `n_t` axis on every leaf) is the escape hatch for
+  non-all-scalar `params`, e.g. a flat `(n_p,)` design vector with
+  `tangents=jnp.eye(n_p)`.
+- **Scope limits, stated plainly**: uniform single-device lane only;
+  "geometry parameter" means the topology-density pixel / `dz_profile` /
+  `pec_occupancy_override` design channels rfx actually has, NOT a
+  parametric dimension (a traced `Box` corner still raises
+  `ConcretizationTypeError`) — no new geometry differentiability shipped
+  here; nonlinear (Kerr) tangents are unverified at the tested chi3.
+- Fail-loud fences, two INHERITED raises and two DOCUMENTED traps (see
+  `jacobian_fwd`'s own docstring "Fail-loud fences" section for the full
+  reasoning): non-uniform+`distributed=True` with a registered DFT-plane
+  probe and `design_mask` on the uniform lane both raise
+  `NotImplementedError` via `forward()`'s own pre-existing checks,
+  propagated unchanged through `jax.jvp`; `n_warmup` (measured SILENT
+  NO-OP on the uniform lane, issue #626) and `checkpoint`/
+  `checkpoint_segments` (measured EXACTLY NEUTRAL under forward mode —
+  remat only pays off under reverse-mode transposition) have no raise to
+  inherit and are documented traps instead, since `jacobian_fwd` is
+  generic over `sim_fn` and never sees `forward()`'s own keyword
+  arguments.
+- Provenance: the issue's own author downgraded #577 to nice-to-have on
+  2026-08-06 in favour of #579 (a reverse-mode scalar-objective need);
+  #579 shipped (PR #619, 2026-08-10). The PI directed this session, in
+  the same window after #579 shipped, to proceed to #577 following
+  #622/#582. `docs/agent-memory/` carries no forward-mode/jvp/jacfwd STOP
+  or do-not-repeat entry.
+- New docs: `docs/agent/recipe-design-loop.mdx` gains a `jacobian_fwd`
+  section; `docs/guides/api_symbol_inventory.json` regenerated
+  (`rfx.jacobian_fwd`'s parameter names `sim_fn, params, tangents,
+  batch_tangents` are now pinned by `scripts/check_api_reference.py`).
+
 ### Fixed — non-uniform-mesh CPML absorber was not impedance-matched (issue #582)
 
 - The uniform-grid material assembler extends the interior-edge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,15 @@ SemVer — **BREAKING** entries are flagged in upper-case.
     discipline in `tests/test_estimate_ad_memory.py`) **10.4x**.
   - grid 59x55x55 = 178,475 cells (5.3x more cells), same `n_steps`: the
     SAME `n_t=10` batched configuration moves to **7.3x** wall time /
-    **18.6x** flops / **10.4x** `temp_bytes` — flops and `temp_bytes` (both
-    deterministic compiler outputs) land within ~1% of the small-grid
-    ratio, while wall time (subject to machine load) moved from 5.9x to
-    7.3x. The point of quoting two grid sizes is that the ratio is not a
-    fixed constant across problem sizes — re-run
+    **18.6x** flops / **10.4x** `temp_bytes` — the flops ratio itself moved
+    6.4% from the small grid's 17.5x (it is NOT a fixed constant across
+    problem sizes, which is the whole point of quoting two grid sizes).
+    Separately, flops and `temp_bytes` (both deterministic compiler
+    outputs, unaffected by machine load) reproduce the *evidence base's own
+    independent probe measurement* on the same two fixtures to within ~1%
+    — a cross-check that this implementation's cost characterization is not an
+    artifact of this particular run. Wall time (subject to machine load)
+    moved from 5.9x to 7.3x between the two grids. Re-run
     `scripts/benchmark_jacobian_fwd.py --grid-scale 24` for the current
     number on your hardware rather than trusting either one quoted here.
   - forward-mode `temp_bytes` is measured INDEPENDENT of `n_steps`

--- a/docs/agent/recipe-design-loop.mdx
+++ b/docs/agent/recipe-design-loop.mdx
@@ -99,6 +99,62 @@ with a `DesignRegion`). Lane-agnostic: works on `run()`/`forward()` results
 from both the uniform and non-uniform meshes; fenced fail-loud on the two
 distributed lanes (neither sharded runner accumulates DFT planes today).
 
+## `jacobian_fwd` — a many-output Jacobian in one batched forward pass
+
+For a many-output objective (the full `dft_field` tensor, not a scalar
+reduction — e.g. training a gradient-augmented surrogate on the field
+itself), reverse mode needs one `jax.grad`/`jax.vjp` call PER output, and
+`jax.jacrev` refuses a complex-dtype output outright (`TypeError` without
+`holomorphic=True`). `rfx.jacobian_fwd(sim_fn, params)` computes the whole
+Jacobian in one batched forward-mode pass instead:
+
+```python
+value, jacobian = rfx.jacobian_fwd(
+    lambda p: dft_field(name)(sim.forward(eps_override=eps(p), checkpoint=False)),
+    params,
+)
+```
+
+with `params` a pytree of scalar design variables (the default
+`tangents="identity"` builds one tangent direction per scalar leaf — pass
+an explicit tangent pytree/matrix, same structure as `params` with a
+leading `n_t` axis, for a flat `(n_p,)` design vector or a subset of
+columns). `jacobian` mirrors `sim_fn`'s OUTPUT, not `params` — every leaf
+gains a new leading `n_t` axis holding the directional derivative along
+each tangent direction, in `tangents="identity"`'s case matching `params`'
+flattened leaf order.
+
+This is PACKAGING over stock `jax.vmap(jax.jvp(...))`, not new solver
+capability — forward mode already ran end-to-end through the same
+`forward()` -> `rfx.observables` path with zero solver changes. Read
+before reaching for it:
+
+- **Not "a few times one solve, not N times."** Measured cost scales
+  roughly `(1 + n_t)` plain solves in both wall time and flops, and that
+  ratio MOVES with grid size — regenerate `scripts/benchmark_jacobian_fwd.py`
+  for a current number rather than trusting one written down elsewhere.
+  The real argument for this mode is MEMORY: forward-mode peak is
+  `O(state) * (1 + n_t)` and independent of `n_steps`, while reverse mode
+  on a single scalar output is tens of times one plain solve on the same
+  fixture and cannot produce a many-output Jacobian at all.
+- The returned Jacobian is `dy/dx` UNCONJUGATED for a complex `value` —
+  differs by a conjugate from anything built through `jax.vjp`/`jax.grad`.
+- Uniform single-device lane only. `design_mask` and non-uniform+
+  `distributed=True` (with a registered DFT-plane probe) both raise
+  `NotImplementedError` via `forward()`'s own pre-existing checks;
+  `n_warmup` is a measured silent no-op and `checkpoint`/
+  `checkpoint_segments` are measured exactly neutral under forward mode —
+  neither has a raise to catch it, so both are documented traps in
+  `jacobian_fwd`'s own docstring rather than being plumbed through.
+- "Geometry parameter" still means the topology-density pixel /
+  `pec_occupancy_override` / `dz_profile` design channels from the section
+  above — not a parametric dimension (`Box` corners are not
+  differentiable through `forward()`).
+
+Full contract, fence reasoning, and gates:
+`rfx/observables.py`'s `jacobian_fwd` docstring and
+`tests/test_jacobian_fwd.py`.
+
 ## Validate either method
 
 - `rfx.validate_port_smatrix(result)` — passivity/shape verdict. A

--- a/docs/agent/repo-map.mdx
+++ b/docs/agent/repo-map.mdx
@@ -19,7 +19,7 @@ before writing any new simulation code.
 | `rfx/materials/` | Material helpers including Debye, Lorentz, and nonlinear dispersion models |
 | `rfx/boundaries/` | Boundary condition implementations (CPML, UPML, PEC, PMC, Floquet/Bloch) |
 | `rfx/sources/`, `rfx/api/_sparams.py` | Port implementations and S-parameter extraction (production lumped/wire driver: `rfx/probes/sparam_driver.py`) |
-| `rfx/observables.py` | Differentiable accessor/objective factories on registered DFT-plane probes (`dft_field`, `field_energy`, `field_softmax`) — same factory style as `rfx/optimize_objectives.py` |
+| `rfx/observables.py` | Differentiable accessor/objective factories on registered DFT-plane probes (`dft_field`, `field_energy`, `field_softmax`) — same factory style as `rfx/optimize_objectives.py` — plus `jacobian_fwd`, a batched forward-mode Jacobian wrapper for any `sim_fn(params) -> value` |
 | `tests/` | Canonical usage examples for every API surface — start here |
 | `validation/crossval/` | Claims-bearing cases and deliberate diagnostic reporters — roles are pinned in `validation/crossval/manifest.json`; check it before citing any script as validation |
 

--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -1198,6 +1198,15 @@
         "kwargs"
       ]
     },
+    "jacobian_fwd": {
+      "kind": "function",
+      "params": [
+        "sim_fn",
+        "params",
+        "tangents",
+        "batch_tangents"
+      ]
+    },
     "load_material_csv": {
       "kind": "function",
       "params": [

--- a/rfx/__init__.py
+++ b/rfx/__init__.py
@@ -153,7 +153,7 @@ from rfx.optimize_objectives import (
     maximize_transmitted_energy,
     steer_probe_array,
 )
-from rfx.observables import dft_field, field_energy, field_softmax
+from rfx.observables import dft_field, field_energy, field_softmax, jacobian_fwd
 try:
     from rfx.eigenmode import WaveguideMode, solve_waveguide_modes
 except ImportError:
@@ -293,7 +293,7 @@ __all__ = [
     "minimize_s11", "maximize_s21", "target_impedance", "maximize_bandwidth",
     "maximize_directivity", "minimize_reflected_energy",
     "maximize_transmitted_energy", "steer_probe_array",
-    "dft_field", "field_energy", "field_softmax",
+    "dft_field", "field_energy", "field_softmax", "jacobian_fwd",
     # sweeps / batch
     "parametric_sweep", "SweepResult", "plot_sweep",
     "vmap_material_sweep", "VmapSweepResult",

--- a/rfx/observables.py
+++ b/rfx/observables.py
@@ -483,7 +483,7 @@ def jacobian_fwd(
     (``out_axes=None`` on an output that DOES depend on the mapped axis is
     a vmap error, not a silent wrong answer).
 
-    Cost profile: NOT "a few times one solve" -- see
+    Cost characterization: NOT "a few times one solve" -- see
     ``scripts/benchmark_jacobian_fwd.py`` (regenerable; run it for current
     numbers on your hardware/grid) and the CHANGELOG entry for this issue
     for measured wall-time/flops/memory ratios. The honest summary: wall

--- a/rfx/observables.py
+++ b/rfx/observables.py
@@ -1,4 +1,5 @@
-"""Differentiable observables built on registered DFT-plane probes (#579).
+"""Differentiable observables built on registered DFT-plane probes (#579),
+plus a batched forward-mode Jacobian wrapper (#577).
 
 ``Simulation.add_dft_plane_probe(...)`` registers a frequency-domain plane
 accumulator that ``run()`` and ``forward()`` both populate into a name-keyed
@@ -18,6 +19,12 @@ layer on top of it, in the same "factory returns ``callable(result) ->
   space + frequency, for objectives that care about the WORST bin (e.g.
   "minimize peak leaked field anywhere behind a shield") rather than the
   average.
+- :func:`jacobian_fwd` -- batch ``jax.jvp`` over a tangent basis to get a
+  many-output Jacobian in one pass, for any ``sim_fn(params) -> observable``
+  built on top of the three accessors above (or anything else that is
+  ``jax``-differentiable). See its own docstring for the full contract,
+  including why it is PACKAGING rather than new solver capability, and the
+  scope limits that come with that.
 
 Both lanes, both entry points: ``result.dft_planes`` is a name-keyed dict on
 the uniform AND non-uniform meshes, for both ``run()`` and ``forward()``
@@ -88,12 +95,13 @@ back-compat break). This mirrors the pre-existing
 
 from __future__ import annotations
 
-from typing import Callable, Sequence
+from typing import Any, Callable, Sequence
 
+import jax
 import jax.numpy as jnp
 from jax.nn import logsumexp
 
-__all__ = ["dft_field", "field_energy", "field_softmax"]
+__all__ = ["dft_field", "field_energy", "field_softmax", "jacobian_fwd"]
 
 
 def _select_planes(result, names, caller: str) -> dict:
@@ -315,3 +323,337 @@ def field_softmax(
         return logsumexp(beta * vals) / beta
 
     return objective
+
+
+def _identity_tangent_batch(params):
+    """Build the ``tangents="identity"`` basis for :func:`jacobian_fwd`.
+
+    Defined as per-ELEMENT identity over SCALAR leaves only -- deliberately
+    NOT a per-leaf identity, and it fails loud rather than silently picking
+    one of the two readings. Measured trap (#577 evidence): on a
+    ``{'scalar': (), 'field': (4, 4)}`` pytree, a per-leaf one-hot tangent
+    (ones on the whole ``field`` leaf) returns 64.0 -- the SUM of the 16
+    Jacobian entries for that leaf, not any single column of them. Because
+    every leaf here is required to be scalar, "one basis vector per leaf"
+    and "one basis vector per scalar element" are the same construction, so
+    that trap cannot occur once the non-scalar check below passes.
+    """
+    leaves, treedef = jax.tree_util.tree_flatten(params)
+    if not leaves:
+        raise ValueError(
+            "jacobian_fwd(tangents='identity'): params pytree has no "
+            "leaves -- nothing to differentiate."
+        )
+    arrays = [jnp.asarray(leaf) for leaf in leaves]
+    non_scalar = [
+        (i, tuple(a.shape)) for i, a in enumerate(arrays) if a.shape != ()
+    ]
+    if non_scalar:
+        raise ValueError(
+            "jacobian_fwd(tangents='identity') requires every params leaf "
+            f"to be a SCALAR (shape ()); found non-scalar leaf shape(s) "
+            f"{non_scalar}. A per-leaf one-hot tangent on a multi-element "
+            "leaf sums that leaf's Jacobian entries instead of isolating "
+            "one column of them (measured: a {'scalar': (), 'field': (4, "
+            "4)} pytree returned the SUM of 16 Jacobian entries, not one "
+            "of them). Pass an explicit tangent pytree/matrix instead: "
+            "same structure as params, each leaf carrying an extra "
+            "leading n_t axis."
+        )
+    non_float = [
+        (i, str(a.dtype)) for i, a in enumerate(arrays)
+        if not jnp.issubdtype(a.dtype, jnp.floating)
+    ]
+    if non_float:
+        raise ValueError(
+            "jacobian_fwd(tangents='identity') requires every params leaf "
+            f"to have a floating dtype; found non-floating leaf dtype(s) "
+            f"{non_float}. An int/bool leaf has no continuous derivative "
+            "(jax.jvp requires a float0 tangent for it, which "
+            "tangents='identity' does not auto-build); pass an explicit "
+            "tangent pytree instead, or drop the non-float leaf(s) from "
+            "params."
+        )
+    n_t = len(leaves)
+    tangent_leaves = [
+        jnp.asarray(1.0, dtype=a.dtype) * (jnp.arange(n_t) == i).astype(a.dtype)
+        for i, a in enumerate(arrays)
+    ]
+    return jax.tree_util.tree_unflatten(treedef, tangent_leaves), n_t
+
+
+def _explicit_tangent_batch(params, tangents):
+    """Validate and pass through an explicit tangent batch (the escape
+    hatch for a non-all-scalar ``params`` pytree, e.g. a flat ``(n_p,)``
+    design vector with an explicit ``(n_t, n_p)`` tangent matrix).
+
+    ``tangents`` must share ``params``' pytree structure, with every leaf
+    carrying one extra LEADING axis of a common size ``n_t`` (so
+    ``tangents`` is exactly what you get by stacking ``n_t`` tangent
+    pytrees, each shaped like ``params``, along a new axis 0).
+    """
+    param_leaves, param_treedef = jax.tree_util.tree_flatten(params)
+    tangent_leaves, tangent_treedef = jax.tree_util.tree_flatten(tangents)
+    if tangent_treedef != param_treedef:
+        raise ValueError(
+            "jacobian_fwd: explicit tangents must share params' pytree "
+            f"structure (with a leading n_t axis on every leaf); got "
+            f"tangents structure {tangent_treedef!r} vs params structure "
+            f"{param_treedef!r}."
+        )
+    bad = []
+    n_t_seen = set()
+    for i, (p, t) in enumerate(zip(param_leaves, tangent_leaves)):
+        p_shape = jnp.shape(p)
+        t_shape = jnp.shape(t)
+        if len(t_shape) != len(p_shape) + 1 or t_shape[1:] != p_shape:
+            bad.append((i, tuple(p_shape), tuple(t_shape)))
+        else:
+            n_t_seen.add(t_shape[0])
+    if bad:
+        raise ValueError(
+            "jacobian_fwd: explicit tangents leaf shapes must equal the "
+            "matching params leaf shape with one leading n_t axis "
+            "prepended; mismatched leaf(s) (index, params_shape, "
+            f"tangents_shape) = {bad}."
+        )
+    if len(n_t_seen) != 1:
+        raise ValueError(
+            "jacobian_fwd: explicit tangents leaves disagree on n_t (the "
+            f"leading axis size): {sorted(n_t_seen)}. Every leaf must "
+            "share one n_t."
+        )
+    n_t = n_t_seen.pop()
+    if n_t < 1:
+        raise ValueError(f"jacobian_fwd: n_t must be >= 1, got {n_t}.")
+    return tangents, n_t
+
+
+def jacobian_fwd(
+    sim_fn: Callable,
+    params: Any,
+    *,
+    tangents: Any = "identity",
+    batch_tangents: bool = True,
+) -> tuple[Any, Any]:
+    """Batched forward-mode Jacobian of ``sim_fn`` at ``params`` (issue #577).
+
+    ``jax.jvp`` / ``jax.jacfwd`` / ``jax.vmap(jax.jvp)`` already run
+    end-to-end through ``sim.forward(eps_override=...)`` ->
+    :func:`dft_field` / :func:`field_energy` / :func:`field_softmax` today,
+    with zero solver changes -- this function is a thin, gated PACKAGING
+    layer over that stock-JAX capability (tangent-basis construction,
+    dtype/shape validation, primal de-duplication, sequential-vs-batched
+    dispatch), not a new AD engine. It computes
+
+        ``value, jacobian = jacobian_fwd(sim_fn, params)``
+
+    where ``value = sim_fn(params)`` (bit-identical to calling ``sim_fn``
+    directly -- see the API trap note below) and ``jacobian`` has the SAME
+    pytree structure as *value* (``sim_fn``'s OUTPUT, not *params* -- this
+    is what ``jax.jvp``'s own tangent output mirrors, and this function
+    does not reshape it into a params-keyed structure the way
+    ``jax.jacfwd`` does), with every leaf gaining one new LEADING axis of
+    size ``n_t``: ``jacobian`` (or ``jacobian[k]`` for an output pytree
+    with leaf ``k``) has shape ``(n_t,) + value.shape``, row ``i`` holding
+    the directional derivative of *value* along tangent direction ``i``.
+    With the default ``tangents="identity"``, direction ``i`` corresponds
+    to ``params``' ``i``-th flattened leaf (``jax.tree_util.tree_flatten``
+    order) -- i.e. ``jacobian[i]`` is ``d(value)/d(params_leaf[i])``.
+
+    Mechanism: ``jax.vmap`` over the TANGENT argument of ``jax.jvp`` (NOT
+    ``jax.linearize``). Measured on the real uniform-lane FDTD scan: the
+    ``vmap(jvp)`` jaxpr contains exactly ONE ``lax.scan`` (the FDTD time
+    loop) whose carry holds one UNBATCHED copy of the field state (the
+    primal sweep) plus ``n_t`` BATCHED tangent copies -- the primal sweep
+    really is shared across every tangent direction, which is the premise
+    #577 asked to verify. ``jax.linearize`` was measured to cost 24x more
+    peak memory on the same fixture (8654 MB vs 355 MB at n_steps=600,
+    n_t=10) because it materialises the whole scan's primal residuals --
+    i.e. the reverse-mode tape -- which forward mode never needs.
+
+    API TRAP (verify this, do not assume it): a naive
+    ``jax.vmap(jax.jvp(...))`` ALSO stacks the primal, returning a
+    ``(n_t,) + value.shape`` array of ``n_t`` copies of the same value.
+    This function passes ``out_axes=(None, 0)`` to ``jax.vmap`` so the
+    returned ``value`` is the single, unstacked primal -- but that only
+    works because the primal computation genuinely does not depend on
+    which tangent direction is being evaluated. If you change ``sim_fn``
+    in a way that breaks that invariant, ``jax.vmap`` raises loudly
+    (``out_axes=None`` on an output that DOES depend on the mapped axis is
+    a vmap error, not a silent wrong answer).
+
+    Cost profile: NOT "a few times one solve" -- see
+    ``scripts/benchmark_jacobian_fwd.py`` (regenerable; run it for current
+    numbers on your hardware/grid) and the CHANGELOG entry for this issue
+    for measured wall-time/flops/memory ratios. The honest summary: wall
+    time and flops scale roughly as ``(1 + n_t)`` plain solves and that
+    ratio MOVES with grid size (do not trust one ratio across problem
+    sizes); memory is the argument FOR this mode, not speed -- forward-mode
+    peak is ``O(state) * (1 + n_t)`` and independent of ``n_steps``, while
+    reverse mode without segmented checkpointing is tens of times one
+    plain solve even for a single scalar output, and ``jax.jacrev`` refuses
+    a complex-valued observable outright (raises ``TypeError`` without
+    ``holomorphic=True``). Numbers are never published here -- see the
+    anti-rot rule in the module/CHANGELOG instead of trusting a docstring
+    number, which rots.
+
+    Parameters
+    ----------
+    sim_fn : Callable
+        ``params -> value``, JAX-differentiable (typically
+        ``lambda p: dft_field(name)(sim.forward(eps_override=eps(p), ...))``
+        or the same composed with :func:`field_energy` /
+        :func:`field_softmax`). Called under ``jax.jvp``, so it must be
+        traceable the same way any ``jax.grad``/``jax.jvp`` target is.
+    params : Any
+        A JAX pytree of the design variables to differentiate with respect
+        to. With the default ``tangents="identity"``, every leaf must be a
+        floating-dtype SCALAR (shape ``()``) -- see :func:`_identity_tangent_batch`.
+        A flat ``(n_p,)`` array (one non-scalar leaf) needs the explicit
+        ``tangents=`` escape hatch below.
+    tangents : "identity" or a pytree, optional
+        ``"identity"`` (default): build one one-hot tangent direction per
+        scalar leaf of *params* (``n_t = number of leaves``); fails loud
+        (``ValueError``) if any leaf is non-scalar or non-floating -- see
+        :func:`_identity_tangent_batch`'s docstring for the measured trap
+        this avoids. Otherwise: an explicit tangent BATCH -- a pytree with
+        the same structure as *params*, every leaf carrying one extra
+        LEADING axis of a common size ``n_t`` (e.g. ``tangents=jnp.eye(n_p)``
+        when *params* is a flat ``(n_p,)`` array, for the full Jacobian, or
+        any ``(n_t, n_p)`` slice of it for a subset of columns).
+    batch_tangents : bool, optional
+        ``True`` (default): run all ``n_t`` tangent directions as ONE
+        ``jax.vmap(jax.jvp(...))`` call -- lower wall time (measured 2.3-3.1x
+        faster than the sequential control at n_t in {4, 10}), higher peak
+        memory (``O(state) * (1 + n_t)``, all ``n_t`` tangent copies live
+        at once). ``False``: run the ``n_t`` directions as independent
+        sequential ``jax.jvp`` calls inside one ``jit`` -- the memory-vs-speed
+        knob, trading the wall-time win for a peak that scales with ONE
+        tangent copy at a time instead of ``n_t`` (measured: primal-sharing
+        still holds sequentially, at ``~1 + n_t`` compute but with a lower
+        peak than the batched path scales to as ``n_t`` grows). The two
+        paths are DIFFERENT XLA programs and may disagree at float32
+        reassociation scale (~1e-6 relative); they are not bit-identical.
+
+    Returns
+    -------
+    (value, jacobian) : tuple
+        ``value``: the single primal, ``sim_fn(params)`` bit-identical
+        (verify this in your own test if you change *sim_fn*'s structure --
+        see the API trap above). ``jacobian``: a pytree mirroring *value*
+        (``sim_fn``'s output, NOT *params* -- see the paragraph above the
+        signature), each leaf an array of shape ``(n_t,) + value.shape``.
+
+    Complex-Jacobian convention
+    ----------------------------
+    For a complex-valued *value* (e.g. :func:`dft_field`'s output), the
+    returned Jacobian is ``dy/dx`` UNCONJUGATED -- exactly what forward-mode
+    AD produces for a real input tangent and a complex output. This
+    DIFFERS BY A CONJUGATE from anything derived through ``jax.vjp`` /
+    ``jax.grad`` on the same computation (measured: 0.02% relative error
+    against an unconjugated central-difference reference, 198% against the
+    conjugated one). If you compare this Jacobian against anything built
+    from reverse-mode AD, conjugate one side first. This is also why
+    ``jax.jacrev`` cannot be used as a drop-in alternative here: it refuses
+    a complex-dtype output outright (``TypeError``, needs
+    ``holomorphic=True``) -- forward mode is the only stock-JAX mode that
+    hands back this Jacobian without a holomorphy declaration.
+
+    Fail-loud fences
+    -----------------
+    Four configurations are unsafe to combine with ``jacobian_fwd`` on
+    ``sim_fn`` bodies built on ``Simulation.forward(...)``. This function
+    is intentionally generic over *sim_fn* (it never sees ``forward()``'s
+    own keyword arguments -- they live inside your closure), so only the
+    first two are enforced by a RAISE that propagates up through
+    ``jax.jvp`` from ``forward()``'s own pre-existing checks; the other two
+    have no raise to inherit and cannot be intercepted from outside the
+    closure, so they are DOCUMENTED traps instead. Read the RAISES/DOCS tag
+    on each before assuming "it didn't raise" means "it's fine":
+
+    - **[RAISES, inherited]** non-uniform + ``distributed=True`` with a
+      registered DFT-plane probe: ``forward()`` itself raises
+      ``NotImplementedError`` (the #619 fence, ``rfx/api/_execute.py``) --
+      neither sharded runner accumulates DFT-plane fields. ``jacobian_fwd``
+      scope is the uniform single-device lane only; a distributed
+      ``sim_fn`` fails loud before this function's own machinery runs.
+    - **[RAISES, inherited]** ``design_mask``: ``forward()`` itself raises
+      ``NotImplementedError`` for ``design_mask`` on the uniform lane
+      (issue #41; ``rfx/api/_execute.py``) -- so on ``jacobian_fwd``'s
+      supported (uniform) lane, a ``design_mask``-using ``sim_fn`` already
+      fails loud. Do not read this as "design_mask is safe elsewhere":
+      on the non-uniform lane, ``design_mask`` measurably returns an
+      EXACTLY ZERO derivative for its intended use in BOTH forward and
+      reverse mode (issue #625) -- it is not fenced there, and any future
+      non-uniform extension of this function must not trust it silently.
+    - **[DOCS ONLY -- no raise exists to inherit]** ``n_warmup``: measured
+      SILENT NO-OP on the uniform ``forward()`` lane (bit-identical value
+      AND tangent at ``n_warmup=0`` vs ``n_warmup=60`` of 80 steps; issue
+      #626) -- it neither errors nor changes the result, so there is
+      nothing for ``jacobian_fwd`` (or ``forward()``) to fail loud on. If
+      your ``sim_fn`` passes a nonzero ``n_warmup`` expecting either a
+      memory saving (forward mode builds no tape, so there is none to
+      save) or a truncated-but-correct derivative (it silently is NOT
+      truncated), both expectations are wrong. Do not use it here.
+    - **[DOCS ONLY -- inert, not a raise]** ``checkpoint`` /
+      ``checkpoint_segments``: measured EXACTLY NEUTRAL under forward mode
+      (flops/temp bytes identical across ``checkpoint=False``,
+      ``checkpoint=True`` (the ``forward()`` default), and
+      ``checkpoint_segments=K``) -- remat only pays off under reverse-mode
+      transposition, and forward mode builds no tape to transpose. A
+      ``sim_fn`` built for use with ``jacobian_fwd`` should pass
+      ``checkpoint=False`` explicitly (``forward()`` defaults to
+      ``checkpoint=True``) to avoid inheriting dead HLO plus
+      ``checkpoint_segments``' ``n_steps % K == 0`` divisibility raise for
+      no forward-mode benefit. These are reverse-mode knobs; document them
+      as such, do not reach for them here.
+
+    Scope limits
+    -------------
+    - Uniform single-device lane only (see the fences above).
+    - "Geometry parameter" is NOT a parametric dimension here. A traced
+      ``Box`` corner raises ``ConcretizationTypeError``
+      (``rfx/geometry/csg.py``) and ``forward()``'s material rasterisation
+      is a binary ``jnp.where`` mask with zero gradient almost everywhere.
+      The only continuous geometry design channels this package has are
+      topology density (via :func:`rfx.topology.density_to_material_fields`),
+      ``pec_occupancy_override``, and the non-uniform ``dz_profile``. If you
+      want ``d/d(patch width in metres)``, this function cannot supply that
+      column -- rfx does not have it to give, on any AD mode.
+    - Nonlinear (Kerr chi3) tangents ran clean under ``vmap(jvp)`` in
+      testing but were numerically indistinguishable from the linear
+      baseline at the tested chi3 -- that is NOT a validation of the
+      nonlinear tangent path. Treat it as unverified until measured at a
+      chi3 large enough to move the Jacobian outside noise.
+    """
+    if isinstance(tangents, str):
+        if tangents != "identity":
+            raise ValueError(
+                f"jacobian_fwd: tangents string must be 'identity', got "
+                f"{tangents!r}."
+            )
+        tangent_batch, n_t = _identity_tangent_batch(params)
+    else:
+        tangent_batch, n_t = _explicit_tangent_batch(params, tangents)
+
+    def _jvp_row(tangent_row):
+        return jax.jvp(sim_fn, (params,), (tangent_row,))
+
+    if batch_tangents:
+        value, jacobian = jax.vmap(
+            _jvp_row, in_axes=0, out_axes=(None, 0),
+        )(tangent_batch)
+    else:
+        values = []
+        jac_rows = []
+        for i in range(n_t):
+            row = jax.tree_util.tree_map(lambda x: x[i], tangent_batch)
+            v, j = jax.jvp(sim_fn, (params,), (row,))
+            values.append(v)
+            jac_rows.append(j)
+        value = values[0]
+        jacobian = jax.tree_util.tree_map(
+            lambda *rows: jnp.stack(rows, axis=0), *jac_rows,
+        )
+    return value, jacobian

--- a/scripts/benchmark_jacobian_fwd.py
+++ b/scripts/benchmark_jacobian_fwd.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-"""Regenerable cost-profile benchmark for `rfx.observables.jacobian_fwd`
-(issue #577).
+"""Regenerable cost-characterization benchmark for
+`rfx.observables.jacobian_fwd` (issue #577).
 
 The repo forbids publishing prose cost numbers (they rot) and forbids
 calling a compiler estimate a "profile" -- see
@@ -33,7 +33,7 @@ near one plain solve; see G3 in tests/test_jacobian_fwd.py for the
 structural, non-numeric version of the same claim) and the SLOPE `b` is
 the marginal per-tangent cost.
 
-Fixture note (issue #577 cost-profile discipline): the fixture registers
+Fixture note (issue #577 cost-measurement discipline): the fixture registers
 NO point probes (no `add_probe`). The uniform forward lane cannot drop the
 probe time-series tape (`emit_time_series=False` raises there), and under
 `vmap(jvp)` that tape would batch to `(n_t, n_steps, n_probes)` -- with
@@ -266,7 +266,7 @@ def build_benchmark_table(
 
 def _print_table(table: dict[str, Any]) -> None:
     print(
-        f"jacobian_fwd cost profile -- backend={table['backend']} "
+        f"jacobian_fwd cost table -- backend={table['backend']} "
         f"dtype={table['dtype']} grid={table['grid_shape']} "
         f"({table['grid_cells']} cells) n_steps={table['n_steps']} "
         f"n_p={table['n_p']} (CPU unless backend says otherwise)"

--- a/scripts/benchmark_jacobian_fwd.py
+++ b/scripts/benchmark_jacobian_fwd.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Regenerable cost-profile benchmark for `rfx.observables.jacobian_fwd`
+(issue #577).
+
+The repo forbids publishing prose cost numbers (they rot) and forbids
+calling a compiler estimate a "profile" -- see
+`tests/test_estimate_ad_memory.py`'s forbidden-terms list, mirrored here.
+This script is the regenerable source of truth: run it, quote its printed
+table (with the grid size / n_steps / backend / dtype it prints in its own
+header) in the PR body and CHANGELOG, and re-run it before trusting a
+number that is more than a few commits old.
+
+ALL numbers from this script are CPU unless you explicitly run it on a
+GPU-backed JAX install -- it prints `jax.default_backend()` in its header
+precisely so a copied number carries its own backend label. No GPU claim
+is made or implied by anything in this file.
+
+Measures, for `n_t` in `--n-t-values` (default 1, 4, 10) against one plain
+`sim.forward()` call:
+    - wall time (median of `--reps` timed calls on an already-compiled
+      program)
+    - flops (`compiled.cost_analysis()` -- a COMPILER ESTIMATE of the scan
+      BODY's per-step cost, not a measured runtime profile)
+    - XLA temp bytes (`compiled.memory_analysis().temp_size_in_bytes` -- a
+      COMPILER ESTIMATE, not a measured/observed/certified runtime peak;
+      see rfx/api/__init__.py's `ad_memory_compiled_certificate` for the
+      one sanctioned way to attach a measured-memory number to a compiled
+      object, which this script does not attempt)
+
+and fits `cost(n_t) = a + b * n_t` through the first and last requested
+`n_t` -- the INTERCEPT `a` is the primal-sharing witness (it should land
+near one plain solve; see G3 in tests/test_jacobian_fwd.py for the
+structural, non-numeric version of the same claim) and the SLOPE `b` is
+the marginal per-tangent cost.
+
+Fixture note (issue #577 cost-profile discipline): the fixture registers
+NO point probes (no `add_probe`). The uniform forward lane cannot drop the
+probe time-series tape (`emit_time_series=False` raises there), and under
+`vmap(jvp)` that tape would batch to `(n_t, n_steps, n_probes)` -- with
+even one point probe registered, that batched time-series tape would
+dominate the measured memory and turn the number into a tape artifact
+instead of a tangent-memory measurement. Only a DFT-plane probe is
+registered (a fixed-size frequency-domain accumulator, not a per-step
+time series).
+
+Run:
+    python scripts/benchmark_jacobian_fwd.py
+    python scripts/benchmark_jacobian_fwd.py --n-p 10 --n-t-values 1 4 10 \
+        --n-steps 120 --grid-scale 24   # the "large" fixture, slower
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import jax
+import jax.numpy as jnp
+
+from rfx import Simulation
+from rfx.observables import dft_field, jacobian_fwd
+
+_DX = 1.0e-3
+# FORBIDDEN honesty-label terms (tests/test_estimate_ad_memory.py's
+# _FORBIDDEN_RECOMMENDATION_TERMS / _FORBIDDEN_CURRENT_EVIDENCE_FIELDS):
+# never call this a "profile", "runtime peak", "guaranteed", or
+# "certified" number, and never name a field observed_peak_gb /
+# profile_peak_gb / peak_bound_gb. This script's field names below are
+# deliberately "flops" / "temp_bytes" / "t_median_s" -- the compiler's own
+# vocabulary, not a claim about measured/observed/certified behaviour.
+
+
+def build_sim(*, nx: int = 24, ny: int = 20, nz: int = 20,
+              cpml_layers: int = 5, freq_max: float = 8.0e9) -> Simulation:
+    """No point probes registered -- see the module docstring's Fixture
+    note. Only a source and one DFT-plane probe."""
+    sim = Simulation(
+        freq_max=freq_max, domain=(nx * _DX, ny * _DX, nz * _DX), dx=_DX,
+        boundary="cpml", cpml_layers=cpml_layers,
+    )
+    sim.add_source(
+        position=(4 * _DX, (ny / 2) * _DX, (nz / 2) * _DX),
+        component="ez", amplitude_kind="current",
+    )
+    sim.add_dft_plane_probe(
+        axis="x", coordinate=(nx - 5) * _DX, component="ez",
+        freqs=jnp.asarray([5.0e9]), name="leak",
+    )
+    return sim
+
+
+def make_design_fn(sim: Simulation, n_p: int, *, n_steps: int):
+    """params: flat (n_p,) float32 array, one design x-slice per entry ->
+    dft_field tensor. Matches the #577 evidence-base fixture convention
+    (a flat array, not a pytree-of-scalars) so `tangents=jnp.eye(n_p)`
+    works directly as the explicit-tangent escape hatch."""
+    grid = sim._build_grid()
+    eps_base = jnp.ones(grid.shape, dtype=jnp.float32)
+    x0 = grid.position_to_index((8 * _DX, 0.0, 0.0))[0]
+
+    def sim_fn(p):
+        eps = eps_base
+        for i in range(n_p):
+            eps = eps.at[x0 + i, :, :].set(1.0 + p[i])
+        result = sim.forward(
+            eps_override=eps, n_steps=n_steps, checkpoint=False,
+            skip_preflight=True,
+        )
+        return dft_field("leak")(result)
+
+    return grid, sim_fn
+
+
+def _compile_and_measure(fn, args, *, reps: int) -> dict[str, Any]:
+    jitted = jax.jit(fn)
+    compiled = jitted.lower(*args).compile()
+
+    info: dict[str, Any] = {}
+    try:
+        ca = compiled.cost_analysis()
+        if isinstance(ca, list):
+            ca = ca[0] if ca else {}
+        info["flops"] = ca.get("flops") if ca else None
+    except Exception:  # pragma: no cover -- backend-dependent availability
+        info["flops"] = None
+    try:
+        ma = compiled.memory_analysis()
+        info["temp_bytes"] = getattr(ma, "temp_size_in_bytes", None)
+    except Exception:  # pragma: no cover -- backend-dependent availability
+        info["temp_bytes"] = None
+
+    times = []
+    out = None
+    for _ in range(reps):
+        t0 = time.perf_counter()
+        out = compiled(*args)
+        jax.block_until_ready(out)
+        times.append(time.perf_counter() - t0)
+    times.sort()
+    info["t_median_s"] = times[len(times) // 2]
+    info["t_min_s"] = times[0]
+    return info
+
+
+def _linear_fit_endpoints(xs: list[int], ys: list[float]) -> tuple[float, float]:
+    """Fit cost(x) = a + b*x through the FIRST and LAST (x, y) points --
+    matches the evidence base's fit convention (bench.py/tables.py),
+    robust to a possibly-noisy interior point without needing a full
+    least-squares dependency."""
+    x0, x1 = xs[0], xs[-1]
+    y0, y1 = ys[0], ys[-1]
+    b = (y1 - y0) / (x1 - x0)
+    a = y0 - b * x0
+    return a, b
+
+
+def build_benchmark_table(
+    *,
+    n_p: int = 10,
+    n_t_values: tuple[int, ...] = (1, 4, 10),
+    n_steps: int = 120,
+    grid_scale: int = 0,
+    reps: int = 5,
+) -> dict[str, Any]:
+    """Return a JSON-serializable table: plain baseline, jvp (batched) at
+    each n_t, jvp (sequential, batch_tangents=False) at the largest n_t,
+    the linear fit, and a second n_steps run for the memory-independence
+    witness. All CPU/GPU-labelled by `jax.default_backend()`."""
+    nx = 24 + grid_scale
+    ny = 20 + grid_scale
+    nz = 20 + grid_scale
+    sim = build_sim(nx=nx, ny=ny, nz=nz)
+    grid, sim_fn = make_design_fn(sim, n_p, n_steps=n_steps)
+    params = jnp.full((n_p,), 1.0, dtype=jnp.float32)
+
+    def plain_fn(p, t):
+        return sim_fn(p)
+
+    def jvp_fn(p, t):
+        return jacobian_fwd(sim_fn, p, tangents=t, batch_tangents=True)
+
+    def jvp_seq_fn(p, t):
+        return jacobian_fwd(sim_fn, p, tangents=t, batch_tangents=False)
+
+    rows = []
+    T_full = jnp.eye(n_p, dtype=jnp.float32)
+    plain_info = _compile_and_measure(plain_fn, (params, T_full[:1]), reps=reps)
+    rows.append({"mode": "plain", "n_t": 1, **plain_info})
+
+    for n_t in n_t_values:
+        info = _compile_and_measure(jvp_fn, (params, T_full[:n_t]), reps=reps)
+        rows.append({"mode": "jvp_batched", "n_t": n_t, **info})
+
+    seq_n_t = n_t_values[-1]
+    seq_info = _compile_and_measure(jvp_seq_fn, (params, T_full[:seq_n_t]), reps=reps)
+    rows.append({"mode": "jvp_sequential", "n_t": seq_n_t, **seq_info})
+
+    # Fit through the jvp_batched SERIES ONLY (n_t = n_t_values[0]..[-1]) --
+    # NOT mixed with the separate "plain" baseline point, which sits on a
+    # DIFFERENT curve (jvp has fixed per-call overhead vs plain even at
+    # n_t=1: measured ~2.6x flops). Mixing them as one series with a
+    # duplicate x=1 point produces a meaningless (even negative) intercept.
+    # The primal-sharing witness instead COMPARES the fitted intercept `a`
+    # against the separately-measured plain baseline (see
+    # `intercept_vs_plain_ratio` below): the two should be close if the
+    # primal sweep really is shared.
+    batched_xs = list(n_t_values)
+    batched_flops = [r["flops"] for r in rows if r["mode"] == "jvp_batched"]
+    batched_temp = [r["temp_bytes"] for r in rows if r["mode"] == "jvp_batched"]
+    batched_wall = [r["t_median_s"] for r in rows if r["mode"] == "jvp_batched"]
+    fit = {}
+    if all(v is not None for v in batched_flops):
+        fit["flops_a_plus_b_nt"] = _linear_fit_endpoints(batched_xs, batched_flops)
+    if all(v is not None for v in batched_temp):
+        fit["temp_bytes_a_plus_b_nt"] = _linear_fit_endpoints(batched_xs, batched_temp)
+    fit["wall_s_a_plus_b_nt"] = _linear_fit_endpoints(batched_xs, batched_wall)
+
+    intercept_vs_plain_ratio = {}
+    if "flops_a_plus_b_nt" in fit and plain_info.get("flops"):
+        intercept_vs_plain_ratio["flops"] = fit["flops_a_plus_b_nt"][0] / plain_info["flops"]
+    if "temp_bytes_a_plus_b_nt" in fit and plain_info.get("temp_bytes"):
+        intercept_vs_plain_ratio["temp_bytes"] = fit["temp_bytes_a_plus_b_nt"][0] / plain_info["temp_bytes"]
+    if plain_info.get("t_median_s"):
+        intercept_vs_plain_ratio["wall_s"] = fit["wall_s_a_plus_b_nt"][0] / plain_info["t_median_s"]
+
+    # n_steps-independence witness (memory only; wall time DOES scale with
+    # n_steps as expected -- only the forward-mode MEMORY claim is
+    # n_steps-independent).
+    n_steps_2x = 2 * n_steps
+    grid2, sim_fn_2x = make_design_fn(sim, n_p, n_steps=n_steps_2x)
+    n_t_witness = n_t_values[len(n_t_values) // 2]
+
+    def jvp_fn_2x(p, t):
+        return jacobian_fwd(sim_fn_2x, p, tangents=t, batch_tangents=True)
+
+    info_2x = _compile_and_measure(
+        jvp_fn_2x, (params, T_full[:n_t_witness]), reps=1,
+    )
+    info_1x = next(r for r in rows if r["mode"] == "jvp_batched" and r["n_t"] == n_t_witness)
+
+    return {
+        "backend": jax.default_backend(),
+        "dtype": "float32",
+        "grid_shape": list(grid.shape),
+        "grid_cells": int(grid.shape[0] * grid.shape[1] * grid.shape[2]),
+        "n_steps": n_steps,
+        "n_p": n_p,
+        "rows": rows,
+        "fit": fit,
+        "intercept_vs_plain_ratio": intercept_vs_plain_ratio,
+        "n_steps_independence_witness": {
+            "n_t": n_t_witness,
+            "n_steps_1x": n_steps,
+            "n_steps_2x": n_steps_2x,
+            "temp_bytes_1x": info_1x.get("temp_bytes"),
+            "temp_bytes_2x": info_2x.get("temp_bytes"),
+        },
+    }
+
+
+def _print_table(table: dict[str, Any]) -> None:
+    print(
+        f"jacobian_fwd cost profile -- backend={table['backend']} "
+        f"dtype={table['dtype']} grid={table['grid_shape']} "
+        f"({table['grid_cells']} cells) n_steps={table['n_steps']} "
+        f"n_p={table['n_p']} (CPU unless backend says otherwise)"
+    )
+    print(f"{'mode':16s} {'n_t':>4s} | {'t_median_s':>11s} {'x':>6s} | "
+          f"{'flops':>12s} {'x':>6s} | {'temp_bytes':>11s} {'x':>6s}")
+    plain = table["rows"][0]
+    for r in table["rows"]:
+        t_x = r["t_median_s"] / plain["t_median_s"] if plain["t_median_s"] else float("nan")
+        f_x = (r["flops"] / plain["flops"]) if (r.get("flops") and plain.get("flops")) else float("nan")
+        m_x = (r["temp_bytes"] / plain["temp_bytes"]) if (r.get("temp_bytes") and plain.get("temp_bytes")) else float("nan")
+        print(f"{r['mode']:16s} {r['n_t']:>4d} | {r['t_median_s']:>11.4f} {t_x:>6.2f} | "
+              f"{str(r.get('flops')):>12s} {f_x:>6.2f} | "
+              f"{str(r.get('temp_bytes')):>11s} {m_x:>6.2f}")
+    print()
+    for name, (a, b) in table["fit"].items():
+        print(f"  fit {name}: a={a:.4g} (intercept) b={b:.4g} (marginal cost per tangent)")
+    for name, ratio in table["intercept_vs_plain_ratio"].items():
+        print(f"  intercept/plain ratio ({name}): {ratio:.3f} "
+              f"(primal-sharing witness -- expect close to 1.0)")
+    w = table["n_steps_independence_witness"]
+    print(
+        f"  n_steps independence (n_t={w['n_t']}): temp_bytes "
+        f"n_steps={w['n_steps_1x']} -> {w['temp_bytes_1x']}, "
+        f"n_steps={w['n_steps_2x']} -> {w['temp_bytes_2x']} "
+        f"(compiler ESTIMATE, not a measured/observed/certified peak)"
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--n-p", type=int, default=10)
+    parser.add_argument("--n-t-values", type=int, nargs="+", default=[1, 4, 10])
+    parser.add_argument("--n-steps", type=int, default=120)
+    parser.add_argument("--grid-scale", type=int, default=0,
+                         help="0 = small fixture; e.g. 24 for a ~5x-cell 'large' fixture")
+    parser.add_argument("--reps", type=int, default=5)
+    parser.add_argument("--output", type=Path, default=None,
+                         help="optional path to write the table as JSON")
+    args = parser.parse_args(argv)
+
+    table = build_benchmark_table(
+        n_p=args.n_p, n_t_values=tuple(args.n_t_values), n_steps=args.n_steps,
+        grid_scale=args.grid_scale, reps=args.reps,
+    )
+    _print_table(table)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(table, indent=2, sort_keys=True) + "\n")
+        print(f"  wrote {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ad_surface_contract.py
+++ b/tests/test_ad_surface_contract.py
@@ -198,6 +198,19 @@ AD_CLASSIFICATION = {
         "tests/test_observables_dft_field.py::test_field_softmax_material_leg_ad_matches_fd, "
         "tests/test_observables_dft_field.py::test_field_softmax_geometry_leg_ad_matches_fd",
     ),
+    "observables.jacobian_fwd": (
+        GRAD_SAFE,
+        "thin jax.vmap(jax.jvp(...)) packaging over the same already-"
+        "differentiable forward()->dft_field/field_energy path (issue "
+        "#577); FD-vs-AD gate, both AC legs (material eps_r scalar; one "
+        "topology-density pixel) plus the many-output complex dft_field "
+        "tensor leg, swept over multiple h values: "
+        "tests/test_jacobian_fwd.py::test_g1_material_and_geometry_legs_ad_matches_fd, "
+        "tests/test_jacobian_fwd.py::test_g1_many_output_tensor_leg_ad_matches_fd — "
+        "severed-tape falsifier confirmed the gate reads exactly 0.0 AD vs "
+        "finite FD when eps_override is stop_gradient'd: "
+        "tests/test_jacobian_fwd.py::test_g7_falsifier_severed_tape_reads_exactly_zero.",
+    ),
 }
 
 

--- a/tests/test_benchmark_jacobian_fwd.py
+++ b/tests/test_benchmark_jacobian_fwd.py
@@ -1,0 +1,70 @@
+"""RELATIONS-only gate for scripts/benchmark_jacobian_fwd.py (issue #577).
+
+Precedent: tests/test_memory_reduction_planning_artifact.py /
+tests/test_estimate_ad_memory.py -- assert RATIOS/RELATIONS between
+measured quantities, never a magic absolute constant (a compiled flops/
+temp_bytes/wall-time number is compiler- and machine-dependent and would
+rot the moment it was pinned). Uses a small, fast fixture (distinct from
+the benchmark script's own default) purely to keep this test's CPU time
+bounded -- the numbers THEMSELVES belong in the PR body/CHANGELOG from a
+real run of the script, not in this file or in any docstring.
+
+Relations gated:
+    - intercept_vs_plain_ratio lands within [0.5x, 2.0x] of the plain
+      baseline for flops/temp_bytes/wall time (the primal-sharing
+      witness; band matches the repo's own established tolerance in
+      tests/test_estimate_ad_memory.py::test_segmented_estimate_within_tolerance).
+    - batched (batch_tangents=True) wall time is faster than sequential
+      (batch_tangents=False) at the same n_t.
+    - XLA temp_bytes is independent of n_steps (forward-mode memory does
+      not scale with n_steps; only wall time does).
+"""
+
+from __future__ import annotations
+
+from scripts.benchmark_jacobian_fwd import build_benchmark_table
+
+
+def test_benchmark_table_relations():
+    table = build_benchmark_table(
+        n_p=4, n_t_values=(1, 2, 4), n_steps=60, grid_scale=0, reps=3,
+    )
+
+    ratios = table["intercept_vs_plain_ratio"]
+    for name, ratio in ratios.items():
+        assert 0.5 <= ratio <= 2.0, (
+            f"intercept_vs_plain_ratio[{name}] = {ratio:.3f} outside the "
+            "primal-sharing band [0.5x, 2.0x]"
+        )
+
+    plain = table["rows"][0]
+    assert plain["mode"] == "plain"
+
+    seq_row = next(r for r in table["rows"] if r["mode"] == "jvp_sequential")
+    batched_row = next(
+        r for r in table["rows"]
+        if r["mode"] == "jvp_batched" and r["n_t"] == seq_row["n_t"]
+    )
+    assert batched_row["t_median_s"] < seq_row["t_median_s"], (
+        f"batched wall time {batched_row['t_median_s']:.4f}s is not faster "
+        f"than sequential {seq_row['t_median_s']:.4f}s at n_t={seq_row['n_t']}"
+    )
+
+    w = table["n_steps_independence_witness"]
+    t1, t2 = w["temp_bytes_1x"], w["temp_bytes_2x"]
+    assert t1 is not None and t2 is not None
+    rel = abs(t2 - t1) / max(t1, t2)
+    assert rel < 0.02, (
+        f"temp_bytes depends on n_steps: n_steps={w['n_steps_1x']} -> {t1}, "
+        f"n_steps={w['n_steps_2x']} -> {t2} (rel diff {rel * 100:.2f}%)"
+    )
+
+    # Honesty-label discipline: the table's own field names must not use
+    # the repo's forbidden AD-memory vocabulary (tests/test_estimate_ad_memory.py
+    # _FORBIDDEN_CURRENT_EVIDENCE_FIELDS / _FORBIDDEN_RECOMMENDATION_TERMS).
+    forbidden_fields = {
+        "observed_peak_gb", "profile_peak_gb", "peak_bound_gb",
+        "compiler_memory_gb", "certificate_status",
+    }
+    for row in table["rows"]:
+        assert forbidden_fields.isdisjoint(row), f"forbidden field name leaked into row: {row.keys()}"

--- a/tests/test_jacobian_fwd.py
+++ b/tests/test_jacobian_fwd.py
@@ -34,15 +34,14 @@ the closure without breaking the pinned generic signature, so they are
 DOCUMENTED traps rather than runtime checks; G6 pins the docstring text
 for those two instead of a raise.
 
-FALSIFIER ARTIFACT: `test_g7_falsifier_severed_tape_reads_exactly_zero`
-below writes its captured red-then-green transcript to
-`scratchpad/i577_falsifier_red.txt` (session scratch, not committed) --
-see that file for the PR body excerpt.
+FALSIFIER ARTIFACT: `test_g7_falsifier_severed_tape_reads_exactly_zero` below
+PRINTS its captured red-then-green transcript (visible under `pytest -s`
+or in CI logs) rather than writing to a fixed path -- no hard-coded
+session/scratch path belongs in a committed public-repo test. Copy the
+printed transcript into the PR body.
 """
 
 from __future__ import annotations
-
-import math
 
 import jax
 import jax.numpy as jnp
@@ -300,7 +299,17 @@ def _find_shallowest_scan(jaxpr):
     """Depth-first search for the SHALLOWEST `lax.scan` equation, recursing
     through nested (Closed)Jaxpr params -- `jax.jit(...)` wraps the traced
     program in a `pjit` equation whose own params carry the inner jaxpr, so
-    a plain top-level scan of `jaxpr.eqns` misses it one level down."""
+    a plain top-level scan of `jaxpr.eqns` misses it one level down.
+
+    Returns ``(eqn, inner_jaxpr, total_scan_count)``. ``total_scan_count``
+    matters: `batch_tangents=False` (independent sequential `jax.jvp` calls,
+    the OPPOSITE of a shared primal sweep) produces N_T separate top-level
+    scan equations, not one -- MEASURED. Examining only the shallowest
+    scan's carry without also checking the total count would silently
+    accept that regression (each independent scan happens to carry the
+    same unbatched byte count as the elision case, so the primal-bytes-
+    equal check alone does not discriminate "shared" from "not shared").
+    """
     by_depth: list[tuple[int, object]] = []
 
     def walk(jx, depth):
@@ -324,7 +333,7 @@ def _find_shallowest_scan(jaxpr):
         raise AssertionError("no lax.scan found anywhere in jaxpr (FDTD time loop)")
     by_depth.sort(key=lambda pair: pair[0])
     eqn = by_depth[0][1]
-    return eqn, eqn.params["jaxpr"].jaxpr
+    return eqn, eqn.params["jaxpr"].jaxpr, len(by_depth)
 
 
 def _carry_grid_bytes(eqn, spatial: tuple[int, int, int], n_t: int):
@@ -369,15 +378,16 @@ def _make_design_sim_fn(sim, n_p: int):
     return grid, sim_fn
 
 
-def _measure_carry_bytes(n_t: int):
+def _measure_carry_bytes(n_t: int, *, batch_tangents: bool = True):
     sim = _build_sim()
     grid, sim_fn = _make_design_sim_fn(sim, n_t)
     params = tuple(jnp.asarray(1.0, dtype=jnp.float32) for _ in range(n_t))
 
-    jitted = jax.jit(lambda p: jacobian_fwd(sim_fn, p))
+    jitted = jax.jit(lambda p: jacobian_fwd(sim_fn, p, batch_tangents=batch_tangents))
     jaxpr = jax.make_jaxpr(jitted)(params).jaxpr
-    eqn, _inner = _find_shallowest_scan(jaxpr)
-    return _carry_grid_bytes(eqn, tuple(grid.shape), n_t)
+    eqn, _inner, scan_count = _find_shallowest_scan(jaxpr)
+    primal_bytes, batched_bytes = _carry_grid_bytes(eqn, tuple(grid.shape), n_t)
+    return primal_bytes, batched_bytes, scan_count
 
 
 def test_g3_primal_carry_is_independent_of_n_t():
@@ -395,11 +405,38 @@ def test_g3_primal_carry_is_independent_of_n_t():
     n_t=2, 3, and 4 all show primal=945,624 B identically while batched
     bytes scale exactly linearly (945,624 x n_t) -- the decisive, elision-
     free evidence -- so n_t=2 and n_t=4 are the comparison pair.
-    """
-    primal_2, batched_2 = _measure_carry_bytes(2)
-    primal_4, batched_4 = _measure_carry_bytes(4)
 
+    Two assertions below exist specifically because a degenerate case was
+    caught in review: running this SAME classifier against
+    `jacobian_fwd(..., batch_tangents=False)` -- genuinely n_t independent
+    sequential jvp calls, the OPPOSITE of a shared primal sweep -- passed
+    the original primal/batched-ratio checks, because `batched_2 ==
+    batched_4 == 0` makes `batched_4 == approx(2 * batched_2)` degenerate
+    to `0 == approx(0)`, and each independent scan happens to carry the
+    same per-scan byte count as the elision case, so `primal_2 ==
+    primal_4` ALSO holds without any real sharing. `batched_2 > 0` /
+    `batched_4 > 0` and `scan_count == 1` close that hole: flipping the
+    default to `batch_tangents=False` now fails both (MEASURED:
+    batched_bytes=0 and scan_count=n_t there, not 1).
+    """
+    primal_2, batched_2, scan_count_2 = _measure_carry_bytes(2)
+    primal_4, batched_4, scan_count_4 = _measure_carry_bytes(4)
+
+    assert scan_count_2 == 1, (
+        f"expected exactly ONE lax.scan (the FDTD time loop, shared across "
+        f"tangent directions) at n_t=2, found {scan_count_2} -- primal "
+        "sharing requires one shared scan, not n_t independent ones"
+    )
+    assert scan_count_4 == 1, (
+        f"expected exactly ONE lax.scan at n_t=4, found {scan_count_4}"
+    )
     assert primal_2 > 0 and primal_4 > 0, "no primal-shaped (unbatched) carry found"
+    assert batched_2 > 0 and batched_4 > 0, (
+        f"no batched (tangent) carry found (n_t=2 -> {batched_2}, n_t=4 -> "
+        f"{batched_4}) -- without this check the ratio assertion below "
+        "degenerates to 0 == approx(0) and would not catch batching being "
+        "broken entirely"
+    )
     assert primal_2 == primal_4, (
         f"primal carry bytes depend on n_t: n_t=2 -> {primal_2}, n_t=4 -> "
         f"{primal_4} -- the primal sweep is NOT shared across tangent directions"
@@ -472,11 +509,16 @@ def test_g5_batched_and_sequential_agree_many_output():
 # gates.
 # ---------------------------------------------------------------------------
 
-def test_g6a_distributed_fence_raises():
-    """Inherited from forward()'s own distributed dispatch check (fires
-    before any DFT-plane-specific check): a uniform sim + distributed=True
-    raises NotImplementedError, and that raise propagates through
-    jax.jvp/jacobian_fwd unchanged -- no new code in jacobian_fwd needed."""
+def test_g6a_uniform_distributed_raises_a_different_earlier_check():
+    """A uniform sim + distributed=True DOES raise NotImplementedError, but
+    via forward()'s general "distributed=True is NU-only" dispatch guard
+    (_execute.py's "only for non-uniform meshes" check) -- NOT the
+    DFT-plane-specific fence jacobian_fwd's own docstring names as fence
+    #1 (the #619 fence, which needs a non-uniform mesh to even reach). This
+    test pins that this EARLIER, more general check also propagates
+    through jax.jvp/jacobian_fwd unchanged; the NAMED fence itself is
+    exercised separately below by
+    test_g6a_distributed_nu_dft_plane_fence_raises."""
     sim = _build_sim()
 
     def sim_fn(alpha):
@@ -486,7 +528,40 @@ def test_g6a_distributed_fence_raises():
         )
         return dft_field(_PLANE)(result)
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(NotImplementedError, match="non-uniform meshes"):
+        jacobian_fwd(sim_fn, jnp.asarray(1.0, dtype=jnp.float32))
+
+
+def test_g6a_distributed_nu_dft_plane_fence_raises():
+    """The fence jacobian_fwd's own docstring actually names as fence #1
+    (issue #619, inherited from forward()): non-uniform + distributed=True
+    WITH a registered DFT-plane probe raises NotImplementedError naming
+    add_dft_plane_probe, and that raise propagates through
+    jax.jvp/jacobian_fwd unchanged -- no new code in jacobian_fwd needed.
+    Same NU-sim construction as
+    tests/test_observables_dft_field.py::test_forward_distributed_nu_dft_planes_fence_raises."""
+    nx, ny, nz = 16, 12, 12
+    dx = 1e-3
+    sim = Simulation(
+        freq_max=8e9, domain=(nx * dx, ny * dx, nz * dx), dx=dx,
+        boundary="cpml", cpml_layers=4,
+    )
+    sim._dx_profile = np.full(nx, dx)
+    sim._dy_profile = np.full(ny, dx)
+    sim._dz_profile = np.full(nz, dx)
+    sim.add_source(
+        position=(4 * dx, 6 * dx, 6 * dx), component="ez", amplitude_kind="current",
+    )
+    sim.add_dft_plane_probe(
+        axis="x", coordinate=10 * dx, component="ez", freqs=_FREQS,
+    )
+
+    def sim_fn(alpha):
+        # alpha is unused: the fence fires during forward()'s Python-level
+        # dispatch, before any traced computation touches eps/alpha at all.
+        return sim.forward(distributed=True, n_steps=2, skip_preflight=True)
+
+    with pytest.raises(NotImplementedError, match="add_dft_plane_probe"):
         jacobian_fwd(sim_fn, jnp.asarray(1.0, dtype=jnp.float32))
 
 
@@ -532,9 +607,10 @@ def test_g6d_checkpoint_knobs_are_documented_inert_not_a_raise():
 
 # ---------------------------------------------------------------------------
 # G7 -- FALSIFIER: sever the tape with stop_gradient on eps_override ->
-# Jacobian must go EXACTLY 0, and (witnessed separately, captured to
-# scratchpad/i577_falsifier_red.txt) G1's own assertion form must go RED
-# against the severed objective before this gate is trusted.
+# Jacobian must go EXACTLY 0, and (witnessed separately, transcript
+# printed for the PR body -- see the module docstring) G1's own assertion
+# form must go RED against the severed objective before this gate is
+# trusted.
 # ---------------------------------------------------------------------------
 
 def test_g7_falsifier_severed_tape_reads_exactly_zero():
@@ -578,12 +654,8 @@ def test_g7_falsifier_severed_tape_reads_exactly_zero():
         f"severed geometry tangent (rho) = {float(jac_severed[1])!r} (must be exactly 0.0)\n"
     )
     assert rel >= 1.0, "falsifier did not actually diverge from the FD reference"
-    try:
-        with open(
-            "/tmp/claude-0/-root-workspace-byungkwan-workspace-research-rfx/"
-            "a15d1025-c3b0-4e66-beea-fecee1eeda44/scratchpad/i577_falsifier_red.txt",
-            "w",
-        ) as fh:
-            fh.write(transcript)
-    except OSError:
-        pass  # best-effort artifact capture; the assertions above are the real gate
+    # Print (not write to a fixed path -- no hard-coded session/scratch path
+    # belongs in a committed public-repo test) so `pytest -s` / CI logs carry
+    # the transcript for a PR body excerpt; the assertions above are the
+    # real gate.
+    print(transcript)

--- a/tests/test_jacobian_fwd.py
+++ b/tests/test_jacobian_fwd.py
@@ -1,0 +1,589 @@
+"""Gate tests for `rfx.observables.jacobian_fwd` (issue #577).
+
+`jacobian_fwd` is a thin PACKAGING layer over stock `jax.vmap(jax.jvp(...))`
+-- forward mode already runs end-to-end through `sim.forward(eps_override=
+...)` -> `rfx.observables.dft_field`/`field_energy` today with zero solver
+changes. This module gates the wrapper's own contract: tangent-basis
+construction (`tangents="identity"`), primal de-duplication, batched-vs-
+sequential agreement, the complex-Jacobian (unconjugated) convention, the
+primal-sharing structural claim, and the four documented fences.
+
+G1-G7 map onto the design contract (`gh issue view 577`):
+    G1 FD accuracy (material + geometry legs, many-output tensor leg)
+    G2 conjugation guard
+    G3 primal-sharing STRUCTURAL witness (load-bearing; deterministic)
+    G4 value identity (bit-identical to a plain sim_fn(params) call)
+    G5 batch_tangents=True vs False agreement
+    G6 fence regressions
+    G7 FALSIFIER (severed tape -> Jacobian exactly 0; witnessed red first)
+
+FENCE TAXONOMY (G6) -- read before editing G6: `jacobian_fwd` is generic
+over `sim_fn` (signature pinned to `sim_fn, params, tangents,
+batch_tangents` by `scripts/check_api_reference.py`'s inventory) and never
+sees `Simulation.forward()`'s own keyword arguments -- they live inside the
+caller's closure. Two of the four documented fences are RUNTIME RAISES
+that `jacobian_fwd` INHERITS for free (the underlying `forward()` call
+raises before `jacobian_fwd`'s own machinery runs, so the raise just
+propagates up through `jax.jvp`): non-uniform+distributed with a
+registered DFT-plane probe (the #619 fence), and `design_mask` on the
+uniform lane (issue #41's own fence). The other two -- `n_warmup` (a
+measured SILENT NO-OP on the uniform lane, issue #626) and
+`checkpoint`/`checkpoint_segments` (measured EXACTLY NEUTRAL under forward
+mode) -- have NO raise to inherit and cannot be intercepted from outside
+the closure without breaking the pinned generic signature, so they are
+DOCUMENTED traps rather than runtime checks; G6 pins the docstring text
+for those two instead of a raise.
+
+FALSIFIER ARTIFACT: `test_g7_falsifier_severed_tape_reads_exactly_zero`
+below writes its captured red-then-green transcript to
+`scratchpad/i577_falsifier_red.txt` (session scratch, not committed) --
+see that file for the PR body excerpt.
+"""
+
+from __future__ import annotations
+
+import math
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.extend.core import ClosedJaxpr as _ClosedJaxpr, Jaxpr as _Jaxpr
+
+from rfx import Simulation
+from rfx.observables import dft_field, field_energy, jacobian_fwd
+from rfx.topology import density_to_material_fields
+
+try:
+    from jax import enable_x64
+except ImportError:  # older JAX (< ~0.4.31) -- see tests/_x64_compat.py
+    from tests._x64_compat import enable_x64
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture -- same geometry family as tests/test_observables_dft_field.py
+# (a proven, currently-green fixture), with the geometry-leg design pixel
+# moved OFF the material-leg slab (x=24mm vs slab 12-18mm) so a JOINT
+# {alpha, rho} params pytree can be gated in one jacobian_fwd call without
+# the two legs' design regions overlapping (the #483-class confound the
+# design contract warns about: keep design regions off each other's and the
+# source's cells so FD and AD differentiate the same single channel).
+# ---------------------------------------------------------------------------
+
+_DX = 1.0e-3
+_NX, _NY, _NZ = 30, 20, 20
+_PLANE = "probe_plane"
+_FREQS = jnp.asarray([5.0e9])
+_SRC_POS_M = (8 * _DX, 10 * _DX, 10 * _DX)
+_SLAB_LO_M = (12 * _DX, 0.0, 0.0)
+_SLAB_HI_M = (18 * _DX, _NY * _DX, _NZ * _DX)
+_PIXEL_POS_M = (24 * _DX, 10 * _DX, 10 * _DX)  # OFF the slab (12-18mm)
+_N_STEPS = 160
+# Material leg has a strong signal (rel_err 0.007-0.038% across this range).
+_FD_H_VALUES_MATERIAL = (0.01, 0.02, 0.04)
+# Geometry leg is a single-pixel perturbation with a much smaller signal
+# (~1e-11 vs material's ~1e-9): MEASURED h=0.01 rel_err 7.4% is float32
+# rounding-lattice noise on that tiny signal, not a real derivative
+# mismatch -- h=0.02/0.04/0.08 all cluster tightly at 0.5-0.6% (the
+# convergent-derivative signature vs. a coincidental-h false green), so
+# the sweep starts at 0.02 for this leg specifically. This IS the h-drift
+# check the design contract asks for: a real derivative holds steady as h
+# grows past the noise floor, while a rounding-lattice coincidence would
+# not.
+_FD_H_VALUES_GEOMETRY = (0.02, 0.04, 0.08)
+
+
+def _build_sim() -> Simulation:
+    sim = Simulation(
+        freq_max=8e9, domain=(_NX * _DX, _NY * _DX, _NZ * _DX), dx=_DX,
+        boundary="cpml", cpml_layers=5,
+    )
+    sim.add_source(
+        position=_SRC_POS_M, component="ez", amplitude_kind="current",
+    )
+    sim.add_dft_plane_probe(
+        axis="x", coordinate=20 * _DX, component="ez",
+        freqs=_FREQS, name=_PLANE,
+    )
+    return sim
+
+
+def _grid_and_eps_base(sim: Simulation):
+    grid = sim._build_grid()
+    eps_base = jnp.ones(grid.shape, dtype=jnp.float32)
+    return grid, eps_base
+
+
+def _slab_and_pixel_indices(sim: Simulation):
+    grid, eps_base = _grid_and_eps_base(sim)
+    lo = grid.position_to_index(_SLAB_LO_M)
+    hi = grid.position_to_index(_SLAB_HI_M)
+    slab = (slice(lo[0], hi[0] + 1), slice(None), slice(None))
+    pix = grid.position_to_index(_PIXEL_POS_M)
+    return grid, eps_base, slab, pix
+
+
+def _make_eps(eps_base, slab, pix, alpha, rho, *, eps_bg=1.0, eps_fg=4.0,
+              stop_gradient_tape: bool = False):
+    eps = eps_base.at[slab].set(alpha)
+    rho_arr = jnp.reshape(rho, (1, 1, 1))
+    fields = density_to_material_fields(rho_arr, eps_bg, eps_fg)
+    eps = eps.at[pix[0], pix[1], pix[2]].set(fields.eps[0, 0, 0])
+    if stop_gradient_tape:
+        eps = jax.lax.stop_gradient(eps)
+    return eps
+
+
+def _joint_objective(sim, functional, *, stop_gradient_tape: bool = False):
+    """params = {'alpha': material slab scale, 'rho': geometry density
+    pixel}, functional applied to the forward() result."""
+    grid, eps_base, slab, pix = _slab_and_pixel_indices(sim)
+
+    def objective(params):
+        eps = _make_eps(
+            eps_base, slab, pix, params["alpha"], params["rho"],
+            stop_gradient_tape=stop_gradient_tape,
+        )
+        result = sim.forward(
+            eps_override=eps, n_steps=_N_STEPS, checkpoint=False,
+            skip_preflight=True,
+        )
+        return functional(result)
+
+    return objective
+
+
+def _material_only_objective(sim, functional, *, stop_gradient_tape: bool = False):
+    """params = scalar alpha (material leg only) -- used for the
+    many-output tensor leg (G1/G2), which needs a single tangent
+    direction, not the joint {alpha, rho} pytree."""
+    grid, eps_base, slab, _pix = _slab_and_pixel_indices(sim)
+
+    def objective(alpha):
+        eps = eps_base.at[slab].set(alpha)
+        if stop_gradient_tape:
+            eps = jax.lax.stop_gradient(eps)
+        result = sim.forward(
+            eps_override=eps, n_steps=_N_STEPS, checkpoint=False,
+            skip_preflight=True,
+        )
+        return functional(result)
+
+    return objective
+
+
+def _central_fd_f64(objective, x0: float, h: float):
+    """Central FD, comparison arithmetic in float64 (#527/#579 discipline):
+    fields stay float32, only the FD/comparison math gains precision."""
+    with enable_x64():
+        fp = objective(jnp.asarray(x0 + h, dtype=jnp.float32))
+        fm = objective(jnp.asarray(x0 - h, dtype=jnp.float32))
+        return (fp - fm) / (2.0 * h)
+
+
+_ALPHA0 = 2.0
+_RHO0 = 0.5
+_PARAMS0 = {"alpha": jnp.asarray(_ALPHA0, dtype=jnp.float32),
+            "rho": jnp.asarray(_RHO0, dtype=jnp.float32)}
+
+
+# ---------------------------------------------------------------------------
+# G1 -- FD accuracy: material leg, geometry leg (joint pytree, tangents=
+# "identity", n_t=2), and the many-output tensor leg.
+# ---------------------------------------------------------------------------
+
+def test_g1_material_and_geometry_legs_ad_matches_fd():
+    sim = _build_sim()
+    functional = field_energy(_PLANE)
+    objective = _joint_objective(sim, functional)
+
+    val, jac = jacobian_fwd(objective, _PARAMS0)
+    assert float(val) > 0.0, "field_energy did not couple to the source"
+    # tangents='identity' flattens {'alpha','rho'} in tree_flatten order
+    # (dict keys sorted): 'alpha' first, 'rho' second.
+    g_ad_alpha = float(jac[0])
+    g_ad_rho = float(jac[1])
+    assert jac.shape == (2,)
+
+    for h in _FD_H_VALUES_MATERIAL:
+        g_fd_alpha = float(_central_fd_f64(
+            lambda a: objective({"alpha": a, "rho": jnp.asarray(_RHO0, dtype=jnp.float32)}),
+            _ALPHA0, h,
+        ))
+        rel = abs(g_ad_alpha - g_fd_alpha) / max(abs(g_fd_alpha), 1e-30)
+        assert rel < 0.05, (
+            f"material leg h={h}: AD {g_ad_alpha:.6e} vs FD {g_fd_alpha:.6e}, "
+            f"rel_err {rel * 100:.2f}%"
+        )
+
+    for h in _FD_H_VALUES_GEOMETRY:
+        g_fd_rho = float(_central_fd_f64(
+            lambda r: objective({"alpha": jnp.asarray(_ALPHA0, dtype=jnp.float32), "rho": r}),
+            _RHO0, h,
+        ))
+        rel = abs(g_ad_rho - g_fd_rho) / max(abs(g_fd_rho), 1e-30)
+        assert rel < 0.05, (
+            f"geometry leg h={h}: AD {g_ad_rho:.6e} vs FD {g_fd_rho:.6e}, "
+            f"rel_err {rel * 100:.2f}%"
+        )
+
+
+def test_g1_many_output_tensor_leg_ad_matches_fd():
+    """The (n_freqs, n1, n2) complex dft_field tensor, not a scalar
+    reduction -- exercises jacobian_fwd on a many-output sim_fn."""
+    sim = _build_sim()
+    accessor = dft_field(_PLANE)
+    objective = _material_only_objective(sim, accessor)
+
+    alpha0 = jnp.asarray(_ALPHA0, dtype=jnp.float32)
+    val, jac = jacobian_fwd(objective, alpha0)
+    assert jac.shape == (1,) + val.shape
+
+    h = 0.02
+    with enable_x64():
+        fp = objective(jnp.asarray(_ALPHA0 + h, dtype=jnp.float32))
+        fm = objective(jnp.asarray(_ALPHA0 - h, dtype=jnp.float32))
+        j_fd = (fp - fm) / (2.0 * h)
+
+    num = float(jnp.linalg.norm((jac[0] - j_fd).ravel()))
+    den = float(jnp.linalg.norm(j_fd.ravel()))
+    rel = num / den
+    assert rel < 0.05, f"tensor leg ||AD-FD||/||FD|| = {rel * 100:.3f}%"
+    assert den > 0.0, "FD tensor Jacobian is exactly zero -- objective did not couple"
+
+
+# ---------------------------------------------------------------------------
+# G2 -- conjugation guard: AD matches the UNCONJUGATED FD, not conj(FD).
+# ---------------------------------------------------------------------------
+
+def test_g2_jacobian_is_unconjugated_dy_dx():
+    sim = _build_sim()
+    accessor = dft_field(_PLANE)
+    objective = _material_only_objective(sim, accessor)
+
+    alpha0 = jnp.asarray(_ALPHA0, dtype=jnp.float32)
+    _val, jac = jacobian_fwd(objective, alpha0)
+    j_ad = jac[0]
+
+    h = 0.02
+    with enable_x64():
+        fp = objective(jnp.asarray(_ALPHA0 + h, dtype=jnp.float32))
+        fm = objective(jnp.asarray(_ALPHA0 - h, dtype=jnp.float32))
+        j_fd = (fp - fm) / (2.0 * h)
+
+    rel_unconj = float(jnp.linalg.norm((j_ad - j_fd).ravel())) / float(jnp.linalg.norm(j_fd.ravel()))
+    rel_conj = float(jnp.linalg.norm((j_ad - jnp.conj(j_fd)).ravel())) / float(jnp.linalg.norm(j_fd.ravel()))
+
+    assert rel_unconj < 0.05, f"AD should match UNCONJUGATED FD: rel_err={rel_unconj * 100:.3f}%"
+    assert rel_conj > 0.5, (
+        f"AD unexpectedly matches conj(FD) (rel_err={rel_conj * 100:.3f}%) -- "
+        "the discriminator that catches a silent conjugation bug did not fire"
+    )
+
+
+# ---------------------------------------------------------------------------
+# G3 -- PRIMAL-SHARING STRUCTURAL WITNESS (load-bearing; deterministic).
+#
+# Walks the jaxpr of jax.jit(lambda p: jacobian_fwd(sim_fn, p)) and finds
+# the top-level lax.scan (the FDTD time loop). If the primal sweep is
+# genuinely shared across tangent directions, the scan's carry holds
+# exactly ONE unbatched copy of the field state (byte count INDEPENDENT of
+# n_t) plus n_t batched tangent copies -- not a wall-clock proxy.
+# ---------------------------------------------------------------------------
+
+class _jcore:
+    ClosedJaxpr = _ClosedJaxpr
+    Jaxpr = _Jaxpr
+
+
+def _find_shallowest_scan(jaxpr):
+    """Depth-first search for the SHALLOWEST `lax.scan` equation, recursing
+    through nested (Closed)Jaxpr params -- `jax.jit(...)` wraps the traced
+    program in a `pjit` equation whose own params carry the inner jaxpr, so
+    a plain top-level scan of `jaxpr.eqns` misses it one level down."""
+    by_depth: list[tuple[int, object]] = []
+
+    def walk(jx, depth):
+        for eqn in jx.eqns:
+            if eqn.primitive.name == "scan":
+                by_depth.append((depth, eqn))
+            for v in eqn.params.values():
+                if isinstance(v, _jcore.ClosedJaxpr):
+                    walk(v.jaxpr, depth + 1)
+                elif isinstance(v, _jcore.Jaxpr):
+                    walk(v, depth + 1)
+                elif isinstance(v, (list, tuple)):
+                    for item in v:
+                        if isinstance(item, _jcore.ClosedJaxpr):
+                            walk(item.jaxpr, depth + 1)
+                        elif isinstance(item, _jcore.Jaxpr):
+                            walk(item, depth + 1)
+
+    walk(jaxpr, 0)
+    if not by_depth:
+        raise AssertionError("no lax.scan found anywhere in jaxpr (FDTD time loop)")
+    by_depth.sort(key=lambda pair: pair[0])
+    eqn = by_depth[0][1]
+    return eqn, eqn.params["jaxpr"].jaxpr
+
+
+def _carry_grid_bytes(eqn, spatial: tuple[int, int, int], n_t: int):
+    num_carry = eqn.params["num_carry"]
+    num_consts = eqn.params["num_consts"]
+    carry_avals = [
+        v.aval for v in eqn.invars[num_consts:num_consts + num_carry]
+    ]
+    primal_bytes, batched_bytes = 0, 0
+    for a in carry_avals:
+        shp = tuple(getattr(a, "shape", ()))
+        if len(shp) < 3 or shp[-3:] != spatial:
+            continue
+        n = 1
+        for d in shp:
+            n *= d
+        nbytes = n * int(jnp.dtype(a.dtype).itemsize)
+        if len(shp) >= 4 and shp[0] == n_t and n_t > 1:
+            batched_bytes += nbytes
+        else:
+            primal_bytes += nbytes
+    return primal_bytes, batched_bytes
+
+
+def _make_design_sim_fn(sim, n_p: int):
+    """params = tuple of n_p independent scalar leaves, each scaling one
+    1-cell-thick x-slice -- gives tangents='identity' exactly n_t=n_p."""
+    grid, eps_base = _grid_and_eps_base(sim)
+    lo = grid.position_to_index(_SLAB_LO_M)[0]
+    xi = [lo + i for i in range(n_p)]
+
+    def sim_fn(params):
+        eps = eps_base
+        for i, a in enumerate(params):
+            eps = eps.at[xi[i], :, :].set(a)
+        result = sim.forward(
+            eps_override=eps, n_steps=_N_STEPS, checkpoint=False,
+            skip_preflight=True,
+        )
+        return dft_field(_PLANE)(result)
+
+    return grid, sim_fn
+
+
+def _measure_carry_bytes(n_t: int):
+    sim = _build_sim()
+    grid, sim_fn = _make_design_sim_fn(sim, n_t)
+    params = tuple(jnp.asarray(1.0, dtype=jnp.float32) for _ in range(n_t))
+
+    jitted = jax.jit(lambda p: jacobian_fwd(sim_fn, p))
+    jaxpr = jax.make_jaxpr(jitted)(params).jaxpr
+    eqn, _inner = _find_shallowest_scan(jaxpr)
+    return _carry_grid_bytes(eqn, tuple(grid.shape), n_t)
+
+
+def test_g3_primal_carry_is_independent_of_n_t():
+    """Deterministic structural witness (no wall-clock): build the
+    compiled jaxpr at n_t=2 and n_t=4 independently within one test (not
+    across separately-ordered parametrized runs, so this cannot silently
+    depend on pytest execution order) and compare the scan's carry byte
+    counts directly.
+
+    n_t=1 is deliberately EXCLUDED, not just an arbitrary choice of two
+    points: MEASURED, at n_t=1 `jax.vmap` elides the size-1 batch axis, so
+    the tangent carry collapses to the SAME shape as the primal carry and
+    this classifier's shape-based primal/batched split cannot tell them
+    apart (both get bucketed as "primal", doubling the count vs n_t=2..4).
+    n_t=2, 3, and 4 all show primal=945,624 B identically while batched
+    bytes scale exactly linearly (945,624 x n_t) -- the decisive, elision-
+    free evidence -- so n_t=2 and n_t=4 are the comparison pair.
+    """
+    primal_2, batched_2 = _measure_carry_bytes(2)
+    primal_4, batched_4 = _measure_carry_bytes(4)
+
+    assert primal_2 > 0 and primal_4 > 0, "no primal-shaped (unbatched) carry found"
+    assert primal_2 == primal_4, (
+        f"primal carry bytes depend on n_t: n_t=2 -> {primal_2}, n_t=4 -> "
+        f"{primal_4} -- the primal sweep is NOT shared across tangent directions"
+    )
+    assert batched_4 == pytest.approx(2 * batched_2, rel=0.05), (
+        f"batched carry bytes did not scale ~linearly with n_t: "
+        f"n_t=2 -> {batched_2}, n_t=4 -> {batched_4}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# G4 -- value identity: returned value bit-identical to a plain sim_fn(params).
+# ---------------------------------------------------------------------------
+
+def test_g4_value_bit_identical_to_plain_call():
+    sim = _build_sim()
+    objective = _joint_objective(sim, field_energy(_PLANE))
+
+    plain = objective(_PARAMS0)
+    val_batched, _jac = jacobian_fwd(objective, _PARAMS0, batch_tangents=True)
+    val_seq, _jac2 = jacobian_fwd(objective, _PARAMS0, batch_tangents=False)
+
+    assert val_batched == plain, f"batched value {val_batched} != plain {plain}"
+    assert val_seq == plain, f"sequential value {val_seq} != plain {plain}"
+
+
+def test_g4_value_bit_identical_many_output():
+    sim = _build_sim()
+    objective = _material_only_objective(sim, dft_field(_PLANE))
+    alpha0 = jnp.asarray(_ALPHA0, dtype=jnp.float32)
+
+    plain = objective(alpha0)
+    val, _jac = jacobian_fwd(objective, alpha0)
+    np.testing.assert_array_equal(np.asarray(val), np.asarray(plain))
+
+
+# ---------------------------------------------------------------------------
+# G5 -- batch_tangents=True vs False agreement (different XLA programs;
+# float32 reassociation tolerance, not bit-identity).
+# ---------------------------------------------------------------------------
+
+def test_g5_batched_and_sequential_jacobians_agree():
+    sim = _build_sim()
+    objective = _joint_objective(sim, field_energy(_PLANE))
+
+    _val_b, jac_batched = jacobian_fwd(objective, _PARAMS0, batch_tangents=True)
+    _val_s, jac_seq = jacobian_fwd(objective, _PARAMS0, batch_tangents=False)
+
+    np.testing.assert_allclose(
+        np.asarray(jac_batched), np.asarray(jac_seq), rtol=1e-4, atol=1e-12,
+    )
+
+
+def test_g5_batched_and_sequential_agree_many_output():
+    sim = _build_sim()
+    objective = _material_only_objective(sim, dft_field(_PLANE))
+    alpha0 = jnp.asarray(_ALPHA0, dtype=jnp.float32)
+
+    _val_b, jac_batched = jacobian_fwd(objective, alpha0, batch_tangents=True)
+    _val_s, jac_seq = jacobian_fwd(objective, alpha0, batch_tangents=False)
+
+    np.testing.assert_allclose(
+        np.asarray(jac_batched), np.asarray(jac_seq), rtol=1e-4, atol=1e-12,
+    )
+
+
+# ---------------------------------------------------------------------------
+# G6 -- fence regressions. See the module docstring's FENCE TAXONOMY for
+# why G6a/G6b are runtime-raise gates and G6c/G6d are docstring-content
+# gates.
+# ---------------------------------------------------------------------------
+
+def test_g6a_distributed_fence_raises():
+    """Inherited from forward()'s own distributed dispatch check (fires
+    before any DFT-plane-specific check): a uniform sim + distributed=True
+    raises NotImplementedError, and that raise propagates through
+    jax.jvp/jacobian_fwd unchanged -- no new code in jacobian_fwd needed."""
+    sim = _build_sim()
+
+    def sim_fn(alpha):
+        eps = jnp.ones(sim._build_grid().shape, dtype=jnp.float32) * alpha
+        result = sim.forward(
+            eps_override=eps, n_steps=2, distributed=True, skip_preflight=True,
+        )
+        return dft_field(_PLANE)(result)
+
+    with pytest.raises(NotImplementedError):
+        jacobian_fwd(sim_fn, jnp.asarray(1.0, dtype=jnp.float32))
+
+
+def test_g6b_design_mask_fence_raises():
+    """Inherited from forward()'s own uniform-lane design_mask fence
+    (issue #41): design_mask is not None on the uniform lane raises
+    NotImplementedError regardless of AD mode."""
+    sim = _build_sim()
+    grid = sim._build_grid()
+    mask = jnp.zeros(grid.shape, dtype=bool).at[15, 10, 10].set(True)
+
+    def sim_fn(alpha):
+        eps = jnp.ones(grid.shape, dtype=jnp.float32) * alpha
+        result = sim.forward(
+            eps_override=eps, n_steps=2, design_mask=mask, skip_preflight=True,
+        )
+        return dft_field(_PLANE)(result)
+
+    with pytest.raises(NotImplementedError, match="design_mask"):
+        jacobian_fwd(sim_fn, jnp.asarray(1.0, dtype=jnp.float32))
+
+
+def test_g6c_n_warmup_is_a_documented_trap_not_a_raise():
+    """No forward()-level raise exists to inherit (n_warmup is a measured
+    SILENT NO-OP on the uniform lane) -- pin the docstring warning instead
+    so it cannot silently be dropped in a future edit."""
+    doc = jacobian_fwd.__doc__
+    assert "n_warmup" in doc
+    assert "SILENT NO-OP" in doc
+    assert "#626" in doc
+
+
+def test_g6d_checkpoint_knobs_are_documented_inert_not_a_raise():
+    """No forward()-level raise exists to inherit (checkpoint/
+    checkpoint_segments are measured EXACTLY NEUTRAL under forward mode) --
+    pin the docstring warning instead."""
+    doc = jacobian_fwd.__doc__
+    assert "checkpoint" in doc
+    assert "checkpoint_segments" in doc
+    assert "EXACTLY NEUTRAL" in doc
+    assert "reverse-mode knobs" in doc
+
+
+# ---------------------------------------------------------------------------
+# G7 -- FALSIFIER: sever the tape with stop_gradient on eps_override ->
+# Jacobian must go EXACTLY 0, and (witnessed separately, captured to
+# scratchpad/i577_falsifier_red.txt) G1's own assertion form must go RED
+# against the severed objective before this gate is trusted.
+# ---------------------------------------------------------------------------
+
+def test_g7_falsifier_severed_tape_reads_exactly_zero():
+    sim = _build_sim()
+    functional = field_energy(_PLANE)
+    severed = _joint_objective(sim, functional, stop_gradient_tape=True)
+    unsevered = _joint_objective(sim, functional, stop_gradient_tape=False)
+
+    val_severed, jac_severed = jacobian_fwd(severed, _PARAMS0)
+    val_unsevered, jac_unsevered = jacobian_fwd(unsevered, _PARAMS0)
+
+    # Values are unaffected by stop_gradient (forward physics unchanged).
+    assert val_severed == val_unsevered
+
+    assert jac_severed[0] == 0.0, f"severed material tangent not exactly 0: {jac_severed[0]!r}"
+    assert jac_severed[1] == 0.0, f"severed geometry tangent not exactly 0: {jac_severed[1]!r}"
+    assert jac_unsevered[0] != 0.0, "unsevered material tangent is exactly 0 -- objective did not couple"
+    assert jac_unsevered[1] != 0.0, "unsevered geometry tangent is exactly 0 -- objective did not couple"
+
+    # Witness that G1's own tolerance check would go RED against the
+    # severed objective (AD=0 exactly, FD finite -> the gate the falsifier
+    # is meant to catch really would fire). Capture the transcript.
+    h = 0.02
+    g_fd_alpha = float(_central_fd_f64(
+        lambda a: severed({"alpha": a, "rho": jnp.asarray(_RHO0, dtype=jnp.float32)}),
+        _ALPHA0, h,
+    ))
+    rel = abs(float(jac_severed[0]) - g_fd_alpha) / max(abs(g_fd_alpha), 1e-30)
+
+    transcript = (
+        "#577 G7 falsifier transcript\n"
+        "============================\n"
+        f"severed AD tangent (alpha) = {float(jac_severed[0])!r} (must be exactly 0.0)\n"
+        f"severed FD reference (alpha, h={h}) = {g_fd_alpha!r} (finite, nonzero)\n"
+        f"rel_err AD-vs-FD on the SEVERED objective = {rel * 100:.2f}%\n"
+        f"G1 tolerance is 5% -- this rel_err is >= 100% (0 vs finite), so G1's\n"
+        f"own assertion form goes RED against the severed objective, confirming\n"
+        f"the gate is witnessed before being trusted green on the unsevered one.\n\n"
+        f"unsevered AD tangent (alpha) = {float(jac_unsevered[0])!r} (finite, matches G1)\n"
+        f"unsevered geometry tangent (rho) = {float(jac_unsevered[1])!r} (finite)\n"
+        f"severed geometry tangent (rho) = {float(jac_severed[1])!r} (must be exactly 0.0)\n"
+    )
+    assert rel >= 1.0, "falsifier did not actually diverge from the FD reference"
+    try:
+        with open(
+            "/tmp/claude-0/-root-workspace-byungkwan-workspace-research-rfx/"
+            "a15d1025-c3b0-4e66-beea-fecee1eeda44/scratchpad/i577_falsifier_red.txt",
+            "w",
+        ) as fh:
+            fh.write(transcript)
+    except OSError:
+        pass  # best-effort artifact capture; the assertions above are the real gate


### PR DESCRIPTION
Closes #577. Follow-ups filed from this arc: #625 (`design_mask` zero derivatives), #626 (`n_warmup` silent no-op), #630 (a third precision stage that caps FD verification of small design perturbations).

**Provenance**, since the issue author had deprioritized this: the author's own 2026-08-06 comment moved #577 off the critical path because #579 displaced it and asked that nobody reprioritize other work for it. #579 shipped on 2026-08-10 (PR #619), and the PI directed this session the same day to proceed to #577 after #622 and #582. That is the request this PR answers.

## The honest headline: forward mode already worked; this is packaging

Before writing any code we measured whether the feature was even needed. It was not, in the way the issue assumed: `jax.jvp`, `jax.jacfwd` and `vmap(jvp)` all already run end-to-end through `sim.forward(eps_override=…)` → `rfx.observables.dft_field(…)` on the uniform single-device lane, with **zero solver changes**, returning FD-matching Jacobians. `rfx.jacobian_fwd` is a thin, well-gated wrapper — a tangent convention, dtype/float0 handling, value de-duplication, fences and documentation — not new capability. The PR says so rather than dressing it up.

## The cost number the issue asked for — and it contradicts the issue's premise

The issue predicted "a few times one solve, not N times". Measured, it is **(1 + n_t) × one plain solve** in both time and memory:

| grid | n_t=10 wall | flops | compiler memory estimate |
|---|---|---|---|
| 33,635 cells | 5.9× plain | 17.5× | 10.4× |
| 178,475 cells (5.3× cells) | 7.3× plain | 18.6× | 10.4× |

CPU, jax 0.10.2, float32, n_steps=120, n_p=10. Wall time is load-sensitive; the deterministic columns reproduce an independent probe's measurements to within ~1% on both grids. The ratio drifts toward the flop ratio as the grid grows, so **every published ratio carries its grid size** and a production 3-D problem should be budgeted nearer 1.5 + 1.7·n_t.

The issue's *premise* does hold — the primal sweep is genuinely shared — with two independent witnesses: the vmap(jvp) jaxpr has exactly one scan whose carry holds one unbatched copy of the field state (945,624 B) at n_t = 2, 3 and 4 while the tangent carry scales exactly ×n_t; and every cost fit `a + b·n_t` has its intercept on one plain solve (flops ratio 0.984). What the issue underestimated is `b`: each tangent costs 1.65–1.76 primal sweeps in flops, i.e. a derivative direction is dearer than the physics it differentiates.

**The real argument is memory, and it should be the headline of the economics.** Forward-mode allocation is O(state)·(1 + 0.93·n_t) and **independent of n_steps** (measured 0.016% change from 120 → 240 steps), whereas reverse mode without segmented remat is 54.5× one solve at only 120 steps. And `jax.jacrev` refuses the complex DFT tensor outright (`TypeError`, wants `holomorphic=True`), while reverse mode would need 961 VJPs for the same Jacobian. The issue's choice of mode is validated even though its cost estimate was optimistic.

## API and semantics

`jacobian_fwd(sim_fn, params, *, tangents="identity", batch_tangents=True) -> (value, jacobian)`, implemented as `vmap(jvp)` over the tangent argument — **not** `jax.linearize`, which measured 8654 MB vs 355 MB (24.4×) at n_steps=600/n_t=10 for the same wall time because it materializes the whole scan's primal residuals, i.e. the reverse tape.

`jacobian` mirrors the **function output's** pytree structure (not `params`), each leaf gaining a leading `n_t` axis — a first-draft docstring said the opposite, which reads fine and ships wrong; the shipped version was verified empirically on multi-leaf input *and* output pytrees. `tangents="identity"` is defined per-element over scalar leaves and **fails loud** on non-scalar leaves: a per-leaf one-hot on a `{'scalar': (), 'field': (4,4)}` pytree silently returns the *sum* of that leaf's 16 Jacobian entries — a directional derivative masquerading as a Jacobian column. The complex convention is declared: the returned Jacobian is unconjugated dy/dx and differs by a conjugate from anything derived through `jax.vjp`/`jax.grad`.

`batch_tangents=False` is kept as the memory-vs-speed knob it measurably is (1 + 0.93 states instead of 1 + 0.93·n_t, at ~3.6× the wall time).

## Fence taxonomy — stated, not fudged

`jacobian_fwd` takes a generic `sim_fn` closure, so it cannot see `forward()`'s own kwargs. Rather than pretend otherwise, each fence is labelled in the docstring: `design_mask` and the distributed DFT-plane path are **[RAISES, inherited]** (verified: `forward()` itself raises before any AD machinery runs, both pinned with `match=`); `n_warmup` and the checkpoint knobs are **[DOCS ONLY]** traps — `n_warmup` is a measured silent no-op on this lane producing a bit-identical jaxpr, so there is provably nothing to detect, and the remat knobs are measured exactly neutral under forward mode because there is no tape to rematerialize.

## Gates

G1 FD accuracy on both AC legs with an h-sweep (material 0.007–0.038%; geometry 0.49–0.59% over h ∈ {0.02, 0.04, 0.08}); G2 conjugation discriminator (unconjugated < 5%, conjugated ≥ 50%); **G3 primal-sharing structural test** — the load-bearing claim, asserted deterministically from the jaxpr rather than from wall-clock; G4 value bit-identical to a plain call; G5 batched ≡ sequential; G6 fence regressions; G7 one-sided falsifier (severed tape → exactly 0.0, witnessed red before anything was trusted green). The benchmark ships as a regenerable script plus a relations-only test (ratio bands and orderings, never magic constants).

**On the geometry leg's h range**, since shifting a sweep to make a gate pass is exactly the trap this repo has been bitten by: review settled it with a decisive experiment rather than an argument. Forcing full float64 fields moves the AD value by 1.0e-7 relative while improving the FD reference ~6× on the gated range — the FD comparator was the noisy side. A third line, raising the geometry signal ~961× by driving a full density slice on stock float32, agrees with AD to 0.003–0.066% across the entire ladder including h = 0.0025. Small-h points stay irregular even in f64; that residual is now #630, and it is a repo-wide limit on FD verification of small localized perturbations, not a defect in this Jacobian.

## Scope limits stated in user-facing docs

"Geometry parameter" is **not** a parametric dimension: a traced `Box` corner raises `ConcretizationTypeError` and the raster is a binary mask with zero gradient a.e. The only continuous geometry DoFs are topology density, `pec_occupancy_override` and NU `dz_profile`. Uniform single-device lane only. The Kerr χ³ tangent path ran clean but was indistinguishable from linear at the tested χ³ and is **not** claimed. All numbers are CPU; no GPU claim is made anywhere — I will run the benchmark once on the GPU lane after merge and post that table to the issue.

R3: memory=none-after-grep for forward-mode/JVP/Sobolev (nearest neighbours #619 observables and #618 vmap batching, both supportive) | R2-attempts=0 (new capability, not a repeat) | falsifier=G7 severed-tape red, witnessed before any green was trusted

🤖 Generated with [Claude Code](https://claude.com/claude-code)