### PR TITLE
fix(vmap-sweep): hand the batched path pre-conductor materials so thin conductors stop leaking into the CPML pad (closes #642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,116 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — thin conductors leaked into the batched sweep's CPML pad (issue #642)
+
+`Simulation._assemble_materials` extends material values into the CPML pad
+and only THEN applies thin conductors, so `Simulation.run()`'s padding
+carries the background material and never a conductor. `vmap_material_sweep`
+was handed `base_materials` — the finished, post-conductor arrays — and
+re-extended those per swept value, replicating a non-PEC conductor's own
+`eps_r`/`sigma` outward into a pad `run()` never builds.
+
+#643 could not close this by making the extension rule more faithful,
+because the rule was never what was wrong: the batched path was given the
+wrong INPUT, not running the wrong algorithm.
+
+**Fix: the batched path is handed pre-conductor materials, and re-applies
+the conductors itself.** `Simulation._assemble_materials` gained a
+keyword-only `include_thin_conductors` (default `True`, and no caller other
+than `rfx/vmap_sweep.py` passes it, so every existing path is unaffected by
+construction). `_build_batched_materials`' material-named branch now
+re-derives the pre-conductor arrays through it, builds the sweep and the pad
+from those, and then re-applies the same shared
+`rfx.materials.thin_conductor.apply_thin_conductor` under `jax.vmap` — the
+package's single conductor rule, in the same order `run()` runs it, rather
+than a second copy of it. Production assembly ORDER is untouched; only what
+the batched path is given changed. The extra assembly is paid only when the
+simulation declares a thin conductor.
+
+- **0 mismatched cells, both material lanes, all three swept fields.**
+  Batched element *b* vs `_assemble_materials` for a simulation carrying
+  that swept value, on a `sigma_bulk=1e4` sheet spanning the domain's full
+  x extent (12167 cells per array, 36501 across the three). Per swept
+  element, main → this branch: `slab.eps_r` sweep 88 (40 `eps_r` + 48
+  `sigma`) → **0**; `slab.sigma` sweep 88 (48 + 40) → **0**; `slab.mu_r`
+  sweep 96 (48 + 48) → **0**. The `sigma` and `mu_r` sweeps were not in the
+  issue's own measurement and leak the same way — the leak is the conductor
+  being replicated outward, so it does not depend on which field is swept.
+  A PEC thin conductor measures 0 on both trees for all three (it routes to
+  `pec_mask`, not to the material arrays) and is committed as the must-pass
+  companion row, not as filler.
+- **This was not only an accuracy leak — it destabilised the run.** R5
+  decile dump of the probe envelope at `n_steps=400` with the pre-#642 pad
+  order restored: the batched path grows monotonically from decile 5
+  (`3.6e-9, 3.0e-8, 4.4e-8, 9.7e-8, 8.8e-7, 2.9e-4, 9.8e-2, 3.3e+01,
+  1.1e+04, 3.8e+06`, last/mid ratio 3.9e13) while the sequential reference
+  decays (last/mid 9.1e-3). Fixed, the batched path's deciles match
+  `run()`'s to every printed digit. Mechanism: a 175 S/m sheet
+  (`sigma_eff = sigma_bulk * thickness / dx`) replicated into the CPML pad,
+  on top of the absorber's own loss.
+- **`Simulation.run()` does not move.** SHA-256 over the raw bytes of the
+  final Yee field state plus the probe time series, base (`ef8a008`) vs
+  branch, on four lanes × with/without a non-PEC thin conductor — pec
+  (`6615242190bedfc9` / `d5a1a4614c419d12`), cpml (`a3ebcc1203fb43b1` /
+  `6cc2b67523278d4b`), lossy+CPML (`a52029cec52bca18` /
+  `97fd6ff74795c881`), non-uniform `dz_profile`+CPML (`9a79f62121917b85` /
+  `5a463547b098b69c`) — all 16 digests (fields + time series per row)
+  identical. Two negative controls: nudging `slab` `eps_r` 4.0 → 4.001
+  moves the digest, and forcing `include_thin_conductors=False` through
+  `run()`'s own assembly moves exactly the thin-conductor rows and leaves
+  the conductor-free rows untouched, so the harness is sensitive to the
+  edited line specifically and not merely to something.
+- **The `xfail(strict=True)` witness is now a normal passing test.**
+  `test_thin_conductor_pad_leak_is_issue_642_not_643` was verified XFAIL on
+  base, then XPASS(strict) — i.e. red — with the fix and the marker still
+  in place, and only then flipped. It is now
+  `test_thin_conductor_pad_matches_run`, parametrized over PEC/non-PEC
+  conductor × three swept fields, plus
+  `test_thin_conductor_fixture_is_live`: a non-vacuity control asserting
+  that the conductor really does sit on the column the pad replicates FROM
+  (so the old code had something to replicate) and that the pad carries the
+  background material anyway (so the new code does not replicate it).
+- **Not reached by this defect:** the global (unnamed-material) sweep,
+  which does no pad extension; and the non-uniform mesh path, where a
+  `dz_profile` makes the simulation ineligible for the vmap fast path
+  entirely (`_build_full_scan_fn` returns `None`) so the sequential
+  fallback — `run()` per value — is exact by construction.
+
+### Fixed — a sweep-parity test that could not see the defect it covers (issue #642b)
+
+`TestVmapSweepCPML::test_cpml_vmap_matches_sequential` ran at `n_steps=30`
+with `atol=1e-5, rtol=1e-4` and stayed green through the entire pre-#637
+era for a reason unrelated to the physics it names: the pulse had not
+meaningfully reached the absorber, so no pad defect could show. Both knobs
+are now measured rather than chosen, by injecting each defect and sweeping
+`n_steps`, reporting `max|diff| / (atol + rtol*|reference|)` — the quantity
+the assertion actually tests, so >1 means it fails.
+
+- **Run length.** With `_extend_batched_cpml_pad` disabled (the pre-#637
+  defect), under the OLD gate: `0.098` at 30 steps, `0.337` at 45, `1.010`
+  at 60, `7.218` at 90, `26.77` at 120, `60.77` at 200. It first crosses at
+  60 — by 1%, which cross-machine float jitter can erase, so 60 is not a
+  safe pick even though it nominally "sees it".
+- **Tolerance is an independent axis, not cosmetic.** The tighter gate
+  catches that same defect at `97x` at the ORIGINAL `n_steps=30`, where the
+  old gate saw `0.098x`. Both are moved because run length is what lets the
+  physics reach the absorber, while the tolerance is what a later
+  flake-chase is most likely to loosen; either alone leaves the other blind.
+- **`n_steps=200`, `atol=1e-8`, `rtol=1e-6`** is the only setting at which
+  BOTH parametrized rows are sensitive: `1.47e4x` over the gate for the
+  plain row's defect and `5.10e2x` for the thin-conductor row's (which
+  measures `0.937` — blind — at 120 AND at 150, then `5.10e2` at 200 and
+  `1.07e9` at 300; the jump is the divergence onset above). The clean tree
+  measures exactly `0.0` on both rows at every step count tried, so neither
+  knob costs anything.
+- **A third blindness shape, found while fixing the second.** The
+  thin-conductor fixture must span the full x extent: #642 is a
+  pad-EXTENSION leak, so the conductor has to sit on the column the x pads
+  replicate from. The first draft placed it interior (x 0.005–0.015) and
+  measured `7.5e-3` even at `n_steps=200` — blind by GEOMETRY, on top of
+  the "blind by run length" and "compared quantity cannot differ" shapes
+  the issue names. Recorded in the fixture so it is not undone.
+
 ### Fixed — two independent implementations of one CPML pad-extension rule, reconciled (issue #643)
 
 #627 (PR #638) and #637 (PR #641) each needed material values extended
@@ -167,6 +277,8 @@ longer a second copy to do so.
   production-side change this issue's own byte-identity requirement
   argues against bundling. Pinned by
   `test_thin_conductor_pad_leak_is_issue_642_not_643`, `xfail(strict=True)`.
+  **CLOSED since** — see the #642 entry above; the witness went XPASS(strict)
+  and is now a normal test under a new name.
 - Memory footprint note: the material-named branch now materialises all
   three `(n_batch, Nx, Ny, Nz)` arrays instead of one plus two broadcast
   views, because the joint pad decision needs all three. Materials go from

--- a/rfx/api/_compile.py
+++ b/rfx/api/_compile.py
@@ -121,8 +121,37 @@ class _CompileMixin:
     def _assemble_materials(
         self,
         grid: Grid,
+        *,
+        include_thin_conductors: bool = True,
     ) -> tuple[MaterialArrays, _DebyeSpec | None, _LorentzSpec | None, jnp.ndarray | None, list, list, jnp.ndarray | None]:
         """Build material arrays plus per-pole dispersion masks.
+
+        Parameters
+        ----------
+        include_thin_conductors : bool, default True
+            When False, stop one step short of the finished arrays and
+            return the state as it is *before* the ``_thin_conductors``
+            loop below — i.e. geometry rasterized and the CPML pad
+            extended, but no thin conductor applied yet. Everything else
+            (pole masks, conformal-face PEC injection, the ``has_pec``
+            decision) is unchanged, so the only difference is that a
+            lossy conductor's cells still carry their background material
+            and a PEC conductor's cells are absent from ``pec_mask``.
+
+            Only ``rfx.vmap_sweep`` passes False, and it needs this
+            because the ORDER here is load-bearing: the pad is extended
+            BEFORE conductors are applied, so ``run()``'s padding never
+            contains a conductor. The batched sweep path has to re-extend
+            the pad for each swept value, and extending the *finished*
+            arrays would replicate the conductor outward — a pad
+            ``run()`` never builds (issue #642). Handing that path the
+            pre-conductor arrays and letting it re-apply the same shared
+            ``apply_thin_conductor`` afterwards reproduces this order
+            instead of approximating it.
+
+            The default is True and no other caller passes it, so
+            ``run()`` and every existing path are unaffected by
+            construction.
 
         Returns
         -------
@@ -219,13 +248,18 @@ class _CompileMixin:
 
         materials = MaterialArrays(eps_r=eps_r, sigma=sigma, mu_r=mu_r)
 
-        # Apply thin conductors (P4: PEC thin sheets go to pec_mask)
-        for tc in self._thin_conductors:
-            materials, pec_mask = apply_thin_conductor(
-                grid, tc, materials, pec_mask=pec_mask)
-            if tc.is_pec:
-                pec_shapes.append(tc.shape)
-                has_pec_cells = True
+        # Apply thin conductors (P4: PEC thin sheets go to pec_mask).
+        # NOTE the position: this runs AFTER the pad extension above, so a
+        # conductor never lands in the CPML padding. rfx.vmap_sweep depends
+        # on being able to observe the state just before this loop — see
+        # ``include_thin_conductors`` in this method's docstring (#642).
+        if include_thin_conductors:
+            for tc in self._thin_conductors:
+                materials, pec_mask = apply_thin_conductor(
+                    grid, tc, materials, pec_mask=pec_mask)
+                if tc.is_pec:
+                    pec_shapes.append(tc.shape)
+                    has_pec_cells = True
 
         # Stage 1 conformal PEC face-shift (issue: WR-90 mesh-conv xfail).
         # When an axis is declared ``Boundary(conformal=True)`` we promote

--- a/rfx/vmap_sweep.py
+++ b/rfx/vmap_sweep.py
@@ -39,6 +39,7 @@ import numpy as np
 
 from rfx.core.yee import MaterialArrays, init_state, update_e, update_h, EPS_0
 from rfx.geometry.rasterize_grid import extend_cpml_pad_materials
+from rfx.materials.thin_conductor import apply_thin_conductor
 from rfx.probes.probes import DFTPlaneProbe, init_dft_plane_probe
 from rfx.simulation import (
     SourceSpec,
@@ -207,6 +208,52 @@ def _extend_batched_cpml_pad(
     return jax.vmap(_one)(eps_r, sigma, mu_r)
 
 
+def _apply_batched_thin_conductors(
+    sim, grid, eps_r: jnp.ndarray, sigma: jnp.ndarray, mu_r: jnp.ndarray,
+):
+    """Apply ``sim``'s thin conductors to BATCHED material arrays, each
+    shape ``(n_batch, Nx, Ny, Nz)``, by running the package's single
+    conductor rule — ``rfx.materials.thin_conductor.apply_thin_conductor``
+    — once per batch element under ``jax.vmap``, in the same order
+    ``Simulation._assemble_materials`` runs it.
+
+    This is the second half of the #642 fix. ``_assemble_materials``
+    extends the CPML pad and only THEN applies conductors, so ``run()``'s
+    padding never contains one. The batched path re-extends the pad per
+    swept value; to reproduce ``run()`` it must therefore re-extend the
+    *pre-conductor* arrays and re-apply the conductors afterwards, which
+    is exactly this call plus the ``include_thin_conductors=False``
+    assembly in ``_build_batched_materials``. Doing it the other way
+    round — extending the finished arrays, as the code did before #642 —
+    replicates the conductor's own ``eps_r``/``sigma`` outward into a pad
+    that ``run()`` fills with the background material instead.
+
+    PEC thin conductors are a no-op here by construction: they route to
+    ``pec_mask``, which the caller takes from the full (conductor-
+    inclusive) assembly and which does not vary across the sweep. The
+    returned mask is therefore discarded, not ignored by oversight.
+
+    A no-op when the simulation declares no thin conductors — the caller
+    guards on that, so this never materialises a batched copy for the
+    overwhelmingly common case.
+
+    Returns
+    -------
+    (eps_r, sigma, mu_r) — same shapes as the inputs.
+    """
+    conductors = tuple(sim._thin_conductors)
+    if not conductors:
+        return eps_r, sigma, mu_r
+
+    def _one(e, s, m):
+        mats = MaterialArrays(eps_r=e, sigma=s, mu_r=m)
+        for tc in conductors:
+            mats, _ = apply_thin_conductor(grid, tc, mats, pec_mask=None)
+        return mats.eps_r, mats.sigma, mats.mu_r
+
+    return jax.vmap(_one)(eps_r, sigma, mu_r)
+
+
 def _build_batched_materials(
     sim,
     grid,
@@ -237,6 +284,24 @@ def _build_batched_materials(
     pad rule rather than a second copy of it): without it, every swept
     batch element would run against a pad matched to the BASE material
     instead of its own.
+
+    **Thin conductors and pipeline ORDER (issue #642).**
+    ``_assemble_materials`` extends the pad and only THEN applies thin
+    conductors, so ``run()``'s padding carries the background material,
+    never the conductor. ``base_materials`` is the finished, post-conductor
+    array; re-extending it would copy the conductor's own ``eps_r`` /
+    ``sigma`` outward into the pad. #643 could not close that by making
+    the extension rule more faithful, because the rule was never the
+    problem — the batched path was handed the wrong INPUT. So when the
+    simulation declares thin conductors, the material-named branch below
+    re-derives the PRE-conductor arrays from the same assembler
+    (``include_thin_conductors=False``), builds the sweep and the pad from
+    those, and re-applies the same shared ``apply_thin_conductor``
+    afterwards — reproducing ``run()``'s order rather than approximating
+    its output. That also fixes a second consequence of the old order: a
+    conductor overlapping the swept material's cells is overwritten by the
+    swept value under the old code, whereas ``run()`` lets the conductor
+    win (it is applied last).
     """
     mat_name, field = _parse_param_name(param_name)
     n_batch = len(param_values)
@@ -246,6 +311,16 @@ def _build_batched_materials(
     mu_r = base_materials.mu_r
 
     if mat_name is not None:
+        # #642: build from the state run() extends the pad from, i.e.
+        # before its own thin-conductor pass. Only pay for the extra
+        # assembly when there is a conductor to be wrong about.
+        if sim._thin_conductors:
+            pre_materials, *_ = sim._assemble_materials(
+                grid, include_thin_conductors=False)
+            eps_r = pre_materials.eps_r
+            sigma = pre_materials.sigma
+            mu_r = pre_materials.mu_r
+
         # Build a mask for the specific material
         sim._resolve_material(mat_name)
         mask = jnp.zeros(grid.shape, dtype=jnp.bool_)
@@ -277,6 +352,12 @@ def _build_batched_materials(
         # hand-maintained copy of it.
         batch_eps, batch_sigma, batch_mu = _extend_batched_cpml_pad(
             batch_eps, batch_sigma, batch_mu, grid,
+        )
+
+        # #642: and only NOW the conductors, which is where
+        # _assemble_materials applies them relative to the extension above.
+        batch_eps, batch_sigma, batch_mu = _apply_batched_thin_conductors(
+            sim, grid, batch_eps, batch_sigma, batch_mu,
         )
     else:
         # Global sweep: apply to all non-background cells

--- a/tests/test_vmap_sweep.py
+++ b/tests/test_vmap_sweep.py
@@ -30,8 +30,17 @@ def _make_dielectric_sim(eps_r: float = 4.0):
     return sim
 
 
-def _make_cpml_sim(eps_r: float = 4.0):
-    """Create a CPML-bounded sim with a dielectric slab and probe."""
+def _make_cpml_sim(eps_r: float = 4.0, thin_conductor: bool = False):
+    """Create a CPML-bounded sim with a dielectric slab and probe.
+
+    ``thin_conductor`` adds a NON-PEC sheet spanning the full x extent
+    (issue #642). The full x span is load-bearing, not decoration: #642 is
+    a pad-EXTENSION leak, so the conductor has to sit on the very column
+    the x pads replicate from. An interior-only conductor
+    (x 0.005..0.015, the first draft of this fixture) measured a
+    diff/budget ratio of 7.5e-3 at n_steps=200 -- blind by GEOMETRY, a
+    third blindness shape on top of the two issue #642 names.
+    """
     sim = Simulation(
         freq_max=5e9,
         domain=(0.02, 0.02, 0.02),
@@ -41,6 +50,10 @@ def _make_cpml_sim(eps_r: float = 4.0):
     )
     sim.add_material("substrate", eps_r=eps_r)
     sim.add(Box((0.005, 0, 0), (0.015, 0.02, 0.02)), material="substrate")
+    if thin_conductor:
+        sim.add_thin_conductor(
+            Box((0.0, 0.008, 0.008), (0.02, 0.012, 0.012)),
+            sigma_bulk=1.0e4, thickness=35e-6)
     sim.add_source((0.01, 0.01, 0.01), "ez",
                     waveform=GaussianPulse(f0=3e9))
     sim.add_probe((0.005, 0.01, 0.01), "ez")
@@ -194,26 +207,68 @@ class TestVmapSweepCPML:
         ))
         assert diff > 0
 
-    def test_cpml_vmap_matches_sequential(self):
-        """CPML vmap results must match sequential runs."""
-        sim = _make_cpml_sim()
+    @pytest.mark.parametrize("thin_conductor", [False, True],
+                             ids=["plain", "thin_conductor"])
+    def test_cpml_vmap_matches_sequential(self, thin_conductor):
+        """CPML vmap results must match sequential runs.
+
+        ``n_steps`` and the tolerance are BOTH measured, not chosen
+        (issue #642(b)). This test ran at ``n_steps=30``,
+        ``atol=1e-5, rtol=1e-4`` and stayed green through the entire
+        pre-#637 era for a reason unrelated to the physics it names: the
+        pulse had not meaningfully reached the absorber yet, so a pad
+        defect could not show. Sensitivity was re-established by
+        INJECTING each defect and sweeping ``n_steps``, reporting
+        ``max|diff| / (atol + rtol*|reference|)`` -- i.e. >1 means this
+        assertion fails. Clean measures exactly ``0.0`` at every row, so
+        neither knob costs anything:
+
+        ``_extend_batched_cpml_pad`` disabled (the pre-#637 defect,
+        ``plain`` row), under the OLD gate:
+
+            n_steps :   30      45      60      90     120     200
+            ratio   : 0.098   0.337   1.010   7.218   26.77   60.77
+
+        60 is where it first crosses -- by 1%, which cross-machine float
+        jitter can erase, so 60 is not a safe pick even though it
+        nominally "sees it".
+
+        Pre-#642 pad order restored (``thin_conductor`` row), under the
+        NEW gate: 0.937 at 120 AND at 150, 5.10e2 at 200, 1.07e9 at 300.
+        That is not drift, it is divergence onset -- the R5 decile dump
+        at 400 steps shows the injected path's probe envelope growing
+        monotonically (last/mid decile 3.9e13) while the sequential
+        reference decays (9.1e-3). Leaking a 175 S/m sheet into the CPML
+        pad destabilises the run; #642 was never only an accuracy leak.
+
+        Hence ``n_steps=200``: the only value at which BOTH rows are
+        sensitive (1.47e4x and 5.10e2x over the gate). And hence the
+        tighter gate, which is an independent axis rather than a
+        cosmetic tightening -- it catches the ``plain`` defect at 97x
+        even at the old ``n_steps=30``, where the old gate saw 0.098x.
+        Both are moved because run length is what lets the physics reach
+        the absorber, while the tolerance is what a later flake-chase is
+        most likely to loosen; either one alone leaves the other blind.
+        """
+        sim = _make_cpml_sim(thin_conductor=thin_conductor)
         eps_values = np.array([2.0, 6.0])
-        n_steps = 30
+        n_steps = 200
 
         vmap_result = vmap_material_sweep(
             sim, "substrate.eps_r", eps_values, n_steps=n_steps,
         )
 
         for idx, eps_val in enumerate(eps_values):
-            sim_single = _make_cpml_sim(eps_r=float(eps_val))
+            sim_single = _make_cpml_sim(eps_r=float(eps_val),
+                                        thin_conductor=thin_conductor)
             single_result = sim_single.run(n_steps=n_steps)
             single_ts = np.asarray(single_result.time_series)
 
             npt.assert_allclose(
                 vmap_result.time_series[idx],
                 single_ts,
-                atol=1e-5,
-                rtol=1e-4,
+                atol=1e-8,
+                rtol=1e-6,
                 err_msg=f"CPML mismatch at eps_r={eps_val}",
             )
 

--- a/tests/test_vmap_sweep_dft_planes.py
+++ b/tests/test_vmap_sweep_dft_planes.py
@@ -678,35 +678,88 @@ class TestVmapBatchedPadByteIdentity:
             kwargs, "slab.mu_r", np.array([1.0, 3.0]),
             base_kwargs=dict(mu_r=2.0))
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "Known gap, issue #642, INHERITED not introduced by #643 -- "
-            "run() applies thin conductors AFTER pad extension "
-            "(rfx/api/_compile.py: extend_cpml_pad_materials, then the "
-            "_thin_conductors loop), while the batched path only ever "
-            "sees base_materials, which is already post-conductor. "
-            "Extending that array therefore replicates the conductor's "
-            "own sigma/eps_r into the pad, which run() never does. "
-            "Measured on the fixture below (NON-PEC thin conductor, "
-            "sigma_bulk=1e4): branch leaves 88 mismatched cells of "
-            "36501 (40 eps_r + 48 sigma, all inside the x pads); main "
-            "leaves 6592 (all eps_r, the #637/#643 defect, and zero "
-            "sigma because main only ever extended the ONE swept "
-            "field). So #643 is a 75x reduction overall AND a new "
-            "sigma-side mismatch this fixture did not have -- disclosed "
-            "rather than folded into #643, whose scope is the "
-            "pad-extension RULE, not the pipeline ORDER that #642 "
-            "tracks. A PEC thin conductor is unaffected (it routes to "
-            "pec_mask, not to the material arrays: 0 mismatched cells "
-            "on both). strict=True so this hard-fails the day #642 "
-            "lands, instead of rotting."
-        ),
+    @pytest.mark.parametrize(
+        "sigma_bulk,conductor_kind",
+        [(1.0e4, "non-PEC"), (5.8e7, "PEC")],
+        ids=["non_pec_conductor", "pec_conductor"],
     )
-    def test_thin_conductor_pad_leak_is_issue_642_not_643(self):
-        """#642 witness on the batched path. Kept next to the #643
-        matrix because the two are one line apart in the same pipeline
-        and the next person to touch either needs to see both."""
+    @pytest.mark.parametrize(
+        "param,values,base_value",
+        [("slab.eps_r", (2.0, 9.0), 4.0),
+         ("slab.sigma", (0.0, 0.05), 0.01),
+         ("slab.mu_r", (1.0, 3.0), 2.0)],
+        ids=["eps_r", "sigma", "mu_r"],
+    )
+    def test_thin_conductor_pad_matches_run(
+            self, sigma_bulk, conductor_kind, param, values, base_value):
+        """Issue #642: ``run()`` applies thin conductors AFTER the pad
+        extension (``rfx/api/_compile.py``: ``extend_cpml_pad_materials``,
+        then the ``_thin_conductors`` loop), so its padding carries the
+        background material and never the conductor.
+
+        HISTORY: this shipped with #643 as ``xfail(strict=True)``, because
+        #643's scope was the pad-extension RULE while this is the pipeline
+        ORDER. #643 made the batched path reuse the shared rule and could
+        not close this, since the batched path was handed the wrong INPUT
+        (``base_materials``, already post-conductor) rather than running
+        the wrong algorithm. Measured on the ``slab.eps_r`` row below:
+        88 mismatched cells per swept element of 12167 (40 ``eps_r`` +
+        48 ``sigma``, all inside the x pads) on #643's tree, 6592 on the
+        pre-#637 tree; **0** once ``_build_batched_materials`` re-derives
+        the PRE-conductor arrays and re-applies ``apply_thin_conductor``
+        after the extension. The ``sigma``/``mu_r`` sweeps were not in
+        the issue's own measurement and leak the same way (96 + 80 and
+        96 + 96 cells per pair respectively on #643's tree) -- the leak
+        is the conductor being replicated outward, so it does not depend
+        on which field is swept.
+
+        The PEC row is the must-pass companion, not filler: it measured
+        0 mismatched cells on every tree (a PEC conductor routes to
+        ``pec_mask``, not to the material arrays), so it is the case that
+        had to keep passing while the non-PEC case went from red to
+        green. An equality test can be satisfied by a fixture where
+        nothing could differ; ``test_thin_conductor_fixture_is_live``
+        below rules that out for the non-PEC row."""
+        field = param.split(".")[1]
+
+        def sim_fn(val):
+            kw = {"eps_r": 4.0, "sigma": 0.0, "mu_r": 1.0}
+            kw[field] = val
+            sim = _matrix_sim((0.0, 0.0, 0.0), (0.02, 0.02, 0.02), **kw)
+            sim.add_thin_conductor(
+                Box((0.0, 0.008, 0.008), (0.02, 0.012, 0.012)),
+                sigma_bulk=sigma_bulk, thickness=35e-6)
+            return sim
+
+        base_sim = sim_fn(base_value)
+        grid = base_sim._build_grid()
+        base_materials, *_ = base_sim._assemble_materials(grid)
+        vals = np.asarray(values, dtype=np.float32)
+        batched = _build_batched_materials(
+            base_sim, grid, base_materials, param, jnp.asarray(vals))
+        for idx, v in enumerate(vals):
+            want, *_ = sim_fn(float(v))._assemble_materials(grid)
+            for name in ("eps_r", "sigma", "mu_r"):
+                npt.assert_array_equal(
+                    np.asarray(getattr(batched, name)[idx]),
+                    np.asarray(getattr(want, name)),
+                    err_msg=(
+                        f"{conductor_kind} thin-conductor {name} pad "
+                        f"disagrees with run() at {param}={v} (#642)"),
+                )
+
+    def test_thin_conductor_fixture_is_live(self):
+        """Control for the non-PEC rows above: the conductor must sit ON
+        the column the pad replicates FROM, and the pad must nevertheless
+        carry the background material. Without this the equality above
+        could hold because the conductor is nowhere near a pad -- exactly
+        the vacuous-fixture failure mode #643's own matrix needed a
+        control for.
+
+        Asserts the two halves separately so a future failure says which
+        one moved: the conductor IS at the x-lo interior edge (so the old
+        code had something to replicate), and the x-lo pad is NOT the
+        conductor (so the new code does not replicate it)."""
         def sim_fn(eps_r):
             sim = _matrix_sim((0.0, 0.0, 0.0), (0.02, 0.02, 0.02),
                               eps_r=eps_r)
@@ -718,17 +771,39 @@ class TestVmapBatchedPadByteIdentity:
         base_sim = sim_fn(4.0)
         grid = base_sim._build_grid()
         base_materials, *_ = base_sim._assemble_materials(grid)
-        values = np.array([2.0, 9.0])
+        values = np.array([2.0, 9.0], dtype=np.float32)
         batched = _build_batched_materials(
             base_sim, grid, base_materials, "slab.eps_r",
             jnp.asarray(values))
+
+        plx = grid.pad_x_lo
+        assert plx > 0
+        # (y, z) inside the conductor bar: 0.008..0.012 m at dx=0.002 is
+        # interior nodes 4 and 5, i.e. grid index pad + 4.
+        jy = grid.pad_y_lo + 4
+        kz = grid.pad_z_lo + 4
+        # sigma_eff = sigma_bulk * thickness / dx
+        sigma_eff = 1.0e4 * 35e-6 / 0.002
+
         for idx, v in enumerate(values):
-            want, *_ = sim_fn(float(v))._assemble_materials(grid)
-            for name in ("eps_r", "sigma", "mu_r"):
-                npt.assert_array_equal(
-                    np.asarray(getattr(batched, name)[idx]),
-                    np.asarray(getattr(want, name)),
-                    err_msg=f"thin-conductor {name} pad leak (#642)")
+            eps = np.asarray(batched.eps_r[idx])
+            sig = np.asarray(batched.sigma[idx])
+            # Half 1: the conductor really is on the replication source.
+            assert sig[plx, jy, kz] == pytest.approx(sigma_eff), (
+                f"conductor absent from the x-lo interior edge column "
+                f"(sigma={sig[plx, jy, kz]}, expected {sigma_eff}) -- the "
+                f"fixture no longer exercises #642 and the equality test "
+                f"above is vacuous")
+            assert eps[plx, jy, kz] == pytest.approx(1.0)
+            # Half 2: and the pad is the background material anyway.
+            npt.assert_array_equal(
+                sig[:plx, jy, kz], np.zeros(plx, dtype=sig.dtype),
+                err_msg="conductor sigma leaked into the x-lo pad (#642)")
+            npt.assert_array_equal(
+                eps[:plx, jy, kz], np.full(plx, v, dtype=eps.dtype),
+                err_msg=("x-lo pad does not carry the swept slab eps_r -- "
+                         "either the conductor leaked (#642) or the pad "
+                         "extension regressed (#637/#643)"))
 
     def test_matrix_is_not_vacuous_swept_value_reaches_the_pad(self):
         """Control for the whole matrix above: at least one row must have


### PR DESCRIPTION
Closes #642.

`Simulation.run()` applies thin conductors AFTER CPML pad extension, but
`vmap_material_sweep`'s batched path only ever saw `base_materials` — already post-conductor.
So it was handed the wrong INPUT, not running the wrong algorithm, and #643's reconciliation
of the extension rule could not fix it.

## Fix

`_assemble_materials` gains a keyword-only `include_thin_conductors: bool = True`, guarding
its conductor loop. `_build_batched_materials`' material-named branch re-derives the
pre-conductor arrays, extends the pad, then re-applies conductors through a new
`_apply_batched_thin_conductors` that vmaps the shared `apply_thin_conductor`.

No caller other than `vmap_sweep` passes the new flag, so `run()` is unaffected by
construction rather than by promise.

## This was not only an accuracy leak — it destabilised the run

The finding that changes how the issue should be read. R5 decile dump at 400 steps with the
old pad order, batched path vs sequential reference:

```
batched (deciles 5..10):  8.8e-7 -> 2.9e-4 -> 9.8e-2 -> 33 -> 1.1e4 -> 3.8e6   (last/mid 3.9e13)
sequential reference:                                                    9.1e-3  (decaying)
```

Leaking a 175 S/m sheet into the CPML pad makes the batched run **diverge** while the
reference decays. Post-fix the two match to every printed digit. The issue was filed as a
parity/accuracy defect; it is a stability defect as well.

## Numbers

Mismatched cells per swept element (12167 per array), non-PEC conductor, main -> branch:

| swept field | main | branch |
|---|---|---|
| `eps_r` | 88 (40 eps + 48 sigma) | **0** |
| `sigma` | 88 (48 + 40) | **0** |
| `mu_r`  | 96 (48 + 48) | **0** |

PEC conductors measure 0 on both trees for all three sweeps — committed as the must-pass
companion row, so the new tests are not raise-only.

**The leak is not specific to the `eps_r` sweep.** The issue measured only that one; `sigma`
and `mu_r` leak identically, because what is replicated is the conductor, independent of which
field is being swept.

## `run()` is untouched

SHA-256 over final Yee field state plus probe time series, base vs branch, across
pec / cpml / lossy+cpml / nonuniform+cpml x with/without conductor: **16/16 identical**.
Independently confirmed on a separate 24-quantity harness: 24/24.

Two negative controls, both behaved: an `eps_r` 4.0 -> 4.001 nudge moves the digest, and
forcing `include_thin_conductors=False` through `run()`'s own assembly moves exactly the
conductor rows while leaving the conductor-free rows untouched.

## The blind test, with a measured threshold

`test_cpml_vmap_matches_sequential` could not see the defect at its committed run length.
Sensitivity measured as `max|diff|/(atol + rtol*|ref|)` (>1 means the test fails):

```
pre-#637 defect, old gate:  0.098@30  0.337@45  1.010@60  7.218@90  26.77@120  60.77@200
pre-#642 order, new gate:   0.937@120  0.937@150  5.10e2@200  1.07e9@300
```

The old gate crosses 1.0 at n_steps=60 by 1% — a threshold, not a safe value. Now
n_steps=200, atol=1e-8, rtol=1e-6: the only setting where both parametrized rows are sensitive
(1.47e4x and 5.10e2x). Tolerance is an independent axis — it catches the first defect at 97x
even at the original n_steps=30. A clean tree measures exactly 0.0 on both rows at every step
count.

## A third blindness shape

The first draft of the sensitivity fixture was itself vacuous: it placed the conductor in the
domain interior and measured 7.5e-3 even at 200 steps. #642 is a *pad-extension* leak, so the
conductor has to sit on the replication source column to be visible at all. That is blindness
by **geometry**, on top of the run-length and marker blindness already recorded in this arc.
The fixture now documents it.

## Not addressed here

- `tests/test_subpixel.py::TestBackwardCompatibility::test_update_e_aniso_matches_update_e_single_step`
  fails on the gpu/slow lane. Reproduces identically on a `git archive` of `ef8a008` —
  pre-existing, untouched by this change, disclosed rather than filtered out.
- Non-uniform sims are ineligible for the vmap fast path entirely (`_build_full_scan_fn`
  returns `None`), so this defect has no NU lane. Established while chasing a negative-control
  row that turned out to be my own wrong expectation, not a code defect.

## Bookkeeping note

This issue was CLOSED on 2026-08-11 by `ef8a008` — the #643 squash commit — whose body
contained `not fixed: #642`. GitHub's closing-keyword parser matched `fixed: #642` and ignored
the negation, so a sentence written to state the issue was NOT being closed closed it. It has
been reopened with an explanation; this PR closes it for real.

R3: memory=project_mesh_strategy_decision (vmap/run parity) | R2-attempts=1 |
falsifier=the strict-xfail witness, watched XFAIL-on-base then XPASS(strict)-red with the fix
before the marker was removed
