### PR TITLE
fix(runners): late-bind rfx.simulation symbols in the uniform runner so a monkeypatch cannot leak permanently (closes #628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,17 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 - Fix: late-bind via `from rfx import simulation as _simulation`, calling
   `_simulation.run(...)` / `_simulation.run_until_decay(...)` — a module
   reference resolved at CALL time, not import time, so it always reflects
-  whatever `rfx.simulation.run` currently is. Not a hot path: each is
-  called exactly once per `run_uniform()` invocation (the single entry
-  point into the compiled `jax.lax.scan` FDTD loop), so the extra
+  whatever `rfx.simulation.run` currently is. `rfx/runners/uniform.py`'s
+  other five `rfx.simulation` names (`make_source`, `make_j_source`,
+  `make_probe`, `make_port_source`, `make_wire_port_sources`) are late-bound
+  the same way, even though none is currently monkeypatched anywhere in the
+  suite: closing the whole block removes the vulnerable SHAPE from the file
+  entirely, rather than leaving it one future `monkeypatch.setattr` away
+  from recurring in the exact file that already produced a multi-hour false
+  attribution during the #582 review. Not a hot path: all seven calls
+  happen at most once per `run_uniform()` invocation (setup-time
+  port/source/probe registration, or the single entry into the compiled
+  `jax.lax.scan` FDTD loop for `run`/`run_until_decay`), so the extra
   attribute lookup is negligible against that call's own runtime.
 - Same-shape audit (module-level `from rfx.X import Y` where `X` is
   monkeypatched by a test somewhere in the suite) across `rfx/runners/`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — import-time binding pollution in the uniform-grid runner (issue #628)
+
+- `rfx/runners/uniform.py` used to do `from rfx.simulation import run as
+  _run, run_until_decay as _run_until_decay` at MODULE level. That module is
+  imported lazily, the first time some `Simulation` call path actually needs
+  it, so if that first import happened while a test had
+  `rfx.simulation.run` monkeypatched, `rfx.runners.uniform._run`
+  permanently captured the patched stub — `monkeypatch`'s teardown restores
+  the attribute on the SOURCE module (`rfx.simulation`) but has no way to
+  reach the copy already bound into `rfx.runners.uniform`'s own namespace.
+  Every later uniform-lane run in that process then silently called the
+  stale stub. Order-dependent symptom: `pytest
+  tests/test_coax_two_port_fdtd.py tests/test_refplane_port_waves.py` gave
+  `1 failed, 63 passed` (a `TypeError` from the leaked stub in
+  `test_run_short_diagonals_byte_frozen_offdiagonals_move`); either file
+  alone, or the suite's usual collection order, passed clean.
+- Fix: late-bind via `from rfx import simulation as _simulation`, calling
+  `_simulation.run(...)` / `_simulation.run_until_decay(...)` — a module
+  reference resolved at CALL time, not import time, so it always reflects
+  whatever `rfx.simulation.run` currently is. Not a hot path: each is
+  called exactly once per `run_uniform()` invocation (the single entry
+  point into the compiled `jax.lax.scan` FDTD loop), so the extra
+  attribute lookup is negligible against that call's own runtime.
+- Same-shape audit (module-level `from rfx.X import Y` where `X` is
+  monkeypatched by a test somewhere in the suite) across `rfx/runners/`,
+  `rfx/api/`, `rfx/probes/`, and the package's other eager/lazy import
+  sites: no other instance is actually exposed. `rfx/__init__.py`,
+  `rfx/gpu.py`, `rfx/rcs.py`, and `rfx/sources/__init__.py` bind the same
+  `rfx.simulation`/`rfx.sources.coaxial_port` names, but all three import
+  eagerly, as part of `import rfx` itself, which necessarily completes
+  before any test can obtain a handle on the source module to patch it —
+  structurally impossible to race. `rfx/runners/__init__.py` re-exports
+  `run_uniform` from a module (`rfx.runners.uniform`) whose `run_uniform`
+  IS monkeypatched by `tests/test_passivity_guard_wiring.py`, but no
+  production call site consumes that package-level alias (every caller
+  imports `run_uniform` directly, locally, inside the calling function),
+  so a stale copy there is inert. `rfx/runners/distributed.py` and
+  `distributed_v2.py` import `make_source`/`make_j_source`/`make_probe`/
+  `make_port_source` from `rfx.simulation` the same lazily-bound way
+  `uniform.py` did, but none of those four names is patched by any current
+  test — left as module-level imports, flagged as the same latent shape
+  should a distributed-lane test ever patch one of them.
+- Regression tests: `tests/test_runner_import_binding.py`. The primary
+  test simulates the import-inside-patch-window sequence directly (forces
+  `rfx.runners.uniform` out of `sys.modules`, imports it inside an open
+  `monkeypatch.context()` on `rfx.simulation.run`, then asserts identity
+  after the window closes) — deterministic, independent of collection
+  order. A second, `@pytest.mark.slow` test locks the original two-file
+  subprocess repro as an ordering regression lock.
 ### Fixed — CPML hi-face pad was vacuum for domain-face-touching boxes (issue #627a; #627b attempted, found unsafe, reverted — deferred to issue #636)
 
 - Follow-up to #582's review, which found two gaps its uniform-vs-NU pad

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 import numpy as np
 import jax.numpy as jnp
 
+from rfx import simulation as _simulation
 from rfx.simulation import (
     make_source, make_j_source, make_probe, make_port_source, make_wire_port_sources,
-    run as _run, run_until_decay as _run_until_decay,
 )
+# `run`/`run_until_decay` stay a module reference (never `from ... import run as
+# _run`, #628): this module is first imported lazily, from inside
+# Simulation.run()/forward(), so an import-time alias can capture a
+# test-monkeypatched rfx.simulation.run permanently even after the patch is
+# torn down. Access as `_simulation.run(...)` so each call re-reads the
+# current attribute off the source module.
 from rfx.sources.sources import LumpedPort, setup_lumped_port, WirePort, setup_wire_port
 from rfx.probes.probes import init_dft_plane_probe, init_flux_monitor
 from rfx.sources.waveguide_port import (
@@ -633,7 +639,7 @@ def run_uniform(
 
     # Main simulation
     if until_decay is not None:
-        sim_result = _run_until_decay(
+        sim_result = _simulation.run_until_decay(
             grid, materials,
             decay_by=until_decay,
             check_interval=decay_check_interval,
@@ -671,7 +677,7 @@ def run_uniform(
             stencil_order=sim._stencil_order,
         )
     else:
-        sim_result = _run(
+        sim_result = _simulation.run(
             grid, materials, n_steps,
             boundary=sim._boundary,
             cpml_axes=cpml_axes,

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -6,15 +6,13 @@ import numpy as np
 import jax.numpy as jnp
 
 from rfx import simulation as _simulation
-from rfx.simulation import (
-    make_source, make_j_source, make_probe, make_port_source, make_wire_port_sources,
-)
-# `run`/`run_until_decay` stay a module reference (never `from ... import run as
-# _run`, #628): this module is first imported lazily, from inside
-# Simulation.run()/forward(), so an import-time alias can capture a
-# test-monkeypatched rfx.simulation.run permanently even after the patch is
-# torn down. Access as `_simulation.run(...)` so each call re-reads the
-# current attribute off the source module.
+# Every rfx.simulation symbol this module needs goes through `_simulation.*`
+# (never `from rfx.simulation import X as _x`, #628): this module is first
+# imported lazily, from inside Simulation.run()/forward(), so an import-time
+# alias can capture a test-monkeypatched rfx.simulation attribute
+# permanently, even after the patch is torn down — a module reference is
+# resolved at CALL time and always reflects the current attribute. These are
+# setup-time calls (once per port/source registration), not per-timestep.
 from rfx.sources.sources import LumpedPort, setup_lumped_port, WirePort, setup_wire_port
 from rfx.probes.probes import init_dft_plane_probe, init_flux_monitor
 from rfx.sources.waveguide_port import (
@@ -322,11 +320,11 @@ def run_uniform(
             # KIND only rescales the waveform inside the helper. kind=None
             # threads through as a no-op (legacy, bit-identical).
             if sim._boundary in ("cpml", "upml"):
-                sources.append(make_j_source(grid, pe.position, pe.component,
+                sources.append(_simulation.make_j_source(grid, pe.position, pe.component,
                                              pe.waveform, n_steps, materials,
                                              amplitude_kind=pe.amplitude_kind))
             else:
-                sources.append(make_source(grid, pe.position, pe.component,
+                sources.append(_simulation.make_source(grid, pe.position, pe.component,
                                            pe.waveform, n_steps,
                                            materials=materials,
                                            amplitude_kind=pe.amplitude_kind))
@@ -350,7 +348,7 @@ def run_uniform(
             materials = setup_wire_port(grid, wp, materials,
                                         pec_mask=pec_mask)
             if pe.excite:
-                sources.extend(make_wire_port_sources(
+                sources.extend(_simulation.make_wire_port_sources(
                     grid, wp, materials, n_steps, pec_mask=pec_mask))
             # Clear PEC mask at LIVE wire cells only (issue #318 commit 2).
             # Dead extent cells stay PEC: the old all-cells clearing punched
@@ -376,7 +374,7 @@ def run_uniform(
             lumped_ports.append(lp)
             materials = setup_lumped_port(grid, lp, materials)
             if pe.excite:
-                sources.append(make_port_source(grid, lp, materials, n_steps))
+                sources.append(_simulation.make_port_source(grid, lp, materials, n_steps))
             # Clear PEC mask at lumped port cell
             if pec_mask is not None:
                 idx = grid.position_to_index(pe.position)
@@ -479,7 +477,7 @@ def run_uniform(
                     pec_mask = pec_mask.at[cell[0], cell[1], cell[2]].set(False)
 
     for pe in sim._probes:
-        probes.append(make_probe(grid, pe.position, pe.component))
+        probes.append(_simulation.make_probe(grid, pe.position, pe.component))
 
     axis_to_index = {"x": 0, "y": 1, "z": 2}
     for pe in sim._dft_planes:

--- a/tests/test_runner_import_binding.py
+++ b/tests/test_runner_import_binding.py
@@ -1,0 +1,109 @@
+"""Regression coverage for issue #628: import-time binding pollution in
+``rfx/runners/uniform.py``.
+
+The defect: ``rfx/runners/uniform.py`` used to do
+``from rfx.simulation import run as _run`` at MODULE level. That module is
+imported lazily -- the first time some ``Simulation`` call path actually
+needs the uniform-grid runner (see ``rfx/api/_execute.py`` /
+``rfx/api/_sparams.py``, both of which import it locally, inside functions).
+If that first import happens while a test has ``rfx.simulation.run``
+monkeypatched (e.g. ``tests/test_coax_two_port_fdtd.py``'s
+``test_compute_coaxial_two_port_drive_index_matches_physical_port``),
+``rfx.runners.uniform._run`` permanently captures the patched stub -- pytest's
+``monkeypatch`` teardown restores ``rfx.simulation.run`` on the SOURCE module,
+but has no way to reach the copy already bound into ``rfx.runners.uniform``'s
+own namespace. Every later uniform-lane run in that process then silently
+calls the stale stub. The concrete symptom was order-dependent:
+``pytest tests/test_coax_two_port_fdtd.py tests/test_refplane_port_waves.py``
+gave ``1 failed, 63 passed`` (a ``TypeError`` from the leaked stub), while
+either file alone, or the suite in its usual collection order, passed clean.
+
+The fix: ``rfx/runners/uniform.py`` now does
+``from rfx import simulation as _simulation`` and calls
+``_simulation.run(...)`` / ``_simulation.run_until_decay(...)`` -- a module
+reference, resolved at CALL time, so it always reflects whatever
+``rfx.simulation.run`` currently is (patched or not).
+"""
+
+import subprocess
+import sys
+
+import pytest
+
+import rfx.simulation as _simulation_mod
+
+
+def _fake_run(*args, **kwargs):
+    raise AssertionError(
+        "rfx.runners.uniform called a stale, torn-down monkeypatched "
+        "rfx.simulation.run -- the #628 import-binding-pollution regression"
+    )
+
+
+def test_runner_uniform_resolves_run_after_patch_window_closes(monkeypatch):
+    """Direct mechanism test: simulate the import-inside-patch-window
+    sequence explicitly, without relying on pytest's collection order.
+
+    Forces ``rfx.runners.uniform`` (and its parent package, which itself
+    imports it at module level: ``rfx/runners/__init__.py``) out of
+    ``sys.modules`` so the next import is a genuine first import, opens a
+    monkeypatch window on ``rfx.simulation.run``, imports
+    ``rfx.runners.uniform`` for the first time *inside* that window (mirrors
+    a monkeypatching test running before any other test has ever touched the
+    uniform runner), then closes the window and asserts the runner still
+    resolves the CURRENT ``rfx.simulation.run`` rather than a frozen
+    reference to the fake.
+    """
+    for mod_name in ("rfx.runners.uniform", "rfx.runners"):
+        sys.modules.pop(mod_name, None)
+
+    real_run = _simulation_mod.run
+
+    with monkeypatch.context() as m:
+        m.setattr(_simulation_mod, "run", _fake_run)
+        import rfx.runners.uniform as uniform  # first import happens HERE, while patched
+        assert "rfx.runners.uniform" in sys.modules
+        # Sanity: the patch is live and reachable from the source module.
+        assert _simulation_mod.run is _fake_run
+
+    # Patch window closed: monkeypatch has restored the source module.
+    assert _simulation_mod.run is real_run
+
+    # The regression under test: the runner module must NOT still be
+    # pointing at the torn-down fake. Pre-fix, `uniform._run` would be
+    # `_fake_run` here (an import-time copy); post-fix, `uniform._simulation`
+    # is the live module object, so `.run` re-reads the current attribute.
+    assert uniform._simulation is _simulation_mod
+    assert uniform._simulation.run is real_run
+    assert uniform._simulation.run is not _fake_run
+
+
+@pytest.mark.slow
+def test_coax_then_refplane_order_does_not_leak_fake_run():
+    """Locks the original, concretely-observed symptom: running these two
+    files together, in this order, must not fail. Pre-fix this reliably gave
+    ``1 failed, 63 passed`` (a ``TypeError`` from the leaked stub in
+    ``test_run_short_diagonals_byte_frozen_offdiagonals_move``); each file
+    alone always passed, which is what made this an import-ORDER bug rather
+    than a bug either test file's author could see on its own.
+
+    Marked ``slow`` (subprocess + two real FDTD test files, ~20s) so it
+    doesn't sit on the fast default lane; it runs in the slow-tests CI shard.
+    """
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "pytest",
+            "tests/test_coax_two_port_fdtd.py",
+            "tests/test_refplane_port_waves.py",
+            "-q",
+        ],
+        cwd=__file__.rsplit("/tests/", 1)[0],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, (
+        "the order-dependent #628 repro reappeared:\n"
+        f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+    assert "failed" not in result.stdout, result.stdout


### PR DESCRIPTION
Closes #628. Found while attributing a failure during the #582 review — where this defect briefly produced a *false* attribution, which is the reason it is worth fixing rather than working around.

## The defect

`rfx/runners/uniform.py` bound `rfx.simulation` symbols at module import time (`from rfx.simulation import run as _run`). That module is imported **lazily**, from inside `Simulation.run()`/`forward()` — so whichever test happens to trigger its first import while `rfx.simulation.run` is monkeypatched captures the stub permanently in its own namespace, and `monkeypatch`'s teardown, which restores the source module, cannot reach the alias.

Two-file repro on base: `pytest tests/test_coax_two_port_fdtd.py tests/test_refplane_port_waves.py` → 1 failed / 63 passed, `TypeError: _fake_run() got an unexpected keyword argument 'pec_axes'`. Either file alone passes.

Mechanism confirmed directly rather than inferred from ordering: running the patching test alone in-process and then inspecting `sys.modules` shows `rfx.simulation.run` correctly restored while `rfx.runners.uniform._run is rfx.simulation.run` is **False** — the alias still held the stub.

## Why it mattered beyond an ordering annoyance

During the #582 review this poisoning produced a reading that the fix under review had broken an unrelated test. The reviewer's own instrument had imported `rfx.runners.nonuniform` at startup, which transitively imported `rfx.runners.uniform` *before* the patch window and accidentally cured the leak — so the contamination was invisible until the attribution was redone on a pristine tree. A defect that silently rewrites who is to blame is worth more than its symptom suggests.

## The fix, and the shape of it

This is a class, not a site, so the audit came first. Module-level `from X import Y` is only dangerous when **both** conditions hold: the module is imported lazily (so a patch window can precede its first import), and something patches the source module. Findings:

- **Fixed:** `rfx/runners/uniform.py`. All seven `rfx.simulation` symbols now resolve through `_simulation.*` at call time, so the module holds no aliases at all.
- **Safe, left alone:** `rfx/__init__.py`, `rfx/gpu.py`, `rfx/rcs.py`, `rfx/sources/__init__.py` — all imported eagerly as part of `import rfx`, so a test cannot obtain a handle to patch before they have executed. Structurally unable to race.
- **Safe by a different mechanism:** several patched symbols (`_pole_key`, `_auto_source_decay_time`, `_PROBE_FIELDS`, `_sigma_profile_1d`, …) are consumed only by bare-name lookup inside their own defining module, so patching the source always reaches every caller regardless of timing.
- **Inert but noted:** `rfx/runners/__init__.py`'s `run_uniform` alias is patched by a test, but nothing calls the package-level name — every real caller imports it locally. Zero blast radius today; recorded in the CHANGELOG as the same latent shape.
- **Same shape, no exposure:** `rfx/runners/distributed.py` and `distributed_v2.py`. Left untouched deliberately, to keep the diff scoped to the demonstrated defect, and documented.

Closing all seven names in the fixed file rather than only the two that were demonstrably exposed is deliberate: "this module holds no aliases into a patchable module" is an invariant a reader can check at a glance, whereas "it holds aliases, but only for names nobody happens to patch yet" is a property that expires silently the day someone adds a monkeypatch — in the very file that already cost one wrong attribution.

## Cost

`_simulation.run` / `run_until_decay` are each called once per `run_uniform()` invocation, and that single call is the entry into the whole compiled `lax.scan` time loop. The remaining five are setup-time. One attribute lookup against a call that runs for seconds to minutes.

## Verification

Regression tests are deliberately not dependent on pytest's future collection order: a fast, deterministic one that pops the module from `sys.modules`, imports it inside a `monkeypatch.context()`, closes the window and asserts the module resolves the real function; plus a `@slow` subprocess test that runs the original two-file repro and pins the symptom itself.

Falsifier: reverting only `rfx/runners/uniform.py` while keeping the tests reds both, with the leaked-stub signature. 73 passed / 0 failed across the directly affected files (`test_runner_import_binding`, `test_coax_two_port_fdtd`, `test_refplane_port_waves`, `test_wire_port_sparams_forward` which exercises the newly late-bound `make_wire_port_sources`/`make_port_source`, and `test_port_preflight`). ruff clean.

A broader ~30-file sweep was attempted and crashed at 76% with a native segfault inside `jaxlib`'s `backend_compile_and_load` while XLA compiled a `lax.scan` — in `test_wg_smatrix_golden_equivalence_float64`, whose call chain reaches `rfx.simulation.run` directly and never touches `rfx/runners/uniform.py` (stack grepped: zero hits). Everything before the crash was clean. Reported as an unrelated infra crash rather than re-run, since a Python-level attribute-access change cannot cause a fault inside the native XLA compiler and the box has been under sustained load.

R3: memory=feedback_verify_process_execution_context (an import-order confound silently rewrote an attribution during the #582 review) | R2-attempts=1 | falsifier=revert the runner alone, both regression tests red with the leaked-stub signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)