### PR TITLE
fix(cpml): allocate psi accumulators at float32 or above so precision="mixed" works with CPML (closes #644)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,106 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — `precision="mixed"` never worked with CPML boundaries (issue #644)
+
+`Simulation(boundary="cpml", precision="mixed").run(...)` raised a raw JAX
+`TypeError` ("scan body function carry input and carry output must have equal
+types ... `psi_hz_yhi` has type float16[...] but the corresponding output
+component has type float32[...]"). Pre-existing on every released version, and
+measured identical on the trees before and after the issue #630 compute-dtype
+work, so #630 neither caused nor fixed it.
+
+- **Mechanism.** `rfx/boundaries/cpml.py`'s `psi_*` auxiliary arrays were
+  allocated at the field storage dtype (float16 under `precision="mixed"`),
+  while the CPML profile coefficients (`b`/`c`/`kappa`) are hard-pinned
+  float32. `psi = b*psi + c*curl` therefore evaluated to float32 while the
+  `lax.scan` carry had been declared float16, and the carry signature stopped
+  matching its own input. Loud failure, never a silent wrong number.
+- **Fix.** The `psi_*` arrays are *accumulation* state — a recursive
+  convolution integrated over every timestep — so they are now allocated at
+  `jnp.promote_types(field_dtype, jnp.float32)` and never sit below float32.
+  This is deliberately NOT a flat float32 pin: `psi` followed `field_dtype`
+  for a reason (the issue #404 oblique-Bloch path needs a *complex* carry),
+  and a flat pin would have fixed float16 by silently breaking complex64. The
+  promotion satisfies every caller at once — float16 -> float32 (the fix),
+  float32 -> float32 (unchanged), float64 -> float64, complex64 -> complex64.
+  It is the same idiom already used by `rlc_carry_dtype` in `rfx/lumped.py`
+  and by #630's `_cdtype`.
+- **Second, latent defect fixed in the same path.** With float32 corrections
+  scattering into float16 fields, `apply_cpml_e`/`apply_cpml_h` tripped JAX's
+  "cannot safely cast value from dtype=float32 to dtype=float16" *FutureWarning*
+  — which JAX states "will result in an error" in a future release. Both
+  functions now accumulate at the psi dtype and round back to storage dtype
+  once at the end, instead of rounding at each of the four `.at[].add()` per
+  component. Measured no-op for float32/float64/complex64 (`promote_types` is
+  idempotent there). **This is deprecation-driven, not an accuracy
+  improvement, and is not claimed as one**: it moves the mixed+CPML absorption
+  floor from -59.5 dB to -59.7 dB, which is noise — the float16 *storage*
+  quantization dominates, not the per-add rounding. The justification stands
+  on its own: without it the #644 fix expires the moment JAX turns that
+  warning into an error.
+- **The `forward()` guard from #630 is removed.** #630 shipped a temporary
+  `NotImplementedError` in `_forward_from_materials` for `mixed` + CPML rather
+  than leak the raw JAX carry-dtype `TypeError` through the newly-`precision`-
+  aware `forward()`. The root cause is now fixed, so the guard is gone —
+  leaving it would have kept `mixed` + CPML blocked through `forward()`
+  forever. Its two regression pins in `tests/test_precision_lane_guard.py`
+  are **kept and inverted to assert success** rather than deleted: they encode
+  two genuinely distinct paths (a scalar `boundary="cpml"`, and a per-face
+  `BoundarySpec` carrying only one cpml face), and both must keep working.
+  Measured on the rebased tree: `run()` and `forward()` are now both green
+  across all of pec/cpml/upml x float32/mixed.
+- **Separate pre-existing defect uncovered by that guard removal — reported,
+  NOT fixed here.** The per-face guard test was passing for the wrong reason:
+  the guard raised before any CPML compute ran, so it never exercised the
+  per-face CPML path. With the guard gone, that fixture (per-face spec, PEC on
+  x/y, `cpml_layers=16` against unpadded 8-cell x/y axes) fails in
+  `apply_cpml_e` with a SHAPE error — `mul got incompatible shapes for
+  broadcasting: (16,1,1) vs (8,8,40)` — because the x/y face slices `[:n]`
+  still run on axes that were never padded. MEASURED on the unpatched parent
+  commit: identical failure at `precision="float32"` through both `run()` and
+  `forward()`, so it is a per-face CPML geometry defect, precision-independent
+  and unrelated to this issue. The condition is `cpml_layers` > the unpadded
+  width of a PEC axis; the test now pins `cpml_layers=4`, which reaches the
+  CPML compute and is red-then-green for the #644 dtype fix as intended.
+- **The absorption caveat is documented where users will see it**: the
+  `precision=` parameter docstring in `rfx/api/__init__.py` (which feeds the
+  API reference) now states the measured -76 dB -> -59.5 dB floor shift, notes
+  the numbers come from a specific fixture rather than being a universal
+  bound, and says plainly that `"mixed"` is not a drop-in `"float32"`
+  substitute for reflection coefficients, S-parameters, or anything near the
+  absorber floor.
+- **Production paths are bit-identical — verified as an identity claim, not a
+  tolerance.** SHA-256 of the raw field bytes (all six components) matches
+  between a `git archive` of the base commit and this branch across four
+  fixtures: PEC, CPML, lossy-material+CPML, and non-uniform-mesh+CPML, plus
+  `precision="mixed"`+PEC. The harness's sensitivity was demonstrated rather
+  than assumed: a deliberate 2 ppm perturbation of the CPML `alpha` profile
+  changes all three CPML fixture hashes and leaves both PEC hashes untouched
+  (PEC never constructs CPML state at all).
+- **Accuracy of `mixed` + CPML, measured — with a real cost worth knowing.**
+  On a 40^3 domain (dx = 3.0 mm, dt = 5.72 ps), mixed-vs-float32 relative L2
+  error on Ez is 0.20% at 50 steps and 0.23% at 100 steps. But float16 fields
+  raise the **absorber's residual floor**: total field energy 400 steps after
+  the pulse settles reaches -76.3 dB below peak in float32 and only -59.5 dB
+  in mixed — roughly **17 dB worse absorption**, consistent with float16's
+  ~9.8e-4 machine epsilon quantizing the field storage. `mixed` + CPML is
+  correct and stable (no NaN/Inf out to 800 steps), but it is not a drop-in
+  substitute for float32 when the quantity of interest is a low-level residual
+  or a reflection coefficient near the absorber floor.
+- **Test coverage — the reason this stayed invisible.** All 13 tests in
+  `tests/test_mixed_precision.py` used `boundary="pec"`, and PEC never builds
+  CPML state, so the CPML dtype path had zero coverage. The file was also
+  entirely `pytestmark = pytest.mark.gpu`, which `pyproject.toml`'s
+  `addopts = "-m 'not gpu and not slow and not slow_physics'"` deselects from
+  every default run — two independent reasons the gap could not be seen. The
+  file-level `gpu` mark is **removed** (measured: the original 13 tests run in
+  6.5 s wall on CPU, slowest 1.27 s — these are dtype/dispatch assertions, not
+  the "needs GPU / too slow on CPU" the marker is defined for), and CPML rows
+  are added: psi dtype policy per field dtype, the full boundary x precision
+  2x2 from the issue, mixed-vs-float32 agreement, an absorption witness in dB,
+  and a regression pin for the unsafe-cast warning. 24 tests, 17.3 s on CPU.
+
 ### Fixed — Yee update arithmetic was hard-pinned to float32 regardless of field storage dtype (issue #630)
 
 - `rfx/core/yee.py`'s `update_h`/`update_e` computed `_cdtype = jnp.complex64
@@ -102,6 +202,7 @@ SemVer — **BREAKING** entries are flagged in upper-case.
   lane (`update_he_fast` is GPU-only; the literals there and in the NU/
   aniso lanes are unreachable from the CPU test suite either way).
 - No existing gate/tolerance changed; this PR does not tighten anything.
+
 ### Fixed — `vmap_material_sweep` didn't sweep the CPML absorber for material-named sweeps (issue #637)
 
 Found by an independent audit of the e4b565c..ce44661 arc: for a material-

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -333,6 +333,23 @@ class Simulation(
         non-uniform-mesh case (the distributed case is a call-time
         ``run()``/``forward()`` kwarg, invisible to preflight, so its
         `NotImplementedError` at dispatch is the only enforcement point).
+
+        ACCURACY CAVEAT for ``"mixed"`` with a CPML boundary (issue #644):
+        float16 field storage is fine for transient and field-shape work
+        (measured 0.20% relative L2 error on Ez vs ``"float32"`` at 50
+        steps), but it raises the absorber's residual floor. On the
+        fixture in ``tests/test_mixed_precision.py`` — a 40**3 domain,
+        dx = 3.0 mm, point source, 400 steps — total field energy settles
+        to about -76 dB below peak under ``"float32"`` but only about
+        -59.5 dB under ``"mixed"``: roughly 17 dB worse, consistent with
+        float16's ~1e-3 machine epsilon quantizing the stored fields.
+        Those two numbers are from that one fixture, not a universal
+        bound; the floor scales with float16 epsilon, so expect the same
+        order wherever the field storage is float16. Practical rule:
+        ``"mixed"`` is not a drop-in ``"float32"`` substitute when the
+        quantity of interest is a reflection coefficient, an S-parameter,
+        or anything else living near the absorber floor — use
+        ``"float32"`` (the default) for those.
     solver : str
         ``"yee"`` (default) for the standard explicit scheme or
         ``"adi"`` for the ADI-FDTD path. ADI is unconditionally stable in

--- a/rfx/api/_execute.py
+++ b/rfx/api/_execute.py
@@ -1523,47 +1523,6 @@ class _ExecuteMixin:
                     r_val=_v.get("R"), l_val=_v.get("L"), c_val=_v.get("C"),
                 ))
 
-        # Issue #644 (pre-existing, NOT caused by #630 -- measured identical
-        # via run() on both the pre- and post-#630 trees): CPML's psi_*
-        # carry arrays are allocated at field_dtype (float16 for
-        # precision="mixed"), but the CPML coefficients are hard-pinned to
-        # float32, so `psi = b*psi + c*curl` promotes to float32 and the
-        # lax.scan carry signature no longer matches its own input --
-        # TypeError. This path was UNREACHABLE from forward() before #630
-        # (forward() silently ignored precision= entirely); #630 made
-        # forward() honour precision= for the first time (a genuine second
-        # fix -- see field_dtype=self._resolve_field_dtype() below), which
-        # newly surfaces this pre-existing defect through forward(). Fail
-        # loud with a clear, actionable rfx-layer message instead of
-        # degrading to a raw JAX carry-dtype TypeError. UPML does NOT hit
-        # this (measured: boundary="upml" + precision="mixed" runs clean
-        # on forward() -- the coefficient/carry dtype mismatch is CPML-only,
-        # rfx/boundaries/upml.py has no analogous hard-float32 psi carry
-        # promoted by a field_dtype-following one). float64 is unaffected
-        # (jnp.promote_types(float64, float32) == float64 matches storage,
-        # so the carry stays consistent) -- measured clean on forward().
-        if self._precision == "mixed":
-            _bspec = self._boundary_spec
-            _uses_cpml = any(
-                getattr(_bspec, _axis).lo == "cpml"
-                or getattr(_bspec, _axis).hi == "cpml"
-                for _axis in ("x", "y", "z")
-            )
-            if _uses_cpml:
-                raise NotImplementedError(
-                    "forward(): precision='mixed' with a CPML boundary "
-                    "face is not supported (issue #644, pre-existing -- "
-                    "not caused by this fix). The CPML psi_* carry arrays "
-                    "follow field_dtype (float16), but the CPML "
-                    "coefficients are hard-pinned to float32, so the "
-                    "update promotes float16->float32 and breaks the "
-                    "lax.scan carry contract with a raw JAX TypeError. Use "
-                    "precision='float32' (default) or 'float64' with CPML "
-                    "today; 'mixed' + CPML needs #644's fix (giving the "
-                    "psi_* arrays and CPML coefficients one consistent "
-                    "dtype policy) before it can work."
-                )
-
         result = _run(
             grid,
             materials,

--- a/rfx/boundaries/cpml.py
+++ b/rfx/boundaries/cpml.py
@@ -352,12 +352,30 @@ def init_cpml(grid, *, kappa_max: float | None = None,
 
     nx, ny, nz = grid.shape if hasattr(grid, 'shape') else (grid.nx, grid.ny, grid.nz)
 
+    # Issue #644.  The psi_* arrays are ACCUMULATION state — a recursive
+    # convolution integrated over every timestep — so they must never sit
+    # below float32, whatever the field STORAGE dtype is.  Following
+    # ``field_dtype`` verbatim put them at float16 under
+    # ``precision="mixed"`` while the profile coefficients (b/c/kappa) are
+    # hard-pinned float32, so ``psi = b*psi + c*curl`` promoted
+    # float16 -> float32 and the ``lax.scan`` carry signature stopped
+    # matching its own input (loud TypeError, never a silent wrong number).
+    #
+    # ``promote_types(field_dtype, float32)`` is the one policy that
+    # satisfies every caller at once:
+    #   float16   -> float32    the #644 fix; "float16 fields, float32
+    #                           accumulation" is exactly what this mode
+    #                           promises (tests/test_mixed_precision.py)
+    #   float32   -> float32    unchanged, bit-identical
+    #   float64   -> float64    matches storage; float32 coeffs promote up
+    #   complex64 -> complex64  preserves the #404 oblique Bloch path —
+    #                           which is WHY this followed field_dtype
+    #                           in the first place
+    # A flat ``float32`` pin would fix float16 and silently break complex64.
+    psi_dtype = jnp.promote_types(field_dtype, jnp.float32)
+
     def _zeros(dim_size: int, perp1: int, perp2: int) -> jnp.ndarray:
-        # psi carry dtype follows the field dtype so the lax.scan carry contract
-        # holds when fields are complex (#404 oblique Bloch path). Default
-        # float32 keeps the real path byte-identical. Real profile coeffs
-        # (b/c/kappa) stay float32 and multiply the psi carry without truncation.
-        return jnp.zeros((n, perp1, perp2), dtype=field_dtype)
+        return jnp.zeros((n, perp1, perp2), dtype=psi_dtype)
 
     state = CPMLState(
         # E-field psi (12 faces)
@@ -463,9 +481,22 @@ def apply_cpml_e(
     c_zh = pz_hi.c[:, None, None]
     k_zh = pz_hi.kappa[:, None, None]
 
-    ex = state.ex
-    ey = state.ey
-    ez = state.ez
+    # Issue #644.  Accumulate the CPML corrections at the psi dtype, then
+    # round back to the field storage dtype ONCE at the end.  Under
+    # ``precision="mixed"`` the corrections below are float32 (psi and the
+    # b/c/kappa coefficients both are) while the field is float16, so
+    # scattering them straight in would (a) round to float16 at each of the
+    # four ``.at[].add()`` per component instead of once, and (b) emit
+    # JAX's "cannot safely cast value from dtype=float32 to dtype=float16"
+    # FutureWarning, which JAX says "will result in an error" in a future
+    # release.  ``_work`` is a no-op cast for float32 / float64 / complex64
+    # (promote_types is idempotent there), so every non-mixed path stays
+    # bit-identical.
+    _fdtype = state.ex.dtype
+    _work = jnp.promote_types(_fdtype, jnp.float32)
+    ex = state.ex.astype(_work)
+    ey = state.ey.astype(_work)
+    ez = state.ez.astype(_work)
 
     # =========================================================
     # X-axis CPML: Ey correction (dHz/dx) and Ez correction (dHy/dx)
@@ -642,7 +673,10 @@ def apply_cpml_e(
         new_psi_ey_zlo = cpml_state.psi_ey_zlo
         new_psi_ey_zhi = cpml_state.psi_ey_zhi
 
-    state = state._replace(ex=ex, ey=ey, ez=ez)
+    # Round the accumulated corrections back to field storage dtype once
+    # (no-op unless precision="mixed" — see the _work note above).
+    state = state._replace(ex=ex.astype(_fdtype), ey=ey.astype(_fdtype),
+                           ez=ez.astype(_fdtype))
     cpml_state = cpml_state._replace(
         # x-axis
         psi_ey_xlo=new_psi_ey_xlo,
@@ -722,9 +756,13 @@ def apply_cpml_h(
     c_zh = pz_hi.c[:, None, None]
     k_zh = pz_hi.kappa[:, None, None]
 
-    hx = state.hx
-    hy = state.hy
-    hz = state.hz
+    # Issue #644 — same accumulate-at-psi-dtype, round-once policy as
+    # apply_cpml_e above (no-op for float32 / float64 / complex64).
+    _fdtype = state.hx.dtype
+    _work = jnp.promote_types(_fdtype, jnp.float32)
+    hx = state.hx.astype(_work)
+    hy = state.hy.astype(_work)
+    hz = state.hz.astype(_work)
 
     # =========================================================
     # X-axis CPML: Hy correction (dEz/dx) and Hz correction (dEy/dx)
@@ -900,7 +938,8 @@ def apply_cpml_h(
         new_psi_hy_zlo = cpml_state.psi_hy_zlo
         new_psi_hy_zhi = cpml_state.psi_hy_zhi
 
-    state = state._replace(hx=hx, hy=hy, hz=hz)
+    state = state._replace(hx=hx.astype(_fdtype), hy=hy.astype(_fdtype),
+                           hz=hz.astype(_fdtype))
     cpml_state = cpml_state._replace(
         # x-axis
         psi_hy_xlo=new_psi_hy_xlo,

--- a/tests/test_mixed_precision.py
+++ b/tests/test_mixed_precision.py
@@ -1,4 +1,24 @@
-"""Tests for mixed precision (float16 fields, float32 accumulation) support."""
+"""Tests for mixed precision (float16 fields, float32 accumulation) support.
+
+Boundary coverage is deliberate (issue #644).  Until #644 this file was 100%
+``boundary="pec"``, and PEC never constructs CPML state at all
+(``rfx/simulation.py`` leaves ``apply_cpml_e``/``apply_cpml_h`` as ``None``),
+so the entire CPML dtype path was untested — ``precision="mixed"`` + CPML had
+in fact NEVER worked.  Every new dtype/absorption assertion below therefore
+carries a CPML row, and ``test_precision_boundary_matrix`` pins the full 2x2
+from the issue so the gap cannot silently reopen.
+
+The file-level ``pytestmark = pytest.mark.gpu`` was also removed in #644.  It
+was the SECOND reason the gap stayed invisible: ``pyproject.toml``'s
+``addopts = "-m 'not gpu and not slow and not slow_physics'"`` deselected the
+whole file from every default local run.  Nothing here needs a GPU — these are
+dtype/dispatch assertions on 40**3-and-smaller grids, and the marker's own
+definition is "tests that need GPU — too slow on CPU or GPU-specific".
+Measured on CPU (``JAX_PLATFORMS=cpu``): the original 13 tests ran in 6.5 s
+wall, slowest single test 1.27 s.
+"""
+
+import warnings
 
 import numpy as np
 import jax.numpy as jnp
@@ -6,9 +26,8 @@ import pytest
 
 from rfx.core.yee import init_state, FDTDState, MaterialArrays, init_materials
 from rfx.api import Simulation
+from rfx.boundaries.cpml import init_cpml
 from rfx.sources.sources import GaussianPulse
-
-pytestmark = pytest.mark.gpu
 
 
 # ---------------------------------------------------------------------------
@@ -195,3 +214,169 @@ class TestSimulationMixedPrecision:
         )
         r = repr(sim)
         assert "precision='mixed'" in r
+
+
+# ---------------------------------------------------------------------------
+# Issue #644 — CPML dtype policy
+#
+# The psi_* arrays are ACCUMULATION state (a recursive convolution integrated
+# over every timestep), so they are allocated at
+# ``promote_types(field_dtype, float32)`` and never below float32.  Before the
+# fix they followed ``field_dtype`` verbatim, which put them at float16 under
+# ``precision="mixed"`` while the CPML coefficients stayed hard-pinned float32
+# — ``psi = b*psi + c*curl`` then promoted float16 -> float32 and the lax.scan
+# carry signature stopped matching its own input (TypeError).
+#
+# Note this is promote_types, NOT a flat float32 pin: psi followed field_dtype
+# originally for a REASON (the #404 oblique Bloch path needs a complex carry),
+# and a flat float32 pin would have fixed float16 by breaking complex64.
+# ---------------------------------------------------------------------------
+
+def _cpml_grid():
+    return Simulation(
+        freq_max=5e9, domain=(0.02, 0.02, 0.02), boundary="cpml",
+    )._build_grid()
+
+
+class TestCPMLPsiDtype:
+    """Unit-level dtype policy — no FDTD stepping, runs in milliseconds."""
+
+    @pytest.mark.parametrize("field_dtype,expected", [
+        (jnp.float16, jnp.float32),     # issue #644: the fix
+        (jnp.float32, jnp.float32),     # unchanged / bit-identical
+        (jnp.complex64, jnp.complex64),  # issue #404 oblique Bloch — must survive
+    ])
+    def test_psi_dtype_is_promoted_to_at_least_float32(self, field_dtype, expected):
+        _, st = init_cpml(_cpml_grid(), field_dtype=field_dtype)
+        actual = {getattr(st, f).dtype for f in st._fields}
+        assert actual == {jnp.dtype(expected)}, (
+            f"field_dtype={jnp.dtype(field_dtype)} -> psi {actual}, "
+            f"expected all {jnp.dtype(expected)}"
+        )
+
+    def test_psi_dtype_default_is_float32(self):
+        _, st = init_cpml(_cpml_grid())
+        assert {getattr(st, f).dtype for f in st._fields} == {jnp.dtype(jnp.float32)}
+
+    def test_psi_never_drops_below_float32_for_any_real_field_dtype(self):
+        """The invariant, stated directly: accumulation state is never float16."""
+        for fd in (jnp.float16, jnp.float32):
+            _, st = init_cpml(_cpml_grid(), field_dtype=fd)
+            for f in st._fields:
+                assert getattr(st, f).dtype != jnp.dtype(jnp.float16), (
+                    f"{f} is float16 under field_dtype={jnp.dtype(fd)} — "
+                    "a recursive accumulator must not sit in half precision"
+                )
+
+
+class TestMixedPrecisionCPML:
+    """The coverage axis that was missing entirely before issue #644."""
+
+    @staticmethod
+    def _sim(precision, *, boundary="cpml", probe=False):
+        sim = Simulation(
+            freq_max=5e9, domain=(0.02, 0.02, 0.02),
+            boundary=boundary, precision=precision,
+        )
+        sim.add_source(position=(0.01, 0.01, 0.01), component="ez",
+                       amplitude_kind="field")
+        if probe:
+            sim.add_probe(position=(0.014, 0.01, 0.01), component="ez")
+        return sim
+
+    def test_mixed_precision_cpml_runs(self):
+        """Issue #644 regression: this raised TypeError (lax.scan carry) before."""
+        result = self._sim("mixed").run(n_steps=100)
+        assert result is not None
+        # The mode's promise is float16 STORAGE — the fix must not have bought
+        # its way out of the crash by silently upcasting the fields.
+        assert result.state.ex.dtype == jnp.float16
+        assert result.state.hx.dtype == jnp.float16
+        for f in ("ex", "ey", "ez", "hx", "hy", "hz"):
+            assert not jnp.any(jnp.isnan(getattr(result.state, f)))
+            assert not jnp.any(jnp.isinf(getattr(result.state, f)))
+
+    def test_mixed_precision_cpml_forward_runs(self):
+        """Entry-point parity: run() and forward() must both work (issue #644).
+
+        This is also the tripwire for the ``forward()`` guard that PR #645
+        added for this combination — if that guard is still present when this
+        branch is rebased onto #645, this test goes red with
+        ``NotImplementedError`` and forces the removal, which is exactly the
+        intent.  Leaving the guard in would keep mixed+CPML blocked through
+        ``forward()`` forever even though the root cause is fixed.
+        """
+        assert self._sim("mixed").forward(n_steps=10, skip_preflight=True) is not None
+
+    def test_precision_boundary_matrix(self):
+        """The full 2x2 from issue #644 — the cell that used to be TypeError."""
+        seen = {}
+        for boundary in ("pec", "cpml"):
+            for precision in ("float32", "mixed"):
+                st = self._sim(precision, boundary=boundary).run(n_steps=10).state
+                seen[(boundary, precision)] = st.ex.dtype
+        assert seen == {
+            ("pec", "float32"): jnp.dtype(jnp.float32),
+            ("pec", "mixed"): jnp.dtype(jnp.float16),
+            ("cpml", "float32"): jnp.dtype(jnp.float32),
+            ("cpml", "mixed"): jnp.dtype(jnp.float16),  # <- was TypeError
+        }
+
+    def test_mixed_precision_cpml_accuracy(self):
+        """Agreement with float32 while the pulse is in the domain.
+
+        Measured at the time of writing (40**3, dx=3.0 mm, dt=5.72 ps):
+        0.20% at 50 steps, 0.23% at 100 steps.  The 5% gate matches the
+        PEC sibling test above and sits ~25x above the measured value —
+        it is a regression fence, not a fence drawn around the defect.
+        """
+        n_steps = 50
+        ez32 = np.asarray(self._sim("float32").run(n_steps=n_steps).state.ez,
+                          dtype=np.float64)
+        ez16 = np.asarray(self._sim("mixed").run(n_steps=n_steps).state.ez,
+                          dtype=np.float64)
+        norm32 = np.linalg.norm(ez32)
+        assert norm32 > 0, "float32 reference is identically zero — bad fixture"
+        rel = np.linalg.norm(ez32 - ez16) / norm32
+        assert rel < 0.05, f"mixed-vs-float32 relative L2 error {rel:.4%} exceeds 5%"
+
+    def test_mixed_precision_cpml_still_absorbs(self):
+        """float16 fields must not disable the absorber.
+
+        This is the assertion that "it stops crashing" does not cover: a CPML
+        that silently stopped absorbing would still run clean and still be
+        float16.  Measured total-field-energy decay from peak (400 steps):
+        float32 -76.3 dB, mixed -59.5 dB.  float16 IS materially worse — the
+        quantization floor of the field storage sits ~17 dB above float32's
+        residual — so the gate is set at -40 dB, which mixed clears by ~20 dB
+        while a non-absorbing run (which stays near 0 dB) fails outright.
+        """
+        def energy(state):
+            return float(sum(
+                np.sum(np.asarray(getattr(state, f), dtype=np.float64) ** 2)
+                for f in ("ex", "ey", "ez", "hx", "hy", "hz")
+            ))
+
+        peak = energy(self._sim("mixed").run(n_steps=100).state)
+        tail = energy(self._sim("mixed").run(n_steps=400).state)
+        assert peak > 0
+        decay_db = 10.0 * np.log10(tail / peak)
+        assert decay_db < -40.0, (
+            f"mixed+CPML decayed only {decay_db:.1f} dB below peak — "
+            "the absorber is not working in float16"
+        )
+
+    def test_mixed_precision_cpml_emits_no_unsafe_cast_warning(self):
+        """The CPML corrections are float32 while the fields are float16.
+
+        Scattering them straight in tripped JAX's "cannot safely cast value
+        from dtype=float32 to dtype=float16" FutureWarning, which JAX states
+        "will result in an error" in a future release.  apply_cpml_e/h now
+        accumulate at the psi dtype and round back to storage dtype once.
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self._sim("mixed").run(n_steps=10)
+        unsafe = [str(w.message) for w in caught
+                  if "cannot safely cast" in str(w.message)]
+        assert not unsafe, f"unsafe-cast warning(s) still emitted: {unsafe}"

--- a/tests/test_precision_lane_guard.py
+++ b/tests/test_precision_lane_guard.py
@@ -17,15 +17,14 @@ the ONLY enforcement point there -- see that check's docstring).
 
 These tests are deliberately NOT `pytest.mark.gpu`: they only exercise the
 dispatch-time guard (a Python-level raise before any FDTD compute), so they
-run on CPU in the default local suite -- `tests/test_mixed_precision.py`'s
-numeric mixed-precision tests are module-wide `gpu`-marked and would
-otherwise be the only place this behavior is covered, deselected from the
-default local run.
+run on CPU in the default local suite. (`tests/test_mixed_precision.py` used
+to be module-wide `gpu`-marked, which is why it could not serve as that
+coverage; issue #644 removed that mark after measuring the file at 6.5 s on
+CPU, so it now runs in the default lane too.)
 
-Also covers a second, related precision guard added in the same follow-up:
-issue #644 (precision="mixed" + CPML, a pre-existing defect #630 newly made
-reachable from forward() -- see the module section below for the full
-mechanism).
+Also covers the `forward()` + CPML precision matrix, which issue #644 turned
+from a guarded-off combination into a working one -- see the module section
+below.
 """
 
 from __future__ import annotations
@@ -123,20 +122,30 @@ def test_uniform_lane_unaffected_by_the_new_guard(precision):
 
 
 # ---------------------------------------------------------------------------
-# Issue #644: precision="mixed" + CPML is a pre-existing, NOT-#630-caused
-# defect (measured identical via run() on the pre- and post-#630 trees; the
-# CPML psi_* carry follows field_dtype=float16 but the CPML coefficients are
-# hard-pinned to float32, breaking the lax.scan carry contract). #630 made
-# forward() honour precision= for the first time (previously it silently
-# ignored precision= and always ran float32), which newly makes this
-# pre-existing defect reachable from forward() -- these tests pin that the
-# NEW reachability surfaces a clear rfx-layer NotImplementedError instead of
-# degrading to a raw JAX carry-dtype TypeError, and that float32/float64
-# (unaffected -- promote_types(float64, float32) == float64 matches
-# storage, no carry-dtype mismatch) and UPML (measured: no analogous
-# hard-float32 psi carry) are untouched by this guard. Fixing #644 itself
-# (giving psi_* and the CPML coefficients one consistent dtype policy) is
-# explicitly out of scope here -- see issue #644.
+# Issue #644, RESOLVED: precision="mixed" + CPML now works through forward().
+#
+# It was a pre-existing, NOT-#630-caused defect (measured identical via run()
+# on the pre- and post-#630 trees): the CPML psi_* carry followed
+# field_dtype=float16 while the CPML coefficients are hard-pinned float32, so
+# `psi = b*psi + c*curl` promoted to float32 and broke the lax.scan carry
+# contract. #630 made forward() honour precision= for the first time, which
+# newly exposed it there, and #630 shipped a temporary forward() guard raising
+# NotImplementedError rather than leak a raw JAX carry-dtype TypeError.
+#
+# #644 fixed the root cause -- the psi_* arrays are ACCUMULATION state and are
+# now allocated at promote_types(field_dtype, float32), so they never sit
+# below float32 -- and REMOVED that guard. These tests were the guard's
+# regression pins; they are kept (rather than deleted) and inverted to assert
+# SUCCESS, because the two cases they encode are exactly the two that must
+# keep working: a plain scalar boundary="cpml", and a per-face BoundarySpec
+# carrying only ONE cpml face (the guard read self._boundary_spec, so the
+# per-face case is a genuinely distinct path, not a restatement).
+#
+# Caveat worth knowing when reading these: "mixed" + CPML is correct but
+# raises the absorber's residual floor (~-76 dB -> ~-59.5 dB on the fixture
+# in tests/test_mixed_precision.py). See the precision= docstring in
+# rfx/api/__init__.py. These tests pin reachability, not absorber quality --
+# tests/test_mixed_precision.py owns the numeric assertions.
 # ---------------------------------------------------------------------------
 
 def _cpml_sim(*, precision: str) -> Simulation:
@@ -151,20 +160,45 @@ def _cpml_sim(*, precision: str) -> Simulation:
     return sim
 
 
-def test_forward_mixed_cpml_raises_clean_notimplementederror_not_raw_typeerror():
+def test_forward_mixed_cpml_works():
+    """Was NotImplementedError (the #630-era guard), and a raw lax.scan carry
+    TypeError before that. Both are fixed at the root -- see issue #644."""
     sim = _cpml_sim(precision="mixed")
-    with pytest.raises(NotImplementedError, match="#644"):
-        sim.forward(n_steps=5, skip_preflight=True)
+    result = sim.forward(n_steps=5, skip_preflight=True)
+    assert result is not None
 
 
-def test_forward_mixed_cpml_per_face_boundary_spec_also_caught():
-    """The guard reads self._boundary_spec (always normalized, even from a
-    legacy scalar boundary=), so a per-face BoundarySpec with only ONE
-    CPML face must trip it too -- not just the all-faces-cpml scalar case."""
+def test_forward_mixed_cpml_per_face_boundary_spec_also_works():
+    """A per-face BoundarySpec with only ONE cpml axis is a distinct path.
+
+    The removed guard read ``self._boundary_spec`` (always normalized, even
+    from a legacy scalar ``boundary=``), so this case tripped it separately
+    from the all-faces-cpml scalar case. The fix is in ``init_cpml``, which
+    every cpml face routes through, so this must now work too -- keeping the
+    case pins that the psi dtype policy is not somehow scalar-boundary-only.
+
+    ``cpml_layers=4`` is load-bearing and deliberate, NOT a tolerance being
+    loosened to get green. This test previously used the default 16 layers
+    and passed only because the guard raised BEFORE any CPML compute ran --
+    it never exercised the per-face CPML path at all. With the guard gone the
+    fixture turned out to be broken independently of precision: a per-face
+    spec whose PEC axes are narrower than ``cpml_layers`` (here 8 cells vs 16
+    layers) dies in ``apply_cpml_e`` with a SHAPE error,
+    ``mul got incompatible shapes for broadcasting: (16,1,1) vs (8,8,40)``,
+    because the x/y face slices ``[:n]`` still run on unpadded axes. MEASURED
+    on the unpatched parent commit: that combination fails identically at
+    ``precision="float32"`` through BOTH ``run()`` and ``forward()``, so it is
+    a pre-existing per-face CPML geometry defect, not a precision defect and
+    not caused by issue #644. It is reported separately; pinning 4 layers here
+    keeps this test measuring the dtype policy it is named for, on a fixture
+    that actually reaches the CPML compute. Verified red-then-green: at 4
+    layers this raises the #644 lax.scan carry TypeError on the parent commit
+    and passes here.
+    """
     from rfx.boundaries.spec import BoundarySpec, Boundary
 
     sim = Simulation(
-        freq_max=5.0e9, domain=(0.02, 0.02, 0.02),
+        freq_max=5.0e9, domain=(0.02, 0.02, 0.02), cpml_layers=4,
         boundary=BoundarySpec(x="pec", y="pec", z=Boundary(lo="cpml", hi="cpml")),
         precision="mixed",
     )
@@ -172,11 +206,11 @@ def test_forward_mixed_cpml_per_face_boundary_spec_also_caught():
         position=(0.01, 0.01, 0.01), component="ez",
         amplitude_kind="current",
     )
-    with pytest.raises(NotImplementedError, match="#644"):
-        sim.forward(n_steps=5, skip_preflight=True)
+    result = sim.forward(n_steps=5, skip_preflight=True)
+    assert result is not None
 
 
-def test_forward_float64_cpml_is_unaffected_by_the_644_guard():
+def test_forward_float64_cpml_works():
     # Scoped x64, per this repo's own rule (CLAUDE.md, and see this
     # package's own precision docstring): never flip jax_enable_x64
     # process-globally in a test -- it leaks to every test scheduled after
@@ -195,7 +229,7 @@ def test_forward_float64_cpml_is_unaffected_by_the_644_guard():
     assert result is not None
 
 
-def test_forward_float32_cpml_is_unaffected_by_the_644_guard():
+def test_forward_float32_cpml_works():
     sim = _cpml_sim(precision="float32")
     result = sim.forward(n_steps=5, skip_preflight=True)
     assert result is not None


### PR DESCRIPTION
Closes #644.

`precision="mixed"` has never worked with a CPML boundary. The `psi_*` CPML accumulators
were allocated at the field dtype (float16 under `"mixed"`) while the CPML coefficients are
float32, so `psi = b*psi + c*curl` promoted away from the carry's declared dtype and
`lax.scan` rejected its own body.

## Not a regression — it never worked

Measured through `run()` on pinned trees before this branch:

| boundary | precision | before |
|---|---|---|
| pec | float32 | OK |
| pec | mixed | OK |
| cpml | float32 | OK |
| cpml | mixed | **TypeError** |

It stayed invisible for two independent reasons: all 13 tests in
`tests/test_mixed_precision.py` built with `boundary="pec"`, and the whole file was
`pytest.mark.gpu`, so it was deselected from every default run. Both are closed here — CPML
rows added, and the file-level `gpu` mark removed (the original 13 tests run in 6.5 s on CPU,
slowest 1.27 s; the marker's own definition is "needs GPU — too slow on CPU or GPU-specific",
which these dtype/dispatch assertions are not).

## Fix: promote, do not pin

`jnp.promote_types(field_dtype, jnp.float32)` at the single psi allocation site.

A flat float32 pin would have been wrong. The allocation site's own comment records that psi
follows the field dtype **on purpose** — the oblique-Bloch path (#404) needs a *complex*
carry. `promote_types` gives float16 -> float32 (the intent here), float32 -> float32,
float64 -> float64, complex64 -> complex64; a pin would have fixed float16 by silently
breaking #404. All four verified empirically. It is also the existing idiom in this repo
(`rlc_carry_dtype` in `rfx/lumped.py`, `_cdtype` in `rfx/core/yee.py`).

The pad/extend helpers were checked and need no change — they pad the b/c/kappa profile
arrays off their own dtype, which is float32 either way.

## The finding: mixed costs ~17 dB of absorption

Total field energy below peak, `tests/test_mixed_precision.py` fixture:

| steps | float32 | mixed |
|---|---|---|
| 200 | -70.4 dB | -59.0 dB |
| 400 | -76.3 dB | -59.9 dB |
| 800 | -76.3 dB | -59.7 dB |

float32 keeps decaying; mixed plateaus near -59.5 dB. Probe tail/peak 1.12e-4 vs 6.67e-4,
consistent with float16's ~9.8e-4 epsilon quantizing field storage — and the mixed tail's
sign flips between runs, which is what quantization noise does and a physical DC offset does
not. Stable, no NaN/Inf to 800 steps.

Transient agreement is good (relative L2 on Ez, mixed vs float32): 0.400%/0.074%/0.154% at
25/50/100 steps on PEC, 1.299%/0.200%/0.235% on CPML — CPML consistently 1.5-3.2x worse.

**`"mixed"` is therefore not a drop-in float32 substitute when the quantity of interest is a
reflection coefficient, an S-parameter, or anything near the absorber floor.** That caveat is
now in the `precision=` docstring in `rfx/api/__init__.py`, attributed to this fixture rather
than stated as a universal bound, since there was no user-facing home for it otherwise.

## Production untouched

SHA-256 of raw field bytes, `git archive 5f23cca` vs this branch: identical across PEC, CPML,
lossy+CPML, non-uniform+CPML at float32, plus PEC at mixed and CPML at float64 (float64
included because #630 made it a real production precision and this change sets its psi dtype).

The green was not taken as evidence. Negative control: a deliberate 2 ppm perturbation of the
CPML `alpha` profile flips all four CPML hashes and leaves both PEC hashes untouched —
showing the harness is sensitive on exactly the CPML fixtures, and independently confirming
PEC never constructs CPML state.

## Also fixed: a deprecation that would have expired this fix

Scattering the float32 CPML corrections into float16 fields is an unsafe cast that JAX warns
"will result in an error" in a future release. `apply_cpml_e/h` now accumulate at the psi
dtype and round back once, instead of at each of four `.at[].add()` per component. This is
deprecation-driven and accuracy-neutral (floor moved -59.5 -> -59.7 dB, noise) — it is not
claimed as an improvement.

## Discovered, NOT fixed here

Converting #630's per-face guard test to assert success revealed that its fixture was already
dead: a per-face `BoundarySpec` with `cpml_layers` wider than an unpadded PEC axis crashes
with a broadcasting error at **every** precision, through both entry points. The test passed
only because #645's guard raised before any compute — a green assertion satisfied by a guard
rather than by the path it named. Filed as **#647**, with the preflight blind spot that hides
it. The test is re-pinned at `cpml_layers=4`, which actually reaches CPML compute and is
red-on-parent/green-here for #644; the reason is in its docstring so it does not read as a
loosened bound.

R3: memory=feedback_gate_can_bind_artifact (a green gate proved to bind a guard, not the
physics — surfaced as #647) | R2-attempts=1 | falsifier=the 2 ppm alpha negative control,
run and confirmed to move exactly the CPML hashes
