### PR TITLE
fix(dispersion): narrow the ADE and dispersive-E carries so precision= works with poles (closes #656)

### DIFF
--- a/rfx/api/_compile.py
+++ b/rfx/api/_compile.py
@@ -349,17 +349,27 @@ class _CompileMixin:
         dt: float,
         debye_spec: _DebyeSpec | None,
         lorentz_spec: _LorentzSpec | None,
+        *,
+        field_dtype=None,
     ) -> tuple[MaterialArrays, tuple | None, tuple | None]:
-        """Initialize Debye/Lorentz coefficients for the given materials."""
+        """Initialize Debye/Lorentz coefficients for the given materials.
+
+        ``field_dtype`` is the field storage dtype the ADE state will be
+        driven by; the P carry is allocated at
+        ``ade_state_dtype(field_dtype)`` (issue #656). Callers that leave it
+        ``None`` get the ambient default float with a float32 floor.
+        """
         debye = None
         if debye_spec is not None:
             debye_poles, debye_masks = debye_spec
-            debye = init_debye(debye_poles, materials, dt, mask=debye_masks)
+            debye = init_debye(debye_poles, materials, dt, mask=debye_masks,
+                               field_dtype=field_dtype)
 
         lorentz = None
         if lorentz_spec is not None:
             lorentz_poles, lorentz_masks = lorentz_spec
-            lorentz = init_lorentz(lorentz_poles, materials, dt, mask=lorentz_masks)
+            lorentz = init_lorentz(lorentz_poles, materials, dt, mask=lorentz_masks,
+                                   field_dtype=field_dtype)
 
         return materials, debye, lorentz
 

--- a/rfx/core/yee.py
+++ b/rfx/core/yee.py
@@ -58,6 +58,48 @@ def init_state(shape: tuple[int, int, int], *, field_dtype=jnp.float32) -> FDTDS
     )
 
 
+def ade_state_dtype(field_dtype=None):
+    """Dtype for a dispersion ADE polarization carry, given the field dtype.
+
+    One policy, shared by ``rfx.materials.debye.init_debye`` and
+    ``rfx.materials.lorentz.init_lorentz`` (allocation); the matching scan
+    bodies derive their output dtype from the carry they were handed, so the
+    ``lax.scan`` carry closes (issue #656, same family as #630/#644/#646).
+
+    ``promote_types(field_dtype, float32)`` — PROMOTE, never pin, never a bare
+    copy of the field dtype:
+
+    * float16 (``precision="mixed"``) -> float32.  The float32 floor is
+      mandatory: P is a recursive accumulator (``P^{n+1}`` is built from
+      ``P^n``/``P^{n-1}``), and float16's 11-bit mantissa would destroy it.
+      ``precision="mixed"`` promises float16 FIELDS with float32 accumulation.
+    * float32 (the default)             -> float32.  Unchanged, x64 or not.
+    * float64 (``precision="float64"``) -> float64.  The hard float32 pin this
+      replaces is what made any Debye/Lorentz/Drude pole crash there.
+    * complex64                         -> complex64.  A flat float32 pin
+      would silently drop the imaginary part; ``promote_types`` preserves it.
+
+    ``field_dtype=None`` (a caller that does not thread the field dtype)
+    falls back to the ambient default float with the same float32 floor —
+    the ``rfx.lumped.init_rlc_state`` precedent from #646 — so the carry
+    tracks ``jax_enable_x64`` instead of pinning under it.
+
+    The float64 row needs x64 actually enabled: the ``jnp.result_type``
+    wrapper clamps an unavailable float64 back to float32, so this returns a
+    dtype that is allocatable rather than one ``jnp.zeros`` would silently
+    truncate. Same clamp, and same wrapper, as ``farfield.ntff_accum_dtype``;
+    it is the documented ``precision="float64"``-without-x64 footgun that
+    ``preflight()`` reports as ``precision_float64_without_x64``.
+
+    NOTE the complex row is a policy statement, not a supported lane: the
+    dispersive branches of ``update_e_dispersive`` ignore the Bloch phase
+    (#404), so oblique-Bloch + dispersion is unsupported and still raises a
+    carry-dtype mismatch rather than closing on wrong physics.
+    """
+    base = jnp.result_type(float) if field_dtype is None else jnp.dtype(field_dtype)
+    return jnp.result_type(jnp.promote_types(base, jnp.float32))
+
+
 def init_materials(shape: tuple[int, int, int]) -> MaterialArrays:
     """Initialize free-space material arrays."""
     ones = jnp.ones(shape, dtype=jnp.float32)

--- a/rfx/materials/debye.py
+++ b/rfx/materials/debye.py
@@ -29,7 +29,9 @@ from typing import NamedTuple
 
 import jax.numpy as jnp
 
-from rfx.core.yee import EPS_0, FDTDState, MaterialArrays, _shift_bwd
+from rfx.core.yee import (
+    EPS_0, FDTDState, MaterialArrays, _shift_bwd, ade_state_dtype,
+)
 
 
 class DebyePole(NamedTuple):
@@ -76,6 +78,8 @@ def init_debye(
     materials: MaterialArrays,
     dt: float,
     mask: jnp.ndarray | list[jnp.ndarray] | tuple[jnp.ndarray, ...] | None = None,
+    *,
+    field_dtype=None,
 ) -> tuple[DebyeCoeffs, DebyeState]:
     """Initialize Debye ADE coefficients and auxiliary state.
 
@@ -90,6 +94,14 @@ def init_debye(
     mask : (nx, ny, nz) bool array or per-pole mask list, optional
         Where to apply Debye dispersion. If a list/tuple is provided,
         it must align one-to-one with ``poles``.
+    field_dtype : jnp dtype, optional
+        Dtype of the E/H field storage this ADE state will be driven by.
+        The P carry is allocated at ``ade_state_dtype(field_dtype)`` —
+        ``promote_types(field_dtype, float32)``. ``None`` (the default, for
+        callers that do not thread it) means the ambient default float with
+        the same float32 floor. This used to be a hard ``dtype=jnp.float32``
+        pin, which made ``precision="float64"`` + any pole fail the
+        ``lax.scan`` carry contract (issue #656).
 
     Returns
     -------
@@ -125,8 +137,14 @@ def init_debye(
             a_arr = jnp.where(pole_mask, a, 0.0)
             b_arr = jnp.where(pole_mask, b, 0.0)
         else:
-            a_arr = jnp.full(shape, a, dtype=jnp.float32)
-            b_arr = jnp.full(shape, b, dtype=jnp.float32)
+            # No dtype pin — see the matching note in
+            # ``rfx.materials.lorentz.init_lorentz`` (issue #656): ``a``/``b``
+            # are numpy scalars (``dt`` is ``grid.dt``, an np.float64), so
+            # this now matches the masked branch above instead of capping the
+            # ADE coefficients at float32 under ``precision="float64"``.
+            # With x64 off JAX clamps to float32: default lane unchanged.
+            a_arr = jnp.full(shape, a)
+            b_arr = jnp.full(shape, b)
 
         alpha_list.append(a_arr)
         beta_list.append(b_arr)
@@ -155,7 +173,7 @@ def init_debye(
     coeffs = DebyeCoeffs(ca=ca, cb=cb, cc=cc, alpha=alpha, beta=beta)
 
     # Zero-initialized polarization state
-    p_zeros = jnp.zeros((n_poles,) + shape, dtype=jnp.float32)
+    p_zeros = jnp.zeros((n_poles,) + shape, dtype=ade_state_dtype(field_dtype))
     state = DebyeState(px=p_zeros, py=p_zeros.copy(), pz=p_zeros.copy())
 
     return coeffs, state
@@ -178,11 +196,22 @@ def update_e_debye(
     1. Compute curl(H) (backward differences)
     2. E^{n+1} = Ca·E^n + Cb·curl(H) + Σ_p Cc_p·P_p^n
     3. P_p^{n+1} = α_p·P_p^n + β_p·(E^{n+1} + E^n)
+
+    Dtype note (issue #656)
+    -----------------------
+    Both outputs are narrowed back to the dtype of the carry they came from.
+    See the fuller note on ``rfx.materials.lorentz.update_e_lorentz``: the
+    coefficients are built at setup time from ``dt`` (``grid.dt``, a numpy
+    float64 scalar, STRONGLY typed in JAX), so allocation-site promotion
+    alone does not close this scan.
     """
     def bwd(arr, axis):
         if periodic[axis]:
             return jnp.roll(arr, 1, axis)
         return _shift_bwd(arr, axis)
+
+    _fdtype = state.ex.dtype
+    _pdtype = jnp.promote_types(debye_state.px.dtype, _fdtype)
 
     hx, hy, hz = state.hx, state.hy, state.hz
     ca, cb, cc = coeffs.ca, coeffs.cb, coeffs.cc
@@ -197,14 +226,20 @@ def update_e_debye(
     ex_old, ey_old, ez_old = state.ex, state.ey, state.ez
 
     # E^{n+1} = Ca·E^n + Cb·curl(H) + Σ_p Cc_p·P_p^n
-    ex_new = ca * ex_old + cb * curl_x + jnp.sum(cc * debye_state.px, axis=0)
-    ey_new = ca * ey_old + cb * curl_y + jnp.sum(cc * debye_state.py, axis=0)
-    ez_new = ca * ez_old + cb * curl_z + jnp.sum(cc * debye_state.pz, axis=0)
+    ex_new = (ca * ex_old + cb * curl_x
+              + jnp.sum(cc * debye_state.px, axis=0)).astype(_fdtype)
+    ey_new = (ca * ey_old + cb * curl_y
+              + jnp.sum(cc * debye_state.py, axis=0)).astype(_fdtype)
+    ez_new = (ca * ez_old + cb * curl_z
+              + jnp.sum(cc * debye_state.pz, axis=0)).astype(_fdtype)
 
     # P_p^{n+1} = α_p·P_p^n + β_p·(E^{n+1} + E^n)
-    px_new = alpha * debye_state.px + beta * (ex_new[None] + ex_old[None])
-    py_new = alpha * debye_state.py + beta * (ey_new[None] + ey_old[None])
-    pz_new = alpha * debye_state.pz + beta * (ez_new[None] + ez_old[None])
+    px_new = (alpha * debye_state.px
+              + beta * (ex_new[None] + ex_old[None])).astype(_pdtype)
+    py_new = (alpha * debye_state.py
+              + beta * (ey_new[None] + ey_old[None])).astype(_pdtype)
+    pz_new = (alpha * debye_state.pz
+              + beta * (ez_new[None] + ez_old[None])).astype(_pdtype)
 
     new_fdtd = state._replace(
         ex=ex_new, ey=ey_new, ez=ez_new,

--- a/rfx/materials/lorentz.py
+++ b/rfx/materials/lorentz.py
@@ -25,7 +25,7 @@ from typing import NamedTuple
 
 import jax.numpy as jnp
 
-from rfx.core.yee import EPS_0, FDTDState, _shift_bwd
+from rfx.core.yee import EPS_0, FDTDState, _shift_bwd, ade_state_dtype
 
 
 class LorentzPole(NamedTuple):
@@ -105,6 +105,8 @@ def init_lorentz(
     materials,
     dt: float,
     mask: jnp.ndarray | list[jnp.ndarray] | tuple[jnp.ndarray, ...] | None = None,
+    *,
+    field_dtype=None,
 ) -> tuple[LorentzCoeffs, LorentzState]:
     """Initialize Lorentz/Drude ADE coefficients and state.
 
@@ -114,6 +116,14 @@ def init_lorentz(
     materials : MaterialArrays (eps_r = ε_∞)
     dt : float
     mask : optional spatial mask
+    field_dtype : jnp dtype, optional
+        Dtype of the E/H field storage this ADE state will be driven by.
+        The P carry is allocated at ``ade_state_dtype(field_dtype)`` —
+        ``promote_types(field_dtype, float32)``. ``None`` (the default, for
+        callers that do not thread it) means the ambient default float with
+        the same float32 floor. This used to be a hard ``dtype=jnp.float32``
+        pin, which made ``precision="float64"`` + any pole fail the
+        ``lax.scan`` carry contract (issue #656).
 
     Returns
     -------
@@ -150,9 +160,16 @@ def init_lorentz(
             b_arr = jnp.where(pole_mask, b_val, 0.0)
             c_arr = jnp.where(pole_mask, c_val, 0.0)
         else:
-            a_arr = jnp.full(shape, a_val, dtype=jnp.float32)
-            b_arr = jnp.full(shape, b_val, dtype=jnp.float32)
-            c_arr = jnp.full(shape, c_val, dtype=jnp.float32)
+            # No dtype pin: ``a_val``/``b_val``/``c_val`` are numpy scalars
+            # (``dt`` is ``grid.dt``, an np.float64), so this matches the
+            # masked branch above, which has always produced whatever
+            # ``jnp.where`` promotes to. A hard float32 here made the two
+            # branches disagree and capped the ADE coefficients at float32
+            # under ``precision="float64"`` (issue #656). With x64 off JAX
+            # clamps to float32, so the default lane is unchanged.
+            a_arr = jnp.full(shape, a_val)
+            b_arr = jnp.full(shape, b_val)
+            c_arr = jnp.full(shape, c_val)
 
         a_list.append(a_arr)
         b_list.append(b_arr)
@@ -171,7 +188,7 @@ def init_lorentz(
 
     coeffs = LorentzCoeffs(ca=ca, cb=cb, a=a, b=b, c=c, cc=cc)
 
-    zeros = jnp.zeros((n_poles,) + shape, dtype=jnp.float32)
+    zeros = jnp.zeros((n_poles,) + shape, dtype=ade_state_dtype(field_dtype))
     state = LorentzState(
         px=zeros, py=zeros.copy(), pz=zeros.copy(),
         px_prev=zeros.copy(), py_prev=zeros.copy(), pz_prev=zeros.copy(),
@@ -193,11 +210,31 @@ def update_e_lorentz(
     Update order:
     1. P^{n+1} = a P^n + b P^{n-1} + c E^n  (explicit)
     2. E^{n+1} = Ca E^n + Cb curl(H) - Cc Σ(P^{n+1} - P^n)
+
+    Dtype note (issue #656)
+    -----------------------
+    Both outputs are narrowed back to the dtype of the carry they came from,
+    the ``rfx.core.yee.update_e`` idiom (#630) plus #646's "let the body
+    derive its dtype from the carry". Allocation-site promotion alone does
+    NOT close this scan: ``ca``/``cb``/``cc`` and (masked) ``a``/``b``/``c``
+    are built at setup time from ``dt``, which is ``grid.dt``, a **numpy
+    float64 scalar** — and numpy scalars are STRONGLY typed in JAX where
+    Python floats are weak. So under x64 the coefficients are float64 and
+    this body would return float64 for a float32 field/P carry.
+
+    ``_pdtype`` promotes rather than pinning to ``lor_state.px.dtype`` on
+    purpose: with a real P carry and a COMPLEX field (oblique Bloch, #404) it
+    stays complex, so the carry mismatch is still raised. Pinning would cast
+    the imaginary part away and close the scan on wrong physics — the
+    dispersive branches ignore the Bloch phase entirely.
     """
     def bwd(arr, axis):
         if periodic[axis]:
             return jnp.roll(arr, 1, axis)
         return _shift_bwd(arr, axis)
+
+    _fdtype = state.ex.dtype
+    _pdtype = jnp.promote_types(lor_state.px.dtype, _fdtype)
 
     hx, hy, hz = state.hx, state.hy, state.hz
     ca, cb, cc = coeffs.ca, coeffs.cb, coeffs.cc
@@ -209,9 +246,12 @@ def update_e_lorentz(
     curl_z = ((hy - bwd(hy, 0)) - (hx - bwd(hx, 1))) / dx
 
     # P^{n+1} = a P^n + b P^{n-1} + c E^n (per pole)
-    px_new = a * lor_state.px + b * lor_state.px_prev + c * state.ex[None]
-    py_new = a * lor_state.py + b * lor_state.py_prev + c * state.ey[None]
-    pz_new = a * lor_state.pz + b * lor_state.pz_prev + c * state.ez[None]
+    px_new = (a * lor_state.px + b * lor_state.px_prev
+              + c * state.ex[None]).astype(_pdtype)
+    py_new = (a * lor_state.py + b * lor_state.py_prev
+              + c * state.ey[None]).astype(_pdtype)
+    pz_new = (a * lor_state.pz + b * lor_state.pz_prev
+              + c * state.ez[None]).astype(_pdtype)
 
     # ΔP = P^{n+1} - P^n, summed over poles
     dpx = jnp.sum(px_new - lor_state.px, axis=0)
@@ -219,9 +259,9 @@ def update_e_lorentz(
     dpz = jnp.sum(pz_new - lor_state.pz, axis=0)
 
     # E^{n+1} = Ca E^n + Cb curl(H) - Cc ΔP
-    ex_new = ca * state.ex + cb * curl_x - cc * dpx
-    ey_new = ca * state.ey + cb * curl_y - cc * dpy
-    ez_new = ca * state.ez + cb * curl_z - cc * dpz
+    ex_new = (ca * state.ex + cb * curl_x - cc * dpx).astype(_fdtype)
+    ey_new = (ca * state.ey + cb * curl_y - cc * dpy).astype(_fdtype)
+    ez_new = (ca * state.ez + cb * curl_z - cc * dpz).astype(_fdtype)
 
     new_fdtd = state._replace(
         ex=ex_new, ey=ey_new, ez=ez_new,

--- a/rfx/nonuniform.py
+++ b/rfx/nonuniform.py
@@ -683,19 +683,33 @@ def _update_e_nu_dispersive(
     else:
         ex_old, ey_old, ez_old = state.ex, state.ey, state.ez
 
+    # Narrow every output back to the dtype of the carry it came from
+    # (issue #656) — the NU lane runs the same ADE recurrences off the same
+    # ``init_debye``/``init_lorentz`` coefficients, which are built from
+    # ``grid.dt`` (an np.float64 scalar, strongly typed in JAX). The full
+    # rationale lives on ``rfx.materials.lorentz.update_e_lorentz``.
+    _fdtype = state.ex.dtype
+
     # --- Debye only ---
     if debye is not None and lorentz is None:
         debye_coeffs, debye_state = debye
         ca, cb, cc = debye_coeffs.ca, debye_coeffs.cb, debye_coeffs.cc
         alpha, beta = debye_coeffs.alpha, debye_coeffs.beta
+        _pdtype = jnp.promote_types(debye_state.px.dtype, _fdtype)
 
-        ex_new = ca * ex_old + cb * curl_x + jnp.sum(cc * debye_state.px, axis=0)
-        ey_new = ca * ey_old + cb * curl_y + jnp.sum(cc * debye_state.py, axis=0)
-        ez_new = ca * ez_old + cb * curl_z + jnp.sum(cc * debye_state.pz, axis=0)
+        ex_new = (ca * ex_old + cb * curl_x
+                  + jnp.sum(cc * debye_state.px, axis=0)).astype(_fdtype)
+        ey_new = (ca * ey_old + cb * curl_y
+                  + jnp.sum(cc * debye_state.py, axis=0)).astype(_fdtype)
+        ez_new = (ca * ez_old + cb * curl_z
+                  + jnp.sum(cc * debye_state.pz, axis=0)).astype(_fdtype)
 
-        px_new = alpha * debye_state.px + beta * (ex_new[None] + ex_old[None])
-        py_new = alpha * debye_state.py + beta * (ey_new[None] + ey_old[None])
-        pz_new = alpha * debye_state.pz + beta * (ez_new[None] + ez_old[None])
+        px_new = (alpha * debye_state.px
+                  + beta * (ex_new[None] + ex_old[None])).astype(_pdtype)
+        py_new = (alpha * debye_state.py
+                  + beta * (ey_new[None] + ey_old[None])).astype(_pdtype)
+        pz_new = (alpha * debye_state.pz
+                  + beta * (ez_new[None] + ez_old[None])).astype(_pdtype)
 
         new_fdtd = state._replace(ex=ex_new, ey=ey_new, ez=ez_new,
                                   step=state.step + 1)
@@ -707,18 +721,22 @@ def _update_e_nu_dispersive(
         lorentz_coeffs, lor_state = lorentz
         ca, cb, cc = lorentz_coeffs.ca, lorentz_coeffs.cb, lorentz_coeffs.cc
         a, b, c = lorentz_coeffs.a, lorentz_coeffs.b, lorentz_coeffs.c
+        _pdtype = jnp.promote_types(lor_state.px.dtype, _fdtype)
 
-        px_new = a * lor_state.px + b * lor_state.px_prev + c * ex_old[None]
-        py_new = a * lor_state.py + b * lor_state.py_prev + c * ey_old[None]
-        pz_new = a * lor_state.pz + b * lor_state.pz_prev + c * ez_old[None]
+        px_new = (a * lor_state.px + b * lor_state.px_prev
+                  + c * ex_old[None]).astype(_pdtype)
+        py_new = (a * lor_state.py + b * lor_state.py_prev
+                  + c * ey_old[None]).astype(_pdtype)
+        pz_new = (a * lor_state.pz + b * lor_state.pz_prev
+                  + c * ez_old[None]).astype(_pdtype)
 
         dpx = jnp.sum(px_new - lor_state.px, axis=0)
         dpy = jnp.sum(py_new - lor_state.py, axis=0)
         dpz = jnp.sum(pz_new - lor_state.pz, axis=0)
 
-        ex_new = ca * ex_old + cb * curl_x - cc * dpx
-        ey_new = ca * ey_old + cb * curl_y - cc * dpy
-        ez_new = ca * ez_old + cb * curl_z - cc * dpz
+        ex_new = (ca * ex_old + cb * curl_x - cc * dpx).astype(_fdtype)
+        ey_new = (ca * ey_old + cb * curl_y - cc * dpy).astype(_fdtype)
+        ez_new = (ca * ez_old + cb * curl_z - cc * dpz).astype(_fdtype)
 
         new_fdtd = state._replace(ex=ex_new, ey=ey_new, ez=ez_new,
                                   step=state.step + 1)
@@ -731,17 +749,19 @@ def _update_e_nu_dispersive(
     # --- Mixed Debye + Lorentz ---
     debye_coeffs, debye_state = debye
     lorentz_coeffs, lor_state = lorentz
+    _dpdtype = jnp.promote_types(debye_state.px.dtype, _fdtype)
+    _lpdtype = jnp.promote_types(lor_state.px.dtype, _fdtype)
 
     # Explicit Lorentz polarization update first
     px_l_new = (lorentz_coeffs.a * lor_state.px
                 + lorentz_coeffs.b * lor_state.px_prev
-                + lorentz_coeffs.c * ex_old[None])
+                + lorentz_coeffs.c * ex_old[None]).astype(_lpdtype)
     py_l_new = (lorentz_coeffs.a * lor_state.py
                 + lorentz_coeffs.b * lor_state.py_prev
-                + lorentz_coeffs.c * ey_old[None])
+                + lorentz_coeffs.c * ey_old[None]).astype(_lpdtype)
     pz_l_new = (lorentz_coeffs.a * lor_state.pz
                 + lorentz_coeffs.b * lor_state.pz_prev
-                + lorentz_coeffs.c * ez_old[None])
+                + lorentz_coeffs.c * ez_old[None]).astype(_lpdtype)
 
     dpx_l = jnp.sum(px_l_new - lor_state.px, axis=0)
     dpy_l = jnp.sum(py_l_new - lor_state.py, axis=0)
@@ -759,20 +779,23 @@ def _update_e_nu_dispersive(
 
     ex_new = (ca * ex_old + cb * curl_x
               + jnp.sum(cc_debye * debye_state.px, axis=0)
-              - cc_lorentz * dpx_l)
+              - cc_lorentz * dpx_l).astype(_fdtype)
     ey_new = (ca * ey_old + cb * curl_y
               + jnp.sum(cc_debye * debye_state.py, axis=0)
-              - cc_lorentz * dpy_l)
+              - cc_lorentz * dpy_l).astype(_fdtype)
     ez_new = (ca * ez_old + cb * curl_z
               + jnp.sum(cc_debye * debye_state.pz, axis=0)
-              - cc_lorentz * dpz_l)
+              - cc_lorentz * dpz_l).astype(_fdtype)
 
     new_fdtd = state._replace(ex=ex_new, ey=ey_new, ez=ez_new,
                               step=state.step + 1)
     new_debye = DebyeState(
-        px=debye_coeffs.alpha * debye_state.px + debye_coeffs.beta * (ex_new[None] + ex_old[None]),
-        py=debye_coeffs.alpha * debye_state.py + debye_coeffs.beta * (ey_new[None] + ey_old[None]),
-        pz=debye_coeffs.alpha * debye_state.pz + debye_coeffs.beta * (ez_new[None] + ez_old[None]),
+        px=(debye_coeffs.alpha * debye_state.px
+            + debye_coeffs.beta * (ex_new[None] + ex_old[None])).astype(_dpdtype),
+        py=(debye_coeffs.alpha * debye_state.py
+            + debye_coeffs.beta * (ey_new[None] + ey_old[None])).astype(_dpdtype),
+        pz=(debye_coeffs.alpha * debye_state.pz
+            + debye_coeffs.beta * (ez_new[None] + ez_old[None])).astype(_dpdtype),
     )
     new_lor = LorentzState(
         px=px_l_new, py=py_l_new, pz=pz_l_new,

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -621,8 +621,16 @@ def run_uniform(
         from rfx.simulation import make_source as _make_src
         sources.append(_make_src(grid, tuple(center), comp, wf, n_steps))
 
+    # Thread the field storage dtype into the ADE carry (issue #656), the
+    # same way ``rfx.simulation.run`` threads it into the CPML psi / NTFF /
+    # RLC carries.  ``None`` here means "default precision", which
+    # ``rfx.simulation.run`` resolves to float32 — resolve it identically so
+    # ``precision="float32"`` keeps a float32 ADE carry even when x64 has
+    # been enabled elsewhere in the process, and ``precision="mixed"``
+    # (float16) gets the float32 accumulation floor it promises.
     _, debye, lorentz = sim._init_dispersion(
-        materials, grid.dt, debye_spec, lorentz_spec)
+        materials, grid.dt, debye_spec, lorentz_spec,
+        field_dtype=field_dtype if field_dtype is not None else jnp.float32)
 
     # NTFF box
     ntff_box = None

--- a/rfx/simulation.py
+++ b/rfx/simulation.py
@@ -427,6 +427,13 @@ def _update_e_with_optional_dispersion(
             return jnp.roll(arr, 1, axis)
         return _shift_bwd(arr, axis)
 
+    # Narrow every output back to the dtype of the carry it came from
+    # (issue #656) — same policy as the single-model bodies in
+    # rfx/materials/{debye,lorentz}.py, which carry the full rationale.
+    _fdtype = state.ex.dtype
+    _dpdtype = jnp.promote_types(debye_state.px.dtype, _fdtype)
+    _lpdtype = jnp.promote_types(lorentz_state.px.dtype, _fdtype)
+
     hx, hy, hz = state.hx, state.hy, state.hz
 
     curl_x = ((hz - bwd(hz, 1)) - (hy - bwd(hy, 2))) / dx
@@ -440,17 +447,17 @@ def _update_e_with_optional_dispersion(
         lorentz_coeffs.a * lorentz_state.px
         + lorentz_coeffs.b * lorentz_state.px_prev
         + lorentz_coeffs.c * ex_old[None]
-    )
+    ).astype(_lpdtype)
     py_l_new = (
         lorentz_coeffs.a * lorentz_state.py
         + lorentz_coeffs.b * lorentz_state.py_prev
         + lorentz_coeffs.c * ey_old[None]
-    )
+    ).astype(_lpdtype)
     pz_l_new = (
         lorentz_coeffs.a * lorentz_state.pz
         + lorentz_coeffs.b * lorentz_state.pz_prev
         + lorentz_coeffs.c * ez_old[None]
-    )
+    ).astype(_lpdtype)
 
     dpx_l = jnp.sum(px_l_new - lorentz_state.px, axis=0)
     dpy_l = jnp.sum(py_l_new - lorentz_state.py, axis=0)
@@ -471,19 +478,19 @@ def _update_e_with_optional_dispersion(
         + cb * curl_x
         + jnp.sum(cc_debye * debye_state.px, axis=0)
         - cc_lorentz * dpx_l
-    )
+    ).astype(_fdtype)
     ey_new = (
         ca * ey_old
         + cb * curl_y
         + jnp.sum(cc_debye * debye_state.py, axis=0)
         - cc_lorentz * dpy_l
-    )
+    ).astype(_fdtype)
     ez_new = (
         ca * ez_old
         + cb * curl_z
         + jnp.sum(cc_debye * debye_state.pz, axis=0)
         - cc_lorentz * dpz_l
-    )
+    ).astype(_fdtype)
 
     new_fdtd = state._replace(
         ex=ex_new,
@@ -492,9 +499,12 @@ def _update_e_with_optional_dispersion(
         step=state.step + 1,
     )
     new_debye = DebyeState(
-        px=debye_coeffs.alpha * debye_state.px + debye_coeffs.beta * (ex_new[None] + ex_old[None]),
-        py=debye_coeffs.alpha * debye_state.py + debye_coeffs.beta * (ey_new[None] + ey_old[None]),
-        pz=debye_coeffs.alpha * debye_state.pz + debye_coeffs.beta * (ez_new[None] + ez_old[None]),
+        px=(debye_coeffs.alpha * debye_state.px
+            + debye_coeffs.beta * (ex_new[None] + ex_old[None])).astype(_dpdtype),
+        py=(debye_coeffs.alpha * debye_state.py
+            + debye_coeffs.beta * (ey_new[None] + ey_old[None])).astype(_dpdtype),
+        pz=(debye_coeffs.alpha * debye_state.pz
+            + debye_coeffs.beta * (ez_new[None] + ez_old[None])).astype(_dpdtype),
     )
     new_lorentz = LorentzState(
         px=px_l_new,

--- a/tests/test_x64_scan_carry_dtypes.py
+++ b/tests/test_x64_scan_carry_dtypes.py
@@ -9,6 +9,17 @@ with ``scan body function carry input and carry output must have equal types``:
     rfx/farfield.py     init_ntff_data()      {x,y,z}_{lo,hi}, c_{x,y,z}_{lo,hi}
     rfx/sources/tfsf_2d.py init_tfsf_2d()     ez_2d, hx_2d, hy_2d, psi_*
 
+Issue #656 added a FOURTH family, missed by #646 because none of the tests
+that exercised x64 (series-RLC, RCS, oblique TFSF) build a dispersive
+material -- so a whole file of ADE allocation sites went unhashed:
+
+    rfx/materials/debye.py    init_debye()     px, py, pz
+    rfx/materials/lorentz.py  init_lorentz()   px, py, pz, p{x,y,z}_prev
+
+which made ``precision="float64"`` + ANY Debye/Lorentz/Drude pole raise, and
+``precision="mixed"`` + any pole raise even with x64 OFF (float16 fields
+against a float32-pinned P state).
+
 MECHANISM (measured, and NOT what the issue first proposed). The promoting
 quantity is not the field dtype -- the fields stay float32 under x64. It is
 ``grid.dt``: ``Grid.__init__`` computes it with numpy, so it is an
@@ -40,10 +51,14 @@ import pytest
 
 from rfx import Simulation
 from rfx.grid import Grid, C0
-from rfx.core.yee import MaterialArrays, init_materials
+from rfx.core.yee import MaterialArrays, ade_state_dtype, init_materials
 from rfx.geometry.csg import Box, rasterize
 from rfx.farfield import ntff_accum_dtype, init_ntff_data, NTFFBox
 from rfx.lumped import init_rlc_state
+import rfx.materials.debye as _debye_mod
+import rfx.materials.lorentz as _lorentz_mod
+from rfx.materials.debye import DebyePole, init_debye
+from rfx.materials.lorentz import drude_pole, init_lorentz, lorentz_pole
 from rfx.rcs import compute_rcs
 from rfx.simulation import run, ProbeSpec
 from rfx.sources.tfsf import init_tfsf
@@ -263,3 +278,246 @@ def test_enable_x64_context_restores_the_flag():
     with enable_x64():
         assert bool(jax.config.jax_enable_x64) is True
     assert bool(jax.config.jax_enable_x64) is before
+
+
+# ---------------------------------------------------------------------------
+# Issue #656 — the dispersion ADE carry (the family member #646 missed)
+# ---------------------------------------------------------------------------
+
+def _dispersive_sim(kind, precision="float32", n=None):
+    """Small PEC cavity with one dispersive Box.
+
+    ``kind`` selects the pole family so all three are covered: a Lorentz
+    resonance, a Debye relaxation and a Drude (Lorentz with omega_0=0) pole.
+    """
+    sim = Simulation(freq_max=8e9, domain=(0.02, 0.01, 0.01), dx=1e-3,
+                     boundary="pec", precision=precision)
+    if kind == "lorentz":
+        sim.add_material("m", eps_r=2.0, lorentz_poles=[
+            lorentz_pole(delta_eps=2.0, omega_0=2 * np.pi * 5e9, delta=1e9)])
+    elif kind == "drude":
+        sim.add_material("m", eps_r=1.0, lorentz_poles=[
+            drude_pole(omega_p=2 * np.pi * 5e9, gamma=1e9)])
+    elif kind == "debye":
+        sim.add_material("m", eps_r=2.0,
+                         debye_poles=[DebyePole(delta_eps=2.0, tau=1e-10)])
+    elif kind == "both":
+        sim.add_material(
+            "m", eps_r=2.0,
+            lorentz_poles=[lorentz_pole(2.0, 2 * np.pi * 5e9, 1e9)],
+            debye_poles=[DebyePole(delta_eps=1.0, tau=1e-10)])
+    else:  # pragma: no cover - guard against a typo in a parametrize list
+        raise ValueError(kind)
+    sim.add(Box((0.006, 0.0, 0.0), (0.014, 0.010, 0.010)), material="m")
+    sim.add_source((0.003, 0.005, 0.005), "ez", amplitude_kind="field")
+    sim.add_probe((0.017, 0.005, 0.005), "ez")
+    return sim
+
+
+def _scan_body_dtypes(monkeypatch, kind, precision):
+    """Dtypes AS SEEN INSIDE the scan body, not inferred from the API.
+
+    Wraps the dispersive E-update so the field storage dtype and the ADE P
+    carry dtype are read off the actual traced arguments. ``rfx.simulation``
+    imports these two names inside the function body, so patching the module
+    attribute is what the scan actually calls.
+    """
+    seen = {}
+
+    def _wrap(orig):
+        def wrapped(state, coeffs, ade_state, *args, **kwargs):
+            seen["field_in"] = state.ex.dtype
+            seen["p_in"] = ade_state.px.dtype
+            out = orig(state, coeffs, ade_state, *args, **kwargs)
+            seen["field_out"] = out[0].ex.dtype
+            seen["p_out"] = out[1].px.dtype
+            return out
+        return wrapped
+
+    monkeypatch.setattr(_lorentz_mod, "update_e_lorentz",
+                        _wrap(_lorentz_mod.update_e_lorentz))
+    monkeypatch.setattr(_debye_mod, "update_e_debye",
+                        _wrap(_debye_mod.update_e_debye))
+    _dispersive_sim(kind, precision).run(n_steps=4, skip_preflight=True)
+    return seen
+
+
+@pytest.mark.parametrize("field_dtype,expected", [
+    (jnp.float16, jnp.float32),      # mixed precision -> float32 FLOOR
+    (jnp.float32, jnp.float32),      # default -> unchanged
+    (jnp.complex64, jnp.complex64),  # complex fields -> stays COMPLEX
+])
+def test_ade_state_dtype_promotes_never_pins(field_dtype, expected):
+    """Holds identically with x64 off and on."""
+    assert ade_state_dtype(field_dtype) == expected
+    with enable_x64():
+        assert ade_state_dtype(field_dtype) == expected
+
+
+def test_ade_state_dtype_float64_needs_x64():
+    """float64 fields -> float64 P, but ONLY once x64 is enabled.
+
+    Same documented clamp as ``test_ntff_accum_dtype_float64_needs_x64``:
+    with x64 off JAX has no float64, so the request is clamped to float32.
+    Keyed off the AMBIENT flag so this file stays green under
+    ``JAX_ENABLE_X64=1``, which is how this issue family is reproduced.
+    """
+    ambient_x64 = bool(jax.config.jax_enable_x64)
+    expected = jnp.float64 if ambient_x64 else jnp.float32
+    assert ade_state_dtype(jnp.float64) == expected
+    with enable_x64():
+        assert ade_state_dtype(jnp.float64) == jnp.float64
+
+
+def test_ade_state_dtype_default_follows_ambient_float():
+    """No threaded field dtype -> ambient default float, float32 floor.
+
+    The ``init_rlc_state`` precedent from #646: a caller that does not thread
+    the field dtype must still track ``jax_enable_x64`` rather than pin under
+    it, or its scan reopens the very defect this file exists for.
+    """
+    ambient = jnp.float64 if bool(jax.config.jax_enable_x64) else jnp.float32
+    assert ade_state_dtype(None) == ambient
+    with enable_x64():
+        assert ade_state_dtype(None) == jnp.float64
+    assert ade_state_dtype(None) == ambient
+
+
+def test_ade_allocation_sites_honour_the_policy():
+    """Both ``init_*`` sites allocate P at the policy dtype, not float32.
+
+    ``rfx/materials/lorentz.py`` carried the pin issue #656 was filed on;
+    ``rfx/materials/debye.py`` carried the identical one two files over.
+    """
+    mats = init_materials((4, 4, 4))
+    dt = 1e-12
+    _, lor = init_lorentz([lorentz_pole(2.0, 2 * np.pi * 5e9, 1e9)], mats, dt,
+                          field_dtype=jnp.float16)
+    _, deb = init_debye([DebyePole(delta_eps=2.0, tau=1e-10)], mats, dt,
+                        field_dtype=jnp.float16)
+    # float16 fields must NOT give a float16 recursive accumulator
+    assert lor.px.dtype == jnp.float32
+    assert lor.px_prev.dtype == jnp.float32
+    assert deb.px.dtype == jnp.float32
+    with enable_x64():
+        _, lor64 = init_lorentz([lorentz_pole(2.0, 2 * np.pi * 5e9, 1e9)],
+                                mats, dt, field_dtype=jnp.float64)
+        _, deb64 = init_debye([DebyePole(delta_eps=2.0, tau=1e-10)], mats, dt,
+                              field_dtype=jnp.float64)
+        assert lor64.px.dtype == jnp.float64
+        assert deb64.px.dtype == jnp.float64
+
+
+# ---- the scans must actually CLOSE, per pole family ----
+
+@pytest.mark.parametrize("kind", ["lorentz", "debye", "drude", "both"])
+def test_dispersive_scan_closes_under_x64(kind):
+    """The reproduction from issue #656, one case per pole family.
+
+    On the parent commit each of these raised ``scan body function carry
+    input and carry output must have equal types`` on
+    ``carry['lorentz'].p*`` / ``carry['debye'].p*``.
+    """
+    with enable_x64():
+        r = _dispersive_sim(kind, "float64").run(n_steps=8, skip_preflight=True)
+    assert np.all(np.isfinite(np.asarray(r.time_series)))
+
+
+@pytest.mark.parametrize("kind", ["lorentz", "debye", "drude", "both"])
+def test_dispersive_scan_closes_at_float32_under_x64(kind):
+    """Enabling x64 anywhere in the worker must not red the DEFAULT lane.
+
+    This is the half of the defect that allocation-site promotion alone
+    would not have fixed: at ``precision="float32"`` the fields stay float32,
+    but the ADE coefficients are built from ``grid.dt`` (np.float64) and so
+    go float64 under x64, pushing the scan body's output above the carry.
+    """
+    with enable_x64():
+        r = _dispersive_sim(kind, "float32").run(n_steps=8, skip_preflight=True)
+    assert np.all(np.isfinite(np.asarray(r.time_series)))
+
+
+def test_dispersive_float64_actually_reaches_float64():
+    """``precision="float64"`` + a pole must deliver float64, not just run.
+
+    Guards against a "fix" that closes the carry by narrowing everything to
+    float32 — the run would pass while silently ignoring ``precision=``.
+    """
+    with enable_x64():
+        r = _dispersive_sim("lorentz", "float64").run(n_steps=6,
+                                                      skip_preflight=True)
+        assert r.state.ex.dtype == jnp.float64
+        assert np.asarray(r.time_series).dtype == jnp.float64
+
+
+# ---- precision="mixed": float16 FIELDS, float32 ACCUMULATION ----
+
+@pytest.mark.parametrize("kind", ["lorentz", "debye"])
+def test_mixed_precision_keeps_float16_fields_and_a_float32_ade_state(
+        monkeypatch, kind):
+    """Asserted on the LIVE traced dtypes inside the scan body.
+
+    ``precision="mixed"`` promises float16 field storage with float32
+    accumulation. Following the field dtype naively would put the recursive
+    P recurrence in float16; the old float32 pin instead crashed the scan
+    outright (float16 fields, float32 P) even with x64 off.
+    """
+    seen = _scan_body_dtypes(monkeypatch, kind, "mixed")
+    assert seen["field_in"] == jnp.float16
+    assert seen["field_out"] == jnp.float16
+    assert seen["p_in"] == jnp.float32
+    assert seen["p_out"] == jnp.float32
+
+
+@pytest.mark.parametrize("kind", ["lorentz", "debye"])
+def test_float32_ade_state_stays_float32_even_under_x64(monkeypatch, kind):
+    """Turning x64 on must not silently widen the default lane's ADE carry.
+
+    The sibling of ``test_float32_ntff_accumulator_is_complex64_even_under_x64``:
+    enabling x64 for an unrelated test must not double the P-state memory of
+    every dispersive run in the same worker.
+    """
+    with enable_x64():
+        seen = _scan_body_dtypes(monkeypatch, kind, "float32")
+    assert seen["field_in"] == jnp.float32
+    assert seen["p_in"] == jnp.float32
+    assert seen["p_out"] == jnp.float32
+
+
+def test_x64_does_not_move_the_default_precision_dispersive_result():
+    """Same probe trace with x64 off and on, at precision="float32"."""
+    ts_off = np.asarray(_dispersive_sim("lorentz").run(
+        n_steps=20, skip_preflight=True).time_series)
+    with enable_x64():
+        ts_on = np.asarray(_dispersive_sim("lorentz").run(
+            n_steps=20, skip_preflight=True).time_series)
+    scale = max(float(np.max(np.abs(ts_off))), 1e-30)
+    assert np.max(np.abs(ts_on - ts_off)) / scale < 1e-5
+
+
+def test_oblique_bloch_plus_dispersion_still_raises():
+    """The unsupported combination must NOT be closed by this dtype policy.
+
+    The dispersive branches of ``update_e_dispersive`` ignore the Bloch phase
+    (#404) entirely, so oblique-Bloch + dispersion is wrong physics. That is
+    why the scan bodies PROMOTE to ``promote_types(carry, field)`` instead of
+    pinning to the carry's dtype: pinning would cast the complex field's
+    imaginary part away and let this scan close silently. Pinned as a
+    behaviour so a future "just make it run" change has to face it.
+    """
+    grid = Grid(freq_max=5e9, domain=(0.06, 0.06, 0.006), dx=0.004,
+                cpml_layers=6)
+    mats = init_materials(grid.shape)
+    cfg, st0 = init_tfsf(grid.nx, grid.dx, grid.dt,
+                         cpml_layers=grid.cpml_layers, tfsf_margin=3,
+                         f0=5e9, bandwidth=0.2, amplitude=1.0,
+                         polarization="ez", angle_deg=30.0, ny=grid.ny)
+    probe = ProbeSpec(i=cfg.x_lo + 3, j=grid.ny // 2, k=grid.nz // 2,
+                      component="ez")
+    mask = jnp.zeros(grid.shape, dtype=bool).at[8:12, :, :].set(True)
+    lor = init_lorentz([lorentz_pole(2.0, 2 * np.pi * 5e9, 1e9)], mats,
+                       grid.dt, mask=[mask], field_dtype=jnp.float32)
+    with pytest.raises(TypeError, match="carry"):
+        run(grid, mats, 8, boundary="cpml", cpml_axes="x",
+            periodic=(False, True, True), tfsf=(cfg, st0), probes=[probe],
+            lorentz=lor)


### PR DESCRIPTION
Closes #656.

## The issue named one crash; there are three, and one needs no x64 at all

| config | on main | mismatching carry |
|---|---|---|
| `float64` + any pole, x64 on | crash | `carry['lorentz'\|'debye'].p*` float32 vs float64 |
| **`mixed` + any pole, x64 OFF** | **crash** | `carry['fdtd'].e*` float16 vs float32 |
| `float32` + any pole, x64 on | crash | `carry['fdtd'].e*` float32 vs float64 |

**`precision="mixed"` with any dispersive material has been broken on every release that
shipped that mode, on a default install, with no x64 involved.** Reproduced on main:

```
float32  x64 OFF -> OK (float32)
mixed    x64 OFF -> TypeError: scan body function carry input and carry output must have equal types
```

The dispersive E-update branches never received the `_fdtype`/`_cdtype` narrowing that
`rfx/core/yee.py::update_e` got in #630, so they were only ever exercised at float32.

## The #646 mechanism applies here too

Under x64 the two branches of `init_lorentz` disagreed with each other:

| branch | `a/b/c` | `ca/cb/cc` |
|---|---|---|
| no-mask | float32 (`jnp.full` pin) | float64 |
| mask (what production uses) | float64 (`jnp.where` + np.float64) | float64 |

`ca/cb/cc` are float64 in both regardless of requested precision, because they derive from
`grid.dt` — an `np.float64` scalar, and numpy scalars are strongly typed in JAX. So
allocation-site promotion alone would not have closed these scans; the update bodies have to
narrow their outputs to the carry they were handed. Same lesson as #646, second site.

## One deliberate deviation from what I asked for

I prescribed `promote_types(field_dtype, float32)` at the allocation AND pinning the body to
the carry. The allocation part is right; the body uses `promote_types(carry_dtype,
field_dtype)` instead, and the reason is sound enough to keep:

**oblique-Bloch + dispersion is wrong physics** — the dispersive branches of
`update_e_dispersive` ignore the Bloch phase entirely, and on main that combination raises a
carry mismatch. Pinning the body to the carry would cast the complex field's imaginary part
away and *close* that scan silently, converting a loud wrong-configuration error into a quiet
wrong answer. That is exactly the newly-reachable-silent-wrong shape #644 and #647 were about.
It still raises, pinned by `test_oblique_bloch_plus_dispersion_still_raises`.

The policy helper also had to be wrapped in `jnp.result_type`: `jnp.promote_types` does **not**
canonicalize float64 away when x64 is off. Found by a test failing, then matched to the sibling
policy (`ntff_accum_dtype` uses `result_type` for the same reason) rather than weakening the
assertion.

## Evidence

- **x64 matrix**, pinned `git archive` of `68a3e37` vs branch, 12 cases (4 material kinds x 3
  precisions): base 9/3 passing at x64=0 and 3/9 at x64=1; branch **12/12 at both**.
- One identical behavioural test file dropped into both trees: base 1 passed / 18 failed
  (x64=0) and 0/19 (x64=1); branch **19 passed at both**. Its `test_default_lane_still_runs`
  control passes on base, so the file is not red for an unrelated reason.
- **Byte-identity 9/9** at `precision="float32"` — SHA-256 of raw final field bytes, base vs
  branch, including NU+Lorentz and NU+Debye (the `nonuniform.py` edit would otherwise be
  unhashed) plus two non-dispersive controls. Independently confirmed on a separate
  4-configuration harness: 24/24 identical.
- **Negative controls**: `dx` +3 ppm moves 9/9; an ADE-pole +3 ppm moves **exactly the 7
  dispersive** fixtures and leaves both plain ones byte-identical.
- **Live in-scan dtypes**, read off traced arguments rather than inferred: `mixed` gives
  float16 fields with a **float32** ADE state at x64 both off and on; `float32` gives
  float32/float32 while the coefficients sit at float64 — direct evidence that the body
  narrowing is what closes the scan.
- Suites: x64 file 35 (at `JAX_ENABLE_X64` 0 and 1), dispersion 26, `slow_physics` dispersive
  Fresnel oracle 2, cpml+mixed+precision-lane 211 (8 skipped), nonuniform 140 (8 skipped),
  material-fit AD 29, surface contracts 12. ruff clean.

## Scope boundary, stated not claimed

`rfx/runners/distributed*.py` carry their own copies of these recurrences and are untouched.
`precision=` is uniform-single-device only by an existing `NotImplementedError` (#630), and
their float32 placeholder ADE states are inert dummies used only when no dispersion is present
— but their bodies would still need the same narrowing to survive an ambient x64 flag.

R3: memory=project_precision_carry_dtype_family (promote-don't-pin, and the numpy-scalar
promotion mechanism from #646) | R2-attempts=1 | falsifier=the 12-case x64 matrix on pinned
trees, which separates "the fix works" from "the test file is red for another reason" via a
control that passes on base
