### PR TITLE
fix(vmap): sweep the CPML absorber for material-named sweeps — and retire the tolerance that was set above the defect (closes #637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,53 @@ this exact-hi-face case). Pinned by
 marked `xfail(strict=True)` so it turns into a hard failure — not a
 silent pass — the day #643 is closed.
 
+**No-worse guard added to `_extend_batched_cpml_pad`, found in review.**
+Re-running #637's own 7-configuration representativeness sweep on the
+rebased tree (unmodified geometries, not the margin-nudged variants
+elsewhere in this entry) surfaced that #627 didn't just leave the
+exact-hi-face case unfixed — for 4 of 7 configurations it made the
+vmap/`run()` divergence WORSE than #637's own pre-fix numbers, wherever
+a swept value happened to equal the base value. Mechanism: pre-#637-fix,
+the unconditional pad copy inherited base's OWN (post-#627, correct)
+pad value everywhere, so the swept-equals-base element was accidentally
+right; post-#637-fix, that same cell falls back to the naive vacuum
+column instead, since `_extend_batched_cpml_pad` doesn't reproduce
+#627's fallback — actively discarding a value that was already correct.
+Fix: skip the pad-cell overwrite when the source column is vacuum,
+using the SAME joint test `rasterize_grid._vacuum` uses
+(`eps_r==1.0 & sigma==0.0 & mu_r==1.0`, not a per-field approximation —
+an earlier draft tested each field against its own default independently
+and, measured against this file's suite, left the same two residuals
+this joint version does, since none of these fixtures carries a second
+material with nonzero sigma or non-unity `mu_r` to distinguish the two
+predicates; the joint version is kept because it is the one that
+matches the rest of the package and generalizes to fixtures the current
+suite doesn't happen to exercise).
+
+Effect, measured per swept element (not aggregated) across all 14
+elements in the 7-configuration sweep: every element where the swept
+value equals the base value is now exact or unchanged (previously
+already-correct by the coincidence described above; confirmed still
+correct, not merely no-worse). Of the 10 elements where the swept value
+differs from base, 8 improved (by 0.4% to 16.7%) or were unchanged, and
+2 remain measurably worse than #637's pre-fix numbers: the "issue-table
+base=2.0" configuration's `eps_r=10.0` element (6.421e-2 -> 6.527e-2,
++1.6%) and the "committed fixture" configuration's `eps_r=2.0` element
+(1.193e-2 -> 1.199e-2, +0.5%). Both residuals are small, reproduced
+identically across repeated measurement (not floating-point noise), and
+their specific mechanism is not established — the joint-vacuum fix did
+not change either number, so whatever produces them is a different,
+smaller effect than the predicate mismatch the guard targets. Both sit
+on the same exact-domain-edge geometry class already disclosed above
+and covered by the `xfail(strict=True)` witness; shipped with the
+residual disclosed rather than pursuing a third guard variant, since
+the class itself is already known-broken and tracked by #643, and #637's
+actual target class (material reaching a pad without sitting exactly on
+the domain edge) is unaffected — the "single-face touch (x_lo only)"
+configuration, which never touches a domain edge exactly, goes
+4.191e-3/8.729e-4 -> 2.623e-7/2.258e-7 pre- to post-fix, unchanged by
+the guard either way.
+
 ### Fixed — import-time binding pollution in the uniform-grid runner (issue #628)
 
 - `rfx/runners/uniform.py` used to do `from rfx.simulation import run as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,102 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — `vmap_material_sweep` didn't sweep the CPML absorber for material-named sweeps (issue #637)
+
+Found by an independent audit of the e4b565c..ce44661 arc: for a material-
+**named** sweep (`"substrate.eps_r"`, as opposed to a global `"eps_r"`
+sweep), `rfx/vmap_sweep.py`'s `_build_batched_materials` built its sweep
+mask from `Shape.mask(grid)` — physical-domain geometry cells only — and
+kept `base_materials` (the BASE simulation's own CPML-padded arrays)
+everywhere else, including the padding. `Simulation._assemble_materials`
+replicates each material's value into the CPML padding it touches
+(so the absorber stays impedance-matched); a material-named sweep never
+reached that replicated padding, so every swept batch element ran with
+an absorber matched to the *base* material instead of its own. Any
+substrate/dielectric running out to a CPML face — ordinary microwave
+geometry — was affected. Measured on the committed test fixture
+(box spanning the full transverse domain extent, `cpml_layers=6`, base
+`eps_r=4.0`, sweep `{2.0, 6.0}`): 780 of 12167 cells held the wrong
+`eps_r`; worst per-bin DFT-plane relative error against `sim.run()` was
+5.281e-4, which the previous `rtol=2e-3` gate absorbed and two test
+docstrings misattributed to "float32 accumulation roundoff" — the
+decisive discriminator (moving the same slab off the CPML faces so no
+material lands in the padding) dropped the identical comparison to
+exactly `0.0`, not merely smaller, which a genuine roundoff floor would
+not do. The error scaled with `|swept - base|`: up to ~6% relative on a
+harder edge-touching fixture, six orders above the old gate's nominal
+floor.
+
+Fix: a new `_extend_batched_cpml_pad` helper re-runs
+`_assemble_materials`'s own per-face edge-slice-copy padding rule on the
+already batch-correct interior (after the sweep mask is applied), so each
+swept batch element's padding matches what `Simulation.run()` would build
+for that value — a no-op on any face with zero CPML depth, so it is safe
+unconditionally. The GLOBAL (`"eps_r"`, no material name) sweep path was
+already accidentally correct (`non_vac = eps_r != 1.0` selects the
+replicated padding too, since it is evaluated on the already-padded base
+array) and is untouched; a new regression test pins that it stays
+correct. Verified post-fix on the original fixture: the edge-touching
+DFT-plane comparison against `run()` is exactly bit-identical (`0.0`),
+matching an inset (non-edge-touching) control that was already exact —
+stronger than the falsifier's own bar of "toward the inset floor" and,
+more generally, evidence that the vmap fast-path scan body reproduces
+`Simulation.run()` bit-for-bit whenever the two are actually handed the
+same materials (the padding mismatch, not independent scan-body
+roundoff, was the entire pre-fix gap). Re-measured across a
+representativeness sweep varying `|swept-base|`, which CPML face(s) the
+material touches, and `cpml_layers` (7 structurally distinct
+configurations, including two directly from the issue's own harder
+table): every configuration lands at or below ~4e-7 post-fix, bit-identical
+(`0.0`) on several including the committed fixture — versus 4.2e-3 to
+5.8e-2 pre-fix — four to five orders of magnitude tighter, none of it
+fitted to any one fixture.
+`tests/test_vmap_sweep_dft_planes.py` gates tightened from `rtol=2e-3` to
+`rtol=1e-6` (anchored near the measured float32/x64 floor with margin for
+cross-machine floating-point jitter) and gained three new tests: a
+mechanism-level pin comparing the batched material arrays directly
+against `Simulation._assemble_materials`, a second DFT-plane equivalence
+test on a structurally different geometry (touches the x_lo face instead
+of y/z, different domain/dx/cpml_layers/delta — its first draft touched
+the x_hi face at the exact domain-edge coordinate instead and turned out
+to be vacuous, since `Box.mask` is inclusive on a shape's `lo` corner but
+not its `hi` corner there; documented in the test's own docstring as a
+falsifier-of-the-test finding), and the global-sweep regression pin
+above. Two docstrings that attributed the defect's symptom to float32
+roundoff are corrected (module docstring and the x64 class docstring); a
+third (`TestVmapAmplitudeKindCurrent`) is partially corrected — its own
+floor also included this defect (4.89e-5 pre-fix, 2.60e-7 post-fix, an
+188x drop) alongside genuine dynamic-Cb float32 noise it was originally
+trying to describe.
+
+`tests/test_vmap_cpml_dielectric.py::test_vmap_cpml_dielectric_is_finite_and_matches_run`
+(a #205 regression pin, unrelated in origin) shared the same fixture
+shape as this defect but asserted only the one sweep element
+(`eps_r=10.0`) that happened to equal its base simulation's own
+material — the one element where #637 can never manifest by
+construction. Now asserts every swept element; the previously-unchecked
+`eps_r=4.0` element measured rel=9.65e-3 against `run()` pre-fix (the
+#637 signature) and is exactly bit-identical post-fix.
+
+**Overlap with issue #627 (landed separately as fce1091, this same
+Unreleased block, below):** #627 moved `Simulation._assemble_materials`'s
+pad-extension rule into a new shared
+`rfx.geometry.rasterize_grid.extend_cpml_pad_materials`, and changed the
+rule itself — a per-transverse-cell hi-face fallback (if the naive
+interior-edge column is vacuum but the column one further in is not,
+replicate from that inner column instead), fixing a case where a `Box`
+touching the domain's hi face loses its edge node to `Box`'s half-open
+rasterization. `_extend_batched_cpml_pad` (this entry) still reproduces
+the PRE-#627 rule — a straight edge-slice copy, no hi-face fallback — so
+after this rebase it is a known, not-yet-reconciled divergence: a
+material-named `vmap_material_sweep` on a box whose HI face lands
+exactly on the domain's last interior node still gets the #627a case
+wrong (vacuum pad on that face) even though `Simulation.run()` on the
+same geometry now gets it right. Both PR bodies already flag this as
+follow-up work rather than something either PR should absorb; see the
+next commit in this branch's history for the concrete before/after
+measurement.
+
 ### Fixed — import-time binding pollution in the uniform-grid runner (issue #628)
 
 - `rfx/runners/uniform.py` used to do `from rfx.simulation import run as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,15 @@ as issue #637's own pre-fix numbers, on a case this entry does not
 correct. Both PR bodies already flag reconciling the two helpers as
 follow-up work rather than something either PR should absorb now; this
 paragraph is that disclosure, not a promise of a later commit in this
-PR.
+PR. Tracked as **issue #643**, which also covers why the fix is not a
+drop-in (the batched arrays carry a leading sweep axis the shared
+helper's fallback test has to be evaluated per element against, not
+once) and its acceptance criterion (byte-identity between the batched
+path and `_assemble_materials` across #637's full geometry matrix plus
+this exact-hi-face case). Pinned by
+`tests/test_vmap_sweep_dft_planes.py::TestVmapMaterialSweepCpmlPad::test_exact_hi_face_touch_matches_run_via_shared_fallback`,
+marked `xfail(strict=True)` so it turns into a hard failure — not a
+silent pass — the day #643 is closed.
 
 ### Fixed — import-time binding pollution in the uniform-grid runner (issue #628)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,13 @@ an absorber matched to the *base* material instead of its own. Any
 substrate/dielectric running out to a CPML face — ordinary microwave
 geometry — was affected. Measured on the committed test fixture
 (box spanning the full transverse domain extent, `cpml_layers=6`, base
-`eps_r=4.0`, sweep `{2.0, 6.0}`): 780 of 12167 cells held the wrong
-`eps_r`; worst per-bin DFT-plane relative error against `sim.run()` was
-5.281e-4, which the previous `rtol=2e-3` gate absorbed and two test
+`eps_r=4.0`, sweep `{2.0, 6.0}`): originally 780 of 12167 cells held the
+wrong `eps_r` (re-measured at 2040/12167 after this branch's rebase onto
+issue #627, which independently fixed a related hi-face pad gap and, in
+doing so, corrected the reference `run()` used for this count too — see
+"Overlap with issue #627" below); worst per-bin DFT-plane relative error
+against `sim.run()` was 5.281e-4 (8.83e-4 on the rebased fixture), which
+the previous `rtol=2e-3` gate absorbed and two test
 docstrings misattributed to "float32 accumulation roundoff" — the
 decisive discriminator (moving the same slab off the CPML faces so no
 material lands in the padding) dropped the identical comparison to
@@ -70,9 +74,10 @@ falsifier-of-the-test finding), and the global-sweep regression pin
 above. Two docstrings that attributed the defect's symptom to float32
 roundoff are corrected (module docstring and the x64 class docstring); a
 third (`TestVmapAmplitudeKindCurrent`) is partially corrected — its own
-floor also included this defect (4.89e-5 pre-fix, 2.60e-7 post-fix, an
-188x drop) alongside genuine dynamic-Cb float32 noise it was originally
-trying to describe.
+floor also included this defect (6.88e-5 pre-fix, 1.74e-7 post-fix, a
+~396x drop, numbers re-measured after the rebase; conclusion unchanged
+from an earlier 4.89e-5/2.60e-7 pair) alongside genuine dynamic-Cb
+float32 noise it was originally trying to describe.
 
 `tests/test_vmap_cpml_dielectric.py::test_vmap_cpml_dielectric_is_finite_and_matches_run`
 (a #205 regression pin, unrelated in origin) shared the same fixture
@@ -84,23 +89,30 @@ construction. Now asserts every swept element; the previously-unchecked
 #637 signature) and is exactly bit-identical post-fix.
 
 **Overlap with issue #627 (landed separately as fce1091, this same
-Unreleased block, below):** #627 moved `Simulation._assemble_materials`'s
-pad-extension rule into a new shared
-`rfx.geometry.rasterize_grid.extend_cpml_pad_materials`, and changed the
-rule itself — a per-transverse-cell hi-face fallback (if the naive
-interior-edge column is vacuum but the column one further in is not,
-replicate from that inner column instead), fixing a case where a `Box`
-touching the domain's hi face loses its edge node to `Box`'s half-open
-rasterization. `_extend_batched_cpml_pad` (this entry) still reproduces
-the PRE-#627 rule — a straight edge-slice copy, no hi-face fallback — so
-after this rebase it is a known, not-yet-reconciled divergence: a
-material-named `vmap_material_sweep` on a box whose HI face lands
-exactly on the domain's last interior node still gets the #627a case
-wrong (vacuum pad on that face) even though `Simulation.run()` on the
-same geometry now gets it right. Both PR bodies already flag this as
-follow-up work rather than something either PR should absorb; see the
-next commit in this branch's history for the concrete before/after
-measurement.
+Unreleased block, below) — confirmed divergence, deliberately NOT fixed
+here.** #627 moved `Simulation._assemble_materials`'s pad-extension rule
+into a new shared `rfx.geometry.rasterize_grid.extend_cpml_pad_materials`,
+and changed the rule itself — a per-transverse-cell hi-face fallback (if
+the naive interior-edge column is vacuum but the column one further in is
+not, replicate from that inner column instead), fixing a case where a
+`Box` touching the domain's hi face loses its edge node to `Box`'s
+half-open rasterization. `_extend_batched_cpml_pad` (this entry) still
+reproduces the PRE-#627 rule — a straight edge-slice copy, no hi-face
+fallback. Measured directly post-rebase on a slab spanning the full
+domain (`Box((0,0,0), domain)`, touching all six CPML faces including
+x-hi exactly at the domain's last interior node, `cpml_layers=6`, base
+`eps_r=4.0`): `Simulation.run()`'s assembled x-hi pad now reads the
+correct `4.0` (the #627a fix); `vmap_material_sweep`'s batched x-hi pad
+for the SAME geometry stays at vacuum `1.0` regardless of the swept
+value (`2.0` and `6.0` both read `1.0` there) — the pre-#627 defect,
+unaffected by this entry's fix, which only ever reproduced the OLD rule.
+DFT-plane impact on this geometry: worst rel err 1.66e-2 (sweep to 2.0)
+/ 4.25e-2 (sweep to 6.0) against `run()` — the same order of magnitude
+as issue #637's own pre-fix numbers, on a case this entry does not
+correct. Both PR bodies already flag reconciling the two helpers as
+follow-up work rather than something either PR should absorb now; this
+paragraph is that disclosure, not a promise of a later commit in this
+PR.
 
 ### Fixed — import-time binding pollution in the uniform-grid runner (issue #628)
 

--- a/rfx/vmap_sweep.py
+++ b/rfx/vmap_sweep.py
@@ -123,7 +123,11 @@ def _parse_param_name(param_name: str) -> tuple[str | None, str]:
     return mat_name, field
 
 
-def _extend_batched_cpml_pad(field: jnp.ndarray, grid) -> jnp.ndarray:
+def _extend_batched_cpml_pad(
+    field: jnp.ndarray, grid, *,
+    companion_eps_r: jnp.ndarray, companion_sigma: jnp.ndarray,
+    companion_mu_r: jnp.ndarray,
+) -> jnp.ndarray:
     """Re-extend a BATCHED material field, shape ``(n_batch, Nx, Ny, Nz)``,
     into the CPML padding — the batched analogue of the per-face edge-slice
     replication in ``Simulation._assemble_materials``
@@ -143,6 +147,51 @@ def _extend_batched_cpml_pad(field: jnp.ndarray, grid) -> jnp.ndarray:
     same swept value, since the interior edge cell each pad cell copies
     from is now correctly set per batch element.
 
+    **No-worse guard (issue #643 interaction, found in review).** #627
+    (``rfx.geometry.rasterize_grid.extend_cpml_pad_materials``, PR #638)
+    added a hi-face fallback this function does not reproduce: when the
+    naive interior-edge column is vacuum but the column one further in is
+    not (the case a ``Box`` flush with the domain's hi face produces,
+    since ``Box``'s rasterization is half-open and drops that exact
+    node), the shared helper sources the pad from the inner column
+    instead. Post-#627, ``base_materials`` already carries that corrected
+    value at affected pad cells. Without this guard, this function would
+    unconditionally overwrite those cells with the (vacuum) naive column
+    — actively DISCARDING a value that was already right, for every swept
+    batch element, not merely failing to reach a cell that was always
+    wrong.
+
+    The guard: only overwrite a pad cell if its own source column is NOT
+    vacuum, where "vacuum" is the SAME joint test
+    ``rfx.geometry.rasterize_grid._vacuum`` uses --
+    ``eps_r == 1.0 & sigma == 0.0 & mu_r == 1.0`` -- not a per-field
+    approximation. An earlier version of this guard tested only the
+    field being extended against its own default (1.0 for eps_r/mu_r,
+    0.0 for sigma); measured against the representativeness sweep, that
+    version left two elements (of 14 measured, both ``swept != base``)
+    measurably worse than no guard at all, on the same class of geometry
+    the joint test is defined for -- a predicate mismatch with the rest
+    of the package, not a physics problem. The joint test resolved both.
+    ``companion_eps_r``/``companion_sigma``/``companion_mu_r`` are the
+    three material arrays to evaluate that joint test against at each
+    pad cell's source column: pass ``field`` itself for whichever of the
+    three IS the field being extended here (so the test uses each batch
+    element's OWN swept value for that field), and the base
+    (constant-across-batch, ``(Nx, Ny, Nz)``) array for the other two —
+    they are not swept, and their own padding is already correct as
+    inherited wholesale from ``base_materials``.
+
+    Where the source IS (jointly) vacuum, skip the overwrite — the
+    destination keeps whatever was already there, which is exactly
+    ``base_materials``' own (possibly #627a-corrected) value, since
+    nothing upstream of this function ever touches pad cells for cells
+    the sweep mask does not cover. This does NOT reproduce #627's
+    fallback (a genuinely-covered swept batch element with a non-base
+    value still won't reach that specific pad cell correctly — see the
+    ``test_exact_hi_face_touch_matches_run_via_shared_fallback`` xfail,
+    issue #643, the actual reconciliation) — it only guarantees this
+    function never makes a cell worse than doing nothing would have.
+
     A no-op on any face with zero pad depth (non-CPML boundary, or a
     reflector/periodic face with ``pad=0`` on that side), so this is safe
     to call unconditionally.
@@ -151,18 +200,41 @@ def _extend_batched_cpml_pad(field: jnp.ndarray, grid) -> jnp.ndarray:
     ply, phy = grid.pad_y_lo, grid.pad_y_hi
     plz, phz = grid.pad_z_lo, grid.pad_z_hi
     out = field
+
+    # Companions are either the batched field itself (ndim 4, whichever of
+    # the three this call is extending) or the base's constant-across-batch
+    # array (ndim 3, the other two) -- add a leading size-1 axis to the
+    # latter so every slice below broadcasts against the batch dimension.
+    def _as_batched(a):
+        return a if a.ndim == 4 else a[None]
+
+    c_eps = _as_batched(companion_eps_r)
+    c_sigma = _as_batched(companion_sigma)
+    c_mu = _as_batched(companion_mu_r)
+
+    def _guarded_set(out, dst_sl, src_sl):
+        src = out[src_sl]
+        cur = out[dst_sl]
+        vacuum = (
+            (c_eps[src_sl] == 1.0)
+            & (c_sigma[src_sl] == 0.0)
+            & (c_mu[src_sl] == 1.0)
+        )
+        new = jnp.where(vacuum, cur, src)
+        return out.at[dst_sl].set(new)
+
     if plx > 0:
-        out = out.at[:, :plx, :, :].set(out[:, plx:plx + 1, :, :])
+        out = _guarded_set(out, np.s_[:, :plx, :, :], np.s_[:, plx:plx + 1, :, :])
     if phx > 0:
-        out = out.at[:, -phx:, :, :].set(out[:, -phx - 1:-phx, :, :])
+        out = _guarded_set(out, np.s_[:, -phx:, :, :], np.s_[:, -phx - 1:-phx, :, :])
     if ply > 0:
-        out = out.at[:, :, :ply, :].set(out[:, :, ply:ply + 1, :])
+        out = _guarded_set(out, np.s_[:, :, :ply, :], np.s_[:, :, ply:ply + 1, :])
     if phy > 0:
-        out = out.at[:, :, -phy:, :].set(out[:, :, -phy - 1:-phy, :])
+        out = _guarded_set(out, np.s_[:, :, -phy:, :], np.s_[:, :, -phy - 1:-phy, :])
     if plz > 0:
-        out = out.at[:, :, :, :plz].set(out[:, :, :, plz:plz + 1])
+        out = _guarded_set(out, np.s_[:, :, :, :plz], np.s_[:, :, :, plz:plz + 1])
     if phz > 0:
-        out = out.at[:, :, :, -phz:].set(out[:, :, :, -phz - 1:-phz])
+        out = _guarded_set(out, np.s_[:, :, :, -phz:], np.s_[:, :, :, -phz - 1:-phz])
     return out
 
 
@@ -221,7 +293,10 @@ def _build_batched_materials(
             # -- extend the (now per-batch-correct) interior into the CPML
             # pad the same way the base simulation would for each swept
             # value, instead of leaving the base material's pad fill.
-            batch_eps = _extend_batched_cpml_pad(batch_eps, grid)
+            batch_eps = _extend_batched_cpml_pad(
+                batch_eps, grid, companion_eps_r=batch_eps,
+                companion_sigma=sigma, companion_mu_r=mu_r,
+            )
             batch_sigma = jnp.broadcast_to(sigma[None], (n_batch,) + sigma.shape)
             batch_mu = jnp.broadcast_to(mu_r[None], (n_batch,) + mu_r.shape)
         elif field == "sigma":
@@ -231,7 +306,10 @@ def _build_batched_materials(
                 param_values[:, None, None, None],
                 sigma[None],
             )
-            batch_sigma = _extend_batched_cpml_pad(batch_sigma, grid)
+            batch_sigma = _extend_batched_cpml_pad(
+                batch_sigma, grid, companion_eps_r=eps_r,
+                companion_sigma=batch_sigma, companion_mu_r=mu_r,
+            )
             batch_mu = jnp.broadcast_to(mu_r[None], (n_batch,) + mu_r.shape)
         else:  # mu_r
             batch_eps = jnp.broadcast_to(eps_r[None], (n_batch,) + eps_r.shape)
@@ -241,7 +319,10 @@ def _build_batched_materials(
                 param_values[:, None, None, None],
                 mu_r[None],
             )
-            batch_mu = _extend_batched_cpml_pad(batch_mu, grid)
+            batch_mu = _extend_batched_cpml_pad(
+                batch_mu, grid, companion_eps_r=eps_r,
+                companion_sigma=sigma, companion_mu_r=batch_mu,
+            )
     else:
         # Global sweep: apply to all non-background cells
         if field == "eps_r":

--- a/rfx/vmap_sweep.py
+++ b/rfx/vmap_sweep.py
@@ -123,6 +123,49 @@ def _parse_param_name(param_name: str) -> tuple[str | None, str]:
     return mat_name, field
 
 
+def _extend_batched_cpml_pad(field: jnp.ndarray, grid) -> jnp.ndarray:
+    """Re-extend a BATCHED material field, shape ``(n_batch, Nx, Ny, Nz)``,
+    into the CPML padding — the batched analogue of the per-face edge-slice
+    replication in ``Simulation._assemble_materials``
+    (``rfx/api/_compile.py:192-228``).
+
+    ``jnp.where(mask, param_values, base_field)`` (the caller) only ever
+    touches the physical-domain-interior cells that ``mask`` covers
+    (``Shape.mask`` returns False everywhere in the padding, since padding
+    cells map to physical coordinates outside the declared domain). The
+    padding faces of ``base_field`` were replicated from the BASE
+    simulation's edge slice, so every batch element inherits the base
+    material's absorber there regardless of its own swept value (issue
+    #637). Re-running the same per-face copy on the already-batch-correct
+    interior — same face order (x_lo, x_hi, y_lo, y_hi, z_lo, z_hi), same
+    "copy the interior-edge slice outward" rule — makes each batch
+    element's padding match what ``Simulation.run()`` would build for that
+    same swept value, since the interior edge cell each pad cell copies
+    from is now correctly set per batch element.
+
+    A no-op on any face with zero pad depth (non-CPML boundary, or a
+    reflector/periodic face with ``pad=0`` on that side), so this is safe
+    to call unconditionally.
+    """
+    plx, phx = grid.pad_x_lo, grid.pad_x_hi
+    ply, phy = grid.pad_y_lo, grid.pad_y_hi
+    plz, phz = grid.pad_z_lo, grid.pad_z_hi
+    out = field
+    if plx > 0:
+        out = out.at[:, :plx, :, :].set(out[:, plx:plx + 1, :, :])
+    if phx > 0:
+        out = out.at[:, -phx:, :, :].set(out[:, -phx - 1:-phx, :, :])
+    if ply > 0:
+        out = out.at[:, :, :ply, :].set(out[:, :, ply:ply + 1, :])
+    if phy > 0:
+        out = out.at[:, :, -phy:, :].set(out[:, :, -phy - 1:-phy, :])
+    if plz > 0:
+        out = out.at[:, :, :, :plz].set(out[:, :, :, plz:plz + 1])
+    if phz > 0:
+        out = out.at[:, :, :, -phz:].set(out[:, :, :, -phz - 1:-phz])
+    return out
+
+
 def _build_batched_materials(
     sim,
     grid,
@@ -134,10 +177,23 @@ def _build_batched_materials(
 
     For a global sweep (e.g. ``"eps_r"``), the parameter is applied to
     **all non-vacuum cells** that have the swept property differing from 1.0
-    (for eps_r/mu_r) or 0.0 (for sigma).
+    (for eps_r/mu_r) or 0.0 (for sigma). This already reaches the CPML
+    padding without special-casing: ``base_materials`` replicates each
+    material's actual (non-vacuum) value into its padding
+    (``_assemble_materials``), so the ``!= 1.0`` / ``!= 0.0`` test is True
+    there too and the global sweep overwrites those pad cells along with
+    the interior ones (issue #637 scope note — verified by
+    ``test_global_sweep_pad_cells_still_correct`` in
+    ``tests/test_vmap_sweep_dft_planes.py``).
 
     For a material-specific sweep (e.g. ``"substrate.eps_r"``), the parameter
-    is applied only to cells occupied by that named material.
+    is applied only to cells occupied by that named material — geometry
+    cells only, via ``Shape.mask``. Unlike the global case, ``mask`` is
+    False everywhere in the CPML padding (padding cells sit outside the
+    physical domain ``Shape.mask`` tests against), so the padding is
+    handled separately below via ``_extend_batched_cpml_pad`` (issue #637):
+    without it, every swept batch element would run against a pad matched
+    to the BASE material instead of its own.
     """
     mat_name, field = _parse_param_name(param_name)
     n_batch = len(param_values)
@@ -161,6 +217,11 @@ def _build_batched_materials(
                 param_values[:, None, None, None],  # (n_batch, 1, 1, 1)
                 eps_r[None],  # (1, Nx, Ny, Nz)
             )
+            # #637: the mask above only covers the physical-domain interior
+            # -- extend the (now per-batch-correct) interior into the CPML
+            # pad the same way the base simulation would for each swept
+            # value, instead of leaving the base material's pad fill.
+            batch_eps = _extend_batched_cpml_pad(batch_eps, grid)
             batch_sigma = jnp.broadcast_to(sigma[None], (n_batch,) + sigma.shape)
             batch_mu = jnp.broadcast_to(mu_r[None], (n_batch,) + mu_r.shape)
         elif field == "sigma":
@@ -170,6 +231,7 @@ def _build_batched_materials(
                 param_values[:, None, None, None],
                 sigma[None],
             )
+            batch_sigma = _extend_batched_cpml_pad(batch_sigma, grid)
             batch_mu = jnp.broadcast_to(mu_r[None], (n_batch,) + mu_r.shape)
         else:  # mu_r
             batch_eps = jnp.broadcast_to(eps_r[None], (n_batch,) + eps_r.shape)
@@ -179,6 +241,7 @@ def _build_batched_materials(
                 param_values[:, None, None, None],
                 mu_r[None],
             )
+            batch_mu = _extend_batched_cpml_pad(batch_mu, grid)
     else:
         # Global sweep: apply to all non-background cells
         if field == "eps_r":

--- a/tests/test_vmap_cpml_dielectric.py
+++ b/tests/test_vmap_cpml_dielectric.py
@@ -45,6 +45,22 @@ def test_vmap_cpml_dielectric_is_finite_and_matches_run():
 
     Pre-#205-fix this diverges to NaN/inf because the vmap scan used free-space
     CPML inside the eps_r dielectric.
+
+    #637 completeness note: this originally asserted ONLY ``ts[1]``
+    (eps_r=10.0) against ``run()`` — the base simulation below is built
+    with ``eps_r=10.0`` too, so ``ts[1]`` is the one sweep element whose
+    value happens to EQUAL the base material. #637 was exactly "a
+    material-named sweep's CPML padding stays matched to the base
+    simulation instead of the swept value" — for the one element that
+    already IS the base value, that padding is correct by construction,
+    so this test could never have caught it (or a regression of its
+    fix) via ``ts[1]`` alone. ``ts[0]`` (eps_r=4.0, which DIFFERS from
+    the base 10.0) is the load-bearing assertion: measured directly,
+    pre-#637-fix ``ts[0]`` disagreed with ``run(eps_r=4.0)`` at
+    rel=9.65e-03 (the #637 defect signature — the padding stayed
+    matched to eps_r=10.0 while the interior correctly swept to 4.0);
+    post-fix both ``ts[0]`` and ``ts[1]`` are exactly bit-identical
+    (0.0) with their respective ``run()`` references.
     """
     eps_values = np.array([4.0, 10.0])
     n_steps = 300  # buggy tree reaches ~1e26 well before this
@@ -66,15 +82,20 @@ def test_vmap_cpml_dielectric_is_finite_and_matches_run():
         "— absorber likely mismatched."
     )
 
-    # Correctness: the eps_r=10 sweep element must reproduce the material-aware
-    # uniform run() path (the supported reference) on the same geometry.
-    ref = np.asarray(
-        _full_dielectric_cpml_sim(10.0).run(n_steps=n_steps).time_series
-    )
-    np.testing.assert_allclose(
-        ts[1], ref, atol=1e-5, rtol=1e-4,
-        err_msg="vmap CPML sweep (eps_r=10) disagrees with material-aware run()",
-    )
+    # Correctness: EVERY sweep element must reproduce the material-aware
+    # uniform run() path (the supported reference) on the same geometry --
+    # eps_r=4.0 (differs from the base 10.0, the #637 CPML-padding
+    # regression guard) AND eps_r=10.0 (matches base, kept for continuity
+    # with the original #205 pin).
+    for idx, ev in enumerate(eps_values):
+        ref = np.asarray(
+            _full_dielectric_cpml_sim(float(ev)).run(n_steps=n_steps).time_series
+        )
+        np.testing.assert_allclose(
+            ts[idx], ref, atol=1e-5, rtol=1e-4,
+            err_msg=f"vmap CPML sweep (eps_r={ev}) disagrees with "
+                    f"material-aware run()",
+        )
 
 
 def test_vmap_cpml_distinct_eps_change_response():

--- a/tests/test_vmap_cpml_dielectric.py
+++ b/tests/test_vmap_cpml_dielectric.py
@@ -27,13 +27,29 @@ from rfx.vmap_sweep import vmap_material_sweep
 def _full_dielectric_cpml_sim(eps_r: float):
     """CPML sim whose dielectric fills the ENTIRE domain (incl. all 6 CPML
     faces), so the absorber sees the dielectric — the geometry that exposes a
-    free-space-CPML divergence."""
+    free-space-CPML divergence.
+
+    Hi bound is domain-edge + half a cell (0.021, not 0.02): ``Box``'s
+    rasterization is half-open (``[lo, hi)``), so a hi bound landing
+    EXACTLY on the domain edge drops that edge node from the box's own
+    mask on all three axes here. Unrelated to this file's #205 mechanism,
+    but it interacts with issue #627 (``rfx.geometry.rasterize_grid``'s
+    hi-face pad vacuum fallback, landed as fce1091): post-#627,
+    ``Simulation.run()`` recovers that node via the fallback while this
+    file's ``vmap_material_sweep`` call does not reproduce that fallback
+    (see #637's CHANGELOG entry, "Overlap with issue #627" — an
+    already-disclosed, deliberately out-of-scope gap for #637). Without
+    this margin, ``test_vmap_cpml_dielectric_is_finite_and_matches_run``
+    would fail for that separate, unrelated reason. Confirmed directly
+    the margin stays inside the interior (0 mask cells inside the actual
+    CPML pad) before landing this change.
+    """
     sim = Simulation(
         freq_max=5e9, domain=(0.02, 0.02, 0.02),
         boundary="cpml", cpml_layers=6, dx=0.002,
     )
     sim.add_material("d", eps_r=eps_r)
-    sim.add(Box((0.0, 0.0, 0.0), (0.02, 0.02, 0.02)), material="d")
+    sim.add(Box((0.0, 0.0, 0.0), (0.021, 0.021, 0.021)), material="d")
     sim.add_source((0.01, 0.01, 0.01), "ez", waveform=GaussianPulse(f0=3e9))
     sim.add_probe((0.006, 0.01, 0.01), "ez")
     return sim

--- a/tests/test_vmap_sweep_dft_planes.py
+++ b/tests/test_vmap_sweep_dft_planes.py
@@ -429,6 +429,69 @@ class TestVmapMaterialSweepCpmlPad:
                 ref.dft_planes, rtol=1e-6, ctx=f"global sweep eps_r={ev}",
             )
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Known gap, issue #643 (opened from this PR's own review): "
+            "_extend_batched_cpml_pad does not reproduce "
+            "rfx.geometry.rasterize_grid.extend_cpml_pad_materials' "
+            "hi-face vacuum fallback (added by #627, PR #638) -- when the "
+            "naive interior-edge column is vacuum but the column one "
+            "further in is not (the case a Box's half-open [lo, hi) "
+            "rasterization produces for a structure flush with the "
+            "domain's hi face), the shared helper sources the pad from "
+            "that inner column; this file's vmap helper still reads the "
+            "naive (vacuum) column. Measured directly on this exact "
+            "fixture: worst per-bin DFT-plane relative error against "
+            "run() is 1.66e-2 (eps_r=2.0) / 4.25e-2 (eps_r=6.0) -- the "
+            "same order of magnitude as #637's own pre-fix defect, on "
+            "the one geometry #637's fix does not reach. strict=True so "
+            "this flips to an XPASS failure (not a silent pass) the day "
+            "someone closes #643 -- delete this test then, do not widen "
+            "it."
+        ),
+    )
+    def test_exact_hi_face_touch_matches_run_via_shared_fallback(self):
+        """Witness for issue #643 -- a slab whose bound sits EXACTLY on
+        the domain's hi face (all six CPML faces via a `Box((0,0,0),
+        domain)`, mirroring the #582/#627 discovery fixture), swept by
+        material name. `Simulation.run()` gets the x-hi/y-hi/z-hi pads
+        right post-#627 (the shared helper's fallback); the vmap fast
+        path does not. Every OTHER test in this file (and #637's own
+        representativeness sweep) deliberately nudges its geometry a
+        half-cell past the domain edge specifically to AVOID this case
+        (see ``_dft_sim`` and the alternate-geometry test's own inline
+        comments) -- without this xfail, nothing in the shipped suite
+        would ever touch the exact property #643 tracks."""
+        domain = (0.02, 0.02, 0.02)
+        cpml_layers = 6
+        dx = 0.002
+        eps_values = np.array([2.0, 6.0])
+        n_steps = 60
+
+        def sim_fn(eps_r):
+            sim = Simulation(freq_max=5e9, domain=domain, boundary="cpml",
+                              cpml_layers=cpml_layers, dx=dx)
+            sim.add_material("slab", eps_r=eps_r)
+            sim.add(Box((0, 0, 0), domain), material="slab")
+            sim.add_source((0.01, 0.01, 0.01), "ez",
+                            waveform=GaussianPulse(f0=3e9))
+            sim.add_probe((0.006, 0.01, 0.01), "ez")
+            sim.add_dft_plane_probe(axis="x", coordinate=0.006,
+                                     component="ez", n_freqs=4, name="p1")
+            return sim
+
+        vmap_res = vmap_material_sweep(
+            sim_fn(4.0), "slab.eps_r", eps_values, n_steps=n_steps,
+        )
+        for idx, ev in enumerate(eps_values):
+            ref = sim_fn(float(ev)).run(n_steps=n_steps, skip_preflight=True)
+            _assert_dft_planes_match(
+                {"p1": vmap_res.dft_planes["p1"][idx]},
+                ref.dft_planes, rtol=1e-6,
+                ctx=f"exact-hi-face-touch (#643) eps_r={ev}",
+            )
+
 
 class TestVmapDftPlaneX64:
     """#477/#484 x64-contract pin, scoped (never module-level, per repo

--- a/tests/test_vmap_sweep_dft_planes.py
+++ b/tests/test_vmap_sweep_dft_planes.py
@@ -17,15 +17,20 @@ That was wrong. The fixture's ``substrate`` box spans the full transverse
 material-NAMED sweep mask (``Shape.mask``, geometry cells only) never
 covers the CPML padding, so every swept batch element ran with a padding
 absorber matched to the BASE simulation's eps_r (4.0) instead of its own
--- 780 of 12167 cells wrong on this exact grid. The ~5e-4 floor was that
-defect, not roundoff: moving the same slab off the CPML faces (so no
-material lands in the padding) made the identical comparison exactly
-``0.0`` -- not merely smaller, bit-identical -- which a genuine
-independent-roundoff floor would not do. #637 fixed the padding
-(``_extend_batched_cpml_pad`` in ``rfx/vmap_sweep.py`` re-runs the same
-per-face edge-slice-copy ``_assemble_materials`` uses, on the already
-batch-correct interior, so each swept batch element's padding matches
-what ``Simulation.run()`` would build for that value).
+-- 2040 of 12167 cells wrong on this exact grid (re-measured after the
+y/z hi bound below was nudged past the domain edge for issue #627's
+rebase interaction -- see that bound's own inline comment; the earlier
+780-cell count predates that nudge and undercounted because #627a's own
+pre-fix bug ALSO left the y_hi/z_hi pad incorrectly vacuum in the
+reference, masking part of this defect's true footprint). The ~5e-4
+floor was that defect, not roundoff: moving the same slab off the CPML
+faces (so no material lands in the padding) made the identical
+comparison exactly ``0.0`` -- not merely smaller, bit-identical -- which
+a genuine independent-roundoff floor would not do. #637 fixed the
+padding (``_extend_batched_cpml_pad`` in ``rfx/vmap_sweep.py`` re-runs
+the same per-face edge-slice-copy ``_assemble_materials`` uses, on the
+already batch-correct interior, so each swept batch element's padding
+matches what ``Simulation.run()`` would build for that value).
 
 R5 per-bin dump, POST-FIX (batched vmap vs. sequential ``sim.run()``,
 plane p1 = axis=x, coordinate=0.010 m, component=ez, n_freqs=4, eps_r=2.0,
@@ -33,10 +38,10 @@ n_steps=60 -- eps_r=6.0 and the non-CPML (``pec``) boundary are also
 exactly ``0.0`` at every bin and are omitted for brevity):
 
     freq (Hz)     |run acc|      |vmap acc|     complex maxdiff   rel diff
-    5.0000e+08    4.857830e-12   4.857830e-12   0.000000e+00      0.000e+00
-    2.0000e+09    4.366568e-12   4.366568e-12   0.000000e+00      0.000e+00
-    3.5000e+09    3.554534e-12   3.554534e-12   0.000000e+00      0.000e+00
-    5.0000e+09    2.804546e-12   2.804546e-12   0.000000e+00      0.000e+00
+    5.0000e+08    4.856995e-12   4.856995e-12   0.000000e+00      0.000e+00
+    2.0000e+09    4.365797e-12   4.365797e-12   0.000000e+00      0.000e+00
+    3.5000e+09    3.553883e-12   3.553883e-12   0.000000e+00      0.000e+00
+    5.0000e+09    2.804024e-12   2.804024e-12   0.000000e+00      0.000e+00
 
 Falsifier (temporary sign flip of the vmap DFT kernel to ``exp(+1j...)``,
 reverted via ``git checkout`` immediately after each run): relative error
@@ -46,45 +51,52 @@ ONLY the ``TestVmapDftPlaneFastPath`` tests went red, confirming the
 falsifier is localized to the code path it is meant to catch (this part
 of the ritual is unchanged by #637 and was re-run against the fixed code
 to confirm it still catches a kernel defect). #637's own falsifier
-(reverting ONLY the pad-extension fix, i.e. the 780-cell defect, while
-keeping everything else fixed) reproduces the original ~5e-4 floor --
-reviewable by reverting ``_extend_batched_cpml_pad``'s call sites in
-``rfx/vmap_sweep.py`` and re-running this file: exactly
+(reverting ONLY the pad-extension fix, i.e. the 2040-cell defect, while
+keeping everything else fixed) reproduces a ~9e-4 floor (8.83e-4
+measured, up from the pre-rebase ~5e-4 for the same reason the cell
+count moved) -- reviewable by reverting ``_extend_batched_cpml_pad``'s
+call sites in ``rfx/vmap_sweep.py`` and re-running this file: exactly
 ``test_dft_plane_matches_run_cpml``,
 ``TestVmapMaterialSweepCpmlPad::test_material_named_sweep_pad_cells_match_run_materials``,
 ``TestVmapMaterialSweepCpmlPad::test_dft_plane_matches_run_alternate_geometry``,
 and ``test_dft_plane_matches_run_cpml_x64`` go red (the global-sweep pin
 and everything unrelated stay green) -- an independent reviewer
-reproduced this exact four-test signature separately. The gate below
-(``rtol=1e-6``) is anchored near the observed floor with margin for
-cross-machine floating-point reduction-order jitter (this repo's own
-experience is that cross-machine float comparisons are not bit-exact --
-see the CI slow-suite agent-memory entry; an independent re-measurement
-of the CHANGELOG's separate 7-configuration representativeness sweep on
+reproduced this exact four-test signature separately (on the pre-rebase
+fixture; not re-verified against this file's post-rebase numbers, but
+the mechanism and the four-test signature are unchanged, only the exact
+magnitude moved with the cell count). The gate below (``rtol=1e-6``) is
+anchored near the observed floor with margin for cross-machine
+floating-point reduction-order jitter (this repo's own experience is
+that cross-machine float comparisons are not bit-exact -- see the CI
+slow-suite agent-memory entry; an independent re-measurement of the
+CHANGELOG's separate 7-configuration representativeness sweep on
 different hardware got exactly ``0.0`` on all seven, where this
 session's machine measured them at-or-below ~4e-7 -- same conclusion,
 different floating-point path), not fitted to hide a defect: it is
-~500x tighter than the old ``2e-3`` and five to six orders of magnitude
-below every pre-fix defect measurement (5.3e-4 on this fixture; 4.2e-3
+~1000x tighter than the old ``2e-3`` and five to six orders of magnitude
+below every pre-fix defect measurement (8.83e-4 on this fixture; 4.2e-3
 to 5.8e-2 across that representativeness sweep, PR
 `fix/637-vmap-sweep-cpml-pad`).
 
 Gate bracketing (why ``1e-6`` and not looser or tighter): from BELOW,
 every measured post-fix residual on this file's DFT-plane fixtures is
-<=4.12e-8 (>=24x margin), and the sibling fixture where the two paths
+<=3.3e-8 at n_steps=60 (>=30x margin; see the x64 class docstring for
+how this floor grows with ``n_steps`` on the SAME fixture -- it is not a
+fixture-independent bound), and the sibling fixture where the two paths
 genuinely execute different arithmetic --
 ``TestVmapAmplitudeKindCurrent`` (dynamic per-batch Cb-normalization,
 not a shared code path with the DFT-plane kernel; a raw-time-series
 comparison, not this file's per-bin DFT metric) -- measured on this
-session's machine at 2.60e-7 (cpml, eps_r=2.0) / 1.56e-7 (eps_r=6.0),
-and independently re-measured at 2.05e-7/3.43e-7 on different hardware:
-both machines land in the same 1.5e-7 to 3.4e-7 band, still >=3x under
-even in the looser direction -- itself a second data point for the
-cross-machine-jitter margin above, not just the ``1e-6`` anchor. From
-ABOVE, the weakest defect signal the gate must still catch is
-``test_dft_plane_matches_run_alternate_geometry``'s ~1.1e-5 pre-fix
-measurement; a gate at ``1e-5`` would leave that only 1.1x headroom and
-destroy it as a falsifier. ``1e-6`` sits inside both bounds. Thread-count
+session's machine at 1.74e-7 (cpml, eps_r=2.0) / 4.17e-7 (eps_r=6.0):
+still comfortably under even at the looser value -- a second data point
+for the cross-machine-jitter margin above, not just the ``1e-6`` anchor
+(an independent, pre-rebase re-measurement on different hardware landed
+in the same 1.5e-7 to 3.4e-7 order of magnitude; not re-verified
+post-rebase). From ABOVE, the weakest defect signal the gate must still
+catch is ``test_dft_plane_matches_run_alternate_geometry``'s ~1.3e-5
+pre-fix measurement; a gate at ``1e-5`` would leave that only 1.3x
+headroom and destroy it as a falsifier. ``1e-6`` sits inside both
+bounds. Thread-count
 sweep (1 to 192 CPUs, same fixtures): zero spread -- the compared
 quantities (a single batch element's DFT accumulator vs. a single
 sequential run's) contain no cross-batch or cross-space reduction for
@@ -128,7 +140,22 @@ def _dft_sim(boundary: str = "cpml", eps_r: float = 4.0,
         dx=0.002, **kwargs,
     )
     sim.add_material("substrate", eps_r=eps_r)
-    sim.add(Box((0.005, 0, 0), (0.015, 0.02, 0.02)), material="substrate")
+    # y/z hi bound is domain-edge + half a cell, not exactly the domain
+    # edge: Box's rasterization is half-open ([lo, hi), see Box's own
+    # docstring) so a hi bound landing EXACTLY on the domain edge drops
+    # that edge node from the box's own mask -- unrelated to #637, but it
+    # interacts with it post-#627 (rfx.geometry.rasterize_grid's hi-face
+    # vacuum fallback, closes-#627 fce1091): run() now correctly
+    # recovers that node via the fallback, this file's vmap helper
+    # doesn't reproduce that fallback (out of scope here, see the #637
+    # CHANGELOG entry's "Overlap with issue #627" paragraph), so without
+    # this margin every test built on this fixture would fail for a
+    # SEPARATE, already-disclosed reason unrelated to what they test.
+    # The margin is far short of entering the CPML pad itself (half a
+    # cell vs. the pad's full cpml_layers=6 cells), so it only recovers
+    # the one excluded interior node -- confirmed directly (0 mask cells
+    # inside the pad region) before landing this change.
+    sim.add(Box((0.005, 0, 0), (0.015, 0.021, 0.021)), material="substrate")
     sim.add_source((0.01, 0.01, 0.01), "ez", waveform=GaussianPulse(f0=3e9),
                     amplitude_kind=amplitude_kind)
     sim.add_probe((0.005, 0.01, 0.01), "ez")
@@ -287,8 +314,10 @@ class TestVmapMaterialSweepCpmlPad:
     def test_material_named_sweep_pad_cells_match_run_materials(self):
         """Direct, bit-exact comparison of the batched material arrays
         against ``sim._assemble_materials`` for each swept value -- the
-        780-wrong-cells measurement from the #637 issue, pinned as a
-        regression instead of an ad-hoc script."""
+        2040-wrong-cells measurement from the #637 issue (see the module
+        docstring for why this count moved from the issue's original 780
+        after the #627 rebase), pinned as a regression instead of an
+        ad-hoc script."""
         from rfx.vmap_sweep import _build_batched_materials
 
         eps_values = np.array([2.0, 6.0])
@@ -334,8 +363,12 @@ class TestVmapMaterialSweepCpmlPad:
         cell CPML padding replicates from (0 non-vacuum pad cells, base
         AND swept alike). Touching via the ``lo`` corner instead (as
         below) reaches the padding: measured pre-fix worst rel err
-        2.08e-05 / 1.13e-05 (comfortably above the ``rtol=1e-6`` gate),
-        exactly ``0.0`` post-fix.
+        2.50e-05 / 1.34e-05 (comfortably above the ``rtol=1e-6`` gate),
+        exactly ``0.0`` post-fix. (Re-measured after the y/z hi bound
+        below was nudged past the domain edge for issue #627's rebase
+        interaction, see that bound's own inline comment -- the earlier
+        2.08e-05/1.13e-05 pair predates that nudge and is superseded by
+        these numbers, not a separate discrepancy.)
         """
         domain = (0.024, 0.016, 0.016)
         cpml_layers = 5
@@ -349,7 +382,11 @@ class TestVmapMaterialSweepCpmlPad:
             sim.add_material("slab", eps_r=eps_r)
             # touches x_lo, full y/z extent -- the committed fixture above
             # touches y/z faces and leaves x alone; this is the mirror.
-            sim.add(Box((0.0, 0.0, 0.0), (0.008, 0.016, 0.016)),
+            # y/z hi bound is domain-edge + half a cell, same reason as
+            # _dft_sim above (Box's half-open-hi exclusion at an exact
+            # domain-edge coordinate, unrelated to #637 but interacting
+            # with #627's hi-face pad fallback post-rebase).
+            sim.add(Box((0.0, 0.0, 0.0), (0.008, 0.017, 0.017)),
                     material="slab")
             sim.add_source((0.016, 0.008, 0.008), "ez",
                             waveform=GaussianPulse(f0=3e9))
@@ -408,35 +445,36 @@ class TestVmapDftPlaneX64:
     genuine precision floor, so there was nothing for x64 to fail to
     tighten. Post-fix, on this fixture AT n_steps=60: default precision
     is exactly 0.0 at every bin (bit-identical vmap-vs-run); x64 is NOT
-    bit-identical, worst observed 4.12e-08 (eps_r=6.0, highest-frequency
+    bit-identical, worst observed 3.30e-08 (eps_r=6.0, highest-frequency
     bin) -- i.e. x64 promotes the DFT accumulator to complex128 but the
     underlying field state is still produced by the same float32-pinned
     Yee kernels, so accumulating in higher precision surfaces a genuine
     (tiny) float32-vs-float64 promotion-order residual that default
     precision's exact bit-identity can't show.
 
-    That 4.12e-08 is a property of THIS fixture AT n_steps=60, not a
+    That 3.30e-08 is a property of THIS fixture AT n_steps=60, not a
     fixture-independent precision bound -- it is not safe to read as "the
-    x64 floor is ~4e-8" in general. Sweeping n_steps on the same fixture
-    (signal-bearing bins only): 1.01e-07 (120 steps), 4.41e-07 (200),
-    ~6.4e-06 (300) -- growing smoothly as the DFT window covers more of
-    the pulse's post-source evolution, more steps of float32-pinned Yee
-    accumulation to promote into the complex128 sum. Past a fixture- and
-    bin-dependent point (this fixture's highest-frequency bin, past
-    n_steps~=300) the reference magnitude itself decays toward the
-    numerical noise floor as that bin's spectral content leaves the
-    window; the ratio then blows up on a shrinking denominator, not a
-    growing numerator -- 4.39e-03 at n_steps=400 on this fixture's
-    weakest bin is that artefact (verified: the ABSOLUTE difference
-    barely moves between n_steps=300 and 400, only the reference
-    magnitude collapses), the same near-zero-denominator failure mode
-    ``_assert_dft_planes_match``'s own docstring warns about for an
-    elementwise check -- not evidence of divergence. ``rtol=1e-6`` covers
-    the genuine n_steps=60 floor with ~24x margin (see the module
-    docstring's gate-bracketing note for the full argument); it is not
-    claimed to generalize to arbitrarily long ``n_steps`` on other
-    fixtures, and a future test built on a longer-duration fixture should
-    re-derive its own floor rather than assume this one."""
+    x64 floor is ~3e-8" in general. Sweeping n_steps on the same fixture
+    (signal-bearing bins only): 1.06e-07 (120 steps), 3.80e-07 (200) --
+    growing smoothly as the DFT window covers more of the pulse's
+    post-source evolution, more steps of float32-pinned Yee accumulation
+    to promote into the complex128 sum. Past a fixture- and bin-dependent
+    point (this fixture's highest-frequency bin, past n_steps~=300) the
+    reference magnitude itself decays toward the numerical noise floor as
+    that bin's spectral content leaves the window; the ratio then blows
+    up on a shrinking denominator, not a growing numerator -- 2.26e-03 at
+    n_steps=400 on this fixture's weakest bin is that artefact (verified:
+    the ABSOLUTE difference barely moves between n_steps=300 and 400
+    (1.40e-17 to 9.13e-18 -- if anything it drops slightly), only the
+    reference magnitude collapses, ~28x (1.21e-13 to 4.04e-15)), the same
+    near-zero-denominator failure mode ``_assert_dft_planes_match``'s own
+    docstring warns about for an elementwise check -- not evidence of
+    divergence. ``rtol=1e-6`` covers the genuine n_steps=60 floor with
+    ~30x margin (see the module docstring's gate-bracketing note for the
+    full argument); it is not claimed to generalize to arbitrarily long
+    ``n_steps`` on other fixtures, and a future test built on a
+    longer-duration fixture should re-derive its own floor rather than
+    assume this one."""
 
     def test_dft_plane_matches_run_cpml_x64(self):
         eps_values = np.array([2.0, 6.0])
@@ -573,16 +611,21 @@ class TestVmapAmplitudeKindCurrent:
     whole observed floor to "ordinary float32 FDTD chaos, not a
     phase/sign defect". That was only half right. Measured directly
     (max|diff| / max|ref| on the raw time series, same fixture, cpml
-    eps_r=2.0, n_steps=20): pre-#637-fix 4.89e-05, post-fix 2.60e-07 --
-    an 188x drop, so part of this test's own floor WAS the #637
+    eps_r=2.0, n_steps=20): pre-#637-fix 6.88e-05, post-fix 1.74e-07 --
+    a ~396x drop (re-measured post-#627-rebase; the exact figures moved
+    from an earlier 4.89e-05/2.60e-07 pair for the same reason the
+    module docstring's cell count moved, but the conclusion is
+    unchanged), so part of this test's own floor WAS the #637
     CPML-padding defect leaking into the probe reading through the
     mismatched absorber, not pure roundoff. The remaining post-fix floor
-    (2.6e-07) IS genuine float32 dynamic-Cb arithmetic noise: it now
+    (1.74e-07) IS genuine float32 dynamic-Cb arithmetic noise: it now
     matches the ``boundary="pec"`` case (1.87e-07, no CPML padding to be
-    wrong in the first place) to within the same order of magnitude, and
-    #637's fix does not touch this code path's Cb computation. The
-    ``rtol=1e-3`` gate below sits ~4000x above that genuine floor, so it
-    was never a tight fit to any defect and is left unchanged."""
+    wrong in the first place, and unchanged by the rebase since it has no
+    CPML pad to interact with #627 either) to within the same order of
+    magnitude, and #637's fix does not touch this code path's Cb
+    computation. The ``rtol=1e-3`` gate below sits ~5700x above that
+    genuine floor, so it was never a tight fit to any defect and is left
+    unchanged."""
 
     def test_amplitude_kind_current_matches_run_cpml(self):
         eps_values = np.array([2.0, 6.0])

--- a/tests/test_vmap_sweep_dft_planes.py
+++ b/tests/test_vmap_sweep_dft_planes.py
@@ -9,35 +9,61 @@ inspected per-bin dump (not asserted blind), and a one-sided falsifier
 ritual (deliberate sign flip in the vmap DFT kernel, which must turn the
 equivalence check red) was run before this tolerance was trusted.
 
-R5 per-bin dump (batched vmap vs. sequential ``sim.run()``, plane p1 =
-axis=x, coordinate=0.010 m, component=ez, n_freqs=4, eps_r=2.0, n_steps=60
--- the eps_r=6.0 case measured tighter, 2.6e-4 to 2.8e-4 uniformly, and is
-omitted for brevity):
+CORRECTED (#637): this docstring previously reported a ~5e-4 relative
+floor on this exact fixture and attributed it to "ordinary float32
+accumulation roundoff between the two independently-coded scan bodies".
+That was wrong. The fixture's ``substrate`` box spans the full transverse
+(y, z) extent of the domain, i.e. it touches the CPML faces; the
+material-NAMED sweep mask (``Shape.mask``, geometry cells only) never
+covers the CPML padding, so every swept batch element ran with a padding
+absorber matched to the BASE simulation's eps_r (4.0) instead of its own
+-- 780 of 12167 cells wrong on this exact grid. The ~5e-4 floor was that
+defect, not roundoff: moving the same slab off the CPML faces (so no
+material lands in the padding) made the identical comparison exactly
+``0.0`` -- not merely smaller, bit-identical -- which a genuine
+independent-roundoff floor would not do. #637 fixed the padding
+(``_extend_batched_cpml_pad`` in ``rfx/vmap_sweep.py`` re-runs the same
+per-face edge-slice-copy ``_assemble_materials`` uses, on the already
+batch-correct interior, so each swept batch element's padding matches
+what ``Simulation.run()`` would build for that value).
+
+R5 per-bin dump, POST-FIX (batched vmap vs. sequential ``sim.run()``,
+plane p1 = axis=x, coordinate=0.010 m, component=ez, n_freqs=4, eps_r=2.0,
+n_steps=60 -- eps_r=6.0 and the non-CPML (``pec``) boundary are also
+exactly ``0.0`` at every bin and are omitted for brevity):
 
     freq (Hz)     |run acc|      |vmap acc|     complex maxdiff   rel diff
-    5.0000e+08    4.857830e-12   4.857516e-12   2.500504e-15      5.147e-04
-    2.0000e+09    4.366568e-12   4.366276e-12   2.269723e-15      5.198e-04
-    3.5000e+09    3.554534e-12   3.554285e-12   1.870204e-15      5.261e-04
-    5.0000e+09    2.804546e-12   2.804345e-12   1.480970e-15      5.281e-04
+    5.0000e+08    4.857830e-12   4.857830e-12   0.000000e+00      0.000e+00
+    2.0000e+09    4.366568e-12   4.366568e-12   0.000000e+00      0.000e+00
+    3.5000e+09    3.554534e-12   3.554534e-12   0.000000e+00      0.000e+00
+    5.0000e+09    2.804546e-12   2.804546e-12   0.000000e+00      0.000e+00
 
-Magnitudes agree to ~5 significant figures at every bin (rel diff 2.6e-4 to
-5.3e-4, uniform across frequency and eps_r) -- consistent with ordinary
-float32 accumulation roundoff between the two independently-coded scan
-bodies, not a systematic phase/sign/off-by-one defect. Falsifier (temporary
-sign flip of the vmap DFT kernel to ``exp(+1j...)``, reverted via ``git
-checkout`` immediately after each run): relative error jumped to 0.11-1.79
-(O(1)) uniformly across every bin, both when run as a standalone script and
-when run against this committed pytest file -- and ONLY the
-``TestVmapDftPlaneFastPath`` tests went red, confirming the falsifier is
-localized to the code path it is meant to catch. So the gates below use
-rtol with a comfortable margin above the observed ~5e-4 floor, not a
-tight-as-possible bound.
+Falsifier (temporary sign flip of the vmap DFT kernel to ``exp(+1j...)``,
+reverted via ``git checkout`` immediately after each run): relative error
+jumped to 0.11-1.79 (O(1)) uniformly across every bin, both when run as a
+standalone script and when run against this committed pytest file -- and
+ONLY the ``TestVmapDftPlaneFastPath`` tests went red, confirming the
+falsifier is localized to the code path it is meant to catch (this part
+of the ritual is unchanged by #637 and was re-run against the fixed code
+to confirm it still catches a kernel defect). #637's own falsifier
+(reverting ONLY the pad-extension fix, i.e. the 780-cell defect, while
+keeping everything else fixed) reproduces the original ~5e-4 floor --
+captured in ``docs/research_notes/`` / the PR body, not re-run on every
+CI pass. The gate below (``rtol=1e-6``) is anchored near the observed
+floor with margin for cross-machine floating-point reduction-order
+jitter (this repo's own experience is that cross-machine float
+comparisons are not bit-exact -- see the CI slow-suite agent-memory
+entry), not fitted to hide a defect: it is ~500x tighter than the old
+``2e-3`` and five to six orders of magnitude below every pre-fix defect
+measurement (5.3e-4 on this fixture; 4.2e-3 to 5.8e-2 across the broader
+#637 representativeness sweep in the PR body).
 """
 
 from __future__ import annotations
 
 import warnings
 
+import jax.numpy as jnp
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -144,9 +170,12 @@ class TestVmapDftPlaneFastPath:
 
         for idx, ev in enumerate(eps_values):
             ref = _dft_sim("cpml", eps_r=float(ev)).run(n_steps=n_steps)
+            # #637: post-fix this is exactly 0.0 at every bin (measured);
+            # rtol=1e-6 anchors near that floor with margin for
+            # cross-machine float jitter, not fitted to the old defect.
             _assert_dft_planes_match(
                 {"p1": vmap_res.dft_planes["p1"][idx]},
-                ref.dft_planes, rtol=2e-3, ctx=f"cpml eps_r={ev}",
+                ref.dft_planes, rtol=1e-6, ctx=f"cpml eps_r={ev}",
             )
 
     def test_dft_plane_matches_run_pec(self):
@@ -162,9 +191,14 @@ class TestVmapDftPlaneFastPath:
         )
         for idx, ev in enumerate(eps_values):
             ref = _dft_sim("pec", eps_r=float(ev)).run(n_steps=n_steps)
+            # PEC has no CPML padding (grid.pad_*=0), so #637 never applied
+            # here -- measured exactly 0.0 at every bin both before and
+            # after the fix. Tightened alongside the cpml gate for the
+            # same reason (was sitting at a loose rtol=2e-3 with no
+            # measurement behind it).
             _assert_dft_planes_match(
                 {"p1": vmap_res.dft_planes["p1"][idx]},
-                ref.dft_planes, rtol=2e-3, ctx=f"pec eps_r={ev}",
+                ref.dft_planes, rtol=1e-6, ctx=f"pec eps_r={ev}",
             )
 
     def test_dft_plane_dtype_matches_run(self):
@@ -193,17 +227,162 @@ class TestVmapDftPlaneFastPath:
         assert res.dft_planes is None
 
 
+class TestVmapMaterialSweepCpmlPad:
+    """#637 regression coverage: a material-NAMED sweep must reach the
+    CPML padding replicated from that material, not inherit the base
+    simulation's padding. Three angles, deliberately not three copies of
+    the same fixture (this arc was previously burned by a fixture-specific
+    claim -- see the #637 PR body's representativeness table):
+
+    1. Mechanism-level: the swept batch ``MaterialArrays`` themselves must
+       match what ``Simulation._assemble_materials`` would build for that
+       swept value, cell-for-cell -- no time-stepping involved, so this
+       isolates ``_build_batched_materials``/``_extend_batched_cpml_pad``
+       from any downstream FDTD-kernel equivalence question.
+    2. A STRUCTURALLY DIFFERENT geometry from the module's ``_dft_sim``
+       fixture (touches only the x_hi CPML face, not all four transverse
+       faces; different domain, dx, cpml_layers, and |swept-base| delta)
+       -- chosen adverse to "the fix only happens to work for the
+       committed shape".
+    3. The GLOBAL (non-material-named) sweep path, which was already
+       accidentally correct before #637 (``non_vac = eps_r != 1.0`` in
+       ``_build_batched_materials`` happens to select the replicated
+       padding too) -- pinned so #637's fix to the material-named branch
+       cannot regress the global branch it does not touch.
+    """
+
+    def test_material_named_sweep_pad_cells_match_run_materials(self):
+        """Direct, bit-exact comparison of the batched material arrays
+        against ``sim._assemble_materials`` for each swept value -- the
+        780-wrong-cells measurement from the #637 issue, pinned as a
+        regression instead of an ad-hoc script."""
+        from rfx.vmap_sweep import _build_batched_materials
+
+        eps_values = np.array([2.0, 6.0])
+        base_sim = _dft_sim("cpml", eps_r=4.0)
+        grid = base_sim._build_grid()
+        base_materials, *_ = base_sim._assemble_materials(grid)
+
+        batched = _build_batched_materials(
+            base_sim, grid, base_materials, "substrate.eps_r",
+            jnp.asarray(eps_values),
+        )
+
+        for idx, ev in enumerate(eps_values):
+            want_sim = _dft_sim("cpml", eps_r=float(ev))
+            want_materials, *_ = want_sim._assemble_materials(grid)
+            npt.assert_array_equal(
+                np.asarray(batched.eps_r[idx]),
+                np.asarray(want_materials.eps_r),
+                err_msg=f"batched eps_r at swept value {ev} disagrees with "
+                        f"run()'s own _assemble_materials -- CPML padding "
+                        f"not correctly swept (#637)",
+            )
+            # sigma/mu_r are not swept by this param_name and must be
+            # untouched (same as run()'s, since the material only varies
+            # eps_r here).
+            npt.assert_array_equal(
+                np.asarray(batched.sigma[idx]), np.asarray(want_materials.sigma))
+            npt.assert_array_equal(
+                np.asarray(batched.mu_r[idx]), np.asarray(want_materials.mu_r))
+
+    def test_dft_plane_matches_run_alternate_geometry(self):
+        """A geometry NOT sharing the committed fixture's shape: touches
+        the x_lo CPML face (the fixture above touches y/z faces, never
+        x), domain/dx/cpml_layers/delta all differ from ``_dft_sim`` too.
+
+        Built via a falsifier ritual of its own: an earlier draft of this
+        test used a box touching the x_HI face at exactly the domain
+        edge and passed identically before and after the #637 fix (a
+        vacuous, non-discriminating test). Inspecting the assembled
+        materials showed why -- ``Box.mask`` is inclusive on a shape's
+        ``lo`` corner but not on its ``hi`` corner at an exact domain-edge
+        coordinate, so that box never actually reached the interior edge
+        cell CPML padding replicates from (0 non-vacuum pad cells, base
+        AND swept alike). Touching via the ``lo`` corner instead (as
+        below) reaches the padding: measured pre-fix worst rel err
+        2.08e-05 / 1.13e-05 (comfortably above the ``rtol=1e-6`` gate),
+        exactly ``0.0`` post-fix.
+        """
+        domain = (0.024, 0.016, 0.016)
+        cpml_layers = 5
+        dx = 0.002
+        eps_values = np.array([2.5, 9.0])
+        n_steps = 40
+
+        def sim_fn(eps_r):
+            sim = Simulation(freq_max=5e9, domain=domain, boundary="cpml",
+                              cpml_layers=cpml_layers, dx=dx)
+            sim.add_material("slab", eps_r=eps_r)
+            # touches x_lo, full y/z extent -- the committed fixture above
+            # touches y/z faces and leaves x alone; this is the mirror.
+            sim.add(Box((0.0, 0.0, 0.0), (0.008, 0.016, 0.016)),
+                    material="slab")
+            sim.add_source((0.016, 0.008, 0.008), "ez",
+                            waveform=GaussianPulse(f0=3e9))
+            sim.add_probe((0.018, 0.008, 0.008), "ez")
+            sim.add_dft_plane_probe(axis="x", coordinate=0.016,
+                                     component="ez", n_freqs=3, name="p1")
+            return sim
+
+        vmap_res = vmap_material_sweep(
+            sim_fn(5.0), "slab.eps_r", eps_values, n_steps=n_steps,
+        )
+        for idx, ev in enumerate(eps_values):
+            ref = sim_fn(float(ev)).run(n_steps=n_steps, skip_preflight=True)
+            _assert_dft_planes_match(
+                {"p1": vmap_res.dft_planes["p1"][idx]},
+                ref.dft_planes, rtol=1e-6,
+                ctx=f"alternate geometry (x_lo-only touch) eps_r={ev}",
+            )
+
+    def test_global_sweep_pad_cells_still_correct(self):
+        """SCOPE CHECK (#637): the GLOBAL ``"eps_r"`` sweep (no material
+        name) does not go through ``_extend_batched_cpml_pad`` at all --
+        it was already correct because ``non_vac = eps_r != 1.0`` is
+        evaluated on the already-padded ``base_materials.eps_r``, which
+        is non-1.0 in the padding too (replicated from the same
+        non-vacuum material). Pin that this stays true post-#637, on the
+        SAME edge-touching fixture the material-named tests use, so a
+        future change to the material-named branch cannot silently break
+        the global branch it must not touch."""
+        eps_values = np.array([2.0, 6.0])
+        n_steps = 60
+
+        vmap_res = vmap_material_sweep(
+            _dft_sim("cpml", eps_r=4.0), "eps_r", eps_values, n_steps=n_steps,
+        )
+        for idx, ev in enumerate(eps_values):
+            ref = _dft_sim("cpml", eps_r=float(ev)).run(n_steps=n_steps)
+            _assert_dft_planes_match(
+                {"p1": vmap_res.dft_planes["p1"][idx]},
+                ref.dft_planes, rtol=1e-6, ctx=f"global sweep eps_r={ev}",
+            )
+
+
 class TestVmapDftPlaneX64:
     """#477/#484 x64-contract pin, scoped (never module-level, per repo
     rule): under ``jax_enable_x64``, ``init_dft_plane_probe`` (called
     identically by both the vmap fast path and ``run()``) selects
     ``complex128`` instead of ``complex64`` (rfx/probes/probes.py:441).
     This is a separate axis from the default-precision equivalence tests
-    above -- confirm the promoted dtype AND that equivalence still holds
-    (same ~5e-4 relative floor observed at default precision; x64 widens
-    the accumulator's storage precision but the underlying field state is
-    still produced by the same float32-pinned Yee kernels, so the
-    numerical agreement floor does not tighten)."""
+    above -- confirm the promoted dtype AND that equivalence still holds.
+
+    CORRECTED (#637): this docstring previously claimed the x64 floor was
+    "the same ~5e-4 relative floor" as default precision and that it
+    "does not tighten" under x64. Both halves were wrong -- that 5e-4 was
+    the #637 CPML-padding defect (see the module docstring), not a
+    genuine precision floor, so there was nothing for x64 to fail to
+    tighten. Post-fix, measured on this fixture: default precision is
+    exactly 0.0 at every bin (bit-identical vmap-vs-run); x64 is NOT
+    bit-identical, worst observed 4.12e-08 (eps_r=6.0, highest-frequency
+    bin) -- i.e. x64 promotes the DFT accumulator to complex128 but the
+    underlying field state is still produced by the same float32-pinned
+    Yee kernels, so accumulating in higher precision surfaces a genuine
+    (tiny) float32-vs-float64 promotion-order residual that default
+    precision's exact bit-identity can't show. ``rtol=1e-6`` covers this
+    with ~24x margin while remaining far below any #637-class defect
+    magnitude."""
 
     def test_dft_plane_matches_run_cpml_x64(self):
         eps_values = np.array([2.0, 6.0])
@@ -221,7 +400,7 @@ class TestVmapDftPlaneX64:
                 assert ref.dft_planes["p1"].accumulator.dtype == np.complex128
                 _assert_dft_planes_match(
                     {"p1": vmap_res.dft_planes["p1"][idx]},
-                    ref.dft_planes, rtol=2e-3, ctx=f"x64 cpml eps_r={ev}",
+                    ref.dft_planes, rtol=1e-6, ctx=f"x64 cpml eps_r={ev}",
                 )
 
 
@@ -334,12 +513,22 @@ class TestVmapAmplitudeKindCurrent:
     ``_build_vmap_scan_fn`` (rfx/vmap_sweep.py:450-468) -- until this
     file, no test exercised it at the ``vmap_material_sweep`` level (the
     #617 coverage gap named in the #578 design doc). Tolerance is looser
-    than the DFT-plane gate above: at n_steps=20 the observed relative
-    floor between the vmap dynamic-Cb path and run()'s equivalent is
-    ~5e-5 (grows with step count as the dielectric-filled small CPML
-    domain accumulates reflections -- ordinary float32 FDTD chaos, not a
-    phase/sign defect; see the module docstring for the falsifier
-    argument)."""
+    than the DFT-plane gate above: ``rtol=1e-3`` on the raw time series.
+
+    PARTIALLY CORRECTED (#637): this docstring previously attributed the
+    whole observed floor to "ordinary float32 FDTD chaos, not a
+    phase/sign defect". That was only half right. Measured directly
+    (max|diff| / max|ref| on the raw time series, same fixture, cpml
+    eps_r=2.0, n_steps=20): pre-#637-fix 4.89e-05, post-fix 2.60e-07 --
+    an 188x drop, so part of this test's own floor WAS the #637
+    CPML-padding defect leaking into the probe reading through the
+    mismatched absorber, not pure roundoff. The remaining post-fix floor
+    (2.6e-07) IS genuine float32 dynamic-Cb arithmetic noise: it now
+    matches the ``boundary="pec"`` case (1.87e-07, no CPML padding to be
+    wrong in the first place) to within the same order of magnitude, and
+    #637's fix does not touch this code path's Cb computation. The
+    ``rtol=1e-3`` gate below sits ~4000x above that genuine floor, so it
+    was never a tight fit to any defect and is left unchanged."""
 
     def test_amplitude_kind_current_matches_run_cpml(self):
         eps_values = np.array([2.0, 6.0])

--- a/tests/test_vmap_sweep_dft_planes.py
+++ b/tests/test_vmap_sweep_dft_planes.py
@@ -48,15 +48,48 @@ of the ritual is unchanged by #637 and was re-run against the fixed code
 to confirm it still catches a kernel defect). #637's own falsifier
 (reverting ONLY the pad-extension fix, i.e. the 780-cell defect, while
 keeping everything else fixed) reproduces the original ~5e-4 floor --
-captured in ``docs/research_notes/`` / the PR body, not re-run on every
-CI pass. The gate below (``rtol=1e-6``) is anchored near the observed
-floor with margin for cross-machine floating-point reduction-order
-jitter (this repo's own experience is that cross-machine float
-comparisons are not bit-exact -- see the CI slow-suite agent-memory
-entry), not fitted to hide a defect: it is ~500x tighter than the old
-``2e-3`` and five to six orders of magnitude below every pre-fix defect
-measurement (5.3e-4 on this fixture; 4.2e-3 to 5.8e-2 across the broader
-#637 representativeness sweep in the PR body).
+reviewable by reverting ``_extend_batched_cpml_pad``'s call sites in
+``rfx/vmap_sweep.py`` and re-running this file: exactly
+``test_dft_plane_matches_run_cpml``,
+``TestVmapMaterialSweepCpmlPad::test_material_named_sweep_pad_cells_match_run_materials``,
+``TestVmapMaterialSweepCpmlPad::test_dft_plane_matches_run_alternate_geometry``,
+and ``test_dft_plane_matches_run_cpml_x64`` go red (the global-sweep pin
+and everything unrelated stay green) -- an independent reviewer
+reproduced this exact four-test signature separately. The gate below
+(``rtol=1e-6``) is anchored near the observed floor with margin for
+cross-machine floating-point reduction-order jitter (this repo's own
+experience is that cross-machine float comparisons are not bit-exact --
+see the CI slow-suite agent-memory entry; an independent re-measurement
+of the CHANGELOG's separate 7-configuration representativeness sweep on
+different hardware got exactly ``0.0`` on all seven, where this
+session's machine measured them at-or-below ~4e-7 -- same conclusion,
+different floating-point path), not fitted to hide a defect: it is
+~500x tighter than the old ``2e-3`` and five to six orders of magnitude
+below every pre-fix defect measurement (5.3e-4 on this fixture; 4.2e-3
+to 5.8e-2 across that representativeness sweep, PR
+`fix/637-vmap-sweep-cpml-pad`).
+
+Gate bracketing (why ``1e-6`` and not looser or tighter): from BELOW,
+every measured post-fix residual on this file's DFT-plane fixtures is
+<=4.12e-8 (>=24x margin), and the sibling fixture where the two paths
+genuinely execute different arithmetic --
+``TestVmapAmplitudeKindCurrent`` (dynamic per-batch Cb-normalization,
+not a shared code path with the DFT-plane kernel; a raw-time-series
+comparison, not this file's per-bin DFT metric) -- measured on this
+session's machine at 2.60e-7 (cpml, eps_r=2.0) / 1.56e-7 (eps_r=6.0),
+and independently re-measured at 2.05e-7/3.43e-7 on different hardware:
+both machines land in the same 1.5e-7 to 3.4e-7 band, still >=3x under
+even in the looser direction -- itself a second data point for the
+cross-machine-jitter margin above, not just the ``1e-6`` anchor. From
+ABOVE, the weakest defect signal the gate must still catch is
+``test_dft_plane_matches_run_alternate_geometry``'s ~1.1e-5 pre-fix
+measurement; a gate at ``1e-5`` would leave that only 1.1x headroom and
+destroy it as a falsifier. ``1e-6`` sits inside both bounds. Thread-count
+sweep (1 to 192 CPUs, same fixtures): zero spread -- the compared
+quantities (a single batch element's DFT accumulator vs. a single
+sequential run's) contain no cross-batch or cross-space reduction for
+either code path to reorder differently under a different thread count,
+so there is no mechanism for this floor to move with parallelism.
 """
 
 from __future__ import annotations
@@ -373,16 +406,37 @@ class TestVmapDftPlaneX64:
     "does not tighten" under x64. Both halves were wrong -- that 5e-4 was
     the #637 CPML-padding defect (see the module docstring), not a
     genuine precision floor, so there was nothing for x64 to fail to
-    tighten. Post-fix, measured on this fixture: default precision is
-    exactly 0.0 at every bin (bit-identical vmap-vs-run); x64 is NOT
+    tighten. Post-fix, on this fixture AT n_steps=60: default precision
+    is exactly 0.0 at every bin (bit-identical vmap-vs-run); x64 is NOT
     bit-identical, worst observed 4.12e-08 (eps_r=6.0, highest-frequency
     bin) -- i.e. x64 promotes the DFT accumulator to complex128 but the
     underlying field state is still produced by the same float32-pinned
     Yee kernels, so accumulating in higher precision surfaces a genuine
     (tiny) float32-vs-float64 promotion-order residual that default
-    precision's exact bit-identity can't show. ``rtol=1e-6`` covers this
-    with ~24x margin while remaining far below any #637-class defect
-    magnitude."""
+    precision's exact bit-identity can't show.
+
+    That 4.12e-08 is a property of THIS fixture AT n_steps=60, not a
+    fixture-independent precision bound -- it is not safe to read as "the
+    x64 floor is ~4e-8" in general. Sweeping n_steps on the same fixture
+    (signal-bearing bins only): 1.01e-07 (120 steps), 4.41e-07 (200),
+    ~6.4e-06 (300) -- growing smoothly as the DFT window covers more of
+    the pulse's post-source evolution, more steps of float32-pinned Yee
+    accumulation to promote into the complex128 sum. Past a fixture- and
+    bin-dependent point (this fixture's highest-frequency bin, past
+    n_steps~=300) the reference magnitude itself decays toward the
+    numerical noise floor as that bin's spectral content leaves the
+    window; the ratio then blows up on a shrinking denominator, not a
+    growing numerator -- 4.39e-03 at n_steps=400 on this fixture's
+    weakest bin is that artefact (verified: the ABSOLUTE difference
+    barely moves between n_steps=300 and 400, only the reference
+    magnitude collapses), the same near-zero-denominator failure mode
+    ``_assert_dft_planes_match``'s own docstring warns about for an
+    elementwise check -- not evidence of divergence. ``rtol=1e-6`` covers
+    the genuine n_steps=60 floor with ~24x margin (see the module
+    docstring's gate-bracketing note for the full argument); it is not
+    claimed to generalize to arbitrarily long ``n_steps`` on other
+    fixtures, and a future test built on a longer-duration fixture should
+    re-derive its own floor rather than assume this one."""
 
     def test_dft_plane_matches_run_cpml_x64(self):
         eps_values = np.array([2.0, 6.0])


### PR DESCRIPTION
Closes #637. Found by an independent audit of the `e4b565c..ce44661` arc. The mechanism predates that arc; what the arc did was route claims-bearing frequency-domain output through it and then set a gate above the error it produced — including in a PR body I wrote, which called the residual float32 roundoff.

## The defect

For a material-**named** sweep, `rfx/vmap_sweep.py` built its mask from `entry.shape.mask(grid)` — geometry cells only — and kept `base_materials` everywhere else. But `base_materials` carries the CPML pad replication filled with the **base** material value. So every swept batch element ran against an absorber matched to the base permittivity rather than its own. Measured on the committed fixture: **2040 of 12167 cells** held the wrong `eps_r`.

## Why it survived review twice

The resulting error was 8.83e-4 worst per-bin, sitting under the committed `rtol=2e-3`, and **three** committed docstrings attributed it to float32 roundoff. It is not roundoff: moving the same slab off the domain faces takes the identical comparison to bit-identity. The residual was never a floor; it was the unswept absorber. Nor was it bounded — it scales with |swept − base|.

## The fix, and what it does and does not cover

A `_extend_batched_cpml_pad` helper re-runs `_assemble_materials`' own per-face edge-slice-copy rule on the already batch-correct interior, after the sweep, for each of the three material-named branches. No public signature changed.

**Representativeness — the class this PR targets.** Seven configurations varying the three things the error depends on (|swept − base|, which faces the material touches, `cpml_layers`), measured on geometry that reaches a pad *without* sitting exactly on the domain edge:

| configuration | before | after |
|---|---|---|
| base 2.0, sweep {2,10}, cpml=8 | 7.843e-02 | 3.934e-07 |
| base 10.0, sweep {2,10}, cpml=8 | 5.820e-02 | 3.934e-07 |
| single-axis touch (y only), base 3 | 2.997e-02 | 2.478e-07 |
| single-face touch (x_lo only), base 5 | 4.191e-03 | 2.623e-07 |
| large delta, cpml=4, base 1.5 | 8.983e-02 | 3.418e-07 |
| large delta, cpml=12, base 8 | 4.307e-02 | 2.758e-07 |
| committed fixture, base 4, cpml=6 | 1.268e-02 | 2.205e-07 |

Four to five orders tighter, no configuration fitted to another. `sigma` and `mu_r` sweeps verified too, not just `eps_r`.

## The overlap with #627, found during rebase

#627 landed a hi-face **vacuum fallback** in the shared `extend_cpml_pad_materials` while this branch was open: a `Box` drawn flush to the domain face loses its edge node to the half-open `[lo, hi)` rasterization, so the naive copy would propagate vacuum outward. `_extend_batched_cpml_pad` does not reproduce that fallback, so for exact-domain-edge geometry the vmap path and `run()` now disagree — measured at 1.66e-2 to 4.25e-2 before mitigation. That is tracked as **#643** (two independent implementations of one padding rule) and pinned here by a committed `xfail(strict=True)` witness, which will hard-fail the suite the day it is reconciled rather than rotting.

Six of the seven configurations above also touch a domain face exactly, so their as-written numbers mix both effects. The table above is measured on margin-adjusted geometry to isolate what this PR actually claims; the as-written divergence is cited separately as #643 evidence rather than folded into one table with two meanings of "post-fix".

## A regression found, and mitigated

Re-running the as-written table after the rebase showed four rows going from bad to **worse** — because pre-fix the batched path wrote base's pad value everywhere, so cells whose swept element happened to equal base were *accidentally* right, and the fix replaced that coincidence with the naive vacuum column.

A guard now skips the overwrite when the source column is vacuum, leaving whatever `base_materials` held. Per-element, across all 14 elements of the 7 configurations:

- every `swept == base` element becomes exact (~1e-7 or better) — the cleanest evidence the guard does what it is designed to;
- 8 of the 10 `swept ≠ base` elements improve, by 0.4% to 16.7%;
- **2 still regress and are disclosed**: 6.421e-2 → 6.527e-2 (+1.6%) and 1.193e-2 → 1.199e-2 (+0.5%), both reproduced twice. The mechanism for those two specifically is **not established**. Both sit on the exact-domain-edge class already covered by the xfail witness and #643, where the numbers are unusable in either direction.

The guard uses the same **joint** vacuum predicate as `rasterize_grid._vacuum` (`eps == 1 & sigma == 0 & mu_r == 1`) rather than testing each field independently. That was tested as a hypothesis for the two residuals and **ruled out**: none of these fixtures carries a second material with nonzero sigma or non-unity mu_r, so the joint test reduces mathematically to the per-field one here. The joint form is kept regardless, because it is the predicate the rest of the package uses and will not silently diverge once such a fixture exists.

#637's actual target class — material reaching a pad without sitting on a domain edge — is unaffected by any of this: 4.191e-3 / 8.729e-4 → 2.623e-7 / 2.258e-7 either way.

## The gates move with the fix

`rtol` goes 2e-3 → 1e-6 for the CPML, PEC and x64 cases. Review argued the value is bracketed from **both** sides and should not be loosened: from below, every measured residual is ≤3.30e-8, and sibling fixtures where the two paths genuinely execute different arithmetic sit at 1.74e-7; from above, the weakest defect signal the gate must catch is ~1.1e-5, so a 1e-5 gate would leave that falsifier 1.1× of headroom and destroy it. Measured spread across nine thread widths (1 to 192 CPUs) is exactly zero, with a structural reason: the compared quantities contain no cross-batch or cross-space reductions, so `vmap` has nothing to reorder.

The x64 floor is stated as a property **of this fixture at n_steps=60**, not of the arithmetic — it grows to 1.0e-7 at 120 steps, 4.4e-7 at 200 and 6.4e-6 at 300 on signal-bearing bins. (A 4.39e-3 figure at 400 steps was checked and is the near-zero-denominator artefact the comparison helper's own docstring warns about, not divergence.)

All three docstrings calling the residual float32 noise are corrected. The third was not in the brief and was found by the author's own pass: `TestVmapAmplitudeKindCurrent`'s claim was *partly* caused by this defect (6.88e-5 → 1.74e-7, ~396×), with PEC's unaffected reference confirming the remainder is genuine dynamic-Cb noise.

## A sibling test that could not have caught a regression

`tests/test_vmap_cpml_dielectric.py` swept `[4.0, 10.0]` against a base of 10.0 and asserted only `ts[1]` — the element where swept == base, i.e. the single case where this defect cannot appear by construction. Pre-fix `ts[0]` measures 9.65e-3; `ts[1]` is 0.0 both before and after. It would have stayed green through a full revert. Both elements are now asserted, with the reason in the docstring.

## Falsifiers

Reverting `rfx/vmap_sweep.py` alone against the tightened gates reds the four target tests plus the folded-in sibling (209/300 mismatched elements on `ts[0]`), while the global-`eps_r` pin correctly stays green — that path was *accidentally* correct before this change, because `non_vac = eps_r != 1.0` also selects the replicated pad cells, and an accidental correctness turning into an accidental incorrectness would have been the worst outcome available here.

Worth recording: the first alternate-geometry test draft was **vacuous** — a box touching the hi face at the exact domain coordinate never reaches the pad at all — so it passed identically before and after. Caught by testing the test, rebuilt with a lo-touching box, documented in the test's own docstring.

Full vmap-tagged suite: 25 passed, 6 skipped, 1 xfailed. ruff clean.

R3: memory=feedback_gate_can_bind_artifact (a tolerance set above the defect it measured, and three docstrings naming that defect as noise) | R2-attempts=1 fix + 1 pre-declared mitigation attempt, stopped at the declared boundary rather than tuning | falsifier=revert-red on five tests, plus the inset-vs-edge-touching pair which is also the acceptance criterion

🤖 Generated with [Claude Code](https://claude.com/claude-code)