### PR TITLE
fix(test): use the numpy>=2.0 trapezoid shim in the PO oracle self-check (closes #650)

### DIFF
--- a/tests/test_oblique_rcs_absolute_sigma.py
+++ b/tests/test_oblique_rcs_absolute_sigma.py
@@ -61,12 +61,14 @@ def _po_sigma(phi_obs, theta_i_deg, W, h, lam):
     """PO / uniform-aperture bistatic sigma(phi) at theta_obs=pi/2 for a PEC
     plate in the y-z plane (normal-x lit face), ez polarization. Numeric
     aperture integral; the closed form below is its independent check."""
+    # numpy 2.0 removed ``np.trapz``; same shim as rfx/sources/coaxial_port.py.
+    trapezoid = np.trapezoid if hasattr(np, "trapezoid") else np.trapz
     k = 2 * np.pi / lam
     t = np.radians(theta_i_deg)
     y = np.linspace(-W / 2, W / 2, 1201)
     out = np.zeros_like(phi_obs, dtype=np.float64)
     for i, p in enumerate(phi_obs):
-        iy = np.trapz(np.exp(1j * k * (np.sin(p) - np.sin(t)) * y), y)
+        iy = trapezoid(np.exp(1j * k * (np.sin(p) - np.sin(t)) * y), y)
         out[i] = 4 * np.pi * ((k / (4 * np.pi)) * 2 * np.cos(t) * np.abs(iy) * h) ** 2
     return out
 


### PR DESCRIPTION
Closes #650.

`np.trapz` was removed in numpy 2.0. `_po_sigma` still called it, so
`test_oblique_rcs_absolute_sigma.py::test_po_oracle_matches_closed_form` raised
`AttributeError` on any numpy-2.x environment (reproduced on 2.4.6).

Uses the shim already established at `rfx/sources/coaxial_port.py:275` rather than
inventing a second spelling. Swept `rfx/`, `tests/`, `validation/`, `examples/` and
`scripts/` — no other bare `np.trapz` remains.

## Why this is a live break, not a dormant test

The test is **unmarked and collected by default** — verified, not assumed: the file has no
module-level `pytestmark`, and `--collect-only` under the repo's real `addopts` collects 7
of its 10 tests including this one.

So CI runs it and CI is green, which means CI resolves a numpy older than 2.0 while a
current local install resolves 2.4.6. `pyproject.toml` declares `numpy>=1.24` with no upper
bound, so this is a latent CI break waiting on a resolution change rather than a stable state.

**Whether to cap numpy or add a numpy-2 CI lane is a dependency-policy decision and is NOT
made here** — it stays open on #650.

## Why it matters beyond a red test

`_po_sigma` is the PO oracle's own self-check: the comparator that must reproduce its closed
form before it is allowed to referee any rfx number. On numpy 2.x that referee was
unavailable, not merely untested.

Post-fix the self-check passes (`1 passed`), which is the comparator-first gate doing its job.

R3: memory=none-after-grep | R2-attempts=1 | falsifier=the node raises AttributeError before
the change and passes after, on the same interpreter