### PR TITLE
fix(distributed): place the uniform lane's x-hi CPML window and PEC/PMC faces at the real boundary in the pad_x>0 lane (closes #623)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,54 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — uniform distributed lane's CPML/PEC x-hi wall displacement in the pad_x>0 lane (issue #623)
+
+- Same class as #622, in the sibling UNIFORM-grid runner:
+  `rfx.runners.distributed._apply_cpml_e_distributed` and
+  `_apply_cpml_h_distributed` (called from `distributed_v2.py`'s
+  `_apply_cpml_e_shmap` / `_apply_cpml_h_shmap`, which is what production
+  `sim.run(distributed=True)` / `devices=...` dispatches to) left the x-hi
+  CPML absorber window at the padded slab end instead of shifting it left
+  by `pad_x`, whenever `nx % n_devices != 0` (the common case post-#564,
+  since an even cell request now realizes an odd node count). Measured on
+  a 2-device CPML fixture with `nx=59` (`pad_x=1`), probe near the x-hi
+  face: `rel_err` **3.14e-01 pre-fix vs 8.13e-06 post-fix** (~38,600x) —
+  a clean physics witness, unlike #622's PEC-face site which needed a
+  structural array assertion because the x-hi terminal node there is an
+  identically-zero fixed point under PEC.
+- The legacy `jax.pmap` runner's `_apply_pec_local` / `_apply_pmc_local`
+  x-hi face appliers had the matching off-by-`pad_x` bug, but this site
+  is currently UNREACHABLE through the public `run_distributed()` entry
+  point — it hard-raises `ValueError` when `nx % n_devices != 0` (no
+  padding support there), so the fix is defensive/consistency-only,
+  witnessed by a direct structural unit test (mirrors #622's F4: no
+  simulation-level fixture can trigger this site).
+- Fix: threads a static `pad_x` (Python int, default 0) into both CPML
+  appliers and the legacy PEC/PMC appliers; the x-hi window/face index
+  shifts by `pad_x` so it covers the real physical face (global node
+  `nx - 1`), matching single-device `cpml.py`'s `[nx-n, nx)`. The
+  `pad_x == 0` lane is unchanged (no-op shift). Four pre-existing
+  2-device tests in `tests/test_distributed.py` already exercised
+  `pad_x=1` (3 Debye + 1 Lorentz fixtures) — measured **0.0 rel_err
+  before AND after** this fix. That is a structural, not a
+  timing/reach, result: those fixtures use `boundary="pec"`, which
+  routes through `distributed_v2.py`'s `_apply_pec_shmap` /
+  `_apply_pmc_shmap` (already made `pad_x`-aware by #622) — the CPML
+  appliers and legacy pmap appliers this PR touches are never invoked
+  on a PEC-boundary run at all, so this PR's fix has no code path to
+  move on that fixture regardless of probe placement or run length.
+- Lane visibility: `tests/test_distributed.py` carried a module-wide
+  `pytest.mark.gpu` (plus a since-superseded `os.environ["XLA_FLAGS"] =
+  ...` override that the root conftest's `setdefault`-based ordering
+  already made a no-op) that put its entire 2-/4-device family in the
+  same runs-nowhere state #622 found and fixed for
+  `test_distributed_nu_kernel.py`. The marker is removed; measured
+  (2-device conftest default): 33/33 passed, 65-68 s wall, 1.74 GiB peak
+  RSS — comparable to (and below) the NU kernel file's precedent (62-66
+  s, 1.93 GiB) and well under the `highmem` marker's 3-24 GB band. The
+  file now runs in the same fast-suite/weekly CPU shards as its NU
+  siblings. `scripts/vessl_gpu_suite.yaml`'s comment is updated to match.
+
 ### Added — `rfx.jacobian_fwd`, a batched forward-mode Jacobian wrapper (issue #577)
 
 - `rfx.observables.jacobian_fwd(sim_fn, params, *, tangents="identity",

--- a/rfx/runners/distributed.py
+++ b/rfx/runners/distributed.py
@@ -529,13 +529,19 @@ def _update_e_local_with_dispersion(state, materials, dt, dx,
     return new_fdtd, new_debye_st, new_lor_st
 
 
-def _apply_pec_local(state, n_devices, nx_local_with_ghost, axis_name="devices"):
+def _apply_pec_local(state, n_devices, nx_local_with_ghost, axis_name="devices",
+                     pad_x: int = 0):
     """Apply PEC boundary on a local slab.
 
     - y and z PEC: always applied (all devices own the full y/z extent).
     - x PEC: only device 0 applies x-lo, only device N-1 applies x-hi.
       These operate on the first/last REAL cell (index ghost and
-      nx_local+ghost-1), not the ghost cell itself.
+      nx_local+ghost-1-pad_x), not the ghost cell itself.
+
+    ``pad_x`` (#623, same class as #622): when the last rank's slab
+    carries alignment-pad cells past the real x-hi face (global node
+    ``nx - 1``), the face must act on that real node, not on the
+    padded slab end.
     """
     device_idx = lax.axis_index(axis_name)
     ghost = 1
@@ -564,9 +570,10 @@ def _apply_pec_local(state, n_devices, nx_local_with_ghost, axis_name="devices")
     ey = ey.at[ghost, :, :].set(ey_xlo)
     ez = ez.at[ghost, :, :].set(ez_xlo)
 
-    # Device N-1: x-hi PEC at last real cell
+    # Device N-1: x-hi PEC at last real cell (skip ghost AND alignment
+    # pad, #623 — same class as #622)
     is_last = (device_idx == n_devices - 1)
-    last_real = nx_local_with_ghost - 1 - ghost  # last real cell index
+    last_real = nx_local_with_ghost - 1 - ghost - pad_x  # last real cell index
     ey_xhi = jnp.where(is_last, 0.0, ey[last_real, :, :])
     ez_xhi = jnp.where(is_last, 0.0, ez[last_real, :, :])
     ey = ey.at[last_real, :, :].set(ey_xhi)
@@ -576,7 +583,7 @@ def _apply_pec_local(state, n_devices, nx_local_with_ghost, axis_name="devices")
 
 
 def _apply_pmc_local(state, n_devices, nx_local_with_ghost, axis_name,
-                     pmc_faces):
+                     pmc_faces, pad_x: int = 0):
     """Apply PMC (``H_tangential = 0``) on a local slab.
 
     Electromagnetic dual of :func:`_apply_pec_local`. Hook point is the
@@ -587,7 +594,9 @@ def _apply_pmc_local(state, n_devices, nx_local_with_ghost, axis_name,
       full y/z extent).
     - x PMC: only device 0 applies x-lo, only device N-1 applies x-hi.
       Acts on the first/last REAL cell (index ghost and
-      ``nx_local_with_ghost - 1 - ghost``), NOT the ghost cell.
+      ``nx_local_with_ghost - 1 - ghost - pad_x``), NOT the ghost cell
+      nor the alignment-pad cells when ``pad_x > 0`` (#623, same class
+      as #622).
     """
     if not pmc_faces:
         return state
@@ -616,7 +625,7 @@ def _apply_pmc_local(state, n_devices, nx_local_with_ghost, axis_name,
 
     is_first = (device_idx == 0)
     is_last = (device_idx == n_devices - 1)
-    last_real = nx_local_with_ghost - 1 - ghost
+    last_real = nx_local_with_ghost - 1 - ghost - pad_x
     last_inside = last_real - 1
 
     if "x_lo" in pmc_faces:
@@ -712,7 +721,7 @@ def _init_cpml_distributed(grid, nx_local, n_devices):
 
 def _apply_cpml_e_distributed(
     state, cpml_params, cpml_state, n_cpml, dt, dx,
-    n_devices, ghost=1, axis_name="devices", eps_r=None,
+    n_devices, ghost=1, axis_name="devices", eps_r=None, pad_x: int = 0,
 ):
     """Apply CPML E-field correction on a distributed slab.
 
@@ -721,7 +730,7 @@ def _apply_cpml_e_distributed(
     Non-active faces are masked to zero via jnp.where.
 
     X-axis indexing accounts for ghost cells: x-lo uses
-    ``[ghost:ghost+n]``, x-hi uses ``[-(ghost+n):-ghost]``.
+    ``[ghost:ghost+n]``, x-hi uses ``[-(ghost+pad_x+n):-(ghost+pad_x)]``.
 
     Parameters
     ----------
@@ -746,16 +755,29 @@ def _apply_cpml_e_distributed(
         absorber stays impedance-matched inside a dielectric (mirrors the
         single-device ``apply_cpml_e``).  ``None`` falls back to the vacuum
         scalar ``dt / eps_0`` (bit-identical to the pre-#205 behaviour).
+    pad_x : int
+        Number of alignment-pad cells appended to the high-x end of the
+        last rank's slab so that ``(nx + pad_x) % n_devices == 0``
+        (#623, same class as #622). The x-hi CPML window is shifted left
+        by ``pad_x`` so it covers the real physical face (global node
+        ``nx - 1``), matching single-device ``cpml.py``'s ``[nx-n, nx)``
+        (a no-op on other ranks / when ``pad_x == 0``).
     """
     n = n_cpml
     g = ghost
+    # #623: on the last rank, pad_x alignment cells sit past the real
+    # x-hi face — shift the window left by pad_x.
+    x_hi_edge = g + pad_x
     # Per-face E-coefficient (material-aware when eps_r is supplied).
     # Each face slice broadcasts element-wise against its correction array
     # (x faces account for the ghost offset; y/z faces have no x-ghost).
     if eps_r is not None:
         _ce = dt / (eps_r * EPS_0)  # (nx_local+2g, ny, nz)
         ce_xlo = _ce[g:g + n, :, :]
-        ce_xhi = _ce[-(g + n):-g, :, :] if g > 0 else _ce[-n:, :, :]
+        ce_xhi = (
+            _ce[-(x_hi_edge + n):-x_hi_edge, :, :]
+            if x_hi_edge > 0 else _ce[-n:, :, :]
+        )
         ce_ylo = _ce[:, :n, :]
         ce_yhi = _ce[:, -n:, :]
         ce_zlo = _ce[:, :, :n]
@@ -778,9 +800,10 @@ def _apply_cpml_e_distributed(
     is_first = (device_idx == 0)
     is_last = (device_idx == n_devices - 1)
 
-    # X-axis slice helpers (account for ghost offset)
+    # X-axis slice helpers (account for ghost offset AND alignment pad,
+    # #623 — xhi shifted left by pad_x so it covers the real x-hi face)
     xlo = slice(g, g + n)          # first n real cells
-    xhi = slice(-(g + n), -g)      # last n real cells
+    xhi = slice(-(x_hi_edge + n), -x_hi_edge) if x_hi_edge > 0 else slice(-n, None)
 
     # =======================================================================
     # X-axis CPML (device-conditional)
@@ -975,7 +998,7 @@ def _apply_cpml_e_distributed(
 
 def _apply_cpml_h_distributed(
     state, cpml_params, cpml_state, n_cpml, dt, dx,
-    n_devices, ghost=1, axis_name="devices", mu_r=None,
+    n_devices, ghost=1, axis_name="devices", mu_r=None, pad_x: int = 0,
 ):
     """Apply CPML H-field correction on a distributed slab.
 
@@ -983,7 +1006,8 @@ def _apply_cpml_h_distributed(
     X faces: x-lo on device 0 only, x-hi on device N-1 only.
 
     X-axis indexing accounts for ghost cells: x-lo uses
-    ``[ghost:ghost+n]``, x-hi uses ``[-(ghost+n):-ghost]``.
+    ``[ghost:ghost+n]``, x-hi uses
+    ``[-(ghost+pad_x+n):-(ghost+pad_x)]``.
 
     Parameters
     ----------
@@ -1006,14 +1030,27 @@ def _apply_cpml_h_distributed(
         H-coefficient is the material-aware ``dt / (mu_r * mu_0)`` (mirrors
         the single-device ``apply_cpml_h``).  ``None`` falls back to the
         vacuum scalar ``dt / mu_0`` (bit-identical to pre-#205 behaviour).
+    pad_x : int
+        Number of alignment-pad cells appended to the high-x end of the
+        last rank's slab so that ``(nx + pad_x) % n_devices == 0``
+        (#623, same class as #622). The x-hi CPML window is shifted left
+        by ``pad_x`` so it covers the real physical face (global node
+        ``nx - 1``), matching single-device ``cpml.py``'s ``[nx-n, nx)``
+        (a no-op on other ranks / when ``pad_x == 0``).
     """
     n = n_cpml
     g = ghost
+    # #623: on the last rank, pad_x alignment cells sit past the real
+    # x-hi face — shift the window left by pad_x.
+    x_hi_edge = g + pad_x
     # Per-face H-coefficient (material-aware when mu_r is supplied).
     if mu_r is not None:
         _ch = dt / (mu_r * MU_0)  # (nx_local+2g, ny, nz)
         ch_xlo = _ch[g:g + n, :, :]
-        ch_xhi = _ch[-(g + n):-g, :, :] if g > 0 else _ch[-n:, :, :]
+        ch_xhi = (
+            _ch[-(x_hi_edge + n):-x_hi_edge, :, :]
+            if x_hi_edge > 0 else _ch[-n:, :, :]
+        )
         ch_ylo = _ch[:, :n, :]
         ch_yhi = _ch[:, -n:, :]
         ch_zlo = _ch[:, :, :n]
@@ -1036,9 +1073,10 @@ def _apply_cpml_h_distributed(
     is_first = (device_idx == 0)
     is_last = (device_idx == n_devices - 1)
 
-    # X-axis slice helpers (account for ghost offset)
+    # X-axis slice helpers (account for ghost offset AND alignment pad,
+    # #623 — xhi shifted left by pad_x so it covers the real x-hi face)
     xlo = slice(g, g + n)          # first n real cells
-    xhi = slice(-(g + n), -g)      # last n real cells
+    xhi = slice(-(x_hi_edge + n), -x_hi_edge) if x_hi_edge > 0 else slice(-n, None)
 
     # =======================================================================
     # X-axis CPML (device-conditional)

--- a/rfx/runners/distributed_v2.py
+++ b/rfx/runners/distributed_v2.py
@@ -284,7 +284,7 @@ def _apply_pmc_shmap(state: FDTDState, mesh: Mesh, n_devices: int,
 # ---------------------------------------------------------------------------
 
 def _apply_cpml_e_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
-                         mesh, n_devices, ghost=1, eps_r=None):
+                         mesh, n_devices, ghost=1, eps_r=None, pad_x=0):
     """Apply CPML E-field correction using shard_map.
 
     ``eps_r`` (the x-sharded per-cell relative permittivity slab) is a new
@@ -292,6 +292,11 @@ def _apply_cpml_e_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
     correction is material-aware (#205).  It is NOT returned, so it gets an
     extra ``P("x")`` entry in ``in_specs`` only.  ``None`` reproduces the
     vacuum (pre-#205) coefficient bit-identically.
+
+    ``pad_x`` (#623, same class as #622): forwarded to
+    :func:`rfx.runners.distributed._apply_cpml_e_distributed` so the x-hi
+    CPML window on the last rank targets the real physical face (global
+    node ``nx - 1``) instead of the padded slab end.
     """
 
     @partial(
@@ -336,7 +341,8 @@ def _apply_cpml_e_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
         )
         new_st, new_cs = _apply_cpml_e_distributed(
             _st, cpml_params, _cs, n_cpml, dt, dx,
-            n_devices, ghost=ghost, axis_name="x", eps_r=eps_r_slab)
+            n_devices, ghost=ghost, axis_name="x", eps_r=eps_r_slab,
+            pad_x=pad_x)
         return (
             new_st.ex, new_st.ey, new_st.ez,
             new_cs.psi_ey_xlo, new_cs.psi_ey_xhi,
@@ -374,7 +380,7 @@ def _apply_cpml_e_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
 
 
 def _apply_cpml_h_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
-                         mesh, n_devices, ghost=1, mu_r=None):
+                         mesh, n_devices, ghost=1, mu_r=None, pad_x=0):
     """Apply CPML H-field correction using shard_map.
 
     ``mu_r`` (the x-sharded per-cell relative permeability slab) is a new
@@ -382,6 +388,11 @@ def _apply_cpml_h_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
     (#205).  Like ``eps_r`` in the E-variant it gets one extra ``P("x")``
     in ``in_specs`` only and is not returned.  ``None`` reproduces the
     vacuum (pre-#205) coefficient bit-identically.
+
+    ``pad_x`` (#623, same class as #622): forwarded to
+    :func:`rfx.runners.distributed._apply_cpml_h_distributed` so the x-hi
+    CPML window on the last rank targets the real physical face (global
+    node ``nx - 1``) instead of the padded slab end.
     """
 
     @partial(
@@ -424,7 +435,8 @@ def _apply_cpml_h_shmap(state, cpml_params, cpml_state, n_cpml, dt, dx,
         )
         new_st, new_cs = _apply_cpml_h_distributed(
             _st, cpml_params, _cs, n_cpml, dt, dx,
-            n_devices, ghost=ghost, axis_name="x", mu_r=mu_r_slab)
+            n_devices, ghost=ghost, axis_name="x", mu_r=mu_r_slab,
+            pad_x=pad_x)
         return (
             new_st.hx, new_st.hy, new_st.hz,
             new_cs.psi_hy_xlo, new_cs.psi_hy_xhi,
@@ -1265,7 +1277,8 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
         # 2. CPML H correction (material-aware, #205)
         st, cpml_st = _apply_cpml_h_shmap(
             st, cpml_params, cpml_st, n_cpml, dt, dx,
-            mesh, n_devices, ghost=ghost, mu_r=sharded_materials.mu_r)
+            mesh, n_devices, ghost=ghost, mu_r=sharded_materials.mu_r,
+            pad_x=pad_x)
 
         # 3. Exchange H ghost cells (conditionally skip)
         do_exchange = (_step_idx % _exchange_interval == 0)
@@ -1291,7 +1304,8 @@ def run_distributed(sim, *, n_steps, devices=None, exchange_interval=1,
         # 5. CPML E correction (material-aware, #205)
         st, cpml_st = _apply_cpml_e_shmap(
             st, cpml_params, cpml_st, n_cpml, dt, dx,
-            mesh, n_devices, ghost=ghost, eps_r=sharded_materials.eps_r)
+            mesh, n_devices, ghost=ghost, eps_r=sharded_materials.eps_r,
+            pad_x=pad_x)
 
         # 6. Exchange E ghost cells
         st = lax.cond(

--- a/scripts/vessl_gpu_suite.yaml
+++ b/scripts/vessl_gpu_suite.yaml
@@ -32,8 +32,9 @@ run: |-
   # tests — distributed coverage lives in regular test files that set their
   # own XLA --xla_force_host_platform_device_count sentinel and run in the
   # fast suite (test_distributed_nu_composition.py always did; as of #622
-  # test_distributed_nu_kernel.py's 2-device family joined it there too —
-  # it used to carry the 'gpu' marker below, which meant its 22 two-device
+  # test_distributed_nu_kernel.py's 2-device family joined it there too, and
+  # as of #623 test_distributed.py's 2-/4-device family joined it as well —
+  # both used to carry the 'gpu' marker below, which meant their two-device
   # tests ran in NO lane at all: this 1-GPU pod only creates *virtual*
   # devices on the CPU backend, so '-m gpu' here always skipped them, and
   # every CPU lane deselects 'gpu'). Re-add a '-m distributed' step here if

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1,11 +1,13 @@
 """Tests for multi-GPU distributed FDTD runner.
 
-Uses XLA_FLAGS to simulate 4 CPU devices for testing.
-Must be set BEFORE importing JAX.
+Uses XLA_FLAGS to simulate up to 4 CPU devices for testing (the root
+``conftest.py`` sets 2 virtual CPU devices, via ``setdefault``, for any
+run that doesn't already set XLA_FLAGS — see its module docstring).
 """
 
 import os
-os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+os.environ.setdefault(
+    "XLA_FLAGS", "--xla_force_host_platform_device_count=4")
 
 import jax
 import jax.numpy as jnp
@@ -22,27 +24,46 @@ from rfx.runners.distributed import (
 )
 from rfx.core.yee import init_state, init_materials
 
-pytestmark = pytest.mark.gpu
-
-# Multi-device tests are device-count-ADAPTIVE: they shard across however many JAX
-# devices are available (up to 4, `_N_MULTI`) instead of hardcoding 4, and SKIP when
-# <2 devices are present (`requires_multidevice`). Issue #162: the GPU suite runs on
-# a single-GPU pod where jax.device_count() == 1 — the host-device-count sentinel
-# (XLA_FLAGS above) does NOT add virtual devices when a GPU backend is present — so
-# the multi-device classes previously FAILED there on a brittle `len(devices) == 4`
-# assert (and could at best run vacuous 1-device "distribution"). They now skip
-# cleanly on <2 devices, turning the GPU suite green, while staying correct for any
-# >=2-device env (a future multi-GPU pod). The runner itself is verified correct
-# (multi == single to ~1e-6) at 2 and 4 devices.
+# Historical note (#623, same class as #622's test_distributed_nu_kernel.py
+# fix): this file carried a module-wide ``pytestmark = pytest.mark.gpu``
+# from creation. Every CPU lane deselects ``gpu`` (pyproject addopts) and
+# a single-GPU pod exposes only 1 CUDA device (the host-device-count
+# sentinel only creates *virtual* devices on the CPU backend), so the
+# marker meant this file's whole 2-/4-device equivalence family ran in NO
+# lane at all — the #623 pad_x displacement (and the once-suspected
+# ``test_interval_monotonic_error_growth`` flake below) both went
+# undetected for exactly that reason. The module-level
+# ``os.environ["XLA_FLAGS"] = ...`` line above was ALSO dead in practice
+# even before this fix: pytest always imports conftest.py (which sets 2
+# virtual devices via ``setdefault``, before any test module is
+# imported) ahead of this module, so this file's own unconditional
+# assignment never won the race — changed to ``setdefault`` here to stop
+# implying otherwise; ``_N_DEVICES`` below is 2 in the fast/weekly CPU
+# shards. The marker is removed so this family runs in the same
+# fast-suite/weekly CPU shards as the sibling
+# ``test_distributed_nu_kernel.py`` / ``test_distributed_nu_composition.py``
+# files. Measured (2026-08-11, this fix, 2-device conftest default):
+# 33/33 passed, 65-68 s wall, 1.74 GiB peak RSS — comparable to (and
+# below) the NU kernel file's precedent (62-66 s, 1.93 GiB) that #622
+# already accepted into the fast lane, and well under the ``highmem``
+# marker's 3-24 GB band (pyproject.toml). This measured run also
+# confirms ``test_interval_monotonic_error_growth`` — flagged in an
+# earlier version of this comment as a "pre-existing latent failure"
+# under genuine multi-device execution — passes cleanly today (its
+# trend-not-strict-monotonicity assertion, see the test body, already
+# absorbed that wobble); no follow-up needed.
 #
-# NOTE (real multi-device CPU coverage — known limitation, not this fix): genuinely
-# running these on the CPU slow suite is blocked by the module-level XLA_FLAGS being
-# process-global + first-jax-init-wins — in a shared pytest process another module
-# usually initialises jax first, so the sentinel is ignored and only 1 device is
-# seen (then they silently skip). A reliable CPU lane would need an ISOLATED pytest
-# invocation. Running them multi-device also surfaces a pre-existing latent failure
-# (TestExchangeInterval::test_interval_monotonic_error_growth) — both are tracked
-# follow-ups, separate from this #162 GPU-suite-green fix.
+# Multi-device tests remain device-count-ADAPTIVE: they shard across
+# however many JAX devices are available (up to 4, `_N_MULTI`) instead of
+# hardcoding 4, and SKIP when <2 devices are present (`requires_multidevice`).
+# Issue #162: a single-GPU pod has jax.device_count() == 1 (the sentinel
+# does not add virtual devices when a GPU backend is present) — the
+# multi-device classes skip cleanly there rather than failing on a
+# brittle `len(devices) == 4` assert, while staying correct for any
+# >=2-device env (a future multi-GPU pod, or the fast/weekly CPU shards
+# now that the marker is gone). The runner itself is verified correct
+# (multi == single to ~1e-6, and to bit-parity on the pad_x-insensitive
+# Debye/Lorentz fixtures) at 2 and 4 devices.
 _N_DEVICES = jax.device_count()
 _N_MULTI = min(4, _N_DEVICES)
 requires_multidevice = pytest.mark.skipif(
@@ -403,6 +424,89 @@ class TestDistributedCPML:
         peak = np.max(np.abs(ts_s)) + 1e-30
         rel_err = np.max(np.abs(ts_s - ts_m)) / peak
         assert rel_err < 1e-3, f"Off-center probe CPML error {rel_err:.2e}"
+
+    def test_distributed_cpml_pad_x_matches_single(self):
+        """#623: uniform CPML distributed lane must place the x-hi
+        absorber at the real physical face when nx is NOT divisible by
+        n_devices (pad_x > 0 — the common case post-#564, since an
+        even cell request now realizes an odd node count).
+
+        Before the fix, ``_apply_cpml_e_distributed`` /
+        ``_apply_cpml_h_distributed`` (called from distributed_v2's
+        shmap wrappers, which is what production ``run(devices=...)``
+        dispatches to) left the x-hi CPML window at the padded slab
+        end instead of shifting it left by pad_x, displacing the
+        absorber by one cell relative to the single-device reference.
+        A probe positioned near the x-hi face (inside the CPML zone,
+        where the displacement is most visible) is sensitive to this:
+        measured rel_err 3.14e-01 pre-fix vs 8.13e-06 post-fix on this
+        exact fixture (R2 falsifier record).
+
+        Two preflight advisories fire on this fixture (both intentional,
+        quoted here per repo policy that preflight output is part of the
+        result — never inferred, always cited):
+          - "Probe at (...) is within 2 cells (...) of the domain edge on
+            the x-axis, just past which the CPML absorber is active.
+            Fields there carry CPML fringe/reflection error; move inward
+            for claims-bearing measurement." — expected: this is a
+            boundary-MECHANISM test, not a claims-bearing physics
+            measurement, so the near-edge probe is deliberate.
+          - "waveform tau=... is below 3*dt (...): pulse unresolved by
+            the time step — an absolute-Hz bandwidth was likely passed
+            where a FRACTIONAL one is expected ... (issue #386)" —
+            inherited unchanged from the ``GaussianPulse(f0=1.5e9,
+            bandwidth=1.5e9)`` convention already used by every other
+            CPML test in this file (e.g. ``test_distributed_cpml_matches_
+            single`` above); harmless here since this test measures
+            boundary placement via the multi-vs-single DIFFERENCE, not an
+            absolute physical quantity, and is not #386's fix target.
+        """
+        # Lx=0.125 -> nx=59 (ODD), pad_x = 2 - (59 % 2) = 1 for n=2 devices.
+        Lx = 0.125
+        n_devices = 2
+        sim = Simulation(
+            freq_max=3e9,
+            domain=(Lx, 0.04, 0.04),
+            boundary="cpml",
+        )
+        sim.add_source(
+            position=(Lx / 2, 0.02, 0.02),
+            component="ez",
+            waveform=GaussianPulse(f0=1.5e9, bandwidth=1.5e9),
+        )
+        # Probe near the x-hi physical face (inside the CPML zone) so
+        # it is sensitive to the absorber window's exact placement.
+        # skip_preflight: intentional near-boundary placement — this
+        # is a boundary-mechanism test, not a claims-bearing physics
+        # measurement (preflight would otherwise advise moving inward).
+        sim.add_probe(position=(Lx - 0.006, 0.02, 0.02), component="ez")
+
+        n_steps = 400
+
+        result_single = sim.run(n_steps=n_steps, skip_preflight=True)
+        devices = jax.devices()[:n_devices]
+        result_multi = sim.run(n_steps=n_steps, devices=devices, skip_preflight=True)
+
+        # Precondition guard on the RUNNER'S OWN realized grid (not a
+        # separate pre-run sim._build_grid() call, which can silently
+        # diverge from what the run actually used — e.g. a dielectric
+        # fixture's resolution can depend on material-aware refinement
+        # that resolves lazily, only visible post-run; #623 review).
+        # The #622 lesson stands: a fixture whose realized dimensions
+        # make the pad path unreachable silently stops testing the thing.
+        nx = int(result_single.grid.shape[0])
+        pad_x = 0 if nx % n_devices == 0 else n_devices - (nx % n_devices)
+        assert pad_x > 0, (
+            f"fixture no longer exercises the pad_x>0 lane: realized "
+            f"nx={nx} is divisible by n_devices={n_devices} -- adjust Lx"
+        )
+
+        ts_s = np.array(result_single.time_series).ravel()
+        ts_m = np.array(result_multi.time_series).ravel()
+
+        peak = np.max(np.abs(ts_s)) + 1e-30
+        rel_err = np.max(np.abs(ts_s - ts_m)) / peak
+        assert rel_err < 1e-4, f"pad_x={pad_x} CPML distributed error {rel_err:.2e}"
 
 
 @requires_multidevice
@@ -868,3 +972,106 @@ class TestExchangeInterval:
         for i in range(len(errors) - 1):
             assert errors[i] <= errors[i + 1] + tol, (
                 f"error trend should be non-decreasing within {tol:.4f}: {errors}")
+
+
+@requires_multidevice
+class TestLegacyPmapPadXFaceAppliers:
+    """#623: ``_apply_pec_local`` / ``_apply_pmc_local`` (the legacy
+    ``jax.pmap`` runner's x-hi face appliers) must honor ``pad_x``, the
+    same class of bug fixed for the shared distributed_v2 PEC/PMC
+    appliers and the NU lane in #622.
+
+    Unlike the CPML lane above, ``pad_x > 0`` is currently UNREACHABLE
+    through the public ``rfx.runners.distributed.run_distributed``
+    entry point: it raises ``ValueError`` when ``nx % n_devices != 0``
+    (no padding support), so no simulation-level fixture can exercise
+    these two sites (the #622 F4 lesson — some sites need a structural
+    witness, not a physics one). These tests therefore call the
+    appliers directly under a synthetic ``jax.pmap``, mirroring the
+    direct-call style already used for the same functions in
+    ``tests/test_boundary_pmc_distributed.py::test_pmc_distributed_legacy_mixed_z``
+    (which exercises them at n_devices=1, where pad_x is always 0 and
+    so never reaches this code path either).
+    """
+
+    def _padded_state(self, n_devices, nx_local, ny, nz):
+        from rfx.core.yee import FDTDState
+        ones = jnp.ones((n_devices, nx_local, ny, nz), dtype=jnp.float32)
+        step = jnp.zeros((n_devices,), dtype=jnp.int32)
+        return FDTDState(ex=ones, ey=ones, ez=ones,
+                         hx=ones, hy=ones, hz=ones, step=step)
+
+    def test_apply_pec_local_pad_x_targets_real_face(self):
+        """x-hi PEC must zero the real face (nx_local-1-ghost-pad_x),
+        NOT the alignment-pad cell at the old (nx_local-1-ghost) index."""
+        from functools import partial
+        from rfx.runners.distributed import _apply_pec_local
+
+        n_devices, nx_local, ny, nz, ghost, pad_x = 2, 10, 4, 4, 1, 2
+        state = self._padded_state(n_devices, nx_local, ny, nz)
+
+        @partial(jax.pmap, axis_name="devices")
+        def run_pec(state):
+            return _apply_pec_local(state, n_devices, nx_local, "devices",
+                                    pad_x=pad_x)
+
+        out = run_pec(state)
+        last_real = nx_local - 1 - ghost - pad_x       # correct real face
+        old_buggy = nx_local - 1 - ghost                # pre-#623 (pad cell)
+        # Interior (y, z) point — the unconditional y/z PEC faces zero
+        # y=0/-1 and z=0/-1 on every device regardless of the x-hi fix,
+        # which would mask the x-hi-specific signal at a boundary index.
+        iy, iz = 1, 1
+        ey_last, ez_last = out.ey[-1], out.ez[-1]
+
+        assert jnp.allclose(ey_last[last_real, iy, iz], 0.0), (
+            f"PEC did not zero the real x-hi face at index {last_real}: "
+            f"ey={float(ey_last[last_real, iy, iz]):.3e}")
+        assert jnp.allclose(ez_last[last_real, iy, iz], 0.0), (
+            f"PEC did not zero the real x-hi face at index {last_real}: "
+            f"ez={float(ez_last[last_real, iy, iz]):.3e}")
+        assert jnp.allclose(ey_last[old_buggy, iy, iz], 1.0), (
+            f"PEC touched the pad cell (old buggy index {old_buggy}) "
+            f"instead of the real face: ey="
+            f"{float(ey_last[old_buggy, iy, iz]):.3e}")
+        assert jnp.allclose(ez_last[old_buggy, iy, iz], 1.0), (
+            f"PEC touched the pad cell (old buggy index {old_buggy}) "
+            f"instead of the real face: ez="
+            f"{float(ez_last[old_buggy, iy, iz]):.3e}")
+
+    def test_apply_pmc_local_pad_x_targets_real_face(self):
+        """x-hi PMC must zero the real inside cell (last_real - 1 with
+        the pad_x-shifted last_real), NOT the old pad-adjacent index."""
+        from functools import partial
+        from rfx.runners.distributed import _apply_pmc_local
+
+        n_devices, nx_local, ny, nz, ghost, pad_x = 2, 10, 4, 4, 1, 2
+        state = self._padded_state(n_devices, nx_local, ny, nz)
+
+        @partial(jax.pmap, axis_name="devices")
+        def run_pmc(state):
+            return _apply_pmc_local(state, n_devices, nx_local, "devices",
+                                    frozenset({"x_hi"}), pad_x=pad_x)
+
+        out = run_pmc(state)
+        last_real = nx_local - 1 - ghost - pad_x
+        old_buggy = nx_local - 1 - ghost
+        last_inside = last_real - 1        # correct inside cell
+        old_inside = old_buggy - 1          # pre-#623 (pad-adjacent)
+        iy, iz = 1, 1
+        hy_last, hz_last = out.hy[-1], out.hz[-1]
+
+        assert jnp.allclose(hy_last[last_inside, iy, iz], 0.0), (
+            f"PMC did not zero the real inside cell at index "
+            f"{last_inside}: hy={float(hy_last[last_inside, iy, iz]):.3e}")
+        assert jnp.allclose(hz_last[last_inside, iy, iz], 0.0), (
+            f"PMC did not zero the real inside cell at index "
+            f"{last_inside}: hz={float(hz_last[last_inside, iy, iz]):.3e}")
+        assert jnp.allclose(hy_last[old_inside, iy, iz], 1.0), (
+            f"PMC touched the pad-adjacent cell (old buggy index "
+            f"{old_inside}) instead: hy="
+            f"{float(hy_last[old_inside, iy, iz]):.3e}")
+        assert jnp.allclose(hz_last[old_inside, iy, iz], 1.0), (
+            f"PMC touched the pad-adjacent cell (old buggy index "
+            f"{old_inside}) instead: hz="
+            f"{float(hz_last[old_inside, iy, iz]):.3e}")


### PR DESCRIPTION
Closes #623. Sibling of #622 (merged 31395e0), which fixed the same class on the non-uniform lane; this completes it on the uniform one and brings the six face-applier sites to character-identical arithmetic.

## Defect

With `pad_x > 0` (nx not divisible by n_devices), the uniform distributed lane placed its x-hi CPML window and its legacy-pmap PEC/PMC faces at the padded slab end rather than at the physical boundary node. Hand-checked on an nx=59, 2-device fixture: the pre-fix x-hi window covers global padded `[44,60)`, ending on pad cell 59, while the single-device reference (`rfx/boundaries/cpml.py`) covers `[43,58]`; post-fix the distributed window is exactly `[43,58]`.

The cleanest statement of what that meant, found in review: on the base tree, the `pad_x=1` (nx=59) run hashes **identically** to the nx=60 geometry at 200/400/800/1600 steps. The buggy path was literally simulating a domain one cell wider than the one requested.

Unlike #622's hard-PEC face — where the corrupted coefficient was an identically-zero fixed point invisible to every physics probe — this lane admits a direct physics witness: 2-device CPML parity against single-device goes **3.14e-01 → 8.13e-06** (~38,600×). Review swept 7 probe offsets × 3 step counts: pre-fix error is 3.4e-1…8.5e-2 across the outer domain and still 3.6e-3 at domain centre, and is insensitive to step count; post-fix the pad lane tracks the `pad_x=0` control on the same generic multi-vs-single float32 noise trajectory (8.1e-6 vs 2.4e-5 at 400 steps; 1.04e-3 vs 1.11e-3 at 1600).

## Fix

`pad_x` (a static Python int) threaded into `_apply_cpml_e_distributed`, `_apply_cpml_h_distributed`, `_apply_pec_local` and `_apply_pmc_local`, plus the two `distributed_v2` CPML shmap wrappers; the x-hi window and face indices shift left by `pad_x` onto global node `nx-1`. `last_real = nx_local - 1 - ghost - pad_x` is now character-identical at all six sites across both runners (`distributed_nu.py:747,:808` and `distributed_v2.py:197,:262` from #622, plus `distributed.py:576,:628` here). `pad_x = 0` is an exact no-op — verified by sha256 byte-identity of the multi-device series at 200/400/800/1600 steps, not merely by tests passing.

`_apply_pmc_local` was fixed alongside `_apply_pec_local` although the issue named only the latter: it carries the identical bug, and #622 set the precedent of fixing both together.

## Reachability, stated honestly

The two legacy-pmap sites are **defensive only**. `run_distributed()` hard-raises when `nx % n_devices != 0`, so `pad_x > 0` is unreachable there through the public entry point and no simulation-level fixture can exercise them — they are covered by direct structural tests instead, mirroring #622's reasoning about a witness that physics cannot supply.

## Falsifier

Reverting **only the index arithmetic**, with `pad_x` kept in every signature (so the failure cannot come from a vanishing kwarg), reds all three new tests on their own semantic assertions: CPML `AssertionError: pad_x=1 CPML distributed error 3.14e-01` against the 1e-4 gate; PEC `did not zero the real x-hi face at index 6: ey=1.000e+00`; PMC `did not zero the real inside cell at index 5: hy=1.000e+00`. The first version of this falsifier only produced `TypeError: unexpected keyword argument`, which is a signature check rather than a correctness check — review caught that and it was redone.

## Non-regression

`tests/test_distributed.py` 33/33 (30 existing + 3 new); against the true base runner with the new tests present, exactly the 3 new tests fail and no existing test changes status. Eight distributed-adjacent files: 62 passed. The four fixtures that actually realize `pad_x=1` (three Debye at nx=65, one Lorentz at nx=41) are byte-identical before and after — and the reason is structural rather than a wave-travel-time argument: those fixtures use `boundary="pec"`, so the appliers this PR touches are never invoked on them at all.

## Lane

`tests/test_distributed.py` loses its module-wide `gpu` marker, the same runs-nowhere state #622 removed for the NU kernel file (CPU lanes deselect `gpu`; the 1-GPU pod cannot create the two virtual devices these tests need). Measured basis: 33/33 in 65–68 s at 1.746 GiB peak RSS, below the NU file's 1.93 GiB precedent and well under the `highmem` 3–24 GB band. Review modelled the pytest-split assignment: all three distributed files land in shard 1, and since memory accumulates in-process rather than overlapping, this PR adds ~1.07 GiB to a shard measured at 3.62 GiB combined. `RFX_WEEKLY_RSS` already reports the real high-water on the first post-merge run — the same mitigation #622 relied on — and it is worth watching there given the #545 history.

Two stale claims in that file's header were corrected while the marker decision was being made: an `os.environ["XLA_FLAGS"]=…4` line that has been dead since the root conftest's `setdefault` ordering always wins (verified by reconstruction — `jax.device_count()` reads 2, not 4), and a "pre-existing latent failure" note for `test_interval_monotonic_error_growth`, which passes reliably at 2, 3 and 4 devices with its assertion body unchanged by this PR.

R3: memory=the #622 arc (same class, same six-site arithmetic) + comparator-first | R2-attempts=1 engineering fix on a measured mechanism | falsifier=arithmetic-only revert with the kwarg kept, red on all three semantic assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)