### PR TITLE
fix(sparams): enforce the -40 dB ring-down bar on the two lanes that computed it and never checked it (closes #662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Fixed — two S-parameter lanes computed the ring-down settling witness and never compared it to its own -40 dB bar (issue #662)
+
+`settling_db` is the repo's mechanical form of the -40 dB ring-down settling
+rule: above that line the fixed-length record ended while the structure was
+still ringing, so the single-bin DFTs behind every S value of that run
+integrate a cut transient. `compute_coaxial_two_port` and
+`compute_coax_msl_transition` computed the witness, documented the -40 dB bar
+in their own result docstrings, and never made the comparison — a caller
+reading `.s_params` got a plausible-looking truncation artifact in silence.
+Both now route the witness through the same `_warn_if_ringdown_truncated`
+warner the waveguide/MSL/mixed lanes already used, so all five lanes share one
+threshold constant and one warning shape.
+
+Measured on the committed coax through-line fixture (domain 8x8x60 mm,
+`freq_max` 40 GHz), before the fix:
+
+| `n_steps` | `settling_db` (dB) | warnings emitted |
+|---|---|---|
+| 400 | -6.84 / -6.93 | 0 |
+| 700 | -28.15 / -29.46 | 0 |
+| 1500 | -43.97 / -44.53 | 0 |
+| 3000 | -67.26 / -68.09 | 0 |
+
+The first two rows violate the bar by 33 and 12 dB. They now warn, naming
+every violating drive, its measured value, and the record-length knob that
+lane is actually driven by (`n_steps` for the coax lanes, `num_periods` for
+the others).
+
+No extracted number changes: SHA-256 over `S`/`Z0`/`beta` (MSL fixture) and
+over `s_params`/`gamma`/`cond_a`/`recurrence_residual`/`fit_residual` (coax
+fixture) are identical before and after, including on the run where the new
+warning fires. The differentiable (`eps_scale`) channel leaves `settling_db`
+`nan` by design — the witness needs a concrete time series — and stays
+silent; the warner's finite mask, not luck, is what keeps it that way.
+
 ### Fixed — a material flush with the domain face left a one-cell vacuum gap before its CPML pad (issue #655)
 
 A `Box` (or any shape) whose hi face lands on the domain's last interior node

--- a/docs/guides/simulation_methodology.md
+++ b/docs/guides/simulation_methodology.md
@@ -128,7 +128,14 @@ to column power ~1.8e3 that shrink monotonically with record length.
 `MSLSMatrixResult.settling_db` (worst end/peak `Ez²` ratio over all port
 probe planes per driven run — multiple planes because a single plane is
 standing-wave-node sensitive, with a measured 18 dB spread across planes on
-one under-settled record) and warns when a run exceeds the line. The rule
+one under-settled record) and warns when a run exceeds the line. Every lane
+that carries the witness enforces the same line through the same warner
+(issue #662): `compute_waveguide_s_matrix`, `compute_msl_s_matrix`,
+`compute_mixed_s_matrix`, `compute_coaxial_two_port` and
+`compute_coax_msl_transition`. The witness is `nan`, and the warning
+correspondingly silent, on the differentiable (`eps_scale`/`eps_override`)
+channels — they cannot build it without concretising a traced time series,
+so on those channels the rule stays the caller's to satisfy. The rule
 does not apply to closed PEC domains (energy conservation is correct there)
 or to CW drive.
 

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -316,20 +316,44 @@ def _validate_extra_flux_monitor_entries(entries, domain, fn_name):
 
 
 def _warn_if_ringdown_truncated(
-    settling_db: np.ndarray, port_names: tuple, *, num_periods: float
+    settling_db: np.ndarray,
+    port_names: tuple,
+    *,
+    num_periods: float | None = None,
+    n_steps: int | None = None,
 ) -> None:
     """Emit one aggregate warning when a driven run's record is truncated.
 
     The witness makes the project's ring-down settling rule mechanical
     (docs/guides/simulation_methodology.md): end/peak
     Ez^2 at the port probe planes, per driven run. Above −40 dB the fixed
-    ``num_periods`` record ended while the structure was still ringing, so
+    record ended while the structure was still ringing, so
     the single-bin DFTs underlying V/I — and every S value of that run —
     integrate a truncated transient. Measured consequence on the Sheen-1990
     LPF (dx=200 µm, resonant stopband): num_periods=20 left the witness hot
     and produced |S| column-power poles up to ~1.8e3 that shrank
     monotonically as the record grew (20→60 periods: worst pole 62→8.8),
     while absorber depth (8→24 CPML layers) did not move them.
+
+    Every lane that computes ``settling_db`` must route it through here
+    (issue #662: the coax two-port and coax<->MSL transition lanes computed
+    the witness, documented the −40 dB bar in their result docstrings, and
+    never compared the two — a caller reading ``.s_params`` got a
+    plausible-looking truncation artifact in silence). Pass whichever
+    record-length knob the lane is actually driven by: ``num_periods`` for
+    the waveguide/MSL/mixed lanes, ``n_steps`` for the coax lanes — the
+    warning names that knob so its remedy is directly actionable.
+
+    NaN entries are skipped by the finite mask, which is what keeps the
+    differentiable paths quiet: they leave ``settling_db`` NaN on purpose
+    (the witness needs a concrete time series, and a traced one cannot be
+    Python-branched on). All callers pass a concrete host-side NumPy array,
+    so nothing here branches on a tracer.
+
+    All violating drives are named, not just the worst: the record length is
+    a per-drive property with a per-drive remedy, and naming only the worst
+    would hide a second drive needing the same fix. It stays ONE warning per
+    call (issue #470: per-probe advisory flooding buried the genuine ones).
     """
     finite = np.isfinite(settling_db)
     hot = finite & (settling_db > _SETTLING_WITNESS_DB)
@@ -338,6 +362,12 @@ def _warn_if_ringdown_truncated(
 
     import warnings
 
+    if num_periods is not None:
+        knob, record = "num_periods", f"num_periods={num_periods:g}"
+    elif n_steps is not None:
+        knob, record = "n_steps", f"n_steps={int(n_steps):d}"
+    else:  # pragma: no cover - guarded by the call sites
+        knob, record = "the record length", "fixed-length"
     per_run = ", ".join(
         f"port {port_names[i] if i < len(port_names) else i} driven: "
         f"{settling_db[i]:+.1f} dB"
@@ -345,14 +375,13 @@ def _warn_if_ringdown_truncated(
     )
     warnings.warn(
         "ring-down settling witness FAILED (end/peak energy above "
-        f"{_SETTLING_WITNESS_DB:.0f} dB): {per_run}. The num_periods="
-        f"{num_periods:g} record ended while the structure was still "
+        f"{_SETTLING_WITNESS_DB:.0f} dB): {per_run}. The {record} "
+        "record ended while the structure was still "
         "ringing, so the DFT-based S-parameters of the affected run(s) are "
         "truncation artifacts wherever the structure is resonant — expect "
-        "spurious |S| poles and passivity violations. Increase num_periods "
-        "until the witness is below −40 dB before quoting any S value "
-        "(see the result's settling_db field — MSLSMatrixResult and, since "
-        "issue #538, WaveguideSMatrixResult).",
+        "spurious |S| poles and passivity violations. Increase "
+        f"{knob} until the witness is below −40 dB before quoting any S "
+        "value (see the result's settling_db field).",
         stacklevel=2,
     )
 
@@ -5662,6 +5691,13 @@ class _SparamMixin:
             status=status,
             flux_monitors=(flux_by_drive if extra_flux_monitors else None),
         )
+        # Issue #662: the witness above is computed but was never compared to
+        # the -40 dB bar this result's own docstring documents. NaN on the
+        # eps_scale path is skipped by the warner's finite mask (this array is
+        # host-side numpy on every path, so no tracer is branched on here).
+        _warn_if_ringdown_truncated(
+            settling_db, ("port1", "port2"), n_steps=int(n_steps),
+        )
         return _finalize_sparam_result(
             result_obj,
             extractor="compute_coaxial_two_port",
@@ -6350,6 +6386,12 @@ class _SparamMixin:
             settling_db=settling_db,
             status="experimental",
             flux_monitors=(flux_by_drive if extra_flux_monitors else None),
+        )
+        # Issue #662, same gap as compute_coaxial_two_port. ``n_steps`` here is
+        # the RESOLVED record length (num_periods was folded into it above), and
+        # it is the knob that overrides num_periods, so it is the actionable one.
+        _warn_if_ringdown_truncated(
+            settling_db, ("coax", "msl"), n_steps=int(n_steps),
         )
         return _finalize_sparam_result(
             result_obj,

--- a/rfx/api/_spec.py
+++ b/rfx/api/_spec.py
@@ -1347,7 +1347,12 @@ class CoaxialTwoPortResult:
     ``settling_db`` is a per-drive ring-down witness (worst end/peak E^2 ratio,
     dB, over one point probe per array — same convention as the MSL/mixed
     lanes; above -40 dB suggests the fixed-length record may have been
-    truncated before the structure rang down).
+    truncated before the structure rang down). Since issue #662 that bar is
+    ENFORCED, not just documented: a violating drive emits a
+    ``UserWarning`` naming the drive and its measured value, so a truncated
+    record can no longer return a plausible-looking ``s_params`` in silence.
+    It stays a warning, never an exception — short diagnostic runs are a
+    legitimate use of this method.
 
     **``eps_scale`` (differentiable) path** (:meth:`compute_coaxial_two_port`'s
     own ``eps_scale`` parameter, issue #489 leg 3): ``status`` takes a FOURTH
@@ -1858,7 +1863,9 @@ class CoaxMSLTransitionResult:
     settling_db : (2,) float
         Ring-down settling witness per drive (worst end/peak field-energy
         ratio, dB; above -40 dB = truncation suspect — see repo ring-down
-        convention).
+        convention). Since issue #662 that bar is ENFORCED, not just
+        documented: a violating drive emits a ``UserWarning`` (never an
+        exception) naming the drive and its measured value.
     status : str
         ``"experimental"`` always (this lane makes no pass/fail physics
         claim beyond what the calling test's own predeclared gate states;

--- a/tests/test_settling_witness_enforcement.py
+++ b/tests/test_settling_witness_enforcement.py
@@ -1,0 +1,279 @@
+"""Issue #662 — the ring-down settling witness must ENFORCE its own -40 dB bar.
+
+The witness (``settling_db``) and its threshold were both already written down;
+what was missing on two lanes was the comparison between them. Measured on this
+worktree BEFORE the fix (``compute_coaxial_two_port``, the
+``tests/test_coax_two_port_fdtd.py`` through-line fixture, JAX_PLATFORMS=cpu):
+
+    n_steps=  400  settling_db=[ -6.84,  -6.93]  warnings emitted: 0
+    n_steps=  700  settling_db=[-28.15, -29.46]  warnings emitted: 0
+    n_steps= 1500  settling_db=[-43.97, -44.53]  warnings emitted: 0
+    n_steps= 3000  settling_db=[-67.26, -68.09]  warnings emitted: 0
+    n_steps= 6000  settling_db=[-65.87, -65.59]  warnings emitted: 0
+
+The 400- and 700-step rows violate the bar this method's own result docstring
+documents by 33 and 12 dB, and returned a plausible-looking ``s_params`` in
+total silence. ``tests/test_coax_msl_transition.py`` carries an independent
+in-repo sighting of the same silence ("a shorter, 1500-step smoke run measured
+only -1.0 / -0.2 dB").
+
+Split, per this repo's physics-run discipline:
+
+  * FAST (no FDTD): the warner's own decision logic — fires / stays silent /
+    skips NaN / names every violating drive / names the lane's own knob — plus
+    a static governance gate that every ``settling_db``-producing lane routes
+    through the ONE shared warner. That gate is the durable part: it is what
+    makes a future sixth lane fail loudly instead of repeating #662.
+  * SLOW (``slow_physics``, real FDTD): the end-to-end firing pair on the
+    silent lane, gates pinned from the measurements above.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import warnings
+
+import numpy as np
+import pytest
+
+from rfx.api._sparams import _SETTLING_WITNESS_DB, _warn_if_ringdown_truncated
+
+_SPARAMS_SRC = pathlib.Path(
+    __import__("rfx.api._sparams", fromlist=["_sparams"]).__file__
+)
+
+
+def _catch(fn):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fn()
+    return [w for w in caught if "settling witness" in str(w.message)]
+
+
+# ---------------------------------------------------------------------------
+# FAST — the warner's decision logic
+# ---------------------------------------------------------------------------
+
+def test_threshold_constant_is_the_documented_bar():
+    """One shared constant, and it is the -40 dB the docstrings quote."""
+    assert _SETTLING_WITNESS_DB == -40.0
+
+
+def test_violating_witness_warns_and_quotes_the_measured_value():
+    hot = _catch(lambda: _warn_if_ringdown_truncated(
+        np.array([-1.1, -55.0]), ("feed", "load"), n_steps=700))
+    assert len(hot) == 1, "one aggregate warning per call, not one per drive"
+    msg = str(hot[0].message)
+    # The measured value, the bar, the field to inspect, and the knob.
+    assert "-1.1 dB" in msg, msg
+    assert "-40" in msg and "settling_db" in msg, msg
+    assert "n_steps=700" in msg, msg
+
+
+def test_settled_witness_stays_silent():
+    """Control: a check that fires on everything is worse than one that fires
+    on nothing. A settled record must produce no warning at all."""
+    assert _catch(lambda: _warn_if_ringdown_truncated(
+        np.array([-67.26, -68.09]), ("port1", "port2"), n_steps=3000)) == []
+
+
+def test_witness_exactly_at_the_bar_is_not_a_violation():
+    """The bar is documented as "above -40 dB"; equality must not fire (an
+    off-by-one here would make the control test above fixture-dependent)."""
+    assert _catch(lambda: _warn_if_ringdown_truncated(
+        np.array([-40.0, -40.0]), ("a", "b"), n_steps=1)) == []
+    assert len(_catch(lambda: _warn_if_ringdown_truncated(
+        np.array([-39.9, -80.0]), ("a", "b"), n_steps=1))) == 1
+
+
+def test_all_nan_witness_is_silent_not_a_false_fire():
+    """NaN is a DESIGNED state, not a failure: the differentiable lanes leave
+    ``settling_db`` NaN because the witness needs a concrete time series. A
+    naive ``settling_db > -40`` would evaluate NaN comparisons; this pins that
+    the finite mask, not luck, is what keeps those lanes quiet."""
+    assert _catch(lambda: _warn_if_ringdown_truncated(
+        np.full(2, np.nan), ("port1", "port2"), n_steps=400)) == []
+
+
+def test_nan_beside_a_violator_does_not_mask_the_violator():
+    """The other half of the NaN decision: a partially-concrete array must
+    still report its concrete violator (``np.nanmax``-style silence here would
+    be a real regression, and a plain ``np.max`` would return NaN and fire
+    never)."""
+    hot = _catch(lambda: _warn_if_ringdown_truncated(
+        np.array([np.nan, -2.0]), ("port1", "port2"), n_steps=400))
+    assert len(hot) == 1
+    assert "port port2 driven: -2.0 dB" in str(hot[0].message)
+    assert "port1" not in str(hot[0].message)
+
+
+def test_every_violating_drive_is_named_not_only_the_worst():
+    """Record length is a per-drive property with a per-drive remedy; naming
+    only the worst drive would hide a second one needing the same fix."""
+    hot = _catch(lambda: _warn_if_ringdown_truncated(
+        np.array([-1.0, -30.0, -70.0]), ("p1", "p2", "p3"), n_steps=400))
+    assert len(hot) == 1
+    msg = str(hot[0].message)
+    assert "port p1 driven: -1.0 dB" in msg and "port p2 driven: -30.0 dB" in msg
+    assert "p3" not in msg, "a settled drive must not be named"
+
+
+def test_warning_names_the_knob_the_lane_is_actually_driven_by():
+    """One warning shape, two record-length knobs: the waveguide/MSL/mixed
+    lanes are driven by ``num_periods``, the coax lanes by ``n_steps``. Naming
+    the wrong one makes the remedy un-actionable."""
+    by_periods = str(_catch(lambda: _warn_if_ringdown_truncated(
+        np.array([-1.0]), ("p1",), num_periods=2.0))[0].message)
+    assert "num_periods=2" in by_periods and "Increase num_periods" in by_periods
+    by_steps = str(_catch(lambda: _warn_if_ringdown_truncated(
+        np.array([-1.0]), ("p1",), n_steps=400))[0].message)
+    assert "n_steps=400" in by_steps and "Increase n_steps" in by_steps
+
+
+# ---------------------------------------------------------------------------
+# FAST — governance: one warner, wired to every producer
+# ---------------------------------------------------------------------------
+
+def _functions_producing_settling_db():
+    """(name, routes_through_warner) for every function in ``_sparams.py``
+    that attaches a ``settling_db=`` to a result object.
+
+    ``_sparams.py`` is the only module that does so (``grep -rn "settling_db="
+    rfx/ --include=*.py`` hits nothing else; ``_spec.py`` only declares the
+    field). If a lane is ever added elsewhere, widen this scan with it.
+    """
+    tree = ast.parse(_SPARAMS_SRC.read_text(encoding="utf-8"))
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        produces = any(
+            isinstance(sub, ast.Call)
+            and any(kw.arg == "settling_db" for kw in sub.keywords)
+            for sub in ast.walk(node)
+        )
+        if not produces:
+            continue
+        routed = any(
+            isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Name)
+            and sub.func.id == "_warn_if_ringdown_truncated"
+            for sub in ast.walk(node)
+        )
+        out.append((node.name, routed))
+    return out
+
+
+def test_every_settling_db_producer_routes_through_the_shared_warner():
+    """The #662 defect in structural form.
+
+    RED on the unfixed tree: ``compute_coaxial_two_port`` and
+    ``compute_coax_msl_transition`` both attach a ``settling_db`` they never
+    compare to the bar. A new lane that copies that pattern fails here rather
+    than shipping another silent witness.
+    """
+    producers = _functions_producing_settling_db()
+    assert producers, "AST probe found no settling_db producers — it has rotted"
+    silent = sorted(name for name, routed in producers if not routed)
+    assert not silent, (
+        f"lane(s) {silent} attach a settling_db that is never compared to "
+        f"{_SETTLING_WITNESS_DB:g} dB — call _warn_if_ringdown_truncated() "
+        "there (issue #662)."
+    )
+
+
+def test_the_known_lanes_are_all_covered():
+    """Companion to the gate above: pins WHICH lanes carry the witness, so a
+    lane silently losing its witness entirely (producer disappears -> the gate
+    above passes vacuously for it) is also caught."""
+    names = {name for name, _ in _functions_producing_settling_db()}
+    assert {
+        "compute_waveguide_s_matrix",
+        "compute_msl_s_matrix",
+        "compute_mixed_s_matrix",
+        "compute_coaxial_two_port",
+        "compute_coax_msl_transition",
+    } <= names, sorted(names)
+
+
+# ---------------------------------------------------------------------------
+# SLOW — end-to-end on the lane that was silent (real FDTD, ~60 s total)
+# ---------------------------------------------------------------------------
+
+_BAND = np.array([4.0e9, 6.0e9, 8.0e9, 10.0e9, 12.0e9])
+
+
+def _coax_two_port_sim():
+    """The committed through-line fixture from tests/test_coax_two_port_fdtd.py
+    (domain 8x8x60 mm, freq_max 40 GHz)."""
+    from rfx.api import Simulation
+    from rfx.sources.sources import GaussianPulse
+
+    sim = Simulation(domain=(0.008, 0.008, 0.060), freq_max=40.0e9,
+                     boundary="cpml")
+    sim.add_coaxial_port((0.004, 0.004, 0.020), face="top", pin_length=5.0e-3,
+                         waveform=GaussianPulse(f0=8.0e9, bandwidth=1.2))
+    return sim
+
+
+@pytest.mark.slow_physics
+def test_underrun_coax_two_port_warns_instead_of_returning_it_quietly():
+    """Deliberately under-run record: measured settling_db [-6.84, -6.93] dB
+    on this fixture at n_steps=400, i.e. 33 dB past the bar. On the unfixed
+    tree this returned a finite, ordinary-looking s_params and zero warnings.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        res = _coax_two_port_sim().compute_coaxial_two_port(
+            n_steps=400, freqs=_BAND)
+
+    sd = np.asarray(res.settling_db)
+    assert sd.shape == (2,) and np.all(np.isfinite(sd)), sd
+    assert np.all(sd > _SETTLING_WITNESS_DB), (
+        f"fixture no longer under-run (settling_db={sd}); it cannot witness "
+        "the truncation warning any more — shorten the record."
+    )
+    hot = [w for w in caught if "settling witness" in str(w.message)]
+    assert hot, (
+        f"settling_db={sd} violates the {_SETTLING_WITNESS_DB:g} dB bar and "
+        "nothing warned (issue #662)"
+    )
+    msg = str(hot[0].message)
+    assert "port port1 driven" in msg and "port port2 driven" in msg, msg
+    assert "n_steps=400" in msg and "settling_db" in msg, msg
+
+
+@pytest.mark.slow_physics
+def test_settled_coax_two_port_stays_silent():
+    """Control on the SAME fixture: measured [-67.26, -68.09] dB at
+    n_steps=3000. A settled run must not warn."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        res = _coax_two_port_sim().compute_coaxial_two_port(
+            n_steps=3000, freqs=_BAND)
+
+    sd = np.asarray(res.settling_db)
+    assert np.all(sd < -60.0), (
+        f"settled control drifted to {sd}; it no longer sits well clear of "
+        "the bar, so its silence would stop meaning anything."
+    )
+    assert not [w for w in caught if "settling witness" in str(w.message)]
+
+
+@pytest.mark.slow_physics
+def test_differentiable_coax_path_leaves_the_witness_nan_and_silent():
+    """The NaN path end-to-end: the ``eps_scale`` lane cannot build the
+    witness (it would need a concrete time series), leaves settling_db NaN by
+    design, and must therefore stay silent even though the SAME 400-step
+    record fires the warning on the concrete lane above."""
+    import jax.numpy as jnp
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        res = _coax_two_port_sim().compute_coaxial_two_port(
+            n_steps=400, freqs=_BAND, eps_scale=jnp.asarray(1.0))
+
+    sd = np.asarray(res.settling_db)
+    assert sd.shape == (2,) and np.all(np.isnan(sd)), sd
+    assert not [w for w in caught if "settling witness" in str(w.message)]


### PR DESCRIPTION
Closes #662.

## The issue's framing was wrong; the defect is narrower and real

I filed this as "rfx warns nobody". The grep behind that was a **false negative**: the warner is
`_warn_if_ringdown_truncated` — "ringdown", not "settling" — and its comparison line carries
`settling` but not `warn`, so a two-stage grep on those tokens matches neither. Corrected on the
issue.

What is actually true:

| lane | computes `settling_db` | compared to -40 dB on base |
|---|---|---|
| `compute_waveguide_s_matrix` | yes | yes |
| `compute_msl_s_matrix` | yes | yes |
| `compute_mixed_s_matrix` | yes | yes |
| `compute_coaxial_two_port` | yes | **no** |
| `compute_coax_msl_transition` | yes | **no** |

The docstring quoted in the issue (`_spec.py:1347`) belongs to `CoaxialTwoPortResult` — one of
the two silent lanes.

## Measured on base

Committed coax through-line fixture, sweeping only the record length:

| `n_steps` | `settling_db` (dB) | warnings |
|---|---|---|
| 400 | -6.84 / -6.93 | **0** |
| 700 | -28.15 / -29.46 | **0** |
| 1500 | -43.97 / -44.53 | 0 |
| 3000 | -67.26 / -68.09 | 0 |

## The warning, verbatim

```
ring-down settling witness FAILED (end/peak energy above -40 dB): port port1 driven: -6.8 dB,
port port2 driven: -6.9 dB. The n_steps=400 record ended while the structure was still ringing,
so the DFT-based S-parameters of the affected run(s) are truncation artifacts wherever the
structure is resonant — expect spurious |S| poles and passivity violations. Increase n_steps
until the witness is below -40 dB before quoting any S value (see the result's settling_db field).
```

Every violating drive is named rather than the worst one: record length is a per-drive property
with a per-drive remedy, and naming only the worst hides a second drive needing the same fix.
Still one aggregate warning per call (#470 flooding). Warning tier, not an exception — short
diagnostic runs stay legal. The warner now names `n_steps=` alongside `num_periods=` so each lane
reports the knob it is actually driven by.

## Red on base first

Base pinned to a `git archive` so a concurrent edit cannot move the target.

Structural gate on base:
```
AssertionError: lane(s) ['compute_coax_msl_transition', 'compute_coaxial_two_port'] attach a
settling_db that is never compared to -40 dB — call _warn_if_ringdown_truncated() there (#662).
```
FDTD gate on base:
```
AssertionError: settling_db=[-6.83735706 -6.9303827] violates the -40 dB bar and nothing warned
```
Branch: 10 fast + 3 `slow_physics` passed.

## Controls

- **Must stay silent**: `n_steps=3000` → -67.26 / -68.09 dB, zero warnings, on **both** trees.
  It passes on base too, which is the point — it is not green because of this change.
- Boundary pair at exactly -40.0 dB (must not fire) and -39.9 dB (must fire).
- **NaN path**, both levels: all-NaN → silent; `[nan, -2.0]` → warns naming only `port2` (a plain
  `np.max` returns NaN and never fires; `nanmax` would fire but would not pin the mask). End to
  end, the `eps_scale` differentiable path returns `[nan, nan]` and stays silent while the same
  400-step record fires on the concrete lane. Nothing branches on a tracer — `settling_db` is
  host-side numpy at every call site.

## Numbers unchanged

This adds a warning; it must not move a value. All digests identical base vs branch **including
on the run where the new warning fires** — `s_params`, `S`, `Z0`, `beta`, `gamma`, `cond_a`,
`recurrence_residual`, `fit_residual`, and `settling_db` to full float precision. A 1-ULP
negative control moves the digest.

## Item 3 (pre-solve run-length hint) declined, with reasons

`_ntff_min_steps_hint` is written and read nowhere. Wiring it is ~6 lines, but it fires only when
an NTFF box is registered, encodes a 10-period *NTFF* requirement, and would emit a
run-length-shaped warning covering neither the resonance case this issue is about nor the
S-parameter lanes. A genuine resonator hint needs a pre-solve Q, and Q comes out of the solve.
That is the half-wired outcome the brief warned against, so it stays a separate candidate.

## Author's predeclaration, including where it was wrong

Predeclared before running, with a falsifier for the premise ("a short run on base emits a
settling warning ⇒ the premise is wrong"). Wrong on two counts, both reported: the predicted
range for the 700-step case was 3 dB off (right sign, bad calibration), and a provenance fixture
put 2 of 5 witness probes under the pad — which turned out to be a fixture defect rfx's own
preflight flagged, not a finding.

Suites: coax+settling 179 passed, MSL+mixed+contract 113 passed, preflight+port 105 passed. ruff
clean.

R3: memory=feedback_no_head_on_existence_checks (the issue's own grep was the false negative) |
R2-attempts=1 | falsifier=the structural + FDTD gates, both watched red on a pinned base