### PR TITLE
fix(boundaries): clamp per-face CPML layer budget to each axis extent, and propagate the per-face spec past three collapsed-string reads (closes #647)

### DIFF
--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -616,6 +616,47 @@ class Simulation(
         else:
             self._boundary_spec = self._build_spec_from_legacy()
 
+        # solver='adi' has no per-face absorber. Its absorbing layer is a
+        # graded sigma stamped on ALL SIX faces at the scalar cpml_layers
+        # (rfx/adi.py make_adi_absorbing_sigma{,_3d}, reached from
+        # rfx/api/_execute.py under `self._boundary == "cpml"`), and
+        # `self._boundary` is 'cpml' as soon as ANY face absorbs. So a
+        # per-face spec with PEC faces, or with a per-face thickness
+        # override, would silently get an absorber where the caller asked
+        # for a reflector — the SILENT_WRONG class preflight exists to
+        # remove (issue #647 grep sweep). Reject it instead of absorbing
+        # into a wall.
+        if self._solver == "adi" and self._cpml_layers > 0:
+            _adi_faces = {
+                f"{ax}_{side}":
+                    getattr(getattr(self._boundary_spec, ax), side)
+                for ax in "xyz" for side in ("lo", "hi")
+            }
+            _adi_thick = {
+                f"{ax}_{side}": getattr(
+                    getattr(self._boundary_spec, ax), f"{side}_thickness")
+                for ax in "xyz" for side in ("lo", "hi")
+            }
+            _nonuniform = (
+                set(_adi_faces.values()) != {"cpml"}
+                or any(t is not None and t != cpml_layers
+                       for t in _adi_thick.values())
+            )
+            if _nonuniform:
+                _layout = ", ".join(
+                    f"{face}={tok!r}"
+                    for face, tok in sorted(_adi_faces.items())
+                )
+                raise ValueError(
+                    "solver='adi' supports only a uniform absorber: its "
+                    "absorbing layer is stamped on all six faces at the "
+                    "scalar cpml_layers, so a per-face boundary layout "
+                    f"({_layout}) would silently absorb on the faces you "
+                    "declared as reflectors. Use solver='yee' for per-face "
+                    "boundaries, or make every face 'cpml' with no per-face "
+                    "thickness override."
+                )
+
         # T7 Phase 2 PR2: per-face CPML thickness now runs end-to-end
         # via the padded-profile engine in rfx/boundaries/cpml.py.
         # The Phase 1 guard _check_thickness_uniformity_phase1 has

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -2054,6 +2054,7 @@ class _PreflightMixin:
             _w, cpml_thick_lo, cpml_thick_hi
         )
         self._validate_cfg_refplane_placement(_w)
+        self._validate_cfg_absorber_budget_vs_grid(_w, dx)
 
         self._check_waveguide_port_evanescent()
         self._check_msl_port_geometry(dx, cpml_thick_lo, cpml_thick_hi)
@@ -2474,39 +2475,152 @@ class _PreflightMixin:
         symmetric scalar forced both sides to the max and produced
         false positives on the reflector face.
 
+        Issue #647: the per-face LAYER COUNT now comes from
+        :meth:`_preflight_face_layers`, which reads
+        ``Boundary.lo_thickness`` / ``hi_thickness`` off the normalized
+        ``_boundary_spec``. Before that, every absorbing face was reported
+        at the global ``cpml_layers`` budget, so
+        ``z=Boundary(lo='pec', hi='cpml', hi_thickness=2)`` with
+        ``cpml_layers=16`` told every consumer the z_hi absorber was
+        ``16*dx`` when the grid allocates ``2*dx`` — an 8x over-report that
+        biases the MSL / waveguide clearance advisories (which use the
+        magnitude as a calibrated buffer, not just as a boolean).
+
         Returns ``(cpml_thick_lo, cpml_thick_hi, _pmc_faces_set)``.
         """
         _pmc_faces_set = set(self._boundary_spec.pmc_faces())
-        _axis_thickness = [cpml_thickness, cpml_thickness, cpml_thickness]
-        if (self._dz_profile is not None
-                and not is_tracer(self._dz_profile)
-                and self._boundary in ("cpml", "upml")
-                and self._cpml_layers > 0):
-            n = min(self._cpml_layers, len(self._dz_profile))
-            _axis_thickness[2] = float(sum(self._dz_profile[:n]))
+        _face_layers = self._preflight_face_layers()
+        # ``cpml_thickness`` is the BUDGET thickness (cpml_layers * dx, or 0
+        # on a non-absorbing boundary); per-cell thickness is that divided
+        # by the budget layer count.
+        _per_layer = (cpml_thickness / self._cpml_layers
+                      if self._cpml_layers else 0.0)
 
         def _face_thickness(ax_idx: int, side: str) -> float:
             ax_name = "xyz"[ax_idx]
-            face = f"{ax_name}_{side}"
-            if self._boundary not in ("cpml", "upml"):
+            n_face = _face_layers[f"{ax_name}_{side}"]
+            if n_face <= 0:
                 return 0.0
-            if ax_name == "z" and self._mode.startswith("2d"):
-                # 2D modes collapse z to a single cell with NO absorber
-                # (Grid sets pad_z_lo = pad_z_hi = 0 and strips z from
-                # cpml_axes — rfx/grid.py). Without this mirror rule the
-                # z thickness is the full cpml budget and every 2D
-                # source/probe at z=0 false-trips absorber_overlap
-                # (issue #166).
-                return 0.0
-            if face in self._pec_faces or face in _pmc_faces_set:
-                return 0.0
-            if ax_name in self._periodic_axes:
-                return 0.0
-            return _axis_thickness[ax_idx]
+            if (ax_name == "z"
+                    and self._dz_profile is not None
+                    and not is_tracer(self._dz_profile)):
+                # Non-uniform z aggregates real cell sizes rather than
+                # n*dx. The LEADING entries are used on both sides, as
+                # before -- a hi-face trailing aggregation would be more
+                # faithful on a graded profile but is a separate change
+                # with its own regression surface.
+                n = min(n_face, len(self._dz_profile))
+                return float(sum(self._dz_profile[:n]))
+            return n_face * _per_layer
 
         cpml_thick_lo = [_face_thickness(ax, "lo") for ax in range(3)]
         cpml_thick_hi = [_face_thickness(ax, "hi") for ax in range(3)]
         return cpml_thick_lo, cpml_thick_hi, _pmc_faces_set
+
+    def _validate_cfg_absorber_budget_vs_grid(self, _w, dx: float) -> None:
+        """``cpml_layers`` wider than an axis of the grid it is applied to.
+
+        Issue #647. ``cpml_layers`` is an ALLOCATION BUDGET shared by all
+        six faces, and the CPML scratch buffers are cut from it on every
+        axis — including axes that allocate no absorber at all. When the
+        budget exceeds an axis's own cell count the face slices ``[:n]`` /
+        ``[-n:]`` shrink to the axis while the length-``n`` coefficient
+        profile does not, and the run used to die inside the scan with a
+        broadcasting ``TypeError`` and NOTHING from preflight
+        ("All checks passed" was the measured output on the reported
+        fixture). ``rfx.boundaries.cpml`` now clamps the buffer per axis,
+        which is exact — the clamped region carries no active absorber
+        layers — so this is an advisory about a mis-sized number, not a
+        rejection: the requested absorber is realized in full.
+
+        Only reachable with a per-face ``BoundarySpec``. With a scalar
+        ``boundary='cpml'`` every axis is padded by ``2*cpml_layers``, so
+        the budget can never exceed an axis extent.
+
+        The extent arithmetic mirrors ``rfx.grid.Grid.__init__``
+        (``ceil(domain/dx) + 1 + pad_lo + pad_hi``) through
+        :meth:`_preflight_face_layers`; it inherits that helper's
+        waveguide-axis divergence, which makes this check UNDER-fire (never
+        over-fire) on waveguide-port simulations.
+        """
+        n_budget = int(self._cpml_layers or 0)
+        if n_budget <= 0 or dx <= 0:
+            return
+        face_layers = self._preflight_face_layers()
+        for ax_idx, ax_name in enumerate("xyz"):
+            if ax_name == "z" and self._mode.startswith("2d"):
+                continue
+            extent_m = (self._domain[ax_idx] if ax_idx < len(self._domain)
+                        else self._domain[-1])
+            pad_lo = face_layers[f"{ax_name}_lo"]
+            pad_hi = face_layers[f"{ax_name}_hi"]
+            n_cells = int(math.ceil(extent_m / dx)) + 1 + pad_lo + pad_hi
+            if n_budget <= n_cells:
+                continue
+            axis_boundary = getattr(self._boundary_spec, ax_name)
+            _w.warn(
+                PreflightWarning(
+                    f"cpml_layers={n_budget} exceeds the {ax_name}-axis grid "
+                    f"extent ({n_cells} cells: "
+                    f"ceil({_fmt_len(extent_m)}/{_fmt_len(dx)})+1 interior "
+                    f"nodes + {pad_lo}/{pad_hi} absorber cells, from "
+                    f"{ax_name}=Boundary(lo={axis_boundary.lo!r}, "
+                    f"hi={axis_boundary.hi!r})). The absorber you asked for "
+                    f"is unaffected — the layer budget is clamped to the "
+                    f"axis for the CPML scratch buffers only, and the "
+                    f"clamped region carries no active absorber layers "
+                    f"(issue #647). It does mean the layer count was sized "
+                    f"for a coarser mesh or a larger domain than this one; "
+                    f"set that face's lo_thickness/hi_thickness explicitly "
+                    f"if you meant a thinner absorber.",
+                    code="absorber_budget_exceeds_axis",
+                    source="_validate_cfg_absorber_budget_vs_grid",
+                ),
+                stacklevel=3,
+            )
+
+    def _preflight_face_layers(self) -> dict[str, int]:
+        """Allocated absorbing layers per face — preflight's mirror of
+        ``rfx.grid.Grid._face_pad`` (issue #647).
+
+        Keyed off the normalized ``_boundary_spec``, which is correct for
+        BOTH legacy scalar construction (``boundary='cpml'`` +
+        ``pec_faces=`` + ``set_periodic_axes()`` are all folded into it by
+        ``_build_spec_from_legacy``) and per-face ``BoundarySpec``
+        construction. A face is allocated
+        ``Boundary.resolved_{lo,hi}_thickness(cpml_layers)`` cells when its
+        own token absorbs, and 0 otherwise — which is what makes PEC / PMC
+        / periodic faces fall out without a separate rule.
+
+        Known divergence from ``Grid._face_pad``, deliberately not
+        mirrored: the grid drops non-port axes from ``cpml_axes`` when
+        waveguide ports are present, so on such a simulation this
+        over-reports the absorber on the non-port axes. That is the
+        pre-existing behaviour every current warning is calibrated
+        against; changing it belongs to a waveguide-lane change, not here.
+        """
+        n_default = int(self._cpml_layers or 0)
+        out: dict[str, int] = {}
+        spec = self._boundary_spec
+        for ax_name, boundary in (("x", spec.x), ("y", spec.y),
+                                  ("z", spec.z)):
+            for side in ("lo", "hi"):
+                face = f"{ax_name}_{side}"
+                token = getattr(boundary, side)
+                if token not in ("cpml", "upml"):
+                    out[face] = 0
+                elif ax_name == "z" and self._mode.startswith("2d"):
+                    # 2D modes collapse z to a single cell with NO absorber
+                    # (Grid sets pad_z_lo = pad_z_hi = 0 and strips z from
+                    # cpml_axes — rfx/grid.py). Without this mirror rule the
+                    # z thickness is the full cpml budget and every 2D
+                    # source/probe at z=0 false-trips absorber_overlap
+                    # (issue #166).
+                    out[face] = 0
+                else:
+                    resolve = getattr(boundary, f"resolved_{side}_thickness")
+                    out[face] = int(resolve(n_default))
+        return out
 
     def _validate_cfg_pec_faces_with_finite_pec(self, _w) -> None:
         """Warn about pec_faces + finite PEC objects co-existing.
@@ -3629,15 +3743,23 @@ class _PreflightMixin:
 
             # P2.6: CPML z-thickness on non-uniform mesh.
             # Skip on tracer profiles — advisory warning only.
+            # Issue #647: the cell count is the z faces' OWN allocation, not
+            # the global budget. Keyed off `_boundary_spec` via
+            # `_preflight_face_layers`, so a per-face spec whose z faces are
+            # PEC/PMC (allocation 0) no longer reports a thin absorber that
+            # does not exist, and a per-face `hi_thickness` is measured at the
+            # thickness it actually allocates.
+            _z_layers = max(self._preflight_face_layers()["z_lo"],
+                            self._preflight_face_layers()["z_hi"])
             if (self._boundary == "cpml"
-                    and self._cpml_layers > 0
+                    and _z_layers > 0
                     and not is_tracer(self._dz_profile)):
-                cpml_z_thick = sum(float(d) for d in self._dz_profile[:self._cpml_layers])
+                cpml_z_thick = sum(float(d) for d in self._dz_profile[:_z_layers])
                 if cpml_z_thick < cpml_thickness * 0.3:
                     _w.warn(
                         PreflightWarning(
                             f"CPML z-thickness is {cpml_z_thick*1e3:.1f}mm "
-                            f"({self._cpml_layers} cells), much thinner than "
+                            f"({_z_layers} cells), much thinner than "
                             f"xy-thickness {cpml_thickness*1e3:.1f}mm. "
                             f"Absorbing performance may be asymmetric. "
                             f"Consider more z cells or fewer CPML layers.",

--- a/rfx/boundaries/cpml.py
+++ b/rfx/boundaries/cpml.py
@@ -269,6 +269,80 @@ def _cpml_noop_profile(n_layers: int) -> CPMLParams:
     )
 
 
+def _grid_extents(grid) -> tuple[int, int, int]:
+    """``(nx, ny, nz)`` for both ``Grid`` and ``NonUniformGrid``."""
+    if hasattr(grid, "shape"):
+        nx, ny, nz = grid.shape
+    else:
+        nx, ny, nz = grid.nx, grid.ny, grid.nz
+    return int(nx), int(ny), int(nz)
+
+
+def _axis_buffer_depths(grid, n_alloc: int) -> tuple[int, int, int]:
+    """Per-axis CPML scratch-buffer depth: ``min(n_alloc, axis_extent)``.
+
+    ``grid.cpml_layers`` is an ALLOCATION BUDGET, not a per-face absorber
+    thickness: every face profile is built with its OWN active layer count
+    and then no-op-padded up to the budget (``_pad_profile_at_end`` /
+    ``_pad_profile_at_start``), and a face with no absorber at all gets the
+    all-no-op ``_cpml_noop_profile``. An axis narrower than the budget
+    cannot hold that buffer — the face slices ``[:n]`` / ``[-n:]`` silently
+    shrink to the axis extent while the length-``n`` profile does not, and
+    the scan dies on ``mul got incompatible shapes for broadcasting``
+    (issue #647). Reachable two ways, both with a per-face ``BoundarySpec``:
+    an axis whose faces are all PEC/PMC (no padding at all, so its extent is
+    just the interior), or an absorbing axis whose per-face
+    ``lo_thickness`` / ``hi_thickness`` is well below the budget.
+
+    Clamping is exact rather than a quiet degradation, and that is WHY it is
+    a clamp and not a raise. A face's ACTIVE layer count equals the pad the
+    grid builder allocated for it (``Grid._face_pad``: ``face_layers[face]``
+    on an absorbing face, ``0`` on PEC/PMC/periodic), and every builder sizes
+    an axis as ``interior(>= 2) + pad_lo + pad_hi``. So
+    ``min(n_alloc, extent) >= max(pad_lo, pad_hi)`` always, and the entries
+    this drops — the tail of a lo profile, the head of a pre-flipped hi
+    profile — are exactly the no-op padding. Nothing absorbing is removed,
+    and the configuration the user asked for is fully realized. Raising
+    would instead reject a legitimate cavity-with-one-open-face.
+
+    Precedent for clamping over raising: the non-uniform runner already
+    drops non-absorbing axes from the applied set
+    (``rfx/nonuniform.py``: ``cpml_axes_eff`` keeps only axes with
+    ``pad_lo + pad_hi > 0``), which is why the #647 fixture survives the NU
+    lane and dies on the uniform one. ``_assert_absorber_fits`` below covers
+    the case this reasoning does NOT license.
+    """
+    nx, ny, nz = _grid_extents(grid)
+    return min(n_alloc, nx), min(n_alloc, ny), min(n_alloc, nz)
+
+
+def _assert_absorber_fits(grid, depths: tuple[int, int, int]) -> None:
+    """Reject a grid whose ALLOCATED absorber is wider than its own axis.
+
+    The clamp in :func:`_axis_buffer_depths` is only exact while every
+    face's allocated pad fits inside its axis. That invariant holds for
+    ``rfx.grid.Grid`` and ``rfx.nonuniform.NonUniformGrid`` by construction
+    (an axis is ``interior + pad_lo + pad_hi``), so this cannot fire from
+    any public constructor today — it exists so a future grid builder
+    cannot reintroduce a SILENTLY thinned absorber through the clamp. A
+    request that genuinely cannot be honoured is an error, not something to
+    round down.
+    """
+    for axis_idx, axis in enumerate("xyz"):
+        depth = depths[axis_idx]
+        for side in ("lo", "hi"):
+            pad = int(getattr(grid, f"pad_{axis}_{side}", 0) or 0)
+            if pad > depth:
+                raise ValueError(
+                    f"CPML face {axis}_{side} allocates {pad} absorbing "
+                    f"layers but the {axis} axis is only {depth} cell(s) "
+                    f"wide, so the absorber cannot be applied at its "
+                    f"requested thickness. Reduce cpml_layers (or that "
+                    f"face's lo_thickness/hi_thickness) or enlarge the "
+                    f"domain on {axis}."
+                )
+
+
 def init_cpml(grid, *, kappa_max: float | None = None,
               pec_faces: set[str] | None = None,
               pmc_faces: set[str] | None = None,
@@ -350,7 +424,13 @@ def init_cpml(grid, *, kappa_max: float | None = None,
         dz_lo=dz_lo, dz_hi=dz_hi,
     )
 
-    nx, ny, nz = grid.shape if hasattr(grid, 'shape') else (grid.nx, grid.ny, grid.nz)
+    nx, ny, nz = _grid_extents(grid)
+    # Issue #647: the psi buffers are indexed by the SAME face slices the
+    # scan body applies, so they carry the same per-axis clamp. ``n_x ==
+    # n_y == n_z == n`` on every configuration that runs today, which keeps
+    # the CPMLState shapes — and therefore the JIT cache — untouched.
+    n_x, n_y, n_z = _axis_buffer_depths(grid, n)
+    _assert_absorber_fits(grid, (n_x, n_y, n_z))
 
     # Issue #644.  The psi_* arrays are ACCUMULATION state — a recursive
     # convolution integrated over every timestep — so they must never sit
@@ -375,26 +455,48 @@ def init_cpml(grid, *, kappa_max: float | None = None,
     psi_dtype = jnp.promote_types(field_dtype, jnp.float32)
 
     def _zeros(dim_size: int, perp1: int, perp2: int) -> jnp.ndarray:
-        return jnp.zeros((n, perp1, perp2), dtype=psi_dtype)
+        return jnp.zeros((dim_size, perp1, perp2), dtype=psi_dtype)
 
     state = CPMLState(
-        # E-field psi (12 faces)
-        psi_ex_ylo=_zeros(n, nx, nz), psi_ex_yhi=_zeros(n, nx, nz),
-        psi_ex_zlo=_zeros(n, nx, ny), psi_ex_zhi=_zeros(n, nx, ny),
-        psi_ey_xlo=_zeros(n, ny, nz), psi_ey_xhi=_zeros(n, ny, nz),
-        psi_ey_zlo=_zeros(n, ny, nx), psi_ey_zhi=_zeros(n, ny, nx),
-        psi_ez_xlo=_zeros(n, nz, ny), psi_ez_xhi=_zeros(n, nz, ny),
-        psi_ez_ylo=_zeros(n, nz, nx), psi_ez_yhi=_zeros(n, nz, nx),
+        # E-field psi (12 faces). The leading dimension is the buffer depth
+        # of the face's OWN axis (#647), not the global budget.
+        psi_ex_ylo=_zeros(n_y, nx, nz), psi_ex_yhi=_zeros(n_y, nx, nz),
+        psi_ex_zlo=_zeros(n_z, nx, ny), psi_ex_zhi=_zeros(n_z, nx, ny),
+        psi_ey_xlo=_zeros(n_x, ny, nz), psi_ey_xhi=_zeros(n_x, ny, nz),
+        psi_ey_zlo=_zeros(n_z, ny, nx), psi_ey_zhi=_zeros(n_z, ny, nx),
+        psi_ez_xlo=_zeros(n_x, nz, ny), psi_ez_xhi=_zeros(n_x, nz, ny),
+        psi_ez_ylo=_zeros(n_y, nz, nx), psi_ez_yhi=_zeros(n_y, nz, nx),
         # H-field psi (12 faces)
-        psi_hx_ylo=_zeros(n, nx, nz), psi_hx_yhi=_zeros(n, nx, nz),
-        psi_hx_zlo=_zeros(n, nx, ny), psi_hx_zhi=_zeros(n, nx, ny),
-        psi_hy_xlo=_zeros(n, ny, nz), psi_hy_xhi=_zeros(n, ny, nz),
-        psi_hy_zlo=_zeros(n, ny, nx), psi_hy_zhi=_zeros(n, ny, nx),
-        psi_hz_xlo=_zeros(n, nz, ny), psi_hz_xhi=_zeros(n, nz, ny),
-        psi_hz_ylo=_zeros(n, nz, nx), psi_hz_yhi=_zeros(n, nz, nx),
+        psi_hx_ylo=_zeros(n_y, nx, nz), psi_hx_yhi=_zeros(n_y, nx, nz),
+        psi_hx_zlo=_zeros(n_z, nx, ny), psi_hx_zhi=_zeros(n_z, nx, ny),
+        psi_hy_xlo=_zeros(n_x, ny, nz), psi_hy_xhi=_zeros(n_x, ny, nz),
+        psi_hy_zlo=_zeros(n_z, ny, nx), psi_hy_zhi=_zeros(n_z, ny, nx),
+        psi_hz_xlo=_zeros(n_x, nz, ny), psi_hz_xhi=_zeros(n_x, nz, ny),
+        psi_hz_ylo=_zeros(n_y, nz, nx), psi_hz_yhi=_zeros(n_y, nz, nx),
     )
 
     return params, state
+
+
+def _clip_lo(arr, depth: int, n_alloc: int):
+    """Front ``depth`` entries of a lo-face profile (#647).
+
+    Returns the array UNCHANGED on the common ``depth == n_alloc`` path so
+    the emitted graph — and therefore every currently-working field byte —
+    is untouched. When the axis is narrower than the allocation budget the
+    dropped tail is no-op padding (see :func:`_axis_buffer_depths`).
+    """
+    return arr if depth >= n_alloc else arr[:depth]
+
+
+def _clip_hi(arr, depth: int, n_alloc: int):
+    """Trailing ``depth`` entries of a PRE-FLIPPED hi-face profile (#647).
+
+    Hi profiles are stored outermost-cell-last, so the active layers live at
+    the END and the head is the no-op padding — the mirror of
+    :func:`_clip_lo`.
+    """
+    return arr if depth >= n_alloc else arr[n_alloc - depth:]
 
 
 def _kappa_correction(kappa, curl_slice, shape_broadcast):
@@ -428,6 +530,7 @@ def apply_cpml_e(
     anisotropic grids).
     """
     n = grid.cpml_layers
+    n_x, n_y, n_z = _axis_buffer_depths(grid, n)
     dt = grid.dt
     # Material-aware CPML: use local eps_r so guided modes in dielectric
     # waveguides see an impedance-matched absorber (equivalent to UPML).
@@ -435,12 +538,12 @@ def apply_cpml_e(
     if materials is not None:
         _ce_full = dt / (materials.eps_r * EPS_0)  # (nx, ny, nz)
         # Pre-slice to each PML face region for broadcasting with psi arrays
-        ce_xlo = _ce_full[:n, :, :]
-        ce_xhi = _ce_full[-n:, :, :]
-        ce_ylo = _ce_full[:, :n, :]
-        ce_yhi = _ce_full[:, -n:, :]
-        ce_zlo = _ce_full[:, :, :n]
-        ce_zhi = _ce_full[:, :, -n:]
+        ce_xlo = _ce_full[:n_x, :, :]
+        ce_xhi = _ce_full[-n_x:, :, :]
+        ce_ylo = _ce_full[:, :n_y, :]
+        ce_yhi = _ce_full[:, -n_y:, :]
+        ce_zlo = _ce_full[:, :, :n_z]
+        ce_zhi = _ce_full[:, :, -n_z:]
     else:
         ce_xlo = ce_xhi = ce_ylo = ce_yhi = ce_zlo = ce_zhi = dt / EPS_0
 
@@ -460,26 +563,26 @@ def apply_cpml_e(
         dx_x_lo = dx_x_hi = dx_y_lo = dx_y_hi = dz_lo = dz_hi = float(grid.dx)
 
     # X-axis profiles (hi-face pre-flipped at init time — no jnp.flip here).
-    b_x_lo = px_lo.b[:, None, None]
-    c_x_lo = px_lo.c[:, None, None]
-    k_x_lo = px_lo.kappa[:, None, None]
-    b_x_hi = px_hi.b[:, None, None]
-    c_x_hi = px_hi.c[:, None, None]
-    k_x_hi = px_hi.kappa[:, None, None]
+    b_x_lo = _clip_lo(px_lo.b, n_x, n)[:, None, None]
+    c_x_lo = _clip_lo(px_lo.c, n_x, n)[:, None, None]
+    k_x_lo = _clip_lo(px_lo.kappa, n_x, n)[:, None, None]
+    b_x_hi = _clip_hi(px_hi.b, n_x, n)[:, None, None]
+    c_x_hi = _clip_hi(px_hi.c, n_x, n)[:, None, None]
+    k_x_hi = _clip_hi(px_hi.kappa, n_x, n)[:, None, None]
     # Y-axis profiles
-    b_y_lo = py_lo.b[:, None, None]
-    c_y_lo = py_lo.c[:, None, None]
-    k_y_lo = py_lo.kappa[:, None, None]
-    b_y_hi = py_hi.b[:, None, None]
-    c_y_hi = py_hi.c[:, None, None]
-    k_y_hi = py_hi.kappa[:, None, None]
+    b_y_lo = _clip_lo(py_lo.b, n_y, n)[:, None, None]
+    c_y_lo = _clip_lo(py_lo.c, n_y, n)[:, None, None]
+    k_y_lo = _clip_lo(py_lo.kappa, n_y, n)[:, None, None]
+    b_y_hi = _clip_hi(py_hi.b, n_y, n)[:, None, None]
+    c_y_hi = _clip_hi(py_hi.c, n_y, n)[:, None, None]
+    k_y_hi = _clip_hi(py_hi.kappa, n_y, n)[:, None, None]
     # Z-axis profiles (lo and hi independent by design)
-    b_zl = pz_lo.b[:, None, None]
-    c_zl = pz_lo.c[:, None, None]
-    k_zl = pz_lo.kappa[:, None, None]
-    b_zh = pz_hi.b[:, None, None]
-    c_zh = pz_hi.c[:, None, None]
-    k_zh = pz_hi.kappa[:, None, None]
+    b_zl = _clip_lo(pz_lo.b, n_z, n)[:, None, None]
+    c_zl = _clip_lo(pz_lo.c, n_z, n)[:, None, None]
+    k_zl = _clip_lo(pz_lo.kappa, n_z, n)[:, None, None]
+    b_zh = _clip_hi(pz_hi.b, n_z, n)[:, None, None]
+    c_zh = _clip_hi(pz_hi.c, n_z, n)[:, None, None]
+    k_zh = _clip_hi(pz_hi.kappa, n_z, n)[:, None, None]
 
     # Issue #644.  Accumulate the CPML corrections at the psi dtype, then
     # round back to the field storage dtype ONCE at the end.  Under
@@ -504,44 +607,44 @@ def apply_cpml_e(
 
     if "x" in axes:
         # --- X-lo: Ey correction from dHz/dx ---
-        hz_xlo = state.hz[:n, :, :]
-        hz_shifted_xlo = _shift_bwd(state.hz, 0)[:n, :, :]
+        hz_xlo = state.hz[:n_x, :, :]
+        hz_shifted_xlo = _shift_bwd(state.hz, 0)[:n_x, :, :]
         curl_hz_dx_xlo = (hz_xlo - hz_shifted_xlo) / dx_x_lo
 
         new_psi_ey_xlo = b_x_lo * cpml_state.psi_ey_xlo + c_x_lo * curl_hz_dx_xlo
-        ey = ey.at[:n, :, :].add(-ce_xlo * new_psi_ey_xlo)
-        ey = ey.at[:n, :, :].add(-ce_xlo * (1.0 / k_x_lo - 1.0) * curl_hz_dx_xlo)
+        ey = ey.at[:n_x, :, :].add(-ce_xlo * new_psi_ey_xlo)
+        ey = ey.at[:n_x, :, :].add(-ce_xlo * (1.0 / k_x_lo - 1.0) * curl_hz_dx_xlo)
 
         # --- X-hi: Ey correction from dHz/dx ---
-        hz_xhi = state.hz[-n:, :, :]
-        hz_shifted_xhi = _shift_bwd(state.hz, 0)[-n:, :, :]
+        hz_xhi = state.hz[-n_x:, :, :]
+        hz_shifted_xhi = _shift_bwd(state.hz, 0)[-n_x:, :, :]
         curl_hz_dx_xhi = (hz_xhi - hz_shifted_xhi) / dx_x_hi
 
         new_psi_ey_xhi = b_x_hi * cpml_state.psi_ey_xhi + c_x_hi * curl_hz_dx_xhi
-        ey = ey.at[-n:, :, :].add(-ce_xhi * new_psi_ey_xhi)
-        ey = ey.at[-n:, :, :].add(-ce_xhi * (1.0 / k_x_hi - 1.0) * curl_hz_dx_xhi)
+        ey = ey.at[-n_x:, :, :].add(-ce_xhi * new_psi_ey_xhi)
+        ey = ey.at[-n_x:, :, :].add(-ce_xhi * (1.0 / k_x_hi - 1.0) * curl_hz_dx_xhi)
 
         # --- X-lo: Ez correction from dHy/dx ---
-        hy_xlo = state.hy[:n, :, :]
-        hy_shifted_xlo = _shift_bwd(state.hy, 0)[:n, :, :]
+        hy_xlo = state.hy[:n_x, :, :]
+        hy_shifted_xlo = _shift_bwd(state.hy, 0)[:n_x, :, :]
         curl_hy_dx_xlo = (hy_xlo - hy_shifted_xlo) / dx_x_lo
         curl_hy_dx_xlo_t = jnp.transpose(curl_hy_dx_xlo, (0, 2, 1))
 
         new_psi_ez_xlo = b_x_lo * cpml_state.psi_ez_xlo + c_x_lo * curl_hy_dx_xlo_t
         correction_ez_xlo = jnp.transpose(new_psi_ez_xlo, (0, 2, 1))
-        ez = ez.at[:n, :, :].add(ce_xlo * correction_ez_xlo)
-        ez = ez.at[:n, :, :].add(ce_xlo * (1.0 / k_x_lo - 1.0) * curl_hy_dx_xlo)
+        ez = ez.at[:n_x, :, :].add(ce_xlo * correction_ez_xlo)
+        ez = ez.at[:n_x, :, :].add(ce_xlo * (1.0 / k_x_lo - 1.0) * curl_hy_dx_xlo)
 
         # --- X-hi: Ez correction from dHy/dx ---
-        hy_xhi = state.hy[-n:, :, :]
-        hy_shifted_xhi = _shift_bwd(state.hy, 0)[-n:, :, :]
+        hy_xhi = state.hy[-n_x:, :, :]
+        hy_shifted_xhi = _shift_bwd(state.hy, 0)[-n_x:, :, :]
         curl_hy_dx_xhi = (hy_xhi - hy_shifted_xhi) / dx_x_hi
         curl_hy_dx_xhi_t = jnp.transpose(curl_hy_dx_xhi, (0, 2, 1))
 
         new_psi_ez_xhi = b_x_hi * cpml_state.psi_ez_xhi + c_x_hi * curl_hy_dx_xhi_t
         correction_ez_xhi = jnp.transpose(new_psi_ez_xhi, (0, 2, 1))
-        ez = ez.at[-n:, :, :].add(ce_xhi * correction_ez_xhi)
-        ez = ez.at[-n:, :, :].add(ce_xhi * (1.0 / k_x_hi - 1.0) * curl_hy_dx_xhi)
+        ez = ez.at[-n_x:, :, :].add(ce_xhi * correction_ez_xhi)
+        ez = ez.at[-n_x:, :, :].add(ce_xhi * (1.0 / k_x_hi - 1.0) * curl_hy_dx_xhi)
     else:
         new_psi_ey_xlo = cpml_state.psi_ey_xlo
         new_psi_ey_xhi = cpml_state.psi_ey_xhi
@@ -554,56 +657,56 @@ def apply_cpml_e(
 
     if "y" in axes:
         # --- Y-lo: Ex correction from dHz/dy ---
-        hz_ylo = state.hz[:, :n, :]
-        hz_shifted_ylo = _shift_bwd(state.hz, 1)[:, :n, :]
+        hz_ylo = state.hz[:, :n_y, :]
+        hz_shifted_ylo = _shift_bwd(state.hz, 1)[:, :n_y, :]
         curl_hz_dy_ylo = (hz_ylo - hz_shifted_ylo) / dx_y_lo
 
         curl_hz_dy_ylo_t = jnp.transpose(curl_hz_dy_ylo, (1, 0, 2))
 
         new_psi_ex_ylo = b_y_lo * cpml_state.psi_ex_ylo + c_y_lo * curl_hz_dy_ylo_t
         correction_ex_ylo = jnp.transpose(new_psi_ex_ylo, (1, 0, 2))
-        ex = ex.at[:, :n, :].add(ce_ylo * correction_ex_ylo)
+        ex = ex.at[:, :n_y, :].add(ce_ylo * correction_ex_ylo)
         kappa_corr_ylo = jnp.transpose((1.0 / k_y_lo - 1.0) * curl_hz_dy_ylo_t, (1, 0, 2))
-        ex = ex.at[:, :n, :].add(ce_ylo * kappa_corr_ylo)
+        ex = ex.at[:, :n_y, :].add(ce_ylo * kappa_corr_ylo)
 
         # --- Y-hi: Ex correction from dHz/dy ---
-        hz_yhi = state.hz[:, -n:, :]
-        hz_shifted_yhi = _shift_bwd(state.hz, 1)[:, -n:, :]
+        hz_yhi = state.hz[:, -n_y:, :]
+        hz_shifted_yhi = _shift_bwd(state.hz, 1)[:, -n_y:, :]
         curl_hz_dy_yhi = (hz_yhi - hz_shifted_yhi) / dx_y_hi
 
         curl_hz_dy_yhi_t = jnp.transpose(curl_hz_dy_yhi, (1, 0, 2))
 
         new_psi_ex_yhi = b_y_hi * cpml_state.psi_ex_yhi + c_y_hi * curl_hz_dy_yhi_t
         correction_ex_yhi = jnp.transpose(new_psi_ex_yhi, (1, 0, 2))
-        ex = ex.at[:, -n:, :].add(ce_yhi * correction_ex_yhi)
+        ex = ex.at[:, -n_y:, :].add(ce_yhi * correction_ex_yhi)
         kappa_corr_yhi = jnp.transpose((1.0 / k_y_hi - 1.0) * curl_hz_dy_yhi_t, (1, 0, 2))
-        ex = ex.at[:, -n:, :].add(ce_yhi * kappa_corr_yhi)
+        ex = ex.at[:, -n_y:, :].add(ce_yhi * kappa_corr_yhi)
 
         # --- Y-lo: Ez correction from dHx/dy ---
-        hx_ylo = state.hx[:, :n, :]
-        hx_shifted_ylo = _shift_bwd(state.hx, 1)[:, :n, :]
+        hx_ylo = state.hx[:, :n_y, :]
+        hx_shifted_ylo = _shift_bwd(state.hx, 1)[:, :n_y, :]
         curl_hx_dy_ylo = (hx_ylo - hx_shifted_ylo) / dx_y_lo
 
         curl_hx_dy_ylo_t = jnp.transpose(curl_hx_dy_ylo, (1, 2, 0))
 
         new_psi_ez_ylo = b_y_lo * cpml_state.psi_ez_ylo + c_y_lo * curl_hx_dy_ylo_t
         correction_ez_ylo = jnp.transpose(new_psi_ez_ylo, (2, 0, 1))
-        ez = ez.at[:, :n, :].add(-ce_ylo * correction_ez_ylo)
+        ez = ez.at[:, :n_y, :].add(-ce_ylo * correction_ez_ylo)
         kappa_corr_ez_ylo = jnp.transpose((1.0 / k_y_lo - 1.0) * curl_hx_dy_ylo_t, (2, 0, 1))
-        ez = ez.at[:, :n, :].add(-ce_ylo * kappa_corr_ez_ylo)
+        ez = ez.at[:, :n_y, :].add(-ce_ylo * kappa_corr_ez_ylo)
 
         # --- Y-hi: Ez correction from dHx/dy ---
-        hx_yhi = state.hx[:, -n:, :]
-        hx_shifted_yhi = _shift_bwd(state.hx, 1)[:, -n:, :]
+        hx_yhi = state.hx[:, -n_y:, :]
+        hx_shifted_yhi = _shift_bwd(state.hx, 1)[:, -n_y:, :]
         curl_hx_dy_yhi = (hx_yhi - hx_shifted_yhi) / dx_y_hi
 
         curl_hx_dy_yhi_t = jnp.transpose(curl_hx_dy_yhi, (1, 2, 0))
 
         new_psi_ez_yhi = b_y_hi * cpml_state.psi_ez_yhi + c_y_hi * curl_hx_dy_yhi_t
         correction_ez_yhi = jnp.transpose(new_psi_ez_yhi, (2, 0, 1))
-        ez = ez.at[:, -n:, :].add(-ce_yhi * correction_ez_yhi)
+        ez = ez.at[:, -n_y:, :].add(-ce_yhi * correction_ez_yhi)
         kappa_corr_ez_yhi = jnp.transpose((1.0 / k_y_hi - 1.0) * curl_hx_dy_yhi_t, (2, 0, 1))
-        ez = ez.at[:, -n:, :].add(-ce_yhi * kappa_corr_ez_yhi)
+        ez = ez.at[:, -n_y:, :].add(-ce_yhi * kappa_corr_ez_yhi)
     else:
         new_psi_ex_ylo = cpml_state.psi_ex_ylo
         new_psi_ex_yhi = cpml_state.psi_ex_yhi
@@ -616,57 +719,57 @@ def apply_cpml_e(
 
     if "z" in axes:
         # --- Z-lo: Ex correction from dHy/dz ---
-        hy_zlo = state.hy[:, :, :n]
-        hy_shifted_zlo = _shift_bwd(state.hy, 2)[:, :, :n]
+        hy_zlo = state.hy[:, :, :n_z]
+        hy_shifted_zlo = _shift_bwd(state.hy, 2)[:, :, :n_z]
         curl_hy_dz_zlo = (hy_zlo - hy_shifted_zlo) / dz_lo
 
         curl_hy_dz_zlo_t = jnp.transpose(curl_hy_dz_zlo, (2, 0, 1))
 
         new_psi_ex_zlo = b_zl * cpml_state.psi_ex_zlo + c_zl * curl_hy_dz_zlo_t
         correction_ex_zlo = jnp.transpose(new_psi_ex_zlo, (1, 2, 0))
-        ex = ex.at[:, :, :n].add(-ce_zlo * correction_ex_zlo)
+        ex = ex.at[:, :, :n_z].add(-ce_zlo * correction_ex_zlo)
         # κ correction for Z-lo Ex
         kappa_corr_ex_zlo = jnp.transpose((1.0 / k_zl - 1.0) * curl_hy_dz_zlo_t, (1, 2, 0))
-        ex = ex.at[:, :, :n].add(-ce_zlo * kappa_corr_ex_zlo)
+        ex = ex.at[:, :, :n_z].add(-ce_zlo * kappa_corr_ex_zlo)
 
         # --- Z-hi: Ex correction from dHy/dz ---
-        hy_zhi = state.hy[:, :, -n:]
-        hy_shifted_zhi = _shift_bwd(state.hy, 2)[:, :, -n:]
+        hy_zhi = state.hy[:, :, -n_z:]
+        hy_shifted_zhi = _shift_bwd(state.hy, 2)[:, :, -n_z:]
         curl_hy_dz_zhi = (hy_zhi - hy_shifted_zhi) / dz_hi
 
         curl_hy_dz_zhi_t = jnp.transpose(curl_hy_dz_zhi, (2, 0, 1))
 
         new_psi_ex_zhi = b_zh * cpml_state.psi_ex_zhi + c_zh * curl_hy_dz_zhi_t
         correction_ex_zhi = jnp.transpose(new_psi_ex_zhi, (1, 2, 0))
-        ex = ex.at[:, :, -n:].add(-ce_zhi * correction_ex_zhi)
+        ex = ex.at[:, :, -n_z:].add(-ce_zhi * correction_ex_zhi)
         kappa_corr_ex_zhi = jnp.transpose((1.0 / k_zh - 1.0) * curl_hy_dz_zhi_t, (1, 2, 0))
-        ex = ex.at[:, :, -n:].add(-ce_zhi * kappa_corr_ex_zhi)
+        ex = ex.at[:, :, -n_z:].add(-ce_zhi * kappa_corr_ex_zhi)
 
         # --- Z-lo: Ey correction from dHx/dz ---
-        hx_zlo = state.hx[:, :, :n]
-        hx_shifted_zlo = _shift_bwd(state.hx, 2)[:, :, :n]
+        hx_zlo = state.hx[:, :, :n_z]
+        hx_shifted_zlo = _shift_bwd(state.hx, 2)[:, :, :n_z]
         curl_hx_dz_zlo = (hx_zlo - hx_shifted_zlo) / dz_lo
 
         curl_hx_dz_zlo_t = jnp.transpose(curl_hx_dz_zlo, (2, 1, 0))
 
         new_psi_ey_zlo = b_zl * cpml_state.psi_ey_zlo + c_zl * curl_hx_dz_zlo_t
         correction_ey_zlo = jnp.transpose(new_psi_ey_zlo, (2, 1, 0))
-        ey = ey.at[:, :, :n].add(ce_zlo * correction_ey_zlo)
+        ey = ey.at[:, :, :n_z].add(ce_zlo * correction_ey_zlo)
         kappa_corr_ey_zlo = jnp.transpose((1.0 / k_zl - 1.0) * curl_hx_dz_zlo_t, (2, 1, 0))
-        ey = ey.at[:, :, :n].add(ce_zlo * kappa_corr_ey_zlo)
+        ey = ey.at[:, :, :n_z].add(ce_zlo * kappa_corr_ey_zlo)
 
         # --- Z-hi: Ey correction from dHx/dz ---
-        hx_zhi = state.hx[:, :, -n:]
-        hx_shifted_zhi = _shift_bwd(state.hx, 2)[:, :, -n:]
+        hx_zhi = state.hx[:, :, -n_z:]
+        hx_shifted_zhi = _shift_bwd(state.hx, 2)[:, :, -n_z:]
         curl_hx_dz_zhi = (hx_zhi - hx_shifted_zhi) / dz_hi
 
         curl_hx_dz_zhi_t = jnp.transpose(curl_hx_dz_zhi, (2, 1, 0))
 
         new_psi_ey_zhi = b_zh * cpml_state.psi_ey_zhi + c_zh * curl_hx_dz_zhi_t
         correction_ey_zhi = jnp.transpose(new_psi_ey_zhi, (2, 1, 0))
-        ey = ey.at[:, :, -n:].add(ce_zhi * correction_ey_zhi)
+        ey = ey.at[:, :, -n_z:].add(ce_zhi * correction_ey_zhi)
         kappa_corr_ey_zhi = jnp.transpose((1.0 / k_zh - 1.0) * curl_hx_dz_zhi_t, (2, 1, 0))
-        ey = ey.at[:, :, -n:].add(ce_zhi * kappa_corr_ey_zhi)
+        ey = ey.at[:, :, -n_z:].add(ce_zhi * kappa_corr_ey_zhi)
     else:
         new_psi_ex_zlo = cpml_state.psi_ex_zlo
         new_psi_ex_zhi = cpml_state.psi_ex_zhi
@@ -709,15 +812,16 @@ def apply_cpml_h(
     guided-mode absorption (equivalent to UPML).
     """
     n = grid.cpml_layers
+    n_x, n_y, n_z = _axis_buffer_depths(grid, n)
     dt = grid.dt
     if materials is not None and hasattr(materials, 'mu_r'):
         _ch_full = dt / (materials.mu_r * MU_0)  # (nx, ny, nz)
-        ch_xlo = _ch_full[:n, :, :]
-        ch_xhi = _ch_full[-n:, :, :]
-        ch_ylo = _ch_full[:, :n, :]
-        ch_yhi = _ch_full[:, -n:, :]
-        ch_zlo = _ch_full[:, :, :n]
-        ch_zhi = _ch_full[:, :, -n:]
+        ch_xlo = _ch_full[:n_x, :, :]
+        ch_xhi = _ch_full[-n_x:, :, :]
+        ch_ylo = _ch_full[:, :n_y, :]
+        ch_yhi = _ch_full[:, -n_y:, :]
+        ch_zlo = _ch_full[:, :, :n_z]
+        ch_zhi = _ch_full[:, :, -n_z:]
     else:
         ch_xlo = ch_xhi = ch_ylo = ch_yhi = ch_zlo = ch_zhi = dt / MU_0
 
@@ -735,26 +839,26 @@ def apply_cpml_h(
         dx_x_lo = dx_x_hi = dx_y_lo = dx_y_hi = dz_lo = dz_hi = float(grid.dx)
 
     # X-axis profiles (hi-face pre-flipped at init time).
-    b_x_lo = px_lo.b[:, None, None]
-    c_x_lo = px_lo.c[:, None, None]
-    k_x_lo = px_lo.kappa[:, None, None]
-    b_x_hi = px_hi.b[:, None, None]
-    c_x_hi = px_hi.c[:, None, None]
-    k_x_hi = px_hi.kappa[:, None, None]
+    b_x_lo = _clip_lo(px_lo.b, n_x, n)[:, None, None]
+    c_x_lo = _clip_lo(px_lo.c, n_x, n)[:, None, None]
+    k_x_lo = _clip_lo(px_lo.kappa, n_x, n)[:, None, None]
+    b_x_hi = _clip_hi(px_hi.b, n_x, n)[:, None, None]
+    c_x_hi = _clip_hi(px_hi.c, n_x, n)[:, None, None]
+    k_x_hi = _clip_hi(px_hi.kappa, n_x, n)[:, None, None]
     # Y-axis profiles
-    b_y_lo = py_lo.b[:, None, None]
-    c_y_lo = py_lo.c[:, None, None]
-    k_y_lo = py_lo.kappa[:, None, None]
-    b_y_hi = py_hi.b[:, None, None]
-    c_y_hi = py_hi.c[:, None, None]
-    k_y_hi = py_hi.kappa[:, None, None]
+    b_y_lo = _clip_lo(py_lo.b, n_y, n)[:, None, None]
+    c_y_lo = _clip_lo(py_lo.c, n_y, n)[:, None, None]
+    k_y_lo = _clip_lo(py_lo.kappa, n_y, n)[:, None, None]
+    b_y_hi = _clip_hi(py_hi.b, n_y, n)[:, None, None]
+    c_y_hi = _clip_hi(py_hi.c, n_y, n)[:, None, None]
+    k_y_hi = _clip_hi(py_hi.kappa, n_y, n)[:, None, None]
     # Z-axis profiles
-    b_zl = pz_lo.b[:, None, None]
-    c_zl = pz_lo.c[:, None, None]
-    k_zl = pz_lo.kappa[:, None, None]
-    b_zh = pz_hi.b[:, None, None]
-    c_zh = pz_hi.c[:, None, None]
-    k_zh = pz_hi.kappa[:, None, None]
+    b_zl = _clip_lo(pz_lo.b, n_z, n)[:, None, None]
+    c_zl = _clip_lo(pz_lo.c, n_z, n)[:, None, None]
+    k_zl = _clip_lo(pz_lo.kappa, n_z, n)[:, None, None]
+    b_zh = _clip_hi(pz_hi.b, n_z, n)[:, None, None]
+    c_zh = _clip_hi(pz_hi.c, n_z, n)[:, None, None]
+    k_zh = _clip_hi(pz_hi.kappa, n_z, n)[:, None, None]
 
     # Issue #644 — same accumulate-at-psi-dtype, round-once policy as
     # apply_cpml_e above (no-op for float32 / float64 / complex64).
@@ -770,44 +874,44 @@ def apply_cpml_h(
 
     if "x" in axes:
         # --- X-lo: Hy correction from dEz/dx ---
-        ez_xlo = state.ez[:n, :, :]
-        ez_shifted_xlo = _shift_fwd(state.ez, 0)[:n, :, :]
+        ez_xlo = state.ez[:n_x, :, :]
+        ez_shifted_xlo = _shift_fwd(state.ez, 0)[:n_x, :, :]
         curl_ez_dx_xlo = (ez_shifted_xlo - ez_xlo) / dx_x_lo
 
         new_psi_hy_xlo = b_x_lo * cpml_state.psi_hy_xlo + c_x_lo * curl_ez_dx_xlo
-        hy = hy.at[:n, :, :].add(ch_xlo * new_psi_hy_xlo)
-        hy = hy.at[:n, :, :].add(ch_xlo * (1.0 / k_x_lo - 1.0) * curl_ez_dx_xlo)
+        hy = hy.at[:n_x, :, :].add(ch_xlo * new_psi_hy_xlo)
+        hy = hy.at[:n_x, :, :].add(ch_xlo * (1.0 / k_x_lo - 1.0) * curl_ez_dx_xlo)
 
         # --- X-hi: Hy correction from dEz/dx ---
-        ez_xhi = state.ez[-n:, :, :]
-        ez_shifted_xhi = _shift_fwd(state.ez, 0)[-n:, :, :]
+        ez_xhi = state.ez[-n_x:, :, :]
+        ez_shifted_xhi = _shift_fwd(state.ez, 0)[-n_x:, :, :]
         curl_ez_dx_xhi = (ez_shifted_xhi - ez_xhi) / dx_x_hi
 
         new_psi_hy_xhi = b_x_hi * cpml_state.psi_hy_xhi + c_x_hi * curl_ez_dx_xhi
-        hy = hy.at[-n:, :, :].add(ch_xhi * new_psi_hy_xhi)
-        hy = hy.at[-n:, :, :].add(ch_xhi * (1.0 / k_x_hi - 1.0) * curl_ez_dx_xhi)
+        hy = hy.at[-n_x:, :, :].add(ch_xhi * new_psi_hy_xhi)
+        hy = hy.at[-n_x:, :, :].add(ch_xhi * (1.0 / k_x_hi - 1.0) * curl_ez_dx_xhi)
 
         # --- X-lo: Hz correction from dEy/dx ---
-        ey_xlo = state.ey[:n, :, :]
-        ey_shifted_xlo = _shift_fwd(state.ey, 0)[:n, :, :]
+        ey_xlo = state.ey[:n_x, :, :]
+        ey_shifted_xlo = _shift_fwd(state.ey, 0)[:n_x, :, :]
         curl_ey_dx_xlo = (ey_shifted_xlo - ey_xlo) / dx_x_lo
         curl_ey_dx_xlo_t = jnp.transpose(curl_ey_dx_xlo, (0, 2, 1))
 
         new_psi_hz_xlo = b_x_lo * cpml_state.psi_hz_xlo + c_x_lo * curl_ey_dx_xlo_t
         correction_hz_xlo = jnp.transpose(new_psi_hz_xlo, (0, 2, 1))
-        hz = hz.at[:n, :, :].add(-ch_xlo * correction_hz_xlo)
-        hz = hz.at[:n, :, :].add(-ch_xlo * (1.0 / k_x_lo - 1.0) * curl_ey_dx_xlo)
+        hz = hz.at[:n_x, :, :].add(-ch_xlo * correction_hz_xlo)
+        hz = hz.at[:n_x, :, :].add(-ch_xlo * (1.0 / k_x_lo - 1.0) * curl_ey_dx_xlo)
 
         # --- X-hi: Hz correction from dEy/dx ---
-        ey_xhi = state.ey[-n:, :, :]
-        ey_shifted_xhi = _shift_fwd(state.ey, 0)[-n:, :, :]
+        ey_xhi = state.ey[-n_x:, :, :]
+        ey_shifted_xhi = _shift_fwd(state.ey, 0)[-n_x:, :, :]
         curl_ey_dx_xhi = (ey_shifted_xhi - ey_xhi) / dx_x_hi
         curl_ey_dx_xhi_t = jnp.transpose(curl_ey_dx_xhi, (0, 2, 1))
 
         new_psi_hz_xhi = b_x_hi * cpml_state.psi_hz_xhi + c_x_hi * curl_ey_dx_xhi_t
         correction_hz_xhi = jnp.transpose(new_psi_hz_xhi, (0, 2, 1))
-        hz = hz.at[-n:, :, :].add(-ch_xhi * correction_hz_xhi)
-        hz = hz.at[-n:, :, :].add(-ch_xhi * (1.0 / k_x_hi - 1.0) * curl_ey_dx_xhi)
+        hz = hz.at[-n_x:, :, :].add(-ch_xhi * correction_hz_xhi)
+        hz = hz.at[-n_x:, :, :].add(-ch_xhi * (1.0 / k_x_hi - 1.0) * curl_ey_dx_xhi)
     else:
         new_psi_hy_xlo = cpml_state.psi_hy_xlo
         new_psi_hy_xhi = cpml_state.psi_hy_xhi
@@ -820,56 +924,56 @@ def apply_cpml_h(
 
     if "y" in axes:
         # --- Y-lo: Hx correction from dEz/dy ---
-        ez_ylo = state.ez[:, :n, :]
-        ez_shifted_ylo = _shift_fwd(state.ez, 1)[:, :n, :]
+        ez_ylo = state.ez[:, :n_y, :]
+        ez_shifted_ylo = _shift_fwd(state.ez, 1)[:, :n_y, :]
         curl_ez_dy_ylo = (ez_shifted_ylo - ez_ylo) / dx_y_lo
 
         curl_ez_dy_ylo_t = jnp.transpose(curl_ez_dy_ylo, (1, 0, 2))
 
         new_psi_hx_ylo = b_y_lo * cpml_state.psi_hx_ylo + c_y_lo * curl_ez_dy_ylo_t
         correction_hx_ylo = jnp.transpose(new_psi_hx_ylo, (1, 0, 2))
-        hx = hx.at[:, :n, :].add(-ch_ylo * correction_hx_ylo)
+        hx = hx.at[:, :n_y, :].add(-ch_ylo * correction_hx_ylo)
         kappa_corr_hx_ylo = jnp.transpose((1.0 / k_y_lo - 1.0) * curl_ez_dy_ylo_t, (1, 0, 2))
-        hx = hx.at[:, :n, :].add(-ch_ylo * kappa_corr_hx_ylo)
+        hx = hx.at[:, :n_y, :].add(-ch_ylo * kappa_corr_hx_ylo)
 
         # --- Y-hi: Hx correction from dEz/dy ---
-        ez_yhi = state.ez[:, -n:, :]
-        ez_shifted_yhi = _shift_fwd(state.ez, 1)[:, -n:, :]
+        ez_yhi = state.ez[:, -n_y:, :]
+        ez_shifted_yhi = _shift_fwd(state.ez, 1)[:, -n_y:, :]
         curl_ez_dy_yhi = (ez_shifted_yhi - ez_yhi) / dx_y_hi
 
         curl_ez_dy_yhi_t = jnp.transpose(curl_ez_dy_yhi, (1, 0, 2))
 
         new_psi_hx_yhi = b_y_hi * cpml_state.psi_hx_yhi + c_y_hi * curl_ez_dy_yhi_t
         correction_hx_yhi = jnp.transpose(new_psi_hx_yhi, (1, 0, 2))
-        hx = hx.at[:, -n:, :].add(-ch_yhi * correction_hx_yhi)
+        hx = hx.at[:, -n_y:, :].add(-ch_yhi * correction_hx_yhi)
         kappa_corr_hx_yhi = jnp.transpose((1.0 / k_y_hi - 1.0) * curl_ez_dy_yhi_t, (1, 0, 2))
-        hx = hx.at[:, -n:, :].add(-ch_yhi * kappa_corr_hx_yhi)
+        hx = hx.at[:, -n_y:, :].add(-ch_yhi * kappa_corr_hx_yhi)
 
         # --- Y-lo: Hz correction from dEx/dy ---
-        ex_ylo = state.ex[:, :n, :]
-        ex_shifted_ylo = _shift_fwd(state.ex, 1)[:, :n, :]
+        ex_ylo = state.ex[:, :n_y, :]
+        ex_shifted_ylo = _shift_fwd(state.ex, 1)[:, :n_y, :]
         curl_ex_dy_ylo = (ex_shifted_ylo - ex_ylo) / dx_y_lo
 
         curl_ex_dy_ylo_t = jnp.transpose(curl_ex_dy_ylo, (1, 2, 0))
 
         new_psi_hz_ylo = b_y_lo * cpml_state.psi_hz_ylo + c_y_lo * curl_ex_dy_ylo_t
         correction_hz_ylo = jnp.transpose(new_psi_hz_ylo, (2, 0, 1))
-        hz = hz.at[:, :n, :].add(ch_ylo * correction_hz_ylo)
+        hz = hz.at[:, :n_y, :].add(ch_ylo * correction_hz_ylo)
         kappa_corr_hz_ylo = jnp.transpose((1.0 / k_y_lo - 1.0) * curl_ex_dy_ylo_t, (2, 0, 1))
-        hz = hz.at[:, :n, :].add(ch_ylo * kappa_corr_hz_ylo)
+        hz = hz.at[:, :n_y, :].add(ch_ylo * kappa_corr_hz_ylo)
 
         # --- Y-hi: Hz correction from dEx/dy ---
-        ex_yhi = state.ex[:, -n:, :]
-        ex_shifted_yhi = _shift_fwd(state.ex, 1)[:, -n:, :]
+        ex_yhi = state.ex[:, -n_y:, :]
+        ex_shifted_yhi = _shift_fwd(state.ex, 1)[:, -n_y:, :]
         curl_ex_dy_yhi = (ex_shifted_yhi - ex_yhi) / dx_y_hi
 
         curl_ex_dy_yhi_t = jnp.transpose(curl_ex_dy_yhi, (1, 2, 0))
 
         new_psi_hz_yhi = b_y_hi * cpml_state.psi_hz_yhi + c_y_hi * curl_ex_dy_yhi_t
         correction_hz_yhi = jnp.transpose(new_psi_hz_yhi, (2, 0, 1))
-        hz = hz.at[:, -n:, :].add(ch_yhi * correction_hz_yhi)
+        hz = hz.at[:, -n_y:, :].add(ch_yhi * correction_hz_yhi)
         kappa_corr_hz_yhi = jnp.transpose((1.0 / k_y_hi - 1.0) * curl_ex_dy_yhi_t, (2, 0, 1))
-        hz = hz.at[:, -n:, :].add(ch_yhi * kappa_corr_hz_yhi)
+        hz = hz.at[:, -n_y:, :].add(ch_yhi * kappa_corr_hz_yhi)
     else:
         new_psi_hx_ylo = cpml_state.psi_hx_ylo
         new_psi_hx_yhi = cpml_state.psi_hx_yhi
@@ -882,56 +986,56 @@ def apply_cpml_h(
 
     if "z" in axes:
         # --- Z-lo: Hx correction from dEy/dz ---
-        ey_zlo = state.ey[:, :, :n]
-        ey_shifted_zlo = _shift_fwd(state.ey, 2)[:, :, :n]
+        ey_zlo = state.ey[:, :, :n_z]
+        ey_shifted_zlo = _shift_fwd(state.ey, 2)[:, :, :n_z]
         curl_ey_dz_zlo = (ey_shifted_zlo - ey_zlo) / dz_lo
 
         curl_ey_dz_zlo_t = jnp.transpose(curl_ey_dz_zlo, (2, 0, 1))
 
         new_psi_hx_zlo = b_zl * cpml_state.psi_hx_zlo + c_zl * curl_ey_dz_zlo_t
         correction_hx_zlo = jnp.transpose(new_psi_hx_zlo, (1, 2, 0))
-        hx = hx.at[:, :, :n].add(ch_zlo * correction_hx_zlo)
+        hx = hx.at[:, :, :n_z].add(ch_zlo * correction_hx_zlo)
         kappa_corr_hx_zlo = jnp.transpose((1.0 / k_zl - 1.0) * curl_ey_dz_zlo_t, (1, 2, 0))
-        hx = hx.at[:, :, :n].add(ch_zlo * kappa_corr_hx_zlo)
+        hx = hx.at[:, :, :n_z].add(ch_zlo * kappa_corr_hx_zlo)
 
         # --- Z-hi: Hx correction from dEy/dz ---
-        ey_zhi = state.ey[:, :, -n:]
-        ey_shifted_zhi = _shift_fwd(state.ey, 2)[:, :, -n:]
+        ey_zhi = state.ey[:, :, -n_z:]
+        ey_shifted_zhi = _shift_fwd(state.ey, 2)[:, :, -n_z:]
         curl_ey_dz_zhi = (ey_shifted_zhi - ey_zhi) / dz_hi
 
         curl_ey_dz_zhi_t = jnp.transpose(curl_ey_dz_zhi, (2, 0, 1))
 
         new_psi_hx_zhi = b_zh * cpml_state.psi_hx_zhi + c_zh * curl_ey_dz_zhi_t
         correction_hx_zhi = jnp.transpose(new_psi_hx_zhi, (1, 2, 0))
-        hx = hx.at[:, :, -n:].add(ch_zhi * correction_hx_zhi)
+        hx = hx.at[:, :, -n_z:].add(ch_zhi * correction_hx_zhi)
         kappa_corr_hx_zhi = jnp.transpose((1.0 / k_zh - 1.0) * curl_ey_dz_zhi_t, (1, 2, 0))
-        hx = hx.at[:, :, -n:].add(ch_zhi * kappa_corr_hx_zhi)
+        hx = hx.at[:, :, -n_z:].add(ch_zhi * kappa_corr_hx_zhi)
 
         # --- Z-lo: Hy correction from dEx/dz ---
-        ex_zlo = state.ex[:, :, :n]
-        ex_shifted_zlo = _shift_fwd(state.ex, 2)[:, :, :n]
+        ex_zlo = state.ex[:, :, :n_z]
+        ex_shifted_zlo = _shift_fwd(state.ex, 2)[:, :, :n_z]
         curl_ex_dz_zlo = (ex_shifted_zlo - ex_zlo) / dz_lo
 
         curl_ex_dz_zlo_t = jnp.transpose(curl_ex_dz_zlo, (2, 1, 0))
 
         new_psi_hy_zlo = b_zl * cpml_state.psi_hy_zlo + c_zl * curl_ex_dz_zlo_t
         correction_hy_zlo = jnp.transpose(new_psi_hy_zlo, (2, 1, 0))
-        hy = hy.at[:, :, :n].add(-ch_zlo * correction_hy_zlo)
+        hy = hy.at[:, :, :n_z].add(-ch_zlo * correction_hy_zlo)
         kappa_corr_hy_zlo = jnp.transpose((1.0 / k_zl - 1.0) * curl_ex_dz_zlo_t, (2, 1, 0))
-        hy = hy.at[:, :, :n].add(-ch_zlo * kappa_corr_hy_zlo)
+        hy = hy.at[:, :, :n_z].add(-ch_zlo * kappa_corr_hy_zlo)
 
         # --- Z-hi: Hy correction from dEx/dz ---
-        ex_zhi = state.ex[:, :, -n:]
-        ex_shifted_zhi = _shift_fwd(state.ex, 2)[:, :, -n:]
+        ex_zhi = state.ex[:, :, -n_z:]
+        ex_shifted_zhi = _shift_fwd(state.ex, 2)[:, :, -n_z:]
         curl_ex_dz_zhi = (ex_shifted_zhi - ex_zhi) / dz_hi
 
         curl_ex_dz_zhi_t = jnp.transpose(curl_ex_dz_zhi, (2, 1, 0))
 
         new_psi_hy_zhi = b_zh * cpml_state.psi_hy_zhi + c_zh * curl_ex_dz_zhi_t
         correction_hy_zhi = jnp.transpose(new_psi_hy_zhi, (2, 1, 0))
-        hy = hy.at[:, :, -n:].add(-ch_zhi * correction_hy_zhi)
+        hy = hy.at[:, :, -n_z:].add(-ch_zhi * correction_hy_zhi)
         kappa_corr_hy_zhi = jnp.transpose((1.0 / k_zh - 1.0) * curl_ex_dz_zhi_t, (2, 1, 0))
-        hy = hy.at[:, :, -n:].add(-ch_zhi * kappa_corr_hy_zhi)
+        hy = hy.at[:, :, -n_z:].add(-ch_zhi * kappa_corr_hy_zhi)
     else:
         new_psi_hx_zlo = cpml_state.psi_hx_zlo
         new_psi_hx_zhi = cpml_state.psi_hx_zhi

--- a/rfx/convergence.py
+++ b/rfx/convergence.py
@@ -429,7 +429,15 @@ def quick_convergence(
         new_sim = Simulation(
             freq_max=sim._freq_max,
             domain=sim._domain,
-            boundary=sim._boundary,
+            # Issue #647 grep sweep: clone the normalized BoundarySpec, not
+            # the collapsed `_boundary` string. `_boundary` is
+            # `spec.absorber_type or "pec"`, so every per-face detail — PEC /
+            # PMC / periodic faces and per-face thickness — was dropped and
+            # each refinement step silently ran a UNIFORM absorber on all six
+            # faces. `_boundary_spec` is the legacy scalar's normalized form
+            # too (`_build_spec_from_legacy`), so scalar-constructed
+            # simulations clone exactly as before.
+            boundary=sim._boundary_spec,
             cpml_layers=sim._cpml_layers,
             dx=dx,
             mode=sim._mode,

--- a/tests/test_boundary_spec_cpml_budget.py
+++ b/tests/test_boundary_spec_cpml_budget.py
@@ -1,0 +1,519 @@
+"""Issue #647 — ``cpml_layers`` as an allocation BUDGET vs the grid it lands on.
+
+``cpml_layers`` is a per-simulation allocation budget shared by all six
+faces; each face's ACTIVE thickness is its own ``lo_thickness`` /
+``hi_thickness`` (or the budget), no-op-padded up to the budget. The CPML
+scratch buffers were cut from that budget on EVERY axis, including axes
+that allocate no absorber at all, so a per-face ``BoundarySpec`` whose
+budget exceeded an axis's cell count died inside the scan with
+``mul got incompatible shapes for broadcasting`` — at every precision,
+through both ``run()`` and ``forward()``, with preflight reporting
+"All checks passed".
+
+Two crashing families, both fixed here and both covered below:
+
+1. an axis whose faces are ALL PEC/PMC, so it gets no padding at all and
+   its extent is just the interior (the reported fixture), and
+2. an ABSORBING axis whose per-face thickness is well below the budget,
+   so its padding is thinner than the buffer (not in the report).
+
+Every threshold in this file is DERIVED from the built grid
+(``min(grid.shape)``), never written as a literal: the reported "fails at
+16, works at 8" is a property of one domain and one frequency, not of the
+code.
+
+Coverage note: per-face ``BoundarySpec`` had almost no executing CPML
+coverage before this file. The two pre-existing tests that ran FDTD with
+asymmetric per-face thickness asserted only shape + finiteness, and
+``test_precision_lane_guard.py`` documents having had to pin
+``cpml_layers=4`` to reach the CPML compute at all. So this file also adds
+the missing physics: an absorbing per-face configuration whose interior
+energy is measured against an all-PEC control.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+import pytest
+
+from rfx import Simulation
+from rfx.boundaries.cpml import _assert_absorber_fits
+from rfx.boundaries.spec import Boundary, BoundarySpec
+
+# The reported fixture: 20 mm cube, 5 GHz, five PEC faces + one CPML face.
+_FREQ = 5.0e9
+_CUBE = (0.02, 0.02, 0.02)
+_CENTRE = (0.01, 0.01, 0.008)
+_PROBE = (0.007, 0.007, 0.006)
+
+
+def _cube_sim(cpml_layers, *, hi_thickness=None, hi_token="cpml",
+              precision="float32"):
+    z = Boundary(lo="pec", hi=hi_token,
+                 hi_thickness=hi_thickness if hi_token == "cpml" else None)
+    sim = Simulation(
+        freq_max=_FREQ, domain=_CUBE, cpml_layers=cpml_layers,
+        boundary=BoundarySpec(x="pec", y="pec", z=z),
+        precision=precision,
+    )
+    sim.add_source(_CENTRE, "ez", amplitude_kind="field")
+    sim.add_probe(_PROBE, "ez")
+    return sim
+
+
+def _field_digest(result) -> str:
+    h = hashlib.sha256()
+    for comp in ("ex", "ey", "ez", "hx", "hy", "hz"):
+        h.update(np.asarray(getattr(result.state, comp)).tobytes())
+    return h.hexdigest()
+
+
+def _interior_energy(result, grid) -> float:
+    return sum(
+        float(np.sum(np.asarray(getattr(result.state, comp),
+                                dtype=np.float64)[grid.interior] ** 2))
+        for comp in ("ex", "ey", "ez")
+    )
+
+
+# --------------------------------------------------------------------------
+# 1. The crash, and the threshold it sits at.
+# --------------------------------------------------------------------------
+
+def test_budget_over_a_pec_axis_extent_runs_instead_of_broadcasting():
+    """Family 1: the reported fixture. Budget > the PEC axes' extent."""
+    sim = _cube_sim(16)
+    grid = sim._build_grid()
+    # Confirm the fixture really is in the failing regime, derived from the
+    # grid rather than assumed from the report's numbers.
+    assert sim._cpml_layers > min(grid.shape)
+
+    result = sim.run(n_steps=60, skip_preflight=True)
+    trace = np.asarray(result.time_series)[:, 0]
+    assert trace.shape[0] == 60
+    assert np.all(np.isfinite(trace))
+    assert np.max(np.abs(trace)) > 0.0
+
+
+def test_budget_over_an_absorbing_axis_extent_runs():
+    """Family 2: the ABSORBING axis is the narrow one.
+
+    ``hi_thickness`` below the budget makes z's padding — and so its whole
+    extent — smaller than the buffer, on the axis that actually absorbs.
+    Not in the issue report; found by asking which axes the crash condition
+    can reach.
+    """
+    sim = _cube_sim(16, hi_thickness=2)
+    grid = sim._build_grid()
+    assert sim._cpml_layers > grid.nz
+    assert grid.pad_z_hi == 2
+
+    result = sim.run(n_steps=60, skip_preflight=True)
+    assert np.all(np.isfinite(np.asarray(result.time_series)))
+
+
+@pytest.mark.parametrize("precision", ["float32", "mixed"])
+def test_crash_family_is_precision_independent(precision):
+    """The report measured this at every precision; pin both lanes."""
+    sim = _cube_sim(16, precision=precision)
+    result = sim.forward(n_steps=5, skip_preflight=True)
+    assert np.all(np.isfinite(np.asarray(result.time_series)))
+
+
+def test_budget_at_the_axis_extent_still_works():
+    """Sibling of the two above: the same fixture just under the threshold.
+
+    Without this the "it raises / it crashes" cases prove nothing about the
+    fixture — a fixture that can only fail is not evidence.
+    """
+    grid = _cube_sim(4)._build_grid()
+    fitting = min(grid.shape)
+    sim = _cube_sim(fitting)
+    assert sim._cpml_layers <= min(sim._build_grid().shape)
+    trace = np.asarray(sim.run(n_steps=60, skip_preflight=True).time_series)
+    assert np.all(np.isfinite(trace))
+    assert np.max(np.abs(trace)) > 0.0
+
+
+# --------------------------------------------------------------------------
+# 2. The clamp is exact: saturation in the budget.
+# --------------------------------------------------------------------------
+
+def test_result_saturates_once_the_budget_covers_the_narrowest_axis():
+    """Fixing the absorber and raising ONLY the budget must stop mattering.
+
+    ``hi_thickness`` is pinned, so every budget here builds the SAME grid
+    with the SAME active absorber; only the scratch-buffer allocation
+    differs. Once the buffer covers the narrowest axis the clamp holds it
+    there, so every larger budget must reproduce the fitting-budget result
+    BIT for BIT. That fitting budget is a configuration the pre-fix code
+    also ran, which is what makes this an invariance witness rather than a
+    self-consistency check: the clamped answer is the unclamped answer.
+    """
+    grid = _cube_sim(4, hi_thickness=4)._build_grid()
+    saturate_at = min(grid.shape)
+
+    reference = None
+    for budget in (saturate_at, saturate_at + 1, saturate_at + 5,
+                   4 * saturate_at, 8 * saturate_at):
+        sim = _cube_sim(budget, hi_thickness=4)
+        assert sim._build_grid().shape == grid.shape, (
+            "pinning hi_thickness must keep the grid fixed"
+        )
+        digest = _field_digest(sim.run(n_steps=120, skip_preflight=True))
+        if reference is None:
+            reference = digest
+        assert digest == reference, (
+            f"budget={budget} changed the fields although the grid and the "
+            f"active absorber are identical to budget={saturate_at}"
+        )
+
+
+def test_a_budget_below_saturation_is_a_different_answer():
+    """Negative control for the test above.
+
+    Below saturation the buffer depth is a real degree of freedom, so the
+    digest MUST move. Without this the saturation assertion would also pass
+    on a harness that simply cannot tell two runs apart.
+    """
+    grid = _cube_sim(4, hi_thickness=4)._build_grid()
+    saturate_at = min(grid.shape)
+    below = _field_digest(
+        _cube_sim(4, hi_thickness=4).run(n_steps=120, skip_preflight=True))
+    at = _field_digest(
+        _cube_sim(saturate_at, hi_thickness=4).run(
+            n_steps=120, skip_preflight=True))
+    assert below != at
+
+
+# --------------------------------------------------------------------------
+# 3. Physics: a clamped per-face absorber still absorbs.
+# --------------------------------------------------------------------------
+
+_PIPE_FREQ = 20e9
+_PIPE_DX = 2.5e-3
+_PIPE_DOMAIN = (0.02, 0.02, 0.08)
+
+
+def _pipe_sim(hi_token, cpml_layers):
+    """Square PEC pipe along z, terminated by ``hi_token`` on z_hi.
+
+    TE10 cutoff of the 20 mm cross-section is c/(2a) = 7.5 GHz, so the
+    10 GHz source content propagates down the pipe and reaches the
+    termination. The cross-section is only 9 cells, so a budget above that
+    exercises the clamp on x and y while the z absorber does real work.
+    """
+    sim = Simulation(
+        freq_max=_PIPE_FREQ, domain=_PIPE_DOMAIN, dx=_PIPE_DX,
+        cpml_layers=cpml_layers,
+        boundary=BoundarySpec(x="pec", y="pec",
+                              z=Boundary(lo="pec", hi=hi_token)),
+    )
+    sim.add_source((0.01, 0.01, 0.01), "ey", amplitude_kind="field")
+    sim.add_probe((0.01, 0.01, 0.04), "ey")
+    return sim
+
+
+@pytest.mark.slow
+def test_clamped_per_face_absorber_actually_absorbs():
+    """The absorber survives the clamp — measured against an all-PEC control.
+
+    Both runs are the same pipe with the same excitation; only the z_hi
+    face differs. The PEC control is lossless, so its interior energy must
+    NOT decay; the CPML termination must take the guided energy out. The
+    bound below is two orders of magnitude inside the measured separation.
+    """
+    open_sim = _pipe_sim("cpml", 16)
+    open_grid = open_sim._build_grid()
+    assert open_sim._cpml_layers > min(open_grid.nx, open_grid.ny), (
+        "fixture must exercise the clamp on the transverse axes"
+    )
+
+    closed_sim = _pipe_sim("pec", 16)
+    closed_grid = closed_sim._build_grid()
+
+    e_open = _interior_energy(
+        open_sim.run(n_steps=1200, skip_preflight=True), open_grid)
+    e_closed = _interior_energy(
+        closed_sim.run(n_steps=1200, skip_preflight=True), closed_grid)
+
+    assert np.isfinite(e_open) and np.isfinite(e_closed)
+    # Measured on this fixture: e_open/e_closed ~ 1e-4 at 1200 steps
+    # (7.6e-2 at 200 steps, falling monotonically). Anything above 1e-2
+    # means the termination stopped absorbing.
+    assert e_open / e_closed < 1e-2, (
+        f"open-ended pipe retained {e_open:.4e} vs closed {e_closed:.4e}"
+    )
+    # The lossless control must not have quietly decayed instead.
+    e_closed_early = _interior_energy(
+        _pipe_sim("pec", 16).run(n_steps=300, skip_preflight=True),
+        closed_grid)
+    assert e_closed > 0.1 * e_closed_early
+
+
+# --------------------------------------------------------------------------
+# 4. Preflight: the advisory, and the per-face thickness it rests on.
+# --------------------------------------------------------------------------
+
+def _advisories(sim) -> list[str]:
+    return [m for m in sim.preflight()]
+
+
+def test_budget_advisory_fires_exactly_above_the_axis_extent():
+    """Advisory boundary derived from the grid, not from the report."""
+    for budget in (2, 4, 8, 9, 16, 40):
+        sim = _cube_sim(budget)
+        grid = sim._build_grid()
+        expected = budget > min(grid.shape)
+        hits = [m for m in _advisories(sim) if "exceeds the" in m]
+        assert bool(hits) == expected, (
+            f"cpml_layers={budget} on grid {grid.shape}: expected "
+            f"advisory={expected}, got {hits}"
+        )
+
+
+def test_scalar_cpml_boundary_never_trips_the_budget_advisory():
+    """Sibling: with every face absorbing, the axis is padded by 2*budget.
+
+    So the budget cannot exceed an axis extent however large it gets, and
+    the advisory must stay silent — it is a per-face-only condition.
+    """
+    sim = Simulation(freq_max=_FREQ, domain=_CUBE, cpml_layers=64,
+                     boundary="cpml")
+    sim.add_source((0.01, 0.01, 0.01), "ez", amplitude_kind="field")
+    assert [m for m in _advisories(sim) if "exceeds the" in m] == []
+
+
+def test_preflight_thickness_follows_the_allocated_per_face_layers():
+    """Preflight must report the ALLOCATED absorber, not the budget.
+
+    ``cpml_thick_*`` is consumed as a calibrated clearance buffer (MSL and
+    waveguide port geometry advisories), so reporting the budget on a face
+    that allocates less biases those distances by the whole ratio.
+    """
+    budget, thickness = 16, 2
+    sim = Simulation(
+        freq_max=_FREQ, domain=(0.06, 0.06, 0.06), cpml_layers=budget,
+        boundary=BoundarySpec(
+            x="pec", y="pec",
+            z=Boundary(lo="pec", hi="cpml", hi_thickness=thickness)),
+    )
+    grid = sim._build_grid()
+    _, thick_hi, _ = sim._validate_cfg_compute_cpml_thickness(budget * grid.dx)
+    assert thick_hi[2] == pytest.approx(grid.pad_z_hi * grid.dx, rel=1e-9)
+    assert thick_hi[2] == pytest.approx(thickness * grid.dx, rel=1e-9)
+
+
+def test_preflight_thickness_is_the_budget_without_an_override():
+    """Sibling of the test above: no override, no change from before."""
+    budget = 16
+    sim = Simulation(
+        freq_max=_FREQ, domain=(0.06, 0.06, 0.06), cpml_layers=budget,
+        boundary=BoundarySpec(x="pec", y="pec",
+                              z=Boundary(lo="pec", hi="cpml")),
+    )
+    grid = sim._build_grid()
+    _, thick_hi, _ = sim._validate_cfg_compute_cpml_thickness(budget * grid.dx)
+    assert thick_hi[2] == pytest.approx(budget * grid.dx, rel=1e-9)
+    assert thick_hi[2] == pytest.approx(grid.pad_z_hi * grid.dx, rel=1e-9)
+
+
+def test_preflight_thickness_is_zero_on_every_reflector_face():
+    """PEC / PMC / periodic faces allocate nothing, on either side."""
+    sim = Simulation(
+        freq_max=_FREQ, domain=(0.06, 0.06, 0.06), cpml_layers=8,
+        boundary=BoundarySpec(x="pmc", y="pec",
+                              z=Boundary(lo="pec", hi="cpml")),
+    )
+    grid = sim._build_grid()
+    thick_lo, thick_hi, _ = sim._validate_cfg_compute_cpml_thickness(
+        8 * grid.dx)
+    assert thick_lo == [0.0, 0.0, 0.0]
+    assert thick_hi[0] == 0.0 and thick_hi[1] == 0.0
+    assert thick_hi[2] > 0.0
+
+
+_NU_DZ = np.full(40, 2.0e-4)
+_NU_DOMAIN = (0.06, 0.06, float(np.sum(_NU_DZ)))
+
+
+def _nu_thin_z_hits(boundary) -> list[str]:
+    sim = Simulation(
+        freq_max=_FREQ, domain=_NU_DOMAIN, dx=3.0e-3, cpml_layers=8,
+        boundary=boundary, dz_profile=_NU_DZ,
+    )
+    sim.add_source((0.03, 0.03, _NU_DOMAIN[2] / 2), "ez",
+                   amplitude_kind="field")
+    return [m for m in sim.preflight() if "z-thickness" in m]
+
+
+def test_thin_nu_z_absorber_advisory_is_silent_when_z_has_no_absorber():
+    """The P2.6 advisory measured the BUDGET against the z cell sizes.
+
+    With per-face PEC z faces there is no z absorber to be thin, but the
+    advisory still fired — the same scalar-attribute blindness, one check
+    over.
+    """
+    assert _nu_thin_z_hits(BoundarySpec(x="cpml", y="cpml", z="pec")) == []
+
+
+@pytest.mark.parametrize(
+    "boundary", ["cpml", BoundarySpec(x="cpml", y="cpml", z="cpml")])
+def test_thin_nu_z_absorber_advisory_still_fires_when_z_absorbs(boundary):
+    """Sibling: the genuine thin-z case must be untouched.
+
+    Same profile, same budget, same domain — only the z faces differ, so a
+    silent result here would mean the fix above disabled the check rather
+    than scoping it.
+    """
+    assert _nu_thin_z_hits(boundary)
+
+
+# --------------------------------------------------------------------------
+# 5. The guard that keeps the clamp honest.
+# --------------------------------------------------------------------------
+
+class _StubGrid:
+    """Minimal duck-typed grid carrying only the per-face pads."""
+
+    def __init__(self, **pads):
+        for face in ("x_lo", "x_hi", "y_lo", "y_hi", "z_lo", "z_hi"):
+            setattr(self, f"pad_{face}", pads.get(face, 0))
+
+
+def test_absorber_wider_than_its_own_axis_is_rejected():
+    """The clamp may only ever drop no-op padding.
+
+    A grid whose ALLOCATED pad exceeds its own axis would make the clamp
+    silently thin a real absorber, so it is rejected instead. No public
+    constructor can build one today (every builder sizes an axis as
+    ``interior + pad_lo + pad_hi``); the guard exists so that a future one
+    cannot reintroduce a quietly weakened absorber through this path, and
+    it is fed the malformed grid directly here rather than assumed.
+    """
+    with pytest.raises(ValueError, match="absorbing layers"):
+        _assert_absorber_fits(_StubGrid(z_hi=12), (8, 8, 10))
+
+
+def test_absorber_exactly_filling_its_axis_is_accepted():
+    """Sibling: the boundary case must NOT raise."""
+    _assert_absorber_fits(_StubGrid(z_hi=10), (8, 8, 10))
+    _assert_absorber_fits(_StubGrid(z_lo=4, z_hi=6), (8, 8, 10))
+
+
+# --------------------------------------------------------------------------
+# 6. Clones must not collapse the per-face layout (found by the grep sweep).
+# --------------------------------------------------------------------------
+
+def test_quick_convergence_clone_keeps_the_per_face_layout():
+    """``quick_convergence`` rebuilds the Simulation at each dx.
+
+    It used to pass the collapsed ``_boundary`` string, so a five-PEC-face
+    cavity came back with an absorber on all six faces at every refinement
+    step — the swept geometry was not the geometry under study.
+    """
+    from rfx.convergence import quick_convergence
+
+    sim = _cube_sim(4)
+
+    factory = None
+    # quick_convergence builds its factory internally; reach it by monkey-
+    # patching convergence_study to capture the factory instead of running
+    # the (expensive) sweep.
+    import rfx.convergence as conv
+    original = conv.convergence_study
+    try:
+        def _capture(*, sim_factory, **_kw):
+            nonlocal factory
+            factory = sim_factory
+            return None
+        conv.convergence_study = _capture
+        quick_convergence(sim, dx_factors=[1.0])
+    finally:
+        conv.convergence_study = original
+
+    assert factory is not None
+    clone = factory(sim._build_grid().dx)
+    assert clone._boundary_spec == sim._boundary_spec
+    assert clone._pec_faces == sim._pec_faces
+    assert clone._build_grid().face_pads == sim._build_grid().face_pads
+
+
+def test_quick_convergence_clone_of_a_scalar_sim_is_unchanged():
+    """Sibling: a legacy scalar-boundary simulation clones as before."""
+    from rfx.convergence import quick_convergence
+
+    sim = Simulation(freq_max=_FREQ, domain=_CUBE, cpml_layers=4,
+                     boundary="cpml")
+    sim.add_source((0.01, 0.01, 0.01), "ez", amplitude_kind="field")
+    sim.add_probe(_PROBE, "ez")
+
+    factory = None
+    import rfx.convergence as conv
+    original = conv.convergence_study
+    try:
+        def _capture(*, sim_factory, **_kw):
+            nonlocal factory
+            factory = sim_factory
+            return None
+        conv.convergence_study = _capture
+        quick_convergence(sim, dx_factors=[1.0])
+    finally:
+        conv.convergence_study = original
+
+    clone = factory(sim._build_grid().dx)
+    assert clone._boundary == "cpml"
+    assert clone._build_grid().face_pads == sim._build_grid().face_pads
+
+
+# --------------------------------------------------------------------------
+# 7. ADI has no per-face absorber (found by the #647 grep sweep).
+# --------------------------------------------------------------------------
+
+def test_adi_rejects_a_non_uniform_absorber_layout():
+    """``solver='adi'`` stamps its absorbing sigma on all six faces.
+
+    It reaches that path off ``self._boundary == 'cpml'``, which is true as
+    soon as ANY face absorbs, so a per-face spec used to get an absorber
+    exactly where the caller asked for a reflector — with nothing said.
+    """
+    with pytest.raises(ValueError, match="uniform absorber"):
+        Simulation(
+            freq_max=_FREQ, domain=(0.06, 0.06, 0.06), cpml_layers=8,
+            boundary=BoundarySpec(x="cpml", y="cpml",
+                                  z=Boundary(lo="pec", hi="cpml")),
+            solver="adi",
+        )
+
+
+def test_adi_rejects_a_per_face_thickness_override():
+    """Same blindness through the thickness knob rather than the token."""
+    with pytest.raises(ValueError, match="uniform absorber"):
+        Simulation(
+            freq_max=_FREQ, domain=(0.06, 0.06, 0.06), cpml_layers=8,
+            boundary=BoundarySpec(
+                x="cpml", y="cpml",
+                z=Boundary(lo="cpml", hi="cpml", hi_thickness=2)),
+            solver="adi",
+        )
+
+
+@pytest.mark.parametrize("boundary", ["cpml", "pec", BoundarySpec.uniform("cpml")])
+def test_adi_accepts_a_uniform_absorber_and_runs(boundary):
+    """Sibling of both rejections: same solver, same domain, same budget.
+
+    A uniform layout — scalar or spelled out as a BoundarySpec — must still
+    construct AND produce a finite non-zero trace, so the rejection above
+    is about the layout and not about ADI plus BoundarySpec in general.
+    """
+    sim = Simulation(
+        freq_max=_FREQ, domain=(0.06, 0.06, 0.06), cpml_layers=8,
+        boundary=boundary, solver="adi",
+    )
+    sim.add_source((0.03, 0.03, 0.03), "ez", amplitude_kind="field")
+    sim.add_probe((0.02, 0.02, 0.02), "ez")
+    trace = np.asarray(sim.run(n_steps=6, skip_preflight=True).time_series)
+    assert np.all(np.isfinite(trace))
+    assert np.max(np.abs(trace)) > 0.0

--- a/tests/test_precision_lane_guard.py
+++ b/tests/test_precision_lane_guard.py
@@ -189,11 +189,16 @@ def test_forward_mixed_cpml_per_face_boundary_spec_also_works():
     on the unpatched parent commit: that combination fails identically at
     ``precision="float32"`` through BOTH ``run()`` and ``forward()``, so it is
     a pre-existing per-face CPML geometry defect, not a precision defect and
-    not caused by issue #644. It is reported separately; pinning 4 layers here
-    keeps this test measuring the dtype policy it is named for, on a fixture
-    that actually reaches the CPML compute. Verified red-then-green: at 4
-    layers this raises the #644 lax.scan carry TypeError on the parent commit
-    and passes here.
+    not caused by issue #644. It was reported as issue #647 and is now FIXED
+    (``rfx/boundaries/cpml.py`` clamps the CPML scratch buffer per axis; the
+    #647 regression lock lives in
+    ``tests/test_boundary_spec_cpml_budget.py``), so 16 layers no longer
+    crashes. ``cpml_layers=4`` stays pinned anyway: this test is about the
+    psi dtype policy, and 4 layers is the smallest fixture that reaches the
+    CPML compute -- moving it now would only make the dtype assertion depend
+    on the buffer-clamp path as well. Verified red-then-green: at 4 layers
+    this raises the #644 lax.scan carry TypeError on the parent commit and
+    passes here.
     """
     from rfx.boundaries.spec import BoundarySpec, Boundary
 


### PR DESCRIPTION
Closes #647.

A per-face `BoundarySpec` crashed whenever `cpml_layers` exceeded the extent available on an
axis — either because that axis carries no absorbing face at all, or because its per-face
thickness is smaller than the budget:

```python
Simulation(freq_max=5e9, domain=(0.02, 0.02, 0.02), cpml_layers=16,
           boundary=BoundarySpec(x="pec", y="pec", z=Boundary(lo="pec", hi="cpml")))
```
```
TypeError: mul got incompatible shapes for broadcasting: (16,1,1), (8,8,24)
```

Precision-independent, both `run()` and `forward()`. Preflight reported "All checks passed"
first. Threshold, derived from the grid rather than assumed: silent at `cpml_layers=8`, dead
at `9`, on a grid whose narrowest axis is 8 — exactly `cpml_layers > min(grid.shape)`.

## The fix already existed in this repo, for one lane only

The same configuration **survives the non-uniform lane and dies on the uniform one**:

```
uniform      -> TypeError: mul got incompatible shapes for broadcasting
non-uniform  -> OK
```

`rfx/nonuniform.py:891` already filters `cpml_axes_eff` to axes that actually carry padding.
That asymmetry — a fix written once and never propagated — is what made this reachable.

It also settles clamp-vs-raise: the codebase already chose clamp, and raising would reject
legitimate physics (a cavity open on one face). The clamp is exact rather than quiet
degradation — a face's active layers equal its allocated pad, and every builder sizes an axis
as `interior(>=2) + pad_lo + pad_hi`, so `min(budget, extent)` can only drop no-op padding.
`_assert_absorber_fits` still RAISES for the case that argument does not cover: an allocated
pad wider than its own axis.

**Witness that the clamp changes no physics**: pin `hi_thickness=4` and vary only the budget.
Digests for budgets 8/9/12/13/16/32/64 are byte-identical to each other AND to the budget-8
result the unpatched tree computes. The clamped answer *is* the unclamped answer. (Budgets
4/5 differ from 8; that step is pre-existing and identical on both trees.)

## Two more silent-wrong sites, from the grep sweep

42 `self._boundary` string comparisons were reviewed. Two were genuinely wrong for a per-face
spec, both fixed:

- **`rfx/api/_execute.py:803,858`** — `solver="adi"` stamps absorbing sigma on all six faces,
  reached off `self._boundary == "cpml"`. A per-face spec silently got an absorber on faces
  declared as reflectors. Now rejected at construction.
- **`rfx/convergence.py:432`** — `quick_convergence` cloned the collapsed boundary string, so
  every refinement step ran a uniform absorber regardless of the spec. Now clones
  `_boundary_spec`.

Plus two per-face preflight defects: the thickness helper reported **47.967 mm for a face
allocating 5.996 mm** (8x — and that magnitude feeds calibrated clearance advisories), and the
non-uniform thin-z advisory fired on a spec whose z faces are PEC.

Sites reviewed and deliberately left alone, with reasons, are listed in the commit message —
including one distributed-lane check that over-fires but is fail-closed with a message that
already names the fix.

Note: `self._boundary` is `spec.absorber_type or "pec"`, so it is truthy for a per-face spec.
It never lies about *whether* an absorber exists — only about whether all six faces have one.
The issue's original description of the preflight mechanism was wrong on this point and is
corrected in a comment there.

## Verification

- **Bit-identity**: SHA-256 over raw final-field bytes and probe series, base `84c76dd` vs
  branch — identical on scalar-cpml, PEC, lossy dielectric, non-uniform, per-face
  `cpml_layers=4`, per-face asymmetric thickness, and PMC+CPML. Negative control (6 layers vs
  8) moves the digest. Independently confirmed on a separate 4-configuration harness: 24/24
  identical.
- **Every guard watched firing**: the budget advisory (silent at 8, fires at 9), the per-face
  thickness report (5.996 vs 47.967 mm), the ADI rejection on both token and thickness paths,
  `_assert_absorber_fits` on a malformed stub, and the non-uniform thin-z advisory (base
  false-warns, branch silent, genuine case still warns).
- **New tests**: 25 in `tests/test_boundary_spec_cpml_budget.py`, **14 red on `84c76dd`**, with
  11 sibling controls green on both trees — so no fixture is raise-only. That pairing is
  deliberate: #647 exists because a raises-test passed against a fixture that was already dead.
- **Physics the per-face lane never had**: a square PEC pipe with a clamped CPML termination
  retains 6e-5 of the all-PEC control's interior energy at 1200 steps, while the lossless
  control does not decay.
- Suites: boundary/CPML 118, preflight 135, ADI/API/interop/hygiene 367 (18 skipped),
  convergence/cavity/physics 12. Ruff clean.

R3: memory=feedback_gate_can_bind_artifact (this issue's origin: a raises-test satisfied by a
guard, so every new gate here has a sibling that must SUCCEED) | R2-attempts=1 |
falsifier=the budget-sweep byte-identity above, run and confirmed equal to the unpatched result
