### PR TITLE
fix(api): fence n_warmup on the uniform lane, and document the gradient truncation it was never described as having (closes #626, #632)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,100 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   was mask-specific. `tests/test_design_mask_removed.py` (new) pins that
   every entry point above now raises `TypeError`.
 
+### Fixed — `forward(n_warmup=...)` on the uniform lane now raises instead of silently doing nothing (**BEHAVIOUR CHANGE**) (issue #626)
+
+- `Simulation.forward()` declared and documented `n_warmup` but only
+  forwarded it to the non-uniform / distributed-non-uniform lanes;
+  `_forward_from_materials` (the uniform single-device lane) has no
+  warmup-split parameter at all, so a nonzero `n_warmup` on a uniform
+  mesh was silently accepted and ignored. Measured: gradient bit-identical
+  at `n_warmup=0` vs `n_warmup=60` on the uniform lane. A nonzero
+  `n_warmup` on the uniform lane now raises `NotImplementedError` in
+  `_dispatch_plan`, matching its two uniform-lane siblings
+  (`emit_time_series=False`, `checkpoint_every`; `design_mask`, the third
+  historical sibling, was removed entirely rather than fenced — see the
+  entry above).
+- **Decision: fail-loud, not implement.** `checkpoint_segments` already
+  gives the uniform lane an EXACT reverse-mode memory reduction
+  (~`sqrt(n_steps)` scaling, no gradient approximation). `n_warmup`, where
+  it IS implemented (the non-uniform lane), turns out to be an
+  APPROXIMATION rather than a free memory lever — see the next entry.
+  Porting that approximation to the uniform lane would add a new,
+  accuracy-lossy feature with no memory benefit `checkpoint_segments`
+  doesn't already cover exactly, and would require threading the
+  warmup/optimize scan split through the uniform-lane-only accumulators
+  the non-uniform lane doesn't have (S11 DFT, Kerr χ³, `mu_r_override` —
+  flux monitors, NTFF and lumped-RLC ADE state are already real
+  non-uniform-lane carries, so those three do NOT add to this cost).
+  Silently accepting-and-ignoring a kwarg is the SILENT_WRONG shape this
+  repo systematically eliminates; a clean raise is the responsible fix.
+- **`rfx.optimize.optimize()` is a second entry point for this behaviour
+  change**: it accepts `n_warmup` (forwarded straight to `sim.forward()`
+  at both the plain and progressive-resolution call sites), so
+  `optimize(..., n_warmup=5)` on a uniform-mesh `Simulation` now raises
+  through the optimizer too — the right outcome, and the surface where a
+  truncated gradient would otherwise actually drive a design loop.
+- **What n_warmup actually does, measured** (non-uniform lane, where it IS
+  implemented): it is NOT an exact truncation. Severing the scan carry at
+  the warmup boundary also severs every gradient path from a design
+  variable's influence during the warmup window back into the loss.
+  Swept `n_warmup=K` against an independent central-FD oracle (loss
+  window held FIXED across the sweep, K varied independently — the
+  existing `test_warmup_grad_finite_and_same_sign` test lets the loss
+  window track `warmup`, which conflates the two and cannot isolate the
+  effect) at two independent design-cell placements: forward output is
+  exactly `n_warmup`-invariant (bit-identical) in both; the gradient
+  error vs. the FD oracle stays near this repo's established AD-vs-FD
+  noise floor (≲1.5%) while K is up to roughly a quarter of the
+  pre-loss-window step count, then grows smoothly and monotonically —
+  fixture 1 (`n_steps=100`, loss window `[80, 100)`): K=0 → 0.25%, K=10 →
+  1.1%, K=30 → 3.3%, K=40 (half the pre-loss-window) → 6.6%, K=50 →
+  12.1%, K=70 → 35.2%, K=80 (the loss-window boundary itself) → 58.4%,
+  K=95 → exactly 0 (gradient fully vanished, not merely small). Two
+  further placements at weaker design/loss coupling (smaller true
+  gradient, so the FD oracle itself sits closer to the float32
+  single-cell noise floor) reproduce the SAME large-K collapse toward
+  the loss-window boundary, but do NOT cleanly reproduce monotonicity at
+  small/medium K — the low-K ordering there is noise-floor-dependent on
+  how well-conditioned the oracle is at that specific cell, which is why
+  the regression test below only asserts strict monotonicity from K=30
+  upward rather than across the whole sweep. Docstrings (`forward()`,
+  `run_nonuniform`, `run_nonuniform_distributed_pec`, `jacobian_fwd`) and
+  `docs/public/guide/memory-reduction.mdx` are updated to state this
+  curve plainly instead of framing `n_warmup` as a free memory lever.
+- **Caveat on the sweep's own monotonicity gate**: an h-sweep of the FD
+  oracle shows K=0 and K=10's errors sit inside the oracle's own noise
+  band (at `h=0.05` the K=10 point reads slightly BELOW K=0) — the
+  published `h=0.02` figures above are correct as measured, but a strict
+  monotonicity assertion across the *whole* sweep would bind that
+  noise-band coincidence. `tests/test_n_warmup.py`'s regression test
+  floors the low-K comparisons and only asserts strict monotonicity from
+  K=30 upward, where the trend is unambiguous.
+- Tests: `tests/test_n_warmup.py::test_uniform_forward_rejects_n_warmup`
+  (the fail-loud regression witness — pins raise vs. no-raise, not merely
+  "both run") and `::test_warmup_truncation_error_grows_with_k` (the
+  measured error-curve witness). `tests/test_jacobian_fwd.py`'s G6 fence
+  taxonomy moves `n_warmup` from a documented trap to an inherited raise
+  (`test_g6b_n_warmup_fence_raises` replaces
+  `test_g6b_n_warmup_is_a_documented_trap_not_a_raise`; the taxonomy is
+  now three configurations / two raises / one docs-only trap, since
+  `design_mask` — one of the prior four — was removed outright rather
+  than fenced).
+
+### Changed — `benchmark_jacobian_fwd.py`'s intercept/plain witness text now flags itself as CPU-calibrated (issue #632)
+
+- The printed `intercept/plain ratio (... -- expect close to 1.0)` line
+  read as a regression on an accelerator: it is 0.98-1.10 on CPU but
+  1.41-1.87 on an RTX 4090 (measured, VESSL runs 369367252824 /
+  369367252825, commit 27c4fad), because the two-point endpoint fit
+  pushes fixed per-call overhead (kernel launch, tiling) that does not
+  scale with `n_t` into the intercept, and that effect is largest exactly
+  where the marginal cost per tangent is smallest. Sharing is not broken
+  there. Reworded the printed line and the module docstring to state the
+  CPU calibration and point at G3 in `tests/test_jacobian_fwd.py` — a
+  jaxpr-structural, backend-independent check — as the authoritative
+  witness. No behaviour change.
+
 ### Fixed — uniform distributed lane's CPML/PEC x-hi wall displacement in the pad_x>0 lane (issue #623)
 
 - Same class as #622, in the sibling UNIFORM-grid runner:

--- a/docs/agent/recipe-design-loop.mdx
+++ b/docs/agent/recipe-design-loop.mdx
@@ -139,13 +139,16 @@ before reaching for it:
   fixture and cannot produce a many-output Jacobian at all.
 - The returned Jacobian is `dy/dx` UNCONJUGATED for a complex `value` —
   differs by a conjugate from anything built through `jax.vjp`/`jax.grad`.
-- Uniform single-device lane only. Non-uniform + `distributed=True` (with
-  a registered DFT-plane probe) raises `NotImplementedError` via
-  `forward()`'s own pre-existing checks; `n_warmup` is a measured silent
-  no-op and `checkpoint`/`checkpoint_segments` are measured exactly
-  neutral under forward mode — neither has a raise to catch it, so both
-  are documented traps in
-  `jacobian_fwd`'s own docstring rather than being plumbed through.
+- Uniform single-device lane only. `n_warmup` and non-uniform +
+  `distributed=True` (with a registered DFT-plane probe) both raise
+  `NotImplementedError` via `forward()`'s own pre-existing checks
+  (`n_warmup` used to be a measured silent no-op on this lane — issue
+  #626 turned that into a fail-loud fence instead; `design_mask` was
+  removed from every public surface entirely by issue #625, so it is no
+  longer a `jacobian_fwd`-specific fence). `checkpoint`/
+  `checkpoint_segments` are measured exactly neutral under forward mode —
+  no raise to catch, so it stays a documented trap in `jacobian_fwd`'s
+  own docstring rather than being plumbed through.
 - "Geometry parameter" still means the topology-density pixel /
   `pec_occupancy_override` / `dz_profile` design channels from the section
   above — not a parametric dimension (`Box` corners are not

--- a/docs/public/guide/memory-reduction.mdx
+++ b/docs/public/guide/memory-reduction.mdx
@@ -252,8 +252,14 @@ per segment; either extreme can increase peak memory, so use the value chosen
 by `plan_ad_memory(...)` rather than minimizing the segment count manually.
 
 `n_warmup` reduces the active reverse-mode timestep count and must satisfy
-`0 <= n_warmup < n_steps`. The plan applies a conservative safety multiplier
-before setting the fit flags and records it in `plan.fit_safety_factor`.
+`0 <= n_warmup < n_steps`. It is an APPROXIMATION, not merely a memory
+optimization — see `forward()`'s own `n_warmup` docstring for the measured
+gradient-truncation error curve — and `estimate_ad_memory`/`plan_ad_memory`
+report it as a hypothetical planning number regardless of mesh type; on the
+uniform (single-device) mesh, `forward(n_warmup=...)` itself raises
+`NotImplementedError` (non-uniform / distributed-non-uniform meshes only).
+The plan applies a conservative safety multiplier before setting the fit
+flags and records it in `plan.fit_safety_factor`.
 
 For a uniform run, gate execution on the fit flags before applying the selected
 checkpoint value:

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -2125,6 +2125,7 @@ class _ExecuteMixin:
         checkpoint_segments: int | None = None,
         emit_time_series: bool = True,
         checkpoint_every: int | None = None,
+        n_warmup: int = 0,
         # run-only inputs
         devices: list | None = None,
         exchange_interval: int = 1,
@@ -2238,6 +2239,22 @@ class _ExecuteMixin:
                     "checkpoint_every (segmented remat) is currently only "
                     "supported on the non-uniform forward path. For the "
                     "uniform path, use checkpoint_segments instead (issue #73)."
+                )
+            if n_warmup > 0:
+                raise NotImplementedError(
+                    "n_warmup (issue #40) is currently only supported on the "
+                    "non-uniform / distributed-non-uniform forward paths "
+                    "(_forward_from_materials has no warmup-split parameter); "
+                    "on the uniform lane it was previously accepted and "
+                    "silently ignored (issue #626 — measured bit-identical "
+                    "gradient at n_warmup=0 vs n_warmup=60), which is worse "
+                    "than an error. For reverse-mode memory relief on the "
+                    "uniform lane use checkpoint_segments instead (issue #73) "
+                    "— it is EXACT (no gradient approximation), unlike "
+                    "n_warmup which trades memory/compute for a truncated, "
+                    "increasingly biased gradient as n_warmup approaches the "
+                    "loss window (measured on the non-uniform lane, issue "
+                    "#626 part 2)."
                 )
             # n_steps for the uniform forward lane is resolved by the caller
             # from the grid it builds and reuses for material assembly.
@@ -2407,7 +2424,32 @@ class _ExecuteMixin:
             initial transient (issue #40).  Only the trailing
             ``n_steps - n_warmup`` steps participate in autodiff.  Must
             satisfy ``n_warmup < n_steps``.  Default ``0`` (all steps
-            differentiated).
+            differentiated).  This is an APPROXIMATION, not merely a memory
+            optimisation: severing the carry at the warmup boundary also
+            severs every gradient path from a design variable's influence
+            during steps ``< n_warmup`` back into the loss, so the returned
+            gradient is a systematically truncated (magnitude-underestimated)
+            version of the true one whenever the design variable's
+            derivative-relevant support extends into the warmup window.
+            Measured on the non-uniform lane (issue #626 part 2, two
+            independent design-cell placements): error stays near this
+            repo's AD-vs-FD noise floor (≲1.5%) while ``n_warmup`` is up to
+            roughly a quarter of the pre-loss-window step count, then grows
+            smoothly and monotonically — ~6-7% at half the pre-loss-window
+            length, >20% by three-quarters, 58% AT the loss-window boundary
+            itself (``n_warmup`` equal to the pre-loss-window length), and
+            EXACTLY zero once ``n_warmup`` extends far enough into the loss
+            window that no differentiable sample remains (measured: exactly
+            0.0, not merely small, in one fixture once ``n_warmup`` covers
+            ~19/20 of the loss window). Forward (non-AD) output is exactly
+            ``n_warmup``-invariant (bit-identical);
+            only the gradient is affected. Currently only supported on the
+            non-uniform / distributed-non-uniform forward paths; on the
+            uniform single-device lane it raises ``NotImplementedError``
+            (issue #626 — previously silently accepted and ignored, worse
+            than an error).  Use *checkpoint_segments* for uniform-lane
+            reverse-mode memory relief instead — it is exact, at the cost of
+            recompute rather than gradient accuracy.
         skip_preflight : bool
             Skip the consolidated :meth:`preflight` validation suite that
             normally runs before the forward simulation (default False).
@@ -2525,6 +2567,7 @@ class _ExecuteMixin:
             checkpoint_segments=checkpoint_segments,
             emit_time_series=emit_time_series,
             checkpoint_every=checkpoint_every,
+            n_warmup=n_warmup,
         )
 
         # WP 4-E: rlc_values_override is only wired on the uniform lane.  Fail

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -1399,6 +1399,25 @@ def run_nonuniform(
     # stop_gradient'd so AD builds no tape for that transient lead-in
     # (issue #40). Only the trailing n_optimize = n_steps - n_warmup
     # steps participate in reverse-mode autodiff.
+    #
+    # This is an APPROXIMATION, not merely a memory optimization: severing
+    # the carry also severs every gradient path from a design variable's
+    # influence during steps < n_warmup back into the loss. Forward output
+    # is exactly n_warmup-invariant (bit-identical), but the gradient is a
+    # truncated (magnitude-underestimated) version of the true one whenever
+    # the design variable's derivative-relevant support extends into the
+    # warmup window -- which it generally does for a static material/design
+    # parameter present throughout the whole run. Measured (issue #626 part
+    # 2, two independent design-cell placements, vs an independent central-
+    # FD oracle at n_warmup=0, fixture n_steps=100 / loss window [80,100)):
+    # error stays near this repo's AD-vs-FD noise floor (~1.5%) while
+    # n_warmup is up to roughly a quarter of the pre-loss-window step count,
+    # then grows smoothly and monotonically -- ~6-7% at half the
+    # pre-loss-window length, 58% AT the loss-window boundary itself
+    # (n_warmup equal to the pre-loss-window length), and EXACTLY zero
+    # (gradient fully vanished, not merely small) once n_warmup extends far
+    # enough into the loss window. Choose n_warmup with that bias curve in
+    # mind, not just a memory budget.
     if n_warmup > 0:
         if n_warmup >= n_steps:
             raise ValueError(

--- a/rfx/observables.py
+++ b/rfx/observables.py
@@ -565,12 +565,12 @@ def jacobian_fwd(
     Three configurations are unsafe to combine with ``jacobian_fwd`` on
     ``sim_fn`` bodies built on ``Simulation.forward(...)``. This function
     is intentionally generic over *sim_fn* (it never sees ``forward()``'s
-    own keyword arguments -- they live inside your closure), so only the
-    first is enforced by a RAISE that propagates up through
-    ``jax.jvp`` from ``forward()``'s own pre-existing checks; the other two
-    have no raise to inherit and cannot be intercepted from outside the
-    closure, so they are DOCUMENTED traps instead. Read the RAISES/DOCS tag
-    on each before assuming "it didn't raise" means "it's fine":
+    own keyword arguments -- they live inside your closure), so the first
+    two are enforced by a RAISE that propagates up through ``jax.jvp``
+    from ``forward()``'s own pre-existing checks; the remaining one has no
+    raise to inherit and cannot be intercepted from outside the closure,
+    so it is a DOCUMENTED trap instead. Read the RAISES/DOCS tag on each
+    before assuming "it didn't raise" means "it's fine":
 
     - **[RAISES, inherited]** non-uniform + ``distributed=True`` with a
       registered DFT-plane probe: ``forward()`` itself raises
@@ -578,15 +578,21 @@ def jacobian_fwd(
       neither sharded runner accumulates DFT-plane fields. ``jacobian_fwd``
       scope is the uniform single-device lane only; a distributed
       ``sim_fn`` fails loud before this function's own machinery runs.
-    - **[DOCS ONLY -- no raise exists to inherit]** ``n_warmup``: measured
-      SILENT NO-OP on the uniform ``forward()`` lane (bit-identical value
-      AND tangent at ``n_warmup=0`` vs ``n_warmup=60`` of 80 steps; issue
-      #626) -- it neither errors nor changes the result, so there is
-      nothing for ``jacobian_fwd`` (or ``forward()``) to fail loud on. If
-      your ``sim_fn`` passes a nonzero ``n_warmup`` expecting either a
-      memory saving (forward mode builds no tape, so there is none to
-      save) or a truncated-but-correct derivative (it silently is NOT
-      truncated), both expectations are wrong. Do not use it here.
+    - **[RAISES, inherited]** ``n_warmup``: ``forward()`` itself raises
+      ``NotImplementedError`` for a nonzero ``n_warmup`` on the uniform
+      lane (issue #626) -- so on ``jacobian_fwd``'s supported (uniform)
+      lane, a ``n_warmup``-using ``sim_fn`` already fails loud. It used to
+      be a measured SILENT NO-OP (bit-identical value AND tangent at
+      ``n_warmup=0`` vs ``n_warmup=60`` of 80 steps) before the fence was
+      added. Do not read this as "n_warmup is safe elsewhere": on the
+      non-uniform lane where it IS implemented, ``n_warmup`` measurably
+      truncates the reverse-mode gradient with an error that grows
+      smoothly -- ~6-7% at half the pre-loss-window length, 58% at the
+      loss-window boundary itself, exactly zero once far enough beyond it
+      (issue #626 part 2) -- it is not fenced there (truncated-BPTT is a
+      legitimate, if approximate, construction), and any future
+      non-uniform extension of this function must account for that bias,
+      not treat ``n_warmup`` as free memory relief.
     - **[DOCS ONLY -- inert, not a raise]** ``checkpoint`` /
       ``checkpoint_segments``: measured EXACTLY NEUTRAL under forward mode
       (flops/temp bytes identical across ``checkpoint=False``,

--- a/rfx/optimize.py
+++ b/rfx/optimize.py
@@ -289,6 +289,18 @@ def optimize(
         10 for lower memory usage with minimal accuracy loss.
     verbose : bool
         Print progress every 10 iterations.
+    n_warmup : int
+        Forwarded verbatim to ``sim.forward(n_warmup=...)`` at every
+        iteration (issue #40). On a non-uniform / distributed-non-uniform
+        ``sim``, this trades an APPROXIMATE (truncated) gradient for
+        reduced reverse-mode memory/compute — see ``Simulation.forward``'s
+        own ``n_warmup`` docstring for the measured error curve (issue
+        #626 part 2); a design loop built on this objective inherits that
+        bias, not just a single forward call, so verify the bias is
+        acceptable for your loss window before using a nonzero value here.
+        On a uniform-mesh ``sim`` it raises ``NotImplementedError``
+        (issue #626 — previously a silent no-op). Default ``0`` (no
+        warmup split, full gradient).
     port_s11_freqs : array-like or None
         Frequencies (Hz) at which to accumulate per-port V/I DFTs in the
         JIT scan body so that ``result.s_params`` is populated with
@@ -663,6 +675,11 @@ def progressive_optimize(
         Latent-upsample interpolation ("linear", "nearest", "cubic").
     verbose : bool
         Print per-stage progress banner.
+    n_warmup : int
+        Forwarded to each stage's ``optimize(..., n_warmup=...)`` call —
+        see :func:`optimize`'s own ``n_warmup`` entry for the full
+        behaviour (issue #40/#626): an approximation on non-uniform
+        meshes, a fail-loud ``NotImplementedError`` on uniform ones.
 
     Returns
     -------

--- a/rfx/runners/distributed_nu.py
+++ b/rfx/runners/distributed_nu.py
@@ -2045,6 +2045,14 @@ def run_nonuniform_distributed_pec(
         ``stop_gradient``'d so AD builds no tape for that transient.
         Only the trailing ``n_steps - n_warmup`` steps participate in
         reverse-mode autodiff.  Must satisfy ``n_warmup < n_steps``.
+        This is an APPROXIMATION, not merely a memory optimisation: the
+        returned gradient is truncated and grows increasingly biased
+        (magnitude-underestimated) as ``n_warmup`` approaches the loss
+        window -- measured ~6-7% at half the pre-loss-window length, 58%
+        at the loss-window boundary itself, exactly zero once far enough
+        beyond it; see the ``n_warmup split`` comment in
+        :func:`rfx.nonuniform.run_nonuniform` for the measured error curve
+        (issue #626 part 2).
     emit_time_series : bool, optional
         Phase 2F.  When ``True`` (default), the runner accumulates per-
         step probe samples and returns ``time_series`` as a

--- a/scripts/benchmark_jacobian_fwd.py
+++ b/scripts/benchmark_jacobian_fwd.py
@@ -28,10 +28,18 @@ Measures, for `n_t` in `--n-t-values` (default 1, 4, 10) against one plain
       object, which this script does not attempt)
 
 and fits `cost(n_t) = a + b * n_t` through the first and last requested
-`n_t` -- the INTERCEPT `a` is the primal-sharing witness (it should land
-near one plain solve; see G3 in tests/test_jacobian_fwd.py for the
-structural, non-numeric version of the same claim) and the SLOPE `b` is
-the marginal per-tangent cost.
+`n_t` -- the INTERCEPT `a` is a DIAGNOSTIC primal-sharing witness (it
+should land near one plain solve on CPU, where it reads ~0.98-1.10) and
+the SLOPE `b` is the marginal per-tangent cost. The printed
+intercept/plain ratio is CPU-calibrated: a two-point fit pushes any fixed
+per-call overhead that does not scale with `n_t` (kernel launch, tiling)
+into the intercept, and that effect is largest where the marginal cost
+per tangent is smallest -- on an RTX 4090 the same ratio reads 1.4-1.9x
+across grid sizes (issue #632) with sharing intact. Do not treat this
+ratio as a regression signal on an accelerator; see G3 in
+tests/test_jacobian_fwd.py for the authoritative, backend-independent
+structural check (it inspects the jaxpr directly for one unbatched
+primal scan rather than fitting wall-clock/flops numbers).
 
 Fixture note (issue #577 cost-measurement discipline): the fixture registers
 NO point probes (no `add_probe`). The uniform forward lane cannot drop the
@@ -286,7 +294,17 @@ def _print_table(table: dict[str, Any]) -> None:
         print(f"  fit {name}: a={a:.4g} (intercept) b={b:.4g} (marginal cost per tangent)")
     for name, ratio in table["intercept_vs_plain_ratio"].items():
         print(f"  intercept/plain ratio ({name}): {ratio:.3f} "
-              f"(primal-sharing witness -- expect close to 1.0)")
+              f"(primal-sharing witness, DIAGNOSTIC not authoritative -- "
+              f"CPU-calibrated expectation ~1.0; on an accelerator this "
+              f"reads higher, e.g. 1.4-1.9x measured on an RTX 4090, "
+              f"because the two-point endpoint fit pushes fixed per-call "
+              f"overhead [kernel launch, tiling] that does not scale with "
+              f"n_t into the intercept, and that effect is largest where "
+              f"per-tangent marginal cost is smallest [issue #632]. Do not "
+              f"read a high ratio here as a sharing regression by itself "
+              f"-- G3 in tests/test_jacobian_fwd.py is the authoritative, "
+              f"backend-independent structural check: it inspects the "
+              f"jaxpr directly for one unbatched primal scan.)")
     w = table["n_steps_independence_witness"]
     print(
         f"  n_steps independence (n_t={w['n_t']}): temp_bytes "

--- a/scripts/diagnostics/i626_n_warmup_truncation_sweep.py
+++ b/scripts/diagnostics/i626_n_warmup_truncation_sweep.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Issue #626 part 2: what does n_warmup do NUMERICALLY to the gradient on
+the non-uniform lane where it IS implemented (rfx/nonuniform.py)?
+
+This is the committed artifact behind the "fixture 2" curve quoted in
+docs/agent-memory/rfx-known-issues.md's "Added 2026-08-11 -- #626 RESOLVED"
+entry and the CHANGELOG.md entry of the same name. Fixture 1 (the smaller,
+faster sweep) is committed directly as a pytest regression test instead --
+see tests/test_n_warmup.py::test_warmup_truncation_error_grows_with_k --
+because it is cheap enough to run on every CI pass; this script's fixture 2
+(larger grid, more steps) is a slower confirmatory sweep kept here as a
+reproducible artifact rather than as a standing test.
+
+Design (see tests/test_n_warmup.py's docstring for the full rationale): the
+LOSS WINDOW is held FIXED at time_series[N_FIXED:] for every K in the
+sweep, and K (n_warmup) is varied independently -- conflating the two (as
+the pre-existing test_warmup_grad_finite_and_same_sign does) cannot isolate
+the truncation effect from "how much of the tail is scored". The oracle is
+an independent central FD at n_warmup=0 (forward output is provably
+n_warmup-invariant, bit-identical, so the oracle is unaffected by K),
+comparison arithmetic in float64 (repo convention, tests/_x64_compat.py +
+test_jacobian_fwd.py's _central_fd_f64).
+
+Run:
+    PYTHONPATH=. JAX_PLATFORMS=cpu python scripts/diagnostics/i626_n_warmup_truncation_sweep.py
+"""
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from rfx import Simulation
+
+try:
+    from jax import enable_x64
+except ImportError:  # pragma: no cover - JAX version drift, see tests/_x64_compat.py
+    from tests._x64_compat import enable_x64
+
+
+def _build_sim():
+    dz = np.array([0.5e-3] * 5 + [0.4e-3] * 4, dtype=np.float64)
+    sim = Simulation(
+        freq_max=10e9, domain=(0.01, 0.01, float(np.sum(dz))),
+        dx=0.5e-3, dz_profile=dz, cpml_layers=4,
+    )
+    sim.add_source((0.005, 0.005, 0.001), "ez")
+    sim.add_probe((0.005, 0.005, 0.003), "ez")
+    return sim
+
+
+# Fixture 2: larger grid / longer run than the committed pytest fixture, a
+# different design-cell placement than fixture 1's, kept as a slower
+# confirmatory sweep (not a standing CI test).
+N_STEPS = 200
+N_FIXED = 160  # loss window = time_series[N_FIXED:], fixed across the K sweep
+ALPHA0 = 2.0
+
+
+def _make_objective(sim, ti, tj, tk, g_shape):
+    eps_base = jnp.ones(g_shape, dtype=jnp.float32)
+
+    def objective(alpha, *, n_warmup):
+        eps = eps_base.at[ti, tj, tk].set(alpha)
+        fr = sim.forward(
+            eps_override=eps, n_steps=N_STEPS, n_warmup=n_warmup,
+            skip_preflight=True,
+        )
+        return jnp.sum(fr.time_series[N_FIXED:] ** 2)
+
+    return objective
+
+
+def _central_fd_f64(objective, x0, h, *, n_warmup):
+    with enable_x64():
+        fp = objective(jnp.asarray(x0 + h, dtype=jnp.float32), n_warmup=n_warmup)
+        fm = objective(jnp.asarray(x0 - h, dtype=jnp.float32), n_warmup=n_warmup)
+        return float((fp - fm) / (2.0 * h))
+
+
+def main():
+    sim = _build_sim()
+    g = sim._build_nonuniform_grid()
+    ti, tj, tk = g.nx // 2 + 2, g.ny // 2 + 2, g.nz // 2
+    print(f"grid shape={g.shape}, design cell=({ti},{tj},{tk})")
+
+    objective = _make_objective(sim, ti, tj, tk, g.shape)
+
+    # Forward-value identity sanity check (must hold per
+    # tests/test_n_warmup.py::test_forward_matches_plain).
+    eps_probe = jnp.ones(g.shape, dtype=jnp.float32).at[ti, tj, tk].set(ALPHA0)
+    ts0 = np.asarray(sim.forward(eps_override=eps_probe, n_steps=N_STEPS, n_warmup=0,
+                                  skip_preflight=True).time_series)
+    ts60 = np.asarray(sim.forward(eps_override=eps_probe, n_steps=N_STEPS, n_warmup=60,
+                                   skip_preflight=True).time_series)
+    fwd_rel = np.max(np.abs(ts0 - ts60)) / max(np.max(np.abs(ts0)), 1e-30)
+    print(f"[sanity] forward value n_warmup=0 vs 60: max abs diff rel to peak = {fwd_rel:.3e}")
+    assert fwd_rel == 0.0, "forward output must be exactly n_warmup-invariant"
+
+    h = 0.02
+    g_fd = _central_fd_f64(objective, ALPHA0, h, n_warmup=0)
+    print(f"[oracle] central FD (h={h}, x64 arithmetic) gradient = {g_fd:.6e}")
+
+    k_sweep = [0, 10, 20, 40, 60, 80, 100, 120, 140, 155, 170, 190]
+    print(f"{'K':>5} {'K/N_FIXED':>10} {'AD grad':>16} {'rel_err vs FD':>16}")
+    results = []
+    for k in k_sweep:
+        alpha0 = jnp.asarray(ALPHA0, dtype=jnp.float32)
+        g_ad = float(jax.grad(lambda a: objective(a, n_warmup=k))(alpha0))
+        rel = abs(g_ad - g_fd) / max(abs(g_fd), 1e-30)
+        results.append((k, g_ad, rel))
+        print(f"{k:5d} {k / N_FIXED:10.3f} {g_ad:16.6e} {rel * 100:15.3f}%")
+
+    print("\nRaw tuples (K, AD_grad, rel_err_vs_FD):")
+    for row in results:
+        print(row)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_jacobian_fwd.py
+++ b/tests/test_jacobian_fwd.py
@@ -21,17 +21,18 @@ FENCE TAXONOMY (G6) -- read before editing G6: `jacobian_fwd` is generic
 over `sim_fn` (signature pinned to `sim_fn, params, tangents,
 batch_tangents` by `scripts/check_api_reference.py`'s inventory) and never
 sees `Simulation.forward()`'s own keyword arguments -- they live inside the
-caller's closure. One of the three documented fences is a RUNTIME RAISE
+caller's closure. Two of the three documented fences are RUNTIME RAISES
 that `jacobian_fwd` INHERITS for free (the underlying `forward()` call
 raises before `jacobian_fwd`'s own machinery runs, so the raise just
 propagates up through `jax.jvp`): non-uniform+distributed with a
-registered DFT-plane probe (the #619 fence). The other two -- `n_warmup`
-(a measured SILENT NO-OP on the uniform lane, issue #626) and
-`checkpoint`/`checkpoint_segments` (measured EXACTLY NEUTRAL under forward
-mode) -- have NO raise to inherit and cannot be intercepted from outside
-the closure without breaking the pinned generic signature, so they are
-DOCUMENTED traps rather than runtime checks; G6 pins the docstring text
-for those two instead of a raise.
+registered DFT-plane probe (the #619 fence), and `n_warmup` on the
+uniform lane (issue #626's own fence -- it used to be a measured SILENT
+NO-OP; the uniform lane now raises instead of silently ignoring it). The
+remaining one -- `checkpoint`/`checkpoint_segments` (measured EXACTLY
+NEUTRAL under forward mode) -- has NO raise to inherit and cannot be
+intercepted from outside the closure without breaking the pinned generic
+signature, so it is a DOCUMENTED trap rather than a runtime check; G6
+pins the docstring text for that one instead of a raise.
 
 (A fourth candidate, `design_mask`, was removed with the parameter itself
 in issue #625: the mask was measured to corrupt the gradient rather than
@@ -596,14 +597,26 @@ def test_g6_design_mask_kwarg_raises_type_error_not_a_fence():
         jacobian_fwd(sim_fn, jnp.asarray(1.0, dtype=jnp.float32))
 
 
-def test_g6b_n_warmup_is_a_documented_trap_not_a_raise():
-    """No forward()-level raise exists to inherit (n_warmup is a measured
-    SILENT NO-OP on the uniform lane) -- pin the docstring warning instead
-    so it cannot silently be dropped in a future edit."""
-    doc = jacobian_fwd.__doc__
-    assert "n_warmup" in doc
-    assert "SILENT NO-OP" in doc
-    assert "#626" in doc
+def test_g6b_n_warmup_fence_raises():
+    """Inherited from forward()'s own uniform-lane n_warmup fence (issue
+    #626): a nonzero n_warmup on the uniform lane raises
+    NotImplementedError regardless of AD mode. (Prior to the #626 fix this
+    was a measured SILENT NO-OP, not a raise -- see
+    tests/test_n_warmup.py::test_uniform_forward_rejects_n_warmup for the
+    forward()-level pin and docs/agent-memory/rfx-known-issues.md for the
+    measured bit-identical-gradient evidence that motivated the fence.)"""
+    sim = _build_sim()
+    grid = sim._build_grid()
+
+    def sim_fn(alpha):
+        eps = jnp.ones(grid.shape, dtype=jnp.float32) * alpha
+        result = sim.forward(
+            eps_override=eps, n_steps=2, n_warmup=1, skip_preflight=True,
+        )
+        return dft_field(_PLANE)(result)
+
+    with pytest.raises(NotImplementedError, match="n_warmup"):
+        jacobian_fwd(sim_fn, jnp.asarray(1.0, dtype=jnp.float32))
 
 
 def test_g6c_checkpoint_knobs_are_documented_inert_not_a_raise():

--- a/tests/test_n_warmup.py
+++ b/tests/test_n_warmup.py
@@ -9,6 +9,20 @@ Guarantees:
      kills tape for steps before n_warmup; physical forward is
      identical).
   3. n_warmup >= n_steps is a clean ValueError.
+
+Issue #626 additions:
+  4. The uniform (single-device) forward lane never implemented n_warmup
+     (no warmup-split parameter on `_forward_from_materials`) but silently
+     accepted and dropped it — measured bit-identical gradient at
+     n_warmup=0 vs n_warmup=60. It now raises NotImplementedError instead
+     (test_uniform_forward_rejects_n_warmup).
+  5. n_warmup IS implemented on this file's non-uniform lane, but it is an
+     APPROXIMATION, not an exact truncation: severing the scan carry at the
+     warmup boundary also severs the gradient path from a design variable's
+     influence during the warmup window. test_warmup_truncation_error_grows_with_k
+     pins the measured error curve against an independent central-FD oracle
+     (held-fixed loss window, K varied independently -- see the docstring
+     there for why that isolation matters).
 """
 
 from __future__ import annotations
@@ -19,6 +33,11 @@ import numpy as np
 import pytest
 
 from rfx import Simulation
+
+try:
+    from jax import enable_x64
+except ImportError:  # pragma: no cover - JAX version drift, see tests/_x64_compat.py
+    from tests._x64_compat import enable_x64
 
 
 def _build_sim():
@@ -83,3 +102,115 @@ def test_n_warmup_composes_with_checkpoint_every():
         sim.forward(n_steps=80, n_warmup=16, checkpoint_every=16).time_series
     )
     np.testing.assert_allclose(ts_plain, ts_combo, rtol=1e-5, atol=1e-10)
+
+
+def test_uniform_forward_rejects_n_warmup():
+    """Issue #626: forward() declared and documented n_warmup but only
+    forwarded it to the NU lanes; `_forward_from_materials` (the uniform
+    lane) has no such parameter, so a nonzero n_warmup was silently
+    accepted and ignored (measured bit-identical gradient at n_warmup=0
+    vs n_warmup=60). It must now fail loud instead, matching its three
+    uniform-lane siblings (emit_time_series=False, checkpoint_every,
+    design_mask). This is the regression witness: a future silent re-drop
+    would make this raise disappear (n_warmup=0 still runs fine below), not
+    merely "both run" -- the required difference is raise vs. no-raise."""
+    sim = Simulation(freq_max=10e9, domain=(0.01, 0.01, 0.005), dx=0.5e-3,
+                      cpml_layers=4)
+    sim.add_source((0.005, 0.005, 0.001), "ez")
+    sim.add_probe((0.005, 0.005, 0.003), "ez")
+
+    # n_warmup=0 (the default / a no-op value) must still run cleanly.
+    fr = sim.forward(n_steps=20, n_warmup=0)
+    assert np.all(np.isfinite(np.asarray(fr.time_series)))
+
+    with pytest.raises(NotImplementedError, match="n_warmup"):
+        sim.forward(n_steps=20, n_warmup=5)
+
+
+def test_warmup_truncation_error_grows_with_k():
+    """Issue #626 part 2: measure what n_warmup does NUMERICALLY to the
+    gradient on the non-uniform lane where it IS implemented, against an
+    INDEPENDENT central-FD oracle -- not merely "finite and same sign"
+    (that was test_warmup_grad_finite_and_same_sign's weaker guarantee).
+
+    Design: the LOSS WINDOW is held FIXED at time_series[N_FIXED:] for
+    every K in the sweep, and K (n_warmup) is varied independently. This
+    is deliberately different from test_warmup_grad_finite_and_same_sign,
+    which lets the loss window itself track `warmup` -- that conflates
+    "how much of the tail is scored" with "how much AD tape is kept" and
+    cannot isolate the truncation effect. The FD oracle uses n_warmup=0
+    (forward output is provably n_warmup-invariant per
+    test_forward_matches_plain, so the oracle is unaffected by K) with
+    comparison arithmetic in float64 (repo convention, tests/_x64_compat.py
+    + test_jacobian_fwd.py's _central_fd_f64).
+
+    Measured (this fixture, N_STEPS=100, N_FIXED=80, design cell offset
+    from source/probe): rel_err vs. FD oracle is roughly
+    K=0: ~0.2-1%, K=10: ~1-1.5%, K=30: 3.3%, K=40 (half the
+    pre-loss-window): 6.6%, K=50: 12.1%, K=70: 35.2% -- growing as K
+    approaches the loss window, consistent with a second independent
+    design-cell placement measured out-of-band (see
+    docs/agent-memory/rfx-known-issues.md, issue #626 part 2, and the
+    forward()/nonuniform.py docstrings this test backs). The K=0/K=10
+    figures are hedged deliberately: an h-sweep of the FD oracle shows
+    those two points sit INSIDE the oracle's own noise band (at h=0.05,
+    K=10's error reads slightly below K=0's), so a strict monotonicity
+    assertion starting at K=0 would bind that noise-band coincidence
+    rather than the truncation mechanism -- this repo's own do-not-repeat
+    lesson (feedback_gate_can_bind_artifact). K>=30 is unambiguous and is
+    where the assertions below get strict. This is NOT a free memory
+    lever: severing the carry at the warmup boundary severs the gradient
+    path from the design variable's influence during the warmup window,
+    and that path is not negligible for a static material parameter
+    present throughout the whole run.
+    """
+    sim = _build_sim()
+    g = sim._build_nonuniform_grid()
+    ti, tj, tk = g.nx // 2 + 2, g.ny // 2 + 2, g.nz // 2
+    n_steps = 100
+    n_fixed = 80
+    alpha0 = 2.0
+    eps_base = jnp.ones(g.shape, dtype=jnp.float32)
+
+    def objective(alpha, *, n_warmup):
+        eps = eps_base.at[ti, tj, tk].set(alpha)
+        fr = sim.forward(
+            eps_override=eps, n_steps=n_steps, n_warmup=n_warmup,
+            skip_preflight=True,
+        )
+        return jnp.sum(fr.time_series[n_fixed:] ** 2)
+
+    h = 0.02
+    with enable_x64():
+        fp = objective(jnp.asarray(alpha0 + h, dtype=jnp.float32), n_warmup=0)
+        fm = objective(jnp.asarray(alpha0 - h, dtype=jnp.float32), n_warmup=0)
+        g_fd = float((fp - fm) / (2.0 * h))
+    assert abs(g_fd) > 0.0, "FD oracle gradient is exactly zero -- fixture did not couple"
+
+    k_sweep = [0, 10, 30, 40, 50, 70]
+    rel_errs = []
+    for k in k_sweep:
+        a0 = jnp.asarray(alpha0, dtype=jnp.float32)
+        g_ad = float(jax.grad(lambda a: objective(a, n_warmup=k))(a0))
+        rel_errs.append(abs(g_ad - g_fd) / max(abs(g_fd), 1e-30))
+
+    # K=0/K=10 (no or minimal truncation) sit inside the FD oracle's own
+    # noise band at this h (measured via an h-sweep -- see the docstring),
+    # so these are loose ceilings, not a tight/ordered pair.
+    assert rel_errs[0] < 0.05, f"K=0 AD vs FD mismatch: {rel_errs[0] * 100:.2f}%"
+    assert rel_errs[1] < 0.05, f"K={k_sweep[1]} rel_err unexpectedly large: {rel_errs[1] * 100:.2f}%"
+    # Large K (approaching the loss window) is a substantial, non-noise
+    # bias -- if this ever drops back near the noise floor, the truncation
+    # mechanism itself has silently changed and needs re-investigation,
+    # not a gate loosening.
+    assert rel_errs[-1] > 0.15, f"K={k_sweep[-1]} rel_err unexpectedly small: {rel_errs[-1] * 100:.2f}%"
+    # Strict monotonicity from K=30 upward ONLY: below K=30 the true
+    # signal is not resolved above the FD oracle's own noise floor at
+    # this h (measured), so asserting order there would bind a noise-band
+    # coincidence rather than the truncation mechanism -- exactly the
+    # failure mode feedback_gate_can_bind_artifact warns about. From
+    # K=30 up the bias is unambiguous and the growth is decisive.
+    k30_idx = k_sweep.index(30)
+    trustworthy = rel_errs[k30_idx:]
+    for a, b in zip(trustworthy, trustworthy[1:]):
+        assert b >= a - 1e-6, f"non-monotone truncation error from K=30 up: {trustworthy}"


### PR DESCRIPTION
Closes #626 and #632.

## Two findings, one of them not in the issue

**#626 as filed:** `forward()` declared and documented `n_warmup` but the uniform lane dropped it — measured bit-identical gradients at `n_warmup=0` and `60`. `_dispatch_plan` already fenced `emit_time_series` and `checkpoint_every` there; `n_warmup` slipped through and was accepted-and-ignored, the SILENT_WRONG shape this repo removes on sight.

**What measuring it turned up:** nobody had ever checked what `n_warmup` does *numerically* on the non-uniform lane, where it is implemented. It applies `stop_gradient` to the `lax.scan` carry at a step boundary — the same construction whose spatial cousin was removed as #625 last night. Applied in time it is a legitimate, standard technique, but it is an **approximation**, and the docs described it purely as a memory lever ("reverse-mode AD builds no tape for the initial transient") with no mention of the derivative changing. Measured against an independent central-FD oracle with the loss window held fixed (n_steps=100, window [80,100), h=0.02):

| n_warmup | 0 | 10 | 30 | 40 | 50 | 60 | 70 | 80 | 95 |
|---|---|---|---|---|---|---|---|---|---|
| gradient error | ~0.2–1% | ~1–1.5% | 3.3% | 6.6% | 12.1% | 21.1% | 35.2% | 58.4% | 100% (exactly 0) |

Smooth and monotone from K=30 up, no sign flips. The mechanism is the same one #625 documented: severing the carry cuts every path by which the design variable's influence *during* the warmup steps returns to the loss. For a static material parameter present the whole run that is not a negligible transient — it is real signal being discarded, and the gradient collapses to exactly zero once K reaches the loss window.

Independently reproduced in review to the digit (0.247 / 1.146 / 3.313 / 12.140 / 35.196%), and confirmed at a third design-cell placement.

## The decision: fence, don't port

`checkpoint_segments` already gives the uniform lane an **exact** √n_steps memory reduction with no gradient approximation, so porting a lossy approximation there buys nothing it does not already have — while costing a warmup/optimize split threaded through the three accumulators that are genuinely uniform-only (S11 DFT, Kerr χ³, `mu_r_override`). Review corrected an earlier version of this rationale that also listed flux monitors, NTFF and lumped-RLC state: those are real non-uniform-lane carries and would have come for free, so they are not part of the argument.

`forward(n_warmup=K>0)` on a uniform mesh now raises `NotImplementedError` alongside its two siblings. `n_warmup=0` still runs (verified, not inferred), and negative values now no-op on both lanes rather than raising on one.

`rfx.optimize.optimize()` is the second entry point for this behaviour — and the one where a truncated gradient actually drives a design loop. It took `n_warmup` undocumented; it is documented now, on both `optimize()` and `progressive_optimize()`, and verified live that a uniform-mesh `optimize(..., n_warmup=5)` raises through the optimizer.

## A gate that bound a coincidence

The first version of the new truncation test asserted strict monotonicity from K=0. Review's h-sweep showed why that was wrong: the FD oracle is well-conditioned for h ∈ [0.01, 0.2] but the K=0 and K=10 points sit inside its own noise band — at h=0.05 the K=10 error (0.440%) reads *below* K=0's (0.466%), so the assertion would have failed there. It passed only because h=0.02 happens to land at the band's minimum for K=0 and near its maximum for K=10: a gate binding a numerical coincidence rather than the mechanism, which is precisely the pattern this repo has a do-not-repeat lesson for — and it would have been ironic to ship it inside a PR about honest gradient documentation.

Fixed by flooring K=0/K=10 to loose ceilings and asserting strict monotonicity only from K=30 up, where review ruled the published figures trustworthy exactly as stated. The small-K figures are hedged to one significant figure instead of quoted to two. Two further placements at weaker design/loss coupling reproduce the large-K collapse cleanly but *not* small-K monotonicity (K=0 baseline noise 12–26% there) — that measurement, not a convenient threshold, is why the floor sits at K=30, and it is recorded as a caveat rather than smoothed away.

Two docstring shape claims were also overstating in the safe direction and are now replaced by the measured curve: "tens of percent at half the pre-loss-window length" was 6.6% at exactly half, and "grows toward 100% at the loss window" was 58.4% at the boundary with 100% reached only at K=95.

The sweep that produces the second fixture's curve ships as `scripts/diagnostics/i626_n_warmup_truncation_sweep.py` — it had been quoted from an uncommitted script, which meant neither review nor the next reader could reproduce it.

## #632

`scripts/benchmark_jacobian_fwd.py`'s `intercept/plain` line is labelled "expect close to 1.0", which is CPU-calibrated: it reads 0.98–1.10 on CPU but 1.41–1.87 on an RTX 4090, because a two-point fit pushes fixed per-call overhead into the intercept and that effect is largest where the marginal cost is smallest. Reworded, and it now points at G3 in `tests/test_jacobian_fwd.py` — the jaxpr-structural, backend-independent check — as authoritative. No behaviour change.

## Verification

`tests/test_n_warmup.py` 6/6 (was 4), `tests/test_jacobian_fwd.py` 14/14, `test_forward_docstring_contract` 4/4, `test_design_mask_removed` 5/5 (rebase sanity against #625), plus the NU/AD-memory/mesh consumers and the distributed-NU `n_warmup` tests — all green; review independently ran 155 tests across the same surfaces. ruff clean; `check_api_reference.py` OK (no public signature changed — behaviour and docstrings only).

Note on the pre-existing `test_warmup_grad_finite_and_same_sign`: its loss window tracks `warmup`, so it conflates how much tail is scored with how much tape is kept and cannot isolate truncation. Its assertions are weak rather than wrong, so they stand; the new test holds the window fixed.

R3: memory=#625's carry-stop_gradient record (same construction, time axis instead of space) + feedback_gate_can_bind_artifact (caught in this PR's own new gate) | R2-attempts=1 | falsifier=the fence raises where the call was previously silent, and the truncation curve reproduced independently at three placements

🤖 Generated with [Claude Code](https://claude.com/claude-code)