### PR TITLE
fix: correct five defects the arc's own audit found in itself — deflake the benchmark gate, retract an over-general n_warmup claim, close two footguns (#632 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,107 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — arc-audit follow-up: flaky benchmark gate, an over-general `n_warmup` claim, an unsafe `field_softmax` default, and asymmetric `jacobian_fwd` safety
+
+An independent adversarial audit of the e4b565c..ce44661 merge arc (10 PRs,
+issues #571/#577/#578/#579/#582/#620/#622/#623/#625/#626/#632) found five
+of our own mistakes after merge. This entry documents the fixes; it is a
+correction of the arc's own errors, not new feature work.
+
+- **Benchmark flakiness (issue #632 follow-up)**:
+  `tests/test_benchmark_jacobian_fwd.py` asserted `intercept_vs_plain_ratio`
+  landed in `[0.5x, 2.0x]` for EVERY column including `wall_s` — confirmed
+  red on main (commit 55fa85b, CI run 31464443445, fast-suite shard 1:
+  `wall_s = 0.474`, just outside the band) and green again on the very
+  next commit with no code change, exactly the machine-dependence #632
+  itself had already diagnosed for this quantity (0.98-1.10 CPU vs
+  1.41-1.87 on an RTX 4090). The assertion now gates only the
+  deterministic compiler-derived columns (`flops`, `temp_bytes`); `wall_s`
+  is still computed and left in the table for a human/CI-log reader, never
+  gated. The batched-vs-sequential wall-time comparison (same file) is the
+  same class of check and gets the same treatment: reported, not asserted.
+  `tests/test_jacobian_fwd.py`'s G3 (jaxpr-structural, backend-independent)
+  remains the authoritative primal-sharing check.
+- **`n_warmup` truncation error is placement-dependent, not universal
+  (issue #626 addendum)**: the shipped curve (near-source design cell,
+  ~3 cells from the source) is the WORST case, not the general case. A
+  far-from-source counter-fixture (design cell 62 cells from the source)
+  measures the AD gradient matching the K=0 FD oracle to 0.008-0.036% for
+  every sampled `n_warmup` at or below the wavefront's arrival time at the
+  design region, only degrading past it — new committed script
+  `scripts/diagnostics/i626_n_warmup_wavefront_locality.py`. Corrected
+  guidance ships in `rfx/nonuniform.py`'s `n_warmup split` comment,
+  `Simulation.forward()`'s `n_warmup` docstring, `rfx.observables.
+  jacobian_fwd`'s fence note, and `rfx.runners.distributed_nu.
+  run_nonuniform_distributed_pec`'s docstring: compute
+  `K_safe ~= floor(min_distance(source, design_region) / (C0 * dt))`;
+  `n_warmup <= K_safe` is (near-)exact. No runtime warning ships —
+  `forward()` does not know which cells are the "design region" (that
+  concept was deliberately removed with `design_mask`, issue #625), so a
+  warning built on a guess would be exactly the kind of unverifiable claim
+  this repo's own discipline forbids; the formula is documentation, not
+  an automated check.
+- **`rfx.observables.field_softmax`'s default `beta=1.0` was unsafe at
+  realistic field magnitudes (issue #619)**: at the old, unscaled
+  `logsumexp(beta*vals)/beta` formulation, a physically tiny field
+  (`|field|**2` ~1e-10 to 1e-22, this repo's own DFT-plane accumulator
+  range) at the default beta made the objective sit at ~100.000002% of
+  the design-independent constant `log(count)/beta` — both the value and
+  gradient measured rounding noise, not physics. `field_softmax` now
+  auto-scales internally, `beta_eff = beta / stop_gradient(max(vals))`,
+  which makes `beta_eff * max(vals) == beta` identically regardless of
+  the field's physical units — the swallow cannot recur at any finite
+  magnitude, at any beta, including the default (now merely LOOSE at
+  low beta, never rounding-noise). `beta` is DIMENSIONLESS after this
+  change. New regression tests:
+  `tests/test_observables_dft_field.py::test_field_softmax_default_beta_is_scale_invariant`
+  (verifies `field_softmax(c*vals) == c*field_softmax(vals)` at the
+  default beta across 30 orders of magnitude) and
+  `::test_field_softmax_default_beta_gradient_not_rounding_noise` (direct
+  FD-vs-AD check at a physically tiny field magnitude). The existing
+  FD-vs-AD gates' `_SOFTMAX_BETA` and `examples/inverse_design/
+  field_observable_shielding.py`'s `BETA` are re-calibrated for the new
+  dimensionless meaning (measured, not guessed).
+- **`jacobian_fwd`'s two tangent-batching paths had asymmetric safety and
+  one false docstring claim**: the docstring stated `batch_tangents=False`
+  runs its sequential `jax.jvp` calls "inside one `jit`" — there is no
+  `jax.jit` anywhere in `rfx/observables.py`; the claim was never true
+  (corrected). More substantively: the batched path (`jax.vmap(...,
+  out_axes=(None, 0))`) raises loudly if `sim_fn`'s primal genuinely
+  depends on the tangent direction (an API-purity invariant); the
+  sequential path had no equivalent check and would have silently
+  returned one arbitrary tangent row's primal. It now carries two guards:
+  (1) a `jax.eval_shape` abstract trace of the same `out_axes=(None, 0)`
+  vmap — zero FLOPs, zero extra memory, works whether or not the caller
+  wraps the call in an outer `jax.jit`; (2) an eager exact pairwise
+  comparison of the actually-computed primal values (skipped only under
+  an enclosing `jax.jit`, where values are not yet concrete). New tests
+  `tests/test_jacobian_fwd.py::test_g8_*` cover both guards, including a
+  deliberately broken `custom_jvp` rule that violates the invariant, a
+  cross-call-impurity case guard 1 structurally cannot see (only guard 2
+  catches it), and confirmation neither guard false-positives on a normal
+  `sim_fn` or breaks under an outer `jax.jit` (the benchmark script's own
+  usage pattern).
+- **Small fixes**: `tests/test_n_warmup.py`'s "three uniform-lane
+  siblings" comment corrected to two (`design_mask` was removed outright,
+  issue #625, one commit before this comment was added — not fenced, so
+  it is not part of this taxonomy). `Simulation.forward()`'s removed-kwarg
+  error used to read `TypeError: _ExecuteMixin.forward() got an
+  unexpected keyword argument 'design_mask'`, leaking the internal mixin
+  class name (the public surface is `Simulation.forward`) with no reason
+  or replacement; `forward()` now accepts `**_removed_kwargs` and raises a
+  `TypeError` naming the removal reason and the one-line migration path
+  instead (`rfx/api/_execute.py::_reject_removed_forward_kwargs`) — still
+  a plain `TypeError`, still matched by `tests/test_design_mask_removed.py`'s
+  existing `pytest.raises(TypeError, match="design_mask")` assertions, plus
+  a new test pinning the improved message. `docs/public/guide/
+  memory-reduction.mdx` gained a "Restricting which cells carry a
+  derivative" section (the `design_mask` migration path previously existed
+  only in this CHANGELOG, not in public docs).
+- `docs/guides/api_symbol_inventory.json` regenerated
+  (`python scripts/check_api_reference.py --write`) for `forward()`'s new
+  `_removed_kwargs` parameter.
+
 ### Removed — `design_mask` deleted from every public surface (issue #625, BREAKING)
 
 - `design_mask` is deleted, not deprecated, from every entry point that
@@ -170,6 +271,13 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   now three configurations / two raises / one docs-only trap, since
   `design_mask` — one of the prior four — was removed outright rather
   than fenced).
+- **Addendum (arc-audit follow-up, below): the curve above is a
+  NEAR-SOURCE worst case, not a universal property of `n_warmup`.** See
+  the "Fixed — arc-audit follow-up" entry near the top of this file for
+  the corrected, distance-dependent statement and the `K_safe` formula —
+  read this entry's measured numbers as "what happens once the wavefront
+  has already reached the design region," not as "what `n_warmup` always
+  does."
 
 ### Changed — `benchmark_jacobian_fwd.py`'s intercept/plain witness text now flags itself as CPU-calibrated (issue #632)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,15 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 An independent adversarial audit of the e4b565c..ce44661 merge arc (10 PRs,
 issues #571/#577/#578/#579/#582/#620/#622/#623/#625/#626/#632) found five
 of our own mistakes after merge. This entry documents the fixes; it is a
-correction of the arc's own errors, not new feature work.
+correction of the arc's own errors, not new feature work. A second,
+independent verification pass over THIS entry's own fixes then found
+several more defects in them (an overflow guard that clipped the value
+but not the gradient, a NaN misdiagnosed as a tangent-dependence
+violation, a guard stricter than the code it was meant to match, an
+under-sampled falsifier sweep that itself overstated its claim, and the
+`_ExecuteMixin` leak turning out to be ten methods, not one) — folded
+into the same bullets below rather than filed separately, since they are
+corrections to fixes that had not yet shipped.
 
 - **Benchmark flakiness (issue #632 follow-up)**:
   `tests/test_benchmark_jacobian_fwd.py` asserted `intercept_vs_plain_ratio`
@@ -30,43 +38,39 @@ correction of the arc's own errors, not new feature work.
 - **`n_warmup` truncation error is placement-dependent, not universal
   (issue #626 addendum)**: the shipped curve (near-source design cell,
   ~3 cells from the source) is the WORST case, not the general case. A
-  far-from-source counter-fixture (design cell 62 cells from the source)
-  measures the AD gradient matching the K=0 FD oracle to 0.008-0.036% for
-  every sampled `n_warmup` at or below the wavefront's arrival time at the
-  design region, only degrading past it — new committed script
+  far-from-source counter-fixture (design cell 62 cells from the source,
+  `K_safe=108`) measures the AD gradient staying within this repo's own
+  established ~1.5% AD-vs-FD noise floor for every `n_warmup <= K_safe`:
+  <0.01% through `K_safe`-20 (deep sub-wavefront, near-exact), growing
+  SMOOTHLY (not a sharp cliff — a finer sweep bracketing `K_safe`, added
+  in the same verification round that found this, shows 0.26% at
+  `K_safe`-4, 0.60% at `K_safe`-2, 1.19% AT `K_safe` itself), only
+  exceeding that noise floor past `K_safe` — new committed script
   `scripts/diagnostics/i626_n_warmup_wavefront_locality.py`. Corrected
   guidance ships in `rfx/nonuniform.py`'s `n_warmup split` comment,
   `Simulation.forward()`'s `n_warmup` docstring, `rfx.observables.
   jacobian_fwd`'s fence note, and `rfx.runners.distributed_nu.
   run_nonuniform_distributed_pec`'s docstring: compute
-  `K_safe ~= floor(min_distance(source, design_region) / (C0 * dt))`;
-  `n_warmup <= K_safe` is (near-)exact. No runtime warning ships —
+  `K_safe ~= floor(min_distance(source, design_region) / (C0 * dt))`
+  (`min_distance` over every active source AND each source's own spatial
+  extent — a TFSF plane-wave source illuminates from an entire box face,
+  not a point);
+  `n_warmup <= K_safe` stays within the noise floor above (near-exact
+  deep below `K_safe`, merely noise-floor-comfortable AT it). No runtime
+  warning ships —
   `forward()` does not know which cells are the "design region" (that
   concept was deliberately removed with `design_mask`, issue #625), so a
   warning built on a guess would be exactly the kind of unverifiable claim
   this repo's own discipline forbids; the formula is documentation, not
   an automated check.
-- **`rfx.observables.field_softmax`'s default `beta=1.0` was unsafe at
-  realistic field magnitudes (issue #619)**: at the old, unscaled
-  `logsumexp(beta*vals)/beta` formulation, a physically tiny field
-  (`|field|**2` ~1e-10 to 1e-22, this repo's own DFT-plane accumulator
-  range) at the default beta made the objective sit at ~100.000002% of
-  the design-independent constant `log(count)/beta` — both the value and
-  gradient measured rounding noise, not physics. `field_softmax` now
-  auto-scales internally, `beta_eff = beta / stop_gradient(max(vals))`,
-  which makes `beta_eff * max(vals) == beta` identically regardless of
-  the field's physical units — the swallow cannot recur at any finite
-  magnitude, at any beta, including the default (now merely LOOSE at
-  low beta, never rounding-noise). `beta` is DIMENSIONLESS after this
-  change. New regression tests:
-  `tests/test_observables_dft_field.py::test_field_softmax_default_beta_is_scale_invariant`
-  (verifies `field_softmax(c*vals) == c*field_softmax(vals)` at the
-  default beta across 30 orders of magnitude) and
-  `::test_field_softmax_default_beta_gradient_not_rounding_noise` (direct
-  FD-vs-AD check at a physically tiny field magnitude). The existing
-  FD-vs-AD gates' `_SOFTMAX_BETA` and `examples/inverse_design/
-  field_observable_shielding.py`'s `BETA` are re-calibrated for the new
-  dimensionless meaning (measured, not guessed).
+- **`rfx.observables.field_softmax`'s `beta` semantics changed — see the
+  dedicated BREAKING entry below** (issue #619). Summary only here: the
+  old default was unsafe at realistic field magnitudes; `beta` is now
+  auto-scaled and DIMENSIONLESS. Filed as its own top-level BREAKING
+  entry, not folded into this list, because it silently changes the
+  numeric meaning of an existing top-level public-export parameter for
+  every caller who passed a non-default `beta` — unlike this list's other
+  four items, there is no raise or new error to notice it by.
 - **`jacobian_fwd`'s two tangent-batching paths had asymmetric safety and
   one false docstring claim**: the docstring stated `batch_tangents=False`
   runs its sequential `jax.jvp` calls "inside one `jit`" — there is no
@@ -103,9 +107,82 @@ correction of the arc's own errors, not new feature work.
   memory-reduction.mdx` gained a "Restricting which cells carry a
   derivative" section (the `design_mask` migration path previously existed
   only in this CHANGELOG, not in public docs).
+- **The `_ExecuteMixin` leak above was not one-off — verification round
+  fix, ten methods.** Every method `Simulation` inherits from its five
+  mixins (`_PreflightMixin`, `_SparamMixin`, `_CompileMixin`,
+  `_ExecuteMixin`, `_ArtifactsMixin`) kept that mixin's name in its
+  `__qualname__` (Python sets it from the class body where a function is
+  DEFINED, not where it is bound via inheritance), so ANY unrecognised
+  keyword argument on ANY public method leaked the internal mixin —
+  measured: `sim.run(n_stepss=2)` read `_ExecuteMixin.run() got an
+  unexpected keyword argument`. `rfx/api/__init__.py` now rebinds every
+  inherited method's `__qualname__` to `Simulation.<method>` once, at
+  class composition time (structural only — does not change behaviour,
+  identity, or MRO). New test:
+  `tests/test_design_mask_removed.py::test_no_public_simulation_method_leaks_a_mixin_class_name`.
 - `docs/guides/api_symbol_inventory.json` regenerated
   (`python scripts/check_api_reference.py --write`) for `forward()`'s new
   `_removed_kwargs` parameter.
+
+### Changed — `rfx.observables.field_softmax`'s `beta` is now auto-scaled and DIMENSIONLESS (**BREAKING**) (issue #619)
+
+- **The numeric meaning of `beta` changed for every existing caller who
+  passed a non-default value — silently, with no raise.** Before this
+  change, `field_softmax(names, beta=B)` computed
+  `logsumexp(B * vals) / B` directly against the raw `|field|**2` values,
+  so `B` had to be hand-matched to whatever physical units/magnitude the
+  DFT-plane accumulator happened to carry (commonly `|field|**2` ~1e-10
+  to 1e-22 in this repo). At the old default `beta=1.0`, a realistic
+  field magnitude made the objective sit at ~100.000002% of the
+  design-independent constant `log(count)/beta` — both the value and
+  gradient measured rounding noise, not physics (measured, `#619`).
+- **The fix**: `field_softmax` now computes
+  `beta_eff = beta / stop_gradient(max(vals))` and uses `beta_eff` in
+  place of a raw `beta` throughout, so `beta_eff * max(vals) == beta`
+  identically regardless of the field's physical units. `beta` is now
+  DIMENSIONLESS (a target sharpness — see the docstring's
+  "What beta now controls" section) rather than a raw multiplier on
+  `|field|**2`. The old rounding-noise swallow cannot recur at any
+  representable field magnitude, at any beta, including the default
+  (now merely LOOSE at low beta, never rounding-noise).
+- **MIGRATION — rescale any beta you already tuned.** A `beta` value
+  chosen under the OLD semantics (e.g. `beta=1e11`, tuned so
+  `beta * max(vals) ≈ 50` for a specific field magnitude) means something
+  completely different under the new one (`beta_eff * max(vals) == beta`
+  identically, so passing `beta=1e11` now targets a wildly over-sharp
+  softmax relative to the old intent). Do not carry an old numeric `beta`
+  forward unexamined: pick the new dimensionless value directly from the
+  "What beta now controls" guidance in the docstring (5-50 is a
+  reasonable range for most plane sizes), or recompute it as
+  `new_beta ≈ old_beta * old_max_vals` if you need to reproduce a
+  specific old operating point. This repo's own callers were re-tuned by
+  measurement, not by that formula: `tests/test_observables_dft_field.py`'s
+  `_SOFTMAX_BETA` (`1e11` raw → `200` dimensionless) and
+  `examples/inverse_design/field_observable_shielding.py`'s `BETA`
+  (`2.0e24` raw → `20` dimensionless).
+- **Follow-up fix, same verification round: the overflow footgun the
+  auto-scaling was meant to close RELOCATED rather than closed.**
+  `beta_eff = beta / max(vals)` can itself overflow for a large enough
+  `beta` against a tiny field — measured: at `max(vals)` ~2.24e-22,
+  `beta=2.0e24` (the literal value the shielding example carried before
+  its own re-calibration above) returned `value=nan, grad=nan` silently.
+  `field_softmax` now clips `beta_eff` to the working dtype's largest
+  finite value when it would overflow, keeping the VALUE finite and
+  accurate. The GRADIENT is a separate, tighter limit the clip does NOT
+  cover: it silently collapses to exactly `0.0` somewhere in the
+  `beta~1e15-1e17` range (fixture-dependent; a `1/beta_eff`
+  floating-point precision limit in the VJP, not fixed here) — both
+  thresholds sit many orders of magnitude above the recommended 5-50
+  range, so this is a documented edge, not a practical concern for any
+  beta this repo's own guidance recommends. New regression tests:
+  `test_field_softmax_beta_eff_overflow_returns_finite_not_nan` and
+  `test_field_softmax_gradient_can_silently_collapse_past_the_recommended_beta_range`.
+- New regression tests (scale-safety, distinct from the overflow tests
+  above): `test_field_softmax_default_beta_is_scale_invariant` (verifies
+  `field_softmax(c*vals) == c*field_softmax(vals)` at the default beta
+  across 30 orders of magnitude) and
+  `test_field_softmax_default_beta_gradient_not_rounding_noise` (direct
+  FD-vs-AD check at a physically tiny field magnitude).
 
 ### Removed — `design_mask` deleted from every public surface (issue #625, BREAKING)
 
@@ -271,7 +348,7 @@ correction of the arc's own errors, not new feature work.
   now three configurations / two raises / one docs-only trap, since
   `design_mask` — one of the prior four — was removed outright rather
   than fenced).
-- **Addendum (arc-audit follow-up, below): the curve above is a
+- **Addendum (arc-audit follow-up, ABOVE): the curve above is a
   NEAR-SOURCE worst case, not a universal property of `n_warmup`.** See
   the "Fixed — arc-audit follow-up" entry near the top of this file for
   the corrected, distance-dependent statement and the `K_safe` formula —

--- a/docs/agent/recipe-design-loop.mdx
+++ b/docs/agent/recipe-design-loop.mdx
@@ -85,12 +85,18 @@ them off the result with `rfx.observables`:
   objective.
 - `field_softmax(names, beta=...)` -- a temperature-controlled soft-max
   over space + frequency, for a worst-case-bin (not average) objective.
-  **`beta` MUST be scale-matched to your `|field|**2` magnitude** (rfx's
-  DFT-accumulator units commonly sit far from O(1) — see the function's
-  own docstring warning and
-  `examples/inverse_design/field_observable_shielding.py`'s measured
-  `BETA` for a worked example); an unscaled `beta` can make the objective
-  silently dominated by a design-variable-independent constant.
+  `beta` is auto-scaled internally (`beta_eff = beta /
+  stop_gradient(max(vals))`) and DIMENSIONLESS — it no longer needs
+  hand-matching to `|field|**2`'s physical magnitude the way an earlier
+  version did (issue #619; rfx's DFT-accumulator units commonly sit far
+  from O(1)). The default (`beta=1.0`) is safe at any field magnitude,
+  merely loose; raise `beta` (5-50 is a reasonable range for most plane
+  sizes) for a tighter max approximation — see the function's own
+  docstring and `examples/inverse_design/field_observable_shielding.py`'s
+  measured `BETA` for a worked example. `beta` values tuned under the OLD
+  (pre-#619-fix) unscaled semantics do NOT carry over — see
+  `field_softmax`'s docstring "Auto-scaling" section for the migration
+  note.
 
 Composition is `lambda p: field_softmax(names)(sim.forward(eps_override=p))`
 — same factory-returns-`callable(Result)` style as `rfx.optimize_objectives`,

--- a/docs/guides/api_symbol_inventory.json
+++ b/docs/guides/api_symbol_inventory.json
@@ -2588,7 +2588,8 @@
       "devices",
       "exchange_interval",
       "port_s11_freqs",
-      "rlc_values_override"
+      "rlc_values_override",
+      "_removed_kwargs"
     ],
     "mesh_intelligence_report": [
       "n_steps",

--- a/docs/public/guide/memory-reduction.mdx
+++ b/docs/public/guide/memory-reduction.mdx
@@ -261,6 +261,32 @@ uniform (single-device) mesh, `forward(n_warmup=...)` itself raises
 The plan applies a conservative safety multiplier before setting the fit
 flags and records it in `plan.fit_safety_factor`.
 
+### Restricting which cells carry a derivative
+
+`forward(design_mask=...)` was removed entirely (issue #625) rather than
+deprecated: it was measured to save **zero** reverse-mode AD memory (JAX's
+partial-eval residuals have whole-array granularity, so confining a design
+variable to a fraction of the grid does not shrink the tape) while
+corrupting the gradient in every configuration tested. It is not a memory
+option — do not look for a direct replacement kwarg.
+
+If you actually need to restrict which cells carry a derivative (not for
+memory — for design-region hygiene, e.g. keeping a gradient from leaking
+into a PML/absorber region), construct the restriction yourself at the
+`eps_override` call site, one line:
+
+```python
+eps = jnp.where(region_mask, eps, jax.lax.stop_gradient(eps))
+result = sim.forward(eps_override=eps, ...)
+```
+
+`region_mask` is a boolean array (or broadcastable to `eps`'s shape) that is
+`True` inside the design region. This is forward-identity (`stop_gradient`
+does not change the value, only the gradient), and the resulting per-cell
+gradient is exactly zero outside `region_mask` and exactly equal to the
+unmasked gradient inside it. For actual memory reduction, use
+`checkpoint_every` / `checkpoint_segments` above instead.
+
 For a uniform run, gate execution on the fit flags before applying the selected
 checkpoint value:
 

--- a/examples/inverse_design/field_observable_shielding.py
+++ b/examples/inverse_design/field_observable_shielding.py
@@ -80,20 +80,31 @@ LEAK_NEAR_X_M = 0.080
 LEAK_FAR_X_M = 0.130
 
 EPS_MIN, EPS_MAX = 1.0, 6.0
-# field_softmax sharpness: rfx's TFSF/DFT-accumulator normalization puts
-# raw |field|^2 at this geometry around 1e-22 (the same tiny-absolute-unit
-# convention documented for NTFF power elsewhere in this repo, e.g.
-# maximize_directivity's docstring notes ~1e-27 raw values) -- BETA must
-# scale to THAT, not to an O(1) assumption. Measured empirically
-# (scripts/tune sweep in the #579 PR body): loss/grad converge (the
-# log(count)/beta constant term becomes negligible) by beta ~ 1e24-1e25;
-# 2e24 sits inside that converged plateau with margin.
-BETA = 2.0e24
+# field_softmax sharpness: BETA is now DIMENSIONLESS (rfx.observables.
+# field_softmax auto-scales internally as beta_eff = beta /
+# stop_gradient(max(vals)), so beta_eff * max(vals) == BETA identically
+# regardless of the field's physical units -- see field_softmax's own
+# docstring). This example's raw |field|^2 sits around 1e-22 at this
+# geometry (the same tiny-absolute-unit convention documented for NTFF
+# power elsewhere in this repo, e.g. maximize_directivity's docstring
+# notes ~1e-27 raw values), which is exactly the magnitude the OLD
+# unscaled beta had to be hand-tuned against (previously BETA=2e24, so
+# that beta*max(vals) cleared the log(count)/beta noise floor). With
+# auto-scaling that hand-tuning is no longer needed: measured (this
+# script's fixture) val0/grad_max stay finite and well-behaved across
+# BETA in [1, 50], tightening from val0=1.42e-21 at BETA=1 toward the
+# true max as BETA grows (val0=2.03e-22 at BETA=50); BETA=20 sits
+# comfortably past this fixture's log(count) noise floor with margin
+# without over-sharpening the gradient.
+BETA = 20.0
 N_STEPS = 500
 N_ITERS = 12
-# Gradient descent step: measured |grad|_max ~ 1e-23 at this beta/geometry
-# (same tiny-unit consequence as BETA above) -- LR is sized so a full step
-# moves the most-sensitive layer's eps_r by a fraction of an eps_r unit.
+# Gradient descent step: measured |grad|_max ~ 1.0e-23 (BETA=20, this
+# fixture) -- essentially unchanged across BETA in [1, 50] (a
+# softmax-weighted average stays near the individual field cells' own
+# ~1e-22 magnitude regardless of temperature), so the pre-auto-scale LR
+# still applies unmodified. LR is sized so a full step moves the
+# most-sensitive layer's eps_r by a fraction of an eps_r unit.
 LR = 1.0e22
 
 

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -18,6 +18,7 @@ Usage
 
 from __future__ import annotations
 
+import inspect
 import math
 import json
 import jax
@@ -3792,6 +3793,41 @@ class Simulation(
         sim_kwargs = config.to_sim_kwargs()
         sim_kwargs.update(kwargs)
         return cls(**sim_kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Arc-audit follow-up (verification round): every method Simulation
+# inherits from its five mixins keeps that mixin's name in its
+# __qualname__ (Python sets __qualname__ from the class body where a
+# function is DEFINED, not where it ends up bound via inheritance), which
+# leaks into user-facing TypeError messages for an unrecognised keyword
+# argument -- e.g. `TypeError: _ExecuteMixin.forward() got an unexpected
+# keyword argument 'design_mask'` instead of naming the actual public
+# surface, `Simulation.forward()`. This was fixed for forward()
+# specifically via an explicit **_removed_kwargs shim
+# (_reject_removed_forward_kwargs in rfx/api/_execute.py), but the
+# verifier found it is not one-off: ten public Simulation methods leak
+# the same way (e.g. `sim.run(n_stepss=2)` still says `_ExecuteMixin.
+# run() got an unexpected keyword argument`). Rebind __qualname__ on
+# every inherited method here, once, at class composition time, so all
+# of them read `Simulation.<method>` regardless of which mixin module
+# happens to define them. Structural only: does not change behaviour,
+# identity, or MRO -- only the __qualname__ string attribute Python's
+# own error formatting (and tracebacks, repr, etc.) reads from. Each of
+# these mixin classes is used ONLY by Simulation (verified: no other
+# `class ...(_ExecuteMixin` etc. anywhere in rfx/), so mutating the
+# function objects in place cannot affect any other class.
+# ---------------------------------------------------------------------------
+for _mixin in (
+    _PreflightMixin, _SparamMixin, _CompileMixin, _ExecuteMixin, _ArtifactsMixin,
+):
+    for _name, _member in vars(_mixin).items():
+        if (
+            inspect.isfunction(_member)
+            and _member.__qualname__ == f"{_mixin.__name__}.{_name}"
+        ):
+            _member.__qualname__ = f"Simulation.{_name}"
+del _mixin, _name, _member
 
 
 # ---------------------------------------------------------------------------

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -2487,28 +2487,40 @@ class _ExecuteMixin:
 
                 K_safe ~= floor(min_distance(source, design_region) / (C0 * dt))
 
-            (grid steps for the wavefront to reach the closest design cell,
-            ``C0`` = vacuum lightspeed, ``dt`` = ``sim._build_grid().dt`` /
+            (``min_distance`` is the minimum over EVERY active source AND
+            over each source's own spatial extent, not just its nominal
+            position — a TFSF plane-wave source illuminates from an
+            entire box face, not a point; grid steps for the wavefront to
+            reach the closest design cell, ``C0`` = vacuum lightspeed,
+            ``dt`` = ``sim._build_grid().dt`` /
             ``sim._build_nonuniform_grid().dt`` — a conservative floor valid
-            for any slower propagation). ``n_warmup <= K_safe`` is
-            (near-)exact; well beyond it, error grows and can reach the
-            full gradient magnitude by the time ``n_warmup`` reaches the
-            loss window. Two measured regimes (issue #626 part 2 /
-            addendum, both vs an independent central-FD oracle): a
-            NEAR-SOURCE placement (design cell ~3 cells from the source, so
-            ``K_safe ~ 0``) shows error growing smoothly from a ~1.5% noise
-            floor up to 58% at the loss-window boundary itself, and EXACTLY
-            zero (gradient fully vanished) once ``n_warmup`` extends far
-            enough into the loss window (``tests/test_n_warmup.py::
+            for any slower propagation). ``n_warmup <= K_safe`` stays
+            within this repo's ~1.5% AD-vs-FD noise floor (near-exact,
+            <0.1%, well below ``K_safe``); well beyond ``K_safe``, error
+            grows further and can reach the full gradient magnitude by
+            the time ``n_warmup`` reaches the loss window. Two measured
+            regimes (issue #626 part 2 / addendum, both vs an independent
+            central-FD oracle): a NEAR-SOURCE placement (design cell ~3
+            cells from the source, so ``K_safe ~ 0``) shows error growing
+            smoothly from a ~1.5% noise floor up to 58% at the
+            loss-window boundary itself, and EXACTLY zero (gradient fully
+            vanished) once ``n_warmup`` extends far enough into the loss
+            window (``tests/test_n_warmup.py::
             test_warmup_truncation_error_grows_with_k``); a
             FAR-FROM-SOURCE placement (design cell 62 cells from the
             source, ``K_safe=108`` measured from the grid's own ``dt``)
-            shows AD matching the ``n_warmup=0`` FD oracle to
-            0.008-0.036% for every sampled ``n_warmup`` at or below
-            ``K_safe``, only starting to degrade past it (0.63% at
-            ``K_safe`` + 12, growing to 75% by ``K_safe`` + 92) —
-            ``scripts/diagnostics/i626_n_warmup_wavefront_locality.py``.
-            The near-source curve above is the WORST case, not the general
+            shows AD matching the ``n_warmup=0`` FD oracle to <0.01%
+            through ``K_safe``-20, then growing SMOOTHLY (not a sharp
+            cliff) as ``n_warmup`` approaches ``K_safe`` -- 0.26% at
+            ``K_safe``-4, 0.60% at ``K_safe``-2, 1.19% AT ``K_safe``
+            itself (still inside the noise floor above) -- continuing to
+            grow past it toward 75% by ``K_safe`` + 92 —
+            ``scripts/diagnostics/i626_n_warmup_wavefront_locality.py``
+            (finely sampled around ``K_safe``; an earlier version of this
+            docstring, read from a coarser sweep that skipped every point
+            near the boundary, overstated the transition as a sharp
+            cliff "exactly at K_safe"). The near-source curve above is
+            the WORST case, not the general
             case: use ``K_safe`` to decide whether YOUR source/design
             placement is in the exact or the truncated regime before
             assuming ``n_warmup`` costs accuracy. Forward (non-AD) output

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -49,6 +49,52 @@ from rfx.api._spec import (
 _DISTRIBUTED_FIRST_CALL_WARNED: bool = False
 
 
+# ---------------------------------------------------------------------------
+# Arc-audit follow-up item 5(b): a removed public kwarg (currently just
+# `design_mask`, issue #625) used to surface as the bare Python default --
+# `TypeError: _ExecuteMixin.forward() got an unexpected keyword argument
+# 'design_mask'` -- which leaks this mixin's internal class name (the
+# public surface is `Simulation.forward`, never `_ExecuteMixin.forward`)
+# and gives no reason or replacement. `forward()` now accepts
+# `**_removed_kwargs` and calls this helper so a removed kwarg gets a
+# `TypeError` naming the actual reason and the one-line migration path
+# instead. Deliberately still a `TypeError` (not some other exception
+# type) -- `tests/test_design_mask_removed.py` pins "the kwarg is
+# rejected" via `pytest.raises(TypeError, match="design_mask")`, and this
+# only changes the MESSAGE, not the exception class or that contract.
+# ---------------------------------------------------------------------------
+_REMOVED_FORWARD_KWARGS: dict = {
+    "design_mask": (
+        "removed entirely in issue #625, not deprecated: it was measured "
+        "to save ZERO reverse-mode AD memory (partial-eval residuals have "
+        "whole-array granularity) while corrupting the gradient in every "
+        "configuration tested. For memory relief use checkpoint_every / "
+        "checkpoint_segments; to restrict which cells carry a derivative, "
+        "wrap eps_override yourself: eps = jnp.where(region, eps, "
+        "jax.lax.stop_gradient(eps)) -- see CHANGELOG.md 'Removed — "
+        "design_mask' and docs/public/guide/memory-reduction.mdx."
+    ),
+}
+
+
+def _reject_removed_forward_kwargs(removed_kwargs: dict) -> None:
+    """Raise a TypeError for an unrecognised forward() kwarg, naming the
+    reason and replacement for a KNOWN removed one (see
+    ``_REMOVED_FORWARD_KWARGS``) instead of leaking ``_ExecuteMixin`` (the
+    internal mixin, not the public ``Simulation.forward`` surface)."""
+    parts = []
+    for name in removed_kwargs:
+        reason = _REMOVED_FORWARD_KWARGS.get(name)
+        if reason is not None:
+            parts.append(f"'{name}' was {reason}")
+        else:
+            parts.append(f"'{name}' is not a recognised forward() keyword argument")
+    raise TypeError(
+        "Simulation.forward() got unexpected keyword argument(s) "
+        f"{sorted(removed_kwargs)}: " + " | ".join(parts)
+    )
+
+
 class _DispatchPlan(NamedTuple):
     """Resolved execution lane for a single ``run()`` / ``forward()`` call.
 
@@ -2362,6 +2408,7 @@ class _ExecuteMixin:
         exchange_interval: int = 1,
         port_s11_freqs: object | None = None,
         rlc_values_override: dict | None = None,
+        **_removed_kwargs,
     ) -> ForwardResult:
         """Run a minimal differentiable forward simulation.
 
@@ -2424,32 +2471,56 @@ class _ExecuteMixin:
             initial transient (issue #40).  Only the trailing
             ``n_steps - n_warmup`` steps participate in autodiff.  Must
             satisfy ``n_warmup < n_steps``.  Default ``0`` (all steps
-            differentiated).  This is an APPROXIMATION, not merely a memory
-            optimisation: severing the carry at the warmup boundary also
-            severs every gradient path from a design variable's influence
-            during steps ``< n_warmup`` back into the loss, so the returned
-            gradient is a systematically truncated (magnitude-underestimated)
-            version of the true one whenever the design variable's
-            derivative-relevant support extends into the warmup window.
-            Measured on the non-uniform lane (issue #626 part 2, two
-            independent design-cell placements): error stays near this
-            repo's AD-vs-FD noise floor (≲1.5%) while ``n_warmup`` is up to
-            roughly a quarter of the pre-loss-window step count, then grows
-            smoothly and monotonically — ~6-7% at half the pre-loss-window
-            length, >20% by three-quarters, 58% AT the loss-window boundary
-            itself (``n_warmup`` equal to the pre-loss-window length), and
-            EXACTLY zero once ``n_warmup`` extends far enough into the loss
-            window that no differentiable sample remains (measured: exactly
-            0.0, not merely small, in one fixture once ``n_warmup`` covers
-            ~19/20 of the loss window). Forward (non-AD) output is exactly
-            ``n_warmup``-invariant (bit-identical);
-            only the gradient is affected. Currently only supported on the
-            non-uniform / distributed-non-uniform forward paths; on the
-            uniform single-device lane it raises ``NotImplementedError``
-            (issue #626 — previously silently accepted and ignored, worse
-            than an error).  Use *checkpoint_segments* for uniform-lane
-            reverse-mode memory relief instead — it is exact, at the cost of
-            recompute rather than gradient accuracy.
+            differentiated).
+
+            The truncation error DEPENDS ON DISTANCE FROM THE SOURCE TO THE
+            DESIGN REGION — it is not simply "an approximation" that always
+            costs accuracy (an earlier version of this docstring implied the
+            error applies unconditionally; that was an overgeneralization
+            from a single, worst-case fixture — see below). Severing the
+            carry severs every gradient path through steps ``< n_warmup``,
+            but only steps during which the WAVEFRONT HAS ALREADY REACHED
+            the design region carry any such path to sever; before the
+            wavefront arrives the field there is ~0, so severing those
+            steps discards ~nothing and the gradient is (near-)exact.
+            Compute a safe bound yourself::
+
+                K_safe ~= floor(min_distance(source, design_region) / (C0 * dt))
+
+            (grid steps for the wavefront to reach the closest design cell,
+            ``C0`` = vacuum lightspeed, ``dt`` = ``sim._build_grid().dt`` /
+            ``sim._build_nonuniform_grid().dt`` — a conservative floor valid
+            for any slower propagation). ``n_warmup <= K_safe`` is
+            (near-)exact; well beyond it, error grows and can reach the
+            full gradient magnitude by the time ``n_warmup`` reaches the
+            loss window. Two measured regimes (issue #626 part 2 /
+            addendum, both vs an independent central-FD oracle): a
+            NEAR-SOURCE placement (design cell ~3 cells from the source, so
+            ``K_safe ~ 0``) shows error growing smoothly from a ~1.5% noise
+            floor up to 58% at the loss-window boundary itself, and EXACTLY
+            zero (gradient fully vanished) once ``n_warmup`` extends far
+            enough into the loss window (``tests/test_n_warmup.py::
+            test_warmup_truncation_error_grows_with_k``); a
+            FAR-FROM-SOURCE placement (design cell 62 cells from the
+            source, ``K_safe=108`` measured from the grid's own ``dt``)
+            shows AD matching the ``n_warmup=0`` FD oracle to
+            0.008-0.036% for every sampled ``n_warmup`` at or below
+            ``K_safe``, only starting to degrade past it (0.63% at
+            ``K_safe`` + 12, growing to 75% by ``K_safe`` + 92) —
+            ``scripts/diagnostics/i626_n_warmup_wavefront_locality.py``.
+            The near-source curve above is the WORST case, not the general
+            case: use ``K_safe`` to decide whether YOUR source/design
+            placement is in the exact or the truncated regime before
+            assuming ``n_warmup`` costs accuracy. Forward (non-AD) output
+            is exactly ``n_warmup``-invariant (bit-identical) in every
+            placement measured; only the gradient is affected. Currently
+            only supported on the non-uniform / distributed-non-uniform
+            forward paths; on the uniform single-device lane it raises
+            ``NotImplementedError`` (issue #626 — previously silently
+            accepted and ignored, worse than an error).  Use
+            *checkpoint_segments* for uniform-lane reverse-mode memory
+            relief instead — it is exact regardless of placement, at the
+            cost of recompute rather than gradient accuracy.
         skip_preflight : bool
             Skip the consolidated :meth:`preflight` validation suite that
             normally runs before the forward simulation (default False).
@@ -2513,6 +2584,9 @@ class _ExecuteMixin:
         ForwardResult
             Minimal differentiable observables (time series and optional NTFF).
         """
+        if _removed_kwargs:
+            _reject_removed_forward_kwargs(_removed_kwargs)
+
         # Phase 3 (issue #44 V3 §M6): one-shot UserWarning for the opt-in
         # distributed=True path so users know the path is opt-in / unstable
         # / pending GPU evidence.  The flag lives at module scope so we

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -1415,11 +1415,17 @@ def run_nonuniform(
     # (near-)exact -- n_warmup is genuinely free compute/memory relief in
     # that regime, not merely an approximation. Define
     #     K_safe ~= floor(min_distance(source, design_region) / (C0 * dt))
-    # (grid steps for the wavefront to reach the closest design cell, C0 =
-    # vacuum lightspeed -- a conservative floor valid for any slower,
-    # non-vacuum propagation). For n_warmup <= K_safe truncation error is
-    # negligible; beyond it, error grows and can reach the full gradient
-    # magnitude by the time n_warmup reaches the loss window.
+    # where min_distance is the MINIMUM over EVERY active source AND over
+    # each source's own spatial extent (not just its nominal position) --
+    # a TFSF plane-wave source, for example, illuminates from an entire
+    # box face, not a point, so "distance from the source" means distance
+    # from the NEAREST point of that box to the nearest point of the
+    # design region. (grid steps for the wavefront to reach the closest
+    # design cell, C0 = vacuum lightspeed -- a conservative floor valid
+    # for any slower, non-vacuum propagation). For n_warmup <= K_safe
+    # truncation error is negligible; beyond it, error grows and can
+    # reach the full gradient magnitude by the time n_warmup reaches the
+    # loss window.
     #
     # Forward output is exactly n_warmup-invariant (bit-identical) in every
     # placement measured. Two measured regimes (issue #626 part 2 /
@@ -1433,17 +1439,30 @@ def run_nonuniform(
     #     tests/test_n_warmup.py::test_warmup_truncation_error_grows_with_k,
     #     n_steps=100, loss window [80,100)).
     #   - FAR-FROM-SOURCE placement (design cell 62 cells from the source,
-    #     K_safe=108 measured from the grid's own dt): AD matches the
-    #     K=0 FD oracle to 0.008-0.036% rel_err for every sampled
-    #     n_warmup in {0,20,40,60,80,100} -- ALL <= K_safe -- and only
-    #     starts degrading past K_safe (0.63% at K=120, growing to 75% by
-    #     K=200), exactly the wavefront-arrival prediction (fixture:
+    #     K_safe=108 measured from the grid's own dt): AD matches the K=0
+    #     FD oracle to <0.01% rel_err through K=88 (deep sub-wavefront,
+    #     K_safe-20), then grows SMOOTHLY -- not a sharp cliff -- as K
+    #     approaches K_safe: 0.015% at K=98, 0.098% at K=102, 0.259% at
+    #     K=104, 0.601% at K=106, 1.186% AT K=108 (=K_safe itself). Every
+    #     one of those K<=K_safe values sits comfortably inside this
+    #     repo's own established ~1.5% AD-vs-FD noise floor. Past K_safe
+    #     the curve keeps growing (1.56% at K=109, ~2.5% around K=112),
+    #     though non-monotonically farther out (numerical-dispersion
+    #     ripple, not noise) before the broader trend continues upward
+    #     toward the loss window (75% by K=200). K_safe is therefore a
+    #     BOUND on where truncation stays within the established noise
+    #     floor, not a literal discontinuity -- an earlier version of
+    #     this comment read the original coarse (multiples-of-20) sweep,
+    #     which skipped every point in [101,119], as "exactly the
+    #     wavefront-arrival prediction" and overstated how sharp the
+    #     transition is (fixture:
     #     scripts/diagnostics/i626_n_warmup_wavefront_locality.py,
-    #     n_steps=220, loss window [180,220)).
+    #     n_steps=220, loss window [180,220), finely sampled around
+    #     K_safe).
     # The near-source curve is the WORST case, not the general case --
     # use K_safe to decide whether a given source/design placement is in
-    # the exact or the truncated regime; do not read "n_warmup truncates
-    # the gradient" as true unconditionally.
+    # the exact-or-noise-floor or the truncated regime; do not read
+    # "n_warmup truncates the gradient" as true unconditionally.
     if n_warmup > 0:
         if n_warmup >= n_steps:
             raise ValueError(

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -1400,24 +1400,50 @@ def run_nonuniform(
     # (issue #40). Only the trailing n_optimize = n_steps - n_warmup
     # steps participate in reverse-mode autodiff.
     #
-    # This is an APPROXIMATION, not merely a memory optimization: severing
-    # the carry also severs every gradient path from a design variable's
-    # influence during steps < n_warmup back into the loss. Forward output
-    # is exactly n_warmup-invariant (bit-identical), but the gradient is a
-    # truncated (magnitude-underestimated) version of the true one whenever
-    # the design variable's derivative-relevant support extends into the
-    # warmup window -- which it generally does for a static material/design
-    # parameter present throughout the whole run. Measured (issue #626 part
-    # 2, two independent design-cell placements, vs an independent central-
-    # FD oracle at n_warmup=0, fixture n_steps=100 / loss window [80,100)):
-    # error stays near this repo's AD-vs-FD noise floor (~1.5%) while
-    # n_warmup is up to roughly a quarter of the pre-loss-window step count,
-    # then grows smoothly and monotonically -- ~6-7% at half the
-    # pre-loss-window length, 58% AT the loss-window boundary itself
-    # (n_warmup equal to the pre-loss-window length), and EXACTLY zero
-    # (gradient fully vanished, not merely small) once n_warmup extends far
-    # enough into the loss window. Choose n_warmup with that bias curve in
-    # mind, not just a memory budget.
+    # The truncation error DEPENDS ON DISTANCE FROM THE SOURCE TO THE
+    # DESIGN REGION -- it is not a blanket property of n_warmup itself
+    # (corrects an earlier version of this comment that said the
+    # design-relevant support "generally" extends into the warmup window;
+    # see the #626 addendum below for why that was an overgeneralization
+    # from a single, worst-case fixture). Mechanism: severing the carry
+    # severs every gradient path from a design variable's influence during
+    # steps < n_warmup back into the loss -- but only steps during which
+    # the WAVEFRONT HAS ALREADY REACHED the design region carry any such
+    # influence to sever. Before the wavefront arrives, the field there
+    # (and hence the loss's sensitivity to that cell) is ~0, so severing
+    # those steps' carry discards ~nothing and the gradient is
+    # (near-)exact -- n_warmup is genuinely free compute/memory relief in
+    # that regime, not merely an approximation. Define
+    #     K_safe ~= floor(min_distance(source, design_region) / (C0 * dt))
+    # (grid steps for the wavefront to reach the closest design cell, C0 =
+    # vacuum lightspeed -- a conservative floor valid for any slower,
+    # non-vacuum propagation). For n_warmup <= K_safe truncation error is
+    # negligible; beyond it, error grows and can reach the full gradient
+    # magnitude by the time n_warmup reaches the loss window.
+    #
+    # Forward output is exactly n_warmup-invariant (bit-identical) in every
+    # placement measured. Two measured regimes (issue #626 part 2 /
+    # addendum, both vs an independent central-FD oracle):
+    #   - NEAR-SOURCE placement (design cell ~3 cells from the source, so
+    #     K_safe ~ 0 -- the wavefront is already present at every step):
+    #     error grows smoothly and monotonically from a ~1.5% noise floor
+    #     at small n_warmup up to 58% at the loss-window boundary itself,
+    #     and EXACTLY zero (gradient fully vanished) once n_warmup extends
+    #     far enough into the loss window (fixture:
+    #     tests/test_n_warmup.py::test_warmup_truncation_error_grows_with_k,
+    #     n_steps=100, loss window [80,100)).
+    #   - FAR-FROM-SOURCE placement (design cell 62 cells from the source,
+    #     K_safe=108 measured from the grid's own dt): AD matches the
+    #     K=0 FD oracle to 0.008-0.036% rel_err for every sampled
+    #     n_warmup in {0,20,40,60,80,100} -- ALL <= K_safe -- and only
+    #     starts degrading past K_safe (0.63% at K=120, growing to 75% by
+    #     K=200), exactly the wavefront-arrival prediction (fixture:
+    #     scripts/diagnostics/i626_n_warmup_wavefront_locality.py,
+    #     n_steps=220, loss window [180,220)).
+    # The near-source curve is the WORST case, not the general case --
+    # use K_safe to decide whether a given source/design placement is in
+    # the exact or the truncated regime; do not read "n_warmup truncates
+    # the gradient" as true unconditionally.
     if n_warmup > 0:
         if n_warmup >= n_steps:
             raise ValueError(

--- a/rfx/observables.py
+++ b/rfx/observables.py
@@ -101,6 +101,8 @@ import jax
 import jax.numpy as jnp
 from jax.nn import logsumexp
 
+from rfx.core.jax_utils import is_tracer
+
 __all__ = ["dft_field", "field_energy", "field_softmax", "jacobian_fwd"]
 
 
@@ -300,15 +302,25 @@ def field_softmax(
     This function now computes ``beta_eff = beta / stop_gradient(max(vals))``
     and uses ``beta_eff`` in place of a raw *beta* everywhere above.
     Because ``vals``' own current max scales out of the product exactly,
-    ``beta_eff * max(vals) == beta`` ALWAYS, regardless of the field's
-    physical units -- the ``log(count)/beta`` swallow above cannot recur
-    at any finite field magnitude, at any *beta*, including the default.
-    ``stop_gradient`` on the normalizer is deliberate: without it, the
-    returned scalar would differentiate the (physically meaningless)
-    rescaling itself rather than approximating ``max``; with it, the
-    gradient is the standard softmax-weighted average at the CURRENT
-    call's ``beta_eff`` (a real, directionally-correct signal, recomputed
-    fresh -- and re-normalized -- every call).
+    ``beta_eff * max(vals) == beta`` ALWAYS (BEFORE any overflow -- see
+    the next paragraph), regardless of the field's physical units -- the
+    ``log(count)/beta`` swallow above cannot recur at any REPRESENTABLE
+    (nonzero) field magnitude, at any *beta*, including the default. This
+    is scoped deliberately: below the working dtype's smallest
+    representable magnitude (~1.4e-45 for float32 subnormals) ``vals``
+    itself underflows to a literal ``0`` array, the degenerate all-zero
+    fallback below kicks in (``beta_eff = beta``, i.e. UNSCALED), and the
+    original swallow pattern can in principle recur there -- rfx's own
+    realistic DFT-plane field magnitudes (``|field|**2`` ~1e-10 to
+    1e-22) sit ~23-35 orders of magnitude above that floor, so this is a
+    dtype-representability edge, not a practical concern at any field
+    magnitude this simulator actually produces. ``stop_gradient`` on
+    the normalizer is deliberate: without it, the returned scalar would
+    differentiate the (physically meaningless) rescaling itself rather
+    than approximating ``max``; with it, the gradient is the standard
+    softmax-weighted average at the CURRENT call's ``beta_eff`` (a real,
+    directionally-correct signal, recomputed fresh -- and re-normalized --
+    every call).
 
     What *beta* now controls (and does not control): a larger *beta*
     tightens the approximation -- the softmax value can exceed the true
@@ -316,14 +328,52 @@ def field_softmax(
     ``beta=1.0`` is therefore LOOSE for a field with many samples: e.g.
     ~14.8x at ``count=1e6``), so raise *beta* (5-50 is a reasonable range
     for most plane sizes) for a tighter approximation once you know you
-    need one, exactly as before -- but the DEFAULT is now safe at any
-    field magnitude, merely loose, never rounding-noise. A large *beta* no
-    longer risks the old top-end overflow footgun either: ``beta_eff *
-    vals`` is bounded by *beta* itself (``vals <= max(vals)`` by
-    definition, so ``beta_eff * vals <= beta_eff * max(vals) == beta``),
-    not by the field's unknown absolute scale, so any finite *beta* you'd
-    plausibly choose (up to jax.nn.logsumexp's own internal
-    max-subtraction headroom) is safe.
+    need one, exactly as before -- and the DEFAULT is now safe at any
+    field magnitude, merely loose, never rounding-noise.
+
+    .. warning::
+        **The top-end overflow footgun MOVED, it did not disappear --
+        and it now has TWO thresholds, not one.** Auto-scaling divides by
+        ``max(vals)`` instead of multiplying by the raw field magnitude,
+        so a large enough *beta* against a physically tiny field can
+        still overflow -- now in computing ``beta_eff = beta /
+        max(vals)`` itself, before ``vals`` is even touched. Measured at
+        ``max(vals)`` ~2.24e-22 (this repo's realistic DFT-plane range):
+
+        1. **Value overflow (``beta_eff`` itself overflows).** ``beta``
+           at or above ~1e17 makes ``beta_eff`` exceed float32's range,
+           previously returning ``value=nan, grad=nan`` silently, no
+           exception. This function guards it: when ``beta_eff`` would
+           be non-finite, it is clipped to the largest finite value the
+           working dtype represents (``jnp.finfo(vals.dtype).max``)
+           rather than propagating ``nan``. The clipped VALUE is
+           accurate (still converges to the true ``max(vals)``, verified
+           at ``beta`` up to 1e38).
+        2. **Gradient collapse, measured to start EARLIER (~1e15-1e17)
+           and NOT covered by the value clip above.** Even where the
+           value stays finite and correct, the returned gradient
+           silently drops to EXACTLY ``0.0`` somewhere in this range --
+           the precise threshold is FIXTURE-DEPENDENT (measured to shift
+           by up to 10x between two fixtures differing only in element
+           values, so no single number is trustworthy across geometries)
+           -- a sharp cliff, not a gradual falloff, correct to machine
+           precision on one side and exactly ``0.0`` on the other. A
+           reciprocal-of-a-huge-number precision limit in the VJP's
+           ``1/beta_eff`` term, distinct from (and tighter than) the
+           value-overflow threshold above. This is NOT fixed by the
+           value clip (it happens at a lower *beta* than clipping even
+           engages) and is not attempted here: it would need a
+           different numerical formulation (e.g. normalizing ``vals`` by
+           ``scale`` before scaling by *beta*, which trades this
+           gradient cliff for a symmetric one on the VALUE side at
+           extreme *beta* / tiny-field combinations -- no formulation
+           tried avoids both).
+
+        **Practical guidance**: both thresholds sit many orders of
+        magnitude above the 5-50 dimensionless range recommended above,
+        and above the 100-1e6 range this repo's own re-calibrated tests
+        and examples actually use -- treat *beta* past ~1e6 as
+        unverified, not merely "less sharp than useful."
     """
     if beta <= 0.0:
         raise ValueError(f"field_softmax: beta must be positive, got {beta}")
@@ -342,6 +392,17 @@ def field_softmax(
         # either way -- there is no signal to lose).
         scale_safe = jnp.where(scale > 0, scale, jnp.asarray(1.0, dtype=vals.dtype))
         beta_eff = beta / scale_safe
+        # Guard the relocated overflow footgun (see the docstring
+        # warning): beta_eff = beta / scale_safe can itself overflow to
+        # inf when beta is large and the field is physically tiny,
+        # producing a silent nan downstream. Clip to the dtype's largest
+        # finite value instead -- beta_eff only ever sharpens the
+        # approximation, so the clip is the sharpest representable
+        # answer, not a wrong one.
+        beta_eff_finite = jnp.isfinite(beta_eff)
+        beta_eff = jnp.where(
+            beta_eff_finite, beta_eff, jnp.asarray(jnp.finfo(vals.dtype).max, dtype=vals.dtype)
+        )
         return logsumexp(beta_eff * vals) / beta_eff
 
     return objective
@@ -576,8 +637,10 @@ def jacobian_fwd(
         compute but with a lower peak than the batched path scales to as
         ``n_t`` grows). CORRECTION: this function does not call
         ``jax.jit`` itself on EITHER path -- there is no ``jax.jit``
-        anywhere in this module (verify: ``grep jax.jit rfx/observables.py``
-        returns nothing). ``batch_tangents=False`` runs the ``n_t``
+        CALL anywhere in this module (verify:
+        ``grep -nE '@jax\\.jit|jax\\.jit\\(' rfx/observables.py`` returns
+        nothing -- a plain ``grep jax.jit`` also matches this sentence's
+        own prose, so it is not a useful self-check). ``batch_tangents=False`` runs the ``n_t``
         sequential ``jax.jvp`` calls exactly as written, at whatever JIT
         boundary the CALLER supplies (eager if the caller does not
         ``jax.jit`` anything; compiled as part of one program if the
@@ -650,9 +713,11 @@ def jacobian_fwd(
       pre-loss-window length, 58% at the loss-window boundary itself,
       exactly zero once far enough beyond it, FOR A NEAR-SOURCE
       placement specifically (issue #626 part 2 / addendum -- a
-      far-from-source placement measured error <0.04% for every
-      ``n_warmup <= K_safe``, see ``rfx/nonuniform.py``'s ``n_warmup
-      split`` comment for the full measured curves and formula) -- it is
+      far-from-source placement stays within this repo's ~1.5% AD-vs-FD
+      noise floor for every ``n_warmup <= K_safe`` (growing smoothly, not
+      a sharp cliff, from <0.01% well below ``K_safe`` to ~1.2% AT
+      ``K_safe`` itself), see ``rfx/nonuniform.py``'s ``n_warmup split``
+      comment for the full measured curves and formula) -- it is
       not fenced there (truncated-BPTT is a legitimate, if
       placement-dependent, construction), and any future non-uniform
       extension of this function must account for ``K_safe``, not treat
@@ -716,10 +781,30 @@ def jacobian_fwd(
         # the sequential path inherits the batched path's fail-loud
         # invariant instead of silently returning one arbitrary row's
         # primal. See jacobian_fwd's "API TRAP" docstring section.
-        jax.eval_shape(
-            lambda t: jax.vmap(_jvp_row, in_axes=0, out_axes=(None, 0))(t),
-            tangent_batch,
-        )
+        #
+        # eval_shape abstracts EVERY value inside the traced function
+        # (unlike a real vmap call, which keeps `params` -- not part of
+        # the vmapped axis -- concrete). A sim_fn with a data-dependent
+        # Python branch on `params` (fine under plain jax.jvp AND under a
+        # REAL jax.vmap(..., out_axes=(None,0)) call, since `params`
+        # never becomes a BatchTracer there) can therefore be untraceable
+        # under eval_shape specifically, raising
+        # ConcretizationTypeError -- that is an eval_shape LIMITATION
+        # (this sim_fn is fine; eval_shape's abstract mode alone cannot
+        # decide), not a genuine out_axes violation. Catch it and fall
+        # through to guard 2 rather than propagating it as if it were the
+        # same class of failure -- otherwise the sequential path would be
+        # STRICTER than every other path (plain jax.jvp, batched
+        # jax.vmap, and eager base all accept this sim_fn), inverting
+        # this guard's own goal of matching the batched path's
+        # behaviour, not exceeding it.
+        try:
+            jax.eval_shape(
+                lambda t: jax.vmap(_jvp_row, in_axes=0, out_axes=(None, 0))(t),
+                tangent_batch,
+            )
+        except jax.errors.ConcretizationTypeError:
+            pass
         values = []
         jac_rows = []
         for i in range(n_t):
@@ -732,17 +817,34 @@ def jacobian_fwd(
         # of guard 1, skipped under an outer jax.jit where the primal
         # values are still abstract tracers and cannot be compared as
         # concrete numbers): every sequentially-computed primal must
-        # agree EXACTLY with value (they are, mathematically, n_t
-        # independent evaluations of the same sim_fn(params)).
+        # agree with value (they are, mathematically, n_t independent
+        # evaluations of the same sim_fn(params)). Checks EVERY params
+        # leaf for tracer-ness, not just the first: under an outer
+        # jax.jit, a mixed concrete/traced params pytree (e.g. a
+        # (concrete, tracer) tuple) would otherwise crash on
+        # bool(jnp.array_equal(...)) below with
+        # TracerBoolConversionError, since JAX's tracing model means
+        # either ALL or NONE of a single trace's values are tracers
+        # together -- checking any one leaf is logically equivalent to
+        # checking all of them, but explicit here so this does not
+        # regress if that invariant ever changes. equal_nan=True: a
+        # PURE, deterministic sim_fn whose FDTD diverged returns the
+        # SAME nan on every tangent row (nan is not a sign of
+        # tangent-dependence, IEEE-754 float semantics just make
+        # nan != nan by default) -- comparing with equal_nan=False would
+        # misdiagnose ordinary divergence as a primal/tangent-purity
+        # violation.
         params_leaves = jax.tree_util.tree_leaves(params)
-        if params_leaves and not isinstance(params_leaves[0], jax.core.Tracer):
+        if params_leaves and not any(
+            is_tracer(leaf) for leaf in params_leaves
+        ):
             value_leaves = jax.tree_util.tree_leaves(value)
             for i, v in enumerate(values[1:], start=1):
                 mismatched = [
                     idx for idx, (a, b) in enumerate(
                         zip(value_leaves, jax.tree_util.tree_leaves(v))
                     )
-                    if not bool(jnp.array_equal(a, b))
+                    if not bool(jnp.array_equal(a, b, equal_nan=True))
                 ]
                 if mismatched:
                     raise ValueError(
@@ -752,10 +854,17 @@ def jacobian_fwd(
                         f"{mismatched} -- sim_fn's primal output depends "
                         "on which tangent direction is being evaluated, "
                         "violating jax.jvp's primal/tangent independence "
-                        "contract. batch_tangents=True would raise this "
-                        "as a jax.vmap out_axes=(None, 0) error (see "
-                        "jacobian_fwd's docstring, 'API TRAP'); fix "
-                        "sim_fn to be a pure function of params alone."
+                        "contract, OR sim_fn has a cross-call side effect "
+                        "(e.g. mutable state) that a single vmap trace "
+                        "cannot see. batch_tangents=True MAY also raise "
+                        "this (as a jax.vmap out_axes=(None, 0) error, "
+                        "see jacobian_fwd's docstring 'API TRAP') if the "
+                        "cause is a genuine tangent dependency -- but NOT "
+                        "if the cause is a cross-call side effect, which "
+                        "vmap's single trace cannot observe (measured: "
+                        "batch_tangents=True silently returns a value in "
+                        "that case, it does not raise). Fix sim_fn to be "
+                        "a pure function of params alone."
                     )
         jacobian = jax.tree_util.tree_map(
             lambda *rows: jnp.stack(rows, axis=0), *jac_rows,

--- a/rfx/observables.py
+++ b/rfx/observables.py
@@ -257,11 +257,14 @@ def field_softmax(
 ) -> Callable:
     """Objective factory: smooth (soft) max of ``|field|**2`` over space+frequency.
 
-    Uses the standard log-sum-exp soft-max:
-    ``softmax = logsumexp(beta * |field|**2) / beta``, computed with
-    ``jax.nn.logsumexp`` for numerical stability. As ``beta -> infinity``
-    this converges to the true ``max(|field|**2)``; a smaller *beta* trades
-    a looser max approximation for a smoother, better-conditioned gradient
+    Uses the standard log-sum-exp soft-max, AUTO-SCALED to the field's own
+    magnitude each call: ``beta_eff = beta / stop_gradient(max(vals))``,
+    ``softmax = logsumexp(beta_eff * vals) / beta_eff``, computed with
+    ``jax.nn.logsumexp`` for numerical stability. As *beta* (equivalently
+    ``beta_eff * max(vals)``, which the normalization pins to exactly
+    *beta* by construction -- see "Auto-scaling", below) grows this
+    converges to the true ``max(|field|**2)``; a smaller *beta* trades a
+    looser max approximation for a smoother, better-conditioned gradient
     (useful early in an optimization run, e.g. the shielding case: minimize
     the worst-case leaked field anywhere behind a barrier, over all
     monitored frequencies, rather than the mean leaked field).
@@ -275,41 +278,52 @@ def field_softmax(
         pattern: register one plane per physical monitor location, then
         soft-max over all of them at once for a single worst-case scalar.
     beta : float
-        Soft-max sharpness (default 1.0). Must be positive, and MUST be
-        scale-matched to the field magnitude -- see the warning below.
+        Soft-max sharpness (default 1.0), now DIMENSIONLESS -- see
+        "Auto-scaling" below. Must be positive.
 
-    .. warning::
-        **beta must be scale-matched to your |field|**2** magnitude, not
-        left at the default.** ``logsumexp(beta*vals)/beta`` equals
-        ``log(count)/beta + (a term that depends on vals)`` where
-        ``count = n_freqs * n1 * n2`` summed over every requested plane; if
-        ``beta`` is too small for the actual ``|field|**2`` scale, the
-        ``log(count)/beta`` CONSTANT (independent of your design variable)
-        dominates the objective and swallows the real signal -- both the
-        objective value and its gradient measure rounding noise in that
-        constant, not physics, and can coincidentally still pass a single
-        finite-difference check while failing at a different step size
-        (rfx's own DFT-plane accumulators commonly sit around
-        ``|field|**2`` ~1e-10 to 1e-22 depending on geometry/normalization,
-        the same tiny-absolute-unit convention documented elsewhere for
-        NTFF power, e.g. ``maximize_directivity``'s ~1e-27 note -- so
-        ``beta=1.0`` is almost always wrong). Pick beta empirically: measure
-        ``max(|field|**2)`` once (e.g. via :func:`dft_field` +
-        ``jnp.max(jnp.abs(x)**2)``) at a representative design point, and
-        choose beta so ``beta * max(|field|**2)`` is at least a few units
-        (pushes past the ``log(count)`` constant) -- see
-        ``examples/inverse_design/field_observable_shielding.py``'s own
-        ``BETA`` comment for a worked, measured example.
-    .. warning::
-        **Top-end overflow is a real, undocumented-by-JAX failure mode.**
-        ``beta * vals`` is computed as a plain array BEFORE
-        ``jax.nn.logsumexp`` gets to apply its internal max-subtraction
-        stabilization; if ``beta * max(vals)`` itself overflows the
-        working dtype's range (~3.4e38 for float32, ~1.8e308 for float64 --
-        measured: ``beta=1e40`` against ``vals`` ~1e-10 already returns
-        ``nan``, while ``beta=1e30`` on the same ``vals`` is fine), the
-        result is silently ``nan``, not a large-but-finite number. Do not
-        pick beta by "bigger is always safer" -- there is a ceiling.
+    Auto-scaling (fixes a measured footgun -- read before raising *beta*
+    "to be safe")
+    -------------------------------------------------------------------
+    Earlier versions of this function computed ``logsumexp(beta*vals)/beta``
+    directly against the RAW ``|field|**2`` values, so *beta* had to be
+    hand-matched to whatever physical units/magnitude the accumulator
+    happened to carry (rfx's own DFT-plane accumulators commonly sit
+    around ``|field|**2`` ~1e-10 to 1e-22 depending on
+    geometry/normalization). At the then-default ``beta=1.0`` the
+    objective sat at ~100.000002% of the design-independent constant
+    ``log(count)/beta`` (measured, `#619`): both the value and its
+    gradient were differentiating ROUNDING NOISE in that constant, not
+    physics, and it could coincidentally still pass a single
+    finite-difference check while failing at a different step size (a
+    `feedback_gate_can_bind_artifact`-class trap).
+
+    This function now computes ``beta_eff = beta / stop_gradient(max(vals))``
+    and uses ``beta_eff`` in place of a raw *beta* everywhere above.
+    Because ``vals``' own current max scales out of the product exactly,
+    ``beta_eff * max(vals) == beta`` ALWAYS, regardless of the field's
+    physical units -- the ``log(count)/beta`` swallow above cannot recur
+    at any finite field magnitude, at any *beta*, including the default.
+    ``stop_gradient`` on the normalizer is deliberate: without it, the
+    returned scalar would differentiate the (physically meaningless)
+    rescaling itself rather than approximating ``max``; with it, the
+    gradient is the standard softmax-weighted average at the CURRENT
+    call's ``beta_eff`` (a real, directionally-correct signal, recomputed
+    fresh -- and re-normalized -- every call).
+
+    What *beta* now controls (and does not control): a larger *beta*
+    tightens the approximation -- the softmax value can exceed the true
+    ``max(vals)`` by a factor of at most ``1 + log(count)/beta`` (default
+    ``beta=1.0`` is therefore LOOSE for a field with many samples: e.g.
+    ~14.8x at ``count=1e6``), so raise *beta* (5-50 is a reasonable range
+    for most plane sizes) for a tighter approximation once you know you
+    need one, exactly as before -- but the DEFAULT is now safe at any
+    field magnitude, merely loose, never rounding-noise. A large *beta* no
+    longer risks the old top-end overflow footgun either: ``beta_eff *
+    vals`` is bounded by *beta* itself (``vals <= max(vals)`` by
+    definition, so ``beta_eff * vals <= beta_eff * max(vals) == beta``),
+    not by the field's unknown absolute scale, so any finite *beta* you'd
+    plausibly choose (up to jax.nn.logsumexp's own internal
+    max-subtraction headroom) is safe.
     """
     if beta <= 0.0:
         raise ValueError(f"field_softmax: beta must be positive, got {beta}")
@@ -320,7 +334,15 @@ def field_softmax(
         vals = jnp.concatenate(
             [jnp.abs(arrays[n]).reshape(-1) ** 2 for n in name_list]
         )
-        return logsumexp(beta * vals) / beta
+        scale = jax.lax.stop_gradient(jnp.max(vals))
+        # Guard the degenerate all-zero-field case (scale == 0) rather
+        # than dividing by it; beta_eff = beta there reproduces the
+        # pre-auto-scale behaviour, which is harmless because vals is
+        # uniformly 0 too (logsumexp(0)/beta = log(count)/beta exactly
+        # either way -- there is no signal to lose).
+        scale_safe = jnp.where(scale > 0, scale, jnp.asarray(1.0, dtype=vals.dtype))
+        beta_eff = beta / scale_safe
+        return logsumexp(beta_eff * vals) / beta_eff
 
     return objective
 
@@ -481,7 +503,26 @@ def jacobian_fwd(
     which tangent direction is being evaluated. If you change ``sim_fn``
     in a way that breaks that invariant, ``jax.vmap`` raises loudly
     (``out_axes=None`` on an output that DOES depend on the mapped axis is
-    a vmap error, not a silent wrong answer).
+    a vmap error, not a silent wrong answer). ``batch_tangents=False``
+    (the sequential path) has NO ``jax.vmap`` of its own to inherit that
+    check from -- it just calls ``jax.jvp`` ``n_t`` times in a plain
+    Python loop and returns ``values[0]``, so without an explicit guard a
+    ``sim_fn`` that violates the invariant would silently return one
+    arbitrary tangent row's primal on that path instead of raising. This
+    function closes that gap on the sequential path via two guards, so
+    the memory-vs-speed knob is not also a safety-vs-speed knob: (1) a
+    ``jax.eval_shape`` abstract trace of the SAME ``out_axes=(None, 0)``
+    vmap the batched path actually runs -- shape-only, zero FLOPs, zero
+    extra memory (verified: reproduces the identical
+    ``ValueError`` a real violating vmap call raises, including when this
+    whole call is itself wrapped in an outer ``jax.jit`` by the caller,
+    since ``eval_shape`` is trace-time like ``vmap``'s own check); (2)
+    when running eagerly (params are not themselves tracers, so the
+    computed primal values are concrete), an exact pairwise comparison of
+    all ``n_t`` sequentially-computed primal values, raising ``ValueError``
+    on any mismatch -- a strictly stronger, numeric confirmation of the
+    same invariant, skipped only when it is not expressible (under an
+    enclosing ``jax.jit``, where guard (1) is the check in effect).
 
     Cost characterization: NOT "a few times one solve" -- see
     ``scripts/benchmark_jacobian_fwd.py`` (regenerable; run it for current
@@ -528,13 +569,28 @@ def jacobian_fwd(
         faster than the sequential control at n_t in {4, 10}), higher peak
         memory (``O(state) * (1 + n_t)``, all ``n_t`` tangent copies live
         at once). ``False``: run the ``n_t`` directions as independent
-        sequential ``jax.jvp`` calls inside one ``jit`` -- the memory-vs-speed
-        knob, trading the wall-time win for a peak that scales with ONE
-        tangent copy at a time instead of ``n_t`` (measured: primal-sharing
-        still holds sequentially, at ``~1 + n_t`` compute but with a lower
-        peak than the batched path scales to as ``n_t`` grows). The two
-        paths are DIFFERENT XLA programs and may disagree at float32
-        reassociation scale (~1e-6 relative); they are not bit-identical.
+        sequential ``jax.jvp`` calls in a plain Python loop -- the
+        memory-vs-speed knob, trading the wall-time win for a peak that
+        scales with ONE tangent copy at a time instead of ``n_t``
+        (measured: primal-sharing still holds sequentially, at ``~1 + n_t``
+        compute but with a lower peak than the batched path scales to as
+        ``n_t`` grows). CORRECTION: this function does not call
+        ``jax.jit`` itself on EITHER path -- there is no ``jax.jit``
+        anywhere in this module (verify: ``grep jax.jit rfx/observables.py``
+        returns nothing). ``batch_tangents=False`` runs the ``n_t``
+        sequential ``jax.jvp`` calls exactly as written, at whatever JIT
+        boundary the CALLER supplies (eager if the caller does not
+        ``jax.jit`` anything; compiled as part of one program if the
+        caller wraps its own outer function, as
+        ``scripts/benchmark_jacobian_fwd.py`` and
+        ``tests/test_jacobian_fwd.py`` both do for compiled/jaxpr
+        measurement) -- an earlier version of this docstring claimed
+        ``jax.jit`` wrapping was part of this function's own behaviour,
+        which was never true. The two paths (batched vs. sequential) are
+        DIFFERENT XLA programs and may disagree at float32 reassociation
+        scale (~1e-6 relative); they are not bit-identical. See "Fail-loud
+        fences" below for how the two paths' SAFETY differs, not just
+        their performance.
 
     Returns
     -------
@@ -585,14 +641,22 @@ def jacobian_fwd(
       be a measured SILENT NO-OP (bit-identical value AND tangent at
       ``n_warmup=0`` vs ``n_warmup=60`` of 80 steps) before the fence was
       added. Do not read this as "n_warmup is safe elsewhere": on the
-      non-uniform lane where it IS implemented, ``n_warmup`` measurably
-      truncates the reverse-mode gradient with an error that grows
-      smoothly -- ~6-7% at half the pre-loss-window length, 58% at the
-      loss-window boundary itself, exactly zero once far enough beyond it
-      (issue #626 part 2) -- it is not fenced there (truncated-BPTT is a
-      legitimate, if approximate, construction), and any future
-      non-uniform extension of this function must account for that bias,
-      not treat ``n_warmup`` as free memory relief.
+      non-uniform lane where it IS implemented, ``n_warmup`` truncation
+      error DEPENDS ON DISTANCE FROM THE SOURCE TO THE DESIGN REGION, not
+      merely on ``n_warmup``'s value -- it is (near-)exact while
+      ``n_warmup`` stays below the wavefront's arrival time at the design
+      region (``K_safe ~= floor(min_distance(source, design_region) /
+      (C0 * dt))``) and grows sharply beyond it, up to ~6-7% at half the
+      pre-loss-window length, 58% at the loss-window boundary itself,
+      exactly zero once far enough beyond it, FOR A NEAR-SOURCE
+      placement specifically (issue #626 part 2 / addendum -- a
+      far-from-source placement measured error <0.04% for every
+      ``n_warmup <= K_safe``, see ``rfx/nonuniform.py``'s ``n_warmup
+      split`` comment for the full measured curves and formula) -- it is
+      not fenced there (truncated-BPTT is a legitimate, if
+      placement-dependent, construction), and any future non-uniform
+      extension of this function must account for ``K_safe``, not treat
+      ``n_warmup`` as uniformly lossy OR uniformly free.
     - **[DOCS ONLY -- inert, not a raise]** ``checkpoint`` /
       ``checkpoint_segments``: measured EXACTLY NEUTRAL under forward mode
       (flops/temp bytes identical across ``checkpoint=False``,
@@ -642,6 +706,20 @@ def jacobian_fwd(
             _jvp_row, in_axes=0, out_axes=(None, 0),
         )(tangent_batch)
     else:
+        # Guard 1 (trace-time, works eager or under an outer jax.jit):
+        # abstractly trace the SAME out_axes=(None, 0) vmap the batched
+        # path actually runs, via jax.eval_shape -- shape-only, zero
+        # FLOPs, zero extra memory (that O(n_t) memory cost is exactly
+        # what this branch exists to avoid). If sim_fn's primal genuinely
+        # depends on the tangent direction, this raises the identical
+        # ValueError a real vmap(..., out_axes=(None, 0)) call would, so
+        # the sequential path inherits the batched path's fail-loud
+        # invariant instead of silently returning one arbitrary row's
+        # primal. See jacobian_fwd's "API TRAP" docstring section.
+        jax.eval_shape(
+            lambda t: jax.vmap(_jvp_row, in_axes=0, out_axes=(None, 0))(t),
+            tangent_batch,
+        )
         values = []
         jac_rows = []
         for i in range(n_t):
@@ -650,6 +728,35 @@ def jacobian_fwd(
             values.append(v)
             jac_rows.append(j)
         value = values[0]
+        # Guard 2 (eager only -- a strictly stronger numeric check on top
+        # of guard 1, skipped under an outer jax.jit where the primal
+        # values are still abstract tracers and cannot be compared as
+        # concrete numbers): every sequentially-computed primal must
+        # agree EXACTLY with value (they are, mathematically, n_t
+        # independent evaluations of the same sim_fn(params)).
+        params_leaves = jax.tree_util.tree_leaves(params)
+        if params_leaves and not isinstance(params_leaves[0], jax.core.Tracer):
+            value_leaves = jax.tree_util.tree_leaves(value)
+            for i, v in enumerate(values[1:], start=1):
+                mismatched = [
+                    idx for idx, (a, b) in enumerate(
+                        zip(value_leaves, jax.tree_util.tree_leaves(v))
+                    )
+                    if not bool(jnp.array_equal(a, b))
+                ]
+                if mismatched:
+                    raise ValueError(
+                        "jacobian_fwd(batch_tangents=False): the primal "
+                        f"value from tangent row {i} differs from tangent "
+                        f"row 0's at output leaf index/indices "
+                        f"{mismatched} -- sim_fn's primal output depends "
+                        "on which tangent direction is being evaluated, "
+                        "violating jax.jvp's primal/tangent independence "
+                        "contract. batch_tangents=True would raise this "
+                        "as a jax.vmap out_axes=(None, 0) error (see "
+                        "jacobian_fwd's docstring, 'API TRAP'); fix "
+                        "sim_fn to be a pure function of params alone."
+                    )
         jacobian = jax.tree_util.tree_map(
             lambda *rows: jnp.stack(rows, axis=0), *jac_rows,
         )

--- a/rfx/runners/distributed_nu.py
+++ b/rfx/runners/distributed_nu.py
@@ -2054,8 +2054,10 @@ def run_nonuniform_distributed_pec(
         NEAR-SOURCE placement specifically, measured ~6-7% at half the
         pre-loss-window length, 58% at the loss-window boundary itself,
         exactly zero once far enough beyond it; a far-from-source
-        placement measured <0.04% error for every ``n_warmup <= K_safe``.
-        See the ``n_warmup split`` comment in
+        placement stays within this repo's ~1.5% AD-vs-FD noise floor for
+        every ``n_warmup <= K_safe`` (growing smoothly, not a sharp
+        cliff, from <0.01% well below ``K_safe`` to ~1.2% AT ``K_safe``
+        itself). See the ``n_warmup split`` comment in
         :func:`rfx.nonuniform.run_nonuniform` for both measured curves,
         the ``K_safe`` formula, and the source scripts (issue #626 part 2
         / addendum).

--- a/rfx/runners/distributed_nu.py
+++ b/rfx/runners/distributed_nu.py
@@ -2045,14 +2045,20 @@ def run_nonuniform_distributed_pec(
         ``stop_gradient``'d so AD builds no tape for that transient.
         Only the trailing ``n_steps - n_warmup`` steps participate in
         reverse-mode autodiff.  Must satisfy ``n_warmup < n_steps``.
-        This is an APPROXIMATION, not merely a memory optimisation: the
-        returned gradient is truncated and grows increasingly biased
-        (magnitude-underestimated) as ``n_warmup`` approaches the loss
-        window -- measured ~6-7% at half the pre-loss-window length, 58%
-        at the loss-window boundary itself, exactly zero once far enough
-        beyond it; see the ``n_warmup split`` comment in
-        :func:`rfx.nonuniform.run_nonuniform` for the measured error curve
-        (issue #626 part 2).
+        Truncation error DEPENDS ON DISTANCE FROM THE SOURCE TO THE
+        DESIGN REGION, not merely on ``n_warmup``'s value: it is
+        (near-)exact while ``n_warmup`` stays below the wavefront's
+        arrival time at the design region (``K_safe ~= floor(
+        min_distance(source, design_region) / (C0 * dt))``) and grows
+        increasingly biased (magnitude-underestimated) beyond it -- for a
+        NEAR-SOURCE placement specifically, measured ~6-7% at half the
+        pre-loss-window length, 58% at the loss-window boundary itself,
+        exactly zero once far enough beyond it; a far-from-source
+        placement measured <0.04% error for every ``n_warmup <= K_safe``.
+        See the ``n_warmup split`` comment in
+        :func:`rfx.nonuniform.run_nonuniform` for both measured curves,
+        the ``K_safe`` formula, and the source scripts (issue #626 part 2
+        / addendum).
     emit_time_series : bool, optional
         Phase 2F.  When ``True`` (default), the runner accumulates per-
         step probe samples and returns ``time_series`` as a

--- a/scripts/diagnostics/i626_n_warmup_wavefront_locality.py
+++ b/scripts/diagnostics/i626_n_warmup_wavefront_locality.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Issue #626 addendum: is the n_warmup truncation error a property of
+n_warmup itself, or of how far the design cell sits from the source
+relative to the wavefront's travel time?
+
+Context: the shipped "fixture 1"/"fixture 2" curves in
+docs/agent-memory/rfx-known-issues.md's "#626 RESOLVED" entry, and in
+tests/test_n_warmup.py::test_warmup_truncation_error_grows_with_k and
+scripts/diagnostics/i626_n_warmup_truncation_sweep.py, both use a design
+cell only ~3 cells from the source. At that placement the field (and
+hence the loss's sensitivity to that cell) is nonzero from the first few
+steps onward, so EVERY warmup step severed by n_warmup carries real
+gradient signal -- the curve those fixtures measure is the WORST case for
+that reason, not necessarily the general case for any design placement.
+
+Hypothesis: before the wavefront (traveling from the source at the
+domain's numerical wave speed) has reached the design cell, the field
+there -- and therefore d(loss)/d(eps) at that cell for any step before
+arrival -- is identically ~0. Severing the carry's gradient tape for
+those steps then discards ~nothing, so n_warmup should be (near-)exact
+whenever it stays below the wavefront's arrival step count at the design
+cell, REGARDLESS of how large that step count is as a fraction of
+n_steps. If true, "n_warmup truncates the gradient" is incomplete without
+"once the wavefront has reached the design region" -- and n_warmup is
+GENUINELY free compute/memory relief (not merely a truncated-BPTT
+approximation) for K below that arrival step.
+
+K_safe formula: for a design cell whose closest point is `d` metres from
+every active source, the wavefront cannot arrive earlier than
+    K_safe = floor(d / (c * dt))
+grid steps (c = C0, the vacuum/vacuum-dominant wave speed -- a
+conservative floor for any non-vacuum-slower propagation). This script
+computes K_safe from the grid's own `dt` and the source/design-cell
+geometry, and checks it against the measured K at which the truncation
+error starts departing from the near-source fixtures' noise floor.
+
+Run:
+    PYTHONPATH=. JAX_PLATFORMS=cpu python scripts/diagnostics/i626_n_warmup_wavefront_locality.py
+"""
+from __future__ import annotations
+
+import math
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from rfx import Simulation
+
+try:
+    from jax import enable_x64
+except ImportError:  # pragma: no cover - JAX version drift, see tests/_x64_compat.py
+    from tests._x64_compat import enable_x64
+
+C0 = 299792458.0
+
+DX = 0.5e-3
+NX = 70  # domain_x = 35mm -- long enough to separate "near" from "far"
+DZ_LAYERS = 9
+N_STEPS = 220
+N_FIXED = 180  # loss window = time_series[N_FIXED:], fixed across the K sweep
+ALPHA0 = 2.0
+
+
+def _build_sim() -> Simulation:
+    dz = np.array([0.5e-3] * DZ_LAYERS, dtype=np.float64)
+    sim = Simulation(
+        freq_max=10e9, domain=(NX * DX, 0.01, float(np.sum(dz))),
+        dx=DX, dz_profile=dz, cpml_layers=4,
+    )
+    sim.add_source((4 * DX, 0.005, 0.002), "ez")
+    sim.add_probe(((NX - 4) * DX, 0.005, 0.002), "ez")
+    return sim
+
+
+def _make_objective(sim, ti, tj, tk, g_shape):
+    eps_base = jnp.ones(g_shape, dtype=jnp.float32)
+
+    def objective(alpha, *, n_warmup):
+        eps = eps_base.at[ti, tj, tk].set(alpha)
+        fr = sim.forward(
+            eps_override=eps, n_steps=N_STEPS, n_warmup=n_warmup,
+            skip_preflight=True,
+        )
+        return jnp.sum(fr.time_series[N_FIXED:] ** 2)
+
+    return objective
+
+
+def _central_fd_f64(objective, x0, h, *, n_warmup):
+    with enable_x64():
+        fp = objective(jnp.asarray(x0 + h, dtype=jnp.float32), n_warmup=n_warmup)
+        fm = objective(jnp.asarray(x0 - h, dtype=jnp.float32), n_warmup=n_warmup)
+        return float((fp - fm) / (2.0 * h))
+
+
+def main():
+    sim = _build_sim()
+    g = sim._build_nonuniform_grid()
+    dt = float(g.dt)
+    j = g.ny // 2
+    k = g.nz // 2
+
+    src_i = 8            # 4mm / 0.5mm
+    near_i = 11           # 3 cells from the source (matches the shipped fixtures)
+    far_i = g.nx - 9      # near the probe, far from the source
+
+    print(f"grid shape={g.shape}, dt={dt:.4e}s, src_i={src_i}, "
+          f"near_i={near_i}, far_i={far_i} "
+          f"(far separation = {far_i - src_i} cells = "
+          f"{(far_i - src_i) * DX * 1e3:.1f} mm)")
+
+    h = 0.02
+    k_sweep = [0, 20, 40, 60, 80, 100, 120, 140, 160, 180, 200]
+
+    results = {}
+    for label, ti in (("near", near_i), ("far", far_i)):
+        d_m = abs(ti - src_i) * DX
+        k_safe = math.floor(d_m / (C0 * dt)) if label == "far" else 0
+        obj = _make_objective(sim, ti, j, k, g.shape)
+
+        g_fd = _central_fd_f64(obj, ALPHA0, h, n_warmup=0)
+        print(f"\n=== design cell {label}: i={ti}, d_from_source={d_m * 1e3:.2f}mm, "
+              f"K_safe={k_safe} steps ===")
+        print(f"FD oracle (K=0) = {g_fd:.6e}")
+
+        row = []
+        for K in k_sweep:
+            if K >= N_STEPS:
+                continue
+            a0 = jnp.asarray(ALPHA0, dtype=jnp.float32)
+            g_ad = float(jax.grad(lambda a: obj(a, n_warmup=K))(a0))
+            rel = abs(g_ad - g_fd) / max(abs(g_fd), 1e-30)
+            row.append((K, g_ad, rel))
+            flag = "  <= K_safe" if label == "far" and K <= k_safe else ""
+            print(f"  K={K:4d}  AD={g_ad:14.6e}  rel_err={rel * 100:8.3f}%{flag}")
+        results[label] = row
+
+    # ---- Falsifiable check: below K_safe, the far-cell gradient must
+    # match EVERY printed digit of the K=0 reference (near-exact, not
+    # merely "small error") -- this is the load-bearing claim, so assert
+    # it rather than just printing it.
+    far_row = results["far"]
+    d_m = abs(far_i - src_i) * DX
+    k_safe = math.floor(d_m / (C0 * dt))
+    sub_wavefront = [(K, g_ad, rel) for K, g_ad, rel in far_row if K <= k_safe]
+    assert sub_wavefront, "no sampled K falls below K_safe -- widen k_sweep or shrink separation"
+    for K, g_ad, rel in sub_wavefront:
+        assert rel < 1e-3, (
+            f"far cell K={K} (<= K_safe={k_safe}) rel_err={rel * 100:.4f}% -- "
+            "expected near-exact (<0.1%) below the wavefront-arrival horizon"
+        )
+    print(
+        f"\n[falsifier PASS] far cell: every sampled K <= K_safe={k_safe} "
+        f"matches the K=0 oracle to <0.1% (values: "
+        f"{[(K, round(rel * 100, 4)) for K, _, rel in sub_wavefront]})"
+    )
+
+    near_row = results["near"]
+    near_far_k = max(K for K, _, _ in near_row if K < N_FIXED)
+    near_far_rel = next(rel for K, _, rel in near_row if K == near_far_k)
+    print(
+        f"[contrast] near cell: at the same K={near_far_k} the rel_err is "
+        f"{near_far_rel * 100:.2f}% -- confirms the near-source fixture's "
+        "large error is a placement effect, not a property of n_warmup itself."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/diagnostics/i626_n_warmup_wavefront_locality.py
+++ b/scripts/diagnostics/i626_n_warmup_wavefront_locality.py
@@ -34,6 +34,22 @@ computes K_safe from the grid's own `dt` and the source/design-cell
 geometry, and checks it against the measured K at which the truncation
 error starts departing from the near-source fixtures' noise floor.
 
+Verification-round correction: the original coarse sweep (multiples of
+20) never sampled inside [101, 119] and reported "error only starts
+growing once K crosses K_safe, exactly at the predicted boundary" as if
+K_safe marked a sharp cliff. A finer sweep bracketing K_safe shows a
+SMOOTH, monotonically growing curve starting well before K_safe (not a
+cliff): at this fixture's K_safe=108, K=104 measures 0.259%, K=106
+measures 0.601%, K=108 (=K_safe itself) measures 1.186% -- all still
+comfortably under this repo's own established ~1.5% AD-vs-FD noise floor
+(see e.g. `tests/test_n_warmup.py`'s docstrings), but not "near-exact to
+every printed digit" the way K<=100 is. The falsifier below now (a)
+samples finely around K_safe rather than only at multiples of 20, and
+(b) gates on the ~1.5% noise floor rather than an arbitrarily tight
+0.1%, which is what the formula's PRACTICAL claim actually needs to
+survive: K_safe is a useful, honest bound on where truncation is
+noise-floor-negligible, not a literal discontinuity.
+
 Run:
     PYTHONPATH=. JAX_PLATFORMS=cpu python scripts/diagnostics/i626_n_warmup_wavefront_locality.py
 """
@@ -111,7 +127,17 @@ def main():
           f"{(far_i - src_i) * DX * 1e3:.1f} mm)")
 
     h = 0.02
-    k_sweep = [0, 20, 40, 60, 80, 100, 120, 140, 160, 180, 200]
+
+    # Far cell's K_safe, computed up front so the sweep can bracket it
+    # finely -- multiples of 20 alone skip right over the boundary.
+    d_far_m = abs(far_i - src_i) * DX
+    k_safe_far = math.floor(d_far_m / (C0 * dt))
+    fine_bracket = sorted({
+        max(0, k_safe_far - d) for d in (20, 10, 6, 4, 2, 1, 0)
+    } | {k_safe_far + d for d in (1, 2, 4, 8, 12)})
+    coarse_tail = [0, 20, 40, 60, 80, 140, 160, 180, 200]
+    k_sweep = sorted(set(fine_bracket) | set(coarse_tail))
+    k_sweep = [K for K in k_sweep if K < N_STEPS]
 
     results = {}
     for label, ti in (("near", near_i), ("far", far_i)):
@@ -126,8 +152,6 @@ def main():
 
         row = []
         for K in k_sweep:
-            if K >= N_STEPS:
-                continue
             a0 = jnp.asarray(ALPHA0, dtype=jnp.float32)
             g_ad = float(jax.grad(lambda a: obj(a, n_warmup=K))(a0))
             rel = abs(g_ad - g_fd) / max(abs(g_fd), 1e-30)
@@ -136,24 +160,47 @@ def main():
             print(f"  K={K:4d}  AD={g_ad:14.6e}  rel_err={rel * 100:8.3f}%{flag}")
         results[label] = row
 
-    # ---- Falsifiable check: below K_safe, the far-cell gradient must
-    # match EVERY printed digit of the K=0 reference (near-exact, not
-    # merely "small error") -- this is the load-bearing claim, so assert
-    # it rather than just printing it.
+    # ---- Falsifiable check: below K_safe, the far-cell gradient stays
+    # within this repo's established ~1.5% AD-vs-FD noise floor -- the
+    # PRACTICAL claim K_safe needs to survive (see the module docstring's
+    # verification-round correction: it is a smooth, monotonically
+    # growing curve approaching K_safe, not a sharp cliff, so a tight
+    # <0.1% band across a merely-coarse sweep was an artifact of never
+    # sampling near the boundary, not evidence of near-exactness AT the
+    # boundary itself).
+    NOISE_FLOOR = 0.015  # this repo's own established AD-vs-FD tolerance
     far_row = results["far"]
     d_m = abs(far_i - src_i) * DX
     k_safe = math.floor(d_m / (C0 * dt))
     sub_wavefront = [(K, g_ad, rel) for K, g_ad, rel in far_row if K <= k_safe]
     assert sub_wavefront, "no sampled K falls below K_safe -- widen k_sweep or shrink separation"
+    assert k_safe in {K for K, _, _ in sub_wavefront}, (
+        "K_safe itself is not a sampled point -- fine_bracket construction changed; "
+        "the boundary value must be checked directly, not only points strictly below it"
+    )
     for K, g_ad, rel in sub_wavefront:
-        assert rel < 1e-3, (
+        assert rel < NOISE_FLOOR, (
             f"far cell K={K} (<= K_safe={k_safe}) rel_err={rel * 100:.4f}% -- "
-            "expected near-exact (<0.1%) below the wavefront-arrival horizon"
+            f"expected within this repo's ~{NOISE_FLOOR * 100:.1f}% AD-vs-FD "
+            "noise floor at or below the wavefront-arrival horizon"
+        )
+    # Separately confirm the DEEP sub-wavefront region (well below K_safe)
+    # really is near-exact, not merely inside the looser noise floor --
+    # this is where the "genuinely free, not merely approximate" claim
+    # lives.
+    deep = [(K, rel) for K, _, rel in sub_wavefront if K <= k_safe - 20]
+    assert deep, "no sampled K falls in the deep sub-wavefront region (K_safe - 20)"
+    for K, rel in deep:
+        assert rel < 1e-3, (
+            f"far cell K={K} (deep sub-wavefront, K_safe-{k_safe - K}) "
+            f"rel_err={rel * 100:.4f}% -- expected near-exact (<0.1%) well "
+            "below the wavefront-arrival horizon"
         )
     print(
-        f"\n[falsifier PASS] far cell: every sampled K <= K_safe={k_safe} "
-        f"matches the K=0 oracle to <0.1% (values: "
-        f"{[(K, round(rel * 100, 4)) for K, _, rel in sub_wavefront]})"
+        f"\n[falsifier PASS] far cell: every sampled K <= K_safe={k_safe} stays "
+        f"within the {NOISE_FLOOR * 100:.1f}% noise floor (values: "
+        f"{[(K, round(rel * 100, 4)) for K, _, rel in sub_wavefront]}); "
+        f"the deep sub-wavefront region (K <= K_safe-20) is near-exact (<0.1%)"
     )
 
     near_row = results["near"]

--- a/tests/test_benchmark_jacobian_fwd.py
+++ b/tests/test_benchmark_jacobian_fwd.py
@@ -47,9 +47,25 @@ def test_benchmark_table_relations():
     # docstring's "Wall-clock is diagnostic, not gated" note for why
     # wall_s is excluded here rather than asserted with a wider band.
     ratios = table["intercept_vs_plain_ratio"]
+    # This CPU-only test fixture (JAX_PLATFORMS=cpu) must always expose
+    # both compiler-derived columns; a missing key here means
+    # scripts/benchmark_jacobian_fwd.py's own bare `except Exception`
+    # around cost_analysis()/memory_analysis() silently swallowed a real
+    # failure (info["flops"]/["temp_bytes"] = None), which would
+    # otherwise make the loop below skip both columns via `continue` and
+    # pass with NOTHING actually checked -- an empty gate that looks
+    # green. Assert the keys exist before trusting the loop's silence.
+    assert "flops" in ratios, (
+        "intercept_vs_plain_ratio has no 'flops' key -- the benchmark "
+        "script's cost_analysis() call likely failed silently (bare "
+        "except in _compile_and_measure); this CPU fixture must expose it"
+    )
+    assert "temp_bytes" in ratios, (
+        "intercept_vs_plain_ratio has no 'temp_bytes' key -- the benchmark "
+        "script's memory_analysis() call likely failed silently (bare "
+        "except in _compile_and_measure); this CPU fixture must expose it"
+    )
     for name in ("flops", "temp_bytes"):
-        if name not in ratios:
-            continue  # backend may not expose one of these (see rows' None)
         ratio = ratios[name]
         assert 0.5 <= ratio <= 2.0, (
             f"intercept_vs_plain_ratio[{name}] = {ratio:.3f} outside the "
@@ -64,12 +80,17 @@ def test_benchmark_table_relations():
         r for r in table["rows"]
         if r["mode"] == "jvp_batched" and r["n_t"] == seq_row["n_t"]
     )
-    # Wall-clock, reported not gated (same class/treatment as
-    # intercept_vs_plain_ratio's wall_s column above): batched is
-    # EXPECTED to beat sequential (that's the whole point of the knob),
-    # but "beat" is a wall-time comparison and can invert on a loaded/
-    # noisy runner without any code regression. No assertion here; the
-    # ratio is available in the table for a human/CI-log reader.
+    # Wall-clock, reported not gated -- but PRECAUTIONARY, not
+    # demonstrated: unlike intercept_vs_plain_ratio's wall_s column above
+    # (confirmed red on a real CI run, commit 55fa85b), this specific
+    # batched-vs-sequential inversion has never actually been observed
+    # (across every local run collected while developing this fix, 0/18
+    # samples inverted; worst measured margin 1.30x in batched's favor,
+    # still comfortably faster). It is de-gated on the SAME reasoning as
+    # wall_s (both are wall-clock, both are compiler/scheduler-dependent
+    # in principle) rather than on independent evidence that this
+    # particular comparison is actually flaky -- treat it as a
+    # consistency choice, not a second confirmed-red case.
     _batched_vs_sequential_speedup = (
         seq_row["t_median_s"] / batched_row["t_median_s"]
         if batched_row["t_median_s"] else float("nan")

--- a/tests/test_benchmark_jacobian_fwd.py
+++ b/tests/test_benchmark_jacobian_fwd.py
@@ -11,13 +11,26 @@ real run of the script, not in this file or in any docstring.
 
 Relations gated:
     - intercept_vs_plain_ratio lands within [0.5x, 2.0x] of the plain
-      baseline for flops/temp_bytes/wall time (the primal-sharing
-      witness; band matches the repo's own established tolerance in
-      tests/test_estimate_ad_memory.py::test_segmented_estimate_within_tolerance).
-    - batched (batch_tangents=True) wall time is faster than sequential
-      (batch_tangents=False) at the same n_t.
+      baseline for flops/temp_bytes ONLY (compiler-derived, deterministic
+      quantities). wall_s is REPORTED, never asserted -- see the
+      wall-clock note below.
     - XLA temp_bytes is independent of n_steps (forward-mode memory does
       not scale with n_steps; only wall time does).
+
+Wall-clock is diagnostic, not gated (issue #632 follow-up): this test's
+own fixture red on a loaded CI runner -- commit 55fa85b, run 31464443445,
+fast-suite shard 1 -- with intercept_vs_plain_ratio[wall_s] = 0.474,
+just outside the [0.5x, 2.0x] band, and went green again on the very next
+commit with no code change. #632 already diagnosed the underlying
+quantity (this same ratio) as machine-dependent (0.98-1.10 measured on
+CPU, 1.41-1.87 on an RTX 4090); wall_s inherits that plus ordinary
+scheduler/thermal noise on a shared runner, which flops/temp_bytes (both
+compiler cost-model outputs, not measured runtime) do not. A flaky
+assertion in a per-PR required gate reds unrelated PRs, so wall_s is
+computed and surfaced in the table for a human to read, never gated in
+CI. The authoritative, backend-independent primal-sharing check is G3 in
+tests/test_jacobian_fwd.py (it inspects the jaxpr directly for one
+unbatched primal scan, a structural property, not a timing measurement).
 """
 
 from __future__ import annotations
@@ -30,8 +43,14 @@ def test_benchmark_table_relations():
         n_p=4, n_t_values=(1, 2, 4), n_steps=60, grid_scale=0, reps=3,
     )
 
+    # Deterministic, compiler-derived columns only -- see the module
+    # docstring's "Wall-clock is diagnostic, not gated" note for why
+    # wall_s is excluded here rather than asserted with a wider band.
     ratios = table["intercept_vs_plain_ratio"]
-    for name, ratio in ratios.items():
+    for name in ("flops", "temp_bytes"):
+        if name not in ratios:
+            continue  # backend may not expose one of these (see rows' None)
+        ratio = ratios[name]
         assert 0.5 <= ratio <= 2.0, (
             f"intercept_vs_plain_ratio[{name}] = {ratio:.3f} outside the "
             "primal-sharing band [0.5x, 2.0x]"
@@ -45,9 +64,15 @@ def test_benchmark_table_relations():
         r for r in table["rows"]
         if r["mode"] == "jvp_batched" and r["n_t"] == seq_row["n_t"]
     )
-    assert batched_row["t_median_s"] < seq_row["t_median_s"], (
-        f"batched wall time {batched_row['t_median_s']:.4f}s is not faster "
-        f"than sequential {seq_row['t_median_s']:.4f}s at n_t={seq_row['n_t']}"
+    # Wall-clock, reported not gated (same class/treatment as
+    # intercept_vs_plain_ratio's wall_s column above): batched is
+    # EXPECTED to beat sequential (that's the whole point of the knob),
+    # but "beat" is a wall-time comparison and can invert on a loaded/
+    # noisy runner without any code regression. No assertion here; the
+    # ratio is available in the table for a human/CI-log reader.
+    _batched_vs_sequential_speedup = (
+        seq_row["t_median_s"] / batched_row["t_median_s"]
+        if batched_row["t_median_s"] else float("nan")
     )
 
     w = table["n_steps_independence_witness"]

--- a/tests/test_design_mask_removed.py
+++ b/tests/test_design_mask_removed.py
@@ -65,6 +65,31 @@ def test_forward_rejects_design_mask_kwarg():
         sim.forward(n_steps=2, design_mask=mask, skip_preflight=True)
 
 
+def test_forward_rejects_design_mask_kwarg_with_a_readable_message():
+    """Arc-audit follow-up item 5(b): the bare Python default for an
+    unrecognised keyword on forward() reads `TypeError:
+    _ExecuteMixin.forward() got an unexpected keyword argument
+    'design_mask'` -- it leaks `_ExecuteMixin` (an internal mixin;
+    `forward` is a public `Simulation` method) and gives no reason or
+    replacement. forward()'s `**_removed_kwargs` shim
+    (rfx/api/_execute.py's `_reject_removed_forward_kwargs`) replaces
+    that with a message naming the actual reason and the one-line
+    migration path, and does not mention `_ExecuteMixin` at all."""
+    sim = _build_uniform_sim()
+    mask = np.zeros(sim._build_grid().shape, dtype=bool)
+    with pytest.raises(TypeError) as exc_info:
+        sim.forward(n_steps=2, design_mask=mask, skip_preflight=True)
+    message = str(exc_info.value)
+    assert "_ExecuteMixin" not in message, (
+        f"error message leaks the internal mixin class name: {message!r}"
+    )
+    assert "design_mask" in message
+    assert "#625" in message or "625" in message
+    assert "checkpoint_every" in message or "checkpoint_segments" in message, (
+        "message should point at the memory-relief replacement"
+    )
+
+
 def test_forward_nonuniform_rejects_design_mask_kwarg():
     """The non-uniform lane used to be design_mask's only SUPPORTED lane;
     it must now reject the kwarg exactly like the uniform lane."""

--- a/tests/test_design_mask_removed.py
+++ b/tests/test_design_mask_removed.py
@@ -90,6 +90,48 @@ def test_forward_rejects_design_mask_kwarg_with_a_readable_message():
     )
 
 
+def test_no_public_simulation_method_leaks_a_mixin_class_name():
+    """Arc-audit follow-up (verification round): the _ExecuteMixin leak
+    fixed for forward() specifically (see
+    test_forward_rejects_design_mask_kwarg_with_a_readable_message) is
+    not one-off -- every method Simulation inherits from its five mixins
+    (_PreflightMixin, _SparamMixin, _CompileMixin, _ExecuteMixin,
+    _ArtifactsMixin) used to keep that mixin's name in its __qualname__,
+    leaking into TypeError messages for ANY unrecognised keyword argument
+    on ANY public method, e.g. `sim.run(n_stepss=2)` reading
+    `_ExecuteMixin.run() got an unexpected keyword argument`.
+    `rfx/api/__init__.py` now rebinds every inherited method's
+    __qualname__ to `Simulation.<method>` at class composition time. Pin
+    both the qualname attribute directly and the resulting error message
+    for a representative method from each mixin."""
+    from rfx import Simulation
+    from rfx.api._preflight import _PreflightMixin
+    from rfx.api._sparams import _SparamMixin
+    from rfx.api._compile import _CompileMixin
+    from rfx.api._execute import _ExecuteMixin
+    from rfx.api._artifacts import _ArtifactsMixin
+
+    for mixin in (_PreflightMixin, _SparamMixin, _CompileMixin, _ExecuteMixin, _ArtifactsMixin):
+        for name, member in vars(mixin).items():
+            if name.startswith("_") or not callable(member):
+                continue
+            qualname = getattr(getattr(Simulation, name, None), "__qualname__", "")
+            assert not qualname.startswith(mixin.__name__), (
+                f"Simulation.{name} still leaks its defining mixin's name "
+                f"in __qualname__: {qualname!r}"
+            )
+            assert qualname == f"Simulation.{name}", (
+                f"Simulation.{name}.__qualname__ = {qualname!r}, expected "
+                f"'Simulation.{name}'"
+            )
+
+    sim = _build_uniform_sim()
+    with pytest.raises(TypeError, match=r"^Simulation\.run\(\)"):
+        sim.run(n_stepss=2)
+    with pytest.raises(TypeError, match=r"^Simulation\.preflight\(\)"):
+        sim.preflight(bogus_kwarg=1)
+
+
 def test_forward_nonuniform_rejects_design_mask_kwarg():
     """The non-uniform lane used to be design_mask's only SUPPORTED lane;
     it must now reject the kwarg exactly like the uniform lane."""

--- a/tests/test_jacobian_fwd.py
+++ b/tests/test_jacobian_fwd.py
@@ -807,3 +807,108 @@ def test_g8_sequential_guard_trace_time_check_survives_outer_jit():
 
     value, jacobian = outer_ok(params)
     assert float(value) == float(jnp.sum(params ** 2))
+
+
+# ---------------------------------------------------------------------------
+# G8 follow-up (arc-audit verification round, items B3/B5 + "guard 1 too
+# strict"): three defects found in the G8 guards themselves.
+# ---------------------------------------------------------------------------
+
+def test_g8_guard2_nan_divergence_not_misdiagnosed_as_tangent_dependence():
+    """B3: jnp.array_equal(nan, nan) is False by default (IEEE-754), so a
+    PURE, deterministic sim_fn whose computation diverged (returns the
+    SAME nan on every tangent row -- divergence is a property of params,
+    not of which tangent direction is evaluated) used to trip guard 2's
+    mismatch check and get told its primal "depends on which tangent
+    direction is being evaluated" -- wrong diagnosis. batch_tangents=True
+    just returns the nan silently (measured); the sequential path must
+    match that, not raise."""
+    def nan_sim_fn(p):
+        return jnp.nan + 0.0 * jnp.sum(p)  # same nan regardless of p or tangent
+
+    params = jnp.asarray([1.0, 2.0, 3.0], dtype=jnp.float32)
+    tangents = jnp.eye(3, dtype=jnp.float32)
+
+    value_seq, jac_seq = jacobian_fwd(nan_sim_fn, params, tangents=tangents, batch_tangents=False)
+    value_batch, jac_batch = jacobian_fwd(nan_sim_fn, params, tangents=tangents, batch_tangents=True)
+    assert jnp.isnan(value_seq) and jnp.isnan(value_batch)
+    np.testing.assert_array_equal(np.asarray(jac_seq), np.asarray(jac_batch))
+
+
+def test_g8_guard2_checks_all_params_leaves_for_tracer_ness():
+    """B5: guard 2 used to test only params_leaves[0] for tracer-ness.
+    A MIXED params pytree -- one leaf a jit-traced argument, one leaf a
+    plain Python/closure-captured CONCRETE value (not itself passed
+    through jit's argument list, so it never becomes a tracer) -- used to
+    crash guard 2's bool(jnp.array_equal(...)) with
+    TracerBoolConversionError whenever the traced leaf sorted before the
+    concrete one in pytree-flatten order, since checking only leaf 0
+    would wrongly conclude "not tracing" and try to concretely compare a
+    tracer. Pinned both orderings (traced-leaf-first and
+    concrete-leaf-first) so this cannot silently regress by luck of leaf
+    order."""
+    def sim_fn(params_tuple):
+        a, b = params_tuple
+        return jnp.sum(a ** 2) + jnp.sum(b ** 2)
+
+    tangents = (jnp.eye(2, dtype=jnp.float32), jnp.zeros((2, 1), dtype=jnp.float32))
+    b0_concrete = jnp.asarray([3.0], dtype=jnp.float32)
+
+    @jax.jit
+    def outer_traced_first(a):
+        # a: jit-traced; b0_concrete: closure-captured, stays concrete.
+        value, jacobian = jacobian_fwd(
+            sim_fn, (a, b0_concrete), tangents=tangents, batch_tangents=False,
+        )
+        return value
+
+    a0_concrete = jnp.asarray([1.0, 2.0], dtype=jnp.float32)
+
+    @jax.jit
+    def outer_concrete_first(b):
+        # a0_concrete: closure-captured, stays concrete; b: jit-traced.
+        value, jacobian = jacobian_fwd(
+            sim_fn, (a0_concrete, b), tangents=tangents, batch_tangents=False,
+        )
+        return value
+
+    out1 = outer_traced_first(jnp.asarray([1.0, 2.0], dtype=jnp.float32))
+    out2 = outer_concrete_first(jnp.asarray([3.0], dtype=jnp.float32))
+    expected = float(jnp.sum(jnp.asarray([1.0, 2.0]) ** 2) + jnp.sum(jnp.asarray([3.0]) ** 2))
+    assert float(out1) == expected
+    assert float(out2) == expected
+
+
+def test_g8_guard1_data_dependent_branch_on_params_not_misdiagnosed():
+    """Guard 1 too strict: jax.eval_shape abstracts EVERY value inside
+    the traced function, including `params` -- which stays CONCRETE
+    under a real jax.vmap(..., out_axes=(None, 0)) call (params is not
+    the vmapped axis) or under plain jax.jvp. A sim_fn with a
+    data-dependent Python branch on `params` (not the tangent) is
+    therefore fine under plain jax.jvp AND the batched path, but used to
+    crash guard 1 with TracerBoolConversionError purely because
+    eval_shape's abstract mode cannot decide the branch -- an eval_shape
+    LIMITATION, not a real out_axes violation. Guard 1 now catches
+    ConcretizationTypeError and falls through to guard 2 instead of
+    propagating it, so the sequential path is no longer STRICTER than
+    every other path for this class of sim_fn."""
+    def branchy_sim_fn(p):
+        return jnp.where(jnp.sum(p) > 0, jnp.sum(p ** 2), -jnp.sum(p ** 2))
+
+    params = jnp.asarray([1.0, 2.0, 3.0], dtype=jnp.float32)
+    tangents = jnp.eye(3, dtype=jnp.float32)
+
+    # A genuine Python `if` (not jnp.where) is the sharper reproduction
+    # of the reported failure -- jnp.where alone is traceable, but an
+    # `if` on a traced boolean is what raises TracerBoolConversionError
+    # under eval_shape's full abstraction.
+    def branchy_sim_fn_python_if(p):
+        if jnp.sum(p) > 0:
+            return jnp.sum(p ** 2)
+        return -jnp.sum(p ** 2)
+
+    for fn in (branchy_sim_fn, branchy_sim_fn_python_if):
+        value_seq, jac_seq = jacobian_fwd(fn, params, tangents=tangents, batch_tangents=False)
+        value_batch, jac_batch = jacobian_fwd(fn, params, tangents=tangents, batch_tangents=True)
+        assert float(value_seq) == float(value_batch) == 14.0
+        np.testing.assert_allclose(np.asarray(jac_seq), np.asarray(jac_batch))

--- a/tests/test_jacobian_fwd.py
+++ b/tests/test_jacobian_fwd.py
@@ -684,3 +684,126 @@ def test_g7_falsifier_severed_tape_reads_exactly_zero():
     # the transcript for a PR body excerpt; the assertions above are the
     # real gate.
     print(transcript)
+
+
+# ---------------------------------------------------------------------------
+# G8: batch_tangents=False's own out_axes=(None, 0) guard (arc-audit
+# follow-up item 4b). The batched path inherits a fail-loud check for free
+# from jax.vmap(..., out_axes=(None, 0)) -- see the API TRAP note in
+# jacobian_fwd's docstring. The sequential path has no vmap of its own, so
+# without an explicit guard a sim_fn that violates the "primal independent
+# of tangent" invariant would silently return one arbitrary tangent row's
+# primal instead of raising. `leaky`/`leaky_jvp` below is a deliberately
+# broken custom_jvp rule -- jax.jvp does not itself enforce primal purity,
+# so this is the only way to construct a genuine violation: the primal
+# output is defined to depend on the tangent argument.
+# ---------------------------------------------------------------------------
+
+@jax.custom_jvp
+def _leaky(x):
+    return x
+
+
+@_leaky.defjvp
+def _leaky_jvp(primals, tangents):
+    (x,), (t,) = primals, tangents
+    return x + jnp.sum(t), t  # BUG (deliberate): primal leaks the tangent
+
+
+def _leaky_sim_fn(params):
+    return _leaky(params)
+
+
+def _pure_sim_fn(params):
+    return jnp.sum(params ** 2)
+
+
+def test_g8_sequential_guard_raises_on_tangent_dependent_primal():
+    """The sequential path must raise -- the SAME class of error the
+    batched path raises for free -- not silently return a wrong primal.
+    Guard 1 (jax.eval_shape) catches THIS construction: `_leaky`'s primal/
+    tangent coupling is visible to vmap's batching interpreter even in a
+    single abstract trace, so it fires before the real sequential loop
+    (and before guard 2, which never gets a chance to run) -- the
+    "out_axes" message below IS guard 1 firing, not a fallback to the
+    default Python TypeError. See
+    test_g8_sequential_guard_catches_cross_call_impurity_guard1_cannot_see
+    below for the complementary case guard 1 structurally cannot detect."""
+    params = jnp.asarray([1.0, 2.0, 3.0], dtype=jnp.float32)
+    tangents = jnp.eye(3, dtype=jnp.float32)  # explicit escape hatch: identity
+    # requires scalar leaves, and params here is one flat (3,) leaf.
+
+    with pytest.raises(ValueError, match="out_axes"):
+        jacobian_fwd(_leaky_sim_fn, params, tangents=tangents, batch_tangents=False)
+
+    # Confirm the batched path independently raises too (both paths agree
+    # this sim_fn is unsafe -- neither one is the "safe" escape hatch).
+    with pytest.raises(ValueError, match="out_axes"):
+        jacobian_fwd(_leaky_sim_fn, params, tangents=tangents, batch_tangents=True)
+
+
+def test_g8_sequential_guard_catches_cross_call_impurity_guard1_cannot_see():
+    """Guard 1 (jax.eval_shape) traces sim_fn's body exactly ONCE (vmap
+    batches rather than looping), so a side effect that only manifests
+    ACROSS repeated independent Python-level calls -- not visible as a
+    structural batching dependency inside one trace -- is invisible to
+    it. The real sequential loop (`batch_tangents=False`, no jit) DOES
+    call sim_fn n_t separate times in eager Python, so it genuinely can
+    observe such a thing. This is guard 2's reason to exist: an exact
+    pairwise comparison of the n_t actually-computed primal values."""
+    call_count = {"n": 0}
+
+    def side_effecting_sim_fn(params):
+        call_count["n"] += 1
+        # A real (if contrived) impurity: the primal depends on how many
+        # times this Python function has been called so far, which a
+        # single abstract trace cannot see, but n_t independent eager
+        # jax.jvp calls can.
+        return jnp.sum(params ** 2) + float(call_count["n"])
+
+    params = jnp.asarray([1.0, 2.0, 3.0], dtype=jnp.float32)
+    tangents = jnp.eye(3, dtype=jnp.float32)
+
+    with pytest.raises(ValueError, match="depends on which tangent"):
+        jacobian_fwd(side_effecting_sim_fn, params, tangents=tangents, batch_tangents=False)
+
+
+def test_g8_sequential_guard_silent_for_well_behaved_sim_fn():
+    """No false positives: a normal, pure sim_fn must not trip the guard
+    on either path, and both paths must still agree on the actual value."""
+    params = jnp.asarray([1.0, 2.0, 3.0], dtype=jnp.float32)
+    tangents = jnp.eye(3, dtype=jnp.float32)
+
+    value_seq, jac_seq = jacobian_fwd(_pure_sim_fn, params, tangents=tangents, batch_tangents=False)
+    value_batch, jac_batch = jacobian_fwd(_pure_sim_fn, params, tangents=tangents, batch_tangents=True)
+
+    assert value_seq == value_batch == jnp.sum(params ** 2)
+    np.testing.assert_allclose(np.asarray(jac_seq), np.asarray(jac_batch))
+
+
+def test_g8_sequential_guard_trace_time_check_survives_outer_jit():
+    """Guard 1 (jax.eval_shape) must fire even when jacobian_fwd itself is
+    called from inside an outer jax.jit -- exactly how
+    scripts/benchmark_jacobian_fwd.py and this file's own compiled-jaxpr
+    measurements (G3) invoke the sequential path. Guard 2 (the eager
+    numeric cross-check) cannot run under trace -- params are tracers --
+    so this specifically isolates guard 1."""
+    params = jnp.asarray([1.0, 2.0, 3.0], dtype=jnp.float32)
+    tangents = jnp.eye(3, dtype=jnp.float32)
+
+    @jax.jit
+    def outer(p):
+        value, jacobian = jacobian_fwd(_leaky_sim_fn, p, tangents=tangents, batch_tangents=False)
+        return value
+
+    with pytest.raises(ValueError, match="out_axes"):
+        outer(params)
+
+    # And a well-behaved sim_fn must still compile and run fine under jit.
+    @jax.jit
+    def outer_ok(p):
+        value, jacobian = jacobian_fwd(_pure_sim_fn, p, tangents=tangents, batch_tangents=False)
+        return value, jacobian
+
+    value, jacobian = outer_ok(params)
+    assert float(value) == float(jnp.sum(params ** 2))

--- a/tests/test_n_warmup.py
+++ b/tests/test_n_warmup.py
@@ -16,11 +16,22 @@ Issue #626 additions:
      accepted and dropped it — measured bit-identical gradient at
      n_warmup=0 vs n_warmup=60. It now raises NotImplementedError instead
      (test_uniform_forward_rejects_n_warmup).
-  5. n_warmup IS implemented on this file's non-uniform lane, but it is an
-     APPROXIMATION, not an exact truncation: severing the scan carry at the
-     warmup boundary also severs the gradient path from a design variable's
-     influence during the warmup window. test_warmup_truncation_error_grows_with_k
-     pins the measured error curve against an independent central-FD oracle
+  5. n_warmup IS implemented on this file's non-uniform lane. Severing the
+     scan carry at the warmup boundary severs the gradient path from a
+     design variable's influence during the warmup window -- but ONLY for
+     steps after the wavefront has reached the design region; before that
+     the field there is ~0, so severing those steps' carry costs nothing
+     and the truncation is (near-)exact. This file's fixture places the
+     design cell only ~3 cells from the source (the worst case: the
+     wavefront is present from step 0), so
+     test_warmup_truncation_error_grows_with_k pins that worst-case curve
+     specifically, NOT a universal property of n_warmup -- see
+     `scripts/diagnostics/i626_n_warmup_wavefront_locality.py` for a
+     far-from-source counter-fixture (K_safe formula + near-exact
+     gradient below it) and `rfx/nonuniform.py`'s `n_warmup split`
+     comment for both curves side by side (issue #626 part 2 /
+     addendum). test_warmup_truncation_error_grows_with_k itself pins the
+     measured error curve against an independent central-FD oracle
      (held-fixed loss window, K varied independently -- see the docstring
      there for why that isolation matters).
 """
@@ -109,11 +120,14 @@ def test_uniform_forward_rejects_n_warmup():
     forwarded it to the NU lanes; `_forward_from_materials` (the uniform
     lane) has no such parameter, so a nonzero n_warmup was silently
     accepted and ignored (measured bit-identical gradient at n_warmup=0
-    vs n_warmup=60). It must now fail loud instead, matching its three
-    uniform-lane siblings (emit_time_series=False, checkpoint_every,
-    design_mask). This is the regression witness: a future silent re-drop
-    would make this raise disappear (n_warmup=0 still runs fine below), not
-    merely "both run" -- the required difference is raise vs. no-raise."""
+    vs n_warmup=60). It must now fail loud instead, matching its two
+    remaining uniform-lane siblings (emit_time_series=False,
+    checkpoint_every) -- design_mask, the third historical sibling, was
+    removed from every public surface entirely (issue #625) rather than
+    fenced, so it is no longer part of this taxonomy. This is the
+    regression witness: a future silent re-drop would make this raise
+    disappear (n_warmup=0 still runs fine below), not merely "both run"
+    -- the required difference is raise vs. no-raise."""
     sim = Simulation(freq_max=10e9, domain=(0.01, 0.01, 0.005), dx=0.5e-3,
                       cpml_layers=4)
     sim.add_source((0.005, 0.005, 0.001), "ez")
@@ -132,6 +146,16 @@ def test_warmup_truncation_error_grows_with_k():
     gradient on the non-uniform lane where it IS implemented, against an
     INDEPENDENT central-FD oracle -- not merely "finite and same sign"
     (that was test_warmup_grad_finite_and_same_sign's weaker guarantee).
+
+    NOTE (issue #626 addendum): this fixture's design cell sits only ~3
+    cells from the source, which is the WORST case for n_warmup (the
+    wavefront is already present at every step, so every severed warmup
+    step carries real gradient signal). This test intentionally keeps
+    pinning that worst-case curve as a regression lock -- it is not a
+    claim that n_warmup always costs this much accuracy. See
+    `scripts/diagnostics/i626_n_warmup_wavefront_locality.py` for the
+    complementary far-from-source case (near-exact below K_safe) and
+    `rfx/nonuniform.py`'s `n_warmup split` comment for the K_safe formula.
 
     Design: the LOSS WINDOW is held FIXED at time_series[N_FIXED:] for
     every K in the sweep, and K (n_warmup) is varied independently. This

--- a/tests/test_observables_dft_field.py
+++ b/tests/test_observables_dft_field.py
@@ -70,26 +70,33 @@ _SLAB_HI_M = (18 * _DX, _NY * _DX, _NZ * _DX)
 _PIXEL_POS_M = (14 * _DX, 10 * _DX, 10 * _DX)  # geometry-leg single design pixel
 _N_STEPS = 160
 _FD_H = 0.02
-# field_softmax needs beta scale-matched to the field magnitude (see
-# rfx.observables.field_softmax's docstring warning) -- this sim's
-# max|field|^2 measures ~5e-10 to 5.4e-10 on both legs, with
+# field_softmax is now auto-scaled (rfx.observables.field_softmax computes
+# beta_eff = beta / stop_gradient(max(vals)) internally), so beta below is
+# DIMENSIONLESS -- it no longer needs hand-matching to this sim's raw
+# max|field|^2 (~5e-10 to 5.4e-10 on both legs). The original footgun this
+# fixture caught (#619): at the OLD unscaled beta=1.0, with
 # count = n_freqs*n1*n2 = 1*31*31 = 961 elements on the single registered
-# plane, so log(count)/beta ~ 6.87/beta is the CONSTANT (design-variable-
-# independent) floor logsumexp(beta*vals)/beta never drops below. At
-# beta=1.0 that constant totally dominates: the objective sits at
-# ~100.000002% of log(961), both AD and FD differentiate rounding noise in
-# that constant rather than physics, and the two coincidentally agreed at
-# h=0.02 (< 5% rel_err) while DISAGREEING at h=0.01 (18.9% rel_err, same
-# AD value) -- proof the original green was luck, not a real measurement.
-# Measured sweep (geometry leg, h=0.02, same sim): beta=1e9 -> 0.257%,
-# beta=1e10 -> 0.177%, beta=1e11 -> 0.112% rel_err, monotonically
-# tightening as beta pushes past the log(count)/beta regime toward the
-# true max (beta*max(vals) ~ 1e11*5e-10 = 50, comfortably >> log(961)~6.87
-# and comfortably below the ~3.4e38 float32 overflow ceiling the
-# docstring warns about). beta=1e11 is used below, and re-verified across
-# THREE h values (not one) so a future coincidental-rounding regression
-# cannot slip back in unnoticed.
-_SOFTMAX_BETA = 1e11
+# plane, log(count)/beta ~ 6.87 totally dominated the objective (it sat at
+# ~100.000002% of log(961)) -- both AD and FD differentiated rounding
+# noise in that constant rather than physics, and the two coincidentally
+# agreed at h=0.02 (< 5% rel_err) while DISAGREEING at h=0.01 (18.9%
+# rel_err, same AD value) -- proof the original green was luck, not a
+# real measurement. Post-auto-scale, beta_eff*max(vals) == beta ALWAYS by
+# construction, so this failure mode cannot recur at any beta -- but
+# stop_gradient on the normalizer means FD (which re-evaluates the WHOLE
+# renormalization at each perturbed point) and AD (which correctly omits
+# that renormalization's own derivative, by design) are not evaluating
+# quite the same thing, and disagree by a few percent at low-to-moderate
+# beta_eff. Re-measured sweep (geometry leg, same sim, three h values):
+# beta=10 -> up to 34.0% rel_err, beta=30 -> up to 7.8%, beta=50 -> up to
+# 3.5%, beta=100 -> up to 1.2%, beta=200 -> up to 0.7% -- monotonically
+# tightening as beta grows (the stop_gradient-omitted term's relative
+# contribution shrinks as the softmax concentrates on fewer terms near the
+# true max), comfortably below the existing 5% gate at beta=200 with
+# similar headroom to the pre-auto-scale calibration. beta=200 is used
+# below, re-verified across THREE h values (not one) so a future
+# coincidental-rounding regression cannot slip back in unnoticed.
+_SOFTMAX_BETA = 200.0
 _SOFTMAX_FD_H_VALUES = (0.01, 0.02, 0.04)
 # A single-Yee-cell material perturbation (the geometry/topology leg) has a
 # proportionally tiny effect on a bulk plane-energy sum -- real,
@@ -270,6 +277,95 @@ def test_field_softmax_geometry_leg_ad_matches_fd():
         g_fd = _central_fd_f64(obj, rho0, h)
         _assert_ad_matches_fd(
             g_ad, g_fd, label=f"field_softmax geometry (1-pixel) leg (h={h})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# (1b) Issue #619 regression: the DEFAULT beta must be safe at ANY field
+# magnitude, not merely at values a caller happened to hand-tune against.
+# Synthetic fixtures (no FDTD -- fast), same _fake_result pattern as (3).
+# ---------------------------------------------------------------------------
+
+def test_field_softmax_default_beta_is_scale_invariant():
+    """The pre-fix implementation computed logsumexp(beta*vals)/beta
+    directly against raw vals, so at a physically tiny field magnitude and
+    the default beta=1.0, the design-independent constant log(count)/beta
+    dominated: the output collapsed toward THAT CONSTANT regardless of
+    the field's actual scale (measured, #619 -- see _SOFTMAX_BETA's
+    comment above). field_softmax now auto-scales internally
+    (beta_eff = beta / stop_gradient(max(vals))), which makes it exactly
+    homogeneous of degree 1 in vals: rescaling every field value by a
+    positive constant c rescales the output by the SAME c, at ANY beta
+    including the default -- a clean, exact invariant the pre-fix
+    implementation violated at small c. Verified at field-magnitude
+    scales spanning rfx's own documented realistic DFT-accumulator range
+    (vals ~1e-22 to ~1e-8, per field_softmax's and this file's docstrings)
+    plus an O(1) and a large point for symmetry.
+    """
+    rng = np.random.default_rng(0)
+    base_field = jnp.asarray(
+        rng.uniform(0.5, 1.5, size=(3, 3, 2)), dtype=jnp.float32
+    ).astype(jnp.complex64)
+    softmax_default = field_softmax("p")  # beta left at its default (1.0)
+
+    def value_at_vals_scale(vals_scale: float) -> float:
+        # vals = |field|**2, so scaling vals by `vals_scale` means scaling
+        # the field itself by sqrt(vals_scale).
+        field = base_field * jnp.asarray(vals_scale, dtype=jnp.float32) ** 0.5
+        result = _fake_result(p=field)
+        return float(softmax_default(result))
+
+    v_ref = value_at_vals_scale(1.0)
+    assert v_ref > 0.0
+
+    for vals_scale in (1e-22, 1e-10, 1e2, 1e8):
+        v = value_at_vals_scale(vals_scale)
+        expected = v_ref * vals_scale
+        assert np.isfinite(v) and v > 0.0, (
+            f"field_softmax(default beta) not finite/positive at vals_scale="
+            f"{vals_scale:.0e}: {v}"
+        )
+        rel = abs(v - expected) / expected
+        assert rel < 1e-3, (
+            f"field_softmax(default beta) is not scale-invariant at "
+            f"vals_scale={vals_scale:.0e}: got {v:.6e}, expected "
+            f"{expected:.6e} (ratio={v / expected:.6f}). Pre-fix, this "
+            "ratio collapsed toward a magnitude-independent constant "
+            "instead of tracking vals_scale -- the exact #619 footgun."
+        )
+
+
+def test_field_softmax_default_beta_gradient_not_rounding_noise():
+    """Direct FD-vs-AD check at the DEFAULT beta and a physically tiny
+    field magnitude (vals ~1e-20, inside rfx's own documented realistic
+    DFT-accumulator range) -- the exact operating point at which the
+    pre-fix implementation's gradient measured rounding noise in
+    log(count)/beta rather than physics (#619)."""
+    rng = np.random.default_rng(1)
+    base = jnp.asarray(rng.uniform(0.5, 1.5, size=(3, 3)), dtype=jnp.float32)
+    field_scale = 1e-10  # |field|**2 ~ 1e-20, matching the realistic range
+    softmax_default = field_softmax("p")
+
+    def obj(alpha):
+        arr = base.at[1, 1].set(alpha) * field_scale
+        result = _fake_result(p=arr.astype(jnp.complex64))
+        return softmax_default(result)
+
+    alpha0 = 1.0
+    g_ad = float(jax.grad(obj)(jnp.asarray(alpha0, dtype=jnp.float32)))
+    assert np.isfinite(g_ad) and g_ad != 0.0, (
+        f"gradient collapsed at tiny field magnitude: {g_ad} -- the exact "
+        "#619 rounding-noise failure mode."
+    )
+    for h in (0.01, 0.02, 0.04):
+        with enable_x64():
+            fp = obj(jnp.asarray(alpha0 + h, dtype=jnp.float32))
+            fm = obj(jnp.asarray(alpha0 - h, dtype=jnp.float32))
+            g_fd = float((fp - fm) / (2.0 * h))
+        rel = abs(g_ad - g_fd) / max(abs(g_fd), 1e-300)
+        assert rel < 0.05, (
+            f"AD vs FD mismatch at tiny field magnitude (h={h}): "
+            f"g_ad={g_ad:.6e} g_fd={g_fd:.6e} rel_err={rel * 100:.2f}%"
         )
 
 

--- a/tests/test_observables_dft_field.py
+++ b/tests/test_observables_dft_field.py
@@ -369,6 +369,80 @@ def test_field_softmax_default_beta_gradient_not_rounding_noise():
         )
 
 
+def test_field_softmax_beta_eff_overflow_returns_finite_not_nan():
+    """Arc-audit follow-up (verification round, item B1): auto-scaling
+    RELOCATES the top-end-overflow footgun from `beta*vals` to
+    `beta_eff = beta/max(vals)` rather than removing it -- at this
+    repo's realistic tiny field magnitude, `beta=2.0e24` (the literal
+    value `examples/inverse_design/field_observable_shielding.py`
+    carried before its own re-calibration in this same follow-up)
+    measured `value=nan, grad=nan` SILENTLY, no exception, before the
+    `jnp.isfinite(beta_eff)` clip was added. Pin: the clip keeps the
+    VALUE finite and correct (converging to the true max) at beta values
+    that would otherwise overflow beta_eff, including the exact
+    previously-nan `2.0e24`."""
+    rng = np.random.default_rng(2)
+    base = jnp.asarray(rng.uniform(0.5, 1.5, size=(3, 3)), dtype=jnp.float32)
+    field_scale = 1.0e-11  # |field|**2 ~ 1e-22, this repo's realistic range
+    field = (base * field_scale).astype(jnp.complex64)
+    result = _fake_result(p=field)
+    true_max = float(jnp.max(jnp.abs(field) ** 2))
+
+    for beta in (1.0e16, 1.0e17, 2.0e24, 1.0e30, 1.0e38):
+        val = float(field_softmax("p", beta=beta)(result))
+        assert np.isfinite(val), f"beta={beta:.1e}: value not finite: {val}"
+        rel = abs(val - true_max) / true_max
+        assert rel < 0.05, (
+            f"beta={beta:.1e}: clipped value {val:.6e} does not converge "
+            f"to true max {true_max:.6e} (rel_err {rel * 100:.2f}%)"
+        )
+
+
+def test_field_softmax_gradient_can_silently_collapse_past_the_recommended_beta_range():
+    """Companion to the overflow-guard test above: the VALUE clip does
+    NOT cover the gradient. Measured: the gradient matches FD accurately
+    through beta~1e15, then collapses to exactly 0.0 somewhere between
+    beta~1e16 and beta~1e17 -- the EXACT transition point is
+    fixture-dependent (measured to shift by up to 10x between two
+    fixtures differing only in element values), so this test does not
+    pin an exact cliff beta, only: (a) the documented-safe range (up to
+    1e15, decades past the recommended 5-50) stays accurate, and (b) a
+    beta comfortably past every fixture's measured transition
+    (1e18 -- two full orders of magnitude past the highest observed
+    cliff) is robustly, reproducibly exactly 0.0, not merely 'often'."""
+    rng = np.random.default_rng(3)
+    base = jnp.asarray(rng.uniform(0.5, 1.5, size=(3,)), dtype=jnp.float32)
+    field_scale = 1.0e-11
+
+    def make_obj(beta):
+        def obj(scale):
+            field = (base * scale * field_scale).astype(jnp.complex64)
+            result = _fake_result(p=field)
+            return field_softmax("p", beta=beta)(result)
+        return obj
+
+    h = 1e-3
+    for beta in (1e2, 1e6, 1e12, 1e15):
+        obj = make_obj(beta)
+        g_ad = float(jax.grad(obj)(jnp.asarray(1.0, dtype=jnp.float32)))
+        g_fd = float((obj(jnp.asarray(1.0 + h)) - obj(jnp.asarray(1.0 - h))) / (2 * h))
+        assert g_ad != 0.0, f"beta={beta:.1e}: gradient unexpectedly 0 inside the documented-safe range"
+        rel = abs(g_ad - g_fd) / max(abs(g_fd), 1e-300)
+        assert rel < 0.05, f"beta={beta:.1e}: AD vs FD mismatch {rel * 100:.2f}%"
+
+    # Robustly past the measured cliff (not pinning the cliff's exact
+    # location, which is fixture-dependent -- see the docstring above):
+    # a future numerical change either preserves this or deliberately
+    # closes it, not silently shifts it without anyone noticing.
+    obj_far = make_obj(1.0e18)
+    g_far = float(jax.grad(obj_far)(jnp.asarray(1.0, dtype=jnp.float32)))
+    assert g_far == 0.0, (
+        f"beta=1e18 gradient no longer exactly 0.0 (got {g_far!r}) -- the "
+        "measured collapse behaviour changed; re-measure and update the "
+        "docstring warning in rfx.observables.field_softmax."
+    )
+
+
 # ---------------------------------------------------------------------------
 # (2) Physics witness: run() and forward() must agree on the accumulator.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
An independent audit of the merged arc `e4b565c..ce44661` found five defects that its own build/verify pairs missed. This PR fixes them, and a second verification round found six more introduced by the fixes themselves — those are fixed too, and named below rather than quietly absorbed.

## 1. A wall-clock assertion in the required per-PR gate

`tests/test_benchmark_jacobian_fwd.py` asserted `0.5 ≤ intercept_vs_plain_ratio ≤ 2.0` for every column including `wall_s`. It has redded main at `55fa85b` (0.474) and an unrelated PR at `#638` (0.230), and review measured **5 failures in 10 samples under contention**, with the quantity going as low as −0.068 — it is a two-point extrapolation `(4y₁−y₄)/3`, so it can go negative.

The sharp part: **#632 diagnosed exactly this metric as machine-dependent** (0.98–1.10 CPU vs 1.41–1.87 on a 4090) and PR #635 reworded the printed label while leaving the assertion. The diagnosis was right and the fix went to the prose.

`wall_s` is now reported and never asserted; the deterministic compiler-derived columns still are, and are bit-identical across 18 runs. A repo-wide sweep found exactly one other timing assertion, predating this arc. `assert "flops" in ratios` was added so a bare `except` upstream cannot silently empty the band check.

## 2. A fixture-specific curve published as universal

#626 documented an n_warmup gradient-truncation error rising to 100% — a property of that fixture's design cell sitting 3 cells from the source. Measured at 52 cells: the AD gradient is **identical to every printed digit** at K = 0, 20, 40 and 60, degrading only near the wavefront arrival time.

The mechanism is causality: before the wave reaches the design region the field there is ~0, so those steps contribute ~0 and severing the carry removes nothing. **n_warmup is exact, not lossy, below K_safe ≈ ⌊min_distance(source, design_region) / (c₀·dt)⌋** — and in that regime it saves compute *and* memory, which `checkpoint_segments` cannot, since checkpointing trades one for the other.

Corrected in all six places the claim was copied to, with both curves cited side by side. A counter-fixture ships as `scripts/diagnostics/i626_n_warmup_wavefront_locality.py`. The durable-memory STOP recorded against "n_warmup as exact-gradient memory reduction" is retracted — a wrong STOP fences off a good idea under this repo's own rules.

No runtime warning: `forward()` has no notion of a design region (that concept was deliberately removed with `design_mask`), so a warning built on a guess would itself be an unverifiable claim.

## 3–5. Three footguns

`field_softmax` shipped `beta=1.0`, the default its own review proved meaningless — at rfx field magnitudes the objective sat at ~100.000002% of the design-independent constant `log(N)/beta`, so the FD gate was differentiating rounding noise. `beta` is now dimensionless via scale normalisation. **This is a semantic break and is filed as BREAKING**, with both of this repo's own callers' old→new values as worked migration examples.

`jacobian_fwd`'s docstring claimed the sequential path runs "inside one jit" — there is no `jax.jit` in the module. Removed, and the sequential path gained the primal cross-check the batched path got for free.

The removed-kwarg `TypeError` leaked `_ExecuteMixin` and pointed nowhere. Review found this affects **ten public methods**, not one, so `__qualname__` is rebound at class composition — `sim.run(n_stepss=2)` now names `Simulation.run`. The `design_mask` migration path, which existed only in the CHANGELOG, is now in the public memory guide.

## What the second verification round caught in the fixes

Named because several are instructive:

- **The overflow footgun moved rather than closed** — from the product into the ratio `beta / scale_safe`, still float32. `beta=2.0e24` — the value this repo's own example carried one commit earlier — returned NaN silently. Guarded. Fixing it then exposed a *separate* gradient-collapse limit around beta ~1e15–1e17 that no reformulation avoids (normalise-then-scale just moves it to the value side); it is documented and tested rather than papered over, and sits ~13 orders past the recommended range.
- **A pure `sim_fn` that diverged to NaN was told it was impure**, because `array_equal(nan, nan)` is False. Now `equal_nan=True`. This matters because divergence-to-NaN was established as a real failure mode elsewhere in this arc.
- **The guard's message claimed the batched path would raise the same error.** Measured false — batched silently returns a value for the cross-call case. Corrected to say the sequential path is genuinely safer there. A PR about removing a false docstring claim should not ship one.
- **The tracer check inspected only the first leaf**, crashing on `(concrete, tracer)` and passing on `(tracer, concrete)`.
- **One guard was stricter than every other path**, rejecting a data-dependent Python branch that plain `jax.jvp` and the batched path both accept — an `eval_shape` limitation, not a contract violation. Now caught and fallen through.
- **The counter-fixture failed its own assertion under fine sampling.** It swept multiples of 20 and skipped 101–119; at K = K_safe the error is 1.186% against its own 0.1% gate, and degradation begins ~6% *below* the boundary. The grid is fixed and the gate re-anchored to this repo's measured ~1.5% AD-vs-FD noise floor, with a tighter check for the deep sub-wavefront region. The memory entry claiming "exactly at the predicted boundary" over-generalised from an under-sampled grid — **the same error class that entry exists to retract** — and now records its own second-pass correction inline rather than being silently rewritten.

## Verification

66 tests across the touched surfaces, including new tests that each fail on the pre-fix code: scale-invariance at the default beta (worst rel 6.8e+21 pre-fix against a 1e-3 gate), the NaN-purity case, mixed concrete/traced params in both orderings, the data-dependent-branch case, and every mixin method's qualname. Review measured against a pinned `git archive` rather than the live worktree — a sibling lane demonstrated that a builder editing the same checkout moves a reviewer's target silently, caught there only because a signature change happened to throw. ruff and `check_api_reference.py` clean.

R3: memory=feedback_gate_can_bind_artifact (a required-lane gate binding machine timing; a falsifier that failed its own assertion under finer sampling) + feedback_pin_verifier_to_archive | R2-attempts=1 per item | falsifier=each new test verified red on the pre-fix code, and the deflaked gate verified to pass on the exact ratio that redded main

🤖 Generated with [Claude Code](https://claude.com/claude-code)