### PR TITLE
fix(geometry): extend static materials into the CPML pad for domain-face-touching boxes; the dispersive half is REVERTED as destabilizing (closes #627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,72 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — CPML pad replication was incomplete: hi-face vacuum for domain-face-touching boxes, and dispersion poles never extended (issue #627)
+
+- Follow-up to #582's review, which found two gaps its uniform-vs-NU pad
+  replication mirror faithfully inherited from the (pre-existing) uniform
+  path. Both are fixed once, in a new shared
+  `rfx.geometry.rasterize_grid.extend_cpml_pad_materials`, used by both
+  `rfx/api/_compile.py`'s `_assemble_materials` and
+  `rfx/runners/nonuniform.py`'s `assemble_materials_nu` — replacing the two
+  hand-duplicated pad-extension blocks that #582 had verified byte-identical
+  (a duplication that is itself the historical defect class here: two
+  hand-maintained copies of one piece of logic drift).
+- **(a) Hi-face vacuum column for a domain-face-touching `Box`.**
+  `rfx.geometry.csg.Box`'s volume rasterization is deliberately half-open,
+  `[lo, hi)`, over node coordinates (see that class's docstring — the
+  convention is load-bearing across the package, e.g. every WR-90
+  aperture/iris measurement, and is explicitly OUT OF SCOPE to change here:
+  doing so would move geometry everywhere in the package). Its documented
+  consequence is that a box's hi face "contributes no node": a structure
+  whose hi face lands on the domain's last interior node loses exactly that
+  node from its own rasterized mask, so the naive interior-edge source for
+  a hi-face CPML pad read vacuum even though the structure's real material
+  sits one column further in. Measured pre-fix on the #582 fixture: x-lo
+  pad `eps_r=4.0`, x-hi pad `eps_r=1.0`, for a slab spanning the full x
+  extent. Fix: per transverse cell, if the naive interior-edge column is
+  vacuum (`eps_r==1 & sigma==0 & mu_r==1`) but the column immediately
+  inside it is not, replicate from that inner column instead — bounded to
+  exactly one column inward, matching the rasterizer's deterministic
+  one-node-per-box shortfall, so a genuine multi-cell vacuum buffer between
+  an interior structure and the CPML pad (the overwhelmingly common
+  simulation layout) is untouched and still replicates plain vacuum, as
+  before. Locked by
+  `tests/test_cpml_pad_material_extension.py::test_genuine_vacuum_buffer_before_cpml_is_not_bridged`.
+- **(b) Dispersion poles were never extended into the pad.** Debye/Lorentz
+  pole masks were built straight from the geometry loop with no
+  pad-extension step at all (on either face) — a dispersive edge-touching
+  material had its static `eps_r` matched into the pad but not its poles,
+  so the pad medium was non-dispersive: matched at DC, mismatched across
+  the band. Fix: the pole masks now go through the same
+  `extend_cpml_pad_materials` call as `eps_r`/`sigma`/`mu_r`, using the
+  identical per-cell hi-face source decision (same box, same dropped node,
+  for every property of that box).
+- **Absorber-quality witness** (4000-step run, `eps_r=9.8, sigma=0.5,
+  mu_r=2.5` slab spanning the full x/y extent, probe near the x-hi pad
+  interface, `cpml_layers=8`, no subpixel smoothing): tail/peak energy
+  improves −85.15 dB → −90.62 dB for the static-only fix (a), and
+  −89.34 dB → −98.84 dB when the material is also dispersive (a+b
+  combined) — consistent in direction and rough scale with #582's own
+  −63.2 dB → −76.7 dB precedent.
+- **Byte-identity preserved.** `eps_r`/`sigma`/`mu_r` and every
+  Debye/Lorentz pole mask are bit-identical between the uniform and NU
+  assemblers post-fix (0 mismatched cells of 72,912, checked for
+  non-dispersive, Debye, and Lorentz materials, including a lossy+magnetic
+  case) — extending the property #582's review established.
+  `tests/test_nonuniform_uniform_end_to_end_reduction.py` (the anchor that
+  originally caught #582) stays green: `staircase-slab-cpml` residual
+  8.83e-5, `subpixel-cpml` residual 1.40e-4 (both well under the 3e-4
+  gate; not expected to move much, since the fix is symmetric across both
+  assemblers — the reduction anchor compares the two paths to each other,
+  not either to ground truth).
+- **Scope.** Rasterizer semantics (`Box.mask`/`mask_on_coords`) are
+  unchanged — the fix lives entirely in the post-rasterization pad-fill
+  step. PEC pad replication remains out of scope (PEC has never been
+  extended into the pad on either path; a PEC surface intersecting a CPML
+  boundary is a pre-existing, separate situation not addressed by #582 or
+  #627). Closes the two gaps #582's Scope clause deferred.
+
 ### Fixed — arc-audit follow-up: flaky benchmark gate, an over-general `n_warmup` claim, an unsafe `field_softmax` default, and asymmetric `jacobian_fwd` safety
 
 An independent adversarial audit of the e4b565c..ce44661 merge arc (10 PRs,
@@ -548,15 +614,16 @@ corrections to fixes that had not yet shipped.
   unaffected (the new step is gated on `cpml_layers > 0`, which
   `Simulation.__init__` forces to 0 for `boundary="pec"`).
   **Scope**: the fix mirrors the uniform path's replication exactly,
-  including two gaps it inherits from that path (tracked separately in
-  #627, not addressed here): (a) for a `Box` whose upper face coincides
-  with the domain face, the hi-face replication copies a column the
-  rasterizer leaves at vacuum, so only the lo-side pad ends up matched;
-  (b) Debye/Lorentz dispersive poles are rasterized with no pad-extension
-  step, so a dispersive edge-touching material gets its static `eps_r`
-  matched into the pad but not its poles. In short: this closes the gap
-  for non-dispersive media, and — for boxes ending exactly on the domain
-  face — for the lo-side faces.
+  including two gaps it inherits from that path — (a) for a `Box` whose
+  upper face coincides with the domain face, the hi-face replication
+  copies a column the rasterizer leaves at vacuum, so only the lo-side pad
+  ends up matched; (b) Debye/Lorentz dispersive poles are rasterized with
+  no pad-extension step, so a dispersive edge-touching material gets its
+  static `eps_r` matched into the pad but not its poles. In short: this
+  closes the gap for non-dispersive media, and — for boxes ending exactly
+  on the domain face — for the lo-side faces. **Both gaps are now closed,
+  by issue #627** (see that entry above) — this clause is kept for
+  historical accuracy about what #582 itself did and did not cover.
   `tests/test_nonuniform_uniform_end_to_end_reduction.py`'s
   `subpixel-cpml` case converts from `xfail(strict=True)` to a normal
   assertion (residual 1.9890e-2 pre-fix -> 1.14e-4 post-fix); a new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,24 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   `extend_cpml_pad_materials` call as `eps_r`/`sigma`/`mu_r`, using the
   identical per-cell hi-face source decision (same box, same dropped node,
   for every property of that box).
+  **Coverage caveat, found in review and NOT fixed here**: that per-cell
+  decision tests whether the naive column is "vacuum" by inspecting only
+  the static `eps_r`/`sigma`/`mu_r` arrays, so it cannot detect a
+  *pole-only* dispersive material — one whose background `eps_r` is left
+  at 1.0 and where the pole alone carries the dispersion. That pattern is
+  not a corner case: it is the public docs' own canonical recipe
+  (`docs/public/guide/materials-geometry.mdx`'s Lorentz example). Measured
+  (this repo's #582 fixture, `eps_r=1.0` pole vs `eps_r=4.0` pole): the
+  `eps_r=1.0` case gets pole cells replicated into the x-lo pad but ZERO
+  into the x-hi pad; `eps_r=4.0` gets the same nonzero count on both
+  faces. The committed regression test below uses `eps_r=4.0` and does
+  not exercise the `eps_r=1.0` case, so it does not catch this. **A
+  pole-only material's hi-face pad is therefore still mismatched at every
+  frequency, not just DC** — the fix in this entry closes (b) only for
+  materials that also carry a non-vacuum static signature. Left open
+  pending resolution of a separate, unrelated stability question raised
+  in review (a high-Q Lorentz pole composed with the CPML memory
+  variables in an edge-touching pad) before extending coverage further.
 - **Absorber-quality witness** (4000-step run, `eps_r=9.8, sigma=0.5,
   mu_r=2.5` slab spanning the full x/y extent, probe near the x-hi pad
   interface, `cpml_layers=8`, no subpixel smoothing): tail/peak energy
@@ -70,7 +88,24 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   step. PEC pad replication remains out of scope (PEC has never been
   extended into the pad on either path; a PEC surface intersecting a CPML
   boundary is a pre-existing, separate situation not addressed by #582 or
-  #627). Closes the two gaps #582's Scope clause deferred.
+  #627). Of the two gaps #582's Scope clause deferred: (a) is closed in
+  full; (b) is closed only for materials with a non-vacuum static
+  signature — see the coverage caveat above for what is still open for
+  pole-only materials.
+  **Also out of scope for both #582 and #627, found in review**:
+  `subpixel_smoothing=True` builds its anisotropic eps tensor (`aniso_eps`)
+  directly from `sim._geometry` shapes with a hardcoded
+  `background_eps=1.0` (`rfx/geometry/smoothing.py`'s
+  `compute_smoothed_eps` / `compute_smoothed_eps_nonuniform`, called from
+  `rfx/runners/uniform.py` and `rfx/runners/nonuniform.py`), independently
+  of — and without reading — the CPML-pad-extended `eps_r`/`sigma`/`mu_r`
+  arrays this entry and #582 fix. Verified directly: with
+  `subpixel_smoothing=True` the field update never sees the pad-replicated
+  material at all, on either path. In short, "impedance-matched absorber"
+  in this file and #582 has only ever meant the non-smoothed (staircase)
+  rasterization; the subpixel-smoothed path's CPML pad has always been
+  plain vacuum regardless of the adjacent structure, unaffected by either
+  fix.
 
 ### Fixed — arc-audit follow-up: flaky benchmark gate, an over-general `n_warmup` claim, an unsafe `field_softmax` default, and asymmetric `jacobian_fwd` safety
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,18 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
-### Fixed — CPML pad replication was incomplete: hi-face vacuum for domain-face-touching boxes, and dispersion poles never extended (issue #627)
+### Fixed — CPML hi-face pad was vacuum for domain-face-touching boxes (issue #627a; #627b attempted, found unsafe, reverted — deferred to issue #636)
 
 - Follow-up to #582's review, which found two gaps its uniform-vs-NU pad
   replication mirror faithfully inherited from the (pre-existing) uniform
-  path. Both are fixed once, in a new shared
+  path. Only the first is fixed here, in a new shared
   `rfx.geometry.rasterize_grid.extend_cpml_pad_materials`, used by both
   `rfx/api/_compile.py`'s `_assemble_materials` and
   `rfx/runners/nonuniform.py`'s `assemble_materials_nu` — replacing the two
   hand-duplicated pad-extension blocks that #582 had verified byte-identical
   (a duplication that is itself the historical defect class here: two
   hand-maintained copies of one piece of logic drift).
-- **(a) Hi-face vacuum column for a domain-face-touching `Box`.**
+- **(a) Hi-face vacuum column for a domain-face-touching `Box` — FIXED.**
   `rfx.geometry.csg.Box`'s volume rasterization is deliberately half-open,
   `[lo, hi)`, over node coordinates (see that class's docstring — the
   convention is load-bearing across the package, e.g. every WR-90
@@ -38,60 +38,66 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   simulation layout) is untouched and still replicates plain vacuum, as
   before. Locked by
   `tests/test_cpml_pad_material_extension.py::test_genuine_vacuum_buffer_before_cpml_is_not_bridged`.
-- **(b) Dispersion poles were never extended into the pad.** Debye/Lorentz
-  pole masks were built straight from the geometry loop with no
-  pad-extension step at all (on either face) — a dispersive edge-touching
-  material had its static `eps_r` matched into the pad but not its poles,
-  so the pad medium was non-dispersive: matched at DC, mismatched across
-  the band. Fix: the pole masks now go through the same
-  `extend_cpml_pad_materials` call as `eps_r`/`sigma`/`mu_r`, using the
-  identical per-cell hi-face source decision (same box, same dropped node,
-  for every property of that box).
-  **Coverage caveat, found in review and NOT fixed here**: that per-cell
-  decision tests whether the naive column is "vacuum" by inspecting only
-  the static `eps_r`/`sigma`/`mu_r` arrays, so it cannot detect a
-  *pole-only* dispersive material — one whose background `eps_r` is left
-  at 1.0 and where the pole alone carries the dispersion. That pattern is
-  not a corner case: it is the public docs' own canonical recipe
-  (`docs/public/guide/materials-geometry.mdx`'s Lorentz example). Measured
-  (this repo's #582 fixture, `eps_r=1.0` pole vs `eps_r=4.0` pole): the
-  `eps_r=1.0` case gets pole cells replicated into the x-lo pad but ZERO
-  into the x-hi pad; `eps_r=4.0` gets the same nonzero count on both
-  faces. The committed regression test below uses `eps_r=4.0` and does
-  not exercise the `eps_r=1.0` case, so it does not catch this. **A
-  pole-only material's hi-face pad is therefore still mismatched at every
-  frequency, not just DC** — the fix in this entry closes (b) only for
-  materials that also carry a non-vacuum static signature. Left open
-  pending resolution of a separate, unrelated stability question raised
-  in review (a high-Q Lorentz pole composed with the CPML memory
-  variables in an edge-touching pad) before extending coverage further.
-- **Absorber-quality witness** (4000-step run, `eps_r=9.8, sigma=0.5,
-  mu_r=2.5` slab spanning the full x/y extent, probe near the x-hi pad
-  interface, `cpml_layers=8`, no subpixel smoothing): tail/peak energy
-  improves −85.15 dB → −90.62 dB for the static-only fix (a), and
-  −89.34 dB → −98.84 dB when the material is also dispersive (a+b
-  combined) — consistent in direction and rough scale with #582's own
-  −63.2 dB → −76.7 dB precedent.
-- **Byte-identity preserved.** `eps_r`/`sigma`/`mu_r` and every
-  Debye/Lorentz pole mask are bit-identical between the uniform and NU
-  assemblers post-fix (0 mismatched cells of 72,912, checked for
-  non-dispersive, Debye, and Lorentz materials, including a lossy+magnetic
-  case) — extending the property #582's review established.
-  `tests/test_nonuniform_uniform_end_to_end_reduction.py` (the anchor that
-  originally caught #582) stays green: `staircase-slab-cpml` residual
-  8.83e-5, `subpixel-cpml` residual 1.40e-4 (both well under the 3e-4
-  gate; not expected to move much, since the fix is symmetric across both
-  assemblers — the reduction anchor compares the two paths to each other,
-  not either to ground truth).
+- **(b) Dispersion poles were never extended into the pad — attempted, then REVERTED; NOT shipped, at all.**
+  Debye/Lorentz pole masks are built straight from the geometry loop with
+  no pad-extension step (on either face) — a dispersive edge-touching
+  material has its static `eps_r` matched into the pad but not its poles,
+  so the pad medium is non-dispersive: matched at DC, mismatched across
+  the band. That gap is **still open**. An earlier revision of this change
+  extended the pole masks the same way as the static arrays, using the
+  same shared function; review's controlled four-way discriminator (one
+  fixture, one harness, only the pad-fill contents varied, printed per
+  variant to confirm each matched its label) found: **extending
+  dispersion poles into the pad turns a stable high-Q (Q≈60) edge-touching
+  Lorentz-slab simulation into a divergent one; the static extension (a)
+  alone, with the same high-Q pole left un-extended in the interior,
+  decays cleanly** — 20,000-step last-decile/mid-decile energy ratio 649
+  (poles extended) vs 0.1557 (statics-only, poles genuinely off in both
+  pads, decaying at the same order as the unpatched tree's 0.12). The
+  divergence has no NaN and no exception — values stay finite and simply
+  grow — so nothing downstream flags it. Because of this, **pole-mask
+  extension is not included in this change at all**:
+  `extend_cpml_pad_materials` only extends `eps_r`/`sigma`/`mu_r`, with no
+  parameter or code path for pole masks. It is not gated behind a flag
+  either — an opt-in that silently turns a stable simulation into a
+  divergent one is worse than no feature. Tracked in full — the factorial,
+  the mechanism hypothesis, and a separate coverage hole the attempted
+  design also had (a *pole-only* material, background `eps_r` left at 1.0,
+  was invisible to the hi-face-vacuum test) — in **issue #636**; that
+  detail is deferred work now, not a caveat on what ships here. Guarded
+  against silent reintroduction by a physics-level regression lock (see
+  below).
+- **Absorber-quality witness, (a) only** (4000-step run, `eps_r=9.8,
+  sigma=0.5, mu_r=2.5` slab spanning the full x/y extent, probe near the
+  x-hi pad interface, `cpml_layers=8`, no subpixel smoothing, no
+  dispersion pole): tail/peak energy improves −85.15 dB → −90.62 dB —
+  consistent in direction and rough scale with #582's own −63.2 dB →
+  −76.7 dB precedent.
+- **Byte-identity preserved.** `eps_r`/`sigma`/`mu_r` are bit-identical
+  between the uniform and NU assemblers post-fix (0 mismatched cells of
+  72,912, checked for non-dispersive, Debye, and Lorentz materials,
+  including a lossy+magnetic case) — extending the property #582's review
+  established. `tests/test_nonuniform_uniform_end_to_end_reduction.py`
+  (the anchor that originally caught #582) stays green:
+  `staircase-slab-cpml` residual 8.83e-5, `subpixel-cpml` residual
+  1.40e-4 (both well under the 3e-4 gate; not expected to move much, since
+  the fix is symmetric across both assemblers — the reduction anchor
+  compares the two paths to each other, not either to ground truth).
+- **Regression lock against silently reintroducing (b).**
+  `tests/test_cpml_pad_material_extension.py::test_pole_extension_stability_lock`
+  runs the (a)-only shipped code on the same edge-touching, high-Q-Lorentz
+  fixture the #636 discriminator used (~8000 steps) and asserts the run
+  decays (last decile below the mid-run decile). It passes on the shipped
+  code and is designed to red the moment pole extension is naively
+  reintroduced — that is its entire purpose, so it stays even though (b)
+  itself is gone.
 - **Scope.** Rasterizer semantics (`Box.mask`/`mask_on_coords`) are
   unchanged — the fix lives entirely in the post-rasterization pad-fill
   step. PEC pad replication remains out of scope (PEC has never been
   extended into the pad on either path; a PEC surface intersecting a CPML
   boundary is a pre-existing, separate situation not addressed by #582 or
   #627). Of the two gaps #582's Scope clause deferred: (a) is closed in
-  full; (b) is closed only for materials with a non-vacuum static
-  signature — see the coverage caveat above for what is still open for
-  pole-only materials.
+  full; **(b) is NOT closed** — see above.
   **Also out of scope for both #582 and #627, found in review**:
   `subpixel_smoothing=True` builds its anisotropic eps tensor (`aniso_eps`)
   directly from `sim._geometry` shapes with a hardcoded

--- a/rfx/api/_compile.py
+++ b/rfx/api/_compile.py
@@ -192,9 +192,18 @@ class _CompileMixin:
         # slice outward, as if the geometry continued beyond the domain.
         # Shared with the NU mirror (rfx/runners/nonuniform.py) via
         # extend_cpml_pad_materials — issue #627 found the two
-        # hand-duplicated copies (#582) both carrying the same gaps
-        # (hi-face vacuum column for a domain-touching box, and
-        # dispersion poles never extended at all); the fix lives once.
+        # hand-duplicated copies (#582) both carrying a hi-face vacuum
+        # column for a domain-touching box; the fix lives once.
+        #
+        # Dispersion-pole masks are deliberately NOT extended here (#627b
+        # tried and reverted): extending a high-Q (Q~60) Lorentz pole into
+        # the pad turns a stable edge-touching simulation into a divergent
+        # one (last/mid energy ratio 649 vs 0.12-0.16 decaying on every
+        # other tested variant, including the static extension below with
+        # the same pole left un-extended in the interior) — with no NaN
+        # and no exception, so nothing downstream catches it. See
+        # extend_cpml_pad_materials's docstring and the follow-up issue
+        # (filed separately, tracking the stability factorial).
         if self._boundary in ("cpml", "upml") and self._cpml_layers > 0:
             # Per-face allocation (2026-04): (pad_{axis}_lo / _hi). Reflector /
             # periodic faces have pad=0 on that side and the corresponding
@@ -204,23 +213,9 @@ class _CompileMixin:
             plx, phx = grid.pad_x_lo, grid.pad_x_hi
             ply, phy = grid.pad_y_lo, grid.pad_y_hi
             plz, phz = grid.pad_z_lo, grid.pad_z_hi
-            debye_keys = list(debye_masks_by_pole.keys())
-            lorentz_keys = list(lorentz_masks_by_pole.keys())
-            extra_masks_in = (
-                [debye_masks_by_pole[k][1] for k in debye_keys]
-                + [lorentz_masks_by_pole[k][1] for k in lorentz_keys]
-            )
-            eps_r, sigma, mu_r, extra_masks_out = extend_cpml_pad_materials(
+            eps_r, sigma, mu_r = extend_cpml_pad_materials(
                 eps_r, sigma, mu_r, plx, phx, ply, phy, plz, phz,
-                extra_masks=extra_masks_in,
             )
-            n_debye = len(debye_keys)
-            for k, mask in zip(debye_keys, extra_masks_out[:n_debye]):
-                pole, _old_mask = debye_masks_by_pole[k]
-                debye_masks_by_pole[k] = (pole, mask)
-            for k, mask in zip(lorentz_keys, extra_masks_out[n_debye:]):
-                pole, _old_mask = lorentz_masks_by_pole[k]
-                lorentz_masks_by_pole[k] = (pole, mask)
 
         materials = MaterialArrays(eps_r=eps_r, sigma=sigma, mu_r=mu_r)
 

--- a/rfx/api/_compile.py
+++ b/rfx/api/_compile.py
@@ -25,6 +25,7 @@ from rfx.geometry.csg import Box
 # broke the rcs_scattering tutorial's ``from rfx.geometry import
 # rasterize``).
 from rfx.geometry._pole_keying import _accumulate_pole_mask, _spec_from_pole_masks
+from rfx.geometry.rasterize_grid import extend_cpml_pad_materials
 from rfx.materials.debye import DebyePole, init_debye
 from rfx.materials.lorentz import LorentzPole, init_lorentz
 from rfx.materials.thin_conductor import apply_thin_conductor
@@ -189,6 +190,11 @@ class _CompileMixin:
         # modes in dielectric waveguides see an impedance-matched absorber
         # (equivalent to UPML).  Each CPML face copies the interior-edge
         # slice outward, as if the geometry continued beyond the domain.
+        # Shared with the NU mirror (rfx/runners/nonuniform.py) via
+        # extend_cpml_pad_materials — issue #627 found the two
+        # hand-duplicated copies (#582) both carrying the same gaps
+        # (hi-face vacuum column for a domain-touching box, and
+        # dispersion poles never extended at all); the fix lives once.
         if self._boundary in ("cpml", "upml") and self._cpml_layers > 0:
             # Per-face allocation (2026-04): (pad_{axis}_lo / _hi). Reflector /
             # periodic faces have pad=0 on that side and the corresponding
@@ -198,34 +204,23 @@ class _CompileMixin:
             plx, phx = grid.pad_x_lo, grid.pad_x_hi
             ply, phy = grid.pad_y_lo, grid.pad_y_hi
             plz, phz = grid.pad_z_lo, grid.pad_z_hi
-            eps_r_ext = eps_r
-            sigma_ext = sigma
-            mu_r_ext = mu_r
-            if plx > 0:
-                eps_r_ext = eps_r_ext.at[:plx,:,:].set(eps_r_ext[plx:plx+1,:,:])
-                sigma_ext = sigma_ext.at[:plx,:,:].set(sigma_ext[plx:plx+1,:,:])
-                mu_r_ext = mu_r_ext.at[:plx,:,:].set(mu_r_ext[plx:plx+1,:,:])
-            if phx > 0:
-                eps_r_ext = eps_r_ext.at[-phx:,:,:].set(eps_r_ext[-phx-1:-phx,:,:])
-                sigma_ext = sigma_ext.at[-phx:,:,:].set(sigma_ext[-phx-1:-phx,:,:])
-                mu_r_ext = mu_r_ext.at[-phx:,:,:].set(mu_r_ext[-phx-1:-phx,:,:])
-            if ply > 0:
-                eps_r_ext = eps_r_ext.at[:,:ply,:].set(eps_r_ext[:,ply:ply+1,:])
-                sigma_ext = sigma_ext.at[:,:ply,:].set(sigma_ext[:,ply:ply+1,:])
-                mu_r_ext = mu_r_ext.at[:,:ply,:].set(mu_r_ext[:,ply:ply+1,:])
-            if phy > 0:
-                eps_r_ext = eps_r_ext.at[:,-phy:,:].set(eps_r_ext[:,-phy-1:-phy,:])
-                sigma_ext = sigma_ext.at[:,-phy:,:].set(sigma_ext[:,-phy-1:-phy,:])
-                mu_r_ext = mu_r_ext.at[:,-phy:,:].set(mu_r_ext[:,-phy-1:-phy,:])
-            if plz > 0:
-                eps_r_ext = eps_r_ext.at[:,:,:plz].set(eps_r_ext[:,:,plz:plz+1])
-                sigma_ext = sigma_ext.at[:,:,:plz].set(sigma_ext[:,:,plz:plz+1])
-                mu_r_ext = mu_r_ext.at[:,:,:plz].set(mu_r_ext[:,:,plz:plz+1])
-            if phz > 0:
-                eps_r_ext = eps_r_ext.at[:,:,-phz:].set(eps_r_ext[:,:,-phz-1:-phz])
-                sigma_ext = sigma_ext.at[:,:,-phz:].set(sigma_ext[:,:,-phz-1:-phz])
-                mu_r_ext = mu_r_ext.at[:,:,-phz:].set(mu_r_ext[:,:,-phz-1:-phz])
-            eps_r, sigma, mu_r = eps_r_ext, sigma_ext, mu_r_ext
+            debye_keys = list(debye_masks_by_pole.keys())
+            lorentz_keys = list(lorentz_masks_by_pole.keys())
+            extra_masks_in = (
+                [debye_masks_by_pole[k][1] for k in debye_keys]
+                + [lorentz_masks_by_pole[k][1] for k in lorentz_keys]
+            )
+            eps_r, sigma, mu_r, extra_masks_out = extend_cpml_pad_materials(
+                eps_r, sigma, mu_r, plx, phx, ply, phy, plz, phz,
+                extra_masks=extra_masks_in,
+            )
+            n_debye = len(debye_keys)
+            for k, mask in zip(debye_keys, extra_masks_out[:n_debye]):
+                pole, _old_mask = debye_masks_by_pole[k]
+                debye_masks_by_pole[k] = (pole, mask)
+            for k, mask in zip(lorentz_keys, extra_masks_out[n_debye:]):
+                pole, _old_mask = lorentz_masks_by_pole[k]
+                lorentz_masks_by_pole[k] = (pole, mask)
 
         materials = MaterialArrays(eps_r=eps_r, sigma=sigma, mu_r=mu_r)
 

--- a/rfx/geometry/rasterize_grid.py
+++ b/rfx/geometry/rasterize_grid.py
@@ -241,27 +241,18 @@ def extend_cpml_pad_materials(
     plx: int, phx: int,
     ply: int, phy: int,
     plz: int, phz: int,
-    extra_masks=(),
 ):
-    """Extend material properties (and dispersion-pole masks) into the CPML
-    padding so guided modes see an impedance-matched absorber, equivalent
-    to UPML. Each CPML face copies the interior-edge slice outward, as if
-    the geometry continued beyond the domain.
+    """Extend eps_r/sigma/mu_r into the CPML padding so guided modes see an
+    impedance-matched absorber, equivalent to UPML. Each CPML face copies
+    the interior-edge slice outward, as if the geometry continued beyond
+    the domain.
 
     Single shared implementation for the uniform (``rfx/api/_compile.py``)
     and non-uniform (``rfx/runners/nonuniform.py``) assemblers — issue #627
     found the two hand-duplicated copies (#582 mirrored one onto the other)
-    both carrying the same two gaps, so the fix lives once, here, and both
-    call sites use it instead of keeping duplicated pad-extension code that
-    can drift.
-
-    ``extra_masks`` is a sequence of additional per-cell arrays (e.g.
-    Debye/Lorentz dispersion-pole boolean masks, #627b — previously never
-    extended into the pad at all, so a dispersive edge-touching material
-    was matched at DC but not across the band) that get the identical
-    lo/hi replication as ``eps_r``/``sigma``/``mu_r``, using the SAME
-    hi-face source column decided below (same box, same dropped node, for
-    every property of that box).
+    both carrying the same gap, so the fix lives once, here, and both call
+    sites use it instead of keeping duplicated pad-extension code that can
+    drift.
 
     **Hi-face fallback (#627a).** ``rfx.geometry.csg.Box``'s volume-branch
     rasterization is deliberately half-open, ``[lo, hi)``, over node
@@ -294,12 +285,32 @@ def extend_cpml_pad_materials(
     considered and rejected: it would bridge that common air gap and smear
     an unrelated interior structure's material into the pad.
 
+    **Dispersion-pole extension was tried and reverted (#627b).** An
+    earlier revision of this function extended Debye/Lorentz pole masks
+    into the pad the same way, via an ``extra_masks`` parameter, so a
+    dispersive edge-touching material would be impedance-matched across
+    the band, not just at DC. Review found this turns a stable simulation
+    into a divergent one for an edge-touching structure carrying a
+    high-Q Lorentz pole (Q~60): the same 20,000-step fixture that decays
+    on both the shipped (statics-only) code and on the pre-#582 tree
+    (last/mid energy ratio 0.12–0.16) grows without bound once the pole
+    mask is also extended (last/mid ratio 649, no NaN and no exception —
+    values stay finite and simply grow, so nothing downstream flags it).
+    Extending the pole alone, on top of an otherwise-unpatched static
+    extension, reproduces the divergence; the static extension alone,
+    with the same high-Q pole left un-extended in the interior, decays
+    cleanly. Do not re-add pole-mask extension here without a stability
+    argument for the resonant-pole-in-a-CPML-pad regime — see the
+    follow-up issue (filed separately from #627, tracking this factorial)
+    and the physics-level regression lock in
+    ``tests/test_cpml_pad_material_extension.py``, which reds if pole
+    extension is naively reintroduced.
+
     Returns
     -------
-    (eps_r, sigma, mu_r, extended_extra_masks) — ``extended_extra_masks``
-    is a list in the same order as ``extra_masks``.
+    (eps_r, sigma, mu_r)
     """
-    arrays = [eps_r, sigma, mu_r] + list(extra_masks)
+    arrays = [eps_r, sigma, mu_r]
 
     def _vacuum(e, s, m):
         return (e == 1.0) & (s == 0.0) & (m == 1.0)
@@ -357,4 +368,4 @@ def extend_cpml_pad_materials(
     )
 
     eps_r, sigma, mu_r = arrays[0], arrays[1], arrays[2]
-    return eps_r, sigma, mu_r, arrays[3:]
+    return eps_r, sigma, mu_r

--- a/rfx/geometry/rasterize_grid.py
+++ b/rfx/geometry/rasterize_grid.py
@@ -232,3 +232,129 @@ def rasterize_geometry(
     has_pec = bool(jnp.any(pec_mask))
     kerr_chi3 = chi3_arr if has_kerr else None
     return materials, debye_spec, lorentz_spec, pec_mask if has_pec else None, pec_shapes, kerr_chi3
+
+
+def extend_cpml_pad_materials(
+    eps_r: jnp.ndarray,
+    sigma: jnp.ndarray,
+    mu_r: jnp.ndarray,
+    plx: int, phx: int,
+    ply: int, phy: int,
+    plz: int, phz: int,
+    extra_masks=(),
+):
+    """Extend material properties (and dispersion-pole masks) into the CPML
+    padding so guided modes see an impedance-matched absorber, equivalent
+    to UPML. Each CPML face copies the interior-edge slice outward, as if
+    the geometry continued beyond the domain.
+
+    Single shared implementation for the uniform (``rfx/api/_compile.py``)
+    and non-uniform (``rfx/runners/nonuniform.py``) assemblers — issue #627
+    found the two hand-duplicated copies (#582 mirrored one onto the other)
+    both carrying the same two gaps, so the fix lives once, here, and both
+    call sites use it instead of keeping duplicated pad-extension code that
+    can drift.
+
+    ``extra_masks`` is a sequence of additional per-cell arrays (e.g.
+    Debye/Lorentz dispersion-pole boolean masks, #627b — previously never
+    extended into the pad at all, so a dispersive edge-touching material
+    was matched at DC but not across the band) that get the identical
+    lo/hi replication as ``eps_r``/``sigma``/``mu_r``, using the SAME
+    hi-face source column decided below (same box, same dropped node, for
+    every property of that box).
+
+    **Hi-face fallback (#627a).** ``rfx.geometry.csg.Box``'s volume-branch
+    rasterization is deliberately half-open, ``[lo, hi)``, over node
+    coordinates (see that class's docstring — the convention is load-
+    bearing across the package, e.g. every WR-90 aperture/iris
+    measurement). Its documented consequence is that the ``hi`` face of a
+    box "contributes no node": a structure whose hi face lands on (or
+    inside) the domain's last interior node loses exactly that one node
+    from its own rasterized mask. The naive interior-edge source for a hi
+    pad — literally the outermost interior column — therefore reads
+    vacuum for such a structure even though its real material sits one
+    column further in, and copying that vacuum outward gives the pad a
+    Fresnel step instead of a match (measured on the #582 fixture: x-lo
+    pad eps_r 4.0, x-hi pad eps_r 1.0, for a slab spanning the full x
+    extent).
+
+    The fix does NOT touch the rasterizer (out of scope — it would move
+    geometry everywhere in the package, and the convention is correct and
+    intentional for the shape mask itself). Instead, per transverse cell:
+    if the naive interior-edge column is vacuum (``eps_r==1 & sigma==0 &
+    mu_r==1``) but the column immediately inside it is not, replicate from
+    that inner column instead. This is bounded to exactly one column
+    inward — the rasterizer's hi-face shortfall for a single box is
+    deterministically one node (Box docstring: "the shortfall is entirely
+    at the hi face"), never more — so a genuine multi-cell vacuum buffer
+    between a structure and the CPML pad (the overwhelmingly common case:
+    almost every example leaves an air gap before the absorber) is left
+    completely alone and still replicates plain vacuum, exactly as before.
+    An unbounded backward scan for "the last non-vacuum column" was
+    considered and rejected: it would bridge that common air gap and smear
+    an unrelated interior structure's material into the pad.
+
+    Returns
+    -------
+    (eps_r, sigma, mu_r, extended_extra_masks) — ``extended_extra_masks``
+    is a list in the same order as ``extra_masks``.
+    """
+    arrays = [eps_r, sigma, mu_r] + list(extra_masks)
+
+    def _vacuum(e, s, m):
+        return (e == 1.0) & (s == 0.0) & (m == 1.0)
+
+    def _extend_lo(arrays, pad_lo, lo_src, lo_dst):
+        if pad_lo <= 0:
+            return arrays
+        return [a.at[lo_dst].set(a[lo_src]) for a in arrays]
+
+    def _extend_hi(arrays, n, pad_lo, pad_hi, outer_sl, inner_sl, dst_sl):
+        if pad_hi <= 0:
+            return arrays
+        e, s, m = arrays[0], arrays[1], arrays[2]
+        outer_vac = _vacuum(e[outer_sl], s[outer_sl], m[outer_sl])
+        use_inner = None
+        if n - pad_lo - pad_hi >= 2:
+            inner_vac = _vacuum(e[inner_sl], s[inner_sl], m[inner_sl])
+            use_inner = outer_vac & (~inner_vac)
+        new_arrays = []
+        for a in arrays:
+            src = a[outer_sl]
+            if use_inner is not None:
+                src = jnp.where(use_inner, a[inner_sl], src)
+            new_arrays.append(a.at[dst_sl].set(src))
+        return new_arrays
+
+    # ---- x ----
+    arrays = _extend_lo(arrays, plx, np.s_[plx:plx + 1, :, :], np.s_[:plx, :, :])
+    nx = arrays[0].shape[0]
+    arrays = _extend_hi(
+        arrays, nx, plx, phx,
+        np.s_[nx - phx - 1:nx - phx, :, :],
+        np.s_[nx - phx - 2:nx - phx - 1, :, :],
+        np.s_[nx - phx:nx, :, :],
+    )
+
+    # ---- y ----
+    arrays = _extend_lo(arrays, ply, np.s_[:, ply:ply + 1, :], np.s_[:, :ply, :])
+    ny = arrays[0].shape[1]
+    arrays = _extend_hi(
+        arrays, ny, ply, phy,
+        np.s_[:, ny - phy - 1:ny - phy, :],
+        np.s_[:, ny - phy - 2:ny - phy - 1, :],
+        np.s_[:, ny - phy:ny, :],
+    )
+
+    # ---- z ----
+    arrays = _extend_lo(arrays, plz, np.s_[:, :, plz:plz + 1], np.s_[:, :, :plz])
+    nz = arrays[0].shape[2]
+    arrays = _extend_hi(
+        arrays, nz, plz, phz,
+        np.s_[:, :, nz - phz - 1:nz - phz],
+        np.s_[:, :, nz - phz - 2:nz - phz - 1],
+        np.s_[:, :, nz - phz:nz],
+    )
+
+    eps_r, sigma, mu_r = arrays[0], arrays[1], arrays[2]
+    return eps_r, sigma, mu_r, arrays[3:]

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -97,29 +97,21 @@ def assemble_materials_nu(
     # per path (#582: measured 736 pad cells eps 4.0-vs-1.0 at the slab's
     # k=9 layer) and the uniform-mesh reduction anchor diverged wherever
     # that mismatch interacted with subpixel smoothing. #627 moved this
-    # (and the uniform mirror) onto one shared implementation after finding
-    # the two hand-duplicated copies both carried the same two gaps: a
-    # hi-face vacuum column for a domain-touching box, and dispersion poles
-    # never extended into the pad at all — see extend_cpml_pad_materials's
-    # docstring for both fixes.
+    # (and the uniform mirror) onto one shared implementation.
+    #
+    # Dispersion-pole masks are deliberately NOT extended here (#627b tried
+    # and reverted): see extend_cpml_pad_materials's docstring — extending
+    # a high-Q Lorentz pole into the pad turns a stable edge-touching
+    # simulation into a divergent one, with no NaN/exception to catch it.
     if sim._boundary in ("cpml", "upml") and sim._cpml_layers > 0:
         plx, phx = grid.pad_x_lo, grid.pad_x_hi
         ply, phy = grid.pad_y_lo, grid.pad_y_hi
         plz, phz = grid.pad_z_lo, grid.pad_z_hi
-        debye_poles, debye_masks_in = debye_spec if debye_spec is not None else ([], [])
-        lorentz_poles, lorentz_masks_in = lorentz_spec if lorentz_spec is not None else ([], [])
-        extra_masks_in = list(debye_masks_in) + list(lorentz_masks_in)
-        eps_r_ext, sigma_ext, mu_r_ext, extra_masks_out = extend_cpml_pad_materials(
+        eps_r_ext, sigma_ext, mu_r_ext = extend_cpml_pad_materials(
             materials.eps_r, materials.sigma, materials.mu_r,
             plx, phx, ply, phy, plz, phz,
-            extra_masks=extra_masks_in,
         )
         materials = MaterialArrays(eps_r=eps_r_ext, sigma=sigma_ext, mu_r=mu_r_ext)
-        n_debye = len(debye_masks_in)
-        if debye_spec is not None:
-            debye_spec = (debye_poles, extra_masks_out[:n_debye])
-        if lorentz_spec is not None:
-            lorentz_spec = (lorentz_poles, extra_masks_out[n_debye:])
 
     # Thin conductors (#369): a PEC thin sheet rasterizes on the coords-based
     # mask exactly like geometry PEC — ``mask_on_coords`` resolves fine on

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -71,7 +71,9 @@ def assemble_materials_nu(
     -------
     materials, debye_spec, lorentz_spec, pec_mask
     """
-    from rfx.geometry.rasterize_grid import rasterize_geometry, coords_from_nonuniform_grid
+    from rfx.geometry.rasterize_grid import (
+        rasterize_geometry, coords_from_nonuniform_grid, extend_cpml_pad_materials,
+    )
 
     coords = coords_from_nonuniform_grid(grid)
 
@@ -87,45 +89,37 @@ def assemble_materials_nu(
     # dielectric waveguides see an impedance-matched absorber (equivalent to
     # UPML). Each CPML face copies the interior-edge slice outward, as if
     # the geometry continued beyond the domain. Mirrors the uniform path's
-    # identical step (rfx/api/_compile.py:188-231) exactly, adapted to the
-    # NU per-face pad bookkeeping (``grid.pad_{axis}_{lo,hi}``, already
-    # zero on PEC/PMC/periodic faces). Before this fix the NU assembler had
-    # NO such step, so an edge-touching structure saw a different absorber
-    # medium per path (#582: measured 736 pad cells eps 4.0-vs-1.0 at the
-    # slab's k=9 layer) and the uniform-mesh reduction anchor diverged
-    # wherever that mismatch interacted with subpixel smoothing.
+    # identical step (rfx/api/_compile.py) exactly via the shared
+    # extend_cpml_pad_materials helper, adapted to the NU per-face pad
+    # bookkeeping (``grid.pad_{axis}_{lo,hi}``, already zero on
+    # PEC/PMC/periodic faces). Before this fix the NU assembler had NO such
+    # step, so an edge-touching structure saw a different absorber medium
+    # per path (#582: measured 736 pad cells eps 4.0-vs-1.0 at the slab's
+    # k=9 layer) and the uniform-mesh reduction anchor diverged wherever
+    # that mismatch interacted with subpixel smoothing. #627 moved this
+    # (and the uniform mirror) onto one shared implementation after finding
+    # the two hand-duplicated copies both carried the same two gaps: a
+    # hi-face vacuum column for a domain-touching box, and dispersion poles
+    # never extended into the pad at all — see extend_cpml_pad_materials's
+    # docstring for both fixes.
     if sim._boundary in ("cpml", "upml") and sim._cpml_layers > 0:
         plx, phx = grid.pad_x_lo, grid.pad_x_hi
         ply, phy = grid.pad_y_lo, grid.pad_y_hi
         plz, phz = grid.pad_z_lo, grid.pad_z_hi
-        eps_r_ext = materials.eps_r
-        sigma_ext = materials.sigma
-        mu_r_ext = materials.mu_r
-        if plx > 0:
-            eps_r_ext = eps_r_ext.at[:plx,:,:].set(eps_r_ext[plx:plx+1,:,:])
-            sigma_ext = sigma_ext.at[:plx,:,:].set(sigma_ext[plx:plx+1,:,:])
-            mu_r_ext = mu_r_ext.at[:plx,:,:].set(mu_r_ext[plx:plx+1,:,:])
-        if phx > 0:
-            eps_r_ext = eps_r_ext.at[-phx:,:,:].set(eps_r_ext[-phx-1:-phx,:,:])
-            sigma_ext = sigma_ext.at[-phx:,:,:].set(sigma_ext[-phx-1:-phx,:,:])
-            mu_r_ext = mu_r_ext.at[-phx:,:,:].set(mu_r_ext[-phx-1:-phx,:,:])
-        if ply > 0:
-            eps_r_ext = eps_r_ext.at[:,:ply,:].set(eps_r_ext[:,ply:ply+1,:])
-            sigma_ext = sigma_ext.at[:,:ply,:].set(sigma_ext[:,ply:ply+1,:])
-            mu_r_ext = mu_r_ext.at[:,:ply,:].set(mu_r_ext[:,ply:ply+1,:])
-        if phy > 0:
-            eps_r_ext = eps_r_ext.at[:,-phy:,:].set(eps_r_ext[:,-phy-1:-phy,:])
-            sigma_ext = sigma_ext.at[:,-phy:,:].set(sigma_ext[:,-phy-1:-phy,:])
-            mu_r_ext = mu_r_ext.at[:,-phy:,:].set(mu_r_ext[:,-phy-1:-phy,:])
-        if plz > 0:
-            eps_r_ext = eps_r_ext.at[:,:,:plz].set(eps_r_ext[:,:,plz:plz+1])
-            sigma_ext = sigma_ext.at[:,:,:plz].set(sigma_ext[:,:,plz:plz+1])
-            mu_r_ext = mu_r_ext.at[:,:,:plz].set(mu_r_ext[:,:,plz:plz+1])
-        if phz > 0:
-            eps_r_ext = eps_r_ext.at[:,:,-phz:].set(eps_r_ext[:,:,-phz-1:-phz])
-            sigma_ext = sigma_ext.at[:,:,-phz:].set(sigma_ext[:,:,-phz-1:-phz])
-            mu_r_ext = mu_r_ext.at[:,:,-phz:].set(mu_r_ext[:,:,-phz-1:-phz])
+        debye_poles, debye_masks_in = debye_spec if debye_spec is not None else ([], [])
+        lorentz_poles, lorentz_masks_in = lorentz_spec if lorentz_spec is not None else ([], [])
+        extra_masks_in = list(debye_masks_in) + list(lorentz_masks_in)
+        eps_r_ext, sigma_ext, mu_r_ext, extra_masks_out = extend_cpml_pad_materials(
+            materials.eps_r, materials.sigma, materials.mu_r,
+            plx, phx, ply, phy, plz, phz,
+            extra_masks=extra_masks_in,
+        )
         materials = MaterialArrays(eps_r=eps_r_ext, sigma=sigma_ext, mu_r=mu_r_ext)
+        n_debye = len(debye_masks_in)
+        if debye_spec is not None:
+            debye_spec = (debye_poles, extra_masks_out[:n_debye])
+        if lorentz_spec is not None:
+            lorentz_spec = (lorentz_poles, extra_masks_out[n_debye:])
 
     # Thin conductors (#369): a PEC thin sheet rasterizes on the coords-based
     # mask exactly like geometry PEC — ``mask_on_coords`` resolves fine on

--- a/tests/test_cpml_pad_material_extension.py
+++ b/tests/test_cpml_pad_material_extension.py
@@ -1,12 +1,11 @@
-"""Locks for CPML pad material/pole extension (issue #627).
+"""Locks for CPML pad material extension (issue #627).
 
 ``rfx/api/_compile.py``'s ``_assemble_materials`` (mirrored on the
 non-uniform mesh by ``rfx/runners/nonuniform.py``'s ``assemble_materials_nu``,
 #582) extends the interior-edge ``eps_r``/``sigma``/``mu_r`` slice outward
 into the CPML padding so guided modes see an impedance-matched absorber.
-#627's review of that mirror found two gaps BOTH assemblers inherited from
-the (pre-existing) uniform path, now fixed once in the shared
-``rfx.geometry.rasterize_grid.extend_cpml_pad_materials``:
+#627's review of that mirror found two gaps both assemblers inherited from
+the (pre-existing) uniform path:
 
 (a) For a ``Box`` whose hi face lands on (or past) the domain's last
     interior node, ``rfx.geometry.csg.Box``'s deliberately half-open
@@ -14,28 +13,40 @@ the (pre-existing) uniform path, now fixed once in the shared
     box's own mask, so the naive interior-edge column for a hi-face pad
     read vacuum even though the structure's real material sits one column
     further in. Measured pre-fix on the #582 fixture: x-lo pad eps_r=4.0,
-    x-hi pad eps_r=1.0, for a slab spanning the full x extent.
-(b) Debye/Lorentz dispersion-pole masks were never extended into the pad
-    at all (only the static eps_r/sigma/mu_r were), so a dispersive
-    edge-touching material was impedance-matched at DC but not across the
-    band.
+    x-hi pad eps_r=1.0, for a slab spanning the full x extent. **FIXED**
+    here, in the shared ``rfx.geometry.rasterize_grid.extend_cpml_pad_materials``.
+(b) Debye/Lorentz dispersion-pole masks are never extended into the pad
+    at all (only the static eps_r/sigma/mu_r are), so a dispersive
+    edge-touching material is impedance-matched at DC but not across the
+    band. **NOT FIXED.** An earlier revision of this change extended pole
+    masks the same way as (a); review's controlled discriminator found
+    that turns a stable high-Q (Q~60) edge-touching Lorentz-slab
+    simulation into a divergent one (20,000-step last/mid energy ratio
+    649, vs 0.1557 for the static extension alone with the same pole
+    left un-extended — no NaN, no exception, values just grow). Reverted
+    in full (no flag, no partial path); tracked with the full factorial,
+    mechanism hypothesis, and a separate pole-only-material coverage hole
+    the attempted design also had, in issue #636.
+    ``test_pole_extension_stability_lock`` below is the physics-level
+    guard against silently reintroducing it.
 
-The fix is bounded to exactly one column inward on the hi-face fallback
-(the rasterizer's per-box shortfall there is deterministically one node)
-so a genuine multi-cell vacuum buffer between an interior structure and
-the CPML pad — the overwhelmingly common case — is untouched; that
-invariant is locked here too (test 4), since an earlier, rejected design
-(an unbounded backward scan for "the last non-vacuum column") would have
-silently bridged it.
+The (a) fix is bounded to exactly one column inward on the hi-face
+fallback (the rasterizer's per-box shortfall there is deterministically
+one node) so a genuine multi-cell vacuum buffer between an interior
+structure and the CPML pad — the overwhelmingly common case — is
+untouched; that invariant is locked here too (test 4), since an earlier,
+rejected design (an unbounded backward scan for "the last non-vacuum
+column") would have silently bridged it.
 """
 
 from __future__ import annotations
 
 import numpy as np
 
-from rfx import Simulation
+from rfx import Simulation, GaussianPulse
 from rfx.geometry.csg import Box
 from rfx.materials.debye import DebyePole
+from rfx.materials.lorentz import LorentzPole
 from rfx.runners.nonuniform import build_nonuniform_grid, assemble_materials_nu
 
 NA, NB, NZ = 45, 39, 4
@@ -98,10 +109,18 @@ def test_hi_face_pad_matches_lo_face_for_domain_touching_box_nu():
         f"NU x-hi pad eps_r={x_hi} != x-lo pad eps_r={x_lo}")
 
 
-def test_dispersion_poles_extend_into_hi_face_pad_uniform():
-    """(#627b) Debye poles must reach the x-hi pad, not stop at the interior
-    edge. Pre-fix this was 0 unconditionally (poles were never extended at
-    all, on EITHER face)."""
+def test_dispersion_poles_are_not_extended_into_the_pad_uniform():
+    """(#627b, deliberately NOT fixed) Lock the reverted state: NEITHER
+    pad gets the slab's Debye pole (the box's own rasterized mask never
+    covers pad indices — they are outside [0, domain_extent) — and no
+    extension step runs for pole masks, on either face, matching the
+    original pre-#582 behaviour). If either count goes nonzero, someone
+    re-added pole-mask extension — read the module docstring and
+    ``test_pole_extension_stability_lock`` before doing that; the
+    extension was reverted because it diverges for a high-Q pole (see
+    that test and the CHANGELOG entry for #627). Contrast with the
+    static eps_r, which DOES reach both pads (test 1/2 above) — that
+    asymmetry is exactly what this test locks."""
     sim = _build_uniform(dispersive=True)
     materials, debye_spec, plx, phx, ply, plz = _assemble_uniform(sim)
     assert debye_spec is not None
@@ -109,14 +128,14 @@ def test_dispersion_poles_extend_into_hi_face_pad_uniform():
     mask = np.asarray(masks[0])
     n_pad_x_hi = int(mask[-phx:, :, :].sum())
     n_pad_x_lo = int(mask[:plx, :, :].sum())
-    assert n_pad_x_hi > 0, "no Debye pole cells reached the x-hi CPML pad"
-    assert n_pad_x_hi == n_pad_x_lo, (
-        f"x-hi pad pole cell count {n_pad_x_hi} != x-lo pad {n_pad_x_lo} "
-        f"(both faces should be extended symmetrically for a slab spanning "
-        f"the full x extent)")
+    assert n_pad_x_lo == 0 and n_pad_x_hi == 0, (
+        f"pole cells reached a CPML pad (x-lo={n_pad_x_lo}, "
+        f"x-hi={n_pad_x_hi}) — pole-mask extension appears to have been "
+        f"reintroduced without the stability question (see "
+        f"test_pole_extension_stability_lock) being resolved first")
 
 
-def test_dispersion_poles_extend_into_hi_face_pad_nu():
+def test_dispersion_poles_are_not_extended_into_the_pad_nu():
     """(#627b) NU mirror of the uniform-path lock above."""
     sim = _build_uniform(dispersive=True)
     materials, debye_spec, plx, phx, ply, plz = _assemble_nu(sim)
@@ -125,8 +144,9 @@ def test_dispersion_poles_extend_into_hi_face_pad_nu():
     mask = np.asarray(masks[0])
     n_pad_x_hi = int(mask[-phx:, :, :].sum())
     n_pad_x_lo = int(mask[:plx, :, :].sum())
-    assert n_pad_x_hi > 0, "no Debye pole cells reached the NU x-hi CPML pad"
-    assert n_pad_x_hi == n_pad_x_lo
+    assert n_pad_x_lo == 0 and n_pad_x_hi == 0, (
+        f"NU pole cells reached a CPML pad (x-lo={n_pad_x_lo}, "
+        f"x-hi={n_pad_x_hi}) — see the uniform-path test's docstring")
 
 
 def test_genuine_vacuum_buffer_before_cpml_is_not_bridged():
@@ -168,9 +188,10 @@ def test_genuine_vacuum_buffer_before_cpml_is_not_bridged():
 
 
 def test_uniform_and_nu_assemblers_stay_byte_identical_after_the_fix():
-    """Extends #582's verified byte-identity property to the #627 fix
-    itself: both assemblers must still agree exactly, including the
-    extended dispersion-pole masks.
+    """Extends #582's verified byte-identity property to the #627(a) fix:
+    both assemblers must still agree exactly on eps_r/sigma/mu_r, and the
+    (un-extended, per #627b's revert) pole masks must still agree with
+    each other too.
     """
     for dispersive in (False, True):
         sim_u = _build_uniform(dispersive=dispersive)
@@ -185,3 +206,110 @@ def test_uniform_and_nu_assemblers_stay_byte_identical_after_the_fix():
             _, masks_u = debye_u
             _, masks_n = debye_n
             assert np.array_equal(np.asarray(masks_u[0]), np.asarray(masks_n[0]))
+
+
+def test_pole_extension_stability_lock():
+    """Physics-level regression guard for issue #636 (see also the module
+    docstring's (b) entry): extending Debye/Lorentz pole masks into the
+    CPML pad turns a stable high-Q edge-touching Lorentz-slab simulation
+    into a divergent one.
+
+    Four-way factorial (review's controlled discriminator, one fixture,
+    one harness, only the pad-fill contents varied, pad contents printed
+    per variant to confirm each matched its label -- reproduced directly
+    by this author before committing, not taken on trust):
+
+      FULL   (statics hi-face-fixed AND poles extended), 20,000 steps:
+              last-decile/mid-decile = 649           DIVERGES
+      S-ONLY (statics hi-face-fixed, poles NOT extended -- what SHIPS),
+              20,000 steps: last/mid = 0.1557         decays
+      unpatched pre-#627 tree, 20,000 steps: last/mid ~ 0.12  decays
+
+    S-ONLY is exactly what ships (issue #627a shipped, #627b reverted in
+    full, no flag) -- this test runs that shipped code, unmodified, on
+    the SAME fixture. At the committed step count (8000, chosen for test
+    suite runtime) the two variants have NOT yet separated by the 20,000-
+    step run's dramatic margin -- this author independently measured
+    FULL's last/mid at 8000 steps as 2.546 (already above 1, i.e. already
+    growing, but not yet past the "diverging" classification the 20,000-
+    step comparison uses) against S-ONLY's 0.4281. The literal criterion
+    from review -- last decile below the mid-run decile, ratio < 1 -- DOES
+    separate them at 8000 steps; a laxer "diverging" threshold would not.
+    Do not loosen this threshold without re-measuring both variants at
+    whatever step count you choose; the margin at 8000 steps is real but
+    not enormous (0.43 vs 2.55), unlike at 20,000 steps (0.16 vs 649).
+
+    Designed to red the moment someone re-adds pole-mask extension
+    naively, without re-litigating the stability question tracked in #636.
+    """
+    DX = 1e-3
+    NA, NB, NZ = 45, 39, 12
+    F0 = 3e9
+    w0 = 2 * np.pi * F0
+    STEPS = 8000
+
+    sim = Simulation(freq_max=2.5 * F0, domain=(NA * DX, NB * DX, NZ * DX),
+                      dx=DX, boundary="cpml", cpml_layers=8)
+    sim.add_material("slab", eps_r=4.0,
+                      lorentz_poles=[LorentzPole(omega_0=w0, delta=w0 / 120.0,
+                                                  kappa=3.0 * w0 ** 2)])
+    # edge-touching in x AND y (the #627a trigger); z is interior (3*DX to
+    # 7*DX inside a 12*DX domain) so the resonance has real vacuum above
+    # and below it to live in -- a thin-in-z fixture (as this author first
+    # tried, and failed to reproduce the divergence with) starves the
+    # resonance of an interior to couple through.
+    sim.add(Box((0.0, 0.0, 3 * DX), (NA * DX, NB * DX, 7 * DX)), material="slab")
+    sim.add_source((NA * DX / 3, NB * DX / 3, 5.0 * DX), "ez",
+                    waveform=GaussianPulse(f0=F0, bandwidth=0.8),
+                    amplitude_kind="field")
+    sim.add_probe(((NA - 3) * DX, NB * DX / 2, 5.0 * DX), "ez")
+
+    # R5 witness -- what actually landed in the pad for THIS run. A
+    # mislabelled variant (pad contents not matching what the code claims
+    # to do) is exactly what the #636 investigation caught once; printed
+    # here (in the assertion messages) so a future failure shows it too.
+    grid = sim._build_grid()
+    materials, debye_spec, lorentz_spec, pec_mask, *_ = sim._assemble_materials(grid)
+    eps = np.asarray(materials.eps_r)
+    plx, phx = grid.pad_x_lo, grid.pad_x_hi
+    ply, plz = grid.pad_y_lo, grid.pad_z_lo
+    pole_pad_hi = pole_pad_lo = None
+    if lorentz_spec is not None:
+        _, masks = lorentz_spec
+        pole = np.asarray(masks[0])
+        pole_pad_hi = int(pole[-phx:, :, :].sum())
+        pole_pad_lo = int(pole[:plx, :, :].sum())
+    pad_witness = (
+        f"x-hi pad eps={float(eps[-phx, ply + 5, plz + 5]):.2f} "
+        f"x-hi pad pole cells={pole_pad_hi} x-lo pad pole cells={pole_pad_lo}")
+
+    # Sanity check first: the shipped code must not extend pole masks at
+    # all (issue #636). If this fails, the divergence assertion below is
+    # not trustworthy either way -- fix this first.
+    assert pole_pad_hi == 0 and pole_pad_lo == 0, (
+        f"pole cells reached a CPML pad ({pad_witness}) -- pole-mask "
+        f"extension appears to have been reintroduced; see issue #636 "
+        f"before touching this")
+
+    result = sim.run(n_steps=STEPS, compute_s_params=False,
+                      skip_preflight=True, subpixel_smoothing=False)
+    ts = np.asarray(result.time_series, dtype=float).ravel()
+    n = len(ts)
+    deciles = [float(np.abs(ts[i * n // 10:(i + 1) * n // 10]).max())
+               for i in range(10)]
+    last, mid = deciles[-1], deciles[3]
+    ratio = last / max(mid, 1e-300)
+
+    assert np.isfinite(ts).all(), (
+        f"non-finite field values ({pad_witness}) -- this fixture should "
+        f"decay cleanly on shipped code")
+    assert ratio < 1.0, (
+        f"last-decile/mid-decile ratio {ratio:.4g} ({pad_witness}) -- the "
+        f"shipped (statics-only) pad fill should have its last decile "
+        f"below its mid-run decile on this high-Q edge-touching Lorentz "
+        f"fixture (measured S-ONLY 0.4281 at this step count, 0.1557 at "
+        f"20,000 steps, in the #636 discriminator). A ratio at or above 1 "
+        f"means either pole-mask extension was reintroduced or the static "
+        f"hi-face fallback (#627a) has somehow become unsafe for a "
+        f"resonant interior material -- see issue #636 before changing "
+        f"this gate. deciles={deciles}")

--- a/tests/test_cpml_pad_material_extension.py
+++ b/tests/test_cpml_pad_material_extension.py
@@ -148,14 +148,22 @@ def test_genuine_vacuum_buffer_before_cpml_is_not_bridged():
     grid = sim._build_grid()
     materials, *_ = sim._assemble_materials(grid)
     eps = np.asarray(materials.eps_r)
-    phx, phy = grid.pad_x_hi, grid.pad_y_hi
+    plx, phx = grid.pad_x_lo, grid.pad_x_hi
+    ply, phy = grid.pad_y_lo, grid.pad_y_hi
     plz = grid.pad_z_lo
     k = plz + 1
-    assert float(eps[-phx, grid.ny // 2, k]) == 1.0, (
+    # Sample transverse positions INSIDE the box's own extent (box spans
+    # interior indices 10..19 on both x and y), not the domain midpoint —
+    # a transverse position outside the box is vacuum under every design,
+    # including the rejected unbounded-scan one, so it cannot distinguish
+    # them. plx+15/ply+15 sit inside [10,20) and are the positions an
+    # unbounded backward scan (from the OPPOSITE face's pad) would walk
+    # through and incorrectly find the box's material.
+    assert float(eps[-phx, ply + 15, k]) == 1.0, (
         "x-hi pad picked up material across a genuine multi-cell vacuum "
         "gap — the hi-face fallback must be bounded to the rasterizer's "
         "documented one-column shortfall, not an unbounded scan")
-    assert float(eps[grid.nx // 2, -phy, k]) == 1.0, (
+    assert float(eps[plx + 15, -phy, k]) == 1.0, (
         "y-hi pad picked up material across a genuine multi-cell vacuum gap")
 
 

--- a/tests/test_cpml_pad_material_extension.py
+++ b/tests/test_cpml_pad_material_extension.py
@@ -1,0 +1,179 @@
+"""Locks for CPML pad material/pole extension (issue #627).
+
+``rfx/api/_compile.py``'s ``_assemble_materials`` (mirrored on the
+non-uniform mesh by ``rfx/runners/nonuniform.py``'s ``assemble_materials_nu``,
+#582) extends the interior-edge ``eps_r``/``sigma``/``mu_r`` slice outward
+into the CPML padding so guided modes see an impedance-matched absorber.
+#627's review of that mirror found two gaps BOTH assemblers inherited from
+the (pre-existing) uniform path, now fixed once in the shared
+``rfx.geometry.rasterize_grid.extend_cpml_pad_materials``:
+
+(a) For a ``Box`` whose hi face lands on (or past) the domain's last
+    interior node, ``rfx.geometry.csg.Box``'s deliberately half-open
+    ``[lo, hi)`` volume rasterization drops exactly that node from the
+    box's own mask, so the naive interior-edge column for a hi-face pad
+    read vacuum even though the structure's real material sits one column
+    further in. Measured pre-fix on the #582 fixture: x-lo pad eps_r=4.0,
+    x-hi pad eps_r=1.0, for a slab spanning the full x extent.
+(b) Debye/Lorentz dispersion-pole masks were never extended into the pad
+    at all (only the static eps_r/sigma/mu_r were), so a dispersive
+    edge-touching material was impedance-matched at DC but not across the
+    band.
+
+The fix is bounded to exactly one column inward on the hi-face fallback
+(the rasterizer's per-box shortfall there is deterministically one node)
+so a genuine multi-cell vacuum buffer between an interior structure and
+the CPML pad — the overwhelmingly common case — is untouched; that
+invariant is locked here too (test 4), since an earlier, rejected design
+(an unbounded backward scan for "the last non-vacuum column") would have
+silently bridged it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from rfx import Simulation
+from rfx.geometry.csg import Box
+from rfx.materials.debye import DebyePole
+from rfx.runners.nonuniform import build_nonuniform_grid, assemble_materials_nu
+
+NA, NB, NZ = 45, 39, 4
+DX = 1e-3
+F0 = 3e9
+
+
+def _build_uniform(*, dispersive: bool):
+    sim = Simulation(freq_max=2.5 * F0, domain=(NA * DX, NB * DX, NZ * DX),
+                      dx=DX, boundary="cpml", cpml_layers=8)
+    if dispersive:
+        sim.add_material("slab", eps_r=4.0,
+                          debye_poles=[DebyePole(delta_eps=1.0, tau=1e-10)])
+    else:
+        sim.add_material("slab", eps_r=4.0)
+    # Domain-face-touching in x AND y — the #627a trigger.
+    sim.add(Box((0.0, 0.0, 0.3 * DX), (NA * DX, NB * DX, 2.0 * DX)), material="slab")
+    return sim
+
+
+def _assemble_uniform(sim):
+    grid = sim._build_grid()
+    materials, debye_spec, lorentz_spec, pec_mask, *_ = sim._assemble_materials(grid)
+    return materials, debye_spec, grid.pad_x_lo, grid.pad_x_hi, grid.pad_y_lo, grid.pad_z_lo
+
+
+def _assemble_nu(sim):
+    grid = build_nonuniform_grid(
+        sim._freq_max, sim._domain, sim._dx, sim._cpml_layers, None,
+        dx_profile=np.full(NA, DX), dy_profile=np.full(NB, DX),
+    )
+    materials, debye_spec, lorentz_spec, pec_mask = assemble_materials_nu(sim, grid)
+    return materials, debye_spec, grid.pad_x_lo, grid.pad_x_hi, grid.pad_y_lo, grid.pad_z_lo
+
+
+def test_hi_face_pad_matches_lo_face_for_domain_touching_box_uniform():
+    """(#627a) x-hi pad must carry the slab's eps_r, not vacuum."""
+    sim = _build_uniform(dispersive=False)
+    materials, _, plx, phx, ply, plz = _assemble_uniform(sim)
+    eps = np.asarray(materials.eps_r)
+    j, k = ply + 1, plz + 1  # interior cell, well away from the y-edge artifact
+    x_lo = float(eps[plx - 1, j, k])
+    x_hi = float(eps[-phx, j, k])
+    assert x_lo == 4.0, x_lo
+    assert x_hi == x_lo, (
+        f"x-hi pad eps_r={x_hi} != x-lo pad eps_r={x_lo}: hi-face pad is not "
+        f"impedance-matched (vacuum copied instead of the slab's material)")
+
+
+def test_hi_face_pad_matches_lo_face_for_domain_touching_box_nu():
+    """(#627a) NU mirror of the uniform-path lock above."""
+    sim = _build_uniform(dispersive=False)
+    materials, _, plx, phx, ply, plz = _assemble_nu(sim)
+    eps = np.asarray(materials.eps_r)
+    j, k = ply + 1, plz + 1
+    x_lo = float(eps[plx - 1, j, k])
+    x_hi = float(eps[-phx, j, k])
+    assert x_lo == 4.0, x_lo
+    assert x_hi == x_lo, (
+        f"NU x-hi pad eps_r={x_hi} != x-lo pad eps_r={x_lo}")
+
+
+def test_dispersion_poles_extend_into_hi_face_pad_uniform():
+    """(#627b) Debye poles must reach the x-hi pad, not stop at the interior
+    edge. Pre-fix this was 0 unconditionally (poles were never extended at
+    all, on EITHER face)."""
+    sim = _build_uniform(dispersive=True)
+    materials, debye_spec, plx, phx, ply, plz = _assemble_uniform(sim)
+    assert debye_spec is not None
+    poles, masks = debye_spec
+    mask = np.asarray(masks[0])
+    n_pad_x_hi = int(mask[-phx:, :, :].sum())
+    n_pad_x_lo = int(mask[:plx, :, :].sum())
+    assert n_pad_x_hi > 0, "no Debye pole cells reached the x-hi CPML pad"
+    assert n_pad_x_hi == n_pad_x_lo, (
+        f"x-hi pad pole cell count {n_pad_x_hi} != x-lo pad {n_pad_x_lo} "
+        f"(both faces should be extended symmetrically for a slab spanning "
+        f"the full x extent)")
+
+
+def test_dispersion_poles_extend_into_hi_face_pad_nu():
+    """(#627b) NU mirror of the uniform-path lock above."""
+    sim = _build_uniform(dispersive=True)
+    materials, debye_spec, plx, phx, ply, plz = _assemble_nu(sim)
+    assert debye_spec is not None
+    poles, masks = debye_spec
+    mask = np.asarray(masks[0])
+    n_pad_x_hi = int(mask[-phx:, :, :].sum())
+    n_pad_x_lo = int(mask[:plx, :, :].sum())
+    assert n_pad_x_hi > 0, "no Debye pole cells reached the NU x-hi CPML pad"
+    assert n_pad_x_hi == n_pad_x_lo
+
+
+def test_genuine_vacuum_buffer_before_cpml_is_not_bridged():
+    """A structure that does NOT reach the domain edge (an ordinary interior
+    box with several cells of air before the CPML pad — the overwhelmingly
+    common simulation layout) must still see a plain-vacuum pad. This is the
+    regression guard for the rejected "unbounded scan for the last
+    non-vacuum column" design: that alternative would have smeared the
+    interior structure's material across the intentional air gap into the
+    absorber.
+    """
+    sim = Simulation(freq_max=2.5 * F0, domain=(NA * DX, NB * DX, NZ * DX),
+                      dx=DX, boundary="cpml", cpml_layers=8)
+    sim.add_material("slab", eps_r=4.0)
+    # well inside the domain on every axis — at least 5 cells of vacuum
+    # before any CPML pad on x/y, and centred on z
+    sim.add(Box((10 * DX, 10 * DX, 0.3 * DX), (20 * DX, 20 * DX, 2.0 * DX)),
+            material="slab")
+    grid = sim._build_grid()
+    materials, *_ = sim._assemble_materials(grid)
+    eps = np.asarray(materials.eps_r)
+    phx, phy = grid.pad_x_hi, grid.pad_y_hi
+    plz = grid.pad_z_lo
+    k = plz + 1
+    assert float(eps[-phx, grid.ny // 2, k]) == 1.0, (
+        "x-hi pad picked up material across a genuine multi-cell vacuum "
+        "gap — the hi-face fallback must be bounded to the rasterizer's "
+        "documented one-column shortfall, not an unbounded scan")
+    assert float(eps[grid.nx // 2, -phy, k]) == 1.0, (
+        "y-hi pad picked up material across a genuine multi-cell vacuum gap")
+
+
+def test_uniform_and_nu_assemblers_stay_byte_identical_after_the_fix():
+    """Extends #582's verified byte-identity property to the #627 fix
+    itself: both assemblers must still agree exactly, including the
+    extended dispersion-pole masks.
+    """
+    for dispersive in (False, True):
+        sim_u = _build_uniform(dispersive=dispersive)
+        mat_u, debye_u, *_ = _assemble_uniform(sim_u)
+        sim_n = _build_uniform(dispersive=dispersive)
+        mat_n, debye_n, *_ = _assemble_nu(sim_n)
+
+        assert np.array_equal(np.asarray(mat_u.eps_r), np.asarray(mat_n.eps_r))
+        assert np.array_equal(np.asarray(mat_u.sigma), np.asarray(mat_n.sigma))
+        assert np.array_equal(np.asarray(mat_u.mu_r), np.asarray(mat_n.mu_r))
+        if debye_u is not None:
+            _, masks_u = debye_u
+            _, masks_n = debye_n
+            assert np.array_equal(np.asarray(masks_u[0]), np.asarray(masks_n[0]))


### PR DESCRIPTION
Closes #627 — the static half. The dispersive half was implemented, measured to destabilize, and reverted; it is now #636.

## What #627 asked for, and what shipped

#582 mirrored the uniform assembler's CPML pad replication onto the non-uniform lane and fenced two gaps it inherited. This PR closes one of them and establishes that the other must not be closed the way it was written.

**(a) Hi-face replication copied vacuum — FIXED.** For a `Box` whose upper face coincides with the domain face, the rasterizer's half-open `[lo, hi)` rule leaves the last interior column at vacuum, so the outward copy propagated vacuum into the pad. Measured before: x-lo pad `eps_r` 4.0, x-hi pad 1.0. After: 4.0 both sides, on both lanes.

**(b) Dispersion poles were never extended — ATTEMPTED, REVERTED, NOT SHIPPED.** See below.

## The rasterizer is correct; the fix goes one column inward

The obvious alternative — scan inward for the last non-vacuum column — was rejected, and the reason is committed as a test: it would bridge a *genuine* air gap between a structure and the absorber, which is the ordinary layout. The bound that makes one column sufficient is structural rather than lucky: the volume mask is `(coords >= lo) & (coords < hi)`, so exactly one NODE is dropped relative to the closed interval, and that is a node count, independent of cell size — review swept graded, geometric and z-graded profiles plus `cpml_layers` 1 and 2 without widening it.

Review also verified independently that the half-open convention itself is load-bearing and must not be touched: flipping `<` to `<=` reds 15 committed tests across 5 files, including one that names the convention. A box ending one cell short is correctly *not* extended.

The two hand-duplicated pad-extension blocks are now one shared `extend_cpml_pad_materials`, so the uniform/NU byte-identity that #582's review established is structural rather than manually maintained. Verified: 0 changed cells for non-edge-touching structures across 8 configurations on both lanes.

## Why the dispersive half is not here

Extending pole masks into the pad turns a stable high-Q simulation into a divergent one. Six pad-fill variants, one fixture, 20,000 steps, only the pad contents differing — each run printing what actually landed in the pad, so every row is tied to a verified configuration rather than a label:

| pad fill | x-hi pad eps | poles (hi/lo) | last/mid energy | outcome |
|---|---|---|---|---|
| pre-#627 | 1.00 | 0 / 0 | 0.1203 | decays |
| **statics only (this PR)** | 4.00 | 0 / 0 | **0.1557** | decays |
| lo-face-only poles | 1.00 | 0 / 1504 | 0.5325 | decays |
| statics + poles | 4.00 | 1760 / 1760 | 649 | diverges |
| poles over vacuum eps | 1.00 | 1760 / 1760 | → 3.55e+31, NaN | diverges catastrophically |

The statics-only row is the one that matters here: with the same high-Q Lorentz pole left un-extended in the interior, the shipped fix decays cleanly. The static extension is not merely uninvolved — it partially *damps* the instability, by making the pad medium self-consistent with the interior instead of leaving a resonant pole on vacuum ε∞.

Full attribution, the ε∞=1 predicate hole, and the sequencing constraint it implies are in #636.

## The lock

A committed stability test pins the high-Q edge-touching case: the last decile must stay below the mid-run decile. It passes on this PR and reds against the real pre-revert implementation (checked out directly, not monkeypatched) — caught first by a pole-count sanity assertion, then independently by the physics ratio.

Its threshold has a story worth reading before anyone loosens it. The investigation's harness classified "diverging" as ratio > 3, calibrated on the 20,000-step gap. At the committed 8,000 steps that threshold would call the divergent case (2.546) *decaying*. The committed criterion is the literal one — ratio < 1 — which separates cleanly at 8,000 (0.4281 against 2.546), with both margins recorded in the docstring. This is the third time in this investigation that a scalar verdict disagreed with the trace it summarised; every assertion message embeds the pad contents for the same reason.

## Also corrected

The regression guard against the rejected scan-inward design **did not bind** as originally written — it sampled cells outside the fixture box's transverse extent, which are vacuum under every design, so the rejected implementation passed all six tests. Fixed and verified in both directions against an independently built copy of that design.

One scope statement, since "impedance-matched absorber" has been used loosely since #582: under `subpixel_smoothing=True` the pad replication never reaches the update at all — `aniso_eps` is built from shapes with `background_eps=1.0`, so only sigma survives there.

## Evidence

Absorber witness, statics-only, 4000 steps, lossy+magnetic edge-touching slab: tail/peak −95.63 → −104.25 dB (author's independent fixture: −85.15 → −90.62 dB, same direction and scale). Reduction anchor green with 2.14× margin at its tightest (`subpixel-cpml` 1.403e-4, `staircase-slab-cpml` 8.831e-5, gate 3e-4) — both moved slightly and are reported. Blast radius bounded analytically and checked against the four committed candidates: the only dispersive geometry outside `tests/` is inset 4 mm on every face, `validation/` has none, and the WR-90 Palace comparison is doubly out of range. Broad NU/waveguide/distributed/api/dispersion batch 304 passed, ruff and api-reference clean.

R3: memory=comparator-first (the decision on the rasterizer was settled before any code changed) + feedback_gate_can_bind_artifact (a guard that passed on the design it existed to reject; a threshold that would have mislabelled the divergent case) | R2-attempts: one non-closing reproduction attempt on a wrong fixture, escalated to ask for the real harness rather than making a third blind attempt | falsifier=the committed lock, red against the real pre-revert implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)