### PR TITLE
fix(core): lift the Yee compute dtype off its float32 pin (closes #630)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — Yee update arithmetic was hard-pinned to float32 regardless of field storage dtype (issue #630)
+
+- `rfx/core/yee.py`'s `update_h`/`update_e` computed `_cdtype = jnp.complex64
+  if jnp.iscomplexobj(state.ex) else jnp.float32` — the real (non-Bloch)
+  path's Yee curl/update ARITHMETIC was hard-pinned to float32 for ANY
+  field storage dtype. `_fdtype = state.ex.dtype` was used only to cast
+  the *result* back, so a float64 field carry was silently re-quantized to
+  float32 at the top of every timestep. The public API had no way to
+  reach float64 storage anyway (`precision=` only accepted `"float32"` /
+  `"mixed"`), so this was previously unobservable from outside — it
+  surfaced only once #630's investigation forced `field_dtype=jnp.float64`
+  directly at the `rfx/simulation.py` resolution site and found the FD
+  side of FD-vs-AD gates still capped at a ~1e-7 relative noise floor with
+  a non-monotone, sign-flipping sub-signal response (the AD side was
+  unaffected — the floor only ever inflated the FD reference).
+- Fix: `_cdtype` is now `jnp.promote_types(state.ex.dtype, jnp.float32)`
+  at both `update_h`/`update_e` call sites, plus the same substitution at
+  all 51 literal `.astype(jnp.float32)` field-arithmetic sites across the
+  NU (`update_h_nu`/`update_e_nu`), GPU-fast (`update_h_fast`/
+  `update_e_fast`/`update_he_fast`), and anisotropic
+  (`update_e_nu_aniso`/`update_e_aniso_inv`/`update_e_aniso`) lanes.
+  `jnp.promote_types(float16, float32) == float32` (preserves the
+  existing mixed-precision upcast intent unchanged) and
+  `jnp.promote_types(float32, float32) == float32` (byte-identical on the
+  production path — measured across `g_ad` and every FD-ladder rung).
+  Material coefficients (`eps_r`/`sigma`/`mu_r`) and the CPML profile
+  arrays stay float32 either way — those are fixed setup-time constants
+  that measurably bias the primal but do not create the per-timestep
+  rounding-lattice noise floor the compute-dtype pin did.
+- **New public knob**: `Simulation(..., precision="float64")` (alongside
+  the existing `"float32"` / `"mixed"`) routes float64 field storage (and
+  now, with the above fix, float64 Yee arithmetic) through both `run()`
+  and `forward()`. Requires the caller to have already enabled JAX's x64
+  mode (`jax.config.update("jax_enable_x64", True)` or
+  `jax.experimental.enable_x64()`); `preflight()` now warns
+  (`precision_float64_without_x64`) if `precision="float64"` is set
+  without x64 enabled, since JAX otherwise silently downcasts back to
+  float32 with no other signal. `forward()` previously never threaded
+  `field_dtype` at all (always float32 regardless of `precision=`), so
+  this also makes `precision="mixed"` reachable from `forward()` for the
+  first time.
+- **BEHAVIOUR CHANGE, opt-in only**: nothing changes for the default
+  `precision="float32"` or `precision="mixed"` paths (verified
+  byte-identical: primal, AD gradient, and every FD-ladder rung
+  unchanged). Only simulations that explicitly opt into
+  `precision="float64"` with x64 enabled see different (more accurate)
+  numbers.
+- Falsifier: reverting only the two `_cdtype` sites while keeping all 51
+  literal-site changes reproduces the stock (unpatched) float64-fields
+  result exactly — confirming `_cdtype` is the entire load-bearing change
+  and the literal-site changes alone are inert on the executed uniform CPU
+  lane (`update_he_fast` is GPU-only; the literals there and in the NU/
+  aniso lanes are unreachable from the CPU test suite either way).
+- No existing gate/tolerance changed; this PR does not tighten anything.
 ### Fixed — `vmap_material_sweep` didn't sweep the CPML absorber for material-named sweeps (issue #637)
 
 Found by an independent audit of the e4b565c..ce44661 arc: for a material-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,48 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   `field_dtype` at all (always float32 regardless of `precision=`), so
   this also makes `precision="mixed"` reachable from `forward()` for the
   first time.
+- **Follow-up (review), lane scope**: `field_dtype` is threaded only by
+  `rfx/runners/uniform.py` — the non-uniform-mesh, distributed,
+  distributed-NU, and subgridded runners do not thread it, so
+  `precision="mixed"`/`"float64"` would silently run float32 fields there
+  with no error. `_dispatch_plan` (the single lane-decision point for
+  `run()`/`forward()`) now raises `NotImplementedError` for
+  `precision != "float32"` on the `run_nonuniform`, `run_distributed`,
+  `run_subgridded`, `fwd_nonuniform`, and `fwd_distributed_nu` lanes;
+  `preflight()`'s `_validate_cfg_precision_x64` also warns in advance for
+  the non-uniform-mesh case (the distributed case is a call-time
+  `run()`/`forward()` kwarg invisible to preflight, so the dispatch-time
+  raise is its only enforcement point). The `precision` docstring now
+  says the knob is uniform-single-device-lane-only today. New committed
+  regression coverage: `tests/test_precision_lane_guard.py`.
+- **Follow-up (review), schema/spec/canonical consistency**: the
+  `precision` enum in `docs/design_notes/schemas/rfx-experiment-v2.schema.json`
+  (widened to accept `"float64"` alongside the compute-dtype fix) was out
+  of sync with `rfx/experiments/spec.py`'s v1 validator and
+  `rfx/experiments/canonical.py`'s v2 validator, both of which still
+  rejected anything outside `{"float32", "mixed"}` — a config with
+  `precision: float64` would pass schema validation and then die at
+  runtime with a message that never mentioned `float64`. Both Python
+  validators now accept `"float32"`/`"mixed"`/`"float64"` consistently
+  with the schema; `tests/test_experiment_spec.py`'s pinned error-message
+  regex updated to match.
+- **Follow-up (review), issue #644 pre-existing defect newly reachable**:
+  `precision="mixed"` (float16 fields) with a CPML boundary face has
+  always crashed with a raw JAX `TypeError` (`lax.scan` carry dtype
+  mismatch: the CPML `psi_*` carry follows `field_dtype`, but the CPML
+  coefficients are hard-pinned to float32) — pre-existing on `run()`,
+  measured identical on the trees before and after the compute-dtype fix
+  above, and NOT caused by it. Because that fix makes `forward()` honour
+  `precision=` for the first time (see above), `forward()` newly reaches
+  this same crash, where it used to silently no-op to float32 instead.
+  `forward()` now raises a clear `NotImplementedError` pointing at #644
+  for this specific combination instead of leaking the raw JAX error;
+  `precision="float32"`/`"float64"` and `boundary="upml"` are unaffected
+  (measured: UPML has no analogous hard-float32 psi carry, and
+  `jnp.promote_types(float64, float32) == float64` keeps the CPML carry
+  dtype-consistent for `"float64"`). Fixing #644 itself (giving `psi_*`
+  and the CPML coefficients one consistent dtype policy) is out of scope
+  here — tracked separately as issue #644.
 - **BEHAVIOUR CHANGE, opt-in only**: nothing changes for the default
   `precision="float32"` or `precision="mixed"` paths (verified
   byte-identical: primal, AD gradient, and every FD-ladder rung

--- a/docs/design_notes/schemas/rfx-experiment-v2.schema.json
+++ b/docs/design_notes/schemas/rfx-experiment-v2.schema.json
@@ -45,7 +45,7 @@
         "domain_m": {"$ref": "#/$defs/positive_xyz"},
         "cell_size_m": {"type": "number", "exclusiveMinimum": 0},
         "freq_max_hz": {"type": "number", "exclusiveMinimum": 0},
-        "precision": {"enum": ["float32", "mixed"]}
+        "precision": {"enum": ["float32", "mixed", "float64"]}
       },
       "additionalProperties": false
     },

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -302,11 +302,26 @@ class Simulation(
         ``"3d"`` (default), ``"2d_tmz"`` (Ez, Hx, Hy), or
         ``"2d_tez"`` (Hz, Ex, Ey).
     precision : str
-        ``"float32"`` (default) or ``"mixed"``.  When ``"mixed"``,
-        field arrays (E, H) use float16 for ~2x memory reduction while
-        material coefficients and DFT accumulators stay float32.
-        Arithmetic is performed in float32 and cast back to float16
-        for storage.
+        ``"float32"`` (default), ``"mixed"``, or ``"float64"``.  When
+        ``"mixed"``, field arrays (E, H) use float16 for ~2x memory
+        reduction while material coefficients and DFT accumulators stay
+        float32.  When ``"float64"``, field arrays use float64 storage
+        AND the Yee update arithmetic runs at float64 (issue #630 — prior
+        releases hard-pinned the Yee curl/update arithmetic to float32
+        regardless of storage dtype, so float64 fields were silently
+        re-quantized to float32 every timestep; the arithmetic dtype is
+        now ``jnp.promote_types(field_dtype, jnp.float32)``, so
+        ``"float32"``/``"mixed"`` are numerically unaffected and
+        byte-identical to before).  ``"float64"`` requires JAX's x64 mode
+        to already be enabled by the caller (``jax.config.update(
+        "jax_enable_x64", True)`` or ``jax.experimental.enable_x64()``) —
+        without it JAX silently downcasts float64 arrays back to
+        float32, and ``preflight()`` warns if this mismatch is detected.
+        Material coefficients (``eps_r``/``sigma``/``mu_r``) and
+        precomputed CPML profile arrays stay float32 either way (fixed
+        setup-time constants measurably bias the primal but do not
+        create the per-timestep rounding-lattice noise floor that the
+        compute-dtype pin did — see issue #630's f64-lift measurement).
     solver : str
         ``"yee"`` (default) for the standard explicit scheme or
         ``"adi"`` for the ADI-FDTD path. ADI is unconditionally stable in
@@ -378,8 +393,10 @@ class Simulation(
             spec = None  # deferred; folded in after legacy fields settle
         if freq_max <= 0:
             raise ValueError(f"freq_max must be positive, got {freq_max}")
-        if precision not in ("float32", "mixed"):
-            raise ValueError(f"precision must be 'float32' or 'mixed', got {precision!r}")
+        if precision not in ("float32", "mixed", "float64"):
+            raise ValueError(
+                f"precision must be 'float32', 'mixed', or 'float64', got {precision!r}"
+            )
         if solver not in ("yee", "adi"):
             raise ValueError(f"solver must be 'yee' or 'adi', got {solver!r}")
         if adi_cfl_factor <= 0:

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -322,6 +322,17 @@ class Simulation(
         setup-time constants measurably bias the primal but do not
         create the per-timestep rounding-lattice noise floor that the
         compute-dtype pin did — see issue #630's f64-lift measurement).
+        ``"mixed"``/``"float64"`` are UNIFORM-SINGLE-DEVICE-LANE ONLY
+        today: ``field_dtype`` is threaded only by
+        ``rfx/runners/uniform.py`` — the non-uniform-mesh, distributed
+        (``devices=``/``distributed=True``), and subgridded
+        (``refinement``) runners do not thread it, so a non-float32
+        precision there would silently run float32 fields. ``run()`` /
+        ``forward()`` raise ``NotImplementedError`` rather than do that
+        silently; ``preflight()`` also warns in advance for the
+        non-uniform-mesh case (the distributed case is a call-time
+        ``run()``/``forward()`` kwarg, invisible to preflight, so its
+        `NotImplementedError` at dispatch is the only enforcement point).
     solver : str
         ``"yee"`` (default) for the standard explicit scheme or
         ``"adi"`` for the ADI-FDTD path. ADI is unconditionally stable in

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -135,6 +135,22 @@ class _ExecuteMixin:
     ``Simulation`` instance (resolved via MRO).
     """
 
+    def _resolve_field_dtype(self):
+        """Map ``self._precision`` to the ``field_dtype`` the Yee core takes.
+
+        Shared by the uniform ``run()`` and ``forward()`` lanes (issue #630)
+        so both honour ``precision=`` identically — before this fix only
+        ``run()`` read ``self._precision`` here; ``forward()`` (the lane
+        FD-vs-AD gates use) always passed ``field_dtype=None`` regardless of
+        ``self._precision``, so ``precision="float64"`` was unreachable from
+        the differentiable path.
+        """
+        if self._precision == "mixed":
+            return jnp.float16
+        if self._precision == "float64":
+            return jnp.float64
+        return None
+
     # ---- (2,4) stencil comprehensive API fence (PR-1b) ----
 
     def _check_stencil_order_supported(self, *, distributed: bool = False) -> None:
@@ -1537,6 +1553,7 @@ class _ExecuteMixin:
             flux_monitors=flux_monitor_cfgs if flux_monitor_cfgs else None,
             return_state=False,
             stencil_order=self._stencil_order,
+            field_dtype=self._resolve_field_dtype(),
         )
 
         # Multi-drive S-matrix hook (item-5 Stage 1): return the raw all-port
@@ -3123,7 +3140,7 @@ class _ExecuteMixin:
             )
 
         from rfx.runners.uniform import run_uniform
-        _field_dtype = jnp.float16 if self._precision == "mixed" else None
+        _field_dtype = self._resolve_field_dtype()
         _res = run_uniform(
             self,
             n_steps=n_steps,

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -1523,6 +1523,47 @@ class _ExecuteMixin:
                     r_val=_v.get("R"), l_val=_v.get("L"), c_val=_v.get("C"),
                 ))
 
+        # Issue #644 (pre-existing, NOT caused by #630 -- measured identical
+        # via run() on both the pre- and post-#630 trees): CPML's psi_*
+        # carry arrays are allocated at field_dtype (float16 for
+        # precision="mixed"), but the CPML coefficients are hard-pinned to
+        # float32, so `psi = b*psi + c*curl` promotes to float32 and the
+        # lax.scan carry signature no longer matches its own input --
+        # TypeError. This path was UNREACHABLE from forward() before #630
+        # (forward() silently ignored precision= entirely); #630 made
+        # forward() honour precision= for the first time (a genuine second
+        # fix -- see field_dtype=self._resolve_field_dtype() below), which
+        # newly surfaces this pre-existing defect through forward(). Fail
+        # loud with a clear, actionable rfx-layer message instead of
+        # degrading to a raw JAX carry-dtype TypeError. UPML does NOT hit
+        # this (measured: boundary="upml" + precision="mixed" runs clean
+        # on forward() -- the coefficient/carry dtype mismatch is CPML-only,
+        # rfx/boundaries/upml.py has no analogous hard-float32 psi carry
+        # promoted by a field_dtype-following one). float64 is unaffected
+        # (jnp.promote_types(float64, float32) == float64 matches storage,
+        # so the carry stays consistent) -- measured clean on forward().
+        if self._precision == "mixed":
+            _bspec = self._boundary_spec
+            _uses_cpml = any(
+                getattr(_bspec, _axis).lo == "cpml"
+                or getattr(_bspec, _axis).hi == "cpml"
+                for _axis in ("x", "y", "z")
+            )
+            if _uses_cpml:
+                raise NotImplementedError(
+                    "forward(): precision='mixed' with a CPML boundary "
+                    "face is not supported (issue #644, pre-existing -- "
+                    "not caused by this fix). The CPML psi_* carry arrays "
+                    "follow field_dtype (float16), but the CPML "
+                    "coefficients are hard-pinned to float32, so the "
+                    "update promotes float16->float32 and breaks the "
+                    "lax.scan carry contract with a raw JAX TypeError. Use "
+                    "precision='float32' (default) or 'float64' with CPML "
+                    "today; 'mixed' + CPML needs #644's fix (giving the "
+                    "psi_* arrays and CPML coefficients one consistent "
+                    "dtype policy) before it can work."
+                )
+
         result = _run(
             grid,
             materials,
@@ -2219,6 +2260,32 @@ class _ExecuteMixin:
             or self._dy_profile is not None
         )
 
+        def _reject_lane_precision(lane: str) -> None:
+            # Issue #630 follow-up: field_dtype is threaded ONLY on the
+            # uniform-lane runner (rfx/runners/uniform.py). The non-uniform,
+            # distributed, distributed-NU, and subgridded runners have zero
+            # field_dtype occurrences, so a non-float32 precision would
+            # silently run float32 fields there -- the exact SILENT_WRONG
+            # class this repo removes on sight. distributed=True is a
+            # call-time kwarg invisible to preflight (see the "P3
+            # (Distributed path)" precedent in
+            # _validate_cfg_subgrid_limitations), so THIS is the only
+            # enforcement point for that case; for the non-uniform-mesh
+            # case _validate_cfg_precision_x64 also warns in advance, but
+            # this raise is what actually stops it (and cannot be bypassed
+            # with skip_preflight=True, unlike a preflight warning).
+            if self._precision != "float32":
+                raise NotImplementedError(
+                    f"precision={self._precision!r} is currently supported "
+                    f"only on the uniform single-device lane (issue #630); "
+                    f"the {lane!r} lane does not thread field_dtype through "
+                    "its runner and would silently run float32 fields "
+                    "regardless of this setting. Use precision='float32' "
+                    "(the default) here, or drop distributed=True / the "
+                    "non-uniform mesh profile / refinement (subgridding) to "
+                    "reach the uniform lane, where this knob is honoured."
+                )
+
         if mode == "forward":
             def _fwd_nu_n_steps() -> int:
                 # Throwaway NU grid build for the step count; mirrors the
@@ -2282,12 +2349,14 @@ class _ExecuteMixin:
                 # hook lives in rfx/simulation.py:703-705 and the sharded
                 # PMC helpers live in each runner next to their PEC analog.
                 _n = n_steps if n_steps is not None else _fwd_nu_n_steps()
+                _reject_lane_precision("fwd_distributed_nu")
                 return _DispatchPlan(lane="fwd_distributed_nu", n_steps=_n)
 
             if is_nonuniform:
                 # Let the NU runner build grid/materials so it can apply the
                 # NU-aware pec_mask and port/source setup against per-axis widths.
                 _n = n_steps if n_steps is not None else _fwd_nu_n_steps()
+                _reject_lane_precision("fwd_nonuniform")
                 return _DispatchPlan(lane="fwd_nonuniform", n_steps=_n)
 
             # Uniform forward lane: the remaining kwargs are NU-only.
@@ -2381,6 +2450,7 @@ class _ExecuteMixin:
                 else:
                     grid = self._build_grid()
                     _n = grid.num_timesteps(num_periods=num_periods)
+            _reject_lane_precision("run_distributed")
             return _DispatchPlan(lane="run_distributed", n_steps=_n)
 
         # ---- Non-uniform mesh lane ----
@@ -2388,6 +2458,7 @@ class _ExecuteMixin:
             _n = n_steps
             if _n is None:
                 _n = self._nu_n_steps(num_periods)
+            _reject_lane_precision("run_nonuniform")
             return _DispatchPlan(lane="run_nonuniform", n_steps=_n)
 
         # ---- ADI lane (n_steps resolved by caller from the reused grid) ----
@@ -2397,6 +2468,7 @@ class _ExecuteMixin:
         # ---- Subgridded lane (n_steps resolved by caller — refinement ratio
         # scaling needs the reused grid) ----
         if self._refinement is not None:
+            _reject_lane_precision("run_subgridded")
             return _DispatchPlan(lane="run_subgridded", n_steps=n_steps)
 
         # ---- Uniform lane (n_steps resolved by caller from the reused grid) ----

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import json
 import math
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -2022,6 +2023,7 @@ class _PreflightMixin:
         absorber_label = "UPML" if self._boundary == "upml" else "CPML"
 
         # --- checks in original order ---------------------------------
+        self._validate_cfg_precision_x64(_w)
         self._validate_cfg_pec_faces_with_finite_pec(_w)
         self._validate_cfg_upml_refinement()
         self._validate_cfg_floquet_nonuniform()
@@ -2055,6 +2057,38 @@ class _PreflightMixin:
 
         self._check_waveguide_port_evanescent()
         self._check_msl_port_geometry(dx, cpml_thick_lo, cpml_thick_hi)
+
+    def _validate_cfg_precision_x64(self, _w) -> None:
+        """Warn when ``precision="float64"`` cannot actually take effect.
+
+        JAX silently downcasts float64 arrays to float32 unless the caller
+        has enabled x64 mode (``jax.config.update("jax_enable_x64", True)``
+        or ``jax.experimental.enable_x64()``) — this is process-global JAX
+        behavior, not something ``Simulation`` can flip on its own (this
+        repo's own rule is to never do that at import/module scope; see
+        CLAUDE.md). Without this check, ``precision="float64"`` would look
+        accepted (no error) while silently running float32 fields, which is
+        exactly the SILENT_WRONG class this preflight system exists to
+        catch (issue #630: the Yee update arithmetic used to re-quantize
+        float64 fields to float32 every timestep even when storage WAS
+        float64 -- that half is fixed, but storage never becoming float64
+        in the first place is a distinct, still-live footgun).
+        """
+        if self._precision != "float64":
+            return
+        if jax.config.jax_enable_x64:
+            return
+        _w.warn(PreflightWarning(
+            "precision='float64' was requested, but JAX x64 mode is not "
+            "enabled (jax.config.jax_enable_x64 is False). JAX silently "
+            "downcasts float64 arrays to float32, so fields will run at "
+            "float32 despite this setting. Enable x64 before constructing "
+            "this Simulation: jax.config.update('jax_enable_x64', True) "
+            "(process-global) or wrap the call in "
+            "jax.experimental.enable_x64() (scoped).",
+            code="precision_float64_without_x64",
+            source="_validate_cfg_precision_x64",
+        ))
 
     def _validate_cfg_tfsf_with_lumped_rlc(self, _w) -> None:
         """Warn: a lumped RLC element illuminated by a TFSF plane wave is unstable.

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2059,36 +2059,78 @@ class _PreflightMixin:
         self._check_msl_port_geometry(dx, cpml_thick_lo, cpml_thick_hi)
 
     def _validate_cfg_precision_x64(self, _w) -> None:
-        """Warn when ``precision="float64"`` cannot actually take effect.
+        """Warn when ``precision`` cannot actually take effect.
 
-        JAX silently downcasts float64 arrays to float32 unless the caller
-        has enabled x64 mode (``jax.config.update("jax_enable_x64", True)``
-        or ``jax.experimental.enable_x64()``) — this is process-global JAX
-        behavior, not something ``Simulation`` can flip on its own (this
-        repo's own rule is to never do that at import/module scope; see
-        CLAUDE.md). Without this check, ``precision="float64"`` would look
-        accepted (no error) while silently running float32 fields, which is
-        exactly the SILENT_WRONG class this preflight system exists to
-        catch (issue #630: the Yee update arithmetic used to re-quantize
-        float64 fields to float32 every timestep even when storage WAS
-        float64 -- that half is fixed, but storage never becoming float64
-        in the first place is a distinct, still-live footgun).
+        Two independent ways ``precision != "float32"`` silently degrades
+        back to float32 with no error:
+
+        1. ``precision="float64"`` requires JAX x64 mode already enabled by
+           the caller (``jax.config.update("jax_enable_x64", True)`` or
+           ``jax.experimental.enable_x64()``) — process-global JAX
+           behavior, not something ``Simulation`` can flip on its own (this
+           repo's own rule is to never do that at import/module scope; see
+           CLAUDE.md). Without this check, ``precision="float64"`` would
+           look accepted (no error) while silently running float32 fields
+           (issue #630: the Yee update arithmetic used to re-quantize
+           float64 fields to float32 every timestep even when storage WAS
+           float64 -- that half is fixed, but storage never becoming
+           float64 in the first place is a distinct, still-live footgun).
+        2. The non-uniform mesh runner (``rfx/runners/nonuniform.py``) does
+           not thread ``field_dtype`` at all (issue #630 review) -- a
+           non-uniform-mesh sim with ``precision="mixed"`` or
+           ``"float64"`` silently runs float32 fields regardless. This is
+           an ADVISORY heads-up only: ``_dispatch_plan`` (the single
+           lane-decision point) hard-rejects the same combination with
+           ``NotImplementedError`` before any compute runs, so this warning
+           cannot actually be missed in practice -- it exists to explain
+           the coming error before the run gets that far, and to cover the
+           ``skip_preflight=True`` escape hatch, which does NOT bypass
+           ``_dispatch_plan``'s own guard. The distributed lanes
+           (``distributed.py``/``distributed_nu.py``/``distributed_v2.py``)
+           have the same gap but ``distributed=True`` is a call-time
+           ``run()``/``forward()`` kwarg, not visible here at
+           ``Simulation``-construction-time preflight (matches the
+           established "P3 (Distributed path)" precedent in
+           ``_validate_cfg_subgrid_limitations`` below) -- ``_dispatch_plan``
+           is therefore the ONLY enforcement point for the distributed
+           case, not merely a backstop.
+
+        Both are exactly the SILENT_WRONG class this preflight system
+        exists to catch.
         """
-        if self._precision != "float64":
-            return
-        if jax.config.jax_enable_x64:
-            return
-        _w.warn(PreflightWarning(
-            "precision='float64' was requested, but JAX x64 mode is not "
-            "enabled (jax.config.jax_enable_x64 is False). JAX silently "
-            "downcasts float64 arrays to float32, so fields will run at "
-            "float32 despite this setting. Enable x64 before constructing "
-            "this Simulation: jax.config.update('jax_enable_x64', True) "
-            "(process-global) or wrap the call in "
-            "jax.experimental.enable_x64() (scoped).",
-            code="precision_float64_without_x64",
-            source="_validate_cfg_precision_x64",
-        ))
+        if self._precision == "float64" and not jax.config.jax_enable_x64:
+            _w.warn(PreflightWarning(
+                "precision='float64' was requested, but JAX x64 mode is not "
+                "enabled (jax.config.jax_enable_x64 is False). JAX silently "
+                "downcasts float64 arrays to float32, so fields will run at "
+                "float32 despite this setting. Enable x64 before constructing "
+                "this Simulation: jax.config.update('jax_enable_x64', True) "
+                "(process-global) or wrap the call in "
+                "jax.experimental.enable_x64() (scoped).",
+                code="precision_float64_without_x64",
+                source="_validate_cfg_precision_x64",
+            ))
+
+        is_nonuniform = (
+            self._dz_profile is not None
+            or self._dx_profile is not None
+            or self._dy_profile is not None
+        )
+        if self._precision != "float32" and is_nonuniform:
+            _w.warn(PreflightWarning(
+                f"precision={self._precision!r} was requested on a "
+                "non-uniform mesh (dx/dy/dz profile set), but the "
+                "non-uniform runner does not thread field_dtype -- fields "
+                "would silently run float32 regardless of this setting "
+                "(issue #630). run()/forward() will raise NotImplementedError "
+                "at dispatch rather than proceed silently; this warning "
+                "exists to explain that error before you hit it. Use "
+                "precision='float32' (the default) with a non-uniform mesh, "
+                "or drop the mesh profile to reach the uniform lane where "
+                "this precision knob is currently supported.",
+                code="precision_nonuniform_lane_unsupported",
+                source="_validate_cfg_precision_x64",
+            ))
 
     def _validate_cfg_tfsf_with_lumped_rlc(self, _w) -> None:
         """Warn: a lumped RLC element illuminated by a TFSF plane wave is unstable.

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2067,10 +2067,12 @@ class _PreflightMixin:
         1. ``precision="float64"`` requires JAX x64 mode already enabled by
            the caller (``jax.config.update("jax_enable_x64", True)`` or
            ``jax.experimental.enable_x64()``) — process-global JAX
-           behavior, not something ``Simulation`` can flip on its own (this
-           repo's own rule is to never do that at import/module scope; see
-           CLAUDE.md). Without this check, ``precision="float64"`` would
-           look accepted (no error) while silently running float32 fields
+           behavior, not something ``Simulation`` can flip on its own: this
+           package never flips ``jax_enable_x64`` at import/module scope,
+           since that would be permanent for the rest of the process and
+           is the caller's decision to make, not a library's to make for
+           them. Without this check, ``precision="float64"`` would look
+           accepted (no error) while silently running float32 fields
            (issue #630: the Yee update arithmetic used to re-quantize
            float64 fields to float32 every timestep even when storage WAS
            float64 -- that half is fixed, but storage never becoming

--- a/rfx/core/yee.py
+++ b/rfx/core/yee.py
@@ -209,10 +209,17 @@ def update_h(state: FDTDState, materials: MaterialArrays, dt: float, dx: float,
         )
 
     # Compute dtype: the oblique-periodic Bloch path carries a complex field
-    # envelope P; the real path stays float32 (upcast for reduced-precision
-    # fields) and is byte-identical.
+    # envelope P; the real path computes at ``max(state dtype, float32)`` --
+    # upcast for reduced-precision (float16) fields (byte-identical for
+    # float32 storage), and PROMOTED for float64 storage so the arithmetic
+    # does not re-quantize a higher-precision field back to float32 every
+    # timestep (issue #630 -- the prior hard `jnp.float32` pin here silently
+    # discarded float64 field precision regardless of storage dtype).
     _fdtype = state.ex.dtype
-    _cdtype = jnp.complex64 if jnp.iscomplexobj(state.ex) else jnp.float32
+    _cdtype = (
+        jnp.complex64 if jnp.iscomplexobj(state.ex)
+        else jnp.promote_types(state.ex.dtype, jnp.float32)
+    )
     ex = state.ex.astype(_cdtype)
     ey = state.ey.astype(_cdtype)
     ez = state.ez.astype(_cdtype)
@@ -271,10 +278,15 @@ def update_e(state: FDTDState, materials: MaterialArrays, dt: float, dx: float,
             f"bloch phase (oblique-periodic BC, #404) requires stencil_order=2, got {so}"
         )
 
-    # Compute dtype: complex for the Bloch envelope path, float32 for the real
-    # path (byte-identical; upcast covers reduced-precision fields).
+    # Compute dtype: complex for the Bloch envelope path, ``max(state dtype,
+    # float32)`` for the real path (byte-identical for float32 storage;
+    # upcast covers reduced-precision fields; promoted for float64 storage
+    # -- see the matching comment in update_h, issue #630).
     _fdtype = state.ex.dtype
-    _cdtype = jnp.complex64 if jnp.iscomplexobj(state.ex) else jnp.float32
+    _cdtype = (
+        jnp.complex64 if jnp.iscomplexobj(state.ex)
+        else jnp.promote_types(state.ex.dtype, jnp.float32)
+    )
     hx = state.hx.astype(_cdtype)
     hy = state.hy.astype(_cdtype)
     hz = state.hz.astype(_cdtype)
@@ -332,10 +344,13 @@ def update_h_nu(state: FDTDState, materials: MaterialArrays, dt: float,
         ``inv_d_h[N-1] = 0``. Built by
         ``rfx.nonuniform._profile_to_inv_arrays`` (second return value).
     """
+    # Compute dtype: max(state dtype, float32) -- byte-identical for float32
+    # storage, upcast for float16, promoted for float64 (issue #630).
     _fdtype = state.ex.dtype
-    ex = state.ex.astype(jnp.float32)
-    ey = state.ey.astype(jnp.float32)
-    ez = state.ez.astype(jnp.float32)
+    _cdtype = jnp.promote_types(_fdtype, jnp.float32)
+    ex = state.ex.astype(_cdtype)
+    ey = state.ey.astype(_cdtype)
+    ez = state.ez.astype(_cdtype)
     mu = materials.mu_r * MU_0
 
     # Forward differences with same shape (zero-pad via _shift_fwd)
@@ -352,9 +367,9 @@ def update_h_nu(state: FDTDState, materials: MaterialArrays, dt: float,
         - (_shift_fwd(ex, 1) - ex) * inv_dy_h[None, :, None]
     )
 
-    hx = (state.hx.astype(jnp.float32) - (dt / mu) * curl_x).astype(_fdtype)
-    hy = (state.hy.astype(jnp.float32) - (dt / mu) * curl_y).astype(_fdtype)
-    hz = (state.hz.astype(jnp.float32) - (dt / mu) * curl_z).astype(_fdtype)
+    hx = (state.hx.astype(_cdtype) - (dt / mu) * curl_x).astype(_fdtype)
+    hy = (state.hy.astype(_cdtype) - (dt / mu) * curl_y).astype(_fdtype)
+    hz = (state.hz.astype(_cdtype) - (dt / mu) * curl_z).astype(_fdtype)
 
     return state._replace(hx=hx, hy=hy, hz=hz)
 
@@ -374,10 +389,13 @@ def update_e_nu(state: FDTDState, materials: MaterialArrays, dt: float,
         k>=1, ``inv_d_e[0] = 1/d[0]``. Built by
         ``rfx.nonuniform._profile_to_inv_arrays`` (first return value).
     """
+    # Compute dtype: max(state dtype, float32) -- byte-identical for float32
+    # storage, upcast for float16, promoted for float64 (issue #630).
     _fdtype = state.ex.dtype
-    hx = state.hx.astype(jnp.float32)
-    hy = state.hy.astype(jnp.float32)
-    hz = state.hz.astype(jnp.float32)
+    _cdtype = jnp.promote_types(_fdtype, jnp.float32)
+    hx = state.hx.astype(_cdtype)
+    hy = state.hy.astype(_cdtype)
+    hz = state.hz.astype(_cdtype)
     eps = materials.eps_r * EPS_0
     sigma = materials.sigma
 
@@ -399,9 +417,9 @@ def update_e_nu(state: FDTDState, materials: MaterialArrays, dt: float,
         - (hx - _shift_bwd(hx, 1)) * inv_dy[None, :, None]
     )
 
-    ex = (ca * state.ex.astype(jnp.float32) + cb * curl_x).astype(_fdtype)
-    ey = (ca * state.ey.astype(jnp.float32) + cb * curl_y).astype(_fdtype)
-    ez = (ca * state.ez.astype(jnp.float32) + cb * curl_z).astype(_fdtype)
+    ex = (ca * state.ex.astype(_cdtype) + cb * curl_x).astype(_fdtype)
+    ey = (ca * state.ey.astype(_cdtype) + cb * curl_y).astype(_fdtype)
+    ez = (ca * state.ez.astype(_cdtype) + cb * curl_z).astype(_fdtype)
 
     return state._replace(ex=ex, ey=ey, ez=ez, step=state.step + 1)
 
@@ -506,13 +524,16 @@ def update_h_fast(state: FDTDState, ch: jnp.ndarray) -> FDTDState:
     Avoids recomputing material coefficients each timestep.
     Non-periodic boundaries only (uses ``_shift_fwd``).
     """
+    # Compute dtype: max(state dtype, float32) -- byte-identical for float32
+    # storage, upcast for float16, promoted for float64 (issue #630).
     _fdtype = state.ex.dtype
-    ex = state.ex.astype(jnp.float32)
-    ey = state.ey.astype(jnp.float32)
-    ez = state.ez.astype(jnp.float32)
-    hx = (state.hx.astype(jnp.float32) - ch * ((_shift_fwd(ez, 1) - ez) - (_shift_fwd(ey, 2) - ey))).astype(_fdtype)
-    hy = (state.hy.astype(jnp.float32) - ch * ((_shift_fwd(ex, 2) - ex) - (_shift_fwd(ez, 0) - ez))).astype(_fdtype)
-    hz = (state.hz.astype(jnp.float32) - ch * ((_shift_fwd(ey, 0) - ey) - (_shift_fwd(ex, 1) - ex))).astype(_fdtype)
+    _cdtype = jnp.promote_types(_fdtype, jnp.float32)
+    ex = state.ex.astype(_cdtype)
+    ey = state.ey.astype(_cdtype)
+    ez = state.ez.astype(_cdtype)
+    hx = (state.hx.astype(_cdtype) - ch * ((_shift_fwd(ez, 1) - ez) - (_shift_fwd(ey, 2) - ey))).astype(_fdtype)
+    hy = (state.hy.astype(_cdtype) - ch * ((_shift_fwd(ex, 2) - ex) - (_shift_fwd(ez, 0) - ez))).astype(_fdtype)
+    hz = (state.hz.astype(_cdtype) - ch * ((_shift_fwd(ey, 0) - ey) - (_shift_fwd(ex, 1) - ex))).astype(_fdtype)
     return state._replace(hx=hx, hy=hy, hz=hz)
 
 
@@ -529,13 +550,16 @@ def update_e_fast(
 
     Non-periodic boundaries only (uses ``_shift_bwd``).
     """
+    # Compute dtype: max(state dtype, float32) -- byte-identical for float32
+    # storage, upcast for float16, promoted for float64 (issue #630).
     _fdtype = state.ex.dtype
-    hx = state.hx.astype(jnp.float32)
-    hy = state.hy.astype(jnp.float32)
-    hz = state.hz.astype(jnp.float32)
-    ex = (ca_ex * state.ex.astype(jnp.float32) + cb_ex * ((hz - _shift_bwd(hz, 1)) - (hy - _shift_bwd(hy, 2)))).astype(_fdtype)
-    ey = (ca_ey * state.ey.astype(jnp.float32) + cb_ey * ((hx - _shift_bwd(hx, 2)) - (hz - _shift_bwd(hz, 0)))).astype(_fdtype)
-    ez = (ca_ez * state.ez.astype(jnp.float32) + cb_ez * ((hy - _shift_bwd(hy, 0)) - (hx - _shift_bwd(hx, 1)))).astype(_fdtype)
+    _cdtype = jnp.promote_types(_fdtype, jnp.float32)
+    hx = state.hx.astype(_cdtype)
+    hy = state.hy.astype(_cdtype)
+    hz = state.hz.astype(_cdtype)
+    ex = (ca_ex * state.ex.astype(_cdtype) + cb_ex * ((hz - _shift_bwd(hz, 1)) - (hy - _shift_bwd(hy, 2)))).astype(_fdtype)
+    ey = (ca_ey * state.ey.astype(_cdtype) + cb_ey * ((hx - _shift_bwd(hx, 2)) - (hz - _shift_bwd(hz, 0)))).astype(_fdtype)
+    ez = (ca_ez * state.ez.astype(_cdtype) + cb_ez * ((hy - _shift_bwd(hy, 0)) - (hx - _shift_bwd(hx, 1)))).astype(_fdtype)
     return state._replace(ex=ex, ey=ey, ez=ez, step=state.step + 1)
 
 
@@ -546,20 +570,25 @@ def update_he_fast(state: FDTDState, coeffs: UpdateCoeffs) -> FDTDState:
     PEC baked into the coefficients.  This is the fastest path for the
     common case of non-periodic boundaries with uniform mesh.
     """
+    # Compute dtype: max(state dtype, float32) -- byte-identical for float32
+    # storage, upcast for float16, promoted for float64 (issue #630). This is
+    # the GPU-only fast lane (rfx/simulation.py's update_he_fast dispatch);
+    # the uniform CPU lane routes through update_h/update_e above instead.
     _fdtype = state.ex.dtype
-    # --- H update (upcast to float32 for arithmetic) ---
-    ex = state.ex.astype(jnp.float32)
-    ey = state.ey.astype(jnp.float32)
-    ez = state.ez.astype(jnp.float32)
+    _cdtype = jnp.promote_types(_fdtype, jnp.float32)
+    # --- H update (upcast to _cdtype for arithmetic) ---
+    ex = state.ex.astype(_cdtype)
+    ey = state.ey.astype(_cdtype)
+    ez = state.ez.astype(_cdtype)
     ch = coeffs.ch
-    hx = (state.hx.astype(jnp.float32) - ch * ((_shift_fwd(ez, 1) - ez) - (_shift_fwd(ey, 2) - ey))).astype(_fdtype)
-    hy = (state.hy.astype(jnp.float32) - ch * ((_shift_fwd(ex, 2) - ex) - (_shift_fwd(ez, 0) - ez))).astype(_fdtype)
-    hz = (state.hz.astype(jnp.float32) - ch * ((_shift_fwd(ey, 0) - ey) - (_shift_fwd(ex, 1) - ex))).astype(_fdtype)
+    hx = (state.hx.astype(_cdtype) - ch * ((_shift_fwd(ez, 1) - ez) - (_shift_fwd(ey, 2) - ey))).astype(_fdtype)
+    hy = (state.hy.astype(_cdtype) - ch * ((_shift_fwd(ex, 2) - ex) - (_shift_fwd(ez, 0) - ez))).astype(_fdtype)
+    hz = (state.hz.astype(_cdtype) - ch * ((_shift_fwd(ey, 0) - ey) - (_shift_fwd(ex, 1) - ex))).astype(_fdtype)
     # --- E update (with PEC baked into coefficients) ---
-    # Upcast newly computed H fields back to float32 for curl computation
-    hx_f = hx.astype(jnp.float32)
-    hy_f = hy.astype(jnp.float32)
-    hz_f = hz.astype(jnp.float32)
+    # Upcast newly computed H fields back to _cdtype for curl computation
+    hx_f = hx.astype(_cdtype)
+    hy_f = hy.astype(_cdtype)
+    hz_f = hz.astype(_cdtype)
     ex = (coeffs.ca_ex * ex + coeffs.cb_ex * ((hz_f - _shift_bwd(hz_f, 1)) - (hy_f - _shift_bwd(hy_f, 2)))).astype(_fdtype)
     ey = (coeffs.ca_ey * ey + coeffs.cb_ey * ((hx_f - _shift_bwd(hx_f, 2)) - (hz_f - _shift_bwd(hz_f, 0)))).astype(_fdtype)
     ez = (coeffs.ca_ez * ez + coeffs.cb_ez * ((hy_f - _shift_bwd(hy_f, 0)) - (hx_f - _shift_bwd(hx_f, 1)))).astype(_fdtype)
@@ -581,10 +610,13 @@ def update_e_nu_aniso(state: FDTDState, materials: MaterialArrays,
     on a non-uniform mesh. ``materials.sigma`` is still applied
     isotropically (matches the uniform-path :func:`update_e_aniso`).
     """
+    # Compute dtype: max(state dtype, float32) -- byte-identical for float32
+    # storage, upcast for float16, promoted for float64 (issue #630).
     _fdtype = state.ex.dtype
-    hx = state.hx.astype(jnp.float32)
-    hy = state.hy.astype(jnp.float32)
-    hz = state.hz.astype(jnp.float32)
+    _cdtype = jnp.promote_types(_fdtype, jnp.float32)
+    hx = state.hx.astype(_cdtype)
+    hy = state.hy.astype(_cdtype)
+    hz = state.hz.astype(_cdtype)
     sigma = materials.sigma
 
     abs_eps_ex = eps_ex * EPS_0
@@ -617,9 +649,9 @@ def update_e_nu_aniso(state: FDTDState, materials: MaterialArrays,
         - (hx - _shift_bwd(hx, 1)) * inv_dy[None, :, None]
     )
 
-    ex = (ca_ex * state.ex.astype(jnp.float32) + cb_ex * curl_x).astype(_fdtype)
-    ey = (ca_ey * state.ey.astype(jnp.float32) + cb_ey * curl_y).astype(_fdtype)
-    ez = (ca_ez * state.ez.astype(jnp.float32) + cb_ez * curl_z).astype(_fdtype)
+    ex = (ca_ex * state.ex.astype(_cdtype) + cb_ex * curl_x).astype(_fdtype)
+    ey = (ca_ey * state.ey.astype(_cdtype) + cb_ey * curl_y).astype(_fdtype)
+    ez = (ca_ez * state.ez.astype(_cdtype) + cb_ez * curl_z).astype(_fdtype)
 
     return state._replace(ex=ex, ey=ey, ez=ez, step=state.step + 1)
 
@@ -675,10 +707,13 @@ def update_e_aniso_inv(state: FDTDState, materials: MaterialArrays,
             return jnp.roll(arr, 1, axis)
         return _shift_bwd(arr, axis)
 
+    # Compute dtype: max(state dtype, float32) -- byte-identical for float32
+    # storage, upcast for float16, promoted for float64 (issue #630).
     _fdtype = state.ex.dtype
-    hx = state.hx.astype(jnp.float32)
-    hy = state.hy.astype(jnp.float32)
-    hz = state.hz.astype(jnp.float32)
+    _cdtype = jnp.promote_types(_fdtype, jnp.float32)
+    hx = state.hx.astype(_cdtype)
+    hy = state.hy.astype(_cdtype)
+    hz = state.hz.astype(_cdtype)
     sigma = materials.sigma
 
     # Per-component lossy update coefficients in inv-eps form.
@@ -711,9 +746,9 @@ def update_e_aniso_inv(state: FDTDState, materials: MaterialArrays,
         - (hx - bwd(hx, 1)) / dx
     )
 
-    ex = (ca_ex * state.ex.astype(jnp.float32) + cb_ex * curl_x).astype(_fdtype)
-    ey = (ca_ey * state.ey.astype(jnp.float32) + cb_ey * curl_y).astype(_fdtype)
-    ez = (ca_ez * state.ez.astype(jnp.float32) + cb_ez * curl_z).astype(_fdtype)
+    ex = (ca_ex * state.ex.astype(_cdtype) + cb_ex * curl_x).astype(_fdtype)
+    ey = (ca_ey * state.ey.astype(_cdtype) + cb_ey * curl_y).astype(_fdtype)
+    ez = (ca_ez * state.ez.astype(_cdtype) + cb_ez * curl_z).astype(_fdtype)
 
     return state._replace(
         ex=ex, ey=ey, ez=ez,
@@ -747,10 +782,13 @@ def update_e_aniso(state: FDTDState, materials: MaterialArrays,
             return jnp.roll(arr, 1, axis)
         return _shift_bwd(arr, axis)
 
+    # Compute dtype: max(state dtype, float32) -- byte-identical for float32
+    # storage, upcast for float16, promoted for float64 (issue #630).
     _fdtype = state.ex.dtype
-    hx = state.hx.astype(jnp.float32)
-    hy = state.hy.astype(jnp.float32)
-    hz = state.hz.astype(jnp.float32)
+    _cdtype = jnp.promote_types(_fdtype, jnp.float32)
+    hx = state.hx.astype(_cdtype)
+    hy = state.hy.astype(_cdtype)
+    hz = state.hz.astype(_cdtype)
     sigma = materials.sigma
 
     # Per-component absolute permittivity
@@ -785,9 +823,9 @@ def update_e_aniso(state: FDTDState, materials: MaterialArrays,
         - (hx - bwd(hx, 1)) / dx
     )
 
-    ex = (ca_ex * state.ex.astype(jnp.float32) + cb_ex * curl_x).astype(_fdtype)
-    ey = (ca_ey * state.ey.astype(jnp.float32) + cb_ey * curl_y).astype(_fdtype)
-    ez = (ca_ez * state.ez.astype(jnp.float32) + cb_ez * curl_z).astype(_fdtype)
+    ex = (ca_ex * state.ex.astype(_cdtype) + cb_ex * curl_x).astype(_fdtype)
+    ey = (ca_ey * state.ey.astype(_cdtype) + cb_ey * curl_y).astype(_fdtype)
+    ez = (ca_ez * state.ez.astype(_cdtype) + cb_ez * curl_z).astype(_fdtype)
 
     return state._replace(
         ex=ex, ey=ey, ez=ez,

--- a/rfx/experiments/canonical.py
+++ b/rfx/experiments/canonical.py
@@ -703,11 +703,11 @@ def _validate_document(document: dict[str, Any]) -> None:
         _fail("range_error", "$.simulation.domain_m", "all dimensions must be > 0")
     _positive(simulation["cell_size_m"], "$.simulation.cell_size_m")
     _positive(simulation["freq_max_hz"], "$.simulation.freq_max_hz")
-    if simulation["precision"] not in {"float32", "mixed"}:
+    if simulation["precision"] not in {"float32", "mixed", "float64"}:
         _fail(
             "unsupported_variant",
             "$.simulation.precision",
-            "expected 'float32' or 'mixed'",
+            "expected 'float32', 'mixed', or 'float64'",
         )
 
     material_ids = {"pec"}

--- a/rfx/experiments/spec.py
+++ b/rfx/experiments/spec.py
@@ -379,8 +379,10 @@ def _parse_current(doc: Mapping[str, Any]) -> ExperimentSpec:
     precision = _text(
         execution_doc.get("precision", "float32"), "spec.execution.precision"
     )
-    if precision not in {"float32", "mixed"}:
-        raise ExperimentSpecError("execution.precision must be 'float32' or 'mixed'")
+    if precision not in {"float32", "mixed", "float64"}:
+        raise ExperimentSpecError(
+            "execution.precision must be 'float32', 'mixed', or 'float64'"
+        )
     execution = ExecutionSpec(
         backend=backend,
         precision=precision,

--- a/tests/test_coax_two_port_ad.py
+++ b/tests/test_coax_two_port_ad.py
@@ -371,8 +371,13 @@ def test_compute_coaxial_two_port_ad_grad_finite_and_fd_consistent():
     """Gate: ``compute_coaxial_two_port`` is differentiable end to end w.r.t.
     ``eps_scale`` and the float32 AD gradient (as shipped) matches a central
     finite difference computed with a float64 LOSS (scoped ``enable_x64()``
-    -- the FDTD fields stay float32 throughout; only the DFT-accumulator-
-    and-downstream math gains precision, exactly like MSL's own referee).
+    -- on this gate's production config the FDTD fields stay float32
+    STORAGE throughout; only the DFT-accumulator-and-downstream math gains
+    precision, exactly like MSL's own referee). Storage vs arithmetic
+    (issue #630): before #630 the Yee update's compute dtype was pinned to
+    float32 for any field storage dtype, so this gate's floor was never a
+    field-storage question in the first place; #630 makes compute dtype
+    follow storage (a no-op here, since storage IS float32 by default).
     This is the AD moat for the two-port coax method (mirrors
     ``tests/test_coax_end_to_end_ad.py::
     test_coax_reflection_grad_finite_and_fd_consistent`` for the 1-port

--- a/tests/test_experiment_spec.py
+++ b/tests/test_experiment_spec.py
@@ -54,8 +54,8 @@ def test_v0_migration_renames_blocks_and_preserves_identity_fields():
         ),
         (lambda doc: doc["execution"].update({"backend": "gpu"}), "only permits"),
         (
-            lambda doc: doc["execution"].update({"precision": "float64"}),
-            "float32.*mixed",
+            lambda doc: doc["execution"].update({"precision": "bogus"}),
+            "float32.*mixed.*float64",
         ),
         (
             lambda doc: doc["model"]["frequency_sweep"].update({"stop_hz": 1.0}),

--- a/tests/test_jacobian_fwd.py
+++ b/tests/test_jacobian_fwd.py
@@ -96,7 +96,11 @@ _FD_H_VALUES_MATERIAL = (0.01, 0.02, 0.04)
 # the sweep starts at 0.02 for this leg specifically. This IS the h-drift
 # check the design contract asks for: a real derivative holds steady as h
 # grows past the noise floor, while a rounding-lattice coincidence would
-# not.
+# not. "float32" here is this gate's storage AND compute dtype (both
+# default float32, unaffected by issue #630's storage-vs-arithmetic fix);
+# it is not a claim that widening field STORAGE alone would raise this
+# floor -- pre-#630 the Yee compute dtype was pinned to float32
+# regardless of storage, so it wouldn't have.
 _FD_H_VALUES_GEOMETRY = (0.02, 0.04, 0.08)
 
 
@@ -181,7 +185,13 @@ def _material_only_objective(sim, functional, *, stop_gradient_tape: bool = Fals
 
 def _central_fd_f64(objective, x0: float, h: float):
     """Central FD, comparison arithmetic in float64 (#527/#579 discipline):
-    fields stay float32, only the FD/comparison math gains precision."""
+    on this gate's production config, fields stay float32 STORAGE; only
+    the FD/comparison math gains precision. "Fields stay float32" is a
+    storage statement, not an arithmetic one (issue #630): before #630 the
+    Yee update's compute dtype was hard-pinned to float32 regardless of
+    storage, so it would not have helped to widen fields here; #630 makes
+    compute dtype follow storage, which is a no-op at this gate's float32
+    default and only takes effect under ``precision="float64"``."""
     with enable_x64():
         fp = objective(jnp.asarray(x0 + h, dtype=jnp.float32))
         fm = objective(jnp.asarray(x0 - h, dtype=jnp.float32))

--- a/tests/test_mixed_precision.py
+++ b/tests/test_mixed_precision.py
@@ -88,7 +88,7 @@ class TestSimulationMixedPrecision:
     def test_precision_parameter_validation(self):
         with pytest.raises(ValueError, match="precision"):
             Simulation(freq_max=5e9, domain=(0.02, 0.02, 0.02),
-                       boundary="pec", precision="float64")
+                       boundary="pec", precision="float128")
 
     def test_mixed_precision_runs(self):
         """Mixed precision simulation completes without NaN."""

--- a/tests/test_n_warmup.py
+++ b/tests/test_n_warmup.py
@@ -166,7 +166,10 @@ def test_warmup_truncation_error_grows_with_k():
     (forward output is provably n_warmup-invariant per
     test_forward_matches_plain, so the oracle is unaffected by K) with
     comparison arithmetic in float64 (repo convention, tests/_x64_compat.py
-    + test_jacobian_fwd.py's _central_fd_f64).
+    + test_jacobian_fwd.py's _central_fd_f64 -- see that function's
+    docstring for the storage-vs-arithmetic distinction, issue #630: this
+    fixture's FDTD fields stay float32 storage, which was and remains
+    also the Yee compute dtype at that storage).
 
     Measured (this fixture, N_STEPS=100, N_FIXED=80, design cell offset
     from source/probe): rel_err vs. FD oracle is roughly

--- a/tests/test_observables_dft_field.py
+++ b/tests/test_observables_dft_field.py
@@ -177,8 +177,20 @@ def _geometry_objective(sim, functional, *, eps_bg=1.0, eps_fg=4.0):
 
 def _central_fd_f64(objective, x0: float, h: float):
     """Central finite difference with the comparison arithmetic in float64
-    (#527 discipline: the FDTD fields stay float32; only the loss/FD
-    comparison gains precision, scoped via enable_x64()).
+    (#527 discipline: on this gate's production config the FDTD fields
+    stay float32 storage; only the loss/FD comparison gains precision,
+    scoped via enable_x64()).
+
+    Storage vs arithmetic (issue #630): "fields stay float32" describes
+    STORAGE, not the Yee update's compute dtype. Before #630 the Yee
+    curl/update arithmetic was hard-pinned to float32 for ANY field
+    storage dtype, so setting fields to float64 alone would NOT have
+    removed the FD noise floor these gates sit above -- the arithmetic
+    would silently re-quantize back to float32 every timestep regardless.
+    #630 made the compute dtype follow storage
+    (``jnp.promote_types(field_dtype, jnp.float32)``); at this gate's
+    float32 storage that is still float32, so #630 changes nothing here
+    -- it only matters if a caller opts into ``precision="float64"``.
 
     The design-variable input is deliberately kept float32 (its natural
     dtype, matching eps_base — test_coax_two_port_ad.py established this:

--- a/tests/test_precision_lane_guard.py
+++ b/tests/test_precision_lane_guard.py
@@ -1,0 +1,190 @@
+"""Issue #630 follow-up: precision="mixed"/"float64" must fail LOUD, not
+silently degrade to float32, on lanes whose runner does not thread
+field_dtype.
+
+`field_dtype` is threaded only by `rfx/runners/uniform.py`. The
+non-uniform-mesh, distributed, distributed-NU, and subgridded runners have
+zero `field_dtype` occurrences (grepped as part of the #630 follow-up
+review), so before this fix a non-uniform-mesh or distributed simulation
+with `precision="mixed"`/`"float64"` would silently run float32 fields
+while reporting no error at all -- the SILENT_WRONG class this repo removes
+on sight. `_dispatch_plan` (the single lane-decision point for `run()` and
+`forward()`) now rejects the combination with `NotImplementedError` before
+any compute runs, on every affected lane. `_validate_cfg_precision_x64`
+also warns in advance for the non-uniform-mesh case (the distributed case
+is a call-time kwarg invisible to preflight, so the dispatch-time raise is
+the ONLY enforcement point there -- see that check's docstring).
+
+These tests are deliberately NOT `pytest.mark.gpu`: they only exercise the
+dispatch-time guard (a Python-level raise before any FDTD compute), so they
+run on CPU in the default local suite -- `tests/test_mixed_precision.py`'s
+numeric mixed-precision tests are module-wide `gpu`-marked and would
+otherwise be the only place this behavior is covered, deselected from the
+default local run.
+
+Also covers a second, related precision guard added in the same follow-up:
+issue #644 (precision="mixed" + CPML, a pre-existing defect #630 newly made
+reachable from forward() -- see the module section below for the full
+mechanism).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from rfx import Simulation
+
+
+def _nu_sim(*, precision: str) -> Simulation:
+    dz = np.full(20, 1.0e-3)
+    sim = Simulation(
+        freq_max=5.0e9, domain=(0.02, 0.02, 0.0), dz_profile=dz,
+        boundary="pec", precision=precision,
+    )
+    sim.add_source(
+        position=(0.01, 0.01, 0.005), component="ez",
+        amplitude_kind="current",
+    )
+    return sim
+
+
+def _uniform_sim(*, precision: str) -> Simulation:
+    sim = Simulation(
+        freq_max=5.0e9, domain=(0.02, 0.02, 0.02), boundary="pec",
+        precision=precision,
+    )
+    sim.add_source(
+        position=(0.01, 0.01, 0.01), component="ez",
+        amplitude_kind="current",
+    )
+    return sim
+
+
+@pytest.mark.parametrize("precision", ["mixed", "float64"])
+def test_nonuniform_run_rejects_nonfloat32_precision(precision):
+    sim = _nu_sim(precision=precision)
+    with pytest.raises(NotImplementedError, match="run_nonuniform"):
+        sim.run(n_steps=5, skip_preflight=True)
+
+
+@pytest.mark.parametrize("precision", ["mixed", "float64"])
+def test_nonuniform_forward_rejects_nonfloat32_precision(precision):
+    sim = _nu_sim(precision=precision)
+    with pytest.raises(NotImplementedError, match="fwd_nonuniform"):
+        sim.forward(n_steps=5, skip_preflight=True)
+
+
+def test_nonuniform_precision_preflight_warns_in_advance():
+    """The preflight warning fires BEFORE the dispatch-time raise -- it is
+    an advisory, not the enforcement point (that is _dispatch_plan)."""
+    sim = _nu_sim(precision="mixed")
+    report = sim.preflight(strict=False)
+    hits = report.by_code("precision_nonuniform_lane_unsupported")
+    assert len(hits) == 1, (
+        f"expected exactly one nonuniform-lane precision warning; got "
+        f"{[getattr(i, 'code', None) for i in report]}"
+    )
+
+
+def test_distributed_forward_rejects_nonfloat32_precision():
+    """distributed=True is a call-time forward() kwarg invisible to
+    preflight (Simulation-construction-time); _dispatch_plan is the only
+    place this can be caught, so this is a distinct code path from the
+    non-uniform-mesh test above, not a duplicate."""
+    sim = _nu_sim(precision="float64")  # DP3: distributed forward is NU-only
+    with pytest.raises(NotImplementedError, match="run_distributed|fwd_distributed_nu"):
+        sim.forward(distributed=True, n_steps=5, skip_preflight=True)
+
+
+def test_subgridded_run_rejects_nonfloat32_precision():
+    sim = _uniform_sim(precision="mixed")
+    # Minimal refinement dict -- only the lane-dispatch guard is under
+    # test here, not subgridding physics, so the other fields don't need
+    # to describe a valid refinement region.
+    sim._refinement = {
+        "z_range": (0.005, 0.015), "ratio": 2, "xy_margin": 0.0,
+        "tau": None, "validation": None, "topology": None,
+    }
+    with pytest.raises(NotImplementedError, match="run_subgridded"):
+        sim.run(n_steps=5, skip_preflight=True)
+
+
+@pytest.mark.parametrize("precision", ["float32", "mixed", "float64"])
+def test_uniform_lane_unaffected_by_the_new_guard(precision):
+    """Negative control: the uniform lane is the ONE lane this knob is
+    documented to support, so none of it should raise here. float64
+    needs x64 enabled or it silently downcasts -- irrelevant to this
+    guard (a separate, already-covered concern), so only dtype-reachable
+    aspects are checked, not the float64 numeric path itself."""
+    sim = _uniform_sim(precision=precision)
+    result = sim.run(n_steps=3, skip_preflight=True)
+    assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# Issue #644: precision="mixed" + CPML is a pre-existing, NOT-#630-caused
+# defect (measured identical via run() on the pre- and post-#630 trees; the
+# CPML psi_* carry follows field_dtype=float16 but the CPML coefficients are
+# hard-pinned to float32, breaking the lax.scan carry contract). #630 made
+# forward() honour precision= for the first time (previously it silently
+# ignored precision= and always ran float32), which newly makes this
+# pre-existing defect reachable from forward() -- these tests pin that the
+# NEW reachability surfaces a clear rfx-layer NotImplementedError instead of
+# degrading to a raw JAX carry-dtype TypeError, and that float32/float64
+# (unaffected -- promote_types(float64, float32) == float64 matches
+# storage, no carry-dtype mismatch) and UPML (measured: no analogous
+# hard-float32 psi carry) are untouched by this guard. Fixing #644 itself
+# (giving psi_* and the CPML coefficients one consistent dtype policy) is
+# explicitly out of scope here -- see issue #644.
+# ---------------------------------------------------------------------------
+
+def _cpml_sim(*, precision: str) -> Simulation:
+    sim = Simulation(
+        freq_max=5.0e9, domain=(0.02, 0.02, 0.02), boundary="cpml",
+        precision=precision,
+    )
+    sim.add_source(
+        position=(0.01, 0.01, 0.01), component="ez",
+        amplitude_kind="current",
+    )
+    return sim
+
+
+def test_forward_mixed_cpml_raises_clean_notimplementederror_not_raw_typeerror():
+    sim = _cpml_sim(precision="mixed")
+    with pytest.raises(NotImplementedError, match="#644"):
+        sim.forward(n_steps=5, skip_preflight=True)
+
+
+def test_forward_mixed_cpml_per_face_boundary_spec_also_caught():
+    """The guard reads self._boundary_spec (always normalized, even from a
+    legacy scalar boundary=), so a per-face BoundarySpec with only ONE
+    CPML face must trip it too -- not just the all-faces-cpml scalar case."""
+    from rfx.boundaries.spec import BoundarySpec, Boundary
+
+    sim = Simulation(
+        freq_max=5.0e9, domain=(0.02, 0.02, 0.02),
+        boundary=BoundarySpec(x="pec", y="pec", z=Boundary(lo="cpml", hi="cpml")),
+        precision="mixed",
+    )
+    sim.add_source(
+        position=(0.01, 0.01, 0.01), component="ez",
+        amplitude_kind="current",
+    )
+    with pytest.raises(NotImplementedError, match="#644"):
+        sim.forward(n_steps=5, skip_preflight=True)
+
+
+def test_forward_float64_cpml_is_unaffected_by_the_644_guard():
+    import jax
+    jax.config.update("jax_enable_x64", True)
+    sim = _cpml_sim(precision="float64")
+    result = sim.forward(n_steps=5, skip_preflight=True)
+    assert result is not None
+
+
+def test_forward_float32_cpml_is_unaffected_by_the_644_guard():
+    sim = _cpml_sim(precision="float32")
+    result = sim.forward(n_steps=5, skip_preflight=True)
+    assert result is not None

--- a/tests/test_precision_lane_guard.py
+++ b/tests/test_precision_lane_guard.py
@@ -177,10 +177,21 @@ def test_forward_mixed_cpml_per_face_boundary_spec_also_caught():
 
 
 def test_forward_float64_cpml_is_unaffected_by_the_644_guard():
-    import jax
-    jax.config.update("jax_enable_x64", True)
+    # Scoped x64, per this repo's own rule (CLAUDE.md, and see this
+    # package's own precision docstring): never flip jax_enable_x64
+    # process-globally in a test -- it leaks to every test scheduled after
+    # this one in the same pytest-split worker. Use the repo's version-
+    # robust scoped context (jax.experimental.enable_x64 upstream, or the
+    # tests/_x64_compat.py shim on newer JAX that removed it), matching
+    # the idiom in tests/test_coax_two_port_ad.py.
+    try:
+        from jax import enable_x64
+    except ImportError:  # older JAX (< ~0.4.31)
+        from tests._x64_compat import enable_x64
+
     sim = _cpml_sim(precision="float64")
-    result = sim.forward(n_steps=5, skip_preflight=True)
+    with enable_x64():
+        result = sim.forward(n_steps=5, skip_preflight=True)
     assert result is not None
 
 

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -185,8 +185,11 @@ def test_gradient_through_dft_plane():
         print(f"  FD check at ({ci},{cj},{ck}): AD={ad:.6e}, FD={fd:.6e}, err={rel_err:.4e}")
         # Relaxed tolerance: DFT accumulator values scale as O(dt) ≈ 5e-12,
         # so the objective and gradients are extremely small (~1e-24).
-        # Float32 FD at this scale has limited precision. We verify same
-        # sign + same order of magnitude (< 50% relative error).
+        # Float32 FD at this scale has limited precision (this test runs
+        # fully float32, no enable_x64() scoping -- both field storage and
+        # Yee compute dtype are float32, unaffected by issue #630's
+        # storage-vs-arithmetic distinction). We verify same sign + same
+        # order of magnitude (< 50% relative error).
         assert rel_err < 0.50, f"DFT plane gradient FD mismatch: rel_err={rel_err:.4f}"
 
 


### PR DESCRIPTION
Closes #630.

`rfx/core/yee.py` computed every Yee update in float32 regardless of how the fields
were stored:

```python
_fdtype = state.ex.dtype                                            # used only to cast BACK
_cdtype = jnp.complex64 if jnp.iscomplexobj(state.ex) else jnp.float32   # the pin
```

So a float64 carry was re-quantised to float32 every timestep. `precision=` set the
storage dtype and the arithmetic ignored it. The fix is
`jnp.promote_types(state.ex.dtype, jnp.float32)` at both sites, plus the equivalent
lift at the literal `.astype(jnp.float32)` sites in the non-uniform lane.

## Evidence

The clearest witness is a perturbation-response trace at float64 storage. Before the
fix the response does not follow the perturbation size at all — a 10x LARGER
perturbation produces a SMALLER response:

| perturbation | before | after |
|---|---|---|
| 1e-4 | +7.28e-15 | +1.04e-14 |
| 1e-3 | +2.26e-14 | +7.78e-15 |
| 1e-2 | +1.56e-14 | +5.19e-15 |
| 1e-1 | +1.80e-14 | +2.59e-15 |

After the fix it is strictly monotone, symmetric and linear.

**Causal falsifier, pre-declared.** Reverting only the two `_cdtype` lines while
KEEPING every literal `.astype` change reproduces the stock result bit-for-bit. That
isolates `_cdtype` as the entire load-bearing change and rules out the literals as an
alternative explanation — a fix limited to them would have read as "hypothesis refuted".

## Production is untouched

`promote_types(s, float32)` differs from the literal only when `s` is WIDER than
float32, so float32 and float16 storage are unaffected by construction. Verified
bitwise (SHA-256 of raw bytes, not a tolerance) across four configurations x six field
components, base vs this branch:

| configuration | result |
|---|---|
| PEC | 6/6 identical |
| CPML | 6/6 identical |
| lossy material + CPML (sigma=0.05) | 6/6 identical |
| non-uniform mesh + CPML | 6/6 identical |

The non-uniform row is the one that matters for the literal-site edits, since that is
where they live. Re-run after the review round below: still 24/24.

## Review round (second commit)

Three gaps found on review, all fixed in `a23106e`:

1. **`precision=` silently degraded off the uniform lane.** Only `rfx/runners/uniform.py`
   threads `field_dtype`; the other seven runners have zero occurrences, so a
   non-uniform or distributed run quietly executed float32. Now a `NotImplementedError`
   at the single lane-decision point, matching the idiom `_dispatch_plan` already uses
   for every other lane-restricted feature. It fires under `skip_preflight=True`, which
   a preflight-only check would not have.
2. **Schema/runtime drift introduced by the first commit.** The JSON schema was widened
   to accept `"float64"` while both experiment-spec validators still rejected it, so a
   config could pass schema validation and then die at runtime. Both are widened now,
   with the pinned error-message test updated.
3. **`forward()` newly reached a pre-existing CPML defect** (#644) and leaked a raw
   `lax.scan` carry error. Now a clear `NotImplementedError` naming the issue. Keyed off
   the normalized boundary spec, so a per-face spec with one CPML face trips it too.

Guard behaviour verified directly, both directions — it fires on
`{non-uniform, distributed} x {float64, mixed}` and on `forward()` + mixed + CPML, and
does NOT touch uniform float64+CPML, uniform float32, non-uniform float32, mixed+PEC,
or mixed+UPML.

## Incidental second fix

`forward()` never threaded `field_dtype` at all — it always passed `None` — so
`precision=` was inert there for every value, not just the new one. Both entry points
now resolve it through one helper.

## Not in scope

`precision="mixed"` with CPML is broken independent of this work: measured through
`run()` on pinned trees, the 2x2 of {PEC, CPML} x {float32, mixed} is identical before
and after, with `cpml+mixed` a `TypeError` on BOTH. Filed as #644, with a note that the
`forward()` guard added here must be removed as part of its fix. It stayed invisible
because all 13 committed mixed-precision tests use `boundary="pec"` and the file is
`gpu`-marked.

R3: memory=project_issue527_f32_comparator (precision-stage discipline; this adds a third
stage — arithmetic dtype is independent of storage dtype) | R2-attempts=1 | falsifier=the
`_cdtype`-only revert above, run and bit-identical to stock
