### PR TITLE
fix(x64): stop numpy-float64 scalars widening scan carries in NTFF, lumped-RLC and 2-D TFSF (closes #646)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -302,6 +302,57 @@ def _maybe_register_rss_reporter(config: "pytest.Config") -> None:
 
 
 @pytest.fixture(scope="session")
+def _x64_baseline():
+    """The ``jax_enable_x64`` value this session STARTED with."""
+    return bool(jax.config.jax_enable_x64)
+
+
+@pytest.fixture(autouse=True)
+def _no_x64_leak(_x64_baseline):
+    """Fail the test that leaves ``jax_enable_x64`` flipped (issue #646).
+
+    ``jax_enable_x64`` is process-global. A test that flips it without scoping
+    (a bare ``jax.config.update("jax_enable_x64", True)`` instead of
+    ``tests/_x64_compat.enable_x64()``) silently changes the dtype environment
+    of every test scheduled after it in the same pytest-split worker. That has
+    already happened once: it reddened 13 unrelated tests in shard 3 on PR
+    #645, and the reported failures pointed at innocent tests. This guard
+    makes the leak fail in the test that CAUSED it.
+
+    Two deliberate deviations from the sketch in issue #646:
+
+    * **Function-scoped, not session-scoped.** A session-scoped teardown fires
+      once, after everything, and so cannot name the culprit — which is the
+      entire point. Per-test teardown can.
+    * **Compares against the session baseline, not against ``False``.** The
+      supported way to reproduce #646 is to run the suite under
+      ``JAX_ENABLE_X64=1``; asserting a hard ``False`` would fail every test
+      in that configuration. Anchoring to the session's initial value catches
+      a leak in either direction and stays correct under both env values.
+
+    Legitimate scoped use (``with enable_x64(): ...``) restores the flag
+    before teardown and is unaffected.
+
+    The flag is RESTORED before the assertion fires, so a leak costs exactly
+    one red test — the one that caused it — instead of cascading into every
+    test after it. Verified: with the restore, a deliberate leaker errors and
+    its neighbour still passes; without it, both error.
+    """
+    yield
+    now = bool(jax.config.jax_enable_x64)
+    if now != _x64_baseline:
+        jax.config.update("jax_enable_x64", _x64_baseline)
+    assert now == _x64_baseline, (
+        f"this test leaked jax_enable_x64: session started with "
+        f"{_x64_baseline}, test left it {now}. jax_enable_x64 is "
+        "process-global, so this changes the dtype environment of every test "
+        "scheduled after it in this worker. Scope the flip with "
+        "tests/_x64_compat.enable_x64() instead of calling "
+        'jax.config.update("jax_enable_x64", ...) directly.'
+    )
+
+
+@pytest.fixture(scope="session")
 def two_devices():
     """Return the first 2 JAX devices, or skip the test if unavailable."""
     devices = jax.devices()

--- a/rfx/farfield.py
+++ b/rfx/farfield.py
@@ -141,19 +141,49 @@ def make_ntff_box(
     )
 
 
-def init_ntff_data(box: NTFFBox) -> NTFFData:
+def ntff_accum_dtype(field_dtype=jnp.float32):
+    """Complex dtype for the NTFF DFT scan carry, given the field dtype.
+
+    One policy, shared by ``init_ntff_data`` (allocation) and
+    ``accumulate_ntff`` (the scan body), so the ``lax.scan`` carry closes:
+    the accumulator is the complex type matching
+    ``promote_types(field_dtype, float32)``.
+
+    * float16 (``precision="mixed"``) -> complex64.  The float32 floor is
+      mandatory: this is a recursive accumulator and must never land in
+      float16, whose 11-bit mantissa would destroy the running DFT.
+    * float32 (the default)           -> complex64.  Unchanged, x64 or not.
+    * float64 (``precision="float64"``) -> complex128.
+    * complex64 (the oblique-Bloch path, #404) -> complex64.  A flat float32
+      pin would break that path; ``promote_types`` preserves complex.
+    """
+    return jnp.result_type(
+        jnp.promote_types(jnp.dtype(field_dtype), jnp.float32), jnp.complex64)
+
+
+def init_ntff_data(box: NTFFBox, *, field_dtype=jnp.float32) -> NTFFData:
     """Initialize zeroed NTFF DFT accumulators.
 
-    Uses complex64 accumulators with Kahan compensated summation (the ``c_*``
-    arrays), which keeps near-float64 precision over thousands of timesteps
-    WITHOUT enabling JAX x64 mode (x64 caused an MLIR scan-carry mismatch,
-    issue #14). Plain float32 accumulation would lose the signal at coarse dx,
-    where the per-step phase rotation is small; Kahan avoids that.
+    Uses Kahan compensated summation (the ``c_*`` arrays), which keeps
+    near-float64 precision in complex64 over thousands of timesteps. Plain
+    float32 accumulation would lose the signal at coarse dx, where the
+    per-step phase rotation is small; Kahan avoids that. That design is
+    unchanged — at the default float32 field storage the accumulator is
+    complex64 whether or not JAX x64 mode is on.
+
+    Dtype note (issue #646)
+    -----------------------
+    The accumulator dtype used to be a hard ``complex64`` pin, justified here
+    by "x64 caused an MLIR scan-carry mismatch, issue #14". That has the
+    causality backwards: the PIN is what raises the mismatch. ``dt`` reaches
+    ``accumulate_ntff`` as a **numpy float64 scalar** (``grid.dt``), and numpy
+    scalars are strongly typed in JAX, so under x64 the phase factor — and
+    therefore the scan body's output — is complex128 while the carry was
+    allocated complex64. The fields are NOT the promoting quantity; they stay
+    float32. So the accumulator follows ``ntff_accum_dtype`` and
+    ``accumulate_ntff`` pins its phase arithmetic to that same dtype.
     """
-    # Always use complex64 — Kahan compensated summation provides near-float64
-    # precision without requiring JAX x64 mode (which causes MLIR issues #14).
-    # No need for x64 mode which causes MLIR scan carry mismatch (issue #14).
-    _cdtype = jnp.complex64
+    _cdtype = ntff_accum_dtype(field_dtype)
     nf = len(box.freqs)
     ni = box.i_hi - box.i_lo
     nj = box.j_hi - box.j_lo
@@ -186,15 +216,26 @@ def accumulate_ntff(
 
     Called from the scan body.  ``step_idx`` comes from the scan xs.
     """
-    # Phase in float32/complex64 — Kahan summation handles precision.
+    # Phase arithmetic is pinned to the ACCUMULATOR's dtype (issue #646), not
+    # to a literal float32/complex64. ``dt`` arrives as a numpy float64 scalar
+    # (``grid.dt``); numpy scalars are strongly typed in JAX, so leaving it
+    # uncast makes this body return complex128 under x64 while the carry was
+    # allocated complex64 — a lax.scan carry-type mismatch. Casting it to the
+    # accumulator's real dtype is a no-op with x64 off (JAX already clamped
+    # float64 -> float32 there), so the default path stays bit-identical.
+    # Kahan summation still supplies the precision, as before.
     # E is at time step n, H at n+1/2 in Yee leapfrog.
     # Apply half-step phase correction to H components (indices 2,3)
     # so that E and H DFTs are co-located in time.
-    t = jnp.float32(step_idx) * jnp.float32(dt)
-    freqs_hi = jnp.asarray(box.freqs, dtype=jnp.float32)
-    omega = 2 * jnp.pi * freqs_hi
-    phase_e = jnp.exp(jnp.complex64(-1j) * omega * t) * dt
-    phase_h = jnp.exp(jnp.complex64(-1j) * omega * (t + dt * 0.5)) * dt
+    _cdtype = ntff_data.x_lo.dtype
+    _rdtype = jnp.finfo(_cdtype).dtype
+    _dt = jnp.asarray(dt, dtype=_rdtype)
+    t = jnp.asarray(step_idx, dtype=_rdtype) * _dt
+    freqs_hi = jnp.asarray(box.freqs, dtype=_rdtype)
+    omega = jnp.asarray(2 * jnp.pi, dtype=_rdtype) * freqs_hi
+    _mj = jnp.asarray(-1j, dtype=_cdtype)
+    phase_e = jnp.exp(_mj * omega * t) * _dt
+    phase_h = jnp.exp(_mj * omega * (t + _dt * 0.5)) * _dt
     # Stack [E_phase, E_phase, H_phase, H_phase] for the 4 tangential components
     ph = jnp.stack([phase_e, phase_e, phase_h, phase_h], axis=-1)
     ph = ph[:, None, None, :]  # (nf, 1, 1, 4)

--- a/rfx/lumped.py
+++ b/rfx/lumped.py
@@ -114,20 +114,37 @@ class RLCState(NamedTuple):
     capacitor_charge: jnp.ndarray  # Q_C in coulombs
 
 
-def init_rlc_state(dtype=jnp.float32) -> RLCState:
+def init_rlc_state(dtype=None) -> RLCState:
     """Create zero-initialised RLC ADE state.
 
     Parameters
     ----------
-    dtype : jnp dtype
+    dtype : jnp dtype, optional
         Real dtype of the ADE carry (``inductor_current``,
-        ``capacitor_charge``).  Defaults to ``float32`` so every existing
-        caller (the concrete ``run()`` path) is byte-identical.  The
-        differentiable ``forward()`` lane threads the promoted dtype (e.g.
-        ``float64`` under a scoped ``jax_enable_x64`` component-value DoF)
-        so the ``lax.scan`` carry input/output dtypes agree — see
-        ``rlc_carry_dtype``.
+        ``capacitor_charge``).  ``None`` (the default) follows the ambient
+        JAX default float dtype with a ``float32`` floor, which is what the
+        ADE update body actually produces — see the dtype note below.  The
+        concrete ``run()`` path and the differentiable ``forward()`` lane both
+        pass an explicit dtype from ``rlc_carry_dtype`` instead.
+
+    Dtype note (issue #646)
+    -----------------------
+    This default used to be a hard ``jnp.float32`` pin, which reds every
+    caller under ``jax_enable_x64``.  The promoting quantity is NOT the field
+    dtype: ``build_rlc_meta`` derives ``D0``/``gamma``/``dt_dx_over_L``/
+    ``dt_over_C_dx``/``dt`` from ``grid.dt``, which is a **numpy float64
+    scalar**.  numpy scalars are strongly typed in JAX, so under x64 they
+    promote the ADE update to float64 even when the fields are float32; with
+    x64 off JAX clamps them to float32 and the pin happened to agree.  So the
+    body returns the ambient default float dtype, and the carry must be
+    allocated at that same dtype for ``lax.scan`` to close.
+
+    ``promote_types(..., float32)`` keeps the float32 floor: this is a
+    recursive accumulator, so it must never land in float16 under
+    ``precision="mixed"``.
     """
+    if dtype is None:
+        dtype = jnp.promote_types(jnp.result_type(float), jnp.float32)
     return RLCState(
         inductor_current=jnp.array(0.0, dtype=dtype),
         capacitor_charge=jnp.array(0.0, dtype=dtype),
@@ -137,11 +154,15 @@ def init_rlc_state(dtype=jnp.float32) -> RLCState:
 def rlc_carry_dtype(metas, field_dtype=jnp.float32):
     """Real dtype for the RLC ADE scan carry given the per-element metas.
 
-    The concrete ``run()`` path builds ``RLCCellMeta`` with Python-float
-    coefficients (``build_rlc_meta`` coerces via ``float()``) and runs with
-    ``field_dtype=float32``; every meta coefficient is a plain ``float`` (no
-    ``.dtype``) so this returns ``float32`` — byte-identical to the historical
-    ``init_rlc_state()`` pin.
+    The concrete ``run()`` path builds ``RLCCellMeta`` from ``grid.dt``, which
+    is a **numpy float64 scalar**, so ``D0``/``gamma``/``dt_dx_over_L``/
+    ``dt_over_C_dx`` are ``np.float64`` (they DO carry a ``.dtype``) and this
+    returns ``float64``, not ``float32``.  With x64 off JAX clamps that back to
+    float32 at allocation, which is why the result is byte-identical to the
+    historical ``init_rlc_state()`` float32 pin; with x64 on it correctly
+    returns float64, matching what the ADE body produces.  (An earlier version
+    of this docstring claimed the metas were plain Python floats and that this
+    returned float32 — measured false, issue #646.)
 
     The differentiable ``forward()`` lane builds metas with
     ``build_rlc_meta_traced``; when a component value is supplied as a tracer

--- a/rfx/simulation.py
+++ b/rfx/simulation.py
@@ -852,7 +852,11 @@ def _build_step_setup(
         from rfx.farfield import accumulate_ntff as _accumulate_ntff
         init_ntff_data_fn = _init_ntff_data
         accumulate_ntff_fn = _accumulate_ntff
-        carry_init["ntff"] = _init_ntff_data(ntff)
+        # NTFF accumulator dtype follows the field dtype with a float32 floor
+        # (#646), mirroring the CPML psi carry above. accumulate_ntff pins its
+        # phase arithmetic to whatever is allocated here, so the scan carry
+        # closes under jax_enable_x64 instead of raising a dtype mismatch.
+        carry_init["ntff"] = _init_ntff_data(ntff, field_dtype=_field_dtype)
 
     if use_dft_planes:
         carry_init["dft_planes"] = tuple(probe.accumulator for probe in dft_planes)

--- a/rfx/sources/tfsf_2d.py
+++ b/rfx/sources/tfsf_2d.py
@@ -475,6 +475,43 @@ def _update_e_tez(cfg, st, dx, dt, t):
 # Mode-dispatching update entry points
 # ---------------------------------------------------------------------------
 
+_AUX_CARRY_FIELDS = ("ez_2d", "hx_2d", "hy_2d",
+                     "psi_ez_xlo", "psi_ez_xhi", "psi_hy_xlo", "psi_hy_xhi")
+
+
+def _narrow_to_carry(st_in: TFSF2DState, st_out: TFSF2DState) -> TFSF2DState:
+    """Return ``st_out`` with every complex field back at ``st_in``'s dtype.
+
+    Issue #646. ``dx``/``dt``/``t`` reach the update bodies as numpy float64
+    scalars (derived from ``grid.dt``), and numpy scalars are strongly typed
+    in JAX. Under ``jax_enable_x64`` they promote the scalar precomputes
+    (``dt/MU_0``, ``exp(-1j*k_y*dx)``, the source term) and hence the whole
+    returned aux state to complex128, while the carry was allocated
+    complex64 — a lax.scan carry-type mismatch.
+
+    The narrowing is done on the OUTPUT rather than by casting dx/dt/t on the
+    way in, and that ordering is deliberate: those scalar precomputes are
+    evaluated in float64/complex128 today and rounded once at the point they
+    meet the complex64 arrays. Casting the inputs first would move the
+    rounding earlier (``float32(dt)/MU_0`` instead of ``float32(dt/MU_0)``,
+    ``exp`` evaluated in complex64 instead of complex128-then-rounded) and
+    perturb the default path by an ULP. Narrowing the output cannot: with x64
+    off every field here is ALREADY the carry dtype, so this is a no-op and
+    the path is bit-identical by construction.
+
+    Derived from the state, never pinned to complex64, so the complex
+    aux-grid carry the oblique-Bloch path needs (#404) is preserved and a
+    complex128 aux state would stay complex128.
+    """
+    repl = {}
+    for name in _AUX_CARRY_FIELDS:
+        want = getattr(st_in, name).dtype
+        cur = getattr(st_out, name)
+        if cur.dtype != want:
+            repl[name] = cur.astype(want)
+    return st_out._replace(**repl) if repl else st_out
+
+
 def update_tfsf_2d_h(cfg: TFSF2DConfig, st: TFSF2DState,
                       dx: float, dt: float) -> TFSF2DState:
     """Advance 2D auxiliary H: H^{n-1/2} -> H^{n+1/2}.
@@ -482,8 +519,10 @@ def update_tfsf_2d_h(cfg: TFSF2DConfig, st: TFSF2DState,
     Dispatches to TMz or TEz based on ``cfg.mode``.
     """
     if cfg.mode == "TEz":
-        return _update_h_tez(cfg, st, dx, dt)
-    return _update_h_tmz(cfg, st, dx, dt)
+        out = _update_h_tez(cfg, st, dx, dt)
+    else:
+        out = _update_h_tmz(cfg, st, dx, dt)
+    return _narrow_to_carry(st, out)
 
 
 def update_tfsf_2d_e(cfg: TFSF2DConfig, st: TFSF2DState,
@@ -493,8 +532,10 @@ def update_tfsf_2d_e(cfg: TFSF2DConfig, st: TFSF2DState,
     Dispatches to TMz or TEz based on ``cfg.mode``.
     """
     if cfg.mode == "TEz":
-        return _update_e_tez(cfg, st, dx, dt, t)
-    return _update_e_tmz(cfg, st, dx, dt, t)
+        out = _update_e_tez(cfg, st, dx, dt, t)
+    else:
+        out = _update_e_tmz(cfg, st, dx, dt, t)
+    return _narrow_to_carry(st, out)
 
 
 def update_tfsf_2d(cfg: TFSF2DConfig, st: TFSF2DState,
@@ -614,9 +655,16 @@ def apply_tfsf_2d_e(state, cfg: TFSF2DConfig, tfsf_st: TFSF2DState,
     # sign is (-coeff, +coeff).  For TEz (Ey/Hz, curl_sign=-1): Ampere
     # has -dHz/dx, so correction sign is (+coeff, -coeff).  Using
     # curl_sign unifies both: (-curl_sign*coeff, +curl_sign*coeff).
+    # Narrow the correction to the 3D field's own dtype (#646). ``coeff`` is a
+    # numpy float64 scalar, so under x64 the product is complex128/float64 and
+    # the scatter-add into a complex64/float32 field emits JAX's
+    # "cannot safely cast" FutureWarning (a future hard error). No-op with x64
+    # off, where the product is already the field dtype.
     e_field = e_ref
-    e_field = e_field.at[cfg.x_lo, :, :].add(-cfg.curl_sign * coeff * h_lo_3d)
-    e_field = e_field.at[cfg.x_hi + 1, :, :].add(cfg.curl_sign * coeff * h_hi_3d)
+    e_field = e_field.at[cfg.x_lo, :, :].add(
+        (-cfg.curl_sign * coeff * h_lo_3d).astype(e_ref.dtype))
+    e_field = e_field.at[cfg.x_hi + 1, :, :].add(
+        (cfg.curl_sign * coeff * h_hi_3d).astype(e_ref.dtype))
 
     return state._replace(**{cfg.electric_component: e_field})
 
@@ -654,8 +702,11 @@ def apply_tfsf_2d_h(state, cfg: TFSF2DConfig, tfsf_st: TFSF2DState,
         e_lo_3d = jnp.broadcast_to(e_inc_lo[:, None], (ny_3d, nz_3d))
         e_hi_3d = jnp.broadcast_to(e_inc_hi[:, None], (ny_3d, nz_3d))
 
+    # Narrow to the 3D field dtype — see the note in apply_tfsf_2d_e (#646).
     h_field = h_ref
-    h_field = h_field.at[cfg.x_lo - 1, :, :].add(-cfg.curl_sign * coeff * e_lo_3d)
-    h_field = h_field.at[cfg.x_hi, :, :].add(cfg.curl_sign * coeff * e_hi_3d)
+    h_field = h_field.at[cfg.x_lo - 1, :, :].add(
+        (-cfg.curl_sign * coeff * e_lo_3d).astype(h_ref.dtype))
+    h_field = h_field.at[cfg.x_hi, :, :].add(
+        (cfg.curl_sign * coeff * e_hi_3d).astype(h_ref.dtype))
 
     return state._replace(**{cfg.magnetic_component: h_field})

--- a/tests/test_x64_scan_carry_dtypes.py
+++ b/tests/test_x64_scan_carry_dtypes.py
@@ -1,0 +1,265 @@
+"""Scan carries must follow the ambient precision, not a hard float32 pin.
+
+Issue #646. Three ``lax.scan`` carry families allocated auxiliary state at a
+hard-pinned float32/complex64 while the quantities driving them followed the
+ambient dtype, so enabling JAX x64 anywhere in a pytest worker reddened them
+with ``scan body function carry input and carry output must have equal types``:
+
+    rfx/lumped.py       init_rlc_state()      inductor_current, capacitor_charge
+    rfx/farfield.py     init_ntff_data()      {x,y,z}_{lo,hi}, c_{x,y,z}_{lo,hi}
+    rfx/sources/tfsf_2d.py init_tfsf_2d()     ez_2d, hx_2d, hy_2d, psi_*
+
+MECHANISM (measured, and NOT what the issue first proposed). The promoting
+quantity is not the field dtype -- the fields stay float32 under x64. It is
+``grid.dt``: ``Grid.__init__`` computes it with numpy, so it is an
+``np.float64`` **scalar**, and numpy scalars are STRONGLY typed in JAX. Under
+x64 they promote the phase/coefficient arithmetic (and hence the scan body's
+output) a step above the dtype the carry was allocated at; with x64 off JAX
+clamps float64 to float32 and the pin happens to agree. See
+``test_dt_is_a_numpy_float64_scalar`` below, which pins that premise directly:
+it is the reason a float32 pin is wrong, so if it ever stops holding, the
+rest of this module is testing the wrong thing.
+
+DTYPE POLICY. ``promote_types(field_dtype, float32)`` -- promote, never pin,
+never a bare copy of the field dtype. Both failure modes are live:
+
+  * a flat float32 pin breaks the oblique-Bloch path (#404), which needs a
+    genuinely COMPLEX carry;
+  * naively following the field dtype puts a recursive accumulator in float16
+    under ``precision="mixed"``, contradicting what that mode promises
+    ("float16 fields, float32 accumulation").
+
+x64 is scoped with ``tests/_x64_compat.enable_x64()``. A bare
+``jax.config.update("jax_enable_x64", True)`` is process-global, is forbidden
+by this repo's CLAUDE.md, and reddened 13 unrelated tests on PR #645.
+"""
+import numpy as np
+import jax
+import jax.numpy as jnp
+import pytest
+
+from rfx import Simulation
+from rfx.grid import Grid, C0
+from rfx.core.yee import MaterialArrays, init_materials
+from rfx.geometry.csg import Box, rasterize
+from rfx.farfield import ntff_accum_dtype, init_ntff_data, NTFFBox
+from rfx.lumped import init_rlc_state
+from rfx.rcs import compute_rcs
+from rfx.simulation import run, ProbeSpec
+from rfx.sources.tfsf import init_tfsf
+
+from tests._x64_compat import enable_x64
+
+PEC_SIGMA = 1e7
+
+
+# ---------------------------------------------------------------------------
+# The premise the whole issue rests on
+# ---------------------------------------------------------------------------
+
+def test_dt_is_a_numpy_float64_scalar():
+    """``grid.dt`` is an np.float64 scalar -> strongly typed in JAX.
+
+    This is WHY the carries must promote rather than pin: the promoting
+    quantity is a numpy scalar coefficient, not the field storage. If this
+    ever becomes a plain Python float (weakly typed), the mechanism recorded
+    in this module's docstring no longer applies and the fix should be
+    re-derived rather than trusted.
+    """
+    grid = Grid(freq_max=10e9, domain=(0.01, 0.01, 0.01), dx=0.5e-3)
+    assert isinstance(grid.dt, np.floating), (
+        f"grid.dt is {type(grid.dt).__name__}, expected a numpy scalar")
+    assert jnp.dtype(np.asarray(grid.dt).dtype) == jnp.float64
+
+    with enable_x64():
+        # A numpy float64 scalar promotes a complex64 array; a Python float
+        # (weakly typed) does not. That asymmetry is the whole defect.
+        c = jnp.zeros(3, dtype=jnp.complex64)
+        assert (c * np.float64(1e-12)).dtype == jnp.complex128
+        assert (c * 1e-12).dtype == jnp.complex64
+
+
+# ---------------------------------------------------------------------------
+# The dtype policy itself
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("field_dtype,expected", [
+    (jnp.float16, jnp.complex64),     # mixed precision -> float32 FLOOR
+    (jnp.float32, jnp.complex64),     # default -> unchanged
+    (jnp.complex64, jnp.complex64),   # oblique Bloch (#404) -> stays COMPLEX
+])
+def test_ntff_accum_dtype_promotes_never_pins(field_dtype, expected):
+    """Holds identically with x64 off and on."""
+    assert ntff_accum_dtype(field_dtype) == expected
+    with enable_x64():
+        assert ntff_accum_dtype(field_dtype) == expected
+
+
+def test_ntff_accum_dtype_float64_needs_x64():
+    """float64 fields -> complex128, but ONLY once x64 is enabled.
+
+    With x64 off JAX has no float64, so ``result_type`` clamps the request to
+    complex64. That is not a bug in this policy, it is the same documented
+    footgun as ``precision="float64"`` without x64 (which silently gives
+    float32 fields; ``preflight()`` warns ``precision_float64_without_x64``).
+    Pinned here so the clamp is a recorded behaviour rather than a surprise.
+
+    Keyed off the AMBIENT flag rather than assuming it is off: the documented
+    way to reproduce #646 is to run this suite under ``JAX_ENABLE_X64=1``, so
+    a test that hard-codes the x64-off branch fails in exactly the
+    configuration the issue asks you to run.
+    """
+    ambient_x64 = bool(jax.config.jax_enable_x64)
+    expected = jnp.complex128 if ambient_x64 else jnp.complex64
+    assert ntff_accum_dtype(jnp.float64) == expected
+    with enable_x64():
+        assert ntff_accum_dtype(jnp.float64) == jnp.complex128
+
+
+def test_ntff_float32_floor_holds_under_mixed_precision():
+    """float16 fields must NOT give a float16 accumulator.
+
+    The NTFF carry is a recursive DFT accumulator; float16's 11-bit mantissa
+    would destroy it. Guards the "naively follow the field dtype" failure.
+    """
+    assert ntff_accum_dtype(jnp.float16) == jnp.complex64
+    box = NTFFBox(i_lo=2, i_hi=6, j_lo=2, j_hi=6, k_lo=2, k_hi=6,
+                  freqs=jnp.array([1e9], dtype=jnp.float32))
+    data = init_ntff_data(box, field_dtype=jnp.float16)
+    assert data.x_lo.dtype == jnp.complex64
+    assert data.c_x_lo.dtype == jnp.complex64
+
+
+def test_ntff_complex_carry_survives_the_oblique_path():
+    """A flat float32 pin would destroy the #404 complex carry."""
+    box = NTFFBox(i_lo=2, i_hi=6, j_lo=2, j_hi=6, k_lo=2, k_hi=6,
+                  freqs=jnp.array([1e9], dtype=jnp.float32))
+    data = init_ntff_data(box, field_dtype=jnp.complex64)
+    assert jnp.issubdtype(data.x_lo.dtype, jnp.complexfloating)
+
+
+def test_rlc_carry_follows_ambient_float_with_a_float32_floor():
+    """The default carry dtype tracks the ambient float, never a float32 pin.
+
+    Keyed off the ambient flag for the same reason as
+    ``test_ntff_accum_dtype_float64_needs_x64`` — this suite has to stay green
+    under ``JAX_ENABLE_X64=1``, which is how #646 is reproduced.
+    """
+    ambient = jnp.float64 if bool(jax.config.jax_enable_x64) else jnp.float32
+    assert init_rlc_state().inductor_current.dtype == ambient
+    with enable_x64():
+        st = init_rlc_state()
+        assert st.inductor_current.dtype == jnp.float64
+        assert st.capacitor_charge.dtype == jnp.float64
+    # flag restored -> back to the ambient default
+    assert init_rlc_state().inductor_current.dtype == ambient
+
+
+# ---------------------------------------------------------------------------
+# The three scans must actually CLOSE under x64
+# ---------------------------------------------------------------------------
+
+def _lumped_sim():
+    sim = Simulation(freq_max=5e9, domain=(0.01, 0.01, 0.01), dx=1e-3,
+                     boundary="pec")
+    sim.add_lumped_rlc(position=(0.005, 0.005, 0.005), component="ez",
+                       R=50.0, L=1e-8, C=1e-12, topology="series")
+    sim.add_source((0.004, 0.005, 0.005), "ez", amplitude_kind="field")
+    sim.add_probe((0.006, 0.005, 0.005), "ez")
+    return sim
+
+
+def test_lumped_rlc_scan_closes_under_x64():
+    with enable_x64():
+        r = _lumped_sim().run(n_steps=20, skip_preflight=True)
+    assert np.all(np.isfinite(np.asarray(r.time_series)))
+
+
+def _rcs_args():
+    f0 = 3e9
+    dx = C0 / f0 / 10
+    domain = 0.12
+    grid = Grid(freq_max=f0 * 1.5, domain=(domain, domain, domain), dx=dx,
+                cpml_layers=8)
+    c = domain / 2
+    ht, hs = dx / 2, 0.04 / 2
+    plate = Box(corner_lo=(c - ht, c - hs, c - hs),
+                corner_hi=(c + ht, c + hs, c + hs))
+    eps_r, sigma = rasterize(grid, [(plate, 1.0, PEC_SIGMA)])
+    mats = MaterialArrays(eps_r=eps_r, sigma=sigma,
+                          mu_r=jnp.ones(grid.shape, dtype=jnp.float32))
+    return grid, mats, f0
+
+
+def test_ntff_rcs_scan_closes_under_x64():
+    grid, mats, f0 = _rcs_args()
+    with enable_x64():
+        res = compute_rcs(grid, mats, 40, f0=f0, bandwidth=0.5,
+                          theta_obs=np.linspace(0.01, np.pi - 0.01, 5),
+                          phi_obs=np.array([0.0]))
+    assert np.all(np.isfinite(np.asarray(res.monostatic_rcs)))
+
+
+def test_oblique_tfsf_2d_scan_closes_under_x64():
+    """The 2-D oblique aux grid — a THIRD site, absent from issue #646's table.
+
+    It raised the same carry-type mismatch on
+    ``carry['tfsf'].{ez_2d,hx_2d,hy_2d,psi_ez_x*,psi_hy_x*}`` and accounted
+    for one of the nine reported failures.
+    """
+    grid = Grid(freq_max=5e9, domain=(0.06, 0.06, 0.006), dx=0.004,
+                cpml_layers=6)
+    mats = init_materials(grid.shape)
+    cfg, st0 = init_tfsf(grid.nx, grid.dx, grid.dt,
+                         cpml_layers=grid.cpml_layers, tfsf_margin=3,
+                         f0=5e9, bandwidth=0.2, amplitude=1.0,
+                         polarization="ez", angle_deg=30.0, ny=grid.ny)
+    probe = ProbeSpec(i=cfg.x_lo + 3, j=grid.ny // 2, k=grid.nz // 2,
+                      component="ez")
+    with enable_x64():
+        r = run(grid, mats, 30, boundary="cpml", cpml_axes="x",
+                periodic=(False, True, True), tfsf=(cfg, st0), probes=[probe])
+    assert np.all(np.isfinite(np.asarray(r.time_series)))
+
+
+# ---------------------------------------------------------------------------
+# x64 must not change the default-precision numbers
+# ---------------------------------------------------------------------------
+
+def test_float32_ntff_accumulator_is_complex64_even_under_x64():
+    """Turning x64 on must not silently widen (or narrow) the default lane.
+
+    With float32 field storage the accumulator stays complex64 whether or not
+    x64 is on -- so enabling x64 for an unrelated test does not double NTFF
+    memory or perturb the validated float32 numbers.
+    """
+    box = NTFFBox(i_lo=2, i_hi=6, j_lo=2, j_hi=6, k_lo=2, k_hi=6,
+                  freqs=jnp.array([1e9], dtype=jnp.float32))
+    assert init_ntff_data(box, field_dtype=jnp.float32).x_lo.dtype == jnp.complex64
+    with enable_x64():
+        d = init_ntff_data(box, field_dtype=jnp.float32)
+        assert d.x_lo.dtype == jnp.complex64
+        assert d.c_x_lo.dtype == jnp.complex64
+
+
+def test_x64_does_not_move_the_default_precision_lumped_result():
+    """Same probe trace with x64 off and on, at precision="float32".
+
+    The carry widens under x64 (that is the fix), but the float32 field lane
+    it drives must be unaffected beyond float32 round-off.
+    """
+    ts_off = np.asarray(_lumped_sim().run(n_steps=20,
+                                          skip_preflight=True).time_series)
+    with enable_x64():
+        ts_on = np.asarray(_lumped_sim().run(n_steps=20,
+                                             skip_preflight=True).time_series)
+    scale = max(float(np.max(np.abs(ts_off))), 1e-30)
+    assert np.max(np.abs(ts_on - ts_off)) / scale < 1e-5
+
+
+def test_enable_x64_context_restores_the_flag():
+    """The guard in conftest depends on this; pin it explicitly."""
+    before = bool(jax.config.jax_enable_x64)
+    with enable_x64():
+        assert bool(jax.config.jax_enable_x64) is True
+    assert bool(jax.config.jax_enable_x64) is before


### PR DESCRIPTION
Closes #646.

With JAX's x64 mode enabled, 9 fast-suite tests died with `scan body function carry input
and carry output must have equal types`. Latent today only because every fast-suite test
that needs x64 scopes it by convention; a single unscoped flip makes it live, which is
exactly what happened on #645 (13 unrelated tests red in shard 3).

## The issue's stated mechanism was wrong

I filed #646 saying the carries widen because the fields driving them go float64. **They do
not — fields stay float32 under x64.** The promoting quantity is `grid.dt`, which
`Grid.__init__` computes with numpy, making it an `np.float64` scalar. numpy scalars are
*strongly* typed in JAX where Python floats are weak:

```
complex64 * np.float64(1.5)  ->  complex128     # the defect
complex64 * 1.5              ->  complex64      # no promotion
float32   * np.float64(1.5)  ->  float64
```

A setup-time scalar constant, not the field state, is what widens the carry.

**This changes the fix.** `promote_types(field_dtype, float32)` at the allocation site alone
is insufficient: with float32 fields it allocates complex64 while the body still returns
complex128 from `dt`. The allocation policy has to be paired with narrowing the body's
arithmetic to the allocated dtype. Both are done here.

## Sites

| site | carry | note |
|---|---|---|
| `rfx/farfield.py` | NTFF accumulators | 5 of the 9 failures |
| `rfx/lumped.py` / `rfx/simulation.py` | `inductor_current`, `capacitor_charge` | 3 failures |
| `rfx/sources/tfsf_2d.py` | `ez_2d`, `hx_2d`, `hy_2d`, `psi_*` | 1 failure — absent from the issue's table |

The lumped-RLC *production* path turned out to be already correct (`rlc_carry_dtype` threads
the metas' dtypes); only the bare `init_rlc_state()` default was broken. Also fixed a latent
same-class defect in `apply_tfsf_2d_e/h`, which scatter-added complex128 into complex64 and
tripped JAX's "cannot safely cast" FutureWarning.

`init_ntff_data`'s existing comment claimed its complex64 pin was justified because "x64
caused an MLIR scan-carry mismatch, issue #14" — causality backwards, the pin is what raises
the mismatch. Its *design* constraint (complex64 + Kahan is deliberately sufficient) is real
and rules out allocating at the ambient dtype, which would silently double NTFF memory under
x64. `promote_types` satisfies both; the comment is rewritten.

## Results

| | x64=0 | x64=1 |
|---|---|---|
| base `84c76dd` | 21 passed | **9 failed / 12 passed** |
| this branch | 21 passed | **21 passed** |

Independently reproduced against pinned `git archive` copies of both trees.

## Production untouched

SHA-256 of raw field bytes at the default `precision="float32"`, base vs branch: 7/7
identical (pec, cpml, lossy+cpml, nu+cpml, ntff/rcs, lumped-rlc, oblique-TFSF — the last
added because `tfsf_2d` was otherwise unhashed). Confirmed independently on a separate
4-configuration harness: 24/24 identical.

The green was not taken as evidence. Negative control, +3 ppm perturbations, each moving
exactly the fixtures it should:

| perturbation | fixtures that moved |
|---|---|
| `dx` (global) | all 7 |
| NTFF phase only | `ntff_rcs` only |
| RLC ADE coefficient only | `lumped_rlc` only |
| 2-D aux source time only | `oblique_tfsf` only |

## Leak detector

An autouse fixture fails the test that leaves `jax_enable_x64` flipped, so a future leak
reds its own cause instead of someone else's test. It is function-scoped (a session-scoped
teardown fires once at the end and cannot name the culprit) and compares against the session
baseline rather than a hard `False`, so it does not fail every test when the whole suite is
deliberately run under `JAX_ENABLE_X64=1`. It restores the flag before asserting, so a leak
costs exactly one red.

Verified against a deliberate unscoped leaker: the leaker errors with an actionable message
naming the fix, and its innocent neighbour still passes.

## Not fixed here

`tests/test_oblique_rcs_absolute_sigma.py::test_po_oracle_matches_closed_form` fails on
`np.trapz`, removed in numpy 2.x. Identical on pinned base — pre-existing, unrelated, filed
separately.

R3: memory=project_precision_carry_dtype_family (promote-don't-pin; this adds the numpy-scalar
promotion mechanism the family's earlier entries did not have) | R2-attempts=1 |
falsifier=the deliberate unscoped leaker above, watched to red with its neighbour still green
