### PR TITLE
feat(msl-port): support +y/-y launch, reject +z/-z with evidence (closes #661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,112 @@ SemVer — **BREAKING** entries are flagged in upper-case.
 
 ## [Unreleased]
 
+### Added — `add_msl_port(direction=...)` accepts the in-board axes (issue #661)
+
+`direction` now takes `"+x"`, `"-x"`, `"+y"` and `"-y"`. A microstrip feed
+entering a board along y no longer forces the whole model to be rotated —
+which mattered because for a CAD-imported `MeshShape` that workaround does
+not exist at all (the mesh import path takes no rotation argument).
+
+`"+z"` / `"-z"` raise `ValueError` naming the reason. This is a documented
+rejection, not an omission: the port's geometry contract is `position =
+(x, y, z_lo)` plus a scalar `height`, which fixes the substrate normal to z.
+A z-propagating microstrip needs its normal along x or y, and the normal
+axis is what the static-Laplace cross-section solve, the `"ez"` source
+component, the modal voltage `V = Σ Ez·dz` and the trace-conductor PEC scan
+all reference. Accepting `"+z"` would have returned a z-normal answer for a
+board lying in a different plane. `mode="eigenmode"` stays `"+x"`/`"-x"`
+only (its Schelkunoff J+M launch hard-codes the x-axis TFSF correction pair
+and rides on a solver that is a fenced dead-end), and the EXPERIMENTAL
+`compute_mixed_s_matrix` lane (#488) is fenced to x rather than extended
+untested.
+
+**The axis inventory was measured, not read.** Instrumenting the live
+extractor split it into stages bound to the *propagation* axis (probe
+ladder, DFT plane normal, the `dx_feed` in the port conductance, the
+port-to-CPML and probe-span preflight checks — all relabelings), stages
+welded to the *substrate normal* (the four listed above), and stages that
+are genuinely axis-free (the N-probe fit, which consumes probe coordinates
+and only their differences; the Hammerstad-Jensen anchor; the multi-drive
+`S = B A⁻¹` solve).
+
+**The dangerous part was the Ampère loop, and it fails silently.** The
+closed-contour current needs the right-handed transverse pair `(a, b)` with
+`â × b̂ = p̂`. Deriving it as a plain `x ↔ y` rename is a reflection, not a
+rotation. Measured on the committed thru fixture's own recorded H planes:
+the cyclic pair reproduces the x-port current to `9.2e-08` relative, the
+naive swap returns exactly `−I` (ratio `−1.00000009`). That flip exchanges
+`a` and `b`, mapping `S = B A⁻¹` to `A B⁻¹ = S⁻¹`; for the low-loss matched
+line every MSL fixture uses, `S` is nearly unitary, so `S⁻¹ ≈ S†` — `|S11|`
+moves only `0.17905 → 0.17875`, `max ||S| − |S_swapped||` is `1.3e-03`,
+column power stays under 1, and `cond(A)` is `1.32`. **No guard in the lane
+fires.** What actually changes is `arg(S21)`, which is exactly negated (the
+two angles sum to ≤ 0.02° across the band — a negative group delay); the
+complex error is `max |S − S_swapped| = 1.912`. The equivalence test
+therefore compares complex `S`; a magnitude-only comparison would have
+passed on this exact bug.
+
+**Falsifier — a y-directed port on the x↔y mirrored fixture reproduces the
+x-directed result** (12 bins, `num_periods=12`, dx=80 µm, CPU float32):
+
+| quantity | agreement |
+|---|---|
+| `max \|S_x − S_y\|` | `3.86e-06` |
+| rel `max \|Z0_x − Z0_y\|` | `2.14e-04` |
+| rel `max \|β_x − β_y\|` | `3.09e-05` |
+| `settling_db` | x `[−98.47, −102.96]`, y `[−98.49, −102.91]` |
+
+Both lanes emit the same advisory set. The three tolerances differ because
+the quantities differ in conditioning, not by choice: `S` is a well-
+conditioned V·I split plus a 2×2 solve and sits at the float32 floor, while
+`β` and `Z0` ride on the N-probe least-squares fit that
+`rfx/probes/msl_wave_decomp.py` runs in float32 by explicit cast, with
+`Z0 = (α − γ)/I` compounding that fit's residual through a difference.
+
+**Existing x-directed behaviour is byte-identical.** SHA-256 over the
+extracted `S`, `Z0` and `β` on the committed thru fixture
+(`test_msl_thru_line_passive_gate` geometry, `n_freqs=30`,
+`num_periods=12`), base `fd37c62` vs branch:
+
+```
+S     eb69f37dcf72a8fcd88a532a9607ff4e20a72199aecfadc2538b37a30f0592b6
+Z0    7873d42cc7c2668d32e7cfc05afce28ddcb8b48c91465faad4e1c215dc49b64c
+beta  529b08fa31f1255b6e63ad4599e7f972444c0167eca43bebde4b73ada5761277
+```
+
+identical on both trees, reproducing the recorded calibration
+(mean |S11| 0.115946, mean |S21| 0.993048, mean Re(Z0) 57.5710 Ω). A
+negative control — the trace width nudged by one part in 10⁴ — moves all
+three digests, so the lock is sensitive rather than vacuous. No committed
+gate or tolerance was changed; the one contract assertion that moved is
+`tests/test_msl_port.py`, which pinned `"+y"` as invalid — the limitation
+this issue removes.
+
+Note for anisotropic meshes: the port conductance scales as `1/d_prop`, so
+on a cubic grid an x-flavoured σ applied to a y port is bit-identical to
+the correct one. The end-to-end rotation-equivalence test runs on a cubic
+mesh and is therefore blind to that stage;
+`test_port_conductance_uses_the_propagation_axis_cell_size` covers it on a
+deliberately anisotropic grid.
+
+**Sign-convention prose corrected along the way (see #524).** Generalising
+the `+x`/`-x` current convention to four directions meant resolving whether
+the contradiction #524 records is real in the code or only in the prose.
+Measured: it is prose only, and the `msl_loop_current` docstring is the
+wrong statement. On the committed thru fixture, each port on its own drive,
+`Re((α − γ)/I1)` reads **+57.52 Ω** at the `"+x"` port and **−57.56 Ω** at
+the `"-x"` port — same magnitude to 0.08 %, opposite sign. So the `#140`
+`dir_sign` comment described the code accurately, while the docstring's
+unqualified "the returned `I` is positive for a forward quasi-TEM wave"
+holds only for a positive-going port. The lane is self-consistent about it:
+`dir_sign` restores both reported `Z0` to positive, the wave split consumes
+the un-normalised current at every port, and the shipped `S` is physical
+(`|S11| = |S22|` to 5 decimals, reciprocity `max ||S21| − |S12|| = 1.27e-05`,
+column power ≤ 0.99998). The docstring is corrected and
+`test_loop_current_negates_on_the_direction_sign_only` pins what it now
+says. No code changed for this. #524 stays open for its other two items —
+the passive port's ~30 Ω termination reading and the 0.194-vs-0.073 drive
+asymmetry — which this work does not touch.
 ### Fixed — two S-parameter lanes computed the ring-down settling witness and never compared it to its own -40 dB bar (issue #662)
 
 `settling_db` is the repo's mechanical form of the -40 dB ring-down settling

--- a/docs/public/guide/sources-ports.mdx
+++ b/docs/public/guide/sources-ports.mdx
@@ -264,6 +264,24 @@ mesh/source/port combinations are rejected rather than silently returning
 `None`. `num_periods` defaults to 40 because MSL transients drain slowly. The
 thru-line and notch examples define the tested uniform-Yee configurations.
 
+### Feed direction
+
+`direction` accepts `"+x"`, `"-x"`, `"+y"` and `"-y"`. The board lies in the
+xy-plane, so the feed may run along either in-board axis — useful when the
+geometry comes from a CAD import and you do not get to choose its orientation.
+`position` is a physical `(x, y, z)` point: the coordinate on the propagation
+axis is the feed plane, the coordinate on the other in-board axis is the trace
+centre, and `z` is the substrate bottom. `width` spans whichever in-board axis
+is *not* the propagation axis.
+
+`"+z"` / `"-z"` raise `ValueError`. The substrate normal is fixed to z by the
+`position` + scalar `height` contract, so a z-propagating microstrip would need
+its substrate normal along x or y — which that contract cannot express, and
+which the mode solve, the `"ez"` source component, the modal voltage and the
+trace-conductor scan all assume. Rotate the board instead.
+
+`mode="eigenmode"` remains `"+x"` / `"-x"` only.
+
 ---
 
 ## Waveguide port (`add_waveguide_port`)

--- a/rfx/api/__init__.py
+++ b/rfx/api/__init__.py
@@ -1505,14 +1505,37 @@ class Simulation(
 
         Parameters
         ----------
-        position : (x_feed, y_centre, z_lo)
-            Feed plane x, trace centre y, and substrate bottom z.
+        position : (x, y, z_lo)
+            Physical feed-plane point. The coordinate on the PROPAGATION
+            axis (named by ``direction``) is the feed plane; the
+            coordinate on the other in-board axis is the trace centre;
+            ``z`` is the substrate bottom. So a ``"+x"`` port reads it as
+            ``(x_feed, y_centre, z_lo)`` and a ``"+y"`` port as
+            ``(x_centre, y_feed, z_lo)``.
         width : float
-            Trace width in metres (y extent of the port).
+            Trace width in metres, spanning the in-board axis that is NOT
+            the propagation axis (y for an x-directed port, x for a
+            y-directed one).
         height : float
-            Substrate thickness in metres (z extent of the port).
-        direction : "+x" or "-x"
-            Direction the launched wave propagates.
+            Substrate thickness in metres — always the z extent, because
+            the substrate normal is fixed to z (see ``direction``).
+        direction : str
+            One of ``"+x"``, ``"-x"``, ``"+y"``, ``"-y"`` — the direction
+            the launched wave propagates. The board lies in the xy-plane
+            and the substrate normal is always z, so the feed may run
+            along either in-board axis (issue #661: a CAD-imported board
+            does not get to choose its orientation).
+
+            ``"+z"`` / ``"-z"`` are REJECTED with a clear error rather
+            than supported: a z-propagating microstrip needs its
+            substrate normal along x or y, which ``position`` + scalar
+            ``height`` cannot express, and which the Laplace mode solve,
+            the ``"ez"`` source component, the modal voltage
+            ``V = Σ Ez·dz`` and the trace-conductor PEC scan all assume.
+            Accepting it would return a z-normal answer for a board that
+            is not oriented that way.
+
+            ``mode="eigenmode"`` remains ``"+x"``/``"-x"`` only.
         impedance : float
             Target Z0 in ohms (default 50). Used for the σ distribution.
         waveform : GaussianPulse or callable, optional
@@ -1572,8 +1595,10 @@ class Simulation(
             if no such dielectric is found it falls back to 1.0, which is
             conservative (largest ``lam_min_eff`` → largest offset).
         """
-        if direction not in ("+x", "-x"):
-            raise ValueError(f"direction must be '+x' or '-x', got {direction!r}")
+        from rfx.sources.msl_port import msl_axis_roles as _msl_axis_roles
+        # Raises with the substrate-normal explanation for "+z"/"-z" and a
+        # plain domain error otherwise (issue #661).
+        _msl_axis_roles(direction)
         if width <= 0:
             raise ValueError(f"width must be positive, got {width}")
         if height <= 0:
@@ -1582,6 +1607,15 @@ class Simulation(
             raise ValueError(f"impedance must be positive, got {impedance}")
         if mode not in ("eigenmode", "laplace", "uniform"):
             raise ValueError(f"mode must be 'eigenmode', 'laplace', or 'uniform', got {mode!r}")
+        if mode == "eigenmode" and direction not in ("+x", "-x"):
+            raise NotImplementedError(
+                f"add_msl_port(mode='eigenmode', direction={direction!r}) is "
+                "not supported: the Schelkunoff J+M launch hard-codes the "
+                "x-axis TFSF correction pair and rides on the FDFD eigenmode "
+                "solver, which is a documented dead-end kept under a strict "
+                "xfail. Use mode='laplace' (the default) for a y-directed "
+                "port (issue #661)."
+            )
         # Wavelength-bound probe-placement defaults (issue #80 Fix B).
         # Cell-counted and fixed-µm defaults both placed probe 1 inside the
         # source reactive zone and the 3-probe quadratic at the q→1
@@ -1598,8 +1632,13 @@ class Simulation(
             eps_r_sub_estimate = float(eps_r_sub)
         else:
             eps_r_sub_estimate = 1.0
-            x_feed, y_centre, z_lo = position
-            probe_pt = (x_feed, y_centre, z_lo + height / 2.0)
+            # ``position`` is physical and ``height`` is always along z
+            # (the substrate normal), so the substrate mid-point probe is
+            # direction-independent (issue #661).
+            probe_pt = (
+                float(position[0]), float(position[1]),
+                float(position[2]) + height / 2.0,
+            )
             for ge in self._geometry:
                 try:
                     (lo0, lo1, lo2), (hi0, hi1, hi2) = ge.shape.bounding_box()

--- a/rfx/api/_preflight.py
+++ b/rfx/api/_preflight.py
@@ -438,6 +438,14 @@ def msl_nearest_downstream_reflector(
     for the nearest box edge at or beyond ``x_probe`` along the propagation
     direction, or ``(inf, None)`` when nothing qualifies.
 
+    Axis generality (issue #661): the parameter names are the ``"+x"``-frame
+    names. ``x_probe`` / ``x_feed`` are coordinates on the PROPAGATION axis,
+    ``y_feed`` is the trace centreline on the WIDTH axis and ``domain_y``
+    that axis's domain extent — the two axes are resolved from ``direction``
+    via :func:`~rfx.sources.msl_port.msl_axis_roles`, so a ``"+y"`` port
+    compares box y-extents along the feed axis and box x-extents across the
+    trace width. Callers pass coordinates already projected onto those roles.
+
     Exclusions (both are #469-arc corrections to the pre-existing
     heuristic):
 
@@ -455,8 +463,11 @@ def msl_nearest_downstream_reflector(
     * **ground-plane-like boxes** (y-extent ≥ 80 % of the domain y).
     """
     from rfx.geometry.csg import Box as _Box
+    from rfx.sources.msl_port import _MSL_AXIS_INDEX, msl_axis_roles
 
-    sign = 1.0 if direction == "+x" else -1.0
+    _prop_ax, _width_ax, _n_ax, sign = msl_axis_roles(direction)
+    _ip = _MSL_AXIS_INDEX[_prop_ax]
+    _iw = _MSL_AXIS_INDEX[_width_ax]
     nearest_d = float("inf")
     nearest_label = None
     for ge in geometry:
@@ -465,8 +476,9 @@ def msl_nearest_downstream_reflector(
         if not isinstance(shape, _Box) or str(mat).lower() != "pec":
             continue
         lo, hi = shape.corner_lo, shape.corner_hi
-        box_x_lo, box_x_hi = float(lo[0]), float(hi[0])
-        box_y_lo, box_y_hi = float(lo[1]), float(hi[1])
+        # "x" = propagation axis, "y" = trace-width axis (issue #661).
+        box_x_lo, box_x_hi = float(lo[_ip]), float(hi[_ip])
+        box_y_lo, box_y_hi = float(lo[_iw]), float(hi[_iw])
         box_y_extent = box_y_hi - box_y_lo
         # Skip the line being measured (see docstring).
         if (
@@ -497,8 +509,9 @@ def msl_nearest_downstream_reflector(
         if d < nearest_d:
             nearest_d = d
             nearest_label = (
-                f"PEC Box at x∈[{box_x_lo*1e3:.2f},{box_x_hi*1e3:.2f}]mm "
-                f"y∈[{box_y_lo*1e3:.2f},{box_y_hi*1e3:.2f}]mm"
+                f"PEC Box at {_prop_ax}∈[{box_x_lo*1e3:.2f},"
+                f"{box_x_hi*1e3:.2f}]mm "
+                f"{_width_ax}∈[{box_y_lo*1e3:.2f},{box_y_hi*1e3:.2f}]mm"
             )
     return nearest_d, nearest_label
 
@@ -541,6 +554,12 @@ def msl_absorber_compliant_offset_max(
 
     Returns ``None`` if no offset in ``[off_lo, guess_hi]`` clears
     (the compliant interval is empty).
+
+    Axis generality (issue #661): ``domain_x`` / ``ct_lo`` / ``ct_hi``
+    describe the port's PROPAGATION axis, not x specifically —
+    ``msl_probe_x_coords_n`` already walks whichever axis ``port.direction``
+    names, so the caller passes that axis's domain extent and CPML
+    thicknesses.
     """
     from rfx.sources.msl_port import msl_probe_x_coords_n as _probe_x_coords_n
 
@@ -4135,37 +4154,55 @@ class _PreflightMixin:
         # must never crash a run over a diagnostics helper, so a failed
         # grid build falls back to the pre-fix continuous formula at the
         # site below rather than raising or skipping checks 4/4a/4b.
-        from rfx.sources.msl_port import MSLPort as _MSLPort, msl_probe_x_coords_n as _probe_x_coords_n
+        from rfx.sources.msl_port import (
+            _MSL_AXIS_INDEX as _MSL_AX,
+            msl_axis_roles as _msl_axis_roles,
+            msl_port_from_entry as _msl_port_from_entry,
+            msl_probe_x_coords_n as _probe_x_coords_n,
+        )
         try:
             _msl_grid = self._build_grid()
         except Exception:
             _msl_grid = None
 
         for pe in self._msl_ports:
-            x_feed, y_centre, z_lo = pe.position
+            # Issue #661: every check below runs on the port's OWN axes.
+            # ``prop`` is the propagation axis (checks 3/4/4a fire along
+            # it), ``width`` the trace-width axis (check 1 fires across
+            # it). For a "+x" port these are x and y, i.e. the historical
+            # behaviour; for a "+y" port they swap, and quoting the wrong
+            # one would measure clearance against the wrong wall.
+            _prop_ax, _width_ax, _norm_ax, _dir_sign = _msl_axis_roles(
+                pe.direction
+            )
+            _ip = _MSL_AX[_prop_ax]
+            _iw = _MSL_AX[_width_ax]
+            _inr = _MSL_AX[_norm_ax]
+            x_feed = float(pe.position[_ip])
+            y_centre = float(pe.position[_iw])
             w_trace = float(pe.width)
             h_sub = float(pe.height)
             recommended = 2.0 * h_sub
 
-            # ---- 1. Lateral (y) clearance ----
+            # ---- 1. Lateral (trace-width axis) clearance ----
             trace_y_lo = y_centre - w_trace / 2.0
             trace_y_hi = y_centre + w_trace / 2.0
-            ly = float(domain[1])
+            ly = float(domain[_iw])
             # Reference position on each y side = the exterior-frame edge
             # (_absorber_boundary_for_axis; None on an inactive/periodic
             # face, treated as the plain domain edge) PLUS the explicit
             # calibrated buffer (issue #500 / MH2 — see class docstring):
             # cpml_thick_{lo,hi} = n_cpml*dx, zero on a PEC/PMC face.
             _ly_lo_b, _ly_hi_b = _absorber_boundary_for_axis(
-                ly, cpml_thick_lo[1], cpml_thick_hi[1]
+                ly, cpml_thick_lo[_iw], cpml_thick_hi[_iw]
             )
-            y_abs_lo = (_ly_lo_b if _ly_lo_b is not None else 0.0) + cpml_thick_lo[1]
-            y_abs_hi = (_ly_hi_b if _ly_hi_b is not None else ly) - cpml_thick_hi[1]
+            y_abs_lo = (_ly_lo_b if _ly_lo_b is not None else 0.0) + cpml_thick_lo[_iw]
+            y_abs_hi = (_ly_hi_b if _ly_hi_b is not None else ly) - cpml_thick_hi[_iw]
             clearance_lo = trace_y_lo - y_abs_lo
             clearance_hi = y_abs_hi - trace_y_hi
             for side, c, buf in (
-                ("−y", clearance_lo, cpml_thick_lo[1]),
-                ("+y", clearance_hi, cpml_thick_hi[1]),
+                (f"−{_width_ax}", clearance_lo, cpml_thick_lo[_iw]),
+                (f"+{_width_ax}", clearance_hi, cpml_thick_hi[_iw]),
             ):
                 if c < recommended:
                     pct = max(0.0, (1.0 - c / recommended)) * 15.0
@@ -4178,8 +4215,8 @@ class _PreflightMixin:
                             f"buffer) < recommended {recommended*1e6:.0f}µm "
                             f"(= 2·h_sub). Fringing field will be clipped → Z0 "
                             f"may be biased HIGH by ~{pct:.0f}%, mesh-conv may "
-                            f"diverge. Increase domain y-extent OR move port "
-                            f"further from sidewall.",
+                            f"diverge. Increase domain {_width_ax}-extent OR "
+                            f"move port further from sidewall.",
                             code="msl_port_geometry",
                             source="_check_msl_port_geometry",
                         ),
@@ -4264,33 +4301,40 @@ class _PreflightMixin:
                     stacklevel=3,
                 )
 
-            # ---- 3. Port-to-CPML distance in x ----
+            # ---- 3. Port-to-CPML distance along the PROPAGATION axis ----
             # Issue #500 / MH2: same reference as check 1 — exterior-frame
-            # edge PLUS the explicit calibrated buffer.
+            # edge PLUS the explicit calibrated buffer. Issue #661: the
+            # source-side wall is the LOW wall for a positive-going port
+            # and the HIGH wall for a negative-going one, on whichever
+            # axis ``direction`` names.
             _lx_lo_b, _lx_hi_b = _absorber_boundary_for_axis(
-                float(domain[0]), cpml_thick_lo[0], cpml_thick_hi[0]
+                float(domain[_ip]), cpml_thick_lo[_ip], cpml_thick_hi[_ip]
             )
-            x_abs_lo = (_lx_lo_b if _lx_lo_b is not None else 0.0) + cpml_thick_lo[0]
+            x_abs_lo = (_lx_lo_b if _lx_lo_b is not None else 0.0) + cpml_thick_lo[_ip]
             x_abs_hi = (
-                (_lx_hi_b if _lx_hi_b is not None else float(domain[0]))
-                - cpml_thick_hi[0]
+                (_lx_hi_b if _lx_hi_b is not None else float(domain[_ip]))
+                - cpml_thick_hi[_ip]
             )
             x_clearance = (
-                x_feed - x_abs_lo if pe.direction == "+x"
+                x_feed - x_abs_lo if _dir_sign > 0
                 else x_abs_hi - x_feed
             )
             if x_clearance < recommended:
-                _x_buf = cpml_thick_lo[0] if pe.direction == "+x" else cpml_thick_hi[0]
+                _x_buf = (
+                    cpml_thick_lo[_ip] if _dir_sign > 0
+                    else cpml_thick_hi[_ip]
+                )
                 _w.warn(
                     PreflightWarning(
-                        f"MSL port '{pe.name}' at x={x_feed*1e3:.2f}mm, "
+                        f"MSL port '{pe.name}' at {_prop_ax}="
+                        f"{x_feed*1e3:.2f}mm, "
                         f"direction={pe.direction!r}: distance to nearest "
-                        f"x-CPML = {x_clearance*1e6:.0f}µm (domain edge + "
-                        f"{_fmt_len(_x_buf)} calibrated CPML buffer) < "
+                        f"{_prop_ax}-CPML = {x_clearance*1e6:.0f}µm (domain "
+                        f"edge + {_fmt_len(_x_buf)} calibrated CPML buffer) < "
                         f"recommended {recommended*1e6:.0f}µm (= 2·h_sub). "
                         f"Source-side CPML reflection may inflate |S11|. Move "
                         f"port further from boundary OR increase domain "
-                        f"x-extent.",
+                        f"{_prop_ax}-extent.",
                         code="msl_port_geometry",
                         source="_check_msl_port_geometry",
                     ),
@@ -4317,18 +4361,9 @@ class _PreflightMixin:
             n_off = pe.n_probe_offset if pe.n_probe_offset is not None else 5
             n_sp = pe.n_probe_spacing if pe.n_probe_spacing is not None else 3
             n_pr = getattr(pe, "n_probes", 5) or 5
-            sign = 1.0 if pe.direction == "+x" else -1.0
+            sign = float(_dir_sign)
 
-            _mp = _MSLPort(
-                feed_x=float(x_feed),
-                y_lo=float(y_centre - w_trace / 2.0),
-                y_hi=float(y_centre + w_trace / 2.0),
-                z_lo=float(z_lo),
-                z_hi=float(z_lo + h_sub),
-                direction=pe.direction,
-                impedance=float(pe.impedance),
-                excitation=pe.waveform,
-            )
+            _mp = _msl_port_from_entry(pe)
             _probe_ladder = None
             if _msl_grid is not None:
                 try:
@@ -4386,7 +4421,7 @@ class _PreflightMixin:
                 y_feed=y_centre,
                 w_trace=w_trace,
                 dx=dx,
-                domain_y=float(domain[1]),
+                domain_y=float(domain[_iw]),
                 direction=pe.direction,
             )
 
@@ -4463,11 +4498,11 @@ class _PreflightMixin:
             # NU-grid deepest probe sits at 3.24mm. Exact parity with
             # every other quantity this whole function already computes
             # off the scalar ``dx`` parameter, so not a new limitation.
-            _domain_x = float(domain[0])
+            _domain_x = float(domain[_ip])
             _deep_idx = n_pr - 1
             _abs_margin = _ABSORBER_PROXIMITY_CELLS * dx
             _abs_headroom = (
-                _domain_x - x_feed if pe.direction == "+x" else x_feed
+                _domain_x - x_feed if _dir_sign > 0 else x_feed
             )
             _abs_hsub_cells = int(round(5.0 * h_sub / dx))
             _abs_off_lo = max(3, _abs_hsub_cells)
@@ -4486,8 +4521,8 @@ class _PreflightMixin:
                 _abs_off_max = msl_absorber_compliant_offset_max(
                     _msl_grid, _mp,
                     n_probes=n_pr, n_spacing=n_sp, off_lo=_abs_off_lo,
-                    domain_x=_domain_x, ct_lo=cpml_thick_lo[0],
-                    ct_hi=cpml_thick_hi[0], dx=dx, guess_hi=_abs_guess_hi,
+                    domain_x=_domain_x, ct_lo=cpml_thick_lo[_ip],
+                    ct_hi=cpml_thick_hi[_ip], dx=dx, guess_hi=_abs_guess_hi,
                 )
             else:
                 # Fallback (grid build failed): the pre-fix algebraic
@@ -4503,12 +4538,13 @@ class _PreflightMixin:
                 else "no compliant n_probe_offset exists on this feed "
                 "length (interval empty)"
             )
-            if _coord_in_absorber(x_deep, _domain_x, cpml_thick_lo[0], cpml_thick_hi[0]):
+            if _coord_in_absorber(x_deep, _domain_x, cpml_thick_lo[_ip], cpml_thick_hi[_ip]):
                 _w.warn(
                     PreflightWarning(
                         f"MSL port '{pe.name}' (direction={pe.direction!r}): "
-                        f"probe {_deep_idx} (deepest, x={x_deep*1e3:.2f}mm) is "
-                        f"past the domain edge (domain x-extent [0, "
+                        f"probe {_deep_idx} (deepest, {_prop_ax}="
+                        f"{x_deep*1e3:.2f}mm) is "
+                        f"past the domain edge (domain {_prop_ax}-extent [0, "
                         f"{_domain_x*1e3:.2f}]mm) — inside the CPML absorbing "
                         f"region. The N-probe extractor's clean-travelling-"
                         f"wave assumption is void there: signal is attenuated "
@@ -4520,7 +4556,7 @@ class _PreflightMixin:
                     stacklevel=3,
                 )
             elif _coord_near_absorber(
-                x_deep, _domain_x, cpml_thick_lo[0], cpml_thick_hi[0], dx
+                x_deep, _domain_x, cpml_thick_lo[_ip], cpml_thick_hi[_ip], dx
             ):
                 # Issue #510 review round-2 (nit B): this site was missed
                 # when the "just past which" rephrasing (see the matching
@@ -4532,7 +4568,8 @@ class _PreflightMixin:
                 _w.warn(
                     PreflightWarning(
                         f"MSL port '{pe.name}' (direction={pe.direction!r}): "
-                        f"probe {_deep_idx} (deepest, x={x_deep*1e3:.2f}mm) is "
+                        f"probe {_deep_idx} (deepest, {_prop_ax}="
+                        f"{x_deep*1e3:.2f}mm) is "
                         f"within {_ABSORBER_PROXIMITY_CELLS} cells "
                         f"({_fmt_len(_abs_margin)}) of the domain edge, just "
                         f"past which the CPML absorber is active. Fields "
@@ -4564,12 +4601,13 @@ class _PreflightMixin:
             # feed / reference plane but are out of scope here (issue
             # #510 review, disclosed rather than fixed).
             _span_lo, _span_hi = (
-                (x_feed, x_deep) if pe.direction == "+x" else (x_deep, x_feed)
+                (x_feed, x_deep) if _dir_sign > 0 else (x_deep, x_feed)
             )
             for _other in list(self._msl_ports) + list(self._ports):
                 if _other is pe:
                     continue
-                _other_x = _other.position[0]
+                # Issue #661: compare on THIS port's propagation axis.
+                _other_x = _other.position[_ip]
                 if _span_lo < _other_x < _span_hi:
                     _other_name = getattr(_other, "name", None)
                     # Issue #510 review (BLOCKING 3): the previous label
@@ -4586,9 +4624,10 @@ class _PreflightMixin:
                     _w.warn(
                         PreflightWarning(
                             f"MSL port '{pe.name}' (direction={pe.direction!r}): "
-                            f"probe span x∈[{_span_lo*1e3:.2f}, "
+                            f"probe span {_prop_ax}∈[{_span_lo*1e3:.2f}, "
                             f"{_span_hi*1e3:.2f}]mm crosses the feed plane "
-                            f"of {_other_owner_txt} at x={_other_x*1e3:.2f}mm. "
+                            f"of {_other_owner_txt} at {_prop_ax}="
+                            f"{_other_x*1e3:.2f}mm. "
                             f"A feed is a source discontinuity the "
                             f"reflector scan above cannot see; probes "
                             f"sampling across it break the N-probe "

--- a/rfx/api/_sparams.py
+++ b/rfx/api/_sparams.py
@@ -422,6 +422,10 @@ def _resolve_msl_auto_offsets(sim, entries, grid):
         msl_min_probe_clearance,
         msl_nearest_downstream_reflector,
     )
+    from rfx.sources.msl_port import (
+        _MSL_AXIS_INDEX as _MSL_AX,
+        msl_axis_roles as _msl_axis_roles,
+    )
 
     dx_u = float(grid.dx)
     clear = msl_min_probe_clearance(float(sim._freq_max))
@@ -432,14 +436,19 @@ def _resolve_msl_auto_offsets(sim, entries, grid):
             resolved.append(pe)
             continue
         span = (int(pe.n_probes) - 1) * int(pe.n_probe_spacing)
+        # Issue #661: project position/domain onto this port's propagation
+        # and width axes before handing them to the x-frame helper.
+        _prop_ax, _width_ax, _, _ = _msl_axis_roles(pe.direction)
+        _ip = _MSL_AX[_prop_ax]
+        _iw = _MSL_AX[_width_ax]
         d_refl, _ = msl_nearest_downstream_reflector(
             getattr(sim, "_geometry", []),
-            x_probe=float(pe.position[0]),
-            x_feed=float(pe.position[0]),
-            y_feed=float(pe.position[1]),
+            x_probe=float(pe.position[_ip]),
+            x_feed=float(pe.position[_ip]),
+            y_feed=float(pe.position[_iw]),
             w_trace=float(pe.width),
             dx=dx_u,
-            domain_y=float(sim._domain[1]),
+            domain_y=float(sim._domain[_iw]),
             direction=pe.direction,
         )
         if not np.isfinite(d_refl):
@@ -2569,9 +2578,13 @@ class _SparamMixin:
         from rfx.probes.msl_wave_decomp import extract_msl_nprobe
         from rfx.sources.msl_eigenmode import hammerstad_jensen_z0_eps_eff
         from rfx.sources.msl_port import (
-            MSLPort,
-            _msl_yz_cells,
+            msl_ampere_pair,
+            msl_axis_roles,
+            msl_cell,
+            msl_cross_section_span,
             msl_loop_current,
+            msl_physical_point,
+            msl_port_from_entry,
             msl_probe_x_coords_n,
         )
 
@@ -2668,20 +2681,10 @@ class _SparamMixin:
         # geometry registered — see _resolve_msl_auto_offsets).
         entries = _resolve_msl_auto_offsets(self, entries, grid)
 
-        # Build MSLPort descriptors and probe x-coords once (geometry shared).
-        msl_ports: list[MSLPort] = []
-        for pe in entries:
-            x_feed, y_centre, z_lo = pe.position
-            msl_ports.append(MSLPort(
-                feed_x=float(x_feed),
-                y_lo=float(y_centre - pe.width / 2),
-                y_hi=float(y_centre + pe.width / 2),
-                z_lo=float(z_lo),
-                z_hi=float(z_lo + pe.height),
-                direction=pe.direction,
-                impedance=pe.impedance,
-                excitation=pe.waveform,
-            ))
+        # Build MSLPort descriptors and probe coords once (geometry shared).
+        # Issue #661: msl_port_from_entry projects ``position`` onto the
+        # port frame for whichever in-plane axis ``direction`` names.
+        msl_ports = [msl_port_from_entry(pe) for pe in entries]
 
         # N-probe placement (issue #80 Fix C). Probe n sits at
         # offset + n*spacing cells from the feed plane. N >= 3.
@@ -2708,24 +2711,46 @@ class _SparamMixin:
         # Per-axis cell-size arrays for V/I integration. Both uniform and
         # non-uniform grids are supported — NonUniformGrid exposes per-cell
         # dx_arr/dy_arr/dz (NOT *_profile); see _msl_cell_profile.
-        dy_arr = _msl_cell_profile(grid, "y", grid.ny)
-        dz_arr = _msl_cell_profile(grid, "z", grid.nz)
+        #
+        # Issue #661: ports may point along different in-plane axes, so the
+        # transverse profiles are resolved PER PORT. The substrate-normal
+        # profile is always z (the normal axis is welded — see
+        # msl_axis_roles), which is why the modal-voltage integration below
+        # needs no per-port branch.
+        _axis_n = {"x": grid.nx, "y": grid.ny, "z": grid.nz}
+
+        def _prof(ax):
+            return _msl_cell_profile(grid, ax, _axis_n[ax])
+
+        dz_arr = _prof("z")     # substrate-normal profile (V integration)
 
         # Fixed cross-section indices per port (same across all runs).
+        # Names are the historical x-frame names; their MEANING is
+        # (width, substrate-normal): ``j_*`` indexes the trace-width axis
+        # and ``k_*`` the normal axis. A DFT plane normal to the
+        # propagation axis is stored as [freq, width, normal] for BOTH
+        # "x" and "y" plane normals (probes.py: axis 0 -> (ny, nz),
+        # axis 1 -> (nx, nz)), so these indices address the recorded
+        # planes directly without a per-direction branch.
         port_idx_meta = []
         for mp in msl_ports:
-            cells = _msl_yz_cells(grid, mp)
-            j_set = sorted({c[1] for c in cells})
-            k_set = sorted({c[2] for c in cells})
-            j_lo, j_hi = j_set[0], j_set[-1]
-            k_lo, k_hi = k_set[0], k_set[-1]
-            j_centre = (j_lo + j_hi) // 2
-            k_top = k_hi  # trace sits at the top of the substrate
+            span = msl_cross_section_span(grid, mp)
+            a_ax, b_ax = msl_ampere_pair(mp.direction)
             port_idx_meta.append(dict(
-                j_lo=j_lo, j_hi=j_hi,
-                k_lo=k_lo, k_hi=k_hi,
-                j_centre=j_centre, k_top=k_top,
+                j_lo=span["w_lo"], j_hi=span["w_hi"],
+                k_lo=span["n_lo"], k_hi=span["n_hi"],
+                j_centre=span["w_centre"], k_top=span["n_hi"],
                 height=mp.z_hi - mp.z_lo,
+                i_feed=span["i_feed"],
+                prop_axis=span["prop_axis"], width_axis=span["width_axis"],
+                normal_axis=span["normal_axis"], sign=span["sign"],
+                prop_idx=span["prop_idx"], width_idx=span["width_idx"],
+                normal_idx=span["normal_idx"],
+                # Closed-Ampere-loop transverse pair (a_hat x b_hat = p_hat).
+                a_axis=a_ax, b_axis=b_ax,
+                a_is_width=(a_ax == span["width_axis"]),
+                a_arr=_prof(a_ax), b_arr=_prof(b_ax),
+                h_a=f"h{a_ax}", h_b=f"h{b_ax}",
             ))
 
         # Analytic Hammerstad-Jensen anchor per port (issue #80 Fix C).
@@ -2760,12 +2785,10 @@ class _SparamMixin:
                 eps_r_ref = float(pe.eps_r_sub)
             else:
                 k_mid = (meta["k_lo"] + meta["k_hi"]) // 2
-                i_feed_p = _msl_yz_cells(grid, msl_ports[p_idx])[0][0]
-                eps_r_ref = float(
-                    np.asarray(
-                        _msl_materials.eps_r[i_feed_p, meta["j_centre"], k_mid]
-                    )
+                eps_cell = msl_cell(
+                    pe.direction, meta["i_feed"], meta["j_centre"], k_mid
                 )
+                eps_r_ref = float(np.asarray(_msl_materials.eps_r[eps_cell]))
             z0_hj, eps_eff_hj = hammerstad_jensen_z0_eps_eff(
                 pe.width, pe.height, eps_r_ref
             )
@@ -2781,10 +2804,16 @@ class _SparamMixin:
         trace_k_per_port: list[tuple[int, int]] = []
         for p_idx in range(n_ports):
             meta = port_idx_meta[p_idx]
-            i_feed_p = _msl_yz_cells(grid, msl_ports[p_idx])[0][0]
+            # Walk UP the substrate-normal axis (always z) from the
+            # substrate top, at the feed cell on the propagation axis and
+            # the trace centre on the width axis (issue #661).
+            _sel = [0, 0, 0]
+            _sel[meta["prop_idx"]] = meta["i_feed"]
+            _sel[meta["width_idx"]] = meta["j_centre"]
+            _sel[meta["normal_idx"]] = slice(meta["k_top"], None)
             col = (
                 None if _msl_pec_mask is None
-                else _msl_pec_mask[i_feed_p, meta["j_centre"], meta["k_top"]:]
+                else _msl_pec_mask[tuple(_sel)]
             )
             k_pec = np.array([], dtype=int) if col is None else np.where(col)[0]
             if k_pec.size == 0:
@@ -2844,13 +2873,18 @@ class _SparamMixin:
             # textbook ring-down witness.
             _witness_base = len(self._probes)
             _witness_counts: list[int] = []
-            for pe_w, pxs_w in zip(entries, probe_xs):
+            for pe_w, pxs_w, meta_w in zip(entries, probe_xs, port_idx_meta):
+                _w_centre_m = float(pe_w.position[meta_w["width_idx"]])
+                _n_lo_m = float(pe_w.position[meta_w["normal_idx"]])
                 for _x_w in pxs_w:
+                    # ``_x_w`` is a coordinate on the PROPAGATION axis;
+                    # rebuild the physical point for this port's direction.
                     self.add_probe(
-                        position=(
+                        position=msl_physical_point(
+                            pe_w.direction,
                             float(_x_w),
-                            float(pe_w.position[1]),
-                            float(pe_w.position[2]) + 0.5 * float(pe_w.height),
+                            _w_centre_m,
+                            _n_lo_m + 0.5 * float(pe_w.height),
                         ),
                         component="ez",
                     )
@@ -2897,27 +2931,32 @@ class _SparamMixin:
                 hy_probe_names: list[str] = [None] * n_ports  # type: ignore
                 hz_probe_names: list[str] = [None] * n_ports  # type: ignore
                 for p_idx, (mp, pxs) in enumerate(zip(msl_ports, probe_xs)):
+                    # Plane normal = this port's PROPAGATION axis; the two
+                    # H components are the closed-Ampere-loop pair
+                    # (a_hat x b_hat = p_hat), not a fixed (hy, hz).
+                    _meta_p = port_idx_meta[p_idx]
+                    _plane_axis = _meta_p["prop_axis"]
                     for q_idx, x_coord in enumerate(pxs):
                         nm = f"_msl_run{driven}_p{p_idx}_ez{q_idx}"
                         self.add_dft_plane_probe(
-                            axis="x", coordinate=float(x_coord),
+                            axis=_plane_axis, coordinate=float(x_coord),
                             component="ez", freqs=jnp.asarray(freqs_arr),
                             name=nm,
                         )
                         ez_probe_names[p_idx].append(nm)
-                    nm_hy = f"_msl_run{driven}_p{p_idx}_hy"
+                    nm_hy = f"_msl_run{driven}_p{p_idx}_{_meta_p['h_a']}"
                     self.add_dft_plane_probe(
-                        axis="x", coordinate=float(pxs[0]),
-                        component="hy", freqs=jnp.asarray(freqs_arr),
+                        axis=_plane_axis, coordinate=float(pxs[0]),
+                        component=_meta_p["h_a"], freqs=jnp.asarray(freqs_arr),
                         name=nm_hy,
                     )
                     hy_probe_names[p_idx] = nm_hy
-                    # Hz plane probe at probe 0 — the side legs of the
+                    # H_b plane probe at probe 0 — the other leg pair of the
                     # closed Ampere-loop current (issue #80 stage S1).
-                    nm_hz = f"_msl_run{driven}_p{p_idx}_hz"
+                    nm_hz = f"_msl_run{driven}_p{p_idx}_{_meta_p['h_b']}"
                     self.add_dft_plane_probe(
-                        axis="x", coordinate=float(pxs[0]),
-                        component="hz", freqs=jnp.asarray(freqs_arr),
+                        axis=_plane_axis, coordinate=float(pxs[0]),
+                        component=_meta_p["h_b"], freqs=jnp.asarray(freqs_arr),
                         name=nm_hz,
                     )
                     hz_probe_names[p_idx] = nm_hz
@@ -2988,6 +3027,10 @@ class _SparamMixin:
                         # trace_k_per_port is the same PEC search the
                         # current integration uses, so V and I share one
                         # conductor plane by construction.
+                        # ez_plane is [freq, width, normal] for an x- OR a
+                        # y-normal plane alike (issue #661), so j_centre /
+                        # k_lo / k_hi address it unchanged and the dz_arr
+                        # here is always the substrate-normal profile.
                         vs.append(msl_modal_voltage(
                             ez_plane, j_centre=meta["j_centre"],
                             k_lo=meta["k_lo"],
@@ -3027,11 +3070,31 @@ class _SparamMixin:
                     # contour (bottom/top Hy legs + left/right Hz legs) and
                     # carries the +x current-sign convention.
                     k_tr_lo, k_tr_hi = trace_k_per_port[p_idx]
+                    # Issue #661: msl_loop_current wants the planes in the
+                    # right-handed transverse frame [freq, a, b] with
+                    # a_hat x b_hat = p_hat. The recorded planes are
+                    # [freq, width, normal]. For "+x"/"-x" the pair is
+                    # (y, z) = (width, normal) — already in frame, no
+                    # transpose, byte-identical to the pre-#661 call. For
+                    # "+y"/"-y" the pair is (z, x) = (normal, width), so
+                    # the two axes swap and the spans swap with them.
+                    # Do NOT "simplify" this into a plain x<->y rename:
+                    # that is a reflection, it flips the sign of I, and it
+                    # inverts S silently (see _MSL_CYCLIC_PAIR).
+                    if meta["a_is_width"]:
+                        _ha, _hb = hy_plane, hz_plane
+                        _a_lo, _a_hi = meta["j_lo"], meta["j_hi"]
+                        _b_lo, _b_hi = k_tr_lo, k_tr_hi
+                    else:
+                        _ha = jnp.transpose(hy_plane, (0, 2, 1))
+                        _hb = jnp.transpose(hz_plane, (0, 2, 1))
+                        _a_lo, _a_hi = k_tr_lo, k_tr_hi
+                        _b_lo, _b_hi = meta["j_lo"], meta["j_hi"]
                     i_f = msl_loop_current(
-                        hy_plane, hz_plane,
-                        j_lo=meta["j_lo"], j_hi=meta["j_hi"],
-                        k_trace_lo=k_tr_lo, k_trace_hi=k_tr_hi,
-                        dy_arr=dy_arr, dz_arr=dz_arr,
+                        _ha, _hb,
+                        j_lo=_a_lo, j_hi=_a_hi,
+                        k_trace_lo=_b_lo, k_trace_hi=_b_hi,
+                        dy_arr=meta["a_arr"], dz_arr=meta["b_arr"],
                         direction=msl_ports[p_idx].direction,
                     )
                     i_first_per_port.append(i_f)
@@ -3063,7 +3126,9 @@ class _SparamMixin:
                     # while leaving the genuine ~20-27% 3-cell Yee-staircase Z0 warning on
                     # both ports. NB: the raw current dump (raw_i1) intentionally keeps
                     # its un-normalized sign; only the DERIVED Z0 is sign-normalized.
-                    dir_sign = 1.0 if msl_ports[p_idx].direction == "+x" else -1.0
+                    dir_sign = float(
+                        msl_axis_roles(msl_ports[p_idx].direction)[3]
+                    )
                     z0_fit = jnp.asarray(res_p["z0"], dtype=_complex_dtype) * dir_sign
                     raw_z0 = raw_z0.at[driven, p_idx, :].set(z0_fit)
                     raw_q = raw_q.at[driven, p_idx, :].set(jnp.asarray(res_p["q"], dtype=_complex_dtype))
@@ -3631,6 +3696,20 @@ class _SparamMixin:
                 "waveguide/Floquet ports are not part of the validated "
                 "mixed lane (issue #488)."
             )
+        _mixed_non_x = [
+            pe.name for pe in self._msl_ports
+            if pe.direction not in ("+x", "-x")
+        ]
+        if _mixed_non_x:
+            raise NotImplementedError(
+                "compute_mixed_s_matrix() v1 covers '+x'/'-x' MSL ports "
+                f"only; {_mixed_non_x} are not x-directed. The y-directed "
+                "MSL lane landed in issue #661 for compute_msl_s_matrix(); "
+                "this mixed lane is itself EXPERIMENTAL (issue #488) with "
+                "both diagonals unverified, so it is fenced rather than "
+                "extended untested. Use compute_msl_s_matrix() for a pure "
+                "MSL multiport."
+            )
         if self._coaxial_ports:
             raise NotImplementedError(
                 "compute_mixed_s_matrix() v1 covers lumped/wire + MSL only; "
@@ -4168,16 +4247,29 @@ class _SparamMixin:
             # scan that lands on the wrong branch SWAPS the two wave
             # roles and flips the sign of (alpha - gamma) — and therefore
             # of z0 = (alpha - gamma)/I1. Measured on one fixture: the
-            # fitted sign differs between num_periods=4 and 20. On top of
-            # that, `msl_loop_current`'s docstring (rfx/sources/
-            # msl_port.py, "the returned I is positive for a forward
-            # quasi-TEM wave") and compute_msl_s_matrix's #140 dir_sign
-            # comment ("a -x port's fitted z0 inherits a negative sign")
-            # describe OPPOSITE conventions; that contradiction is
-            # unresolved and is tracked in issue #524 (together with the
-            # two orphaned #507 loose ends: the passive port's ~30 ohm
-            # termination reading and the 0.194-vs-0.073 drive
-            # asymmetry), not papered over here.
+            # fitted sign differs between num_periods=4 and 20.
+            #
+            # The SECOND half of what this comment used to allege — that
+            # `msl_loop_current`'s docstring ("the returned I is positive
+            # for a forward quasi-TEM wave") and compute_msl_s_matrix's
+            # #140 dir_sign comment ("a -x port's fitted z0 inherits a
+            # negative sign") describe OPPOSITE conventions — was
+            # measured during issue #661 and is a PROSE defect only, now
+            # corrected in msl_loop_current's docstring. Own-drive
+            # diagonal on the committed thru fixture:
+            # Re((alpha-gamma)/I1) = +57.52 ohm at the "+x" port and
+            # -57.56 ohm at the "-x" port (same magnitude to 0.08%), so
+            # the #140 comment described the code and the docstring's
+            # blanket claim was scoped wrong. The lane is self-consistent
+            # about it: |S11|=|S22| to 5 decimals, reciprocity 1.27e-05,
+            # column power <= 0.99998, both reported Z0 positive. No code
+            # changed. The beta-branch instability above is separate and
+            # still stands.
+            #
+            # Issue #524 remains open for its other two items (the
+            # passive port's ~30 ohm termination reading and the
+            # 0.194-vs-0.073 drive asymmetry, both orphaned from #507);
+            # see #524.
             #
             # The fit is still computed and EXPOSED (return_diagnostics)
             # because it is the only handle on the open 30-vs-48 ohm

--- a/rfx/probes/msl_wave_decomp.py
+++ b/rfx/probes/msl_wave_decomp.py
@@ -220,25 +220,33 @@ def register_msl_plane_probes(
     """
     import numpy as np
     from rfx.sources.msl_port import (
-        MSLPort, _msl_yz_cells, msl_probe_x_coords,
+        _msl_yz_cells, msl_port_from_entry, msl_probe_x_coords,
     )
 
     if name_prefix is None:
         name_prefix = f"msl_p{port_index}"
 
     pe = sim._msl_ports[port_index]
+
+    # Issue #661: this helper is the retained 3-probe geometry primitive
+    # (diagnostic only — the production S-matrix path is
+    # compute_msl_s_matrix). Its cross-section bookkeeping below reads
+    # ``c[1]``/``c[2]`` as (y, z) and registers x-normal plane probes with
+    # a fixed (ez, hy, hz) component set, all of which are x-frame. Rather
+    # than generalise an off-production path without its own evidence, a
+    # non-x port is refused here — the alternative would be returning an
+    # x-flavoured answer for a y-directed port.
+    if pe.direction not in ("+x", "-x"):
+        raise NotImplementedError(
+            f"register_msl_plane_probes supports direction '+x'/'-x' only, "
+            f"got {pe.direction!r} for port {port_index}. This is the "
+            f"retained 3-probe DIAGNOSTIC primitive, not the production "
+            f"S-matrix path; use Simulation.compute_msl_s_matrix(), which "
+            f"handles every supported direction."
+        )
+
     grid = sim._build_grid()
-    x_feed, y_centre, z_lo = pe.position
-    mp = MSLPort(
-        feed_x=float(x_feed),
-        y_lo=float(y_centre - pe.width / 2),
-        y_hi=float(y_centre + pe.width / 2),
-        z_lo=float(z_lo),
-        z_hi=float(z_lo + pe.height),
-        direction=pe.direction,
-        impedance=pe.impedance,
-        excitation=pe.waveform,
-    )
+    mp = msl_port_from_entry(pe)
 
     pxs = msl_probe_x_coords(
         grid, mp,

--- a/rfx/runners/nonuniform.py
+++ b/rfx/runners/nonuniform.py
@@ -324,24 +324,17 @@ def _setup_msl_ports_nu(sim, grid, materials, materials_concrete, sources,
     the (possibly σ-updated) ``materials`` and ``pec_mask``.
     """
     from rfx.sources.msl_port import (
-        MSLPort,
         _msl_yz_cells,
         compute_msl_mode_profile,
         make_msl_port_sources,
+        msl_cell,
+        msl_cross_section_span,
+        msl_port_from_entry,
         setup_msl_port,
     )
     for pe in sim._msl_ports:
-        x_feed, y_centre, z_lo = pe.position
-        mp = MSLPort(
-            feed_x=float(x_feed),
-            y_lo=float(y_centre - pe.width / 2),
-            y_hi=float(y_centre + pe.width / 2),
-            z_lo=float(z_lo),
-            z_hi=float(z_lo + pe.height),
-            direction=pe.direction,
-            impedance=pe.impedance,
-            excitation=pe.waveform,
-        )
+        # Issue #661: one shared projection of position -> port frame.
+        mp = msl_port_from_entry(pe)
         port_mode = getattr(pe, "mode", "laplace")
         if port_mode == "eigenmode":
             raise NotImplementedError(
@@ -353,17 +346,15 @@ def _setup_msl_ports_nu(sim, grid, materials, materials_concrete, sources,
             )
         # laplace / uniform: build the static-Laplace Ez mode profile from the
         # substrate eps_r read concretely under the trace centre.
-        cells = _msl_yz_cells(grid, mp)
-        j_set = sorted({c[1] for c in cells})
-        k_set = sorted({c[2] for c in cells})
-        j_centre = (j_set[0] + j_set[-1]) // 2
-        k_mid = (k_set[0] + k_set[-1]) // 2
-        i_feed = cells[0][0]
+        span = msl_cross_section_span(grid, mp)
+        k_mid = (span["n_lo"] + span["n_hi"]) // 2
+        eps_cell = msl_cell(
+            pe.direction, span["i_feed"], span["w_centre"], k_mid
+        )
         if pe.eps_r_sub is not None:
             eps_r_sub = float(pe.eps_r_sub)
         else:
-            eps_r_sub = float(np.asarray(
-                materials_concrete.eps_r[i_feed, j_centre, k_mid]))
+            eps_r_sub = float(np.asarray(materials_concrete.eps_r[eps_cell]))
         mode_profile = compute_msl_mode_profile(grid, mp, eps_r_sub)
 
         materials = setup_msl_port(grid, mp, materials, mode_profile=mode_profile)

--- a/rfx/runners/uniform.py
+++ b/rfx/runners/uniform.py
@@ -400,43 +400,36 @@ def run_uniform(
     # MSL ports — full cross-section distributed feed
     if getattr(sim, "_msl_ports", None):
         from rfx.sources.msl_port import (
-            MSLPort,
             _msl_yz_cells,
             compute_msl_mode_profile,
             make_msl_port_sources,
             make_msl_port_sources_jm,
+            msl_cell,
+            msl_cross_section_span,
+            msl_port_from_entry,
             setup_msl_port,
         )
         for pe in sim._msl_ports:
-            x_feed, y_centre, z_lo = pe.position
-            mp = MSLPort(
-                feed_x=float(x_feed),
-                y_lo=float(y_centre - pe.width / 2),
-                y_hi=float(y_centre + pe.width / 2),
-                z_lo=float(z_lo),
-                z_hi=float(z_lo + pe.height),
-                direction=pe.direction,
-                impedance=pe.impedance,
-                excitation=pe.waveform,
-            )
+            # Issue #661: one shared projection of position -> port frame.
+            mp = msl_port_from_entry(pe)
             mode_profile = None
             eigenmode_data = None
             port_mode = getattr(pe, "mode", "uniform")
-            if port_mode == "eigenmode":
-                from rfx.sources.msl_eigenmode import compute_msl_eigenmode_profile
+            if port_mode in ("eigenmode", "laplace"):
                 # Substrate eps_r: use explicit value if provided,
                 # otherwise read from the FDTD eps_r array directly
                 # under the trace centre (most representative cell).
-                cells = _msl_yz_cells(grid, mp)
-                k_set = sorted({c[2] for c in cells})
-                j_set = sorted({c[1] for c in cells})
-                j_centre = (j_set[0] + j_set[-1]) // 2
-                k_mid = (k_set[0] + k_set[-1]) // 2
-                i_feed = cells[0][0]
+                span = msl_cross_section_span(grid, mp)
+                k_mid = (span["n_lo"] + span["n_hi"]) // 2
+                eps_cell = msl_cell(
+                    pe.direction, span["i_feed"], span["w_centre"], k_mid
+                )
                 if pe.eps_r_sub is not None:
                     eps_r_sub = float(pe.eps_r_sub)
                 else:
-                    eps_r_sub = float(np.asarray(materials.eps_r[i_feed, j_centre, k_mid]))
+                    eps_r_sub = float(np.asarray(materials.eps_r[eps_cell]))
+            if port_mode == "eigenmode":
+                from rfx.sources.msl_eigenmode import compute_msl_eigenmode_profile
                 # Build frequency array from grid for β(ω) curve
                 freqs_for_em = np.linspace(
                     sim._freq_max / 10.0, sim._freq_max, 20)
@@ -447,16 +440,6 @@ def run_uniform(
                 mode_profile = compute_msl_mode_profile(grid, mp, eps_r_sub)
             elif port_mode == "laplace":
                 # Explicit static-Laplace Ez-only mode (no J+M).
-                cells = _msl_yz_cells(grid, mp)
-                k_set = sorted({c[2] for c in cells})
-                j_set = sorted({c[1] for c in cells})
-                j_centre = (j_set[0] + j_set[-1]) // 2
-                k_mid = (k_set[0] + k_set[-1]) // 2
-                i_feed = cells[0][0]
-                if pe.eps_r_sub is not None:
-                    eps_r_sub = float(pe.eps_r_sub)
-                else:
-                    eps_r_sub = float(np.asarray(materials.eps_r[i_feed, j_centre, k_mid]))
                 mode_profile = compute_msl_mode_profile(grid, mp, eps_r_sub)
             materials = setup_msl_port(grid, mp, materials,
                                        mode_profile=mode_profile)

--- a/rfx/sources/msl_port.py
+++ b/rfx/sources/msl_port.py
@@ -40,6 +40,124 @@ _ETA0 = np.sqrt(MU_0 / EPS_0)
 
 
 # ---------------------------------------------------------------------------
+# Axis roles (issue #661)
+# ---------------------------------------------------------------------------
+
+#: Axis name -> index into a physical ``(x, y, z)`` tuple.
+_MSL_AXIS_INDEX = {"x": 0, "y": 1, "z": 2}
+
+#: ``direction`` -> ``(propagation, width, substrate-normal, sign)``.
+#: The substrate normal is always z; see :func:`msl_axis_roles`.
+_MSL_AXIS_ROLES = {
+    "+x": ("x", "y", "z", +1.0),
+    "-x": ("x", "y", "z", -1.0),
+    "+y": ("y", "x", "z", +1.0),
+    "-y": ("y", "x", "z", -1.0),
+}
+
+#: Right-handed cyclic transverse pair ``(a, b)`` for a propagation axis
+#: ``p``, defined by ``a_hat x b_hat = p_hat``.  This is what makes the
+#: closed Ampere loop enclose current along ``+p_hat``: traversing
+#: ``+a`` at low ``b``, ``+b`` at high ``a``, ``-a`` at high ``b``,
+#: ``-b`` at low ``a`` is a counter-clockwise circuit about ``+p_hat``.
+#:
+#: Getting this wrong is NOT a loud failure.  A naive ``x <-> y`` axis
+#: SWAP (determinant -1, a reflection rather than a rotation) flips the
+#: sign of the enclosed current exactly -- measured ``I_swap / I_x =
+#: -1.00000009`` on the committed thru fixture's recorded H planes.  That
+#: exchanges the wave amplitudes ``a = (V + Z0*I)/2`` and ``b = (V -
+#: Z0*I)/2``, which maps the assembled ``S = B A^-1`` to ``A B^-1 =
+#: S^-1``.  For the low-loss, nearly-matched line that any MSL lane is
+#: validated on, ``S`` is nearly unitary, so ``S^-1 ~ S^dagger``: the
+#: MAGNITUDES barely move (measured max ||S| - |S_swapped|| = 1.3e-3,
+#: |S11| 0.17905 -> 0.17875) while ``arg(S21)`` is exactly NEGATED
+#: (measured: the two angles sum to <= 0.02 deg across the band, i.e. a
+#: negative group delay).  Nothing in the lane catches it: |S11| stays
+#: far under the 1.05 honesty-guard threshold, column power stays below
+#: 1 so the passivity projection is silent, and cond(A) = 1.32.  The
+#: complex error is O(1) (max |S - S_swapped| = 1.912).
+#: Hence: derive the pair here, never hand-write a per-direction swap,
+#: and compare COMPLEX S in any equivalence test.
+_MSL_CYCLIC_PAIR = {"x": ("y", "z"), "y": ("z", "x"), "z": ("x", "y")}
+
+#: Directions ``add_msl_port`` / :class:`MSLPort` accept.
+MSL_SUPPORTED_DIRECTIONS = ("+x", "-x", "+y", "-y")
+
+#: Directions that are axis-aligned but cannot be expressed by this port's
+#: geometry contract -- see :func:`msl_axis_roles`.
+MSL_REJECTED_DIRECTIONS = ("+z", "-z")
+
+
+def msl_axis_roles(direction: str) -> tuple[str, str, str, float]:
+    """Resolve ``direction`` to ``(propagation, width, normal, sign)`` axes.
+
+    A microstrip port has three distinct axis roles:
+
+    * **propagation** -- the axis the launched wave travels along, normal
+      to the feed plane and to every N-probe plane;
+    * **width** -- the in-board axis the trace width spans;
+    * **normal** -- the substrate normal, from ground plane up to the
+      trace.
+
+    ``direction`` names the propagation axis and its sign.  The substrate
+    normal is **always z**: the port's geometry contract is
+    ``position = (x, y, z_lo)`` plus a scalar ``height``, and ``z_lo +
+    height`` is what places the substrate.  Nothing in that contract can
+    name a different normal, so the board always lies in the xy-plane and
+    the free choice is which in-plane axis the feed runs along.
+
+    That is why ``"+z"`` / ``"-z"`` are rejected rather than supported: a
+    z-propagating microstrip needs its substrate normal along x or y, and
+    the whole normal-axis chain would have to move with it -- the static
+    Laplace cross-section solve and its ``ez_profile``, the ``"ez"``
+    source component, the modal voltage ``V = sum(Ez*dz)``, and the
+    trace-conductor PEC scan that walks upward from the substrate top.
+    Accepting ``"+z"`` while leaving those on z would silently return a
+    z-normal-flavoured answer for a board that is not oriented that way.
+
+    Returns
+    -------
+    (propagation, width, normal, sign)
+        Axis names ``"x"``/``"y"``/``"z"`` and ``sign`` = +1.0 / -1.0.
+    """
+    try:
+        return _MSL_AXIS_ROLES[direction]
+    except (KeyError, TypeError):
+        pass
+    if direction in MSL_REJECTED_DIRECTIONS:
+        raise ValueError(
+            f"MSL port direction={direction!r} is not supported. The "
+            "microstrip port fixes the substrate normal to z -- its "
+            "geometry contract is position=(x, y, z_lo) plus a scalar "
+            "height, so the substrate spans z_lo..z_lo+height along z and "
+            "the board lies in the xy-plane. A wave propagating along z "
+            "would need the substrate normal along x or y, which this "
+            "contract cannot express: the Laplace mode solve, the 'ez' "
+            "source component, the modal voltage V = sum(Ez*dz) and the "
+            "trace-PEC scan all reference the normal axis. Rotate the "
+            "board so the feed runs along x or y "
+            f"(supported: {', '.join(MSL_SUPPORTED_DIRECTIONS)}), or open "
+            "an issue for a substrate-normal parameter."
+        )
+    raise ValueError(
+        f"direction must be one of {MSL_SUPPORTED_DIRECTIONS}, got "
+        f"{direction!r}"
+    )
+
+
+def msl_ampere_pair(direction: str) -> tuple[str, str]:
+    """Right-handed transverse pair ``(a, b)`` with ``a_hat x b_hat = p_hat``.
+
+    ``a`` and ``b`` name the axes the four closed-Ampere-loop legs run
+    along, in the order :func:`msl_loop_current` expects.  Derived from
+    :data:`_MSL_CYCLIC_PAIR` -- see the warning recorded there about what
+    a hand-written axis swap costs.
+    """
+    prop, _width, _normal, _sign = msl_axis_roles(direction)
+    return _MSL_CYCLIC_PAIR[prop]
+
+
+# ---------------------------------------------------------------------------
 # Port description
 # ---------------------------------------------------------------------------
 
@@ -48,19 +166,37 @@ _ETA0 = np.sqrt(MU_0 / EPS_0)
 class MSLPort:
     """Microstrip line port spanning the full trace cross-section.
 
+    The field names below are historical (they date from the x-only port)
+    and are pinned by the design-IR contract, so they are read in the
+    **port frame**, not literally as x/y/z.  :func:`msl_axis_roles`
+    resolves ``direction`` to the three axis roles; the mapping is
+
+    ==========  ====================  ====================
+    field       ``"+x"`` / ``"-x"``   ``"+y"`` / ``"-y"``
+    ==========  ====================  ====================
+    ``feed_x``  x (propagation)       y (propagation)
+    ``y_lo/hi`` y (trace width)       x (trace width)
+    ``z_lo/hi`` z (substrate normal)  z (substrate normal)
+    ==========  ====================  ====================
+
+    Use :func:`msl_physical_point` to turn port-frame coordinates back
+    into a physical ``(x, y, z)`` tuple.
+
     Parameters
     ----------
     feed_x : float
-        Feed-plane x-coordinate (metres) where the source and termination
-        are placed.
+        Feed-plane coordinate (metres) along the PROPAGATION axis, where
+        the source and termination are placed.
     y_lo, y_hi : float
-        Trace lateral extent (metres). ``y_hi - y_lo`` is the trace width.
+        Trace extent (metres) along the WIDTH axis. ``y_hi - y_lo`` is
+        the trace width.
     z_lo, z_hi : float
-        Substrate vertical extent (metres). ``z_lo`` is typically the
-        ground plane / substrate bottom; ``z_hi`` the top of the
-        substrate (where the trace lies).
-    direction : "+x" or "-x"
-        Direction the launched wave propagates away from the feed plane.
+        Substrate extent (metres) along the NORMAL axis (always z).
+        ``z_lo`` is typically the ground plane / substrate bottom;
+        ``z_hi`` the top of the substrate (where the trace lies).
+    direction : str
+        One of :data:`MSL_SUPPORTED_DIRECTIONS` -- the direction the
+        launched wave propagates away from the feed plane.
     impedance : float
         Target characteristic impedance Z0 in ohms (used to set σ).
     excitation : callable or None
@@ -76,6 +212,44 @@ class MSLPort:
     direction: str
     impedance: float
     excitation: object = None
+
+
+def msl_physical_point(
+    direction: str, prop_c: float, width_c: float, normal_c: float
+) -> tuple[float, float, float]:
+    """Assemble a physical ``(x, y, z)`` point from port-frame coordinates."""
+    prop, width, normal, _sign = msl_axis_roles(direction)
+    pt = [0.0, 0.0, 0.0]
+    pt[_MSL_AXIS_INDEX[prop]] = float(prop_c)
+    pt[_MSL_AXIS_INDEX[width]] = float(width_c)
+    pt[_MSL_AXIS_INDEX[normal]] = float(normal_c)
+    return (pt[0], pt[1], pt[2])
+
+
+def msl_port_from_entry(pe) -> "MSLPort":
+    """Build an :class:`MSLPort` from a ``_MSLPortEntry``.
+
+    ``pe.position`` is a PHYSICAL ``(x, y, z)`` tuple: the feed coordinate
+    on the propagation axis, the trace centre on the width axis, and the
+    substrate bottom on the normal axis -- each already in its own slot.
+    This is the single place that projection happens, so the runners,
+    ``compute_msl_s_matrix`` and preflight cannot drift apart on it.
+    """
+    prop, width, normal, _sign = msl_axis_roles(pe.direction)
+    pos = pe.position
+    feed = float(pos[_MSL_AXIS_INDEX[prop]])
+    centre = float(pos[_MSL_AXIS_INDEX[width]])
+    base = float(pos[_MSL_AXIS_INDEX[normal]])
+    return MSLPort(
+        feed_x=feed,
+        y_lo=centre - float(pe.width) / 2.0,
+        y_hi=centre + float(pe.width) / 2.0,
+        z_lo=base,
+        z_hi=base + float(pe.height),
+        direction=pe.direction,
+        impedance=float(pe.impedance),
+        excitation=pe.waveform,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -116,18 +290,74 @@ def _axis_cell_size(grid, axis: str, idx: int) -> float:
 def _msl_yz_cells(grid, port: MSLPort) -> list[tuple[int, int, int]]:
     """Return the (i, j, k) grid indices spanning the MSL cross-section.
 
-    ``i`` is the feed-plane x index. ``j`` ranges over the y-cells from
-    ``port.y_lo`` to ``port.y_hi`` (inclusive); ``k`` likewise over z.
+    The cross-section is the plane normal to the PROPAGATION axis at the
+    feed coordinate, spanning the trace WIDTH axis and the substrate
+    NORMAL axis. Indices are returned in physical ``(i, j, k)`` order, and
+    the iteration order is width-major then normal -- for a ``"+x"`` port
+    that is exactly the historical ``for j: for k:`` order over y then z.
     """
-    i_feed, j_lo, k_lo = _msl_position_to_index(grid, (port.feed_x, port.y_lo, port.z_lo))
-    _, j_hi, k_hi = _msl_position_to_index(grid, (port.feed_x, port.y_hi, port.z_hi))
-    j_a, j_b = (j_lo, j_hi) if j_lo <= j_hi else (j_hi, j_lo)
-    k_a, k_b = (k_lo, k_hi) if k_lo <= k_hi else (k_hi, k_lo)
+    prop, width, normal, _sign = msl_axis_roles(port.direction)
+    ip = _MSL_AXIS_INDEX[prop]
+    iw = _MSL_AXIS_INDEX[width]
+    inr = _MSL_AXIS_INDEX[normal]
+
+    lo_idx = _msl_position_to_index(
+        grid, msl_physical_point(port.direction, port.feed_x, port.y_lo, port.z_lo)
+    )
+    hi_idx = _msl_position_to_index(
+        grid, msl_physical_point(port.direction, port.feed_x, port.y_hi, port.z_hi)
+    )
+    i_feed = int(lo_idx[ip])
+    w_a, w_b = sorted((int(lo_idx[iw]), int(hi_idx[iw])))
+    n_a, n_b = sorted((int(lo_idx[inr]), int(hi_idx[inr])))
+
     cells = []
-    for j in range(j_a, j_b + 1):
-        for k in range(k_a, k_b + 1):
-            cells.append((int(i_feed), int(j), int(k)))
+    for w in range(w_a, w_b + 1):
+        for n in range(n_a, n_b + 1):
+            cell = [0, 0, 0]
+            cell[ip] = i_feed
+            cell[iw] = int(w)
+            cell[inr] = int(n)
+            cells.append((cell[0], cell[1], cell[2]))
     return cells
+
+
+def msl_cross_section_span(grid, port: MSLPort) -> dict:
+    """Feed index plus the width / normal cell spans of the cross-section.
+
+    Returns a dict with ``i_feed``, ``w_lo``/``w_hi``, ``w_centre``,
+    ``n_lo``/``n_hi`` (all ints, inclusive spans) and the resolved axis
+    names/indices. Every consumer that used to unpack ``c[0]``/``c[1]``/
+    ``c[2]`` from :func:`_msl_yz_cells` should read this instead, so the
+    axis projection lives in one place.
+    """
+    prop, width, normal, sign = msl_axis_roles(port.direction)
+    ip = _MSL_AXIS_INDEX[prop]
+    iw = _MSL_AXIS_INDEX[width]
+    inr = _MSL_AXIS_INDEX[normal]
+    cells = _msl_yz_cells(grid, port)
+    ws = sorted({c[iw] for c in cells})
+    ns = sorted({c[inr] for c in cells})
+    return dict(
+        prop_axis=prop, width_axis=width, normal_axis=normal, sign=sign,
+        prop_idx=ip, width_idx=iw, normal_idx=inr,
+        i_feed=int(cells[0][ip]),
+        w_lo=int(ws[0]), w_hi=int(ws[-1]),
+        w_centre=int((ws[0] + ws[-1]) // 2),
+        n_lo=int(ns[0]), n_hi=int(ns[-1]),
+        cells=cells,
+    )
+
+
+def msl_cell(direction: str, i_prop: int, i_width: int, i_normal: int
+             ) -> tuple[int, int, int]:
+    """Assemble a physical ``(i, j, k)`` index from port-frame indices."""
+    prop, width, normal, _sign = msl_axis_roles(direction)
+    cell = [0, 0, 0]
+    cell[_MSL_AXIS_INDEX[prop]] = int(i_prop)
+    cell[_MSL_AXIS_INDEX[width]] = int(i_width)
+    cell[_MSL_AXIS_INDEX[normal]] = int(i_normal)
+    return (cell[0], cell[1], cell[2])
 
 
 # ---------------------------------------------------------------------------
@@ -323,18 +553,24 @@ def compute_msl_mode_profile(
         ``trace_j_hi``   : int — inclusive.
     """
     # Cross-section indices on the FDTD grid (substrate only).
-    cells = _msl_yz_cells(grid, port)
-    j_set = sorted({c[1] for c in cells})
-    k_set = sorted({c[2] for c in cells})
-    j_trace_lo = j_set[0]
-    j_trace_hi = j_set[-1]
-    k_sub_lo = k_set[0]
-    i_feed = cells[0][0]
+    # "y" below is the trace-WIDTH axis and "z" the substrate-NORMAL axis
+    # (issue #661): for a "+x"/"-x" port those are literally y and z, for
+    # a "+y"/"-y" port the width axis is x. The solve itself is a pure
+    # (width, normal) cross-section problem -- measured independent of the
+    # propagation axis beyond ``i_feed`` (identical ez_profile/z0_static/
+    # eps_eff across two feed planes and opposite directions).
+    span = msl_cross_section_span(grid, port)
+    width_axis = span["width_axis"]
+    normal_axis = span["normal_axis"]
+    j_trace_lo = span["w_lo"]
+    j_trace_hi = span["w_hi"]
+    k_sub_lo = span["n_lo"]
+    i_feed = span["i_feed"]
 
-    n_y_trace = len(j_set)
-    n_z_sub = len(k_set)
-    dy = float(_axis_cell_size(grid, "y", j_trace_lo))
-    dz = float(_axis_cell_size(grid, "z", k_sub_lo))
+    n_y_trace = j_trace_hi - j_trace_lo + 1
+    n_z_sub = span["n_hi"] - k_sub_lo + 1
+    dy = float(_axis_cell_size(grid, width_axis, j_trace_lo))
+    dz = float(_axis_cell_size(grid, normal_axis, k_sub_lo))
 
     H_sub = float(port.z_hi - port.z_lo)
     W_trace = float(port.y_hi - port.y_lo)
@@ -358,7 +594,7 @@ def compute_msl_mode_profile(
     # FDTD-grid cells that will receive an Ez source (clamped into the
     # available grid). Capture the maximum y-padding the grid allows.
     j_grid_lo = max(0, j_trace_lo - pad_y_cells)
-    j_grid_hi = min(grid.shape[1] - 1, j_trace_hi + pad_y_cells)
+    j_grid_hi = min(grid.shape[span["width_idx"]] - 1, j_trace_hi + pad_y_cells)
     k_grid_lo = k_sub_lo  # ground at bottom of substrate
     n_y_grid = j_grid_hi - j_grid_lo + 1
 
@@ -482,7 +718,9 @@ def compute_msl_mode_profile(
         j_grid = j_grid_lo + j_loc
         for k_loc in range(n_z_sub):
             k_grid = k_grid_lo + k_loc
-            cell_indices.append((int(i_feed), int(j_grid), int(k_grid)))
+            cell_indices.append(
+                msl_cell(port.direction, i_feed, j_grid, k_grid)
+            )
 
     return dict(
         ez_profile=ez_box_grid,
@@ -496,6 +734,16 @@ def compute_msl_mode_profile(
         n_z_sub=int(n_z_sub),
         dy=float(dy),
         dz=float(dz),
+        # Issue #661: which physical axis each of the two cross-section
+        # indices belongs to, so consumers can project a physical
+        # (i, j, k) cell back onto (width, normal) without re-deriving it.
+        direction=str(port.direction),
+        prop_idx=int(span["prop_idx"]),
+        width_idx=int(span["width_idx"]),
+        normal_idx=int(span["normal_idx"]),
+        prop_axis=str(span["prop_axis"]),
+        width_axis=str(width_axis),
+        normal_axis=str(normal_axis),
     )
 
 
@@ -522,20 +770,31 @@ def setup_msl_port(grid, port: MSLPort, materials, *, mode_profile: dict | None 
     Returns the updated ``materials`` NamedTuple.
     """
     if mode_profile is None:
-        cells = _msl_yz_cells(grid, port)
+        span = msl_cross_section_span(grid, port)
+        cells = span["cells"]
         if not cells:
             return materials
-        j_set = sorted({c[1] for c in cells})
-        k_set = sorted({c[2] for c in cells})
-        n_y = len(j_set)
-        n_z = len(k_set)
-
+        n_y = span["w_hi"] - span["w_lo"] + 1
+        n_z = span["n_hi"] - span["n_lo"] + 1
+        # Issue #661: these three cell sizes are the PROPAGATION, WIDTH
+        # and NORMAL cell sizes -- not literally dx/dy/dz. sigma scales as
+        # 1/d_prop (measured: halving the propagation-axis cell doubles
+        # sum(sigma), ratio 2.0000), so reading dx here for a "+y" port
+        # would be wrong by dy/dx -- and EXACTLY RIGHT on a cubic grid,
+        # which is why no cubic-cell equivalence test can catch it.
+        ax_p = span["prop_axis"]
+        ax_w = span["width_axis"]
+        ax_n = span["normal_axis"]
+        ip, iw, inr = span["prop_idx"], span["width_idx"], span["normal_idx"]
         sigma = materials.sigma
-        for (i, j, k) in cells:
-            dx_cell = _axis_cell_size(grid, "x", i)
-            dy_cell = _axis_cell_size(grid, "y", j)
-            dz_cell = _axis_cell_size(grid, "z", k)
-            sigma_cell = (n_z * dz_cell) / (port.impedance * n_y * dx_cell * dy_cell)
+        for cell in cells:
+            i, j, k = cell
+            d_prop = _axis_cell_size(grid, ax_p, cell[ip])
+            d_width = _axis_cell_size(grid, ax_w, cell[iw])
+            d_norm = _axis_cell_size(grid, ax_n, cell[inr])
+            sigma_cell = (
+                (n_z * d_norm) / (port.impedance * n_y * d_prop * d_width)
+            )
             sigma = sigma.at[i, j, k].add(sigma_cell)
         return materials._replace(sigma=sigma)
 
@@ -557,10 +816,15 @@ def setup_msl_port(grid, port: MSLPort, materials, *, mode_profile: dict | None 
     n_z_sub = int(mode_profile["n_z_sub"])
     dy = float(mode_profile["dy"])
     dz = float(mode_profile["dz"])
+    # Issue #661: project physical cells onto (width, normal) indices.
+    ip = int(mode_profile["prop_idx"])
+    iw = int(mode_profile["width_idx"])
+    inr = int(mode_profile["normal_idx"])
+    ax_p = str(mode_profile["prop_axis"])
 
-    # i_feed is constant across cell_indices.
-    i_feed = cell_indices[0][0]
-    dx_feed = float(_axis_cell_size(grid, "x", i_feed))
+    # i_feed is constant across cell_indices, on the PROPAGATION axis.
+    i_feed = cell_indices[0][ip]
+    dx_feed = float(_axis_cell_size(grid, ax_p, i_feed))
 
     integrand = float(np.sum(ez_profile * ez_profile) * dy * dz)
     if integrand <= 0:
@@ -568,9 +832,10 @@ def setup_msl_port(grid, port: MSLPort, materials, *, mode_profile: dict | None 
     sigma_uniform = 1.0 / (port.impedance * dx_feed * integrand)
 
     sigma = materials.sigma
-    for (i, j, k) in cell_indices:
-        j_loc = j - j_box_lo
-        k_loc = k - k_box_lo
+    for cell in cell_indices:
+        i, j, k = cell
+        j_loc = cell[iw] - j_box_lo
+        k_loc = cell[inr] - k_box_lo
         if not (0 <= k_loc < n_z_sub):
             continue
         if not (0 <= j_loc < ez_profile.shape[0]):
@@ -628,17 +893,23 @@ def make_msl_port_sources(grid, port: MSLPort, materials, n_steps,
     base_wave = jax.vmap(port.excitation)(times)
 
     if mode_profile is None:
-        cells = _msl_yz_cells(grid, port)
+        span = msl_cross_section_span(grid, port)
+        cells = span["cells"]
         if not cells:
             return []
-        n_z = len({c[2] for c in cells})
+        n_z = span["n_hi"] - span["n_lo"] + 1
+        ax_n = span["normal_axis"]
+        inr = span["normal_idx"]
         specs = []
-        for (i, j, k) in cells:
+        for cell in cells:
+            i, j, k = cell
             eps = materials.eps_r[i, j, k] * EPS_0
             sigma = materials.sigma[i, j, k]
             loss = sigma * grid.dt / (2.0 * eps)
             cb = (grid.dt / eps) / (1.0 + loss)
-            d_par = _axis_cell_size(grid, "z", k)
+            # d_par is the cell size along the SUBSTRATE NORMAL (always z,
+            # the axis "ez" points along) -- not the propagation axis.
+            d_par = _axis_cell_size(grid, ax_n, cell[inr])
             waveform = (cb / d_par) * base_wave / float(n_z)
             specs.append(SourceSpec(i=i, j=j, k=k, component="ez", waveform=waveform))
         return specs
@@ -651,11 +922,14 @@ def make_msl_port_sources(grid, port: MSLPort, materials, n_steps,
     j_box_lo = int(mode_profile["j_grid_lo"])
     k_box_lo = int(mode_profile["k_grid_lo"])
     n_z_sub = int(mode_profile["n_z_sub"])
+    iw = int(mode_profile["width_idx"])
+    inr = int(mode_profile["normal_idx"])
 
     specs = []
-    for (i, j, k) in cell_indices:
-        j_loc = j - j_box_lo
-        k_loc = k - k_box_lo
+    for cell in cell_indices:
+        i, j, k = cell
+        j_loc = cell[iw] - j_box_lo
+        k_loc = cell[inr] - k_box_lo
         if not (0 <= k_loc < n_z_sub):
             continue
         if not (0 <= j_loc < ez_profile.shape[0]):
@@ -720,6 +994,22 @@ def make_msl_port_sources_jm(
     """
     if port.excitation is None:
         return [], []
+
+    # Issue #661: this launch is x-only and stays that way. It hard-codes
+    # the (hy, hz) / (ey, ez) TFSF correction pair and ``coeff_H = dt /
+    # (MU_0 * dx)`` to the x propagation axis, and its eigenmode source
+    # (``rfx.sources.msl_eigenmode``) is itself a documented falsified
+    # dead-end kept only under a strict xfail. Generalising it would mean
+    # re-deriving a solver that is not on the supported lane, so a non-x
+    # direction is refused rather than half-rotated.
+    if port.direction not in ("+x", "-x"):
+        raise NotImplementedError(
+            f"MSL mode='eigenmode' supports direction '+x'/'-x' only, got "
+            f"{port.direction!r}. The Schelkunoff J+M launch hard-codes the "
+            "x-axis TFSF correction pair and rides on the FDFD eigenmode "
+            "solver, which is not a supported lane. Use mode='laplace' (the "
+            "add_msl_port default) for a y-directed port."
+        )
 
     from rfx.simulation import SourceSpec, MagneticSourceSpec  # local import: avoid cycles
 
@@ -830,34 +1120,44 @@ def _msl_position_to_index(grid, pos):
     return _nu_position_to_index(grid, pos)
 
 
-def _msl_x_for_index(grid, target_i: int) -> float:
-    """Physical x-coordinate of a (clamped) grid index, graded-aware.
+def _msl_coord_for_index(grid, axis: str, target_i: int) -> float:
+    """Physical coordinate along ``axis`` of a (clamped) grid index.
 
-    On a uniform ``Grid`` this is the legacy ``(clamped - pad_x_lo) *
-    grid.dx`` and is byte-identical (``Grid`` has no ``dx_arr``). On a
-    ``NonUniformGrid`` ``grid.dx`` is ONLY the boundary cell, so the index
-    must be converted to a physical coordinate via the cumulative
-    cell-edge sum of the interior ``dx_arr`` profile (mirroring
-    ``_range_to_slice_nu`` in ``rfx/runners/nonuniform.py``). Indices are
-    clamped into the in-domain range. (In the leading-CPML region ``u<0``
-    the uniform branch returns a negative coord while the NU branch clamps
-    to ``edges[0]=0``; valid probe placement never targets that region.)
+    Graded-mesh aware. On a uniform ``Grid`` this is the legacy
+    ``(clamped - pad_lo) * grid.dx`` and is byte-identical (``Grid`` has
+    no ``*_arr``). On a ``NonUniformGrid`` ``grid.dx`` is ONLY the
+    boundary cell, so the index must be converted to a physical
+    coordinate via the cumulative cell-edge sum of the interior per-cell
+    profile (mirroring ``_range_to_slice_nu`` in
+    ``rfx/runners/nonuniform.py``). Indices are clamped into the
+    in-domain range. (In the leading-CPML region ``u<0`` the uniform
+    branch returns a negative coord while the NU branch clamps to
+    ``edges[0]=0``; valid probe placement never targets that region.)
     """
-    nx = int(grid.nx)
-    pad = int(getattr(grid, "pad_x_lo", 0))
-    clamped = max(0, min(int(target_i), nx - 1))
+    n_axis = int(getattr(grid, {"x": "nx", "y": "ny", "z": "nz"}[axis]))
+    pad = int(getattr(grid, f"pad_{axis}_lo", 0))
+    clamped = max(0, min(int(target_i), n_axis - 1))
     u = clamped - pad  # user-domain (non-CPML) interior index
-    dx_arr = getattr(grid, "dx_arr", None)
-    if dx_arr is None:
+    arr_attr = {"x": "dx_arr", "y": "dy_arr", "z": "dz"}[axis]
+    from rfx.nonuniform import NonUniformGrid
+    if not isinstance(grid, NonUniformGrid):
         # Uniform Grid — legacy scalar spacing (byte-identical).
         return float(u * grid.dx)
+    per_cell = getattr(grid, arr_attr, None)
+    if per_cell is None:
+        return float(u * grid.dx)
     # NonUniformGrid — cumulative interior cell-edge positions.
-    pad_hi = int(getattr(grid, "pad_x_hi", 0))
+    pad_hi = int(getattr(grid, f"pad_{axis}_hi", 0))
     from rfx.nonuniform import interior_cells
-    interior = interior_cells(np.asarray(dx_arr, dtype=float), pad, pad_hi)
+    interior = interior_cells(np.asarray(per_cell, dtype=float), pad, pad_hi)
     edges = np.insert(np.cumsum(interior), 0, 0.0)
     u_c = max(0, min(u, len(edges) - 1))
     return float(edges[u_c])
+
+
+def _msl_x_for_index(grid, target_i: int) -> float:
+    """x-axis alias of :func:`_msl_coord_for_index` (external callers)."""
+    return _msl_coord_for_index(grid, "x", target_i)
 
 
 def msl_probe_x_coords(
@@ -874,15 +1174,19 @@ def msl_probe_x_coords(
     range so callers always receive in-domain physical coordinates.
     Graded-mesh aware (see :func:`_msl_x_for_index`).
     """
-    i_feed, _, _ = _msl_position_to_index(grid, (port.feed_x, port.y_lo, port.z_lo))
-    sign = 1 if port.direction == "+x" else -1
+    prop, _w, _n, sign_f = msl_axis_roles(port.direction)
+    idx = _msl_position_to_index(
+        grid, msl_physical_point(port.direction, port.feed_x, port.y_lo, port.z_lo)
+    )
+    i_feed = int(idx[_MSL_AXIS_INDEX[prop]])
+    sign = int(sign_f)
     i1 = i_feed + sign * n_offset_cells
     i2 = i1 + sign * n_spacing_cells
     i3 = i2 + sign * n_spacing_cells
     return (
-        _msl_x_for_index(grid, i1),
-        _msl_x_for_index(grid, i2),
-        _msl_x_for_index(grid, i3),
+        _msl_coord_for_index(grid, prop, i1),
+        _msl_coord_for_index(grid, prop, i2),
+        _msl_coord_for_index(grid, prop, i3),
     )
 
 
@@ -903,10 +1207,16 @@ def msl_probe_x_coords_n(
     """
     if n_probes < 3:
         raise ValueError(f"n_probes must be >= 3, got {n_probes}")
-    i_feed, _, _ = _msl_position_to_index(grid, (port.feed_x, port.y_lo, port.z_lo))
-    sign = 1 if port.direction == "+x" else -1
+    prop, _w, _n, sign_f = msl_axis_roles(port.direction)
+    idx = _msl_position_to_index(
+        grid, msl_physical_point(port.direction, port.feed_x, port.y_lo, port.z_lo)
+    )
+    i_feed = int(idx[_MSL_AXIS_INDEX[prop]])
+    sign = int(sign_f)
     return tuple(
-        _msl_x_for_index(grid, i_feed + sign * (n_offset_cells + n * n_spacing_cells))
+        _msl_coord_for_index(
+            grid, prop, i_feed + sign * (n_offset_cells + n * n_spacing_cells)
+        )
         for n in range(n_probes)
     )
 
@@ -967,12 +1277,70 @@ def msl_loop_current(
     k_trace_lo, k_trace_hi : int
         Trace-conductor z-cell span (inclusive).
     dy_arr, dz_arr : array
-        Per-cell sizes along y / z (uniform or non-uniform).
-    direction : "+x" or "-x"
-        Propagation direction.  The raw contour integral is negated for
-        ``+x`` ports so the returned ``I`` is positive for a forward
-        quasi-TEM wave (``Z0 = V/I > 0``), matching the legacy current
-        convention.
+        Per-cell sizes along the ``a`` / ``b`` axes (uniform or
+        non-uniform).
+    direction : str
+        Propagation direction, one of :data:`MSL_SUPPORTED_DIRECTIONS`.
+        The raw contour integral is negated for POSITIVE-going ports
+        (``"+x"``, ``"+y"``) and left as-is for negative-going ones.
+
+        **Sign convention, corrected (see issue #524).** This docstring
+        used to claim without qualification that "the returned ``I`` is
+        positive for a forward quasi-TEM wave (``Z0 = V/I > 0``)". That
+        is true only for a POSITIVE-going port. The contour is traversed
+        right-handedly about ``+p_hat`` regardless of the direction sign,
+        so the raw integral is the current along ``+p_hat`` for both
+        signs; negating it only on positive-going ports leaves a
+        negative-going port's ``I`` referenced the opposite way round.
+        Measured on the committed thru fixture, each port on its OWN
+        drive: ``Re((alpha - gamma)/I1)`` = **+57.52 ohm** for the
+        ``"+x"`` port and **-57.56 ohm** for the ``"-x"`` port — same
+        magnitude to 0.08 %, opposite sign.
+
+        That is not a defect, it is the #140 convention, and the lane is
+        self-consistent about it: ``compute_msl_s_matrix`` multiplies the
+        REPORTED ``Z0`` by ``msl_axis_roles(direction)[3]`` so both ports
+        report positive, while the wave split ``a = (V + Z0*I)/2``,
+        ``b = (V - Z0*I)/2`` consumes the un-normalised current at every
+        port, which keeps ``S = B A^-1`` physical (same fixture:
+        ``|S11| = |S22|`` to 5 decimals, reciprocity
+        ``max ||S21| - |S12|| = 1.27e-05``, column power <= 0.99998).
+        The mechanism behind the flip is that ``extract_msl_nprobe`` is
+        fed raw physical coordinates, so ``alpha`` is the ``+p_hat``
+        wave at BOTH ports and the ``(alpha - gamma)`` numerator swaps
+        role with the direction — visible in the same measurement as
+        ``|alpha| >> |gamma|`` at both ports on drive 0 and the reverse
+        on drive 1.
+
+        Only the docstring was wrong; no code changed for this. The
+        other two items on issue #524 — the passive port's ~30 ohm
+        termination reading and the 0.194-vs-0.073 drive asymmetry — are
+        untouched here and keep that issue open.
+
+    Axis generality (issue #661)
+    ----------------------------
+    The parameter names above are the ``"+x"``-frame names, but what the
+    body actually needs is the right-handed transverse pair ``(a, b)``
+    with ``a_hat x b_hat = p_hat`` for propagation axis ``p``
+    (:func:`msl_ampere_pair`).  Read the arguments in that frame:
+
+    * ``hy_plane`` / ``hz_plane`` are ``H_a`` / ``H_b``, each indexed
+      ``[freq, a_index, b_index]``;
+    * ``j_lo``/``j_hi`` is the trace span along ``a``, ``k_trace_lo``/
+      ``k_trace_hi`` the span along ``b``;
+    * ``dy_arr``/``dz_arr`` are the per-cell sizes along ``a`` / ``b``.
+
+    For ``"+x"`` that is ``(a, b) = (y, z)``, i.e. literally the legacy
+    meaning — this function's arithmetic is unchanged.  For ``"+y"`` it
+    is ``(a, b) = (z, x)``: ``H_a`` is **Hz** and ``H_b`` is **Hx**, and
+    the caller must transpose the recorded y-normal plane (which the DFT
+    probe stores as ``[freq, x, z]``) into ``[freq, z, x]``.
+
+    Do not "generalise" this by swapping x and y.  That is a reflection,
+    not a rotation: measured on the committed thru fixture's own recorded
+    H planes, the cyclic pair reproduces the x-port current to 9.2e-8
+    relative while the swap returns exactly ``-I`` (ratio -1.00000009),
+    which silently inverts the S-matrix.  See :data:`_MSL_CYCLIC_PAIR`.
 
     Returns
     -------
@@ -1001,6 +1369,13 @@ def msl_loop_current(
     left = (hz_plane[:, j_lo - 1, ks] * dz[ks]).sum(axis=1)
 
     i_loop = bottom - top + right - left
-    if direction == "+x":
+    # Negate for positive-going ports (issue #140 convention, generalised
+    # over the axis roles in issue #661): "+x" and "+y" both negate, "-x"
+    # and "-y" both do not. Resolving through msl_axis_roles also makes an
+    # unsupported direction fail loudly here rather than silently skipping
+    # the negation, which is what a bare ``== "+x"`` test would have done
+    # for a "+y" port.
+    _prop, _w, _n, sign = msl_axis_roles(direction)
+    if sign > 0:
         i_loop = -i_loop
     return i_loop

--- a/tests/test_msl_port.py
+++ b/tests/test_msl_port.py
@@ -238,10 +238,31 @@ def test_add_msl_port_api():
     assert entry.height == 2.54e-4
     assert entry.name == "msl_0"
 
-    # Invalid direction.
-    with pytest.raises(ValueError):
-        sim.add_msl_port(position=(2e-3, 1.5e-3, 0.0),
-                         width=1e-3, height=2.54e-4, direction="+y")
+    # In-plane directions are all accepted (issue #661): the board lies in
+    # the xy-plane, so the feed may run along either in-board axis. This
+    # assertion used to read ``pytest.raises(ValueError)`` for "+y" — that
+    # was the limitation #661 removes, not a physics bound.
+    for _d in ("-x", "+y", "-y"):
+        sim_d = Simulation(freq_max=10e9, domain=(5e-3, 3e-3, 1e-3))
+        sim_d.add_msl_port(position=(2e-3, 1.5e-3, 0.0), width=1e-3,
+                           height=2.54e-4, direction=_d)
+        assert sim_d._msl_ports[0].direction == _d
+
+    # Out-of-plane directions are REJECTED, and the error must say why:
+    # the substrate normal is welded to z by the position/height contract.
+    for _d in ("+z", "-z"):
+        with pytest.raises(ValueError, match="substrate normal"):
+            sim.add_msl_port(position=(2e-3, 1.5e-3, 0.0), width=1e-3,
+                             height=2.54e-4, direction=_d)
+    # Garbage directions still raise the plain domain error.
+    for _d in ("x", "+w", "", None):
+        with pytest.raises(ValueError):
+            sim.add_msl_port(position=(2e-3, 1.5e-3, 0.0), width=1e-3,
+                             height=2.54e-4, direction=_d)
+    # mode='eigenmode' stays x-only.
+    with pytest.raises(NotImplementedError, match="eigenmode"):
+        sim.add_msl_port(position=(2e-3, 1.5e-3, 0.0), width=1e-3,
+                         height=2.54e-4, direction="+y", mode="eigenmode")
     # Invalid width.
     with pytest.raises(ValueError):
         sim.add_msl_port(position=(2e-3, 1.5e-3, 0.0),

--- a/tests/test_msl_port_axis_generality.py
+++ b/tests/test_msl_port_axis_generality.py
@@ -1,0 +1,699 @@
+"""MSL port axis generality — issue #661.
+
+``add_msl_port`` used to accept ``direction`` of ``"+x"``/``"-x"`` only, so
+a CAD-imported board whose feed enters along y had to be rotated. A
+``MeshShape`` cannot be rotated (the import path takes no rotation
+argument), so the workaround was unavailable exactly where it was needed.
+
+What this file pins, and why each part exists
+---------------------------------------------
+
+**The measured axis inventory.** The MSL lane has three axis roles, not
+one. Instrumenting the live extractor (rather than reading it) split the
+code into:
+
+* stages bound to the **propagation** axis -- the probe ladder, the DFT
+  plane normal, the ``dx_feed`` in the port conductance, the port-to-CPML
+  and probe-span preflight checks. All of these are relabelings.
+* stages bound to the **substrate normal**, which is welded to z -- the
+  static-Laplace cross-section solve and its ``ez_profile``, the ``"ez"``
+  source component, the modal voltage ``V = sum(Ez*dz)``, and the
+  trace-conductor PEC scan that walks up from the substrate top. The port
+  geometry contract (``position`` + scalar ``height``) cannot name a
+  different normal.
+* stages that are genuinely axis-free -- the N-probe fit (it consumes
+  probe coordinates and only their differences), the Hammerstad-Jensen
+  anchor, and the multi-drive ``S = B A^-1`` solve.
+
+Hence ``"+x"/"-x"/"+y"/"-y"`` are supported (a rotation about the
+substrate normal) and ``"+z"/"-z"`` are REJECTED rather than
+half-generalised -- accepting them would return a z-normal answer for a
+board that is not oriented that way.
+
+**The handedness.** The closed Ampere loop needs the right-handed
+transverse pair ``(a, b)`` with ``a_hat x b_hat = p_hat``. Deriving it as
+a plain ``x <-> y`` rename is a reflection, not a rotation, and it is the
+dangerous failure here because it is SILENT. Measured on the committed
+thru fixture's own recorded H planes:
+
+* cyclic pair reproduces the x-port current to 9.2e-8 relative;
+  naive swap returns exactly ``-I`` (ratio ``-1.00000009``);
+* that flip exchanges ``a`` and ``b``, mapping ``S = B A^-1`` to
+  ``A B^-1 = S^-1``; for the low-loss matched line every MSL fixture uses,
+  ``S`` is nearly unitary so ``S^-1 ~ S^dagger``;
+* consequence: ``|S11|`` moves 0.17905 -> 0.17875 and max
+  ``||S| - |S_swapped||`` is 1.3e-3, column power stays below 1, and
+  ``cond(A)`` is 1.32 -- **no guard in the lane fires**;
+* but ``arg(S21)`` is exactly NEGATED (the two angles sum to <= 0.02 deg
+  across the band -- a negative group delay), and the complex error is
+  ``max |S - S_swapped| = 1.912``.
+
+So the equivalence test below compares COMPLEX S. A magnitude-only
+comparison would pass on the very bug it exists to catch.
+"""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+from rfx.api import Simulation
+from rfx.boundaries.spec import Boundary, BoundarySpec
+from rfx.geometry.csg import Box
+from rfx.sources.msl_port import (
+    MSL_SUPPORTED_DIRECTIONS,
+    MSLPort,
+    _msl_yz_cells,
+    msl_ampere_pair,
+    msl_axis_roles,
+    msl_cross_section_span,
+    msl_physical_point,
+    msl_port_from_entry,
+    msl_probe_x_coords_n,
+    setup_msl_port,
+)
+
+EPS_R, H_SUB, W_TRACE = 3.66, 254e-6, 600e-6
+L_LINE, PORT_MARGIN, DX, F_MAX = 10e-3, 2e-3, 80e-6, 5e9
+L_PROP = L_LINE + 2 * PORT_MARGIN
+L_LAT = W_TRACE + 2 * (2 * H_SUB + 8 * DX)
+LZ = H_SUB + 1.5e-3
+
+
+# ---------------------------------------------------------------------------
+# 1. The direction contract
+# ---------------------------------------------------------------------------
+
+
+def test_supported_directions_resolve_to_three_distinct_axis_roles():
+    assert MSL_SUPPORTED_DIRECTIONS == ("+x", "-x", "+y", "-y")
+    assert msl_axis_roles("+x") == ("x", "y", "z", +1.0)
+    assert msl_axis_roles("-x") == ("x", "y", "z", -1.0)
+    assert msl_axis_roles("+y") == ("y", "x", "z", +1.0)
+    assert msl_axis_roles("-y") == ("y", "x", "z", -1.0)
+    # The substrate normal is z for EVERY supported direction. That is the
+    # invariant which makes "+z"/"-z" inexpressible.
+    for d in MSL_SUPPORTED_DIRECTIONS:
+        assert msl_axis_roles(d)[2] == "z"
+
+
+@pytest.mark.parametrize("direction", ["+z", "-z"])
+def test_z_directions_are_rejected_and_say_why(direction):
+    """A z-propagating microstrip needs a non-z substrate normal.
+
+    Rejected rather than half-supported: the Laplace solve, the "ez"
+    source, ``V = sum(Ez*dz)`` and the trace-PEC scan all reference the
+    normal axis, so accepting "+z" would quietly answer for a board lying
+    in a different plane than the user's.
+    """
+    with pytest.raises(ValueError) as ei:
+        msl_axis_roles(direction)
+    msg = str(ei.value)
+    assert "substrate normal" in msg
+    assert "+x" in msg and "+y" in msg
+
+
+@pytest.mark.parametrize("direction", ["x", "y", "+w", "", None, 0])
+def test_garbage_directions_raise_the_plain_domain_error(direction):
+    with pytest.raises(ValueError, match="direction must be one of"):
+        msl_axis_roles(direction)
+
+
+# ---------------------------------------------------------------------------
+# 2. Ampere-loop handedness — the silent-failure guard
+# ---------------------------------------------------------------------------
+
+
+def test_ampere_pair_is_the_right_handed_cyclic_pair_not_an_axis_swap():
+    """``a_hat x b_hat`` must equal ``p_hat`` for every direction.
+
+    Pinned as a cross-product identity rather than a literal table so the
+    property, not the spelling, is what is protected. The reflection this
+    forbids (``(x, z)`` for a y-propagating port) flips the sign of the
+    extracted current and inverts S with no guard firing -- see the module
+    docstring for the measured numbers.
+    """
+    basis = {"x": np.array([1.0, 0, 0]),
+             "y": np.array([0, 1.0, 0]),
+             "z": np.array([0, 0, 1.0])}
+    for d in MSL_SUPPORTED_DIRECTIONS:
+        prop, _w, _n, _s = msl_axis_roles(d)
+        a_ax, b_ax = msl_ampere_pair(d)
+        cross = np.cross(basis[a_ax], basis[b_ax])
+        assert np.allclose(cross, basis[prop]), (
+            f"direction {d!r}: ({a_ax},{b_ax}) is not right-handed about "
+            f"{prop} -- cross = {cross}, expected {basis[prop]}. A "
+            f"left-handed pair negates the Ampere-loop current and "
+            f"inverts the S-matrix silently."
+        )
+    # And specifically: the y-port pair is NOT the naive (x, z) swap.
+    assert msl_ampere_pair("+y") == ("z", "x")
+    assert msl_ampere_pair("+y") != ("x", "z")
+
+
+def test_loop_current_negates_on_the_direction_sign_only():
+    """The raw contour is direction-INDEPENDENT; only the negation flips.
+
+    Pins the corrected ``msl_loop_current`` docstring (issue #524). The
+    contour is traversed right-handedly about ``+p_hat`` whatever the
+    direction SIGN is, so the raw integral is the current along
+    ``+p_hat`` for both signs and the only difference is the #140
+    negation applied to positive-going ports.
+
+    The docstring previously claimed without qualification that "the
+    returned I is positive for a forward quasi-TEM wave"; measured on the
+    committed thru fixture, each port on its own drive, that holds for
+    ``"+x"`` (``Re((alpha-gamma)/I1) = +57.52 ohm``) and fails for
+    ``"-x"`` (``-57.56 ohm``, same magnitude to 0.08%). The lane is
+    self-consistent about it -- ``dir_sign`` restores both REPORTED Z0 to
+    positive while the wave split consumes the un-normalised current --
+    so this is a prose defect, not a code one, and the assertion below is
+    what the corrected prose actually says.
+    """
+    from rfx.sources.msl_port import msl_loop_current
+
+    rng = np.random.default_rng(6610)
+    n_f, n_a, n_b = 3, 12, 9
+    ha = rng.normal(size=(n_f, n_a, n_b)) + 1j * rng.normal(size=(n_f, n_a, n_b))
+    hb = rng.normal(size=(n_f, n_a, n_b)) + 1j * rng.normal(size=(n_f, n_a, n_b))
+    kw = dict(j_lo=3, j_hi=8, k_trace_lo=2, k_trace_hi=5,
+              dy_arr=np.full(n_a, 8e-5), dz_arr=np.full(n_b, 8e-5))
+
+    for pos, neg in (("+x", "-x"), ("+y", "-y")):
+        i_pos = np.asarray(msl_loop_current(ha, hb, direction=pos, **kw))
+        i_neg = np.asarray(msl_loop_current(ha, hb, direction=neg, **kw))
+        assert np.allclose(i_pos, -i_neg, rtol=0, atol=0), (
+            f"{pos}/{neg} must differ by exactly the #140 negation and "
+            f"nothing else; got {i_pos} vs {i_neg}"
+        )
+        assert not np.allclose(i_pos, i_neg), "the negation must actually fire"
+
+    # And the negation follows the SIGN, not the axis letter: the two
+    # positive-going directions agree with each other on identical input,
+    # as do the two negative-going ones.
+    assert np.allclose(
+        np.asarray(msl_loop_current(ha, hb, direction="+x", **kw)),
+        np.asarray(msl_loop_current(ha, hb, direction="+y", **kw)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Geometry projection
+# ---------------------------------------------------------------------------
+
+
+def test_physical_point_places_each_role_on_its_own_axis():
+    assert msl_physical_point("+x", 1.0, 2.0, 3.0) == (1.0, 2.0, 3.0)
+    assert msl_physical_point("-x", 1.0, 2.0, 3.0) == (1.0, 2.0, 3.0)
+    # For a y port the feed coordinate lands in the y slot and the trace
+    # width centre in the x slot; the normal stays z.
+    assert msl_physical_point("+y", 1.0, 2.0, 3.0) == (2.0, 1.0, 3.0)
+    assert msl_physical_point("-y", 1.0, 2.0, 3.0) == (2.0, 1.0, 3.0)
+
+
+def _grid(domain):
+    sim = Simulation(freq_max=F_MAX, domain=domain, dx=DX, cpml_layers=8,
+                     boundary=BoundarySpec(x="cpml", y="cpml",
+                                           z=Boundary(lo="pec", hi="cpml")))
+    return sim._build_grid()
+
+
+def test_cross_section_cells_span_width_and_normal_at_the_feed_plane():
+    """The y-port cross-section is the x<->y image of the x-port one."""
+    gx = _grid((L_PROP, L_LAT, LZ))
+    gy = _grid((L_LAT, L_PROP, LZ))
+    lat_c = L_LAT / 2.0
+    px = MSLPort(feed_x=PORT_MARGIN, y_lo=lat_c - W_TRACE / 2,
+                 y_hi=lat_c + W_TRACE / 2, z_lo=0.0, z_hi=H_SUB,
+                 direction="+x", impedance=50.0)
+    py = MSLPort(feed_x=PORT_MARGIN, y_lo=lat_c - W_TRACE / 2,
+                 y_hi=lat_c + W_TRACE / 2, z_lo=0.0, z_hi=H_SUB,
+                 direction="+y", impedance=50.0)
+    cx = _msl_yz_cells(gx, px)
+    cy = _msl_yz_cells(gy, py)
+    assert len(cx) == len(cy) > 0
+    # Same cells, with the first two index slots exchanged.
+    assert [(j, i, k) for (i, j, k) in cx] == list(cy)
+    sx = msl_cross_section_span(gx, px)
+    sy = msl_cross_section_span(gy, py)
+    for key in ("i_feed", "w_lo", "w_hi", "w_centre", "n_lo", "n_hi"):
+        assert sx[key] == sy[key], key
+    assert (sx["prop_idx"], sx["width_idx"]) == (0, 1)
+    assert (sy["prop_idx"], sy["width_idx"]) == (1, 0)
+
+
+def test_probe_ladder_steps_along_the_propagation_axis():
+    gx = _grid((L_PROP, L_LAT, LZ))
+    gy = _grid((L_LAT, L_PROP, LZ))
+    lat_c = L_LAT / 2.0
+    kw = dict(n_probes=5, n_offset_cells=16, n_spacing_cells=3)
+    for d_fwd, d_rev in (("+x", "-x"), ("+y", "-y")):
+        g = gx if d_fwd == "+x" else gy
+        fwd = msl_probe_x_coords_n(
+            g, MSLPort(PORT_MARGIN, lat_c - W_TRACE / 2, lat_c + W_TRACE / 2,
+                       0.0, H_SUB, d_fwd, 50.0), **kw)
+        rev = msl_probe_x_coords_n(
+            g, MSLPort(PORT_MARGIN + L_LINE, lat_c - W_TRACE / 2,
+                       lat_c + W_TRACE / 2, 0.0, H_SUB, d_rev, 50.0), **kw)
+        assert all(np.diff(fwd) > 0), f"{d_fwd} ladder must increase"
+        assert all(np.diff(rev) < 0), f"{d_rev} ladder must decrease"
+    # The y ladder is the x ladder (same 1-D geometry along the feed axis).
+    lx = msl_probe_x_coords_n(
+        gx, MSLPort(PORT_MARGIN, lat_c - W_TRACE / 2, lat_c + W_TRACE / 2,
+                    0.0, H_SUB, "+x", 50.0), **kw)
+    ly = msl_probe_x_coords_n(
+        gy, MSLPort(PORT_MARGIN, lat_c - W_TRACE / 2, lat_c + W_TRACE / 2,
+                    0.0, H_SUB, "+y", 50.0), **kw)
+    assert np.allclose(lx, ly)
+
+
+def test_graded_mesh_probe_ladder_reads_its_own_axis_profile():
+    """On a NonUniformGrid the y ladder must read ``dy_arr``, not ``dx_arr``.
+
+    This is the y-axis instance of a bug class this repo has already paid
+    for once: the transverse cell-profile helper used to fall through to
+    the SCALAR boundary ``grid.dx`` for every cell, which is both the
+    wrong axis and not per-cell. Built with DIFFERENT grading on x and y
+    so reading the wrong array changes the answer -- on a mesh graded
+    identically on both axes the two ladders coincide and the test would
+    be vacuous.
+    """
+    from rfx.nonuniform import make_nonuniform_grid
+    from rfx.api._sparams import _msl_cell_profile
+
+    # make_nonuniform_grid requires the boundary cell to equal ``dx``, so
+    # the refinement sits in the interior.
+    dxp = np.concatenate([np.full(20, 5e-4), np.full(40, 2.5e-4),
+                          np.full(20, 5e-4)])
+    dyp = np.concatenate([np.full(15, 5e-4), np.full(30, 2.5e-4),
+                          np.full(15, 5e-4)])
+    g = make_nonuniform_grid(
+        domain_xy=(float(np.sum(dxp)), float(np.sum(dyp))),
+        dz_profile=np.full(24, 5e-4), dx=5e-4, cpml_layers=8,
+        dx_profile=dxp, dy_profile=dyp,
+        pec_faces={"z_lo"}, cpml_axes="xy",
+    )
+    # Per-axis profiles keep their own lengths (the NU branch is
+    # authoritative; a scalar fallback would be the defect).
+    for ax, n in (("x", g.nx), ("y", g.ny), ("z", g.nz)):
+        assert _msl_cell_profile(g, ax, n).shape == (n,)
+
+    kw = dict(n_probes=5, n_offset_cells=6, n_spacing_cells=3)
+    mk = lambda d: MSLPort(feed_x=0.006, y_lo=0.008, y_hi=0.010, z_lo=0.0,
+                           z_hi=0.002, direction=d, impedance=50.0)
+    lad_x = np.asarray(msl_probe_x_coords_n(g, mk("+x"), **kw))
+    lad_y = np.asarray(msl_probe_x_coords_n(g, mk("+y"), **kw))
+
+    # Both are strictly increasing and in-domain...
+    for tag, lad in (("+x", lad_x), ("+y", lad_y)):
+        assert np.all(np.diff(lad) > 0), f"{tag} ladder not monotonic: {lad}"
+    # ...and they DIFFER, because the two axes are graded differently.
+    # Equality here would mean the y ladder walked the x profile.
+    assert not np.allclose(lad_x, lad_y), (
+        f"the y ladder reproduced the x ladder on a mesh graded differently "
+        f"on the two axes ({lad_x} vs {lad_y}) -- it is reading dx_arr "
+        f"instead of dy_arr"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. The anisotropic sigma witness
+# ---------------------------------------------------------------------------
+
+
+class _AnisoGrid:
+    """Uniform-Grid duck type with independently settable per-axis spacing.
+
+    Exists because a CUBIC grid cannot detect a propagation-axis mix-up:
+    sigma scales as ``1/d_prop``, so on ``dx == dy`` an x-flavoured sigma
+    applied to a y-port is bit-identical to the correct one. The
+    end-to-end rotation-equivalence test below runs on a cubic mesh and is
+    therefore BLIND to this stage -- this test is the one that sees it.
+    """
+
+    def __init__(self, dx, dy, dz, shape):
+        self.dx = dx
+        self.dx_profile = np.full(shape[0], dx)
+        self.dy_profile = np.full(shape[1], dy)
+        self.dz_profile = np.full(shape[2], dz)
+        self.shape = shape
+        self.nx, self.ny, self.nz = shape
+        self.dt = 1e-13
+
+    def position_to_index(self, pos):
+        return (int(round(pos[0] / self.dx_profile[0])),
+                int(round(pos[1] / self.dy_profile[0])),
+                int(round(pos[2] / self.dz_profile[0])))
+
+
+class _Mat:
+    def __init__(self, shape):
+        import jax.numpy as jnp
+        self.sigma = jnp.zeros(shape)
+        self.eps_r = jnp.ones(shape)
+
+    def _replace(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+        return self
+
+
+def _sigma_sum(direction, d_prop, d_width, d_norm):
+    """Total added sigma with cell sizes assigned BY ROLE."""
+    shape = (48, 48, 20)
+    sizes = {"z": d_norm}
+    prop, width, _n, _s = msl_axis_roles(direction)
+    sizes[prop] = d_prop
+    sizes[width] = d_width
+    g = _AnisoGrid(sizes["x"], sizes["y"], sizes["z"], shape)
+    port = MSLPort(feed_x=10 * d_prop, y_lo=10 * d_width, y_hi=16 * d_width,
+                   z_lo=0.0, z_hi=3 * d_norm, direction=direction,
+                   impedance=50.0)
+    out = setup_msl_port(g, port, _Mat(shape))
+    return float(np.sum(np.asarray(out.sigma)))
+
+
+def test_port_conductance_uses_the_propagation_axis_cell_size():
+    """sigma must scale as 1/d_prop for a y port exactly as for an x port.
+
+    If the y lane still read ``dx`` where it should read ``dy``, these two
+    would disagree by ``d_width/d_prop`` = 2. On a cubic grid they agree
+    either way -- which is precisely why this test is not cubic.
+    """
+    base_x = _sigma_sum("+x", 80e-6, 80e-6, 80e-6)
+    base_y = _sigma_sum("+y", 80e-6, 80e-6, 80e-6)
+    assert base_x == pytest.approx(base_y, rel=1e-12)
+
+    # Halve the PROPAGATION cell only: sigma must double, both lanes.
+    for d in ("+x", "-x", "+y", "-y"):
+        got = _sigma_sum(d, 40e-6, 80e-6, 80e-6)
+        assert got == pytest.approx(2.0 * base_x, rel=1e-12), (
+            f"{d}: sigma did not scale as 1/d_prop (got {got}, expected "
+            f"{2.0 * base_x}) -- the port conductance is reading the wrong "
+            f"axis's cell size."
+        )
+    # Halve the WIDTH cell only: sigma must double as well (it is the
+    # parallel-cell count that changes), and NORMAL halving must halve it.
+    for d in ("+x", "+y"):
+        assert _sigma_sum(d, 80e-6, 40e-6, 80e-6) == pytest.approx(
+            2.0 * base_x, rel=1e-12)
+        assert _sigma_sum(d, 80e-6, 80e-6, 40e-6) == pytest.approx(
+            0.5 * base_x, rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# 5. Preflight fires on the correct axis per direction
+# ---------------------------------------------------------------------------
+
+
+def _msl_warnings(sim):
+    """MSL-port advisories from ``preflight()`` (same helper shape as
+    ``tests/test_msl_port_preflight.py``: the report is a list of str)."""
+    return [m for m in sim.preflight() if "MSL port" in m]
+
+
+def _board(domain, direction, feed, lat_c, *, trace_len_axis):
+    """Thru-line board with one port; ``feed``/``lat_c`` are port-frame."""
+    sim = Simulation(freq_max=F_MAX, domain=domain, dx=DX, cpml_layers=8,
+                     boundary=BoundarySpec(x="cpml", y="cpml",
+                                           z=Boundary(lo="pec", hi="cpml")))
+    sim.add_material("ro4350b", eps_r=EPS_R)
+    sim.add(Box((0.0, 0.0, 0.0), (domain[0], domain[1], H_SUB)),
+            material="ro4350b")
+    if trace_len_axis == "x":
+        lo = (0.0, lat_c - W_TRACE / 2, H_SUB)
+        hi = (domain[0], lat_c + W_TRACE / 2, H_SUB + DX)
+    else:
+        lo = (lat_c - W_TRACE / 2, 0.0, H_SUB)
+        hi = (lat_c + W_TRACE / 2, domain[1], H_SUB + DX)
+    sim.add(Box(lo, hi), material="pec")
+    sim.add_msl_port(
+        position=msl_physical_point(direction, feed, lat_c, 0.0),
+        width=W_TRACE, height=H_SUB, direction=direction, impedance=50.0,
+        n_probe_offset=16,
+    )
+    return sim
+
+
+def test_lateral_clearance_check_fires_on_the_width_axis_for_a_y_port():
+    """Check 1 measures across the TRACE WIDTH axis — x for a y port.
+
+    Built so an axis mix-up is visible: the width axis is deliberately
+    starved while the propagation axis is generous, so a check still
+    looking at ``domain[1]`` would stay silent.
+    """
+    tight = W_TRACE + 2 * (0.2 * H_SUB)      # far under the 2*h_sub rule
+    sim = _board((tight, L_PROP, LZ), "+y", PORT_MARGIN, tight / 2.0,
+                 trace_len_axis="y")
+    msgs = [m for m in _msl_warnings(sim) if "lateral clearance" in m]
+    assert msgs, "lateral-clearance check did not fire on the width axis"
+    joined = " ".join(msgs)
+    assert "−x" in joined or "+x" in joined, (
+        f"clearance warning must name the x (width) sides for a y port: "
+        f"{joined}"
+    )
+    assert "domain x-extent" in joined
+    # And it must NOT fire when the width axis is generous, even though
+    # the propagation axis is now the narrow one.
+    ok = _board((L_LAT, L_PROP, LZ), "+y", PORT_MARGIN, L_LAT / 2.0,
+                trace_len_axis="y")
+    assert not [m for m in _msl_warnings(ok) if "lateral clearance" in m]
+
+
+def test_port_to_cpml_check_fires_on_the_propagation_axis_for_a_y_port():
+    """Check 3 measures along the PROPAGATION axis — y for a y port."""
+    # Feed pressed right up against the y_lo wall; the x extent is fine.
+    sim = _board((L_LAT, L_PROP, LZ), "+y", 0.2 * H_SUB, L_LAT / 2.0,
+                 trace_len_axis="y")
+    msgs = [m for m in _msl_warnings(sim) if "distance to nearest" in m]
+    assert msgs, "port-to-CPML check did not fire on the propagation axis"
+    joined = " ".join(msgs)
+    assert "y-CPML" in joined, f"must name the y CPML for a +y port: {joined}"
+    assert "domain y-extent" in joined
+    # A "-y" port is bounded by the OPPOSITE wall: the same tight feed
+    # coordinate is now comfortably clear.
+    ok = _board((L_LAT, L_PROP, LZ), "-y", 0.2 * H_SUB, L_LAT / 2.0,
+                trace_len_axis="y")
+    assert not [m for m in _msl_warnings(ok) if "distance to nearest" in m]
+
+
+@pytest.mark.parametrize("direction", ["+x", "-x", "+y", "-y"])
+def test_h_sub_alignment_checks_fire_for_every_direction(direction):
+    """Checks 2 and 2b (substrate cell count, mixed-cell danger zone).
+
+    These are the one preflight family that must NOT move axis: h_sub is
+    measured along the substrate normal, and the normal is welded to z for
+    every supported direction. So the correct behaviour is that both fire
+    identically regardless of ``direction`` -- an implementation that
+    "generalised" them onto the propagation axis would be wrong, and would
+    stop reporting the substrate resolution for a y port.
+
+    dx = 80 um with h_sub = 254 um gives h_sub/dx = 3.175: under 4 cells
+    (check 2) and fractional part 0.175, inside the [0.10, 0.40] mixed-cell
+    danger zone (check 2b).
+    """
+    prop, width, _n, _s = msl_axis_roles(direction)
+    domain = [0.0, 0.0, LZ]
+    domain[{"x": 0, "y": 1}[prop]] = L_PROP
+    domain[{"x": 0, "y": 1}[width]] = L_LAT
+    sim = _board(tuple(domain), direction, PORT_MARGIN, L_LAT / 2.0,
+                 trace_len_axis=prop)
+    msgs = _msl_warnings(sim)
+    cells = [m for m in msgs if "substrate cell(s) in z" in m]
+    frac = [m for m in msgs if "mixed-cell danger zone" in m]
+    assert cells, f"substrate-resolution check silent for {direction}: {msgs}"
+    assert frac, f"mixed-cell check silent for {direction}: {msgs}"
+    # Same numbers on every axis — h_sub does not depend on direction.
+    assert "only 3 substrate cell(s) in z" in cells[0], cells[0]
+    assert "h_sub/dx = 3.175" in frac[0], frac[0]
+
+
+def test_probe_span_absorber_check_fires_on_the_propagation_axis():
+    """Check 4a walks the probe ladder along the propagation axis."""
+    sim = Simulation(freq_max=F_MAX, domain=(L_LAT, L_PROP, LZ), dx=DX,
+                     cpml_layers=8,
+                     boundary=BoundarySpec(x="cpml", y="cpml",
+                                           z=Boundary(lo="pec", hi="cpml")))
+    sim.add_material("ro4350b", eps_r=EPS_R)
+    sim.add(Box((0.0, 0.0, 0.0), (L_LAT, L_PROP, H_SUB)), material="ro4350b")
+    sim.add(Box((L_LAT / 2 - W_TRACE / 2, 0.0, H_SUB),
+                (L_LAT / 2 + W_TRACE / 2, L_PROP, H_SUB + DX)), material="pec")
+    # Ladder deliberately long enough to run off the far y edge.
+    sim.add_msl_port(position=(L_LAT / 2, L_PROP - 1e-3, 0.0), width=W_TRACE,
+                     height=H_SUB, direction="+y", impedance=50.0,
+                     n_probe_offset=20, n_probe_spacing=6)
+    msgs = [m for m in _msl_warnings(sim)
+            if "deepest" in m and "domain" in m]
+    assert msgs, "probe-span absorber check did not fire"
+    assert "domain y-extent" in " ".join(msgs)
+
+
+# ---------------------------------------------------------------------------
+# 6. The falsifier: rotation equivalence end to end
+# ---------------------------------------------------------------------------
+
+
+def _thru(axis, n_freqs, num_periods):
+    if axis == "x":
+        domain, sub = (L_PROP, L_LAT, LZ), (L_PROP, L_LAT, H_SUB)
+        lat_c = L_LAT / 2.0
+        tlo = (0.0, lat_c - W_TRACE / 2, H_SUB)
+        thi = (L_PROP, lat_c + W_TRACE / 2, H_SUB + DX)
+        p0, p1, d0, d1 = ((PORT_MARGIN, lat_c, 0.0),
+                          (PORT_MARGIN + L_LINE, lat_c, 0.0), "+x", "-x")
+    else:
+        domain, sub = (L_LAT, L_PROP, LZ), (L_LAT, L_PROP, H_SUB)
+        lat_c = L_LAT / 2.0
+        tlo = (lat_c - W_TRACE / 2, 0.0, H_SUB)
+        thi = (lat_c + W_TRACE / 2, L_PROP, H_SUB + DX)
+        p0, p1, d0, d1 = ((lat_c, PORT_MARGIN, 0.0),
+                          (lat_c, PORT_MARGIN + L_LINE, 0.0), "+y", "-y")
+    sim = Simulation(freq_max=F_MAX, domain=domain, dx=DX, cpml_layers=8,
+                     boundary=BoundarySpec(x="cpml", y="cpml",
+                                           z=Boundary(lo="pec", hi="cpml")))
+    sim.add_material("ro4350b", eps_r=EPS_R)
+    sim.add(Box((0.0, 0.0, 0.0), sub), material="ro4350b")
+    sim.add(Box(tlo, thi), material="pec")
+    sim.add_msl_port(position=p0, width=W_TRACE, height=H_SUB,
+                     direction=d0, impedance=50.0)
+    sim.add_msl_port(position=p1, width=W_TRACE, height=H_SUB,
+                     direction=d1, impedance=50.0)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        res = sim.compute_msl_s_matrix(n_freqs=n_freqs,
+                                       num_periods=num_periods)
+    return res, [str(c.message) for c in caught]
+
+
+@pytest.mark.slow
+def test_y_directed_thru_reproduces_the_x_directed_thru():
+    """THE FALSIFIER for issue #661.
+
+    Identical physical thru line, built once with the feed along x and
+    once on the x<->y mirrored fixture with the feed along y. Same
+    structure, same mesh pitch, so every extracted quantity must agree to
+    the extraction floor. If it does not, some part of the extractor was
+    x-specific after all -- and that finding matters more than the
+    feature.
+
+    Compared on COMPLEX S: see the module docstring for why a
+    magnitude-only comparison passes on the exact bug this guards.
+
+    Measured (12 bins, num_periods=12, dx=80um, CPU float32)::
+
+        max |S_x - S_y|        3.86e-06   (rel 3.86e-06)
+        rel max |Z0_x - Z0_y|  2.14e-04
+        rel max |beta_x-beta_y| 3.09e-05
+        settling_db  x = [-98.47, -102.96]   y = [-98.49, -102.91]
+
+    The three bounds below are NOT one number, because the three
+    quantities do not share a conditioning class -- the measured spread
+    is a ladder, and the ladder has a cause:
+
+    * ``S`` is a V*I split at one plane plus a 2x2 ``B A^-1`` solve --
+      well conditioned, lands at the float32 reassociation floor;
+    * ``beta`` comes from the N-probe scan, which
+      ``rfx/probes/msl_wave_decomp.py`` runs in float32 by explicit cast
+      (``_estimate_beta``'s own comment records that the residual curve
+      is "numerically flat in float32");
+    * ``Z0 = (alpha - gamma) / I`` compounds that fit's residual through a
+      DIFFERENCE of two fitted amplitudes, so it sits an order above
+      beta.
+
+    Each bound is the measured value with roughly an order of margin, and
+    all three are >= 3 orders below the failure signature they exist to
+    catch (the swap measures ``max|dS| = 1.912``). ``test_equivalence_
+    harness_can_move`` is the negative control for that claim.
+    """
+    rx, wx = _thru("x", n_freqs=12, num_periods=12)
+    ry, wy = _thru("y", n_freqs=12, num_periods=12)
+
+    # Preflight output is part of the result (repo rule): the two lanes
+    # must raise the SAME advisories. Normalised for (a) axis letters,
+    # (b) numeric literals -- the reported Z0 differs in its last printed
+    # digit (57.61 vs 57.60 ohm) purely from the float32 fit above, and
+    # (c) one-shot import-time DeprecationWarnings, which fire only for
+    # whichever lane happens to run first in the process.
+    import re
+
+    def _canon(ms):
+        out = []
+        for m in ms:
+            if "deprecated" in m.lower():
+                continue
+            m = (m.replace("y-CPML", "@-CPML").replace("x-CPML", "@-CPML")
+                  .replace("domain x-extent", "domain @-extent")
+                  .replace("domain y-extent", "domain @-extent"))
+            out.append(re.sub(r"[-+]?\d[\d.,]*(?:[eE][-+]?\d+)?", "#", m))
+        return sorted(out)
+
+    cx, cy = _canon(wx), _canon(wy)
+    assert cx == cy, (
+        "the two lanes produced different advisories:\n"
+        f"only in x: {[m for m in cx if m not in cy]}\n"
+        f"only in y: {[m for m in cy if m not in cx]}"
+    )
+
+    Sx, Sy = np.asarray(rx.S), np.asarray(ry.S)
+    Zx, Zy = np.asarray(rx.Z0), np.asarray(ry.Z0)
+    Bx, By = np.asarray(rx.beta), np.asarray(ry.beta)
+    assert np.allclose(rx.freqs, ry.freqs)
+
+    d_s = float(np.max(np.abs(Sx - Sy)))
+    d_z = float(np.max(np.abs(Zx - Zy)) / max(np.max(np.abs(Zx)), 1e-30))
+    d_b = float(np.max(np.abs(Bx - By)) / max(np.max(np.abs(Bx)), 1e-30))
+    print(f"\n[#661 equivalence] max|dS|={d_s:.3e} rel dZ0={d_z:.3e} "
+          f"rel dbeta={d_b:.3e}")
+    print(f"[#661 equivalence] settling_db x={np.asarray(rx.settling_db)} "
+          f"y={np.asarray(ry.settling_db)}")
+
+    # Ring-down settling witness: fixed-length open-domain records must
+    # quote end/peak energy before any claims-bearing number.
+    for tag, r in (("x", rx), ("y", ry)):
+        sd = np.asarray(r.settling_db, dtype=float)
+        assert np.all(sd < -40.0), (
+            f"{tag} lane under-settled (settling_db={sd}); the equivalence "
+            f"comparison would be reading truncation, not physics"
+        )
+
+    assert d_s < 1e-4, f"complex S disagreement {d_s:.3e} exceeds the floor"
+    assert d_z < 3e-3, f"Z0 disagreement {d_z:.3e} exceeds the fit floor"
+    assert d_b < 1e-3, f"beta disagreement {d_b:.3e} exceeds the fit floor"
+
+
+@pytest.mark.slow
+def test_equivalence_harness_can_move():
+    """Negative control for the falsifier above.
+
+    A rotation-equivalence assertion that compares two runs is worthless
+    if the comparison cannot register a difference. Perturb the y lane's
+    trace width by one mesh cell and confirm the same statistic moves far
+    past the 1e-4 bound -- so a PASS above is evidence, not a tautology.
+    """
+    rx, _ = _thru("x", n_freqs=6, num_periods=8)
+
+    lat_c = L_LAT / 2.0
+    w_bad = W_TRACE + DX
+    sim = Simulation(freq_max=F_MAX, domain=(L_LAT, L_PROP, LZ), dx=DX,
+                     cpml_layers=8,
+                     boundary=BoundarySpec(x="cpml", y="cpml",
+                                           z=Boundary(lo="pec", hi="cpml")))
+    sim.add_material("ro4350b", eps_r=EPS_R)
+    sim.add(Box((0.0, 0.0, 0.0), (L_LAT, L_PROP, H_SUB)), material="ro4350b")
+    sim.add(Box((lat_c - w_bad / 2, 0.0, H_SUB),
+                (lat_c + w_bad / 2, L_PROP, H_SUB + DX)), material="pec")
+    sim.add_msl_port(position=(lat_c, PORT_MARGIN, 0.0), width=w_bad,
+                     height=H_SUB, direction="+y", impedance=50.0)
+    sim.add_msl_port(position=(lat_c, PORT_MARGIN + L_LINE, 0.0), width=w_bad,
+                     height=H_SUB, direction="-y", impedance=50.0)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        r_bad = sim.compute_msl_s_matrix(n_freqs=6, num_periods=8)
+
+    d = float(np.max(np.abs(np.asarray(rx.S) - np.asarray(r_bad.S))))
+    print(f"\n[#661 negative control] one-cell wider trace -> max|dS|={d:.3e}")
+    assert d > 1e-3, (
+        f"the equivalence statistic moved only {d:.3e} for a one-cell "
+        f"geometry change -- it is too blunt to be evidence"
+    )


### PR DESCRIPTION
Closes #661.

## My premise in the issue was two-thirds right, and the remaining third mattered

I wrote that "nothing in the construction looks intrinsically x-specific", labelled as read from
source rather than instrumented. A runtime census over a real two-port run says:

| class | sites |
|---|---|
| **propagation-bound** — clean relabelings | probe ladder `_msl_x_for_index`, DFT plane normal + its two H components, `dx_feed` in sigma, preflight checks 3/4/4a/4b |
| **substrate-normal-bound — NOT relabelable** | `SourceSpec(component="ez")`, `msl_modal_voltage(ez_plane, dz_arr)`, the Laplace solve's `ez_profile`, the trace-PEC scan |
| axis-free | N-probe fit, Hammerstad-Jensen anchor, multi-drive `S = B·A⁻¹` |

The free choice is which **in-board** axis carries the feed; the substrate normal is welded to z.
So `+y`/`-y` is a relabeling and `+z`/`-z` is not — the latter is rejected rather than
half-generalized.

Corroboration that the mode solve is propagation-agnostic: identical `ez_profile` / `z0_static` /
`eps_eff`, delta **0.000000e+00**, across two feed planes and opposite directions.

## The finding that changes how this had to be tested

A naive `x<->y` swap is a **reflection**. On the committed fixture's own recorded H planes, the
cyclic pair reproduces `I_x` to 9.2e-08 while the swap returns exactly **−I** (ratio −1.00000009).

I predicted the honesty guards would catch that. **They do not**, and the reason is worth
recording: the flip maps `S = B·A⁻¹` to `A·B⁻¹ = S⁻¹`, and a low-loss matched line is nearly
unitary, so `S⁻¹ ≈ S†`.

- `|S11|` 0.17905 -> 0.17875; `max ||S| − |S_swapped||` = **1.3e-03**
- column power < 1, so the passivity projection stays silent; `cond(A)` = 1.32, silent;
  `|S11|` nowhere near the 1.05 guard, silent
- but `arg(S21)` is exactly negated — angles summing to <= 0.02 deg across the band, i.e. negative
  group delay — and the complex error is **1.912**

**A magnitude-only equivalence test passes on this exact bug.** The falsifier therefore compares
complex S.

## Falsifier and its mutation control

y-directed port on the x<->y mirrored fixture vs x-directed, 12 bins:

```
max |S_x − S_y|   3.86e-06     rel |Z0| 2.14e-04     rel |beta| 3.09e-05
settling_db  x [−98.47, −102.96]   y [−98.49, −102.91]
```

Mutation control — flipping `_MSL_CYCLIC_PAIR["y"]` to `("x","z")` drives the same statistic to
**1.558**, 5.6 orders of discrimination. Note beta is *unchanged* under that mutation
(3.09e-05), so a beta-only check would have missed it.

Three separate tolerances rather than one, root-caused: `extract_msl_nprobe` casts to float32
explicitly, and `Z0 = (alpha−gamma)/I` compounds that fit's residual through a difference.

## Existing behaviour unchanged

SHA-256 over S / Z0 / beta on the committed thru fixture, base `fd37c62` vs branch — identical,
reproducing the recorded calibration (0.115946 / 0.993048 / 57.5710 ohm). Negative control: a
1e-4 relative trace-width change moves all three digests.

## #524, measured — it is prose, not code

Own-drive diagonal `Re((alpha−gamma)/I1)` = **+57.52 ohm** at the `+x` port and **−57.56 ohm** at
`-x`, same magnitude to 0.08%. The `#140` comment describes what the code does; the
`msl_loop_current` docstring's unqualified claim is the wrong statement. Docstring corrected and
pinned by a test; no code changed. **#524 stays open** for its other items, and no closing keyword
appears anywhere near it.

## Scope fenced deliberately

`compute_mixed_s_matrix` (#488, experimental) and `register_msl_plane_probes` stay x-only rather
than being extended without their own evidence.

## Two reds, neither introduced here

- `test_coax_two_port_ad.py -k fd_consistent`: `rel = 0.026310 <= 0.02` fails. I reproduced it on
  a pinned `git archive` of `fd37c62` **to the digit** — pre-existing on main, now filed
  separately.
- A 79-file single-process run segfaulted at ~70% inside `test_sparam_ad_end_to_end.py`, which
  passes in isolation in 161.85 s. Documented XLA-state accumulation for long single-process runs
  here, aggravated by a concurrent suite from another session. Re-run in 4 chunks.

Preflight on the y-lane fixture is verbatim identical to the x-lane's 7 advisories, including the
`h_sub`/dx danger-zone check — which correctly does **not** move axis, since the normal is z.
Pinned for all four directions.

ruff clean, api-reference gate OK, 73 contract tests, MSL fast suites 65 passed, new axis file 23
fast + 2 slow passed.

R3: memory=feedback_label_mechanism_provenance (my premise was read, not instrumented, and the
census corrected it) | R2-attempts=1 | falsifier=the cyclic-pair mutation, watched at 1.558 vs
3.86e-06