### PR TITLE
fix(vmap): reuse the shared CPML pad-extension helper under vmap instead of a second copy of the rule (closes #643)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,174 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — two independent implementations of one CPML pad-extension rule, reconciled (issue #643)
+
+#627 (PR #638) and #637 (PR #641) each needed material values extended
+from the interior edge into the CPML pad, and each landed its own
+implementation. #627 then changed the rule — adding a per-transverse-cell
+hi-face fallback (if the naive interior-edge column is vacuum but the
+column one further in is not, replicate from that inner column instead,
+recovering the node a `Box` flush with the domain's hi face loses to
+`Box`'s half-open `[lo, hi)` rasterization) — while `_extend_batched_cpml_pad`
+in `rfx/vmap_sweep.py` went on reproducing the PRE-#627 rule. For a slab
+sitting exactly on a domain face, `Simulation.run()` read the material in
+its hi pads and `vmap_material_sweep` read vacuum.
+
+**Fix: the second copy is gone, not resynced.** `_extend_batched_cpml_pad`
+now calls the package's single shared rule,
+`rfx.geometry.rasterize_grid.extend_cpml_pad_materials`, under
+`jax.vmap` over the sweep axis. That is what makes reuse possible at all:
+the shared helper slices axes 0/1/2 and evaluates its vacuum predicate on
+whole transverse planes, while the batched arrays carry a leading sweep
+axis whose elements can answer that predicate differently; mapping over
+that axis hides it from the helper, so the helper sees exactly the
+`(Nx, Ny, Nz)` arrays it was written for and its fallback is evaluated
+against each element's own materials. No axis-aware rewrite, no third
+implementation. All three material arrays are now extended in ONE call
+(the helper takes a single `use_inner` decision from the joint vacuum
+predicate and applies it to all three, so a swept value that empties a
+column changes that element's `sigma`/`mu_r` pad too — a coupling the
+per-field version could not express). The no-worse guard #641 added is
+deleted along with the copy it was guarding: it existed only because that
+copy could discard a value #627 had already got right, and there is no
+longer a second copy to do so.
+
+- **Acceptance criterion met.** Byte-identity between what the batched
+  path builds for element *b* and what `Simulation._assemble_materials`
+  builds for a simulation carrying that swept value, across #637's
+  geometry/boundary matrix plus the exact-hi-face case: single face, all
+  six faces (exact-hi AND past-hi), corner, inset, transverse span,
+  `cpml_layers=0`, pec, upml, periodic-x with CPML y/z, two materials
+  (the second lossy AND magnetic, the only shape that can distinguish
+  the joint vacuum predicate from a per-field one — #637 noted none of
+  its fixtures could), and asymmetric per-face pads. 12 rows x 3 swept
+  fields (`eps_r`, `sigma`, `mu_r`) = 36 comparisons, all three arrays
+  each, 0 mismatched cells. On main, 18 of those 36 fail. Committed as
+  `TestVmapBatchedPadByteIdentity`.
+- **The `xfail(strict=True)` witness is now a normal passing test.**
+  `test_exact_hi_face_touch_matches_run_via_shared_fallback` was verified
+  XFAIL on base and XPASS(strict) — i.e. red — with the fix, before the
+  marker was removed. Its DFT-plane comparison against `run()` is exactly
+  `0.0` at every bin for both swept elements, versus the 1.66e-2 /
+  4.25e-2 #637 measured. It gained an assert-first non-vacuity
+  precondition (run()'s x-hi pad must read the slab, the naive source
+  column must read vacuum) so it cannot later pass by no longer
+  exercising the fallback — the failure mode this same arc already hit
+  once, when the alternate-geometry test's first draft used a fixture
+  that never reached the pad.
+- **#637's 7-configuration representativeness sweep, re-run per swept
+  element (14 elements), three states.** #637's harness is not committed
+  anywhere in the repo, so these fixtures are RECONSTRUCTED from the #637
+  issue body (30x20x20 mm, dx=1 mm, `cpml_layers=8`, 200 steps, base 2.0
+  / 10.0, sweep {2.0, 10.0}) and PR #641's table; the absolute magnitudes
+  below are one to two orders below #641's, so this is a new sweep on the
+  same classes, not a reproduction of those numbers. Worst per-bin
+  DFT-plane relative error against `run()`:
+
+  | configuration | swept | pre-#637 | main | this branch |
+  |---|---|---|---|---|
+  | issue-table base=2.0 | 2.0 (=base) | 0.0 | 0.0 | **0.0** |
+  | issue-table base=2.0 | 10.0 | 7.7037e-04 | 7.5970e-04 | **0.0** |
+  | issue-table base=10.0 | 2.0 | 3.1653e-04 | 2.9872e-04 | **0.0** |
+  | issue-table base=10.0 | 10.0 (=base) | 0.0 | 0.0 | **0.0** |
+  | single-axis touch (y), base=3 | 2.0 | 3.1527e-04 | 2.8198e-04 | **0.0** |
+  | single-axis touch (y), base=3 | 6.0 | 7.2871e-04 | 7.3497e-04 | **0.0** |
+  | single-face touch (x_lo), base=5 | 2.5 | 2.2078e-06 | 0.0 | **0.0** |
+  | single-face touch (x_lo), base=5 | 9.0 | 3.8385e-06 | 0.0 | **0.0** |
+  | large delta, cpml=4, base=1.5 | 1.5 (=base) | 0.0 | 0.0 | **0.0** |
+  | large delta, cpml=4, base=1.5 | 12.0 | 1.4852e-02 | 1.1973e-02 | **0.0** |
+  | large delta, cpml=12, base=8 | 2.0 | 2.5857e-03 | 2.3729e-03 | **0.0** |
+  | large delta, cpml=12, base=8 | 14.0 | 5.3260e-03 | 4.1713e-03 | **0.0** |
+  | committed fixture, base=4, cpml=6 | 2.0 | 1.3487e-03 | 1.2792e-03 | **0.0** |
+  | committed fixture, base=4, cpml=6 | 6.0 | 1.9302e-03 | 1.5955e-03 | **0.0** |
+
+  Every element is exactly `0.0` with 0 mismatched material cells — not
+  "at or below a floor", bit-identical. No element is worse than either
+  prior state.
+
+- **#637's two disclosed residuals, explained and eliminated.** #641
+  shipped its guard with two elements measurably WORSE than the pre-#637
+  state (6.421e-2 -> 6.527e-2, +1.6%; 1.193e-2 -> 1.199e-2, +0.5%),
+  reproducible but with "their specific mechanism not established". They
+  are not a separate effect. Running one fixture through four batched-pad
+  states in the same tree (so no cross-tree float path is involved),
+  reporting BOTH the wrong-cell count against `_assemble_materials` and
+  the DFT-plane error. Comparator check first, since two of those states
+  are re-implementations: the `pre-#637` and `main (guard)` rows below
+  reproduce the real base-tree runs bit-for-bit (1920 cells /
+  1.3487e-03 / 1.9302e-03 and 1140 cells / 1.2792e-03 / 1.5955e-03
+  respectively, identical to the same fixture measured on an actual
+  checkout of each state), so the emulation is faithful and not an
+  artefact of the harness:
+
+  | fixture / element | state | wrong cells | worst rel err |
+  |---|---|---|---|
+  | committed fixture, swept 2.0 | pre-#637 | 1920 / 12167 | 1.3487e-03 |
+  | | main (guard) | 1140 | 1.2792e-03 |
+  | | #641 draft, no guard | 1140 | 1.8661e-03 |
+  | | this branch | **0** | **0.0** |
+  | committed fixture, swept 6.0 | pre-#637 | 1920 | 1.9302e-03 |
+  | | main (guard) | 1140 | 1.5955e-03 |
+  | | #641 draft, no guard | 1140 | 8.4886e-03 |
+  | | this branch | **0** | **0.0** |
+  | issue-table base=2.0, swept 2.0 (=base) | pre-#637 | 0 | 0.0 |
+  | | main (guard) | 0 | 0.0 |
+  | | #641 draft, no guard | 5120 | 2.0642e-04 |
+  | | this branch | **0** | **0.0** |
+
+  Two things fall out. The guard did what it was designed to (the
+  `swept == base` element: 5120 wrong cells and 2.06e-4 without it, 0 and
+  0.0 with it). And the metric is not monotone in the wrong-cell count:
+  main and the no-guard draft have the SAME 1140 wrong cells and differ
+  by 5.3x in error, while pre-#637 has 68% MORE wrong cells than main
+  and a smaller error on one element of this class. Mechanism: pre-#637
+  the whole pad was uniformly wrong (base's value); #637 corrects the
+  normal pad cells but cannot correct the hi-face-fallback cells, so it
+  leaves a permittivity STEP inside the absorber that the uniformly-wrong
+  pad did not have, and a step inside a CPML reflects. Whether that trade
+  reads better or worse than uniformly-wrong is fixture-dependent and has
+  no reason to be monotone — this branch's own reconstruction shows both
+  signs (of 14 elements, pre-#637 -> main: 10 improve, 3 unchanged at
+  exactly 0.0 — all three are `swept == base` — and 1 regresses,
+  single-axis-y swept 6.0 at 7.2871e-04 -> 7.3497e-04, +0.86%, the same
+  signature as #641's +0.5% / +1.6%). No third guard
+  variant was needed: byte-identity removes the choice, and both residual
+  elements' *class* is covered directly — on the committed fixture at
+  n_steps 300 / 400 / 600, where main measures 1.45e-2/1.61e-2,
+  3.52e-2/7.94e-2 and 1.69e-2/2.21e-2 (bracketing both disclosed
+  residuals), this branch measures exactly `0.0` at every bin.
+- **`Simulation.run()` does not move.** SHA-256 over the raw bytes of all
+  six final Yee field components plus the probe time series, base vs
+  branch, on four production lanes — pec (`e4dbb5fa327093d4`), cpml
+  (`a3a6bc1d733b36e7`), lossy+magnetic+CPML (`02bdd2db2572df1b`),
+  non-uniform `dz_profile`+CPML (`ef96cbf44e9aa14f`) — all 8 digests
+  (fields + time series per lane) identical. Negative control: bumping
+  `n_steps` 60 -> 61 changes all 8, so the harness can report
+  "different".
+- **Known gap this INHERITS and slightly widens, disclosed (issue #642).**
+  `run()` applies thin conductors AFTER pad extension; the batched path
+  only ever sees `base_materials`, which is already post-conductor, so
+  extending it replicates a non-PEC thin conductor's own `sigma`/`eps_r`
+  into the pad. Routing through the shared helper does not change that
+  ordering. Measured on a `sigma_bulk=1e4` thin conductor: this branch
+  leaves 88 mismatched cells of 36501 (40 `eps_r` + 48 `sigma`, all
+  inside the x pads) where main leaves 6592 (all `eps_r`; zero `sigma`,
+  because main only ever extended the ONE swept field) — a 75x reduction
+  overall AND a new sigma-side mismatch on this fixture. A PEC thin
+  conductor is unaffected (it routes to `pec_mask`, not to the material
+  arrays: 0 mismatched cells on both). Not fixed here: #643's scope is
+  the pad-extension RULE, #642's is the pipeline ORDER, and closing it
+  needs the batched path to see pre-conductor materials, which is a
+  production-side change this issue's own byte-identity requirement
+  argues against bundling. Pinned by
+  `test_thin_conductor_pad_leak_is_issue_642_not_643`, `xfail(strict=True)`.
+- Memory footprint note: the material-named branch now materialises all
+  three `(n_batch, Nx, Ny, Nz)` arrays instead of one plus two broadcast
+  views, because the joint pad decision needs all three. Materials go from
+  ~1 to ~3 batched arrays against the ~6 the batched field state already
+  carries. Unchanged for the global sweep path and for any simulation with
+  no CPML pad on any face (early return, inputs untouched).
+
 ### Fixed — `precision="mixed"` never worked with CPML boundaries (issue #644)
 
 `Simulation(boundary="cpml", precision="mixed").run(...)` raised a raw JAX

--- a/rfx/vmap_sweep.py
+++ b/rfx/vmap_sweep.py
@@ -38,6 +38,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from rfx.core.yee import MaterialArrays, init_state, update_e, update_h, EPS_0
+from rfx.geometry.rasterize_grid import extend_cpml_pad_materials
 from rfx.probes.probes import DFTPlaneProbe, init_dft_plane_probe
 from rfx.simulation import (
     SourceSpec,
@@ -124,118 +125,86 @@ def _parse_param_name(param_name: str) -> tuple[str | None, str]:
 
 
 def _extend_batched_cpml_pad(
-    field: jnp.ndarray, grid, *,
-    companion_eps_r: jnp.ndarray, companion_sigma: jnp.ndarray,
-    companion_mu_r: jnp.ndarray,
-) -> jnp.ndarray:
-    """Re-extend a BATCHED material field, shape ``(n_batch, Nx, Ny, Nz)``,
-    into the CPML padding — the batched analogue of the per-face edge-slice
-    replication in ``Simulation._assemble_materials``
-    (``rfx/api/_compile.py:192-228``).
+    eps_r: jnp.ndarray, sigma: jnp.ndarray, mu_r: jnp.ndarray, grid,
+):
+    """Extend BATCHED material arrays, each shape ``(n_batch, Nx, Ny, Nz)``,
+    into the CPML padding, by running the package's single pad-extension
+    rule — ``rfx.geometry.rasterize_grid.extend_cpml_pad_materials`` — once
+    per batch element under ``jax.vmap``.
 
     ``jnp.where(mask, param_values, base_field)`` (the caller) only ever
     touches the physical-domain-interior cells that ``mask`` covers
     (``Shape.mask`` returns False everywhere in the padding, since padding
     cells map to physical coordinates outside the declared domain). The
-    padding faces of ``base_field`` were replicated from the BASE
-    simulation's edge slice, so every batch element inherits the base
-    material's absorber there regardless of its own swept value (issue
-    #637). Re-running the same per-face copy on the already-batch-correct
-    interior — same face order (x_lo, x_hi, y_lo, y_hi, z_lo, z_hi), same
-    "copy the interior-edge slice outward" rule — makes each batch
-    element's padding match what ``Simulation.run()`` would build for that
-    same swept value, since the interior edge cell each pad cell copies
-    from is now correctly set per batch element.
+    padding faces of ``base_materials`` were replicated from the BASE
+    simulation's edge slice, so every batch element would otherwise
+    inherit the base material's absorber there regardless of its own
+    swept value (issue #637). Re-running the shared rule on the
+    already-batch-correct interior makes each batch element's padding
+    byte-identical to what ``Simulation.run()`` builds for that same
+    swept value.
 
-    **No-worse guard (issue #643 interaction, found in review).** #627
-    (``rfx.geometry.rasterize_grid.extend_cpml_pad_materials``, PR #638)
-    added a hi-face fallback this function does not reproduce: when the
-    naive interior-edge column is vacuum but the column one further in is
-    not (the case a ``Box`` flush with the domain's hi face produces,
-    since ``Box``'s rasterization is half-open and drops that exact
-    node), the shared helper sources the pad from the inner column
-    instead. Post-#627, ``base_materials`` already carries that corrected
-    value at affected pad cells. Without this guard, this function would
-    unconditionally overwrite those cells with the (vacuum) naive column
-    — actively DISCARDING a value that was already right, for every swept
-    batch element, not merely failing to reach a cell that was always
-    wrong.
+    **Why ``jax.vmap`` and not a hand-written batched copy (issue #643).**
+    #637's original version of this function reproduced
+    ``_assemble_materials``' rule *as it stood at the time* — a straight
+    per-face edge-slice copy — in a second, hand-maintained
+    implementation. #627 (PR #638) then changed that rule underneath it,
+    adding a per-transverse-cell hi-face fallback (if the naive
+    interior-edge column is vacuum but the column one further in is not,
+    replicate from that inner column instead, recovering the node a
+    ``Box`` flush with the domain's hi face loses to half-open ``[lo,
+    hi)`` rasterization). The two copies then disagreed for exactly that
+    geometry: ``run()``'s x-hi pad read the material, the batched path
+    read vacuum. That is the defect this repo's own feature-discovery
+    rule names — two hand-maintained copies of one rule is the defect,
+    not which copy is right — so the copy is gone rather than resynced.
 
-    The guard: only overwrite a pad cell if its own source column is NOT
-    vacuum, where "vacuum" is the SAME joint test
-    ``rfx.geometry.rasterize_grid._vacuum`` uses --
-    ``eps_r == 1.0 & sigma == 0.0 & mu_r == 1.0`` -- not a per-field
-    approximation. An earlier version of this guard tested only the
-    field being extended against its own default (1.0 for eps_r/mu_r,
-    0.0 for sigma); measured against the representativeness sweep, that
-    version left two elements (of 14 measured, both ``swept != base``)
-    measurably worse than no guard at all, on the same class of geometry
-    the joint test is defined for -- a predicate mismatch with the rest
-    of the package, not a physics problem. The joint test resolved both.
-    ``companion_eps_r``/``companion_sigma``/``companion_mu_r`` are the
-    three material arrays to evaluate that joint test against at each
-    pad cell's source column: pass ``field`` itself for whichever of the
-    three IS the field being extended here (so the test uses each batch
-    element's OWN swept value for that field), and the base
-    (constant-across-batch, ``(Nx, Ny, Nz)``) array for the other two —
-    they are not swept, and their own padding is already correct as
-    inherited wholesale from ``base_materials``.
+    ``vmap`` is what makes reuse possible at all. The shared helper slices
+    axes 0/1/2 and evaluates its vacuum predicate on whole transverse
+    planes; the batched arrays carry a leading sweep axis, and the
+    predicate's answer differs per element (one swept value can leave a
+    column vacuum where another does not). Mapping over that leading axis
+    hides it from the helper entirely, so the helper sees exactly the
+    ``(Nx, Ny, Nz)`` arrays it was written for and its fallback test is
+    evaluated against each element's OWN materials — no axis-aware
+    rewrite, no third implementation.
 
-    Where the source IS (jointly) vacuum, skip the overwrite — the
-    destination keeps whatever was already there, which is exactly
-    ``base_materials``' own (possibly #627a-corrected) value, since
-    nothing upstream of this function ever touches pad cells for cells
-    the sweep mask does not cover. This does NOT reproduce #627's
-    fallback (a genuinely-covered swept batch element with a non-base
-    value still won't reach that specific pad cell correctly — see the
-    ``test_exact_hi_face_touch_matches_run_via_shared_fallback`` xfail,
-    issue #643, the actual reconciliation) — it only guarantees this
-    function never makes a cell worse than doing nothing would have.
+    All three arrays are extended together in ONE call, not one at a time:
+    the shared helper takes a single ``use_inner`` decision from the joint
+    vacuum predicate (``eps_r == 1 & sigma == 0 & mu_r == 1``) and applies
+    it to all three, so a swept value that turns a column vacuum for one
+    element changes that element's ``sigma``/``mu_r`` pad too. A per-field
+    call cannot express that coupling.
+
+    Note this runs on ``base_materials``-derived arrays, i.e. arrays whose
+    pad cells are ALREADY extended (by the base simulation's own
+    assembly). That is not a double-application: every pad cell is
+    overwritten by one of the three passes, and each pass's source lies
+    either in the interior (identical in both) or in a pad region that a
+    later pass overwrites, so the result depends only on the interior
+    values — which are the batch-correct ones. Verified by the
+    byte-identity matrix in
+    ``tests/test_vmap_sweep_dft_planes.py::TestVmapBatchedPadByteIdentity``.
 
     A no-op on any face with zero pad depth (non-CPML boundary, or a
     reflector/periodic face with ``pad=0`` on that side), so this is safe
-    to call unconditionally.
+    to call unconditionally; with every face at zero it returns its inputs
+    untouched rather than materialising broadcast views through ``vmap``.
+
+    Returns
+    -------
+    (eps_r, sigma, mu_r) — same shapes as the inputs.
     """
     plx, phx = grid.pad_x_lo, grid.pad_x_hi
     ply, phy = grid.pad_y_lo, grid.pad_y_hi
     plz, phz = grid.pad_z_lo, grid.pad_z_hi
-    out = field
+    if max(plx, phx, ply, phy, plz, phz) <= 0:
+        return eps_r, sigma, mu_r
 
-    # Companions are either the batched field itself (ndim 4, whichever of
-    # the three this call is extending) or the base's constant-across-batch
-    # array (ndim 3, the other two) -- add a leading size-1 axis to the
-    # latter so every slice below broadcasts against the batch dimension.
-    def _as_batched(a):
-        return a if a.ndim == 4 else a[None]
+    def _one(e, s, m):
+        return extend_cpml_pad_materials(e, s, m, plx, phx, ply, phy, plz, phz)
 
-    c_eps = _as_batched(companion_eps_r)
-    c_sigma = _as_batched(companion_sigma)
-    c_mu = _as_batched(companion_mu_r)
-
-    def _guarded_set(out, dst_sl, src_sl):
-        src = out[src_sl]
-        cur = out[dst_sl]
-        vacuum = (
-            (c_eps[src_sl] == 1.0)
-            & (c_sigma[src_sl] == 0.0)
-            & (c_mu[src_sl] == 1.0)
-        )
-        new = jnp.where(vacuum, cur, src)
-        return out.at[dst_sl].set(new)
-
-    if plx > 0:
-        out = _guarded_set(out, np.s_[:, :plx, :, :], np.s_[:, plx:plx + 1, :, :])
-    if phx > 0:
-        out = _guarded_set(out, np.s_[:, -phx:, :, :], np.s_[:, -phx - 1:-phx, :, :])
-    if ply > 0:
-        out = _guarded_set(out, np.s_[:, :, :ply, :], np.s_[:, :, ply:ply + 1, :])
-    if phy > 0:
-        out = _guarded_set(out, np.s_[:, :, -phy:, :], np.s_[:, :, -phy - 1:-phy, :])
-    if plz > 0:
-        out = _guarded_set(out, np.s_[:, :, :, :plz], np.s_[:, :, :, plz:plz + 1])
-    if phz > 0:
-        out = _guarded_set(out, np.s_[:, :, :, -phz:], np.s_[:, :, :, -phz - 1:-phz])
-    return out
+    return jax.vmap(_one)(eps_r, sigma, mu_r)
 
 
 def _build_batched_materials(
@@ -263,9 +232,11 @@ def _build_batched_materials(
     cells only, via ``Shape.mask``. Unlike the global case, ``mask`` is
     False everywhere in the CPML padding (padding cells sit outside the
     physical domain ``Shape.mask`` tests against), so the padding is
-    handled separately below via ``_extend_batched_cpml_pad`` (issue #637):
-    without it, every swept batch element would run against a pad matched
-    to the BASE material instead of its own.
+    handled separately below via ``_extend_batched_cpml_pad`` (issue #637;
+    issue #643 for why that now routes through the package's single shared
+    pad rule rather than a second copy of it): without it, every swept
+    batch element would run against a pad matched to the BASE material
+    instead of its own.
     """
     mat_name, field = _parse_param_name(param_name)
     n_batch = len(param_values)
@@ -282,47 +253,31 @@ def _build_batched_materials(
             if entry.material_name == mat_name:
                 mask = mask | entry.shape.mask(grid)
 
+        # For each batch: where mask, use param_values[b]; else keep base.
+        # The two unswept fields still have to be broadcast to the batch
+        # shape, because the pad extension below takes ONE joint decision
+        # across all three (see _extend_batched_cpml_pad) and a swept value
+        # can change that decision per element.
+        batch_eps = jnp.broadcast_to(eps_r[None], (n_batch,) + eps_r.shape)
+        batch_sigma = jnp.broadcast_to(sigma[None], (n_batch,) + sigma.shape)
+        batch_mu = jnp.broadcast_to(mu_r[None], (n_batch,) + mu_r.shape)
+        swept = param_values[:, None, None, None]   # (n_batch, 1, 1, 1)
         if field == "eps_r":
-            # For each batch: where mask, use param_values[b]; else keep base
-            batch_eps = jnp.where(
-                mask[None],  # (1, Nx, Ny, Nz)
-                param_values[:, None, None, None],  # (n_batch, 1, 1, 1)
-                eps_r[None],  # (1, Nx, Ny, Nz)
-            )
-            # #637: the mask above only covers the physical-domain interior
-            # -- extend the (now per-batch-correct) interior into the CPML
-            # pad the same way the base simulation would for each swept
-            # value, instead of leaving the base material's pad fill.
-            batch_eps = _extend_batched_cpml_pad(
-                batch_eps, grid, companion_eps_r=batch_eps,
-                companion_sigma=sigma, companion_mu_r=mu_r,
-            )
-            batch_sigma = jnp.broadcast_to(sigma[None], (n_batch,) + sigma.shape)
-            batch_mu = jnp.broadcast_to(mu_r[None], (n_batch,) + mu_r.shape)
+            batch_eps = jnp.where(mask[None], swept, eps_r[None])
         elif field == "sigma":
-            batch_eps = jnp.broadcast_to(eps_r[None], (n_batch,) + eps_r.shape)
-            batch_sigma = jnp.where(
-                mask[None],
-                param_values[:, None, None, None],
-                sigma[None],
-            )
-            batch_sigma = _extend_batched_cpml_pad(
-                batch_sigma, grid, companion_eps_r=eps_r,
-                companion_sigma=batch_sigma, companion_mu_r=mu_r,
-            )
-            batch_mu = jnp.broadcast_to(mu_r[None], (n_batch,) + mu_r.shape)
+            batch_sigma = jnp.where(mask[None], swept, sigma[None])
         else:  # mu_r
-            batch_eps = jnp.broadcast_to(eps_r[None], (n_batch,) + eps_r.shape)
-            batch_sigma = jnp.broadcast_to(sigma[None], (n_batch,) + sigma.shape)
-            batch_mu = jnp.where(
-                mask[None],
-                param_values[:, None, None, None],
-                mu_r[None],
-            )
-            batch_mu = _extend_batched_cpml_pad(
-                batch_mu, grid, companion_eps_r=eps_r,
-                companion_sigma=sigma, companion_mu_r=batch_mu,
-            )
+            batch_mu = jnp.where(mask[None], swept, mu_r[None])
+
+        # #637: the mask above only covers the physical-domain interior --
+        # extend the (now per-batch-correct) interior into the CPML pad the
+        # same way the base simulation would for each swept value, instead
+        # of leaving the base material's pad fill. #643: via the package's
+        # single shared rule, vmapped over the sweep axis, not a second
+        # hand-maintained copy of it.
+        batch_eps, batch_sigma, batch_mu = _extend_batched_cpml_pad(
+            batch_eps, batch_sigma, batch_mu, grid,
+        )
     else:
         # Global sweep: apply to all non-background cells
         if field == "eps_r":

--- a/tests/test_vmap_sweep_dft_planes.py
+++ b/tests/test_vmap_sweep_dft_planes.py
@@ -119,7 +119,10 @@ except ImportError:  # older JAX (< ~0.4.31)
     from tests._x64_compat import enable_x64 as _enable_x64
 
 from rfx import Simulation, GaussianPulse, Box
-from rfx.vmap_sweep import vmap_material_sweep, VmapSweepResult
+from rfx.boundaries.spec import Boundary, BoundarySpec
+from rfx.vmap_sweep import (
+    vmap_material_sweep, VmapSweepResult, _build_batched_materials,
+)
 
 _FALLBACK_MATCH = "Falling back to sequential"
 
@@ -145,16 +148,20 @@ def _dft_sim(boundary: str = "cpml", eps_r: float = 4.0,
     # docstring) so a hi bound landing EXACTLY on the domain edge drops
     # that edge node from the box's own mask -- unrelated to #637, but it
     # interacts with it post-#627 (rfx.geometry.rasterize_grid's hi-face
-    # vacuum fallback, closes-#627 fce1091): run() now correctly
-    # recovers that node via the fallback, this file's vmap helper
-    # doesn't reproduce that fallback (out of scope here, see the #637
-    # CHANGELOG entry's "Overlap with issue #627" paragraph), so without
-    # this margin every test built on this fixture would fail for a
-    # SEPARATE, already-disclosed reason unrelated to what they test.
-    # The margin is far short of entering the CPML pad itself (half a
-    # cell vs. the pad's full cpml_layers=6 cells), so it only recovers
-    # the one excluded interior node -- confirmed directly (0 mask cells
-    # inside the pad region) before landing this change.
+    # vacuum fallback, closes-#627 fce1091). The margin was added because
+    # the vmap helper did not reproduce that fallback, so every test
+    # built on this fixture would otherwise have failed for a SEPARATE,
+    # already-disclosed reason unrelated to what they test. #643 closed
+    # that gap (the helper now vmaps the shared rule, so the exact-edge
+    # case agrees bit-for-bit too -- see
+    # test_exact_hi_face_touch_matches_run_via_shared_fallback and
+    # TestVmapBatchedPadByteIdentity's all_six_faces_exact_hi row). The
+    # margin is KEPT so the numbers quoted throughout this file stay
+    # attached to the geometry they were measured on; it is no longer
+    # load-bearing. It is far short of entering the CPML pad itself
+    # (half a cell vs. the pad's full cpml_layers=6 cells), so it only
+    # recovers the one excluded interior node -- confirmed directly
+    # (0 mask cells inside the pad region) before landing this change.
     sim.add(Box((0.005, 0, 0), (0.015, 0.021, 0.021)), material="substrate")
     sim.add_source((0.01, 0.01, 0.01), "ez", waveform=GaussianPulse(f0=3e9),
                     amplitude_kind=amplitude_kind)
@@ -429,40 +436,41 @@ class TestVmapMaterialSweepCpmlPad:
                 ref.dft_planes, rtol=1e-6, ctx=f"global sweep eps_r={ev}",
             )
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Known gap, issue #643 (opened from this PR's own review): "
-            "_extend_batched_cpml_pad does not reproduce "
-            "rfx.geometry.rasterize_grid.extend_cpml_pad_materials' "
-            "hi-face vacuum fallback (added by #627, PR #638) -- when the "
-            "naive interior-edge column is vacuum but the column one "
-            "further in is not (the case a Box's half-open [lo, hi) "
-            "rasterization produces for a structure flush with the "
-            "domain's hi face), the shared helper sources the pad from "
-            "that inner column; this file's vmap helper still reads the "
-            "naive (vacuum) column. Measured directly on this exact "
-            "fixture: worst per-bin DFT-plane relative error against "
-            "run() is 1.66e-2 (eps_r=2.0) / 4.25e-2 (eps_r=6.0) -- the "
-            "same order of magnitude as #637's own pre-fix defect, on "
-            "the one geometry #637's fix does not reach. strict=True so "
-            "this flips to an XPASS failure (not a silent pass) the day "
-            "someone closes #643 -- delete this test then, do not widen "
-            "it."
-        ),
-    )
     def test_exact_hi_face_touch_matches_run_via_shared_fallback(self):
-        """Witness for issue #643 -- a slab whose bound sits EXACTLY on
-        the domain's hi face (all six CPML faces via a `Box((0,0,0),
-        domain)`, mirroring the #582/#627 discovery fixture), swept by
-        material name. `Simulation.run()` gets the x-hi/y-hi/z-hi pads
-        right post-#627 (the shared helper's fallback); the vmap fast
-        path does not. Every OTHER test in this file (and #637's own
-        representativeness sweep) deliberately nudges its geometry a
-        half-cell past the domain edge specifically to AVOID this case
-        (see ``_dft_sim`` and the alternate-geometry test's own inline
-        comments) -- without this xfail, nothing in the shipped suite
-        would ever touch the exact property #643 tracks."""
+        """Regression lock for issue #643, CLOSED -- a slab whose bound
+        sits EXACTLY on the domain's hi face (all six CPML faces via a
+        `Box((0,0,0), domain)`, mirroring the #582/#627 discovery
+        fixture), swept by material name.
+
+        HISTORY: this test shipped with #637 as ``xfail(strict=True)``.
+        Its gap was real: ``_extend_batched_cpml_pad`` reproduced
+        ``_assemble_materials``' PRE-#627 rule (a straight edge-slice
+        copy) and so missed the hi-face inner-column fallback #627 added
+        to ``rfx.geometry.rasterize_grid.extend_cpml_pad_materials``.
+        ``Simulation.run()`` read the material in its x/y/z-hi pads; the
+        vmap path read vacuum. Measured worst per-bin DFT-plane relative
+        error against ``run()`` on this exact fixture: 1.66e-2
+        (eps_r=2.0) / 4.25e-2 (eps_r=6.0). #643 removed the second copy
+        of the rule entirely -- ``_extend_batched_cpml_pad`` now vmaps
+        the shared helper over the sweep axis -- and this comparison is
+        exactly ``0.0`` at every bin for both elements. The marker is
+        gone rather than the test: this is the only fixture in the suite
+        that sits exactly on the domain edge (``_dft_sim`` and the
+        alternate-geometry test both nudge a half-cell past it on
+        purpose), so it is the only thing pinning the fallback's
+        reachability from the batched path.
+
+        NON-VACUITY PRECONDITION (assert-first, before the equality
+        assert): the same arc already produced one test that passed for
+        the wrong reason -- the alternate-geometry test's first draft
+        used a hi-face-touching box that never reached the pad at all,
+        so it agreed pre- and post-fix while measuring nothing. Here the
+        precondition is checked directly against ``run()``'s own
+        assembled materials: the x-hi pad must read the slab's eps_r,
+        NOT vacuum, which is true only because #627's fallback fires.
+        If a future rasterizer change made this fixture stop exercising
+        the fallback, the precondition fails loudly instead of the
+        equality passing vacuously."""
         domain = (0.02, 0.02, 0.02)
         cpml_layers = 6
         dx = 0.002
@@ -481,6 +489,36 @@ class TestVmapMaterialSweepCpmlPad:
                                      component="ez", n_freqs=4, name="p1")
             return sim
 
+        # --- precondition: this fixture really does exercise #627's
+        # hi-face fallback, i.e. run()'s x-hi pad is NOT vacuum and the
+        # naive source column (the last interior column) IS.
+        probe_sim = sim_fn(4.0)
+        probe_grid = probe_sim._build_grid()
+        probe_mats, *_ = probe_sim._assemble_materials(probe_grid)
+        eps = np.asarray(probe_mats.eps_r)
+        phx = probe_grid.pad_x_hi
+        assert phx > 0, "fixture lost its x-hi CPML pad"
+        # Sample the transverse CENTRE. Not the whole pad slab: the same
+        # half-open rasterization also drops this box's y/z hi nodes, so
+        # genuine vacuum survives at those transverse coordinates in
+        # run()'s OWN arrays -- asserting "all of the pad is 4.0" would
+        # assert something false about run(), not about the vmap path.
+        cy, cz = probe_grid.shape[1] // 2, probe_grid.shape[2] // 2
+        naive_src = eps[-phx - 1, cy, cz]
+        inner_src = eps[-phx - 2, cy, cz]
+        hi_pad = eps[-phx:, cy, cz]
+        assert naive_src == 1.0 and inner_src == 4.0, (
+            "fixture no longer reproduces the half-open-hi vacuum column "
+            "the #627 fallback exists for (naive source column "
+            f"{naive_src}, inner column {inner_src}) -- this test would "
+            "pass vacuously; rebuild the fixture, do not delete the assert"
+        )
+        assert np.all(hi_pad == 4.0), (
+            "run()'s x-hi pad is not the slab material -- #627's hi-face "
+            f"fallback did not fire, so there is nothing here for the "
+            f"batched path to match (pad column: {hi_pad})"
+        )
+
         vmap_res = vmap_material_sweep(
             sim_fn(4.0), "slab.eps_r", eps_values, n_steps=n_steps,
         )
@@ -491,6 +529,247 @@ class TestVmapMaterialSweepCpmlPad:
                 ref.dft_planes, rtol=1e-6,
                 ctx=f"exact-hi-face-touch (#643) eps_r={ev}",
             )
+
+
+def _matrix_sim(shape_lo, shape_hi, *, boundary="cpml", cpml_layers=6,
+                domain=(0.02, 0.02, 0.02), dx=0.002, boundary_spec=None,
+                eps_r=4.0, sigma=0.0, mu_r=1.0, second_material=False):
+    """Builder for the #643 byte-identity matrix. One knob per matrix
+    dimension; the sweep itself is applied by the caller through
+    ``add_material``'s three material fields."""
+    kwargs = {"boundary": boundary_spec if boundary_spec is not None
+              else boundary}
+    if cpml_layers is not None:
+        kwargs["cpml_layers"] = cpml_layers
+    sim = Simulation(freq_max=5e9, domain=domain, dx=dx, **kwargs)
+    sim.add_material("slab", eps_r=eps_r, sigma=sigma, mu_r=mu_r)
+    sim.add(Box(shape_lo, shape_hi), material="slab")
+    if second_material:
+        # A lossy, magnetic second material -- the ONLY way the shared
+        # helper's JOINT vacuum predicate can differ from a per-field one
+        # (#637's own note: none of its fixtures carried such a material,
+        # so the two predicates were indistinguishable there).
+        sim.add_material("lossy", eps_r=1.0, sigma=0.02, mu_r=2.0)
+        sim.add(Box((0.0, 0.0, 0.0), (0.006, 0.02, 0.02)), material="lossy")
+    sim.add_source((0.01, 0.01, 0.01), "ez", waveform=GaussianPulse(f0=3e9))
+    sim.add_probe((0.006, 0.01, 0.01), "ez")
+    return sim
+
+
+_D = (0.02, 0.02, 0.02)
+
+# (id, builder-kwargs) -- the geometry/boundary matrix from issue #643's
+# acceptance criterion: #637's own matrix PLUS the exact-hi-face case.
+_BYTE_IDENTITY_MATRIX = [
+    ("single_face_xlo", dict(shape_lo=(0.0, 0.006, 0.006),
+                             shape_hi=(0.008, 0.014, 0.014))),
+    ("all_six_faces_exact_hi", dict(shape_lo=(0.0, 0.0, 0.0), shape_hi=_D)),
+    ("all_six_faces_past_hi", dict(shape_lo=(0.0, 0.0, 0.0),
+                                   shape_hi=(0.021, 0.021, 0.021))),
+    ("corner_touch", dict(shape_lo=(0.0, 0.0, 0.0),
+                          shape_hi=(0.008, 0.008, 0.008))),
+    ("inset_no_face_touch", dict(shape_lo=(0.006, 0.006, 0.006),
+                                 shape_hi=(0.014, 0.014, 0.014))),
+    ("transverse_span_yz", dict(shape_lo=(0.005, 0.0, 0.0),
+                                shape_hi=(0.015, 0.02, 0.02))),
+    ("cpml_layers_0", dict(shape_lo=(0.0, 0.0, 0.0), shape_hi=_D,
+                           cpml_layers=0)),
+    ("pec", dict(shape_lo=(0.0, 0.0, 0.0), shape_hi=_D, boundary="pec",
+                 cpml_layers=None)),
+    ("upml", dict(shape_lo=(0.0, 0.0, 0.0), shape_hi=_D, boundary="upml")),
+    # periodic is only expressible through a BoundarySpec, and only
+    # symmetrically per axis -- x periodic (pad 0 on both x faces) with
+    # y/z still absorbing is the mixed case worth pinning.
+    ("periodic_x_cpml_yz", dict(
+        shape_lo=(0.0, 0.0, 0.0), shape_hi=_D,
+        boundary_spec=BoundarySpec(
+            x=Boundary(lo="periodic", hi="periodic"), y="cpml", z="cpml"))),
+    ("two_materials", dict(shape_lo=(0.006, 0.0, 0.0), shape_hi=(0.02, 0.02, 0.02),
+                           second_material=True)),
+    ("asymmetric_per_face_pads", dict(
+        shape_lo=(0.0, 0.0, 0.0), shape_hi=_D, cpml_layers=None,
+        boundary_spec=BoundarySpec(
+            x=Boundary(lo="cpml", hi="cpml", lo_thickness=4, hi_thickness=9),
+            y=Boundary(lo="pec", hi="cpml", hi_thickness=6),
+            z=Boundary(lo="cpml", hi="pec", lo_thickness=7),
+        ))),
+]
+
+
+class TestVmapBatchedPadByteIdentity:
+    """Issue #643's acceptance criterion, as a committed matrix.
+
+    What the batched path builds for element *b* must be BYTE-IDENTICAL
+    to what ``Simulation._assemble_materials`` builds for a simulation
+    carrying that swept value -- all three material arrays, every cell,
+    across the geometry/boundary matrix #637 used (single face, all six
+    faces, corner, inset, ``cpml_layers=0``, pec, upml, periodic, two
+    materials, asymmetric per-face pads) PLUS the exact-hi-face-touching
+    case #643 is about.
+
+    This is the mechanism-level lock. It costs no time-stepping, so it
+    can afford to be wide where the DFT-plane equivalence tests (which
+    do step) have to be narrow. #637 shipped ONE such comparison on ONE
+    fixture; the reason #643 existed at all is that a rule can be right
+    on the one fixture that is checked and wrong on the class.
+
+    Both directions are exercised on every row: the swept field is
+    compared for equality (it must MOVE with the sweep and still match
+    run()), and the two unswept fields are compared too (they must NOT
+    drift -- the shared helper takes one joint decision across all
+    three, so a swept value that empties a column changes the other two
+    arrays' pads as well, and that coupling has to match run() rather
+    than merely be self-consistent)."""
+
+    @staticmethod
+    def _assert_identical(kwargs, param, values, base_kwargs):
+        base_sim = _matrix_sim(**{**kwargs, **base_kwargs})
+        grid = base_sim._build_grid()
+        base_materials, *_ = base_sim._assemble_materials(grid)
+        batched = _build_batched_materials(
+            base_sim, grid, base_materials, param, jnp.asarray(values))
+
+        field = param.split(".")[1]
+        for idx, v in enumerate(values):
+            want_sim = _matrix_sim(**{**kwargs, **{field: float(v)}})
+            want, *_ = want_sim._assemble_materials(grid)
+            for name in ("eps_r", "sigma", "mu_r"):
+                npt.assert_array_equal(
+                    np.asarray(getattr(batched, name)[idx]),
+                    np.asarray(getattr(want, name)),
+                    err_msg=(
+                        f"batched {name} at {param}={v} disagrees with "
+                        f"run()'s own _assemble_materials -- the batched "
+                        f"pad rule and the shared rule have drifted "
+                        f"again (#643)"
+                    ),
+                )
+
+    @pytest.mark.parametrize(
+        "case_id,kwargs",
+        _BYTE_IDENTITY_MATRIX,
+        ids=[c[0] for c in _BYTE_IDENTITY_MATRIX],
+    )
+    def test_eps_r_sweep_byte_identical_to_assemble_materials(
+            self, case_id, kwargs):
+        self._assert_identical(
+            kwargs, "slab.eps_r", np.array([2.0, 4.0, 9.0]),
+            base_kwargs=dict(eps_r=4.0))
+
+    @pytest.mark.parametrize(
+        "case_id,kwargs",
+        _BYTE_IDENTITY_MATRIX,
+        ids=[c[0] for c in _BYTE_IDENTITY_MATRIX],
+    )
+    def test_sigma_sweep_byte_identical_to_assemble_materials(
+            self, case_id, kwargs):
+        self._assert_identical(
+            kwargs, "slab.sigma", np.array([0.0, 0.05]),
+            base_kwargs=dict(sigma=0.01))
+
+    @pytest.mark.parametrize(
+        "case_id,kwargs",
+        _BYTE_IDENTITY_MATRIX,
+        ids=[c[0] for c in _BYTE_IDENTITY_MATRIX],
+    )
+    def test_mu_r_sweep_byte_identical_to_assemble_materials(
+            self, case_id, kwargs):
+        self._assert_identical(
+            kwargs, "slab.mu_r", np.array([1.0, 3.0]),
+            base_kwargs=dict(mu_r=2.0))
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "Known gap, issue #642, INHERITED not introduced by #643 -- "
+            "run() applies thin conductors AFTER pad extension "
+            "(rfx/api/_compile.py: extend_cpml_pad_materials, then the "
+            "_thin_conductors loop), while the batched path only ever "
+            "sees base_materials, which is already post-conductor. "
+            "Extending that array therefore replicates the conductor's "
+            "own sigma/eps_r into the pad, which run() never does. "
+            "Measured on the fixture below (NON-PEC thin conductor, "
+            "sigma_bulk=1e4): branch leaves 88 mismatched cells of "
+            "36501 (40 eps_r + 48 sigma, all inside the x pads); main "
+            "leaves 6592 (all eps_r, the #637/#643 defect, and zero "
+            "sigma because main only ever extended the ONE swept "
+            "field). So #643 is a 75x reduction overall AND a new "
+            "sigma-side mismatch this fixture did not have -- disclosed "
+            "rather than folded into #643, whose scope is the "
+            "pad-extension RULE, not the pipeline ORDER that #642 "
+            "tracks. A PEC thin conductor is unaffected (it routes to "
+            "pec_mask, not to the material arrays: 0 mismatched cells "
+            "on both). strict=True so this hard-fails the day #642 "
+            "lands, instead of rotting."
+        ),
+    )
+    def test_thin_conductor_pad_leak_is_issue_642_not_643(self):
+        """#642 witness on the batched path. Kept next to the #643
+        matrix because the two are one line apart in the same pipeline
+        and the next person to touch either needs to see both."""
+        def sim_fn(eps_r):
+            sim = _matrix_sim((0.0, 0.0, 0.0), (0.02, 0.02, 0.02),
+                              eps_r=eps_r)
+            sim.add_thin_conductor(
+                Box((0.0, 0.008, 0.008), (0.02, 0.012, 0.012)),
+                sigma_bulk=1.0e4, thickness=35e-6)
+            return sim
+
+        base_sim = sim_fn(4.0)
+        grid = base_sim._build_grid()
+        base_materials, *_ = base_sim._assemble_materials(grid)
+        values = np.array([2.0, 9.0])
+        batched = _build_batched_materials(
+            base_sim, grid, base_materials, "slab.eps_r",
+            jnp.asarray(values))
+        for idx, v in enumerate(values):
+            want, *_ = sim_fn(float(v))._assemble_materials(grid)
+            for name in ("eps_r", "sigma", "mu_r"):
+                npt.assert_array_equal(
+                    np.asarray(getattr(batched, name)[idx]),
+                    np.asarray(getattr(want, name)),
+                    err_msg=f"thin-conductor {name} pad leak (#642)")
+
+    def test_matrix_is_not_vacuous_swept_value_reaches_the_pad(self):
+        """Control for the whole matrix above: at least one row must have
+        the swept value actually LANDING in the CPML pad, otherwise every
+        equality in this class could hold trivially (both sides vacuum).
+
+        This is the same failure the alternate-geometry test's first
+        draft had -- a fixture that agreed before and after the fix
+        because it never reached the pad. Pinned as its own test so the
+        matrix cannot silently become decorative."""
+        kwargs = dict(_BYTE_IDENTITY_MATRIX[1][1])   # all_six_faces_exact_hi
+        base_sim = _matrix_sim(**kwargs, eps_r=4.0)
+        grid = base_sim._build_grid()
+        base_materials, *_ = base_sim._assemble_materials(grid)
+        batched = _build_batched_materials(
+            base_sim, grid, base_materials, "slab.eps_r",
+            jnp.asarray([2.0, 9.0]))
+
+        phx = grid.pad_x_hi
+        assert phx > 0
+        # Sample the transverse CENTRE of the x-hi pad. Not the whole
+        # slab: the same half-open rasterization that motivates #627's
+        # fallback also leaves genuine vacuum at the y/z hi nodes this
+        # box excludes, and run() reproduces that exactly -- asserting
+        # "all of the pad is the material" would be asserting something
+        # false about run() too, not about the batched path.
+        cy, cz = grid.shape[1] // 2, grid.shape[2] // 2
+        hi_col_0 = np.asarray(batched.eps_r[0])[-phx:, cy, cz]
+        hi_col_1 = np.asarray(batched.eps_r[1])[-phx:, cy, cz]
+        assert np.all(hi_col_0 == 2.0), (
+            "swept value 2.0 did not reach the x-hi pad "
+            f"(got {hi_col_0}) -- the matrix above would be comparing "
+            "vacuum against vacuum"
+        )
+        assert np.all(hi_col_1 == 9.0), (
+            f"swept value 9.0 did not reach the x-hi pad (got {hi_col_1})"
+        )
+        # ...and the two elements must actually DIFFER there, which is
+        # the property #637 + #643 together buy. On main this column read
+        # 1.0 for BOTH elements (the #643 defect).
+        assert not np.array_equal(hi_col_0, hi_col_1)
 
 
 class TestVmapDftPlaneX64:


### PR DESCRIPTION
Closes #643.

Two implementations of one CPML pad-extension rule had drifted:
`rfx/geometry/rasterize_grid.py::extend_cpml_pad_materials` (shared with
`Simulation._assemble_materials`, carrying #627's per-transverse-cell hi-face fallback) and
`rfx/vmap_sweep.py::_extend_batched_cpml_pad` (still the pre-#627 straight edge-slice copy).
So `vmap_material_sweep` and `run()` disagreed for geometry touching a hi face exactly.

## One rule, one implementation

`_extend_batched_cpml_pad` now calls the shared helper under `jax.vmap` over the sweep axis.
~15 executable lines; the rest of the diff is tests and docs.

The issue expected reuse would not be a drop-in, because the batched arrays carry a leading
sweep axis the fallback's vacuum test has to be evaluated against per element. `jax.vmap`
dissolves that: mapping over the leading axis hides it, so the shared helper sees exactly the
`(Nx, Ny, Nz)` arrays it was written for and its fallback is evaluated per element against
that element's own materials. No axis-aware rewrite, no third implementation.

All three material arrays now go through one call, so the helper takes a single joint
`use_inner` decision and applies it to all three — a coupling the per-field copy could not
express. #641's no-worse guard is deleted along with the copy it existed to guard.

## Acceptance criterion met

- **Byte-identity vs `_assemble_materials`**: 12 geometry/boundary rows x 3 swept fields — 0
  mismatched cells. **18 of those 36 fail on base.**
- **The strict xfail**: verified XFAIL on base, then XPASS(strict) — i.e. genuinely red — with
  the fix applied, before the marker came off. Now a normal passing test with an assert-first
  non-vacuity precondition so it cannot later pass by no longer exercising the fallback.
- **14-element sweep**: every element exactly `0.0`, 0 mismatched cells (base main: 0.0 to
  1.20e-2).

Independently confirmed on a separate harness: the new test file scores **20 failed / 34
passed on base** and **54 passed on branch**, so the tests discriminate rather than describe.

## `run()` is untouched

SHA-256 over all six final field components plus probe series, base vs branch: identical on
PEC / CPML / lossy+CPML / non-uniform+CPML. Negative control (`n_steps` 60 to 61) moves all 8
digests. Separately confirmed on a 4-configuration, 24-quantity harness: 24/24 identical.

## The two residuals from #637 are explained and eliminated

#637 shipped with two unexplained regressions (+1.6% and +0.5%) that reproduced identically
across repeated measurement and did not move under its vacuum guard.

They are not a separate mechanism. A four-state comparison in one tree shows **the DFT-plane
error is not monotone in the wrong-cell count**: main and #641's no-guard draft share 1140
wrong cells yet differ 5.3x in error, while the pre-#637 state has 68% MORE wrong cells and a
smaller error on one element. Correcting the ordinary pad cells while leaving the fallback
cells wrong puts a permittivity STEP inside the absorber that a uniformly-wrong pad did not
have. Both disclosed magnitudes' class now measures exactly 0.0 (on the committed fixture at
300/400/600 steps, where main measures 1.45e-2 to 7.94e-2).

The emulated states reproduce real base-tree runs bit-for-bit, which is what makes that table
evidence rather than a harness artefact.

## Honest limitation

#637's own 7-configuration harness is not committed anywhere, so it could not be re-run. The
reconstruction's magnitudes sit 1-2 orders below PR #641's, meaning the table above is a NEW
sweep over the same geometry classes, not a reproduction of those numbers. Stated here rather
than presented as a re-run.

## #642 is inherited and slightly widened, NOT closed

`run()` applies thin conductors AFTER pad extension, and the batched path only ever sees
post-conductor `base_materials` — so it is handed the wrong input, not running the wrong
algorithm, and no fidelity of rule replication can fix it.

On a non-PEC thin conductor: 88 mismatched cells of 36501 (40 `eps_r` + 48 `sigma`) against
main's 6592 — 75x better overall, but with a **new sigma-side mismatch main did not have**,
because main only ever extended the single swept field while this extends all three through
one joint decision. PEC thin conductors are unaffected (0 on both; they route via `pec_mask`).

Deliberately not fixed here: closing it needs the batched path to see pre-conductor materials,
a production-side change that this issue's own `run()` byte-identity requirement argues
against bundling. Pinned by a strict-xfail witness so it hard-fails the day #642 lands, and
the mechanism is recorded on that issue.

R3: memory=project_mesh_strategy_decision (vmap/NU pad parity) | R2-attempts=1 |
falsifier=the strict xfail, watched XFAIL-on-base then XPASS-with-fix before the marker moved
